### PR TITLE
fix: runner entrypoint, platform provider version, CLI apply rejection

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -113,6 +113,10 @@ credentials "$MIRROR_HOST" {
 provider_installation {
   network_mirror {
     url = "${TP_API_URL}/v1/providers/"
+    exclude = ["${MIRROR_HOST}/*/*"]
+  }
+  direct {
+    include = ["${MIRROR_HOST}/*/*"]
   }
 }
 TFEOF
@@ -135,7 +139,20 @@ fi
 
 # --- Initialize ---
 echo "[entrypoint] Running $TP_BACKEND init..."
-"$TP_BIN" init -input=false 2>&1
+INIT_EXIT=0
+"$TP_BIN" init -input=false > /tmp/init.log 2>&1 || INIT_EXIT=$?
+cat /tmp/init.log
+if [ "$INIT_EXIT" != "0" ]; then
+    echo "[entrypoint] Init failed with exit code $INIT_EXIT"
+    # Upload init output as plan log so it's visible in the UI
+    if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
+        curl -sSf -X PUT -H "$AUTH_HEADER" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @/tmp/init.log \
+            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/plan-log" || true
+    fi
+    exit "$INIT_EXIT"
+fi
 
 # --- Build -var-file arguments from TP_VAR_FILES JSON ---
 # Uses a temp file + line-by-line read to safely handle paths with spaces.

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -54,6 +54,8 @@ spec:
               containerPort: 8000
               protocol: TCP
           env:
+            - name: TERRAPOD_VERSION
+              value: {{ .Chart.AppVersion | quote }}
             - name: TERRAPOD_STORAGE__FILESYSTEM__HMAC_SECRET
               valueFrom:
                 secretKeyRef:

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -176,11 +176,17 @@ async def create_run(
 
     ws = await _get_workspace(ws_id, db)
 
-    # CLI-initiated runs in remote mode are always plan-only.
+    # CLI-initiated runs in remote mode: plan is allowed, apply is not.
     # Only VCS-sourced runs are allowed to apply.
     plan_only = attrs.get("plan-only", False)
     source = attrs.get("source", "tfe-api")
     if ws.execution_mode == "remote" and source not in ("vcs", "drift-detection"):
+        if not plan_only:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Apply is not allowed from the CLI on remote execution workspaces. "
+                "Use 'terraform plan' for speculative plans, or trigger applies using VCS integration and/or the UX.",
+            )
         plan_only = True
 
     # Check permission: plan-only requires plan, apply requires write

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -480,6 +480,10 @@ class Settings(BaseSettings):
 
     # Application
     app_name: str = Field(default="terrapod-api")
+    version: str = Field(
+        default="",
+        description="Platform version (injected from Chart.AppVersion at deploy time)",
+    )
     debug: bool = Field(default=False)
     log_level: str = Field(default="INFO")
     json_logs: bool = Field(default=True, description="JSON logging in production")

--- a/services/terrapod/services/platform_provider_service.py
+++ b/services/terrapod/services/platform_provider_service.py
@@ -84,7 +84,7 @@ def get_platform_version() -> str:
 
     Falls back to '0.0.0-dev' if the version is not set in config.
     """
-    version = getattr(settings, "version", None) or "0.0.1"
+    version = settings.version or "0.0.1"
     return version.lstrip("v")
 
 


### PR DESCRIPTION
## Summary

- **Network mirror exclude/direct**: Platform's own hostname is excluded from the network mirror and uses direct registry protocol instead, so private providers (e.g. `terrapod.example.com/default/terrapod`) resolve correctly alongside cached upstream providers
- **Init output capture**: `terraform init` output is now captured and uploaded as the plan log on failure, making init errors visible in the UX instead of only in `kubectl logs`
- **Platform provider version**: `TERRAPOD_VERSION` env var injected from `Chart.AppVersion` into the API deployment, so the provider registry serves the actual platform version instead of hardcoded `0.0.1`
- **CLI apply rejection**: `terraform apply` from CLI on remote execution workspaces now returns a clear 422 error instead of silently running a plan-only run

## Test plan

- [ ] `tofu init` with both platform provider and upstream provider resolves correctly
- [ ] Failed init shows error output in the run detail UX
- [ ] Provider registry serves correct version matching Chart.AppVersion
- [ ] `terraform apply` from CLI on remote workspace returns 422 error
- [ ] `terraform plan` from CLI on remote workspace still works (plan-only)
- [ ] VCS-triggered applies still work end-to-end