### PR TITLE
fix: remove redundant json import (CodeQL #100)

### DIFF
--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -451,8 +451,6 @@ async def listener_heartbeat(
     active_runs = body.get("active_runs", 0)
     runner_defs = body.get("runner_definitions", [])
 
-    import json
-
     await redis.setex(f"{prefix}:status", ttl, "online")
     await redis.setex(f"{prefix}:heartbeat", ttl, str(int(__import__("time").time())))
     await redis.setex(f"{prefix}:capacity", ttl, str(capacity))


### PR DESCRIPTION
## Summary
- Removes duplicate `import json` at line 454 in `agent_pools.py` — the module is already imported at line 23

Resolves https://github.com/mattrobinsonsre/terrapod/security/code-scanning/100