### PR TITLE
fix: use middleware for API proxy to respect runtime API_URL

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,34 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
-  async rewrites() {
-    return [
-      {
-        source: '/api/:path*',
-        destination: process.env.API_URL
-          ? `${process.env.API_URL}/api/:path*`
-          : 'http://localhost:8001/api/:path*',
-      },
-      {
-        source: '/.well-known/:path*',
-        destination: process.env.API_URL
-          ? `${process.env.API_URL}/.well-known/:path*`
-          : 'http://localhost:8001/.well-known/:path*',
-      },
-      {
-        source: '/oauth/:path*',
-        destination: process.env.API_URL
-          ? `${process.env.API_URL}/oauth/:path*`
-          : 'http://localhost:8001/oauth/:path*',
-      },
-      {
-        source: '/v1/:path*',
-        destination: process.env.API_URL
-          ? `${process.env.API_URL}/v1/:path*`
-          : 'http://localhost:8001/v1/:path*',
-      },
-    ]
-  },
 }
 
 module.exports = nextConfig

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const PROXY_PREFIXES = ['/api/', '/.well-known/', '/oauth/', '/v1/']
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (!PROXY_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return NextResponse.next()
+  }
+
+  const apiUrl = process.env.API_URL || 'http://localhost:8001'
+  const target = new URL(pathname + request.nextUrl.search, apiUrl)
+
+  return NextResponse.rewrite(target, {
+    request: {
+      headers: request.headers,
+    },
+  })
+}
+
+export const config = {
+  matcher: ['/api/:path*', '/.well-known/:path*', '/oauth/:path*', '/v1/:path*'],
+}


### PR DESCRIPTION
## Summary

- **Root cause**: Next.js `rewrites()` in `next.config.js` are evaluated at build time during `next build`, not at container startup. Since the Dockerfile doesn't set `API_URL`, the rewrites always baked in the fallback `http://localhost:8001`, ignoring the Helm-injected env var
- **Fix**: Replace build-time `rewrites()` with Next.js middleware that reads `process.env.API_URL` at request time, when the Helm-configured env var is available
- No changes needed to the Helm chart or Dockerfile — `deployment-web.yaml` already injects `API_URL` correctly

Fixes #47

## Test plan

- [x] Deploy via Helm chart — web pod logs should show API requests proxied to the correct API service URL (not `localhost:8001`)
- [x] `env | grep API_URL` in the web container confirms the Helm-injected value
- [x] All frontend pages load and proxy API calls correctly
- [x] Local development (`next dev`) still works with the `localhost:8001` fallback