### PR TITLE
Remove org_name from database and API paths

### DIFF
--- a/alembic/versions/018_drop_org_name.py
+++ b/alembic/versions/018_drop_org_name.py
@@ -1,0 +1,118 @@
+"""Drop org_name columns from all tables.
+
+Terrapod is single-organization by design. The "default" org exists solely
+as a static string in TFE-compatible API paths. There is no multi-org
+support at any level. This migration removes the vestigial org_name columns
+and updates unique constraints accordingly.
+
+Revision ID: 018
+Revises: 017
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "018"
+down_revision = "017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- workspaces ---
+    op.drop_constraint("uq_workspaces", "workspaces", type_="unique")
+    op.create_unique_constraint("uq_workspaces", "workspaces", ["name"])
+    op.drop_column("workspaces", "org_name")
+
+    # --- registry_modules ---
+    op.drop_constraint("uq_registry_modules", "registry_modules", type_="unique")
+    op.create_unique_constraint(
+        "uq_registry_modules", "registry_modules", ["namespace", "name", "provider"]
+    )
+    op.drop_column("registry_modules", "org_name")
+
+    # --- registry_providers ---
+    op.drop_constraint("uq_registry_providers", "registry_providers", type_="unique")
+    op.create_unique_constraint(
+        "uq_registry_providers", "registry_providers", ["namespace", "name"]
+    )
+    op.drop_column("registry_providers", "org_name")
+
+    # --- gpg_keys ---
+    op.drop_constraint("uq_gpg_keys", "gpg_keys", type_="unique")
+    op.create_unique_constraint("uq_gpg_keys", "gpg_keys", ["key_id"])
+    op.drop_column("gpg_keys", "org_name")
+
+    # --- variable_sets ---
+    op.drop_constraint("uq_variable_sets", "variable_sets", type_="unique")
+    op.create_unique_constraint("uq_variable_sets", "variable_sets", ["name"])
+    op.drop_column("variable_sets", "org_name")
+
+    # --- vcs_connections (no unique constraint on org_name, just drop column) ---
+    op.drop_column("vcs_connections", "org_name")
+
+    # --- agent_pools (nullable, no unique constraint on org_name) ---
+    op.drop_column("agent_pools", "org_name")
+
+    # --- api_tokens (nullable, no unique constraint on org_name) ---
+    op.drop_column("api_tokens", "org_name")
+
+
+def downgrade() -> None:
+    # Re-add all org_name columns with default "default"
+    op.add_column(
+        "api_tokens",
+        sa.Column("org_name", sa.String(63), nullable=True),
+    )
+    op.add_column(
+        "agent_pools",
+        sa.Column("org_name", sa.String(63), nullable=True),
+    )
+    op.add_column(
+        "vcs_connections",
+        sa.Column("org_name", sa.String(63), nullable=False, server_default="default"),
+    )
+
+    # variable_sets
+    op.add_column(
+        "variable_sets",
+        sa.Column("org_name", sa.String(63), nullable=False, server_default="default"),
+    )
+    op.drop_constraint("uq_variable_sets", "variable_sets", type_="unique")
+    op.create_unique_constraint("uq_variable_sets", "variable_sets", ["org_name", "name"])
+
+    # gpg_keys
+    op.add_column(
+        "gpg_keys",
+        sa.Column("org_name", sa.String(63), nullable=False, server_default="default"),
+    )
+    op.drop_constraint("uq_gpg_keys", "gpg_keys", type_="unique")
+    op.create_unique_constraint("uq_gpg_keys", "gpg_keys", ["org_name", "key_id"])
+
+    # registry_providers
+    op.add_column(
+        "registry_providers",
+        sa.Column("org_name", sa.String(63), nullable=False, server_default="default"),
+    )
+    op.drop_constraint("uq_registry_providers", "registry_providers", type_="unique")
+    op.create_unique_constraint(
+        "uq_registry_providers", "registry_providers", ["org_name", "namespace", "name"]
+    )
+
+    # registry_modules
+    op.add_column(
+        "registry_modules",
+        sa.Column("org_name", sa.String(63), nullable=False, server_default="default"),
+    )
+    op.drop_constraint("uq_registry_modules", "registry_modules", type_="unique")
+    op.create_unique_constraint(
+        "uq_registry_modules", "registry_modules", ["org_name", "namespace", "name", "provider"]
+    )
+
+    # workspaces
+    op.add_column(
+        "workspaces",
+        sa.Column("org_name", sa.String(63), nullable=False, server_default="default"),
+    )
+    op.drop_constraint("uq_workspaces", "workspaces", type_="unique")
+    op.create_unique_constraint("uq_workspaces", "workspaces", ["org_name", "name"])

--- a/services/terrapod/api/dependencies.py
+++ b/services/terrapod/api/dependencies.py
@@ -34,6 +34,13 @@ from terrapod.logging_config import get_logger
 logger = get_logger(__name__)
 security = HTTPBearer(auto_error=False)
 
+# ── Organization ─────────────────────────────────────────────────────────
+# Single org, always "default". Organization paths use literal "default"
+# in route patterns — no dynamic path parameter.
+
+DEFAULT_ORG = "default"
+
+
 # Redis cache TTL for API token role resolution (seconds)
 _TOKEN_ROLES_CACHE_TTL = 60
 _TOKEN_ROLES_PREFIX = "tp:token_roles:"

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -7,7 +7,7 @@ UX CONTRACT: Pool/token/listener endpoints are consumed by the web frontend:
   matched by corresponding updates to those frontend pages.
 
 Endpoints:
-    GET/POST   /api/v2/organizations/{org}/agent-pools
+    GET/POST   /api/v2/organizations/default/agent-pools
     GET/PATCH/DELETE /api/v2/agent-pools/{pool_id}
     POST/GET   /api/v2/agent-pools/{pool_id}/tokens
     DELETE     /api/v2/agent-pools/{pool_id}/tokens/{token_id}
@@ -25,15 +25,18 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_admin
+from terrapod.api.dependencies import (
+    DEFAULT_ORG,
+    AuthenticatedUser,
+    get_current_user,
+    require_admin,
+)
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service
 
 router = APIRouter(prefix="/api/v2", tags=["agent-pools"])
 logger = get_logger(__name__)
-
-DEFAULT_ORG = "default"
 
 
 def _rfc3339(dt) -> str:
@@ -55,7 +58,7 @@ def _pool_json(pool) -> dict:
         },
         "relationships": {
             "organization": {
-                "data": {"id": pool.org_name or DEFAULT_ORG, "type": "organizations"},
+                "data": {"id": DEFAULT_ORG, "type": "organizations"},
             },
         },
     }
@@ -100,11 +103,6 @@ def _listener_json(listener) -> dict:
     }
 
 
-def _validate_org(org: str) -> None:
-    if org != DEFAULT_ORG:
-        raise HTTPException(status_code=404, detail="Organization not found")
-
-
 async def _get_pool(pool_id: str, db: AsyncSession):
     pool_uuid = uuid.UUID(pool_id.removeprefix("apool-"))
     pool = await agent_pool_service.get_pool(db, pool_uuid)
@@ -116,27 +114,23 @@ async def _get_pool(pool_id: str, db: AsyncSession):
 # ── Agent Pools ──────────────────────────────────────────────────────────
 
 
-@router.get("/organizations/{org}/agent-pools")
+@router.get("/organizations/default/agent-pools")
 async def list_pools(
-    org: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """List all agent pools."""
-    _validate_org(org)
-    pools = await agent_pool_service.list_pools(db, org)
+    pools = await agent_pool_service.list_pools(db)
     return JSONResponse(content={"data": [_pool_json(p) for p in pools]})
 
 
-@router.post("/organizations/{org}/agent-pools", status_code=201)
+@router.post("/organizations/default/agent-pools", status_code=201)
 async def create_pool(
-    org: str = Path(...),
     body: dict = Body(...),
     user: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Create an agent pool (admin only)."""
-    _validate_org(org)
 
     attrs = body.get("data", {}).get("attributes", {})
     name = attrs.get("name", "")
@@ -147,7 +141,6 @@ async def create_pool(
         db,
         name=name,
         description=attrs.get("description", ""),
-        org_name=org,
         service_account_name=attrs.get("service-account-name", ""),
     )
     await db.commit()

