### PR TITLE
feat: composite status badges on workspace list

### DIFF
--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -49,7 +49,7 @@ from terrapod.api.dependencies import (
     get_current_user,
     require_non_runner,
 )
-from terrapod.db.models import StateVersion, Workspace
+from terrapod.db.models import Run, StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.workspace_rbac_service import (
@@ -271,7 +271,11 @@ async def organization_entitlements(
 # ── Workspaces ───────────────────────────────────────────────────────────────
 
 
-def _workspace_json(ws: Workspace, effective_permission: str | None = None) -> dict:
+def _workspace_json(
+    ws: Workspace,
+    effective_permission: str | None = None,
+    latest_run: Run | None = None,
+) -> dict:
     """Serialize a Workspace to TFE V2 JSON:API format.
 
     When effective_permission is provided, the permissions block reflects
@@ -279,6 +283,15 @@ def _workspace_json(ws: Workspace, effective_permission: str | None = None) -> d
     (for backwards compat with internal callers).
     """
     perm = effective_permission
+
+    latest_run_attr = None
+    if latest_run is not None:
+        latest_run_attr = {
+            "id": f"run-{latest_run.id}",
+            "status": latest_run.status,
+            "plan-only": latest_run.plan_only,
+            "created-at": _rfc3339(latest_run.created_at),
+        }
 
     return {
         "data": {
@@ -303,6 +316,7 @@ def _workspace_json(ws: Workspace, effective_permission: str | None = None) -> d
                 "drift-detection-interval-seconds": ws.drift_detection_interval_seconds,
                 "drift-last-checked-at": _rfc3339(ws.drift_last_checked_at),
                 "drift-status": ws.drift_status,
+                "latest-run": latest_run_attr,
                 "agent-pool-id": f"apool-{ws.agent_pool_id}" if ws.agent_pool_id else None,
                 "agent-pool-name": ws.agent_pool.name if ws.agent_pool else None,
                 "labels": ws.labels or {},
@@ -365,12 +379,26 @@ async def list_workspaces(
     result = await db.execute(query)
     workspaces = result.scalars().all()
 
+    # Batch-load latest run per workspace using DISTINCT ON
+    ws_ids = [ws.id for ws in workspaces]
+    latest_runs: dict = {}
+    if ws_ids:
+        latest_run_q = (
+            select(Run)
+            .where(Run.workspace_id.in_(ws_ids))
+            .order_by(Run.workspace_id, Run.created_at.desc())
+            .distinct(Run.workspace_id)
+        )
+        run_result = await db.execute(latest_run_q)
+        for run in run_result.scalars().all():
+            latest_runs[run.workspace_id] = run
+
     # Filter to workspaces user has at least read access to
     visible = []
     for ws in workspaces:
         perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
         if perm is not None:
-            visible.append(_workspace_json(ws, perm)["data"])
+            visible.append(_workspace_json(ws, perm, latest_run=latest_runs.get(ws.id))["data"])
 
     return JSONResponse(
         content={"data": visible},
@@ -395,7 +423,16 @@ async def show_workspace(
     if perm is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    return JSONResponse(content=_workspace_json(ws, perm), headers=_tfe_headers())
+    # Load latest run for this workspace
+    run_result = await db.execute(
+        select(Run).where(Run.workspace_id == ws.id).order_by(Run.created_at.desc()).limit(1)
+    )
+    latest_run = run_result.scalar_one_or_none()
+
+    return JSONResponse(
+        content=_workspace_json(ws, perm, latest_run=latest_run),
+        headers=_tfe_headers(),
+    )
 
 
 @router.post("/organizations/default/workspaces")
@@ -550,7 +587,17 @@ async def show_workspace_by_id(
 ) -> JSONResponse:
     """Show a workspace by its ID."""
     ws, perm = await _require_ws_permission(workspace_id, "read", user, db)
-    return JSONResponse(content=_workspace_json(ws, perm), headers=_tfe_headers())
+
+    # Load latest run for this workspace
+    run_result = await db.execute(
+        select(Run).where(Run.workspace_id == ws.id).order_by(Run.created_at.desc()).limit(1)
+    )
+    latest_run = run_result.scalar_one_or_none()
+
+    return JSONResponse(
+        content=_workspace_json(ws, perm, latest_run=latest_run),
+        headers=_tfe_headers(),
+    )
 
 
 @router.patch("/workspaces/{workspace_id}")

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -77,9 +77,11 @@ class TestWorkspaceDriftAttributes:
         ws = _mock_workspace(drift_detection_enabled=True, drift_status="no_drift")
 
         app, mock_db = _make_app(_user())
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = ws
-        mock_db.execute.return_value = mock_result
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run_result = MagicMock()
+        no_run_result.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run_result]
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -164,9 +164,11 @@ class TestShowWorkspace:
         ws = _mock_workspace(name="test-ws")
         user = _user()
         app, mock_db = _make_app(user)
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = ws
-        mock_db.execute.return_value = mock_result
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run_result = MagicMock()
+        no_run_result.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run_result]
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
@@ -225,9 +227,11 @@ class TestShowWorkspaceById:
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = ws
-        mock_db.execute.return_value = mock_result
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run_result = MagicMock()
+        no_run_result.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run_result]
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
@@ -478,9 +482,11 @@ class TestPermissionsBlock:
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = ws
-        mock_db.execute.return_value = mock_result
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run_result = MagicMock()
+        no_run_result.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run_result]
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
@@ -501,9 +507,11 @@ class TestPermissionsBlock:
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
         app, mock_db = _make_app(_user(roles=["admin"]))
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = ws
-        mock_db.execute.return_value = mock_result
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run_result = MagicMock()
+        no_run_result.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run_result]
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -14,6 +14,13 @@ import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
 import { useWorkspaceListEvents } from '@/lib/use-workspace-list-events'
 
+interface LatestRun {
+  id: string
+  status: string
+  'plan-only': boolean
+  'created-at': string
+}
+
 interface Workspace {
   id: string
   attributes: {
@@ -26,6 +33,7 @@ interface Workspace {
     'resource-memory': string
     'drift-detection-enabled': boolean
     'drift-status': string
+    'latest-run': LatestRun | null
     'created-at': string
   }
 }
@@ -52,6 +60,39 @@ export default function WorkspacesPage() {
   const [versionsBackend, setVersionsBackend] = useState('')
 
   type WsSortKey = 'name' | 'mode' | 'resources' | 'status' | 'created'
+
+  function resolveStatus(ws: Workspace): { label: string; color: string; priority: number } {
+    const drift = ws.attributes['drift-status']
+    const run = ws.attributes['latest-run']
+
+    if (drift === 'drifted') return { label: 'Drifted', color: 'amber', priority: 1 }
+    if (run) {
+      const s = run.status
+      const planOnly = run['plan-only']
+      if (s === 'errored') return { label: 'Errored', color: 'red', priority: 2 }
+      if (s === 'planned' && !planOnly) return { label: 'Needs Confirm', color: 'amber', priority: 3 }
+      if (s === 'planning') return { label: 'Planning', color: 'blue', priority: 4 }
+      if (s === 'applying') return { label: 'Applying', color: 'blue', priority: 4 }
+      if (s === 'confirmed') return { label: 'Confirmed', color: 'blue', priority: 4 }
+      if (s === 'queued') return { label: 'Queued', color: 'blue', priority: 4 }
+      if (s === 'pending') return { label: 'Pending', color: 'slate', priority: 5 }
+      if (s === 'applied') return { label: 'Applied', color: 'green', priority: 6 }
+      if (s === 'planned' && planOnly) return { label: 'Planned', color: 'green', priority: 7 }
+      if (s === 'canceled') return { label: 'Canceled', color: 'slate', priority: 8 }
+      if (s === 'discarded') return { label: 'Discarded', color: 'slate', priority: 8 }
+    }
+    return { label: '\u2014', color: 'gray', priority: 9 }
+  }
+
+  const badgeColors: Record<string, string> = {
+    amber: 'bg-amber-900/50 text-amber-300',
+    red: 'bg-red-900/50 text-red-300',
+    blue: 'bg-blue-900/50 text-blue-300',
+    green: 'bg-green-900/50 text-green-300',
+    slate: 'bg-slate-700/50 text-slate-400',
+    gray: 'text-slate-500',
+  }
+
   const { sortedItems: sortedWorkspaces, sortState, toggleSort } = useSortable<Workspace, WsSortKey>(
     workspaces, 'name', 'asc',
     useCallback((item: Workspace, key: WsSortKey) => {
@@ -59,7 +100,7 @@ export default function WorkspacesPage() {
         case 'name': return item.attributes.name
         case 'mode': return item.attributes['execution-mode']
         case 'resources': return item.attributes['resource-cpu']
-        case 'status': return item.attributes.locked ? 'locked' : 'unlocked'
+        case 'status': return resolveStatus(item).label
         case 'created': return item.attributes['created-at']
       }
     }, []),
@@ -280,28 +321,17 @@ export default function WorkspacesPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-700/30">
-                {sortedWorkspaces.map((ws) => (
+                {sortedWorkspaces.map((ws) => {
+                  const status = resolveStatus(ws)
+                  return (
                   <tr key={ws.id} className="hover:bg-slate-700/20 transition-colors">
                     <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <Link
-                          href={`/workspaces/${ws.id}`}
-                          className="text-sm font-medium text-brand-400 hover:text-brand-300"
-                        >
-                          {ws.attributes.name}
-                        </Link>
-                        {ws.attributes['drift-detection-enabled'] && ws.attributes['drift-status'] && (
-                          <span
-                            className={`inline-block w-2 h-2 rounded-full ${
-                              ws.attributes['drift-status'] === 'no_drift' ? 'bg-green-400' :
-                              ws.attributes['drift-status'] === 'drifted' ? 'bg-amber-400' :
-                              ws.attributes['drift-status'] === 'errored' ? 'bg-red-400' :
-                              'bg-slate-500'
-                            }`}
-                            title={`Drift: ${ws.attributes['drift-status'].replace('_', ' ')}`}
-                          />
-                        )}
-                      </div>
+                      <Link
+                        href={`/workspaces/${ws.id}`}
+                        className="text-sm font-medium text-brand-400 hover:text-brand-300"
+                      >
+                        {ws.attributes.name}
+                      </Link>
                     </td>
                     <td className="px-4 py-3 hidden sm:table-cell">
                       <span className="text-xs text-slate-400">{ws.attributes['execution-mode']}</span>
@@ -312,13 +342,13 @@ export default function WorkspacesPage() {
                       </span>
                     </td>
                     <td className="px-4 py-3 hidden lg:table-cell">
-                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                        ws.attributes.locked
-                          ? 'bg-amber-900/50 text-amber-300'
-                          : 'bg-green-900/50 text-green-300'
-                      }`}>
-                        {ws.attributes.locked ? 'Locked' : 'Unlocked'}
-                      </span>
+                      {status.color === 'gray' ? (
+                        <span className="text-xs text-slate-500">{status.label}</span>
+                      ) : (
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors[status.color]}`}>
+                          {status.label}
+                        </span>
+                      )}
                     </td>
                     <td className="px-4 py-3 hidden lg:table-cell">
                       <span className="text-xs text-slate-500">
@@ -326,7 +356,8 @@ export default function WorkspacesPage() {
                       </span>
                     </td>
                   </tr>
-                ))}
+                  )
+                })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary

- Replace the locked/unlocked Status column on `/workspaces` with a composite status badge showing the most important attention signal per workspace
- Add `latest-run` attribute to workspace API responses (batch-loaded via `DISTINCT ON` in list, single query in show endpoints)
- 9-priority badge resolution: drifted (amber) > errored (red) > needs confirm (amber) > in-progress (blue) > pending (slate) > applied (green) > planned (green) > canceled (slate) > no runs (dash)
- Remove drift dot from name column — drift is now surfaced in the status badge

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 580 passed
- [x] Local Tilt stack: verified red "Errored" badge renders correctly for workspace with errored run
- [ ] Verify on live deployment with multiple workspaces in varied states (drifted, applied, planned, etc.)