### PR TITLE
fix: set TLS 1.3 minimum version in provider client

### DIFF
--- a/provider/internal/client/client.go
+++ b/provider/internal/client/client.go
@@ -36,9 +36,11 @@ func NewClient(hostname, token string, skipTLSVerify bool) *Client {
 	}
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
-	transport := &http.Transport{}
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS13}, //nolint:gosec
+	}
 	if skipTLSVerify {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	return &Client{


### PR DESCRIPTION
## Summary

- Set `MinVersion: tls.VersionTLS13` on the provider HTTP client's TLS config
- Addresses [CodeQL alert #97](https://github.com/mattrobinsonsre/terrapod/security/code-scanning/97)

## Test plan

- [ ] Provider lint/test pass
- [ ] Verify no regression with `terraform login` or provider init against TLS 1.3 endpoints