### PR TITLE
fix: pass workspace resource requests to runner Jobs

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -70,6 +70,8 @@ def _run_json(run: Run) -> dict:
                 "source": run.source,
                 "execution-backend": run.execution_backend,
                 "terraform-version": run.terraform_version,
+                "resource-cpu": run.resource_cpu,
+                "resource-memory": run.resource_memory,
                 "error-message": run.error_message,
                 "target-addrs": run.target_addrs or [],
                 "replace-addrs": run.replace_addrs or [],

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -288,6 +288,8 @@ class TestRunDriftAttributes:
         run.refresh_only = False
         run.refresh = True
         run.allow_empty_apply = False
+        run.resource_cpu = "1"
+        run.resource_memory = "2Gi"
 
         ws = _mock_workspace(ws_id=ws_id)
 

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -61,6 +61,8 @@ def _mock_run(
     run.refresh_only = False
     run.refresh = True
     run.allow_empty_apply = False
+    run.resource_cpu = "1"
+    run.resource_memory = "2Gi"
     return run
 
 


### PR DESCRIPTION
## Summary

- `resource-cpu` and `resource-memory` were stored on the Run model but never included in `_run_json()`, so the listener always fell back to hardcoded defaults (1 CPU / 2Gi)
- Add both fields to the serialized run attributes so per-workspace resource sizing is honoured by runner Jobs

## Test plan

- [x] `make test` passes (580 tests)
- [ ] Set custom resource values on a workspace, queue a run, verify the Job spec uses the custom values