### PR TITLE
fix: don't rewrite cloud storage presigned URLs in listener

### DIFF
--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -318,9 +318,14 @@ class RunnerListener:
     def _rewrite_urls(self, urls: dict[str, str]) -> dict[str, str]:
         """Rewrite presigned URL hostnames to the runner server_url.
 
-        Storage backends generate URLs with the external base URL (e.g.
-        https://terrapod.local) but runner Jobs need to reach the API via
-        the internal K8s service URL (e.g. http://terrapod-api:8000).
+        Filesystem storage generates URLs pointing at the external API
+        (e.g. https://terrapod.local/api/v2/storage/...) but runner Jobs
+        need to reach the API via the internal K8s service URL (e.g.
+        http://terrapod-api:8000). Cloud storage URLs (S3, Azure, GCS)
+        already point at the correct endpoint and must not be rewritten.
+
+        Heuristic: only rewrite URLs whose path starts with /api/ — those
+        are Terrapod API endpoints. Cloud presigned URLs never have /api/ paths.
         """
         server_url = self.runner_config.server_url or os.environ.get("TERRAPOD_API_URL", "")
         if not server_url:
@@ -330,12 +335,15 @@ class RunnerListener:
         rewritten = {}
         for key, url in urls.items():
             parsed = urlparse(url)
-            rewritten[key] = urlunparse(
-                parsed._replace(
-                    scheme=target.scheme,
-                    netloc=target.netloc,
+            if parsed.path.startswith("/api/"):
+                rewritten[key] = urlunparse(
+                    parsed._replace(
+                        scheme=target.scheme,
+                        netloc=target.netloc,
+                    )
                 )
-            )
+            else:
+                rewritten[key] = url
         return rewritten
 
     async def _execute_run(


### PR DESCRIPTION
## Summary

- The listener's `_rewrite_urls()` was blindly rewriting all presigned URL hostnames to the internal K8s service URL
- For cloud storage backends (S3, Azure Blob, GCS), presigned URLs already point at the correct cloud endpoint and must not be rewritten
- This turned valid S3 presigned URLs into nonsensical API server paths that returned 404
- Fix: only rewrite URLs whose path starts with `/api/` — cloud storage presigned URLs never have `/api/` paths

## Root Cause

When the runner listener claims a run, it receives presigned URLs for artifacts (config download, state, logs, binary cache). For the filesystem storage backend, these URLs point at the Terrapod API (`https://terrapod.local/api/v2/storage/...`) and need hostname rewriting to the internal K8s service URL. For S3/Azure/GCS, the URLs point directly at the cloud provider and are already correct.

The previous code rewrote **all** URL hostnames unconditionally, breaking cloud storage URLs.

## Test plan

- [x] Lint passes
- [x] 549 tests pass
- [ ] Verify with S3 backend: runner binary download succeeds (no more 404)
- [ ] Verify with filesystem backend: presigned URLs still correctly rewritten

Fixes #52