### PR TITLE
fix: update session expiry banner on sliding window refresh

### DIFF
--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -317,6 +317,11 @@ def create_application() -> FastAPI:
             response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
+
+        # Propagate refreshed session expiry to frontend
+        if hasattr(request.state, "session_expires_at"):
+            response.headers["X-Session-Expires"] = request.state.session_expires_at
+
         return response
 
     # Audit logging middleware

--- a/services/terrapod/api/dependencies.py
+++ b/services/terrapod/api/dependencies.py
@@ -133,7 +133,8 @@ async def get_current_user(
         if session is not None:
             # Sliding window: refresh TTL on activity (rate-limited to every 5 min)
             if _should_refresh_session(session):
-                await refresh_session(token, session)
+                new_expires = await refresh_session(token, session)
+                request.state.session_expires_at = new_expires
 
             request.state.user_email = session.email  # for audit middleware
             return AuthenticatedUser(

--- a/services/terrapod/auth/sessions.py
+++ b/services/terrapod/auth/sessions.py
@@ -113,12 +113,14 @@ async def get_session(token: str) -> Session | None:
 SESSION_REFRESH_INTERVAL = 300  # 5 minutes
 
 
-async def refresh_session(token: str, session: Session) -> None:
+async def refresh_session(token: str, session: Session) -> str:
     """Extend session TTL on activity (sliding window).
 
     Called by get_current_session when last_active_at is older than
     SESSION_REFRESH_INTERVAL. Updates last_active_at, recalculates
     expires_at, and resets the Redis TTL.
+
+    Returns the new expires_at ISO 8601 timestamp.
     """
     redis = get_redis_client()
     ttl = _session_ttl()
@@ -127,11 +129,12 @@ async def refresh_session(token: str, session: Session) -> None:
     session_key = SESSION_PREFIX + token
     raw = await redis.get(session_key)
     if raw is None:
-        return  # Session vanished between check and refresh — harmless
+        return session.expires_at  # Session vanished — return original
 
+    new_expires_at = (now + timedelta(seconds=ttl)).isoformat()
     data = json.loads(raw)
     data["last_active_at"] = now.isoformat()
-    data["expires_at"] = (now + timedelta(seconds=ttl)).isoformat()
+    data["expires_at"] = new_expires_at
 
     user_key = USER_SESSIONS_PREFIX + session.email
 
@@ -139,6 +142,8 @@ async def refresh_session(token: str, session: Session) -> None:
         pipe.set(session_key, json.dumps(data), ex=ttl)
         pipe.expire(user_key, ttl)
         await pipe.execute()
+
+    return new_expires_at
 
 
 def _should_refresh_session(session: Session) -> bool:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,7 +5,7 @@
  * and redirects to login.
  */
 
-import { clearAuth, getAuthState, loginRedirectUrl } from '@/lib/auth'
+import { clearAuth, getAuthState, loginRedirectUrl, updateExpiresAt } from '@/lib/auth'
 
 export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   const auth = getAuthState()
@@ -22,6 +22,12 @@ export async function apiFetch(path: string, init?: RequestInit): Promise<Respon
     if (typeof window !== 'undefined') {
       window.location.href = loginRedirectUrl()
     }
+  }
+
+  // Update local session expiry when server refreshes it (sliding window)
+  const newExpiry = res.headers.get('X-Session-Expires')
+  if (newExpiry) {
+    updateExpiresAt(newExpiry)
   }
 
   return res

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -53,6 +53,15 @@ export function isAdminOrAudit(): boolean {
   return auth.roles.includes('admin') || auth.roles.includes('audit')
 }
 
+export function updateExpiresAt(expiresAt: string): void {
+  const auth = loadAuth()
+  if (!auth) return
+  auth.expiresAt = expiresAt
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(AUTH_KEY, JSON.stringify(auth))
+  }
+}
+
 export function getExpiresAt(): Date | null {
   const auth = loadAuth()
   if (!auth?.expiresAt) return null


### PR DESCRIPTION
## Summary

- The session expiry banner showed false "session expiring" warnings because `expiresAt` in localStorage was set once at login and never updated
- For OIDC sessions capped by `max_ttl` (id_token lifetime), the initial expiry could be as short as ~1h, while the server refreshes the session to the full 12h TTL on activity
- Returns `X-Session-Expires` response header when the server refreshes a session's sliding window TTL
- Frontend fetch wrapper reads the header and updates localStorage, keeping the banner in sync with the actual session expiry