### PR TITLE
fix: allow additional properties on global values schema

### DIFF
--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -10,7 +10,7 @@
 
     "global": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "imagePullSecrets": {
           "type": "array",


### PR DESCRIPTION
## Summary

- Allow `additionalProperties` on the `global` object in `values.schema.json`
- Helm's `global` is a cross-chart shared namespace — when Terrapod is used as a subchart dependency, parent charts pass cluster metadata (`awsAccountId`, `awsRegion`, `oidcProvider`, etc.) via `global`
- `additionalProperties: false` rejected these, breaking standard wrapper chart patterns

One-line change: `false` → `true` on `global` only. All other Terrapod-specific objects retain strict schema validation.