### PR TITLE
fix: GoReleaser project_name for terraform provider naming

### DIFF
--- a/provider/.goreleaser.yml
+++ b/provider/.goreleaser.yml
@@ -1,5 +1,7 @@
 version: 2
 
+project_name: terraform-provider-terrapod
+
 builds:
   - env:
       - CGO_ENABLED=0


### PR DESCRIPTION
## Summary

- Set `project_name: terraform-provider-terrapod` in GoReleaser config

GoReleaser was defaulting the project name to `terrapod`, producing archives like `terrapod_0.4.1_linux_arm64.zip` with a binary named `terrapod_v0.4.1` inside. The platform provider service expects `terraform-provider-terrapod_0.4.1_linux_arm64.zip` with `terraform-provider-terrapod_v0.4.1` inside — matching the standard terraform provider naming convention.

This caused 502 errors when runners tried to install the platform provider via the direct registry protocol.

## Test plan

- [ ] Release produces `terraform-provider-terrapod_X.Y.Z_{os}_{arch}.zip` archives
- [ ] Binary inside zip is named `terraform-provider-terrapod_vX.Y.Z`
- [ ] SHA256SUMS file is named `terraform-provider-terrapod_X.Y.Z_SHA256SUMS`
- [ ] Runner can install platform provider during `terraform init`