### PR TITLE
fix: hide cancel button on completed plan-only runs

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -99,14 +99,18 @@ def _run_json(run: Run) -> dict:
                     and not run.auto_apply
                     and not run.plan_only,
                     "is-discardable": run.status == "planned" and not run.plan_only,
-                    "is-cancelable": run.status not in run_service.TERMINAL_STATES,
-                    "is-retryable": run.status in run_service.TERMINAL_STATES,
+                    "is-cancelable": run.status not in run_service.TERMINAL_STATES
+                    and not (run.plan_only and run.status == "planned"),
+                    "is-retryable": run.status in run_service.TERMINAL_STATES
+                    or (run.plan_only and run.status == "planned"),
                 },
                 "permissions": {
                     "can-apply": run.status == "planned" and not run.plan_only,
-                    "can-cancel": run.status not in run_service.TERMINAL_STATES,
+                    "can-cancel": run.status not in run_service.TERMINAL_STATES
+                    and not (run.plan_only and run.status == "planned"),
                     "can-discard": run.status == "planned" and not run.plan_only,
-                    "can-retry": run.status in run_service.TERMINAL_STATES,
+                    "can-retry": run.status in run_service.TERMINAL_STATES
+                    or (run.plan_only and run.status == "planned"),
                     "can-force-execute": False,
                     "can-force-cancel": False,
                 },


### PR DESCRIPTION
## Summary

- Plan-only runs in `planned` status are effectively terminal (no confirm/apply phase), but the UI was showing a Cancel button because `planned` isn't in `TERMINAL_STATES`
- Fixed `is-cancelable` and `can-cancel` to exclude plan-only runs that have reached `planned`
- Fixed `is-retryable` and `can-retry` to include plan-only runs that have reached `planned`

## Test plan

- [x] `make test` — 580 tests pass
- [x] `make lint` — clean
- [ ] Verify on live deployment: completed plan-only run shows Retry (not Cancel)