### PR TITLE
feat(helm): agent-only deployment mode

### DIFF
--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.api.enabled false }}
 {{- include "terrapod.validateStorageConfig" . -}}
 apiVersion: v1
 kind: ConfigMap
@@ -195,3 +196,4 @@ data:
         - {{ . | quote }}
         {{- end }}
     {{- end }}
+{{- end }}

--- a/helm/terrapod/templates/configmap-runner.yaml
+++ b/helm/terrapod/templates/configmap-runner.yaml
@@ -13,7 +13,7 @@ data:
       repository: {{ .Values.runners.image.repository | quote }}
       tag: {{ .Values.runners.image.tag | default .Chart.AppVersion | quote }}
       pull_policy: {{ .Values.runners.image.pullPolicy | quote }}
-    server_url: {{ .Values.runners.serverUrl | default (printf "http://%s-api:8000" (include "terrapod.fullname" .)) | quote }}
+    server_url: {{ .Values.runners.serverUrl | default .Values.listener.apiUrl | default (printf "http://%s-api:8000" (include "terrapod.fullname" .)) | quote }}
     service_account_name: {{ include "terrapod.runnerServiceAccountName" . | quote }}
     azure_workload_identity: {{ .Values.runners.azureWorkloadIdentity | default false }}
     ttl_seconds_after_finished: {{ .Values.runners.ttlSecondsAfterFinished }}

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.api.enabled false }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -175,3 +176,4 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/terrapod/templates/deployment-listener.yaml
+++ b/helm/terrapod/templates/deployment-listener.yaml
@@ -65,7 +65,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: TERRAPOD_API_URL
-              value: "http://{{ include "terrapod.fullname" . }}-api:8000"
+              value: {{ .Values.listener.apiUrl | default (printf "http://%s-api:8000" (include "terrapod.fullname" .)) | quote }}
             {{- if .Values.listener.existingSecret }}
             - name: TERRAPOD_JOIN_TOKEN
               valueFrom:

--- a/helm/terrapod/templates/hpa-api.yaml
+++ b/helm/terrapod/templates/hpa-api.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.api.enabled false }}
 {{- if .Values.api.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -30,4 +31,5 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/terrapod/templates/job-bootstrap.yaml
+++ b/helm/terrapod/templates/job-bootstrap.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.api.enabled false }}
 {{- if .Values.bootstrap }}
 {{- if or (and .Values.bootstrap.adminEmail .Values.bootstrap.adminPassword) .Values.bootstrap.existingSecret }}
 apiVersion: batch/v1
@@ -80,5 +81,6 @@ spec:
               memory: 512Mi
           securityContext:
             {{- toYaml .Values.api.containerSecurityContext | nindent 12 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/terrapod/templates/job-migrations.yaml
+++ b/helm/terrapod/templates/job-migrations.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.migrations.enabled }}
+{{- if and (ne .Values.api.enabled false) .Values.migrations.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/terrapod/templates/pdb-api.yaml
+++ b/helm/terrapod/templates/pdb-api.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.api.enabled false }}
 {{- if .Values.api.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -15,4 +16,5 @@ spec:
   selector:
     matchLabels:
       {{- include "terrapod.api.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/helm/terrapod/templates/pdb-web.yaml
+++ b/helm/terrapod/templates/pdb-web.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.web.pdb.enabled }}
+{{- if and .Values.web.enabled .Values.web.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/helm/terrapod/templates/pvc-storage.yaml
+++ b/helm/terrapod/templates/pvc-storage.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.api.enabled false }}
 {{- if and (eq .Values.api.config.storage.backend "filesystem") .Values.storage.filesystem.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -15,4 +16,5 @@ spec:
   {{- if .Values.storage.filesystem.persistence.storageClass }}
   storageClassName: {{ .Values.storage.filesystem.persistence.storageClass | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/terrapod/templates/service-api.yaml
+++ b/helm/terrapod/templates/service-api.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.api.enabled false }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
       name: http
   selector:
     {{- include "terrapod.api.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/terrapod/templates/serviceaccount.yaml
+++ b/helm/terrapod/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.serviceAccount.create }}
+{{- if and (ne .Values.api.enabled false) .Values.api.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/terrapod/templates/servicemonitor-api.yaml
+++ b/helm/terrapod/templates/servicemonitor-api.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.api.enabled false }}
 {{- if and .Values.api.config.metrics.enabled .Values.api.config.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -17,4 +18,5 @@ spec:
     - port: http
       path: /metrics
       interval: {{ .Values.api.config.metrics.serviceMonitor.interval | default "30s" }}
+{{- end }}
 {{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -24,6 +24,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 1 },
         "image": { "$ref": "#/$defs/imageSpec" },
         "command": { "type": "array", "items": { "type": "string" } },
@@ -133,6 +134,7 @@
         "replicas": { "type": "integer", "minimum": 1 },
         "name": { "type": "string" },
         "healthPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "apiUrl": { "type": "string" },
         "joinToken": { "type": "string" },
         "existingSecret": { "type": "string" },
         "joinTokenKey": { "type": "string" },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -18,6 +18,11 @@ global:
 
 # ── API Server (Python/FastAPI) ───────────────────────────────────────────────
 api:
+  # Set to false for agent-only deployments (listener + runners in a remote
+  # cluster, API running elsewhere). When false, the API Deployment, Service,
+  # ConfigMap, ServiceAccount, and storage PVC are not rendered.
+  enabled: true
+
   # Filesystem storage (default) only supports a single replica.
   # For multi-replica HA, configure a cloud storage backend (s3, azure, gcs).
   replicas: 1
@@ -481,6 +486,13 @@ listener:
   name: "listener"
   # Port for /health and /ready HTTP probe endpoints
   healthPort: 8081
+
+  # API URL for the listener to connect to. Leave empty when the API runs in
+  # the same release (auto-detected as http://<release>-api:8000).
+  # Set for agent-only deployments where the API is in a different cluster:
+  #   apiUrl: "https://terrapod.example.com"
+  # Also used as the default for runners.serverUrl when that value is empty.
+  apiUrl: ""
 
   # Join token for pool registration.
   # Either set joinToken directly or reference an existing K8s Secret (recommended).


### PR DESCRIPTION
## Summary

- Adds `api.enabled` (default `true`) to gate all API-side resources. Set to `false` for clusters that only run listener agents
- Adds `listener.apiUrl` for the listener to connect to a remote API. Cascades to `runners.serverUrl` as default, so one value configures both the listener and runner Jobs
- Gates web PDB behind `web.enabled` (was rendering even when web was disabled)

**Agent-only values example:**
```yaml
api:
  enabled: false
listener:
  enabled: true
  apiUrl: "https://terrapod.example.com"
  existingSecret: my-join-token
```

Renders only: listener Deployment, listener RBAC, listener PDB, runner SA, runner ConfigMap.

## Test plan

- [x] `helm lint` passes (default + agent-only modes)
- [x] `helm template` with `api.enabled=false` renders only listener resources
- [x] `helm template` with defaults renders all resources (backward compatible)
- [x] `TERRAPOD_API_URL` and `server_url` correctly resolve to `listener.apiUrl` when set
- [x] `make lint` passes