### PR TITLE
fix: add Content-Type header to runner upload curl commands

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -143,12 +143,12 @@ if [ "$TP_PHASE" = "plan" ]; then
 
     # Upload plan log
     if [ -n "$TP_PLAN_LOG_UPLOAD_URL" ] && [ -f /tmp/plan.log ]; then
-        curl -sSf -X PUT --data-binary @/tmp/plan.log "$TP_PLAN_LOG_UPLOAD_URL" || true
+        curl -sSf -X PUT -H "Content-Type: application/octet-stream" --data-binary @/tmp/plan.log "$TP_PLAN_LOG_UPLOAD_URL" || true
     fi
 
     # Upload plan file
     if [ -n "$TP_PLAN_FILE_UPLOAD_URL" ] && [ -f tfplan ]; then
-        curl -sSf -X PUT --data-binary @tfplan "$TP_PLAN_FILE_UPLOAD_URL" || true
+        curl -sSf -X PUT -H "Content-Type: application/octet-stream" --data-binary @tfplan "$TP_PLAN_FILE_UPLOAD_URL" || true
     fi
 
 elif [ "$TP_PHASE" = "apply" ]; then
@@ -174,12 +174,12 @@ elif [ "$TP_PHASE" = "apply" ]; then
 
     # Upload apply log
     if [ -n "$TP_APPLY_LOG_UPLOAD_URL" ] && [ -f /tmp/apply.log ]; then
-        curl -sSf -X PUT --data-binary @/tmp/apply.log "$TP_APPLY_LOG_UPLOAD_URL" || true
+        curl -sSf -X PUT -H "Content-Type: application/octet-stream" --data-binary @/tmp/apply.log "$TP_APPLY_LOG_UPLOAD_URL" || true
     fi
 
     # Upload new state
     if [ -n "$TP_STATE_UPLOAD_URL" ] && [ -f terraform.tfstate ]; then
-        curl -sSf -X PUT --data-binary @terraform.tfstate "$TP_STATE_UPLOAD_URL" || true
+        curl -sSf -X PUT -H "Content-Type: application/octet-stream" --data-binary @terraform.tfstate "$TP_STATE_UPLOAD_URL" || true
     fi
 fi
 


### PR DESCRIPTION
## Summary

Fixes #54

- Add `-H "Content-Type: application/octet-stream"` to all four presigned PUT curl commands in the runner entrypoint
- S3 presigned URLs are signed with `ContentType=application/octet-stream`, but curl's `--data-binary` sends `application/x-www-form-urlencoded` by default — causing a signature mismatch and 403 on S3-compatible backends (MinIO, etc.)

## Test plan

- [ ] Runner plan upload succeeds against S3-compatible storage (no more 403)
- [ ] Plan logs and plan file visible in UI after plan completes