### PR TITLE
fix: patch glibc and PyJWT CVEs in API image

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -7,7 +7,8 @@
 FROM python:3.14-slim AS builder
 
 # Install build + runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-get upgrade picks up security patches for base OS packages
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     pkg-config \
     gcc \
     libc6-dev \
@@ -33,7 +34,8 @@ FROM python:3.14-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # Runtime-only system libraries (no gcc, no -dev headers)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-get upgrade picks up security patches for base OS packages (e.g. glibc)
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     xmlsec1 \
     libxmlsec1-openssl \


### PR DESCRIPTION
## Summary
- Adds `apt-get upgrade` to both builder and runtime stages of `Dockerfile.api` to pick up glibc security patch (CVE-2026-0861)
- PyJWT CVE-2026-32597 is resolved by the rebuild pulling `2.12.0` (no lock file, `^2.8.0` constraint allows it)

Resolves code scanning alerts #102, #103, #104.