--- a/services/terrapod/api/routers/gpg_keys.py
+++ b/services/terrapod/api/routers/gpg_keys.py
@@ -57,7 +57,7 @@ def _gpg_key_to_jsonapi(key) -> dict:  # type: ignore[no-untyped-def]
         "attributes": {
             "key-id": key.key_id,
             "ascii-armor": key.ascii_armor,
-            "namespace": key.org_name,
+            "namespace": "default",
             "source": key.source,
             "source-url": key.source_url,
             "created-at": key.created_at.isoformat() if key.created_at else None,
@@ -80,7 +80,6 @@ async def create_gpg_key_endpoint(
     try:
         key = await create_gpg_key(
             db,
-            org=attrs.namespace,
             ascii_armor=attrs.ascii_armor,
             source=attrs.source,
             source_url=attrs.source_url,
@@ -106,7 +105,7 @@ async def list_gpg_keys_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """List GPG keys, optionally filtered by namespace (org)."""
-    keys = await list_gpg_keys(db, org=filter_namespace)
+    keys = await list_gpg_keys(db)
     return JSONResponse(
         content={"data": [_gpg_key_to_jsonapi(k) for k in keys]},
     )

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -11,16 +11,16 @@ UX CONTRACT: Management endpoints are consumed by the web frontend:
   matched by corresponding updates to those frontend pages.
 
 CLI Protocol:
-    GET  /api/v2/registry/modules/{org}/{name}/{provider}/versions
-    GET  /api/v2/registry/modules/{org}/{name}/{provider}/{version}/download
+    GET  /api/v2/registry/modules/{namespace}/{name}/{provider}/versions
+    GET  /api/v2/registry/modules/{namespace}/{name}/{provider}/{version}/download
 
 TFE V2 Management:
-    POST   /api/v2/organizations/{org}/registry-modules
-    GET    /api/v2/organizations/{org}/registry-modules
-    GET    /api/v2/organizations/{org}/registry-modules/private/{ns}/{name}/{prov}
-    DELETE /api/v2/organizations/{org}/registry-modules/private/{ns}/{name}/{prov}
-    POST   /api/v2/organizations/{org}/registry-modules/private/{ns}/{name}/{prov}/versions
-    DELETE /api/v2/organizations/{org}/registry-modules/private/{ns}/{name}/{prov}/{ver}
+    POST   /api/v2/organizations/default/registry-modules
+    GET    /api/v2/organizations/default/registry-modules
+    GET    /api/v2/organizations/default/registry-modules/private/{ns}/{name}/{prov}
+    DELETE /api/v2/organizations/default/registry-modules/private/{ns}/{name}/{prov}
+    POST   /api/v2/organizations/default/registry-modules/private/{ns}/{name}/{prov}/versions
+    DELETE /api/v2/organizations/default/registry-modules/private/{ns}/{name}/{prov}/{ver}
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -104,16 +104,16 @@ def _module_to_jsonapi(module) -> dict:  # type: ignore[no-untyped-def]
 # --- CLI Protocol Endpoints ---
 
 
-@router.get("/api/v2/registry/modules/{org}/{name}/{provider}/versions")
+@router.get("/api/v2/registry/modules/{namespace}/{name}/{provider}/versions")
 async def list_module_versions_cli(
-    org: str,
+    namespace: str,
     name: str,
     provider: str,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """List available versions for a module (CLI protocol). Requires read."""
-    module = await get_module(db, org, org, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
@@ -131,9 +131,9 @@ async def list_module_versions_cli(
     )
 
 
-@router.get("/api/v2/registry/modules/{org}/{name}/{provider}/{version}/download")
+@router.get("/api/v2/registry/modules/{namespace}/{name}/{provider}/{version}/download")
 async def download_module_cli(
-    org: str,
+    namespace: str,
     name: str,
     provider: str,
     version: str,
@@ -142,7 +142,7 @@ async def download_module_cli(
     storage: ObjectStore = Depends(get_storage),
 ) -> Response:
     """Get download URL for a module version (CLI protocol). Requires read."""
-    module = await get_module(db, org, org, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is not None:
         perm = await resolve_registry_permission(
             db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
@@ -150,7 +150,7 @@ async def download_module_cli(
         if not has_registry_permission(perm, "read"):
             raise HTTPException(status_code=404, detail="Module version not found")
 
-    url = await get_module_download_url(db, storage, org, org, name, provider, version)
+    url = await get_module_download_url(db, storage, namespace, name, provider, version)
     if url is None:
         raise HTTPException(status_code=404, detail="Module version not found")
 
@@ -163,25 +163,24 @@ async def download_module_cli(
 # --- TFE V2 Management Endpoints ---
 
 
-@router.post("/api/v2/organizations/{org}/registry-modules")
+@router.post("/api/v2/organizations/default/registry-modules")
 async def create_module_endpoint(
-    org: str,
     body: CreateModuleRequest,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Create a new registry module. Any authenticated user; creator becomes owner."""
     attrs = body.data.attributes
-    namespace = attrs.namespace or org
+    namespace = attrs.namespace or "default"
 
-    module = await create_module(db, org, namespace, attrs.name, attrs.provider)
+    module = await create_module(db, namespace, attrs.name, attrs.provider)
     module.owner_email = user.email
     module.labels = attrs.labels
     await db.commit()
+    await db.refresh(module, attribute_names=["versions"])
 
     logger.info(
         "Registry module created",
-        org=org,
         name=attrs.name,
         provider=attrs.provider,
         owner=user.email,
@@ -193,14 +192,13 @@ async def create_module_endpoint(
     )
 
 
-@router.get("/api/v2/organizations/{org}/registry-modules")
+@router.get("/api/v2/organizations/default/registry-modules")
 async def list_modules_endpoint(
-    org: str,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List all registry modules for an organization (filtered by permissions)."""
-    modules = await list_modules(db, org)
+    """List all registry modules (filtered by permissions)."""
+    modules = await list_modules(db)
     visible = []
     for m in modules:
         perm = await resolve_registry_permission(
@@ -211,9 +209,8 @@ async def list_modules_endpoint(
     return JSONResponse(content={"data": visible})
 
 
-@router.get("/api/v2/organizations/{org}/registry-modules/private/{namespace}/{name}/{provider}")
+@router.get("/api/v2/organizations/default/registry-modules/private/{namespace}/{name}/{provider}")
 async def show_module_endpoint(
-    org: str,
     namespace: str,
     name: str,
     provider: str,
@@ -221,7 +218,7 @@ async def show_module_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Show a specific registry module. Requires read."""
-    module = await get_module(db, org, namespace, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
@@ -234,9 +231,10 @@ async def show_module_endpoint(
     return JSONResponse(content={"data": _module_to_jsonapi(module)})
 
 
-@router.delete("/api/v2/organizations/{org}/registry-modules/private/{namespace}/{name}/{provider}")
+@router.delete(
+    "/api/v2/organizations/default/registry-modules/private/{namespace}/{name}/{provider}"
+)
 async def delete_module_endpoint(
-    org: str,
     namespace: str,
     name: str,
     provider: str,
@@ -245,7 +243,7 @@ async def delete_module_endpoint(
     storage: ObjectStore = Depends(get_storage),
 ) -> Response:
     """Delete a registry module and all its versions. Requires admin on module."""
-    module = await get_module(db, org, namespace, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
@@ -258,7 +256,7 @@ async def delete_module_endpoint(
             detail="Requires admin permission on module",
         )
 
-    deleted = await delete_module(db, storage, org, namespace, name, provider)
+    deleted = await delete_module(db, storage, namespace, name, provider)
     if not deleted:
         raise HTTPException(status_code=404, detail="Module not found")
 
@@ -267,10 +265,9 @@ async def delete_module_endpoint(
 
 
 @router.post(
-    "/api/v2/organizations/{org}/registry-modules/private/{namespace}/{name}/{provider}/versions"
+    "/api/v2/organizations/default/registry-modules/private/{namespace}/{name}/{provider}/versions"
 )
 async def create_module_version_endpoint(
-    org: str,
     namespace: str,
     name: str,
     provider: str,
@@ -280,7 +277,7 @@ async def create_module_version_endpoint(
     storage: ObjectStore = Depends(get_storage),
 ) -> JSONResponse:
     """Create a new module version and get an upload URL. Requires write."""
-    module = await get_module(db, org, namespace, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
@@ -325,10 +322,9 @@ async def create_module_version_endpoint(
 
 
 @router.delete(
-    "/api/v2/organizations/{org}/registry-modules/private/{namespace}/{name}/{provider}/{version}"
+    "/api/v2/organizations/default/registry-modules/private/{namespace}/{name}/{provider}/{version}"
 )
 async def delete_module_version_endpoint(
-    org: str,
     namespace: str,
     name: str,
     provider: str,
@@ -338,7 +334,7 @@ async def delete_module_version_endpoint(
     storage: ObjectStore = Depends(get_storage),
 ) -> Response:
     """Delete a specific module version. Requires admin on module."""
-    module = await get_module(db, org, namespace, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is not None:
         perm = await resolve_registry_permission(
             db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
@@ -349,7 +345,7 @@ async def delete_module_version_endpoint(
                 detail="Requires admin permission on module",
             )
 
-    deleted = await delete_module_version(db, storage, org, namespace, name, provider, version)
+    deleted = await delete_module_version(db, storage, namespace, name, provider, version)
     if not deleted:
         raise HTTPException(status_code=404, detail="Module version not found")
 

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -11,14 +11,14 @@ UX CONTRACT: Management endpoints are consumed by the web frontend:
   matched by corresponding updates to those frontend pages.
 
 CLI Protocol:
-    GET  /api/v2/registry/providers/{org}/{name}/versions
-    GET  /api/v2/registry/providers/{org}/{name}/{version}/download/{os}/{arch}
+    GET  /api/v2/registry/providers/{namespace}/{name}/versions
+    GET  /api/v2/registry/providers/{namespace}/{name}/{version}/download/{os}/{arch}
 
 TFE V2 Management:
-    POST   /api/v2/organizations/{org}/registry-providers
-    GET    /api/v2/organizations/{org}/registry-providers
-    GET    /api/v2/organizations/{org}/registry-providers/private/{ns}/{name}
-    DELETE /api/v2/organizations/{org}/registry-providers/private/{ns}/{name}
+    POST   /api/v2/organizations/default/registry-providers
+    GET    /api/v2/organizations/default/registry-providers
+    GET    /api/v2/organizations/default/registry-providers/private/{ns}/{name}
+    DELETE /api/v2/organizations/default/registry-providers/private/{ns}/{name}
     POST   .../private/{ns}/{name}/versions
     GET    .../private/{ns}/{name}/versions
     DELETE .../private/{ns}/{name}/versions/{ver}
@@ -183,15 +183,15 @@ async def _require_provider_permission(
 # --- CLI Protocol Endpoints ---
 
 
-@router.get("/api/v2/registry/providers/{org}/{name}/versions")
+@router.get("/api/v2/registry/providers/{namespace}/{name}/versions")
 async def list_provider_versions_cli(
-    org: str,
+    namespace: str,
     name: str,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """List available versions for a provider (CLI protocol). Requires read."""
-    provider = await get_provider(db, org, org, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
@@ -217,9 +217,9 @@ async def list_provider_versions_cli(
     return JSONResponse(content={"versions": versions})
 
 
-@router.get("/api/v2/registry/providers/{org}/{name}/{version}/download/{os}/{arch}")
+@router.get("/api/v2/registry/providers/{namespace}/{name}/{version}/download/{os}/{arch}")
 async def download_provider_cli(
-    org: str,
+    namespace: str,
     name: str,
     version: str,
     os: str,
@@ -229,7 +229,7 @@ async def download_provider_cli(
     storage: ObjectStore = Depends(get_storage),
 ) -> JSONResponse:
     """Get download info for a provider version (CLI protocol). Requires read."""
-    provider = await get_provider(db, org, org, name)
+    provider = await get_provider(db, namespace, name)
     if provider is not None:
         perm = await resolve_registry_permission(
             db, user.email, user.roles, provider.name, provider.labels or {}, provider.owner_email
@@ -237,7 +237,7 @@ async def download_provider_cli(
         if not has_registry_permission(perm, "read"):
             raise HTTPException(status_code=404, detail="Provider platform not found")
 
-    info = await get_provider_download_info(db, storage, org, org, name, version, os, arch)
+    info = await get_provider_download_info(db, storage, namespace, name, version, os, arch)
     if info is None:
         raise HTTPException(status_code=404, detail="Provider platform not found")
 
@@ -246,26 +246,25 @@ async def download_provider_cli(
 
 # --- TFE V2 Management Endpoints ---
 
-_ORG_PREFIX = "/api/v2/organizations/{org}/registry-providers"
+_ORG_PREFIX = "/api/v2/organizations/default/registry-providers"
 
 
 @router.post(_ORG_PREFIX)
 async def create_provider_endpoint(
-    org: str,
     body: CreateProviderRequest,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Create a new registry provider. Any authenticated user; creator becomes owner."""
     attrs = body.data.attributes
-    namespace = attrs.namespace or org
+    namespace = attrs.namespace or "default"
 
-    provider = await create_provider(db, org, namespace, attrs.name)
+    provider = await create_provider(db, namespace, attrs.name)
     provider.owner_email = user.email
     provider.labels = attrs.labels
     await db.commit()
 
-    logger.info("Registry provider created", org=org, name=attrs.name, owner=user.email)
+    logger.info("Registry provider created", name=attrs.name, owner=user.email)
 
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,
@@ -275,12 +274,11 @@ async def create_provider_endpoint(
 
 @router.get(_ORG_PREFIX)
 async def list_providers_endpoint(
-    org: str,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List all registry providers for an organization (filtered by permissions)."""
-    providers = await list_providers(db, org)
+    """List all registry providers (filtered by permissions)."""
+    providers = await list_providers(db)
     visible = []
     for p in providers:
         perm = await resolve_registry_permission(
@@ -293,14 +291,13 @@ async def list_providers_endpoint(
 
 @router.get(_ORG_PREFIX + "/private/{namespace}/{name}")
 async def show_provider_endpoint(
-    org: str,
     namespace: str,
     name: str,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Show a specific registry provider. Requires read."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
@@ -315,7 +312,6 @@ async def show_provider_endpoint(
 
 @router.delete(_ORG_PREFIX + "/private/{namespace}/{name}")
 async def delete_provider_endpoint(
-    org: str,
     namespace: str,
     name: str,
     user: AuthenticatedUser = Depends(get_current_user),
@@ -323,13 +319,13 @@ async def delete_provider_endpoint(
     storage: ObjectStore = Depends(get_storage),
 ) -> Response:
     """Delete a registry provider and all its versions. Requires admin on provider."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
     await _require_provider_permission(db, user, provider, "admin")
 
-    deleted = await delete_provider(db, storage, org, namespace, name)
+    deleted = await delete_provider(db, storage, namespace, name)
     if not deleted:
         raise HTTPException(status_code=404, detail="Provider not found")
 
@@ -342,7 +338,6 @@ async def delete_provider_endpoint(
 
 @router.post(_ORG_PREFIX + "/private/{namespace}/{name}/versions")
 async def create_provider_version_endpoint(
-    org: str,
     namespace: str,
     name: str,
     body: CreateProviderVersionRequest,
@@ -351,7 +346,7 @@ async def create_provider_version_endpoint(
     storage: ObjectStore = Depends(get_storage),
 ) -> JSONResponse:
     """Create a provider version and get upload URLs. Requires write."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
@@ -364,7 +359,7 @@ async def create_provider_version_endpoint(
     if attrs.key_id:
         from terrapod.services.gpg_key_service import get_gpg_key_by_key_id
 
-        gpg_key = await get_gpg_key_by_key_id(db, org, attrs.key_id)
+        gpg_key = await get_gpg_key_by_key_id(db, attrs.key_id)
         if gpg_key is not None:
             gpg_key_uuid = gpg_key.id
 
@@ -395,14 +390,13 @@ async def create_provider_version_endpoint(
 
 @router.get(_ORG_PREFIX + "/private/{namespace}/{name}/versions")
 async def list_provider_versions_endpoint(
-    org: str,
     namespace: str,
     name: str,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """List all versions for a provider. Requires read."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
@@ -420,7 +414,6 @@ async def list_provider_versions_endpoint(
 
 @router.delete(_ORG_PREFIX + "/private/{namespace}/{name}/versions/{version}")
 async def delete_provider_version_endpoint(
-    org: str,
     namespace: str,
     name: str,
     version: str,
@@ -429,11 +422,11 @@ async def delete_provider_version_endpoint(
     storage: ObjectStore = Depends(get_storage),
 ) -> Response:
     """Delete a provider version and its platforms. Requires admin."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is not None:
         await _require_provider_permission(db, user, provider, "admin")
 
-    deleted = await delete_provider_version(db, storage, org, namespace, name, version)
+    deleted = await delete_provider_version(db, storage, namespace, name, version)
     if not deleted:
         raise HTTPException(status_code=404, detail="Provider version not found")
 
@@ -446,7 +439,6 @@ async def delete_provider_version_endpoint(
 
 @router.post(_ORG_PREFIX + "/private/{namespace}/{name}/versions/{version}/platforms")
 async def create_provider_platform_endpoint(
-    org: str,
     namespace: str,
     name: str,
     version: str,
@@ -456,7 +448,7 @@ async def create_provider_platform_endpoint(
     storage: ObjectStore = Depends(get_storage),
 ) -> JSONResponse:
     """Create a platform entry and get an upload URL. Requires write."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
@@ -480,7 +472,6 @@ async def create_provider_platform_endpoint(
 
 @router.get(_ORG_PREFIX + "/private/{namespace}/{name}/versions/{version}/platforms")
 async def list_provider_platforms_endpoint(
-    org: str,
     namespace: str,
     name: str,
     version: str,
@@ -488,7 +479,7 @@ async def list_provider_platforms_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """List all platforms for a provider version. Requires read."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
@@ -510,7 +501,6 @@ async def list_provider_platforms_endpoint(
 
 @router.delete(_ORG_PREFIX + "/private/{namespace}/{name}/versions/{version}/platforms/{os}/{arch}")
 async def delete_provider_platform_endpoint(
-    org: str,
     namespace: str,
     name: str,
     version: str,
@@ -521,11 +511,11 @@ async def delete_provider_platform_endpoint(
     storage: ObjectStore = Depends(get_storage),
 ) -> Response:
     """Delete a specific provider platform binary. Requires admin."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is not None:
         await _require_provider_permission(db, user, provider, "admin")
 
-    deleted = await delete_provider_platform(db, storage, org, namespace, name, version, os, arch)
+    deleted = await delete_provider_platform(db, storage, namespace, name, version, os, arch)
     if not deleted:
         raise HTTPException(status_code=404, detail="Provider platform not found")
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -12,11 +12,11 @@ UX CONTRACT: Workspace endpoints are consumed by the web frontend:
 Endpoints:
     GET  /api/v2/ping — API version handshake
     GET  /api/v2/account/details — current user info
-    GET  /api/v2/organizations/{org} — organization details
-    GET  /api/v2/organizations/{org}/entitlement-set — feature entitlements
-    GET  /api/v2/organizations/{org}/workspaces — list workspaces
-    GET  /api/v2/organizations/{org}/workspaces/{name} — workspace by name
-    POST /api/v2/organizations/{org}/workspaces — create workspace
+    GET  /api/v2/organizations/default — organization details
+    GET  /api/v2/organizations/default/entitlement-set — feature entitlements
+    GET  /api/v2/organizations/default/workspaces — list workspaces
+    GET  /api/v2/organizations/default/workspaces/{name} — workspace by name
+    POST /api/v2/organizations/default/workspaces — create workspace
     GET  /api/v2/workspaces/{id} — workspace by ID
     PATCH /api/v2/workspaces/{id} — update workspace
     DELETE /api/v2/workspaces/{id} — delete workspace
@@ -39,7 +39,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.api.dependencies import DEFAULT_ORG, AuthenticatedUser, get_current_user
 from terrapod.db.models import StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -56,10 +56,6 @@ logger = get_logger(__name__)
 TFP_API_VERSION = "2.6"
 TFP_APP_NAME = "Terrapod"
 X_TFE_VERSION = "v0.1.0"
-
-# All resources belong to the hardcoded "default" organization.
-# Multi-org is intentionally not supported — Terrapod is self-hosted, one org per instance.
-DEFAULT_ORG = "default"
 
 
 def _rfc3339(dt: datetime | None) -> str:
@@ -82,15 +78,6 @@ def _clamp_drift_interval(value: int) -> int:
     from terrapod.config import settings
 
     return max(int(value), settings.drift_detection.min_workspace_interval_seconds)
-
-
-def _validate_org(org: str) -> None:
-    """Raise 404 if the organization doesn't match the default."""
-    if org != DEFAULT_ORG:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f'organization "{org}" at host not found',
-        )
 
 
 @router.get("/ping")
@@ -141,16 +128,14 @@ async def account_details(
 # ── Organizations ────────────────────────────────────────────────────────────
 
 
-@router.get("/organizations/{org}")
+@router.get("/organizations/default")
 async def show_organization(
-    org: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> JSONResponse:
     """Return organization details in JSON:API format.
 
-    Stub: only the hardcoded "default" organization exists.
+    Only the hardcoded "default" organization exists.
     """
-    _validate_org(org)
 
     return JSONResponse(
         content={
@@ -196,16 +181,14 @@ async def show_organization(
     )
 
 
-@router.get("/organizations/{org}/entitlement-set")
+@router.get("/organizations/default/entitlement-set")
 async def organization_entitlements(
-    org: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> JSONResponse:
     """Return feature entitlements for an organization.
 
     Enables all features — Terrapod is open source with no feature gating.
     """
-    _validate_org(org)
 
     return JSONResponse(
         content={
@@ -300,7 +283,7 @@ def _workspace_json(ws: Workspace, effective_permission: str | None = None) -> d
             },
             "relationships": {
                 "organization": {
-                    "data": {"id": ws.org_name, "type": "organizations"},
+                    "data": {"id": DEFAULT_ORG, "type": "organizations"},
                 },
                 **(
                     {
@@ -319,17 +302,15 @@ def _workspace_json(ws: Workspace, effective_permission: str | None = None) -> d
     }
 
 
-@router.get("/organizations/{org}/workspaces")
+@router.get("/organizations/default/workspaces")
 async def list_workspaces(
-    org: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     request: Request = None,
 ) -> JSONResponse:
-    """List all workspaces in an organization (filtered by user permissions)."""
-    _validate_org(org)
+    """List all workspaces (filtered by user permissions)."""
 
-    query = select(Workspace).where(Workspace.org_name == org).order_by(Workspace.name)
+    query = select(Workspace).order_by(Workspace.name)
 
     # Support ?search[name]= filter
     search_name = request.query_params.get("search[name]", "") if request else ""
@@ -352,22 +333,15 @@ async def list_workspaces(
     )
 
 
-@router.get("/organizations/{org}/workspaces/{workspace_name}")
+@router.get("/organizations/default/workspaces/{workspace_name}")
 async def show_workspace(
-    org: str = Path(...),
     workspace_name: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Show a workspace by organization and name."""
-    _validate_org(org)
 
-    result = await db.execute(
-        select(Workspace).where(
-            Workspace.org_name == org,
-            Workspace.name == workspace_name,
-        )
-    )
+    result = await db.execute(select(Workspace).where(Workspace.name == workspace_name))
     ws = result.scalar_one_or_none()
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
@@ -379,15 +353,13 @@ async def show_workspace(
     return JSONResponse(content=_workspace_json(ws, perm), headers=_tfe_headers())
 
 
-@router.post("/organizations/{org}/workspaces")
+@router.post("/organizations/default/workspaces")
 async def create_workspace(
-    org: str = Path(...),
     body: dict = Body(...),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Create a workspace in an organization. Any authenticated user can create."""
-    _validate_org(org)
+    """Create a workspace. Any authenticated user can create."""
 
     attrs = body.get("data", {}).get("attributes", {})
     name = attrs.get("name", "")
@@ -395,9 +367,7 @@ async def create_workspace(
         raise HTTPException(status_code=422, detail="Workspace name is required")
 
     # Check for existing
-    result = await db.execute(
-        select(Workspace).where(Workspace.org_name == org, Workspace.name == name)
-    )
+    result = await db.execute(select(Workspace).where(Workspace.name == name))
     if result.scalar_one_or_none() is not None:
         raise HTTPException(status_code=422, detail=f"Workspace '{name}' already exists")
 
@@ -413,7 +383,6 @@ async def create_workspace(
             vcs_connection_id = _uuid.UUID(vcs_conn_id_str.removeprefix("vcs-"))
 
     ws = Workspace(
-        org_name=org,
         name=name,
         execution_mode=attrs.get("execution-mode", "local"),
         auto_apply=attrs.get("auto-apply", False),
@@ -436,7 +405,7 @@ async def create_workspace(
     await db.commit()
     await db.refresh(ws)
 
-    logger.info("Workspace created", org=org, workspace=name, owner=user.email)
+    logger.info("Workspace created", workspace=name, owner=user.email)
     return JSONResponse(
         content=_workspace_json(ws, "admin"),
         status_code=201,

--- a/services/terrapod/api/routers/users.py
+++ b/services/terrapod/api/routers/users.py
@@ -42,16 +42,15 @@ def _user_to_jsonapi(user: User) -> dict:
     }
 
 
-@router.get("/organizations/{org}/users")
+@router.get("/organizations/default/users")
 async def list_users(
-    org: str,
     user: AuthenticatedUser = Depends(require_admin_or_audit),
     db: AsyncSession = Depends(get_db),
     filter_email: str | None = Query(None, alias="filter[email]"),
     page_number: int = Query(1, alias="page[number]", ge=1),
     page_size: int = Query(20, alias="page[size]", ge=1, le=100),
 ) -> dict:
-    """List users in the organization."""
+    """List users."""
     stmt = select(User)
     count_stmt = select(func.count()).select_from(User)
 

--- a/services/terrapod/api/routers/variables.py
+++ b/services/terrapod/api/routers/variables.py
@@ -9,7 +9,7 @@ UX CONTRACT: Variable endpoints are consumed by the web frontend:
 Endpoints:
     GET/POST       /api/v2/workspaces/{id}/vars
     PATCH/DELETE   /api/v2/workspaces/{id}/vars/{var_id}
-    POST/GET       /api/v2/organizations/{org}/varsets
+    POST/GET       /api/v2/organizations/default/varsets
     GET/PATCH/DELETE /api/v2/varsets/{varset_id}
     POST/GET/PATCH/DELETE /api/v2/varsets/{varset_id}/relationships/vars[/{var_id}]
     POST/DELETE    /api/v2/varsets/{varset_id}/relationships/workspaces
@@ -38,8 +38,6 @@ from terrapod.services.workspace_rbac_service import has_permission, resolve_wor
 
 router = APIRouter(prefix="/api/v2", tags=["variables"])
 logger = get_logger(__name__)
-
-DEFAULT_ORG = "default"
 
 
 def _rfc3339(dt) -> str:
@@ -225,39 +223,31 @@ def _varset_json(vs: VariableSet) -> dict:
         },
         "relationships": {
             "organization": {
-                "data": {"id": vs.org_name, "type": "organizations"},
+                "data": {"id": "default", "type": "organizations"},
             },
         },
     }
 
 
-@router.get("/organizations/{org}/varsets")
+@router.get("/organizations/default/varsets")
 async def list_varsets(
-    org: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List all variable sets for an organization."""
-    if org != DEFAULT_ORG:
-        raise HTTPException(status_code=404, detail="Organization not found")
+    """List all variable sets."""
 
-    result = await db.execute(
-        select(VariableSet).where(VariableSet.org_name == org).order_by(VariableSet.name)
-    )
+    result = await db.execute(select(VariableSet).order_by(VariableSet.name))
     varsets = result.scalars().all()
     return JSONResponse(content={"data": [_varset_json(vs) for vs in varsets]})
 
 
-@router.post("/organizations/{org}/varsets", status_code=201)
+@router.post("/organizations/default/varsets", status_code=201)
 async def create_varset(
-    org: str = Path(...),
     body: dict = Body(...),
     user: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Create a variable set. Requires admin."""
-    if org != DEFAULT_ORG:
-        raise HTTPException(status_code=404, detail="Organization not found")
 
     attrs = body.get("data", {}).get("attributes", {})
     name = attrs.get("name", "")
@@ -265,7 +255,6 @@ async def create_varset(
         raise HTTPException(status_code=422, detail="Variable set name is required")
 
     vs = VariableSet(
-        org_name=org,
         name=name,
         description=attrs.get("description", ""),
         global_set=attrs.get("global", False),

--- a/services/terrapod/api/routers/vcs_connections.py
+++ b/services/terrapod/api/routers/vcs_connections.py
@@ -10,8 +10,8 @@ UX CONTRACT: VCS connection endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    GET    /api/v2/organizations/{org}/vcs-connections   (list connections)
-    POST   /api/v2/organizations/{org}/vcs-connections   (create connection)
+    GET    /api/v2/organizations/default/vcs-connections   (list connections)
+    POST   /api/v2/organizations/default/vcs-connections   (create connection)
     GET    /api/v2/vcs-connections/{id}                  (show connection)
     DELETE /api/v2/vcs-connections/{id}                  (delete connection)
 """
@@ -32,7 +32,6 @@ from terrapod.logging_config import get_logger
 router = APIRouter(prefix="/api/v2", tags=["vcs-connections"])
 logger = get_logger(__name__)
 
-DEFAULT_ORG = "default"
 SUPPORTED_PROVIDERS = {"github", "gitlab"}
 
 
@@ -41,11 +40,6 @@ def _rfc3339(dt) -> str:
         return ""
 
     return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _validate_org(org: str) -> None:
-    if org != DEFAULT_ORG:
-        raise HTTPException(status_code=404, detail="Organization not found")
 
 
 def _connection_json(conn: VCSConnection) -> dict:
@@ -73,18 +67,14 @@ def _connection_json(conn: VCSConnection) -> dict:
         "attributes": attrs,
         "relationships": {
             "organization": {
-                "data": {"id": conn.org_name, "type": "organizations"},
+                "data": {"id": "default", "type": "organizations"},
             },
         },
     }
 
 
-async def _list_connections(db: AsyncSession, org_name: str) -> list[VCSConnection]:
-    result = await db.execute(
-        select(VCSConnection)
-        .where(VCSConnection.org_name == org_name)
-        .order_by(VCSConnection.created_at)
-    )
+async def _list_connections(db: AsyncSession) -> list[VCSConnection]:
+    result = await db.execute(select(VCSConnection).order_by(VCSConnection.created_at))
     return list(result.scalars().all())
 
 
@@ -93,21 +83,18 @@ async def _get_connection(db: AsyncSession, connection_id: uuid.UUID) -> VCSConn
     return result.scalar_one_or_none()
 
 
-@router.get("/organizations/{org}/vcs-connections")
+@router.get("/organizations/default/vcs-connections")
 async def list_connections(
-    org: str = Path(...),
     user: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """List all VCS connections (admin only)."""
-    _validate_org(org)
-    connections = await _list_connections(db, org)
+    connections = await _list_connections(db)
     return JSONResponse(content={"data": [_connection_json(c) for c in connections]})
 
 
-@router.post("/organizations/{org}/vcs-connections", status_code=201)
+@router.post("/organizations/default/vcs-connections", status_code=201)
 async def create_connection(
-    org: str = Path(...),
     body: dict = Body(...),
     user: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
@@ -118,7 +105,6 @@ async def create_connection(
     (the PEM-encoded GitHub App private key). Optionally server-url for GHE.
     For GitLab: provide token and optionally server-url (defaults to gitlab.com).
     """
-    _validate_org(org)
 
     attrs = body.get("data", {}).get("attributes", {})
     name = attrs.get("name", "")
@@ -177,7 +163,6 @@ async def create_connection(
 
     conn = VCSConnection(
         id=generate_uuid7(),
-        org_name=org,
         provider=provider,
         name=name,
         server_url=attrs.get("server-url", ""),

--- a/services/terrapod/auth/api_tokens.py
+++ b/services/terrapod/auth/api_tokens.py
@@ -47,7 +47,6 @@ async def create_api_token(
     user_email: str,
     description: str = "",
     token_type: str = "user",
-    org_name: str | None = None,
 ) -> tuple[APIToken, str]:
     """Create an API token. Returns (model, raw_token_value).
 
@@ -62,7 +61,6 @@ async def create_api_token(
         description=description,
         user_email=user_email,
         token_type=token_type,
-        org_name=org_name,
     )
 
     db.add(api_token)

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -161,8 +161,6 @@ class APIToken(Base):
     token_type: Mapped[str] = mapped_column(
         String(20), nullable=False, default="user"
     )  # "user", "organization"
-    org_name: Mapped[str | None] = mapped_column(String(63), nullable=True)
-
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, nullable=False
@@ -185,7 +183,6 @@ class AgentPool(Base):
     )
     name: Mapped[str] = mapped_column(String(63), unique=True, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    org_name: Mapped[str | None] = mapped_column(String(63), nullable=True)
     service_account_name: Mapped[str] = mapped_column(String(63), nullable=False, default="")
 
     created_at: Mapped[datetime] = mapped_column(
@@ -269,17 +266,13 @@ class RunnerListener(Base):
 
 
 class Workspace(Base):
-    """Terraform workspace — isolates state, variables, and runs.
-
-    Part of a single hardcoded "default" organization for now.
-    """
+    """Terraform workspace — isolates state, variables, and runs."""
 
     __tablename__ = "workspaces"
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
-    org_name: Mapped[str] = mapped_column(String(63), nullable=False, default="default")
     name: Mapped[str] = mapped_column(String(90), nullable=False)
     execution_mode: Mapped[str] = mapped_column(
         String(20), nullable=False, default="local"
@@ -341,7 +334,7 @@ class Workspace(Base):
         back_populates="workspace", cascade="all, delete-orphan"
     )
 
-    __table_args__ = (sa.UniqueConstraint("org_name", "name", name="uq_workspaces"),)
+    __table_args__ = (sa.UniqueConstraint("name", name="uq_workspaces"),)
 
 
 class StateVersion(Base):
@@ -384,8 +377,7 @@ class StateVersion(Base):
 class RegistryModule(Base):
     """Top-level module entity in the private registry.
 
-    Identified by (org_name, namespace, name, provider). The namespace
-    typically equals the org name for private registries.
+    Identified by (namespace, name, provider).
     """
 
     __tablename__ = "registry_modules"
@@ -393,7 +385,6 @@ class RegistryModule(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
-    org_name: Mapped[str] = mapped_column(String(63), nullable=False)
     namespace: Mapped[str] = mapped_column(String(63), nullable=False)
     name: Mapped[str] = mapped_column(String(63), nullable=False)
     provider: Mapped[str] = mapped_column(String(63), nullable=False)
@@ -413,9 +404,7 @@ class RegistryModule(Base):
     )
 
     __table_args__ = (
-        sa.UniqueConstraint(
-            "org_name", "namespace", "name", "provider", name="uq_registry_modules"
-        ),
+        sa.UniqueConstraint("namespace", "name", "provider", name="uq_registry_modules"),
     )
 
 
@@ -457,7 +446,6 @@ class RegistryProvider(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
-    org_name: Mapped[str] = mapped_column(String(63), nullable=False)
     namespace: Mapped[str] = mapped_column(String(63), nullable=False)
     name: Mapped[str] = mapped_column(String(63), nullable=False)
     labels: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
@@ -474,9 +462,7 @@ class RegistryProvider(Base):
         back_populates="provider", cascade="all, delete-orphan"
     )
 
-    __table_args__ = (
-        sa.UniqueConstraint("org_name", "namespace", "name", name="uq_registry_providers"),
-    )
+    __table_args__ = (sa.UniqueConstraint("namespace", "name", name="uq_registry_providers"),)
 
 
 class GPGKey(Base):
@@ -487,7 +473,6 @@ class GPGKey(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
-    org_name: Mapped[str] = mapped_column(String(63), nullable=False)
     key_id: Mapped[str] = mapped_column(String(40), nullable=False)
     ascii_armor: Mapped[str] = mapped_column(Text, nullable=False)
     source: Mapped[str] = mapped_column(String(63), nullable=False, default="terrapod")
@@ -500,7 +485,7 @@ class GPGKey(Base):
         DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
     )
 
-    __table_args__ = (sa.UniqueConstraint("org_name", "key_id", name="uq_gpg_keys"),)
+    __table_args__ = (sa.UniqueConstraint("key_id", name="uq_gpg_keys"),)
 
 
 class RegistryProviderVersion(Base):
@@ -705,7 +690,6 @@ class VCSConnection(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
-    org_name: Mapped[str] = mapped_column(String(63), nullable=False, default="default")
     provider: Mapped[str] = mapped_column(
         String(20), nullable=False, default="github"
     )  # github, gitlab
@@ -799,7 +783,6 @@ class VariableSet(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
-    org_name: Mapped[str] = mapped_column(String(63), nullable=False, default="default")
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False, default="")
     global_set: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
@@ -816,7 +799,7 @@ class VariableSet(Base):
         back_populates="variable_set", cascade="all, delete-orphan"
     )
 
-    __table_args__ = (sa.UniqueConstraint("org_name", "name", name="uq_variable_sets"),)
+    __table_args__ = (sa.UniqueConstraint("name", name="uq_variable_sets"),)
 
 
 class VariableSetVariable(Base):

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -23,14 +23,12 @@ async def create_pool(
     db: AsyncSession,
     name: str,
     description: str = "",
-    org_name: str = "default",
     service_account_name: str = "",
 ) -> AgentPool:
     """Create a new agent pool."""
     pool = AgentPool(
         name=name,
         description=description,
-        org_name=org_name,
         service_account_name=service_account_name,
     )
     db.add(pool)
@@ -50,11 +48,9 @@ async def get_pool_by_name(db: AsyncSession, name: str) -> AgentPool | None:
     return result.scalar_one_or_none()
 
 
-async def list_pools(db: AsyncSession, org_name: str = "default") -> list[AgentPool]:
+async def list_pools(db: AsyncSession) -> list[AgentPool]:
     """List all agent pools."""
-    result = await db.execute(
-        select(AgentPool).where(AgentPool.org_name == org_name).order_by(AgentPool.name)
-    )
+    result = await db.execute(select(AgentPool).order_by(AgentPool.name))
     return list(result.scalars().all())
 
 

--- a/services/terrapod/services/gpg_key_service.py
+++ b/services/terrapod/services/gpg_key_service.py
@@ -27,7 +27,6 @@ def extract_key_id(ascii_armor: str) -> str:
 
 async def create_gpg_key(
     db: AsyncSession,
-    org: str,
     ascii_armor: str,
     source: str = "terrapod",
     source_url: str | None = None,
@@ -36,7 +35,6 @@ async def create_gpg_key(
     key_id = extract_key_id(ascii_armor)
 
     gpg_key = GPGKey(
-        org_name=org,
         key_id=key_id,
         ascii_armor=ascii_armor,
         source=source,
@@ -45,18 +43,15 @@ async def create_gpg_key(
     db.add(gpg_key)
     await db.flush()
 
-    logger.info("GPG key created", org=org, key_id=key_id)
+    logger.info("GPG key created", key_id=key_id)
     return gpg_key
 
 
 async def list_gpg_keys(
     db: AsyncSession,
-    org: str | None = None,
 ) -> list[GPGKey]:
-    """List GPG keys, optionally filtered by organization."""
+    """List all GPG keys."""
     stmt = select(GPGKey).order_by(GPGKey.created_at.desc())
-    if org is not None:
-        stmt = stmt.where(GPGKey.org_name == org)
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
@@ -72,11 +67,10 @@ async def get_gpg_key(
 
 async def get_gpg_key_by_key_id(
     db: AsyncSession,
-    org: str,
     key_id: str,
 ) -> GPGKey | None:
-    """Get a GPG key by org + GPG key ID."""
-    result = await db.execute(select(GPGKey).where(GPGKey.org_name == org, GPGKey.key_id == key_id))
+    """Get a GPG key by its GPG key ID."""
+    result = await db.execute(select(GPGKey).where(GPGKey.key_id == key_id))
     return result.scalars().first()
 
 

--- a/services/terrapod/services/registry_module_service.py
+++ b/services/terrapod/services/registry_module_service.py
@@ -20,14 +20,12 @@ logger = get_logger(__name__)
 
 async def create_module(
     db: AsyncSession,
-    org: str,
     namespace: str,
     name: str,
     provider: str,
 ) -> RegistryModule:
     """Create a new registry module."""
     module = RegistryModule(
-        org_name=org,
         namespace=namespace,
         name=name,
         provider=provider,
@@ -40,12 +38,10 @@ async def create_module(
 
 async def list_modules(
     db: AsyncSession,
-    org: str,
 ) -> list[RegistryModule]:
-    """List all registry modules for an organization."""
+    """List all registry modules."""
     result = await db.execute(
         select(RegistryModule)
-        .where(RegistryModule.org_name == org)
         .options(selectinload(RegistryModule.versions))
         .order_by(RegistryModule.name)
     )
@@ -54,7 +50,6 @@ async def list_modules(
 
 async def get_module(
     db: AsyncSession,
-    org: str,
     namespace: str,
     name: str,
     provider: str,
@@ -63,7 +58,6 @@ async def get_module(
     result = await db.execute(
         select(RegistryModule)
         .where(
-            RegistryModule.org_name == org,
             RegistryModule.namespace == namespace,
             RegistryModule.name == name,
             RegistryModule.provider == provider,
@@ -76,19 +70,18 @@ async def get_module(
 async def delete_module(
     db: AsyncSession,
     storage: ObjectStore,
-    org: str,
     namespace: str,
     name: str,
     provider: str,
 ) -> bool:
     """Delete a module and all its versions. Returns True if found."""
-    module = await get_module(db, org, namespace, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is None:
         return False
 
     # Clean up storage for all versions
     for version in module.versions:
-        key = module_tarball_key(org, namespace, name, provider, version.version)
+        key = module_tarball_key(namespace, name, provider, version.version)
         await storage.delete(key)
 
     await db.delete(module)
@@ -118,9 +111,7 @@ async def create_module_version(
     await db.flush()
 
     # Generate presigned upload URL
-    key = module_tarball_key(
-        module.org_name, module.namespace, module.name, module.provider, version
-    )
+    key = module_tarball_key(module.namespace, module.name, module.provider, version)
     upload_url = await storage.presigned_put_url(key, content_type="application/gzip")
 
     # Update module status
@@ -151,14 +142,13 @@ async def confirm_module_upload(
 async def delete_module_version(
     db: AsyncSession,
     storage: ObjectStore,
-    org: str,
     namespace: str,
     name: str,
     provider: str,
     version: str,
 ) -> bool:
     """Delete a specific module version."""
-    module = await get_module(db, org, namespace, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is None:
         return False
 
@@ -172,7 +162,7 @@ async def delete_module_version(
     if mod_version is None:
         return False
 
-    key = module_tarball_key(org, namespace, name, provider, version)
+    key = module_tarball_key(namespace, name, provider, version)
     await storage.delete(key)
     await db.delete(mod_version)
     await db.flush()
@@ -182,14 +172,13 @@ async def delete_module_version(
 async def get_module_download_url(
     db: AsyncSession,
     storage: ObjectStore,
-    org: str,
     namespace: str,
     name: str,
     provider: str,
     version: str,
 ) -> str | None:
     """Get a presigned download URL for a module version tarball."""
-    module = await get_module(db, org, namespace, name, provider)
+    module = await get_module(db, namespace, name, provider)
     if module is None:
         return None
 
@@ -203,6 +192,6 @@ async def get_module_download_url(
     if mod_version is None:
         return None
 
-    key = module_tarball_key(org, namespace, name, provider, version)
+    key = module_tarball_key(namespace, name, provider, version)
     presigned = await storage.presigned_get_url(key)
     return presigned.url

--- a/services/terrapod/services/registry_provider_service.py
+++ b/services/terrapod/services/registry_provider_service.py
@@ -32,13 +32,11 @@ logger = get_logger(__name__)
 
 async def create_provider(
     db: AsyncSession,
-    org: str,
     namespace: str,
     name: str,
 ) -> RegistryProvider:
     """Create a new registry provider."""
     provider = RegistryProvider(
-        org_name=org,
         namespace=namespace,
         name=name,
     )
@@ -49,12 +47,10 @@ async def create_provider(
 
 async def list_providers(
     db: AsyncSession,
-    org: str,
 ) -> list[RegistryProvider]:
-    """List all registry providers for an organization."""
+    """List all registry providers."""
     result = await db.execute(
         select(RegistryProvider)
-        .where(RegistryProvider.org_name == org)
         .options(
             selectinload(RegistryProvider.versions).selectinload(RegistryProviderVersion.platforms)
         )
@@ -65,7 +61,6 @@ async def list_providers(
 
 async def get_provider(
     db: AsyncSession,
-    org: str,
     namespace: str,
     name: str,
 ) -> RegistryProvider | None:
@@ -73,7 +68,6 @@ async def get_provider(
     result = await db.execute(
         select(RegistryProvider)
         .where(
-            RegistryProvider.org_name == org,
             RegistryProvider.namespace == namespace,
             RegistryProvider.name == name,
         )
@@ -87,18 +81,17 @@ async def get_provider(
 async def delete_provider(
     db: AsyncSession,
     storage: ObjectStore,
-    org: str,
     namespace: str,
     name: str,
 ) -> bool:
     """Delete a provider and all its versions/platforms. Returns True if found."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         return False
 
     # Clean up storage for all versions and platforms
     for version in provider.versions:
-        await _delete_version_storage(storage, org, namespace, name, version)
+        await _delete_version_storage(storage, namespace, name, version)
 
     await db.delete(provider)
     await db.flush()
@@ -132,12 +125,8 @@ async def create_provider_version(
     await db.flush()
 
     # Generate presigned upload URLs for shasums files
-    shasums_key = provider_shasums_key(
-        provider.org_name, provider.namespace, provider.name, version
-    )
-    sig_key = provider_shasums_sig_key(
-        provider.org_name, provider.namespace, provider.name, version
-    )
+    shasums_key = provider_shasums_key(provider.namespace, provider.name, version)
+    sig_key = provider_shasums_sig_key(provider.namespace, provider.name, version)
     shasums_url = await storage.presigned_put_url(shasums_key, content_type="text/plain")
     sig_url = await storage.presigned_put_url(sig_key, content_type="application/octet-stream")
 
@@ -178,13 +167,12 @@ async def get_provider_version(
 async def delete_provider_version(
     db: AsyncSession,
     storage: ObjectStore,
-    org: str,
     namespace: str,
     name: str,
     version: str,
 ) -> bool:
     """Delete a provider version and its platforms."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         return False
 
@@ -192,7 +180,7 @@ async def delete_provider_version(
     if prov_version is None:
         return False
 
-    await _delete_version_storage(storage, org, namespace, name, prov_version)
+    await _delete_version_storage(storage, namespace, name, prov_version)
     await db.delete(prov_version)
     await db.flush()
     return True
@@ -233,7 +221,6 @@ async def create_provider_platform(
     await db.flush()
 
     key = provider_binary_key(
-        provider.org_name,
         provider.namespace,
         provider.name,
         prov_version.version,
@@ -261,7 +248,6 @@ async def list_provider_platforms(
 async def delete_provider_platform(
     db: AsyncSession,
     storage: ObjectStore,
-    org: str,
     namespace: str,
     name: str,
     version: str,
@@ -269,7 +255,7 @@ async def delete_provider_platform(
     arch: str,
 ) -> bool:
     """Delete a specific provider platform binary."""
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         return False
 
@@ -288,7 +274,7 @@ async def delete_provider_platform(
     if platform is None:
         return False
 
-    key = provider_binary_key(org, namespace, name, version, os_, arch)
+    key = provider_binary_key(namespace, name, version, os_, arch)
     await storage.delete(key)
     await db.delete(platform)
     await db.flush()
@@ -301,7 +287,6 @@ async def delete_provider_platform(
 async def get_provider_download_info(
     db: AsyncSession,
     storage: ObjectStore,
-    org: str,
     namespace: str,
     name: str,
     version: str,
@@ -313,7 +298,7 @@ async def get_provider_download_info(
     Returns the dict that the CLI expects with download_url, shasums_url,
     signing_keys, etc. Returns None if not found.
     """
-    provider = await get_provider(db, org, namespace, name)
+    provider = await get_provider(db, namespace, name)
     if provider is None:
         return None
 
@@ -334,9 +319,9 @@ async def get_provider_download_info(
         return None
 
     # Generate presigned URLs
-    binary_k = provider_binary_key(org, namespace, name, version, os_, arch)
-    shasums_k = provider_shasums_key(org, namespace, name, version)
-    sig_k = provider_shasums_sig_key(org, namespace, name, version)
+    binary_k = provider_binary_key(namespace, name, version, os_, arch)
+    shasums_k = provider_shasums_key(namespace, name, version)
+    sig_k = provider_shasums_sig_key(namespace, name, version)
 
     download_url = await storage.presigned_get_url(binary_k)
     shasums_url = await storage.presigned_get_url(shasums_k)
@@ -377,19 +362,18 @@ async def get_provider_download_info(
 
 async def _delete_version_storage(
     storage: ObjectStore,
-    org: str,
     namespace: str,
     name: str,
     version: RegistryProviderVersion,
 ) -> None:
     """Delete all storage objects for a provider version."""
     # Delete shasums files
-    shasums_k = provider_shasums_key(org, namespace, name, version.version)
-    sig_k = provider_shasums_sig_key(org, namespace, name, version.version)
+    shasums_k = provider_shasums_key(namespace, name, version.version)
+    sig_k = provider_shasums_sig_key(namespace, name, version.version)
     await storage.delete(shasums_k)
     await storage.delete(sig_k)
 
     # Delete platform binaries
     for platform in version.platforms:
-        key = provider_binary_key(org, namespace, name, version.version, platform.os, platform.arch)
+        key = provider_binary_key(namespace, name, version.version, platform.os, platform.arch)
         await storage.delete(key)

--- a/services/terrapod/storage/keys.py
+++ b/services/terrapod/storage/keys.py
@@ -49,31 +49,27 @@ def policy_set_key(policy_set_id: str, version_id: str) -> str:
 # --- Module Registry ---
 
 
-def module_tarball_key(org: str, namespace: str, name: str, provider: str, version: str) -> str:
+def module_tarball_key(namespace: str, name: str, provider: str, version: str) -> str:
     """Key for a module version tarball."""
-    return f"registry/modules/{org}/{namespace}/{name}/{provider}/{version}.tar.gz"
+    return f"registry/modules/{namespace}/{name}/{provider}/{version}.tar.gz"
 
 
 # --- Provider Registry ---
 
 
-def provider_binary_key(
-    org: str, namespace: str, name: str, version: str, os_: str, arch: str
-) -> str:
+def provider_binary_key(namespace: str, name: str, version: str, os_: str, arch: str) -> str:
     """Key for a provider binary zip."""
-    return (
-        f"registry/providers/{org}/{namespace}/{name}/{version}/{name}_{version}_{os_}_{arch}.zip"
-    )
+    return f"registry/providers/{namespace}/{name}/{version}/{name}_{version}_{os_}_{arch}.zip"
 
 
-def provider_shasums_key(org: str, namespace: str, name: str, version: str) -> str:
+def provider_shasums_key(namespace: str, name: str, version: str) -> str:
     """Key for a provider version's SHA256SUMS file."""
-    return f"registry/providers/{org}/{namespace}/{name}/{version}/SHA256SUMS"
+    return f"registry/providers/{namespace}/{name}/{version}/SHA256SUMS"
 
 
-def provider_shasums_sig_key(org: str, namespace: str, name: str, version: str) -> str:
+def provider_shasums_sig_key(namespace: str, name: str, version: str) -> str:
     """Key for a provider version's SHA256SUMS.sig file."""
-    return f"registry/providers/{org}/{namespace}/{name}/{version}/SHA256SUMS.sig"
+    return f"registry/providers/{namespace}/{name}/{version}/SHA256SUMS.sig"
 
 
 # --- Module Cache ---

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -28,7 +28,6 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws = MagicMock()
     ws.id = ws_id or uuid.uuid4()
     ws.name = name
-    ws.org_name = "default"
     ws.auto_apply = False
     ws.execution_mode = "remote"
     ws.terraform_version = "1.9.8"

--- a/services/tests/api/test_variables.py
+++ b/services/tests/api/test_variables.py
@@ -316,7 +316,6 @@ def _mock_varset(name="my-varset", vs_id=None):
     vs.id = vs_id or uuid.uuid4()
     vs.name = name
     vs.description = ""
-    vs.org_name = "default"
     vs.global_set = False
     vs.priority = False
     vs.created_at = datetime(2026, 1, 1, tzinfo=UTC)

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -36,12 +36,10 @@ def _mock_workspace(
     terraform_version="1.9.0",
     resource_cpu="1",
     resource_memory="2Gi",
-    org_name="default",
 ):
     ws = MagicMock()
     ws.id = ws_id or uuid.uuid4()
     ws.name = name
-    ws.org_name = org_name
     ws.auto_apply = auto_apply
     ws.execution_mode = execution_mode
     ws.terraform_version = terraform_version

--- a/services/tests/auth/test_api_tokens.py
+++ b/services/tests/auth/test_api_tokens.py
@@ -83,10 +83,8 @@ class TestCreateAPIToken:
             db=mock_db,
             user_email="test@example.com",
             token_type="organization",
-            org_name="default",
         )
         assert api_token.token_type == "organization"
-        assert api_token.org_name == "default"
 
 
 class TestValidateAPIToken:

--- a/web/src/app/registry/modules/[org]/[namespace]/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[org]/[namespace]/[name]/[provider]/page.tsx
@@ -56,7 +56,7 @@ export default function ModuleDetailPage() {
     setLoading(true)
     try {
       const res = await apiFetch(
-        `/api/v2/organizations/${org}/registry-modules/private/${namespace}/${name}/${provider}`
+        `/api/v2/organizations/default/registry-modules/private/${namespace}/${name}/${provider}`
       )
       if (!res.ok) throw new Error('Module not found')
       const data = await res.json()
@@ -75,7 +75,7 @@ export default function ModuleDetailPage() {
     setUploadUrl('')
     try {
       const res = await apiFetch(
-        `/api/v2/organizations/${org}/registry-modules/private/${namespace}/${name}/${provider}/versions`,
+        `/api/v2/organizations/default/registry-modules/private/${namespace}/${name}/${provider}/versions`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/vnd.api+json' },
@@ -108,8 +108,8 @@ export default function ModuleDetailPage() {
     setError('')
     try {
       const path = deleteTarget === 'module'
-        ? `/api/v2/organizations/${org}/registry-modules/private/${namespace}/${name}/${provider}`
-        : `/api/v2/organizations/${org}/registry-modules/private/${namespace}/${name}/${provider}/${deleteTarget}`
+        ? `/api/v2/organizations/default/registry-modules/private/${namespace}/${name}/${provider}`
+        : `/api/v2/organizations/default/registry-modules/private/${namespace}/${name}/${provider}/${deleteTarget}`
 
       const res = await apiFetch(path, { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {

--- a/web/src/app/registry/modules/page.tsx
+++ b/web/src/app/registry/modules/page.tsx
@@ -8,7 +8,7 @@ import { PageHeader } from '@/components/page-header'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
-import { getAuthState, getUserId } from '@/lib/auth'
+import { getAuthState } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 
 interface Module {
@@ -35,7 +35,7 @@ export default function ModulesPage() {
   const [newProvider, setNewProvider] = useState('')
   const [creating, setCreating] = useState(false)
 
-  const org = getUserId()
+
 
   useEffect(() => {
     if (!getAuthState()) { router.push('/login'); return }
@@ -45,7 +45,7 @@ export default function ModulesPage() {
   async function loadModules() {
     setLoading(true)
     try {
-      const res = await apiFetch(`/api/v2/organizations/${org}/registry-modules`)
+      const res = await apiFetch('/api/v2/organizations/default/registry-modules')
       if (!res.ok) throw new Error('Failed to load modules')
       const data = await res.json()
       setModules(data.data || [])
@@ -61,7 +61,7 @@ export default function ModulesPage() {
     setCreating(true)
     setError('')
     try {
-      const res = await apiFetch(`/api/v2/organizations/${org}/registry-modules`, {
+      const res = await apiFetch('/api/v2/organizations/default/registry-modules', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -152,7 +152,7 @@ export default function ModulesPage() {
             {modules.map((mod) => (
               <Link
                 key={mod.id}
-                href={`/registry/modules/${org}/${mod.attributes.namespace}/${mod.attributes.name}/${mod.attributes.provider}`}
+                href={`/registry/modules/default/${mod.attributes.namespace}/${mod.attributes.name}/${mod.attributes.provider}`}
                 className="bg-slate-800/50 rounded-lg border border-slate-700/50 hover:border-brand-600/30 p-4 transition-colors"
               >
                 <h3 className="font-semibold text-slate-200">{mod.attributes.name}</h3>

--- a/web/src/app/registry/providers/[org]/[namespace]/[name]/page.tsx
+++ b/web/src/app/registry/providers/[org]/[namespace]/[name]/page.tsx
@@ -64,7 +64,7 @@ export default function ProviderDetailPage() {
     loadVersions()
   }, [router, org, namespace, name])
 
-  const basePath = `/api/v2/organizations/${org}/registry-providers/private/${namespace}/${name}`
+  const basePath = `/api/v2/organizations/default/registry-providers/private/${namespace}/${name}`
 
   async function loadVersions() {
     setLoading(true)

--- a/web/src/app/registry/providers/page.tsx
+++ b/web/src/app/registry/providers/page.tsx
@@ -8,7 +8,7 @@ import { PageHeader } from '@/components/page-header'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
-import { getAuthState, getUserId } from '@/lib/auth'
+import { getAuthState } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 
 interface Provider {
@@ -31,7 +31,6 @@ export default function ProvidersPage() {
   const [newNamespace, setNewNamespace] = useState('')
   const [creating, setCreating] = useState(false)
 
-  const org = getUserId()
 
   useEffect(() => {
     if (!getAuthState()) { router.push('/login'); return }
@@ -41,7 +40,7 @@ export default function ProvidersPage() {
   async function loadProviders() {
     setLoading(true)
     try {
-      const res = await apiFetch(`/api/v2/organizations/${org}/registry-providers`)
+      const res = await apiFetch('/api/v2/organizations/default/registry-providers')
       if (!res.ok) throw new Error('Failed to load providers')
       const data = await res.json()
       setProviders(data.data || [])
@@ -57,7 +56,7 @@ export default function ProvidersPage() {
     setCreating(true)
     setError('')
     try {
-      const res = await apiFetch(`/api/v2/organizations/${org}/registry-providers`, {
+      const res = await apiFetch('/api/v2/organizations/default/registry-providers', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -147,7 +146,7 @@ export default function ProvidersPage() {
             {providers.map((prov) => (
               <Link
                 key={prov.id}
-                href={`/registry/providers/${org}/${prov.attributes.namespace}/${prov.attributes.name}`}
+                href={`/registry/providers/default/${prov.attributes.namespace}/${prov.attributes.name}`}
                 className="bg-slate-800/50 rounded-lg border border-slate-700/50 hover:border-brand-600/30 p-4 transition-colors"
               >
                 <h3 className="font-semibold text-slate-200">{prov.attributes.name}</h3>


### PR DESCRIPTION
## Summary

- Drop `org_name` column from all 8 database tables via Alembic migration 018
- Replace `{org}` path parameters with literal `default` in all management API endpoints
- Rename `{org}` to `{namespace}` in CLI registry protocol paths (where it represents a module/provider namespace, not an organization)
- Remove `validate_org()` function — routing itself now enforces single-org
- Remove `org` parameter from all service functions and storage key paths
- Update all tests and frontend API URLs

## Motivation

Single-org is a hard architectural requirement. Previously `org_name` existed in the database and `{org}` was a path parameter validated at runtime. Now the database has no concept of organization, and FastAPI routes use literal `/organizations/default/` — any other org gets a 404 from path matching itself.

## Test plan

- [x] All 511 tests pass
- [x] Lint clean (ruff check + format)
- [ ] Manual: verify workspace CRUD via UI
- [ ] Manual: verify module registry via UI
- [ ] Manual: verify `terraform init` with cloud block still works