### PR TITLE
fix: use secretKeyRef for GitHub webhook secret

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -265,7 +265,8 @@ The chart ships with a `values.schema.json` that validates all values at `helm i
 |---|---|---|
 | `api.config.vcs.enabled` | `true` | Enable VCS integration |
 | `api.config.vcs.poll_interval_seconds` | `60` | Poll interval |
-| `api.config.vcs.github.webhook_secret` | `""` | GitHub webhook HMAC secret |
+| `api.config.vcs.github.existingSecret` | `""` | K8s Secret containing the GitHub webhook HMAC secret |
+| `api.config.vcs.github.existingSecretKey` | `"webhook_secret"` | Key within the Secret |
 
 ### Drift Detection
 

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -486,20 +486,22 @@ If Terrapod is accessible from GitHub (not behind a firewall), you can add webho
 
 ![GitHub App Webhook Settings](images/github-app-webhook.png)
 
-Then set the webhook secret in Terrapod:
+Then set the webhook secret in Terrapod. Create a K8s Secret:
 
 ```zsh
-TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET=your-webhook-secret-here
+kubectl -n terrapod create secret generic terrapod-github-webhook \
+  --from-literal=webhook_secret=your-webhook-secret-here
 ```
 
-Or in Helm values:
+Then reference it in Helm values:
 
 ```yaml
 api:
   config:
     vcs:
       github:
-        webhook_secret: ""  # Inject via TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET env var
+        existingSecret: "terrapod-github-webhook"
+        existingSecretKey: "webhook_secret"
 ```
 
 When a push event arrives, the webhook handler validates the HMAC-SHA256 signature and triggers an immediate poll for the affected repository. The poller still does all the work -- the webhook just makes it faster.

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -87,6 +87,13 @@ spec:
                   name: {{ .existingSecret | default (printf "%s-%s" (include "terrapod.fullname" $) .name) }}
                   key: {{ .existingSecretKey | default "client_secret" }}
             {{- end }}
+            {{- if .Values.api.config.vcs.github.existingSecret }}
+            - name: TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.config.vcs.github.existingSecret }}
+                  key: {{ .Values.api.config.vcs.github.existingSecretKey | default "webhook_secret" }}
+            {{- end }}
             {{- with .Values.api.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -528,7 +528,8 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "webhook_secret": { "type": "string" }
+                "existingSecret": { "type": "string" },
+                "existingSecretKey": { "type": "string" }
               }
             }
           }

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -190,10 +190,10 @@ api:
       enabled: true
       poll_interval_seconds: 60
       github:
-        # Optional: webhook secret for HMAC signature validation.
+        # Optional: K8s Secret containing the webhook HMAC secret.
         # Only needed if GitHub webhooks are enabled for faster feedback.
-        # Inject via env var: TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET
-        webhook_secret: ""
+        existingSecret: ""
+        existingSecretKey: "webhook_secret"
 
     # Audit logging
     audit:


### PR DESCRIPTION
## Summary

- Replace `vcs.github.webhook_secret` (plain-text in ConfigMap) with `existingSecret`/`existingSecretKey` pattern
- Add `TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET` env var via `secretKeyRef` in the API Deployment template (conditional — only when `existingSecret` is set)
- Update `values.schema.json`, `deployment.md`, and `vcs-integration.md` to match

## Test plan

- [x] `helm template` with `existingSecret` set — confirms `secretKeyRef` env var renders
- [x] `helm template` without `existingSecret` — confirms no env var injected
- [x] `helm lint` passes