### PR TITLE
fix: agent pool delete fails with IntegrityError

### DIFF
--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -193,8 +193,12 @@ class AgentPool(Base):
         DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
     )
 
-    tokens: Mapped[list["AgentPoolToken"]] = relationship(back_populates="pool")
-    listeners: Mapped[list["RunnerListener"]] = relationship(back_populates="pool")
+    tokens: Mapped[list["AgentPoolToken"]] = relationship(
+        back_populates="pool", passive_deletes=True
+    )
+    listeners: Mapped[list["RunnerListener"]] = relationship(
+        back_populates="pool", passive_deletes=True
+    )
 
 
 class AgentPoolToken(Base):


### PR DESCRIPTION
## Summary

Deleting an agent pool that has tokens or listeners fails with `IntegrityError: null value in column "pool_id" violates not-null constraint`.

SQLAlchemy's default behavior is to SET NULL on child FKs before deleting the parent. The `agent_pool_tokens.pool_id` and `runner_listeners.pool_id` columns are `NOT NULL` with `ondelete=CASCADE` at the DB level, so SQLAlchemy's SET NULL attempt fails before the DB cascade can fire.

Fix: add `passive_deletes=True` to both relationships so SQLAlchemy defers to the database CASCADE.

## Test plan

- [ ] Delete an agent pool that has tokens — succeeds, tokens cascade-deleted
- [ ] Delete an agent pool that has listeners — succeeds, listeners cascade-deleted