### PR TITLE
fix: plan log truncation at 64KB and multiline variable values

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1002,7 +1002,7 @@ _POST_PLAN_STATES = frozenset(
 async def plan_log(
     plan_id: str = Path(...),
     offset: int = Query(0),
-    limit: int = Query(65536),
+    limit: int = Query(0),
     format: Literal["raw", "plain"] = Query("raw"),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
@@ -1026,7 +1026,7 @@ async def plan_log(
 async def apply_log(
     apply_id: str = Path(...),
     offset: int = Query(0),
-    limit: int = Query(65536),
+    limit: int = Query(0),
     format: Literal["raw", "plain"] = Query("raw"),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
@@ -1094,12 +1094,15 @@ async def _serve_log(
     if strip_ansi:
         data = _ANSI_RE.sub(b"", data)
 
-    chunk = data[offset : offset + limit]
+    if limit > 0:
+        chunk = data[offset : offset + limit]
+    else:
+        chunk = data[offset:]
     result = b""
     if offset == 0:
         result += _STX
     result += chunk
     # Append ETX if phase is done and this is the last chunk
-    if phase_done and offset + limit >= len(data):
+    if phase_done and (limit == 0 or offset + limit >= len(data)):
         result += _ETX
     return Response(content=result, media_type="text/plain")

--- a/web/src/app/admin/variable-sets/[id]/page.tsx
+++ b/web/src/app/admin/variable-sets/[id]/page.tsx
@@ -515,8 +515,8 @@ export default function VariableSetDetailPage() {
                   </div>
                   <div>
                     <label htmlFor="var-val" className="block text-sm font-medium text-slate-300 mb-1">Value</label>
-                    <input id="var-val" type="text" value={varValue} onChange={(e) => setVarValue(e.target.value)} placeholder="us-east-1"
-                      className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
+                    <textarea id="var-val" value={varValue} onChange={(e) => setVarValue(e.target.value)} placeholder="us-east-1"
+                      rows={2} className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent resize-y" />
                   </div>
                   <div>
                     <label htmlFor="var-cat" className="block text-sm font-medium text-slate-300 mb-1">Category</label>
@@ -570,9 +570,10 @@ export default function VariableSetDetailPage() {
                               className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 font-mono focus:outline-none focus:ring-1 focus:ring-brand-500" />
                           </td>
                           <td className="px-4 py-3">
-                            <input type="text" value={editVarValue} onChange={(e) => setEditVarValue(e.target.value)}
+                            <textarea value={editVarValue} onChange={(e) => setEditVarValue(e.target.value)}
                               placeholder={editVarSensitive ? 'Enter new value' : ''}
-                              className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 font-mono focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                              rows={2}
+                              className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 font-mono focus:outline-none focus:ring-1 focus:ring-brand-500 resize-y" />
                           </td>
                           <td className="px-4 py-3 hidden sm:table-cell">
                             <div className="flex items-center gap-3">

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1426,7 +1426,7 @@ function WorkspaceDetailContent() {
                   </div>
                   <div>
                     <label htmlFor="var-val" className="block text-sm font-medium text-slate-300 mb-1">Value</label>
-                    <input id="var-val" type="text" value={varValue} onChange={(e) => setVarValue(e.target.value)} placeholder="us-east-1" className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
+                    <textarea id="var-val" value={varValue} onChange={(e) => setVarValue(e.target.value)} placeholder="us-east-1" rows={2} className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent resize-y" />
                   </div>
                   <div>
                     <label htmlFor="var-cat" className="block text-sm font-medium text-slate-300 mb-1">Category</label>
@@ -1476,9 +1476,10 @@ function WorkspaceDetailContent() {
                               className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 font-mono focus:outline-none focus:ring-1 focus:ring-brand-500" />
                           </td>
                           <td className="px-4 py-3">
-                            <input type="text" value={editVarValue} onChange={(e) => setEditVarValue(e.target.value)}
+                            <textarea value={editVarValue} onChange={(e) => setEditVarValue(e.target.value)}
                               placeholder={editVarSensitive ? 'Enter new value' : ''}
-                              className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 font-mono focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                              rows={2}
+                              className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 font-mono focus:outline-none focus:ring-1 focus:ring-brand-500 resize-y" />
                           </td>
                           <td className="px-4 py-3 hidden sm:table-cell">
                             <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

- **Log truncation fix**: Plan/apply log endpoints defaulted to `limit=65536` (64KB), silently truncating large plan outputs. Changed default to `0` (unlimited) so the full log is returned. The `limit` parameter still works for clients that want pagination.
- **Multiline variable values**: Variable value fields were `<input type="text">` which can't handle newlines. Swapped to `<textarea>` in both workspace variables and variable-set pages, enabling PEM keys, JSON blobs, and HCL blocks as variable values.

## Test plan

- [x] `make lint` passes (0 errors)
- [x] `make test` passes (580 tests)
- [ ] Verify full plan log loads on run detail page (no truncation)
- [ ] Verify variable creation with multiline value works