### PR TITLE
feat: plan-only runs from arbitrary VCS branch or tag

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -307,6 +307,32 @@ The following read-only attributes are included in workspace responses when drif
 | `drift-last-checked-at` | string (RFC3339) or null | Timestamp of the last completed drift detection check |
 | `drift-status` | string | Current drift status: `""` (never checked), `"no_drift"`, `"drifted"`, or `"errored"` |
 
+### List VCS Refs
+
+```
+GET /api/v2/workspaces/{id}/vcs-refs
+```
+
+Returns branches, tags, and the default branch for a VCS-connected workspace. Used by the UI to populate the VCS ref picker when queueing runs.
+
+**Required permission:** `read` on the workspace.
+
+**Response:**
+```json
+{
+  "branches": [
+    {"name": "main", "sha": "abc123..."},
+    {"name": "feature-x", "sha": "def456..."}
+  ],
+  "tags": [
+    {"name": "v1.0.0", "sha": "789abc..."}
+  ],
+  "default-branch": "main"
+}
+```
+
+Returns 422 if the workspace is not VCS-connected or the VCS connection is inactive.
+
 ---
 
 ## State Versions
@@ -430,6 +456,7 @@ POST /api/v2/runs
 | `refresh-only` | boolean | `false` | Refresh-only plan — reconcile state without planning changes (equivalent to `-refresh-only`) |
 | `refresh` | boolean | `true` | Whether to refresh state before planning. Set to `false` to skip refresh (equivalent to `-refresh=false`) |
 | `allow-empty-apply` | boolean | `false` | Allow apply even when the plan has no changes (equivalent to `-allow-empty-apply`) |
+| `vcs-ref` | string | `""` | Branch, tag, or SHA to fetch code from instead of the workspace's tracked branch. Only valid on VCS-connected workspaces. **Runs with a non-default ref are always plan-only** — the server enforces this regardless of the `plan-only` attribute value |
 
 ### Run Response Attributes (Drift Detection)
 

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -178,7 +178,9 @@ async def _require_run_ws_permission(
         )
 
 
