### PR TITLE
fix: add py/empty-except to CodeQL exclusions

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -13,6 +13,7 @@
 # py/weak-sensitive-data-hashing       — SHA-256 on high-entropy secrets.token_urlsafe() output, not passwords
 # py/unnecessary-lambda                — FastAPI dependency overrides need fresh mock per request
 # py/multiple-definition               — intentional re-fetch after DB mutation
+# py/empty-except                      — intentional fail-open patterns (Redis, K8s, URL parsing)
 
 query-filters:
   - exclude:
@@ -33,3 +34,5 @@ query-filters:
       id: py/unnecessary-lambda
   - exclude:
       id: py/multiple-definition
+  - exclude:
+      id: py/empty-except


### PR DESCRIPTION
## Summary

Adds `py/empty-except` to CodeQL config exclusions. The inline comments for this rule were removed in PR #42 but the query ID wasn't added to the config, leaving 12 alerts open.

## Previous CI failure

The Trivy runner scan failed with a transient GHCR timeout (`context deadline exceeded`) — not a code issue. This push should re-run it.