-async def _fetch_vcs_config(db: AsyncSession, ws: Workspace) -> tuple[uuid.UUID, str, str]:
+async def _fetch_vcs_config(
+    db: AsyncSession, ws: Workspace, *, ref_override: str = ""
+) -> tuple[uuid.UUID, str, str]:
     """Download code from VCS and create a ConfigurationVersion.
 
     Used when the UI queues a run on a VCS-connected workspace without
@@ -186,11 +188,15 @@ async def _fetch_vcs_config(db: AsyncSession, ws: Workspace) -> tuple[uuid.UUID,
     the VCS poller uses: resolve branch → get HEAD SHA → download
     tarball → create CV → upload → mark uploaded.
 
-    Returns (cv_id, commit_sha, branch).
+    When ref_override is set, fetches code from that branch/tag/SHA instead
+    of the workspace's tracked branch.
+
+    Returns (cv_id, commit_sha, ref_name).
     """
     from terrapod.services.vcs_poller import (
         _download_archive,
         _get_branch_sha,
+        _list_tags,
         _parse_repo_url,
         _resolve_branch,
         _strip_top_level_dir,
@@ -207,13 +213,25 @@ async def _fetch_vcs_config(db: AsyncSession, ws: Workspace) -> tuple[uuid.UUID,
         raise HTTPException(status_code=422, detail="Cannot parse VCS repo URL")
     owner, repo = parsed
 
-    branch = await _resolve_branch(conn, ws, owner, repo)
-    if not branch:
-        raise HTTPException(status_code=422, detail="Cannot determine VCS branch")
-
-    sha = await _get_branch_sha(conn, owner, repo, branch)
-    if not sha:
-        raise HTTPException(status_code=422, detail="Cannot get branch HEAD SHA")
+    if ref_override:
+        # Try as branch first, then tag, then treat as raw SHA
+        sha = await _get_branch_sha(conn, owner, repo, ref_override)
+        ref_name = ref_override
+        if not sha:
+            tags = await _list_tags(conn, owner, repo)
+            tag_match = next((t for t in tags if t["name"] == ref_override), None)
+            if tag_match:
+                sha = tag_match["sha"]
+            else:
+                # Treat as raw SHA — download_archive accepts any git ref
+                sha = ref_override
+    else:
+        ref_name = await _resolve_branch(conn, ws, owner, repo) or ""
+        if not ref_name:
+            raise HTTPException(status_code=422, detail="Cannot determine VCS branch")
+        sha = await _get_branch_sha(conn, owner, repo, ref_name)
+        if not sha:
+            raise HTTPException(status_code=422, detail="Cannot get branch HEAD SHA")
 
     archive = await _download_archive(conn, owner, repo, sha)
     archive = _strip_top_level_dir(archive)
@@ -229,7 +247,7 @@ async def _fetch_vcs_config(db: AsyncSession, ws: Workspace) -> tuple[uuid.UUID,
 
     cv = await run_service.mark_configuration_uploaded(db, cv)
 
-    return cv.id, sha, branch
+    return cv.id, sha, ref_name
 
 
 @router.post("/runs", status_code=201)
@@ -282,11 +300,21 @@ async def create_run(
     if cv_id:
         cv_uuid = uuid.UUID(cv_id.removeprefix("cv-"))
 
+    # VCS ref override: plan against an arbitrary branch/tag (always plan-only)
+    vcs_ref = attrs.get("vcs-ref", "")
+    if vcs_ref:
+        if not ws.vcs_connection_id or not ws.vcs_repo_url:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="vcs-ref can only be used on VCS-connected workspaces",
+            )
+        plan_only = True  # Server-side enforcement — non-default refs are always plan-only
+
     # If no config version provided and workspace has VCS, fetch code from VCS
     vcs_sha = ""
     vcs_branch = ""
     if cv_uuid is None and ws.vcs_connection_id and ws.vcs_repo_url:
-        cv_uuid, vcs_sha, vcs_branch = await _fetch_vcs_config(db, ws)
+        cv_uuid, vcs_sha, vcs_branch = await _fetch_vcs_config(db, ws, ref_override=vcs_ref)
 
     run = await run_service.create_run(
         db,

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -29,6 +29,7 @@ Endpoints:
     GET  /api/v2/state-versions/{id}/download — download raw state
     PUT  /api/v2/state-versions/{id}/content — upload raw state
     PUT  /api/v2/state-versions/{id}/json-content — upload JSON state
+    GET  /api/v2/workspaces/{id}/vcs-refs — list VCS branches/tags for workspace
 """
 
 import asyncio
@@ -1063,3 +1064,54 @@ async def unlock_workspace(
     await publish_workspace_event(str(ws.id), "workspace_lock_change", {"locked": False})
 
     return JSONResponse(content=_workspace_json(ws, perm), headers=_tfe_headers())
+
+
+@router.get("/workspaces/{workspace_id}/vcs-refs")
+async def list_vcs_refs(
+    workspace_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """List branches, tags, and default branch for a VCS-connected workspace.
+
+    Requires read permission on the workspace.
+    """
+    from terrapod.db.models import VCSConnection
+    from terrapod.services.vcs_poller import (
+        _list_branches,
+        _list_tags,
+        _parse_repo_url,
+        _resolve_branch,
+    )
+
+    ws = await _get_workspace_by_id(workspace_id, db)
+    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    if not has_permission(perm, "read"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Requires read permission on workspace",
+        )
+
+    if not ws.vcs_connection_id or not ws.vcs_repo_url:
+        raise HTTPException(status_code=422, detail="Workspace is not VCS-connected")
+
+    conn = await db.get(VCSConnection, ws.vcs_connection_id)
+    if not conn or conn.status != "active":
+        raise HTTPException(status_code=422, detail="VCS connection is not active")
+
+    parsed = _parse_repo_url(conn, ws.vcs_repo_url)
+    if not parsed:
+        raise HTTPException(status_code=422, detail="Cannot parse VCS repo URL")
+    owner, repo = parsed
+
+    branches = await _list_branches(conn, owner, repo)
+    tags = await _list_tags(conn, owner, repo)
+    default_branch = await _resolve_branch(conn, ws, owner, repo) or ""
+
+    return JSONResponse(
+        content={
+            "branches": branches,
+            "tags": tags,
+            "default-branch": default_branch,
+        }
+    )

--- a/services/terrapod/services/github_service.py
+++ b/services/terrapod/services/github_service.py
@@ -213,6 +213,29 @@ async def list_open_pull_requests(
     ]
 
 
+async def list_repo_branches(conn: VCSConnection, owner: str, repo: str) -> list[dict[str, str]]:
+    """List repository branches.
+
+    Returns a list of dicts with keys: name, sha.
+    """
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{api_url}/repos/{owner}/{repo}/branches",
+            params={"per_page": 100},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        resp.raise_for_status()
+
+    return [{"name": b["name"], "sha": b["commit"]["sha"]} for b in resp.json()]
+
+
 async def list_repo_tags(conn: VCSConnection, owner: str, repo: str) -> list[dict[str, str]]:
     """List repository tags.
 

--- a/services/terrapod/services/gitlab_service.py
+++ b/services/terrapod/services/gitlab_service.py
@@ -118,6 +118,25 @@ async def list_open_prs(
     ]
 
 
+async def list_branches(conn: VCSConnection, owner: str, repo: str) -> list[dict[str, str]]:
+    """List repository branches.
+
+    Returns a list of dicts with keys: name, sha.
+    """
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{api}/projects/{project}/repository/branches",
+            params={"per_page": 100},
+            headers=_headers(conn),
+        )
+        resp.raise_for_status()
+
+    return [{"name": b["name"], "sha": b["commit"]["id"]} for b in resp.json()]
+
+
 async def list_tags(conn: VCSConnection, owner: str, repo: str) -> list[dict[str, str]]:
     """List repository tags.
 

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -88,6 +88,20 @@ def _changes_affect_directory(changed_files: list[str], working_directory: str) 
     return any(f.startswith(prefix) for f in changed_files)
 
 
+async def _list_branches(conn: VCSConnection, owner: str, repo: str) -> list[dict[str, str]]:
+    """List branches via the appropriate provider."""
+    if conn.provider == "gitlab":
+        return await gitlab_service.list_branches(conn, owner, repo)
+    return await github_service.list_repo_branches(conn, owner, repo)
+
+
+async def _list_tags(conn: VCSConnection, owner: str, repo: str) -> list[dict[str, str]]:
+    """List tags via the appropriate provider."""
+    if conn.provider == "gitlab":
+        return await gitlab_service.list_tags(conn, owner, repo)
+    return await github_service.list_repo_tags(conn, owner, repo)
+
+
 async def _list_open_prs(
     conn: VCSConnection, owner: str, repo: str, base_branch: str
 ) -> list[PullRequest]:

--- a/services/terrapod/services/vcs_provider.py
+++ b/services/terrapod/services/vcs_provider.py
@@ -58,6 +58,12 @@ class VCSProvider(Protocol):
         """
         ...
 
+    async def list_branches(
+        self, conn: VCSConnection, owner: str, repo: str
+    ) -> list[dict[str, str]]:
+        """List repository branches. Returns [{"name": str, "sha": str}]."""
+        ...
+
     async def list_tags(self, conn: VCSConnection, owner: str, repo: str) -> list[dict[str, str]]:
         """List repository tags. Returns [{"name": str, "sha": str}]."""
         ...

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -43,6 +43,8 @@ interface WorkspaceAttrs {
   labels: Record<string, string>
   'owner-email': string
   'var-files': string[]
+  'vcs-repo-url': string
+  'vcs-branch': string
   'drift-detection-enabled': boolean
   'drift-detection-interval-seconds': number
   'drift-last-checked-at': string
@@ -220,6 +222,15 @@ function WorkspaceDetailContent() {
   const [planAllowEmpty, setPlanAllowEmpty] = useState(false)
   const [planOnly, setPlanOnly] = useState(true)
 
+  // VCS ref picker
+  const [vcsRef, setVcsRef] = useState('')
+  const [vcsRefType, setVcsRefType] = useState<'branch' | 'tag'>('branch')
+  const [vcsBranches, setVcsBranches] = useState<{ name: string; sha: string }[]>([])
+  const [vcsTags, setVcsTags] = useState<{ name: string; sha: string }[]>([])
+  const [vcsDefaultBranch, setVcsDefaultBranch] = useState('')
+  const [vcsRefsLoading, setVcsRefsLoading] = useState(false)
+  const [vcsRefsLoaded, setVcsRefsLoaded] = useState(false)
+
   // State versions
   const [stateVersions, setStateVersions] = useState<StateVersionItem[]>([])
   const [stateLoading, setStateLoading] = useState(false)
@@ -345,6 +356,24 @@ function WorkspaceDetailContent() {
     }
   }, [workspaceId])
 
+  const loadVcsRefs = useCallback(async () => {
+    if (vcsRefsLoaded || vcsRefsLoading) return
+    setVcsRefsLoading(true)
+    try {
+      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/vcs-refs`)
+      if (!res.ok) return
+      const data = await res.json()
+      setVcsBranches(data.branches || [])
+      setVcsTags(data.tags || [])
+      setVcsDefaultBranch(data['default-branch'] || '')
+      setVcsRefsLoaded(true)
+    } catch {
+      // Non-critical — picker just won't show refs
+    } finally {
+      setVcsRefsLoading(false)
+    }
+  }, [workspaceId, vcsRefsLoaded, vcsRefsLoading])
+
   // Load tab data when tab changes
   useEffect(() => {
     if (!workspace) return
@@ -354,6 +383,20 @@ function WorkspaceDetailContent() {
     if (activeTab === 'notifications') loadNotifications()
     if (activeTab === 'run-tasks') loadRunTasks()
   }, [activeTab, workspace, loadRuns])
+
+  // Load VCS refs when plan options panel opens on a VCS-connected workspace
+  useEffect(() => {
+    if (showPlanOptions && workspace?.attributes['vcs-repo-url']) {
+      loadVcsRefs()
+    }
+  }, [showPlanOptions, workspace, loadVcsRefs])
+
+  // Force plan-only when a non-default VCS ref is selected
+  useEffect(() => {
+    if (vcsRef) {
+      setPlanOnly(true)
+    }
+  }, [vcsRef])
 
   // Real-time workspace events via SSE (run status, lock/unlock, state, settings)
   useRunEvents(workspaceId, useCallback((event) => {
@@ -726,6 +769,7 @@ function WorkspaceDetailContent() {
       if (planRefreshOnly) attrs['refresh-only'] = true
       if (!planRefresh) attrs['refresh'] = false
       if (planAllowEmpty) attrs['allow-empty-apply'] = true
+      if (vcsRef) attrs['vcs-ref'] = vcsRef
 
       const res = await apiFetch(`/api/v2/runs`, {
         method: 'POST',
@@ -757,6 +801,7 @@ function WorkspaceDetailContent() {
       setPlanRefresh(true)
       setPlanAllowEmpty(false)
       setPlanOnly(true)
+      setVcsRef('')
       await loadRuns()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to queue plan')
@@ -1541,12 +1586,13 @@ function WorkspaceDetailContent() {
                       </div>
                     </div>
                     <div className="flex flex-wrap gap-4 mt-3">
-                      <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
+                      <label className={`flex items-center gap-2 text-sm cursor-pointer ${vcsRef ? 'text-slate-500' : 'text-slate-300'}`}>
                         <input
                           type="checkbox"
                           checked={planOnly}
                           onChange={e => setPlanOnly(e.target.checked)}
-                          className="rounded border-slate-600 bg-slate-900 text-brand-500 focus:ring-brand-500"
+                          disabled={!!vcsRef}
+                          className="rounded border-slate-600 bg-slate-900 text-brand-500 focus:ring-brand-500 disabled:opacity-50"
                         />
                         Plan Only
                       </label>
@@ -1574,16 +1620,58 @@ function WorkspaceDetailContent() {
                         />
                         Skip Refresh
                       </label>
-                      <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={planAllowEmpty}
-                          onChange={e => setPlanAllowEmpty(e.target.checked)}
-                          className="rounded border-slate-600 bg-slate-900 text-brand-500 focus:ring-brand-500"
-                        />
-                        Allow Empty Apply
-                      </label>
+                      {!vcsRef && (
+                        <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={planAllowEmpty}
+                            onChange={e => setPlanAllowEmpty(e.target.checked)}
+                            className="rounded border-slate-600 bg-slate-900 text-brand-500 focus:ring-brand-500"
+                          />
+                          Allow Empty Apply
+                        </label>
+                      )}
                     </div>
+                    {attrs['vcs-repo-url'] && (
+                      <div className="mt-4 pt-3 border-t border-slate-700/50">
+                        <label className="block text-xs text-slate-400 mb-2">VCS Ref</label>
+                        <div className="flex gap-2">
+                          <select
+                            value={vcsRefType}
+                            onChange={e => {
+                              setVcsRefType(e.target.value as 'branch' | 'tag')
+                              setVcsRef('')
+                            }}
+                            className="px-2 py-2 bg-slate-900 border border-slate-600 rounded-lg text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                          >
+                            <option value="branch">Branch</option>
+                            <option value="tag">Tag</option>
+                          </select>
+                          <select
+                            value={vcsRef}
+                            onChange={e => setVcsRef(e.target.value)}
+                            disabled={vcsRefsLoading}
+                            className="flex-1 px-2 py-2 bg-slate-900 border border-slate-600 rounded-lg text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:opacity-50"
+                          >
+                            <option value="">
+                              {vcsRefsLoading
+                                ? 'Loading...'
+                                : `Default${vcsDefaultBranch ? ` (${vcsDefaultBranch})` : ''}`}
+                            </option>
+                            {(vcsRefType === 'branch' ? vcsBranches : vcsTags).map(ref => (
+                              <option key={ref.name} value={ref.name}>
+                                {ref.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        {vcsRef && (
+                          <p className="mt-2 text-xs text-amber-400">
+                            Non-default ref selected — run will be plan-only
+                          </p>
+                        )}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary

- Add VCS ref picker to the plan options panel — users can select any branch or tag on a VCS-connected workspace to plan against
- Non-default refs are **always plan-only**, enforced server-side regardless of client request
- New `GET /workspaces/{id}/vcs-refs` endpoint returns branches, tags, and default branch for the UI picker

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 580/580 passed
- [x] API returns 422 for `vcs-refs` on non-VCS workspace
- [x] API returns 422 for `vcs-ref` attribute on non-VCS workspace
- [x] UI hides VCS ref picker on non-VCS workspaces
- [ ] UI loads branches/tags on VCS-connected workspace (requires GitHub App PEM)
- [ ] Selecting non-default ref disables plan-only checkbox with amber warning
- [ ] Queued plan with non-default ref creates plan-only run with correct code