### PR TITLE
feat: module impact analysis — speculative plans for module PRs

### DIFF
--- a/alembic/versions/1b7bc2b4e011_add_module_impact_analysis.py
+++ b/alembic/versions/1b7bc2b4e011_add_module_impact_analysis.py
@@ -1,0 +1,75 @@
+"""Add module impact analysis tables and columns.
+
+New table: module_workspace_links (link modules to consuming workspaces)
+New column: registry_modules.vcs_last_pr_shas (PR dedup tracking)
+New column: runs.module_overrides (module override storage paths per run)
+
+Revision ID: 1b7bc2b4e011
+Revises: 68bb56b372a1
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+revision = "1b7bc2b4e011"
+down_revision = "68bb56b372a1"
+
+
+def upgrade() -> None:
+    # New junction table: link modules to consuming workspaces
+    op.create_table(
+        "module_workspace_links",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "module_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("registry_modules.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "workspace_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("created_by", sa.Text(), nullable=False),
+        sa.UniqueConstraint("module_id", "workspace_id", name="uq_module_workspace_links"),
+    )
+    op.create_index(
+        "ix_module_workspace_links_module_id",
+        "module_workspace_links",
+        ["module_id"],
+    )
+    op.create_index(
+        "ix_module_workspace_links_workspace_id",
+        "module_workspace_links",
+        ["workspace_id"],
+    )
+
+    # Track PR SHAs for dedup on module PR polling
+    op.add_column(
+        "registry_modules",
+        sa.Column("vcs_last_pr_shas", JSONB, nullable=True),
+    )
+
+    # Module overrides per run (maps module coords to override storage paths)
+    op.add_column(
+        "runs",
+        sa.Column("module_overrides", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "module_overrides")
+    op.drop_column("registry_modules", "vcs_last_pr_shas")
+    op.drop_index("ix_module_workspace_links_workspace_id", "module_workspace_links")
+    op.drop_index("ix_module_workspace_links_module_id", "module_workspace_links")
+    op.drop_table("module_workspace_links")

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -232,6 +232,99 @@ Each version exposes VCS metadata in the API response:
 
 ---
 
+## Module Impact Analysis
+
+When a PR is opened against a VCS-connected module, Terrapod can automatically generate **speculative (plan-only) runs** on linked workspaces to show the impact of the module change before it's merged. This is a novel feature with no equivalent in TFE/TFC.
+
+### How It Works
+
+1. An admin **links workspaces** to a module — these are workspaces that consume the module
+2. When a PR is opened or updated on the module's VCS repo, Terrapod's background poller detects it
+3. For each linked workspace, Terrapod creates a **plan-only run** that uses the PR branch code instead of the published module version
+4. The plan results are posted back to the PR as commit statuses and comments
+
+The key insight: the module download endpoint is intercepted at the registry level. When the runner executes `terraform init`, it transparently receives the PR branch tarball instead of the published version — no modification of Terraform code required.
+
+### Linking Workspaces
+
+Link workspaces to a module via the API or the web UI (on the module detail page):
+
+```zsh
+# Link a workspace
+curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws/workspace-links \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN" \
+  -H "Content-Type: application/vnd.api+json" \
+  -d '{
+    "data": {
+      "type": "workspace-links",
+      "attributes": {
+        "workspace_id": "<workspace-id>"
+      }
+    }
+  }'
+
+# List linked workspaces
+curl https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws/workspace-links \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN"
+
+# Remove a link
+curl -X DELETE https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws/workspace-links/<link-id> \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN"
+```
+
+Linking requires **admin** permission on the module.
+
+### Module Override Mechanism
+
+Each speculative run carries a `module_overrides` field — a JSON map of module coordinates to override storage paths:
+
+```json
+{
+  "default/vpc/aws": "module_overrides/abc123def/default/vpc/aws.tar.gz"
+}
+```
+
+When the runner downloads the module during `terraform init`, the download endpoint checks the run's overrides and serves the PR tarball instead of the published version. Override tarballs are keyed by commit SHA, so retries and multiple linked workspaces share the same tarball.
+
+### PR Polling and Deduplication
+
+- The module impact poller runs as a periodic task alongside the registry VCS poller (same interval)
+- For each VCS-connected module with workspace links, it lists open PRs targeting the default branch
+- New commits on a PR trigger new speculative runs; same SHA is skipped (deduplication via `vcs_last_pr_shas`)
+- When a PR is closed or merged, active speculative runs for that PR are cancelled
+
+### Automatic Runs on Version Publish
+
+When a new module version is published — either via manual upload or VCS tag auto-publish — Terrapod automatically queues **standard runs** (not plan-only) on all linked workspaces. This ensures consuming workspaces are updated when a new module version becomes available.
+
+### Run Sources
+
+| Source | Trigger | Run Type |
+|---|---|---|
+| `module-test` | PR opened/updated on module repo | Plan-only (speculative) |
+| `module-publish` | New module version published | Standard (plan + apply) |
+
+### VCS Status Reporting
+
+For `module-test` runs, Terrapod posts commit statuses and PR comments to the module's VCS repository:
+- **Pending** status when the run starts
+- **Success/failure** status when the run completes
+- PR comment with a link to the run detail page and plan summary
+
+### Requirements
+
+- Module must be VCS-connected (source = `vcs` with a configured VCS connection)
+- At least one workspace must be linked to the module
+- The VCS connection must have permissions to list PRs and download archives
+
+### Limitations
+
+- Only works with VCS-connected modules (manual-upload modules don't have a repo to poll)
+- PR polling uses the same interval as the workspace VCS poller (default 60 seconds)
+- Override mechanism works at the module level — if a workspace uses multiple modules from the same PR, each needs its own link
+
+---
+
 ## Private Provider Registry
 
 Publish, version, and share Terraform providers internally with GPG signing.

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -97,6 +97,25 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             description="Poll VCS providers for new module version tags",
         )
 
+        # Module impact analysis: speculative plans for module PRs
+        from terrapod.services.module_impact_service import (
+            handle_module_test_completed,
+            module_impact_poll_cycle,
+        )
+
+        register_periodic_task(
+            "module_impact_poll",
+            interval_seconds=settings.vcs.poll_interval_seconds,
+            handler=module_impact_poll_cycle,
+            description="Poll VCS-connected modules for open PRs and create speculative runs",
+        )
+
+        register_trigger_handler(
+            "module_test_completed",
+            handler=handle_module_test_completed,
+            description="Post VCS status when module-test run completes",
+        )
+
     # Notification delivery handler (always registered)
     from terrapod.services.notification_dispatcher import handle_notification_delivery
 

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -23,12 +23,17 @@ TFE V2 Management:
     DELETE /api/v2/organizations/default/registry-modules/private/default/{name}/{prov}/{ver}
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+import uuid as _uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_non_runner
+from terrapod.db.models import ModuleWorkspaceLink, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.registry_module_service import (
@@ -173,7 +178,15 @@ async def download_module_cli(
         if not has_registry_permission(perm, "read"):
             raise HTTPException(status_code=404, detail="Module version not found")
 
-    url = await get_module_download_url(db, storage, namespace, name, provider, version)
+    url = await get_module_download_url(
+        db,
+        storage,
+        namespace,
+        name,
+        provider,
+        version,
+        run_id=getattr(user, "run_id", None),
+    )
     if url is None:
         raise HTTPException(status_code=404, detail="Module version not found")
 
@@ -555,7 +568,7 @@ async def update_module_vcs_endpoint(
         from terrapod.db.models import VCSConnection
 
         try:
-            conn_id = _uuid.UUID(attrs.vcs_connection_id)
+            conn_id = _uuid.UUID(attrs.vcs_connection_id.removeprefix("vcs-"))
         except ValueError as exc:
             raise HTTPException(status_code=400, detail="Invalid vcs_connection_id") from exc
 
@@ -581,3 +594,167 @@ async def update_module_vcs_endpoint(
     )
 
     return JSONResponse(content={"data": _module_to_jsonapi(module)})
+
+
+# --- Module-Workspace Links (Impact Analysis) ---
+
+
+class CreateWorkspaceLinkRequest(BaseModel):
+    class Data(BaseModel):
+        class Attributes(BaseModel):
+            workspace_id: str
+
+        type: str = "workspace-links"
+        attributes: Attributes
+
+    data: Data
+
+
+def _link_to_jsonapi(link: ModuleWorkspaceLink) -> dict:
+    ws = link.workspace
+    return {
+        "id": str(link.id),
+        "type": "workspace-links",
+        "attributes": {
+            "workspace-id": str(link.workspace_id),
+            "workspace-name": ws.name if ws else "",
+            "created-at": link.created_at.isoformat() if link.created_at else None,
+            "created-by": link.created_by,
+        },
+    }
+
+
+@router.get(
+    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links"
+)
+async def list_workspace_links(
+    name: str,
+    provider: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """List workspaces linked to this module. Requires read."""
+    module = await get_module(db, "default", name, provider)
+    if module is None:
+        raise HTTPException(status_code=404, detail="Module not found")
+
+    perm = await resolve_registry_permission(
+        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+    )
+    if not has_registry_permission(perm, "read"):
+        raise HTTPException(status_code=404, detail="Module not found")
+
+    result = await db.execute(
+        select(ModuleWorkspaceLink)
+        .where(ModuleWorkspaceLink.module_id == module.id)
+        .options(selectinload(ModuleWorkspaceLink.workspace))
+    )
+    links = list(result.scalars().all())
+
+    return JSONResponse(content={"data": [_link_to_jsonapi(link) for link in links]})
+
+
+@router.post(
+    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links"
+)
+async def create_workspace_link(
+    name: str,
+    provider: str,
+    body: CreateWorkspaceLinkRequest,
+    user: AuthenticatedUser = Depends(require_non_runner),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Link a workspace to this module. Requires admin on module."""
+    module = await get_module(db, "default", name, provider)
+    if module is None:
+        raise HTTPException(status_code=404, detail="Module not found")
+
+    perm = await resolve_registry_permission(
+        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+    )
+    if not has_registry_permission(perm, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Requires admin permission on module",
+        )
+
+    ws_id_str = body.data.attributes.workspace_id.removeprefix("ws-")
+    try:
+        ws_uuid = _uuid.UUID(ws_id_str)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid workspace ID") from exc
+
+    ws = await db.get(Workspace, ws_uuid)
+    if ws is None:
+        raise HTTPException(status_code=400, detail="Workspace not found")
+
+    # Check for duplicate
+    existing = await db.execute(
+        select(ModuleWorkspaceLink).where(
+            ModuleWorkspaceLink.module_id == module.id,
+            ModuleWorkspaceLink.workspace_id == ws_uuid,
+        )
+    )
+    if existing.scalars().first() is not None:
+        raise HTTPException(status_code=409, detail="Workspace already linked")
+
+    link = ModuleWorkspaceLink(
+        module_id=module.id,
+        workspace_id=ws_uuid,
+        created_by=user.email,
+    )
+    db.add(link)
+    await db.flush()
+    await db.refresh(link, attribute_names=["workspace"])
+    await db.commit()
+
+    logger.info(
+        "Module-workspace link created",
+        module=name,
+        provider=provider,
+        workspace=ws.name,
+    )
+
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={"data": _link_to_jsonapi(link)},
+    )
+
+
+@router.delete(
+    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links/{link_id}"
+)
+async def delete_workspace_link(
+    name: str,
+    provider: str,
+    link_id: str = Path(...),
+    user: AuthenticatedUser = Depends(require_non_runner),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Remove a workspace link. Requires admin on module."""
+    module = await get_module(db, "default", name, provider)
+    if module is None:
+        raise HTTPException(status_code=404, detail="Module not found")
+
+    perm = await resolve_registry_permission(
+        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+    )
+    if not has_registry_permission(perm, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Requires admin permission on module",
+        )
+
+    try:
+        link_uuid = _uuid.UUID(link_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid link ID") from exc
+
+    link = await db.get(ModuleWorkspaceLink, link_uuid)
+    if link is None or link.module_id != module.id:
+        raise HTTPException(status_code=404, detail="Link not found")
+
+    await db.delete(link)
+    await db.commit()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -80,6 +80,7 @@ def _run_json(run: Run) -> dict:
                 "allow-empty-apply": run.allow_empty_apply,
                 "is-drift-detection": run.is_drift_detection,
                 "has-changes": run.has_changes,
+                "module-overrides": run.module_overrides,
                 "vcs-commit-sha": run.vcs_commit_sha,
                 "vcs-branch": run.vcs_branch,
                 "vcs-pull-request-number": run.vcs_pull_request_number,
@@ -492,10 +493,11 @@ async def retry_run(
         allow_empty_apply=run.allow_empty_apply,
     )
 
-    # Copy VCS metadata from the original run
+    # Copy VCS metadata and module overrides from the original run
     new_run.vcs_commit_sha = run.vcs_commit_sha
     new_run.vcs_branch = run.vcs_branch
     new_run.vcs_pull_request_number = run.vcs_pull_request_number
+    new_run.module_overrides = run.module_overrides
 
     new_run = await run_service.queue_run(db, new_run)
     await db.commit()

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -419,6 +419,7 @@ class RegistryModule(Base):
     vcs_branch: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     vcs_tag_pattern: Mapped[str] = mapped_column(String(255), nullable=False, default="v*")
     vcs_last_tag: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    vcs_last_pr_shas: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, nullable=False
@@ -428,6 +429,9 @@ class RegistryModule(Base):
     )
 
     versions: Mapped[list["RegistryModuleVersion"]] = relationship(
+        back_populates="module", cascade="all, delete-orphan"
+    )
+    workspace_links: Mapped[list["ModuleWorkspaceLink"]] = relationship(
         back_populates="module", cascade="all, delete-orphan"
     )
 
@@ -465,6 +469,44 @@ class RegistryModuleVersion(Base):
 
     __table_args__ = (
         sa.UniqueConstraint("module_id", "version", name="uq_registry_module_versions"),
+    )
+
+
+class ModuleWorkspaceLink(Base):
+    """Links a registry module to a consuming workspace.
+
+    When a PR is opened against the module's VCS repo, speculative plan-only
+    runs are automatically queued on linked workspaces. When a new module
+    version is published, standard runs are queued on linked workspaces.
+    """
+
+    __tablename__ = "module_workspace_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=generate_uuid7
+    )
+    module_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("registry_modules.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    created_by: Mapped[str] = mapped_column(Text, nullable=False)
+
+    module: Mapped["RegistryModule"] = relationship(back_populates="workspace_links")
+    workspace: Mapped["Workspace"] = relationship(lazy="joined")
+
+    __table_args__ = (
+        sa.UniqueConstraint("module_id", "workspace_id", name="uq_module_workspace_links"),
+        Index("ix_module_workspace_links_module_id", "module_id"),
+        Index("ix_module_workspace_links_workspace_id", "workspace_id"),
     )
 
 
@@ -946,6 +988,9 @@ class Run(Base):
     refresh_only: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     refresh: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     allow_empty_apply: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Module impact analysis overrides (maps module coords to override storage paths)
+    module_overrides: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
 
     # Drift detection
     is_drift_detection: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/services/terrapod/services/module_impact_service.py
+++ b/services/terrapod/services/module_impact_service.py
@@ -1,0 +1,511 @@
+"""Module impact analysis — speculative plans for module PRs and triggered runs on publish.
+
+Registered with the distributed scheduler as:
+- Periodic task: polls VCS-connected modules with workspace links for open PRs
+- Trigger handler: fires when a module-test run reaches a terminal state
+
+When a PR is opened against a module's VCS repo, override tarballs are uploaded to
+object storage and speculative plan-only runs are queued on all linked workspaces.
+The runner's terraform init transparently receives the PR branch tarball via the
+module download endpoint override mechanism.
+
+When a new module version is published (tag-based or manual upload), standard runs
+are queued on all linked workspaces to apply the updated module.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from terrapod.db.models import (
+    ModuleWorkspaceLink,
+    RegistryModule,
+    Run,
+    VCSConnection,
+    Workspace,
+)
+from terrapod.db.session import get_db_session
+from terrapod.logging_config import get_logger
+from terrapod.services import github_service, gitlab_service, run_service
+from terrapod.services.vcs_provider import PullRequest
+from terrapod.storage import get_storage
+from terrapod.storage.keys import module_override_key
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# VCS dispatch helpers (shared with registry_vcs_poller / vcs_poller)
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_parse_repo_url(provider: str):  # type: ignore[no-untyped-def]
+    if provider == "github":
+        return github_service.parse_repo_url
+    elif provider == "gitlab":
+        return gitlab_service.parse_repo_url
+    raise ValueError(f"Unsupported VCS provider: {provider}")
+
+
+async def _list_open_prs(
+    conn: VCSConnection, owner: str, repo: str, base_branch: str
+) -> list[PullRequest]:
+    if conn.provider == "gitlab":
+        return await gitlab_service.list_open_prs(conn, owner, repo, base_branch)
+    prs = await github_service.list_open_pull_requests(conn, owner, repo, base_branch)
+    return [
+        PullRequest(
+            number=pr["number"],
+            head_sha=pr["head_sha"],
+            head_ref=pr["head_ref"],
+            title=pr["title"],
+        )
+        for pr in prs
+    ]
+
+
+async def _download_archive(conn: VCSConnection, owner: str, repo: str, ref: str) -> bytes:
+    if conn.provider == "gitlab":
+        return await gitlab_service.download_archive(conn, owner, repo, ref)
+    return await github_service.download_repo_archive(conn, owner, repo, ref)
+
+
+async def _get_default_branch(conn: VCSConnection, owner: str, repo: str) -> str | None:
+    if conn.provider == "gitlab":
+        return await gitlab_service.get_default_branch(conn, owner, repo)
+    return await github_service.get_repo_default_branch(conn, owner, repo)
+
+
+# ---------------------------------------------------------------------------
+# Periodic task: poll module PRs for linked workspaces
+# ---------------------------------------------------------------------------
+
+
+async def module_impact_poll_cycle() -> None:
+    """Poll VCS-connected modules (with workspace links) for open PRs."""
+    async with get_db_session() as db:
+        storage = get_storage()
+
+        # Only poll modules that have at least one workspace link
+        result = await db.execute(
+            select(RegistryModule)
+            .where(
+                RegistryModule.source == "vcs",
+                RegistryModule.vcs_connection_id.isnot(None),
+                RegistryModule.vcs_repo_url != "",
+            )
+            .options(
+                selectinload(RegistryModule.workspace_links).selectinload(
+                    ModuleWorkspaceLink.workspace
+                ),
+            )
+        )
+        modules = [m for m in result.scalars().all() if m.workspace_links]
+
+        if not modules:
+            return
+
+        logger.info("Module impact poll starting", module_count=len(modules))
+
+        for module in modules:
+            try:
+                await _poll_module_prs(db, storage, module)
+            except Exception:
+                logger.warning(
+                    "Module impact poll failed for module",
+                    module_id=str(module.id),
+                    module_name=module.name,
+                    exc_info=True,
+                )
+
+        await db.commit()
+        logger.info("Module impact poll complete")
+
+
+async def _poll_module_prs(
+    db: AsyncSession,
+    storage,  # type: ignore[no-untyped-def]
+    module: RegistryModule,
+) -> None:
+    """Poll a single module's VCS repo for open PRs and create speculative runs."""
+    conn = await db.get(VCSConnection, module.vcs_connection_id)
+    if conn is None or conn.status != "active":
+        return
+
+    parse_fn = _dispatch_parse_repo_url(conn.provider)
+    parsed = parse_fn(module.vcs_repo_url)
+    if parsed is None:
+        logger.warning("Cannot parse module repo URL", url=module.vcs_repo_url)
+        return
+
+    owner, repo = parsed
+
+    # Determine base branch (module's configured branch or repo default)
+    base_branch = module.vcs_branch
+    if not base_branch:
+        base_branch = await _get_default_branch(conn, owner, repo) or "main"
+
+    prs = await _list_open_prs(conn, owner, repo, base_branch)
+
+    # Load existing PR SHA tracking
+    pr_shas: dict[str, str] = dict(module.vcs_last_pr_shas or {})
+    open_pr_numbers = {str(pr.number) for pr in prs}
+
+    # Cancel runs for PRs that are no longer open (closed/merged)
+    for pr_num_str in list(pr_shas.keys()):
+        if pr_num_str not in open_pr_numbers:
+            await _cancel_stale_module_runs(db, module, int(pr_num_str))
+            del pr_shas[pr_num_str]
+
+    for pr in prs:
+        pr_num_str = str(pr.number)
+        prev_sha = pr_shas.get(pr_num_str)
+
+        if prev_sha == pr.head_sha:
+            continue  # No new commits on this PR
+
+        # New or updated PR — create speculative runs
+        try:
+            await _create_module_test_runs(db, storage, module, conn, owner, repo, pr)
+            pr_shas[pr_num_str] = pr.head_sha
+        except Exception:
+            logger.warning(
+                "Failed to create module test runs",
+                module_name=module.name,
+                pr_number=pr.number,
+                exc_info=True,
+            )
+
+    module.vcs_last_pr_shas = pr_shas
+    await db.flush()
+
+
+async def _cancel_stale_module_runs(
+    db: AsyncSession,
+    module: RegistryModule,
+    pr_number: int,
+) -> None:
+    """Cancel active module-test runs for a closed/merged PR."""
+    for link in module.workspace_links:
+        result = await db.execute(
+            select(Run).where(
+                Run.workspace_id == link.workspace_id,
+                Run.source == "module-test",
+                Run.vcs_pull_request_number == pr_number,
+                Run.status.notin_(run_service.TERMINAL_STATES),
+            )
+        )
+        for stale_run in result.scalars().all():
+            try:
+                await run_service.cancel_run(db, stale_run)
+                logger.info(
+                    "Canceled stale module-test run",
+                    run_id=str(stale_run.id),
+                    pr_number=pr_number,
+                    module=module.name,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to cancel stale module-test run",
+                    run_id=str(stale_run.id),
+                    error=str(e),
+                )
+
+
+async def _create_module_test_runs(
+    db: AsyncSession,
+    storage,  # type: ignore[no-untyped-def]
+    module: RegistryModule,
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    pr: PullRequest,
+) -> None:
+    """Download PR archive, upload override tarball, and create speculative runs."""
+    # Download archive from PR head
+    try:
+        archive_bytes = await _download_archive(conn, owner, repo, pr.head_sha)
+    except Exception:
+        logger.warning(
+            "Failed to download archive for module PR",
+            module=module.name,
+            pr_number=pr.number,
+            exc_info=True,
+        )
+        return
+
+    # Upload override tarball (keyed by commit SHA for reuse across workspaces/retries)
+    override_key = module_override_key(pr.head_sha, module.namespace, module.name, module.provider)
+    await storage.put(override_key, archive_bytes, "application/gzip")
+
+    # Build overrides dict for this module
+    module_coord = f"{module.namespace}/{module.name}/{module.provider}"
+    overrides = {module_coord: override_key}
+
+    # Cancel existing non-terminal module-test runs for this PR (superseded)
+    for link in module.workspace_links:
+        result = await db.execute(
+            select(Run).where(
+                Run.workspace_id == link.workspace_id,
+                Run.source == "module-test",
+                Run.vcs_pull_request_number == pr.number,
+                Run.status.notin_(run_service.TERMINAL_STATES),
+            )
+        )
+        for stale_run in result.scalars().all():
+            try:
+                await run_service.cancel_run(db, stale_run)
+            except Exception:
+                pass
+
+    # Create speculative plan-only runs on each linked workspace
+    for link in module.workspace_links:
+        ws = link.workspace
+        if ws is None:
+            continue
+
+        run = await run_service.create_run(
+            db,
+            workspace=ws,
+            message=f"Module impact: PR #{pr.number} on {module.name}/{module.provider} — {pr.title}",
+            source="module-test",
+            plan_only=True,
+            created_by="module-impact-analysis",
+        )
+        run.module_overrides = overrides
+        run.vcs_commit_sha = pr.head_sha
+        run.vcs_branch = pr.head_ref
+        run.vcs_pull_request_number = pr.number
+        await db.flush()
+
+        run = await run_service.queue_run(db, run)
+
+        logger.info(
+            "Module-test run created",
+            run_id=str(run.id),
+            module=f"{module.name}/{module.provider}",
+            workspace=ws.name,
+            pr_number=pr.number,
+            head_sha=pr.head_sha[:8],
+        )
+
+        # Enqueue VCS commit status for the module repo
+        await _enqueue_module_vcs_status(run, module, "pending")
+
+
+# ---------------------------------------------------------------------------
+# Triggered runs on module version publish
+# ---------------------------------------------------------------------------
+
+
+async def trigger_linked_workspace_runs(
+    db: AsyncSession,
+    module: RegistryModule,
+    version: str,
+    commit_sha: str = "",
+) -> list[Run]:
+    """Queue standard runs on all linked workspaces when a module version is published.
+
+    Called from registry_module_service (manual upload) and registry_vcs_poller
+    (tag-based auto-publish).
+    """
+    result = await db.execute(
+        select(ModuleWorkspaceLink)
+        .where(ModuleWorkspaceLink.module_id == module.id)
+        .options(selectinload(ModuleWorkspaceLink.workspace))
+    )
+    links = list(result.scalars().all())
+
+    if not links:
+        return []
+
+    runs: list[Run] = []
+    for link in links:
+        ws = link.workspace
+        if ws is None:
+            continue
+
+        run = await run_service.create_run(
+            db,
+            workspace=ws,
+            message=f"Module {module.name}/{module.provider} v{version} published",
+            source="module-publish",
+            plan_only=False,
+            created_by="module-impact-analysis",
+        )
+        if commit_sha:
+            run.vcs_commit_sha = commit_sha
+        await db.flush()
+
+        run = await run_service.queue_run(db, run)
+        runs.append(run)
+
+        logger.info(
+            "Module publish run created",
+            run_id=str(run.id),
+            module=f"{module.name}/{module.provider}",
+            version=version,
+            workspace=ws.name,
+        )
+
+    return runs
+
+
+# ---------------------------------------------------------------------------
+# Trigger handler: module-test run completed
+# ---------------------------------------------------------------------------
+
+
+async def handle_module_test_completed(payload: dict) -> None:
+    """Post VCS commit status to the module's repo when a module-test run finishes."""
+    run_id_str = payload.get("run_id", "")
+    target_status = payload.get("target_status", "")
+
+    if not run_id_str or not target_status:
+        return
+
+    async with get_db_session() as db:
+        run = await db.get(Run, uuid.UUID(run_id_str))
+        if run is None or run.source not in ("module-test",):
+            return
+
+        if not run.module_overrides or not run.vcs_commit_sha:
+            return
+
+        # Find the module from the override keys
+        module = await _resolve_module_from_overrides(db, run.module_overrides)
+        if module is None:
+            return
+
+        await _post_module_vcs_status(db, run, module, target_status)
+
+
+async def _resolve_module_from_overrides(
+    db: AsyncSession,
+    overrides: dict,
+) -> RegistryModule | None:
+    """Resolve the RegistryModule from a module_overrides dict."""
+    for coord in overrides:
+        parts = coord.split("/")
+        if len(parts) == 3:
+            namespace, name, provider = parts
+            result = await db.execute(
+                select(RegistryModule).where(
+                    RegistryModule.namespace == namespace,
+                    RegistryModule.name == name,
+                    RegistryModule.provider == provider,
+                )
+            )
+            module = result.scalars().first()
+            if module:
+                return module
+    return None
+
+
+async def _enqueue_module_vcs_status(
+    run: Run,
+    module: RegistryModule,
+    target_status: str,
+) -> None:
+    """Enqueue a VCS commit status trigger for a module-test run."""
+    from terrapod.services.scheduler import enqueue_trigger
+
+    try:
+        await enqueue_trigger(
+            "module_test_completed",
+            {
+                "run_id": str(run.id),
+                "target_status": target_status,
+            },
+            dedup_key=f"modtest:{run.id}:{target_status}",
+            dedup_ttl=60,
+        )
+    except Exception as e:
+        logger.warning("Failed to enqueue module test status", error=str(e))
+
+
+async def _post_module_vcs_status(
+    db: AsyncSession,
+    run: Run,
+    module: RegistryModule,
+    target_status: str,
+) -> None:
+    """Post commit status and PR comment to the module's VCS repo."""
+    from terrapod.config import settings
+    from terrapod.services.vcs_status_dispatcher import (
+        _build_comment_body,
+        _find_or_create_comment,
+        _resolve_status,
+    )
+
+    if not module.vcs_connection_id:
+        return
+
+    conn = await db.get(VCSConnection, module.vcs_connection_id)
+    if conn is None or conn.status != "active":
+        return
+
+    parse_fn = _dispatch_parse_repo_url(conn.provider)
+    parsed = parse_fn(module.vcs_repo_url)
+    if parsed is None:
+        return
+
+    owner, repo = parsed
+
+    # Resolve workspace name for the comment
+    ws = await db.get(Workspace, run.workspace_id)
+    ws_name = ws.name if ws else str(run.workspace_id)
+
+    # Build target URL
+    target_url = ""
+    if settings.external_url:
+        target_url = (
+            f"{settings.external_url.rstrip('/')}/workspaces/{run.workspace_id}/runs/{run.id}"
+        )
+
+    # Post commit status
+    github_state, gitlab_state, description = _resolve_status(target_status, run.plan_only)
+    context = f"terrapod/{ws_name}"
+
+    try:
+        if conn.provider == "gitlab":
+            await gitlab_service.create_commit_status(
+                conn,
+                owner,
+                repo,
+                run.vcs_commit_sha,
+                state=gitlab_state,
+                description=description,
+                target_url=target_url,
+            )
+        else:
+            await github_service.create_commit_status(
+                conn,
+                owner,
+                repo,
+                run.vcs_commit_sha,
+                state=github_state,
+                description=description,
+                target_url=target_url,
+                context=context,
+            )
+    except Exception as e:
+        logger.warning("Failed to post module VCS commit status", error=str(e))
+
+    # Post PR comment
+    if run.vcs_pull_request_number:
+        run_url = target_url or f"run-{run.id}"
+        body = _build_comment_body(
+            workspace_name=ws_name,
+            workspace_id=str(run.workspace_id),
+            run_id=f"run-{run.id}",
+            run_status=target_status,
+            plan_only=run.plan_only,
+            has_changes=run.has_changes,
+            run_url=run_url,
+        )
+        await _find_or_create_comment(
+            conn, owner, repo, run.vcs_pull_request_number, str(run.workspace_id), body
+        )

--- a/services/terrapod/services/registry_module_service.py
+++ b/services/terrapod/services/registry_module_service.py
@@ -161,6 +161,15 @@ async def upload_module_tarball(
     if module is None:
         raise ValueError(f"Module {namespace}/{name}/{provider} not found")
 
+    is_new = (
+        await db.execute(
+            select(RegistryModuleVersion).where(
+                RegistryModuleVersion.module_id == module.id,
+                RegistryModuleVersion.version == version,
+            )
+        )
+    ).scalars().first() is None
+
     mod_version = await upsert_module_version(db, module.id, version)
 
     key = module_tarball_key(namespace, name, provider, version)
@@ -169,6 +178,20 @@ async def upload_module_tarball(
     mod_version.upload_status = "uploaded"
     module.status = "setup_complete"
     await db.flush()
+
+    # Trigger runs on linked workspaces for new versions
+    if is_new:
+        try:
+            from terrapod.services.module_impact_service import trigger_linked_workspace_runs
+
+            await trigger_linked_workspace_runs(db, module, version)
+        except Exception:
+            logger.warning(
+                "Failed to trigger linked workspace runs on upload",
+                module=name,
+                version=version,
+                exc_info=True,
+            )
 
     return mod_version
 
@@ -228,8 +251,29 @@ async def get_module_download_url(
     name: str,
     provider: str,
     version: str,
+    run_id: str | None = None,
 ) -> str | None:
-    """Get a presigned download URL for a module version tarball."""
+    """Get a presigned download URL for a module version tarball.
+
+    If run_id is provided and the run has module_overrides for this module,
+    the override tarball is returned instead of the published version.
+    """
+    # Check for module override first (module impact analysis)
+    if run_id:
+        from terrapod.db.models import Run
+
+        try:
+            run = await db.get(Run, uuid.UUID(run_id))
+        except (ValueError, AttributeError):
+            run = None
+        if run and run.module_overrides:
+            coord = f"{namespace}/{name}/{provider}"
+            override_path = run.module_overrides.get(coord)
+            if override_path:
+                presigned = await storage.presigned_get_url(override_path)
+                return presigned.url
+
+    # Normal path: look up published version
     module = await get_module(db, namespace, name, provider)
     if module is None:
         return None

--- a/services/terrapod/services/registry_vcs_poller.py
+++ b/services/terrapod/services/registry_vcs_poller.py
@@ -146,6 +146,7 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
 
     changed_count = 0
     latest_tag = module.vcs_last_tag
+    new_versions: list[tuple[str, str]] = []  # (version_str, commit_sha) for triggering
 
     for tag in tags:
         tag_name = tag["name"]
@@ -206,6 +207,7 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
             )
             db.add(mod_version)
             existing_versions[version_str] = mod_version
+            new_versions.append((version_str, tag_sha))
             logger.info(
                 "Module version created from VCS tag",
                 module_name=module.name,
@@ -223,6 +225,22 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
         if latest_tag:
             module.vcs_last_tag = latest_tag
         await db.flush()
+
+        # Trigger runs on linked workspaces for newly published versions
+        for ver_str, ver_sha in new_versions:
+            try:
+                from terrapod.services.module_impact_service import (
+                    trigger_linked_workspace_runs,
+                )
+
+                await trigger_linked_workspace_runs(db, module, ver_str, commit_sha=ver_sha)
+            except Exception:
+                logger.warning(
+                    "Failed to trigger linked workspace runs",
+                    module=module.name,
+                    version=ver_str,
+                    exc_info=True,
+                )
 
         logger.info(
             "Module VCS poll complete",

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -94,6 +94,24 @@ async def _enqueue_vcs_status(run: Run, target_status: str) -> None:
         logger.warning("Failed to enqueue VCS status", error=str(e))
 
 
+async def _enqueue_module_test_status(run: Run, target_status: str) -> None:
+    """Enqueue a module_test_completed trigger for VCS status posting."""
+    from terrapod.services.scheduler import enqueue_trigger
+
+    try:
+        await enqueue_trigger(
+            "module_test_completed",
+            {
+                "run_id": str(run.id),
+                "target_status": target_status,
+            },
+            dedup_key=f"modtest:{run.id}:{target_status}",
+            dedup_ttl=60,
+        )
+    except Exception as e:
+        logger.warning("Failed to enqueue module test status", error=str(e))
+
+
 async def _enqueue_drift_completed(run: Run) -> None:
     """Enqueue a drift_run_completed trigger when a drift run finishes."""
     from terrapod.services.scheduler import enqueue_trigger
@@ -295,6 +313,10 @@ async def transition_run(
     # Enqueue VCS commit status for VCS-sourced runs
     if run.vcs_commit_sha:
         await _enqueue_vcs_status(run, target_status)
+
+    # Enqueue module test status when a module-test run reaches a meaningful state
+    if run.source == "module-test" and run.module_overrides:
+        await _enqueue_module_test_status(run, target_status)
 
     # Enqueue drift status update when a drift detection run reaches a terminal state.
     # Plan-only drift runs end in "planned" (not in TERMINAL_STATES), so check that too.

--- a/services/terrapod/storage/keys.py
+++ b/services/terrapod/storage/keys.py
@@ -108,3 +108,11 @@ def platform_provider_shasums_key(version: str) -> str:
 def platform_provider_shasums_sig_key(version: str) -> str:
     """Key for a cached Terrapod platform provider SHA256SUMS.sig."""
     return f"cache/provider/terrapod/{version}/terraform-provider-terrapod_{version}_SHA256SUMS.sig"
+
+
+# --- Module Override (Impact Analysis) ---
+
+
+def module_override_key(commit_sha: str, namespace: str, name: str, provider: str) -> str:
+    """Key for a module override tarball (keyed by commit SHA for reuse across runs)."""
+    return f"module_overrides/{commit_sha}/{namespace}/{name}/{provider}.tar.gz"

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -290,6 +290,7 @@ class TestRunDriftAttributes:
         run.allow_empty_apply = False
         run.resource_cpu = "1"
         run.resource_memory = "2Gi"
+        run.module_overrides = None
 
         ws = _mock_workspace(ws_id=ws_id)
 

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -1,0 +1,359 @@
+"""Tests for module impact analysis: workspace links, download override, retry."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.session import get_db
+from terrapod.storage import get_storage
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+def _admin_user(email="admin@example.com"):
+    return AuthenticatedUser(
+        email=email,
+        display_name="Admin",
+        roles=["admin"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _runner_user(run_id: str):
+    return AuthenticatedUser(
+        email="runner",
+        display_name="runner",
+        roles=["everyone"],
+        provider_name="runner_token",
+        auth_method="runner_token",
+        run_id=run_id,
+    )
+
+
+def _mock_module(module_id=None, name="eks", provider="aws", namespace="default"):
+    m = MagicMock()
+    m.id = module_id or uuid.uuid4()
+    m.name = name
+    m.provider = provider
+    m.namespace = namespace
+    m.status = "setup_complete"
+    m.labels = {}
+    m.owner_email = "admin@example.com"
+    m.source = "vcs"
+    m.vcs_connection_id = uuid.uuid4()
+    m.vcs_repo_url = "https://github.com/org/terraform-module-eks"
+    m.vcs_branch = ""
+    m.vcs_tag_pattern = "v*"
+    m.vcs_last_tag = ""
+    m.vcs_last_pr_shas = None
+    m.versions = []
+    m.workspace_links = []
+    m.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    m.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return m
+
+
+def _mock_workspace(ws_id=None, name="test-ws"):
+    ws = MagicMock()
+    ws.id = ws_id or uuid.uuid4()
+    ws.name = name
+    return ws
+
+
+def _mock_link(link_id=None, module_id=None, ws_id=None, ws_name="test-ws"):
+    link = MagicMock()
+    link.id = link_id or uuid.uuid4()
+    link.module_id = module_id or uuid.uuid4()
+    link.workspace_id = ws_id or uuid.uuid4()
+    link.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    link.created_by = "admin@example.com"
+    ws = MagicMock()
+    ws.name = ws_name
+    link.workspace = ws
+    return link
+
+
+def _mock_run(
+    run_id=None,
+    status="pending",
+    source="tfe-api",
+    module_overrides=None,
+    ws_id=None,
+):
+    run = MagicMock()
+    run.id = run_id or uuid.uuid4()
+    run.workspace_id = ws_id or uuid.uuid4()
+    run.status = status
+    run.source = source
+    run.module_overrides = module_overrides
+    run.message = ""
+    run.is_destroy = False
+    run.auto_apply = False
+    run.plan_only = False
+    run.execution_backend = "tofu"
+    run.terraform_version = "1.9.0"
+    run.error_message = ""
+    run.is_drift_detection = False
+    run.has_changes = None
+    run.vcs_commit_sha = ""
+    run.vcs_branch = ""
+    run.vcs_pull_request_number = None
+    run.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    run.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    run.plan_started_at = None
+    run.plan_finished_at = None
+    run.apply_started_at = None
+    run.apply_finished_at = None
+    run.listener_id = None
+    run.target_addrs = None
+    run.replace_addrs = None
+    run.refresh_only = False
+    run.refresh = True
+    run.allow_empty_apply = False
+    run.resource_cpu = "1"
+    run.resource_memory = "2Gi"
+    run.configuration_version_id = None
+    return run
+
+
+def _make_app(user, mock_db=None, mock_storage=None):
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    if mock_storage is not None:
+        app.dependency_overrides[get_storage] = lambda: mock_storage
+    return app, mock_db
+
+
+# ── Run JSON includes module-overrides ──────────────────────────────
+
+
+class TestRunJsonModuleOverrides:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    async def test_run_json_includes_module_overrides(self, mock_resolve, mock_get_run, *mocks):
+        overrides = {"default/eks/aws": "module_overrides/abc123/default/eks/aws.tar.gz"}
+        run = _mock_run(module_overrides=overrides, source="module-test")
+        mock_get_run.return_value = run
+        mock_resolve.return_value = "read"
+
+        app, _ = _make_app(_admin_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        assert resp.status_code == 200
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["module-overrides"] == overrides
+        assert attrs["source"] == "module-test"
+
+
+# ── Module download override ────────────────────────────────────────
+
+
+class TestModuleDownloadOverride:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.registry_module_service.get_module")
+    async def test_download_with_override_returns_override_url(self, mock_get_module, *mocks):
+        """When run has overrides for this module, serve the override tarball."""
+        run_id = uuid.uuid4()
+        overrides = {"default/eks/aws": "module_overrides/abc123/default/eks/aws.tar.gz"}
+        run = _mock_run(run_id=run_id, module_overrides=overrides)
+
+        mock_storage = AsyncMock()
+        presigned = MagicMock()
+        presigned.url = "https://storage.example.com/override-tarball"
+        mock_storage.presigned_get_url.return_value = presigned
+
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+
+        from terrapod.services.registry_module_service import get_module_download_url
+
+        url = await get_module_download_url(
+            mock_db,
+            mock_storage,
+            "default",
+            "eks",
+            "aws",
+            "1.0.0",
+            run_id=str(run_id),
+        )
+
+        assert url == "https://storage.example.com/override-tarball"
+        mock_storage.presigned_get_url.assert_called_once_with(overrides["default/eks/aws"])
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.registry_module_service.get_module")
+    async def test_download_without_override_returns_normal_url(self, mock_get_module, *mocks):
+        """When run has no overrides for this module, serve the published version."""
+        run_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, module_overrides=None)
+
+        mock_module = _mock_module()
+        mock_get_module.return_value = mock_module
+
+        mock_version = MagicMock()
+        mock_version.version = "1.0.0"
+
+        mock_storage = AsyncMock()
+        presigned = MagicMock()
+        presigned.url = "https://storage.example.com/normal-tarball"
+        mock_storage.presigned_get_url.return_value = presigned
+
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+
+        # Mock the version lookup
+        version_result = MagicMock()
+        version_result.scalars.return_value.first.return_value = mock_version
+        mock_db.execute.return_value = version_result
+
+        from terrapod.services.registry_module_service import get_module_download_url
+
+        url = await get_module_download_url(
+            mock_db,
+            mock_storage,
+            "default",
+            "eks",
+            "aws",
+            "1.0.0",
+            run_id=str(run_id),
+        )
+
+        assert url == "https://storage.example.com/normal-tarball"
+
+
+# ── Retry copies module_overrides ───────────────────────────────────
+
+
+class TestRetryRunCopiesOverrides:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.queue_run")
+    @patch("terrapod.api.routers.runs.run_service.create_run")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    async def test_retry_copies_module_overrides(
+        self, mock_resolve, mock_get_run, mock_create_run, mock_queue, *mocks
+    ):
+        overrides = {"default/eks/aws": "module_overrides/abc123/default/eks/aws.tar.gz"}
+        original = _mock_run(
+            status="errored",
+            source="module-test",
+            module_overrides=overrides,
+        )
+        mock_get_run.return_value = original
+        mock_resolve.return_value = "plan"
+
+        new_run = _mock_run()
+        mock_create_run.return_value = new_run
+        mock_queue.return_value = new_run
+
+        mock_db = AsyncMock()
+        mock_db.get.return_value = _mock_workspace()
+
+        app, _ = _make_app(_admin_user(), mock_db=mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.post(
+                f"/api/v2/runs/run-{original.id}/actions/retry",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 201
+        # Verify module_overrides was copied
+        assert new_run.module_overrides == overrides
+
+
+# ── Workspace Link CRUD ─────────────────────────────────────────────
+
+
+class TestWorkspaceLinkCRUD:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission")
+    @patch("terrapod.api.routers.registry_modules.get_module")
+    async def test_list_workspace_links(self, mock_get_module, mock_resolve, *mocks):
+        module = _mock_module()
+        mock_get_module.return_value = module
+        mock_resolve.return_value = "read"
+
+        link = _mock_link(module_id=module.id)
+
+        mock_db = AsyncMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [link]
+        mock_db.execute.return_value = result
+
+        app, _ = _make_app(_admin_user(), mock_db=mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.get(
+                "/api/v2/organizations/default/registry-modules/private/default/eks/aws/workspace-links",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert len(data) == 1
+        assert data[0]["attributes"]["workspace-name"] == "test-ws"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission")
+    @patch("terrapod.api.routers.registry_modules.get_module")
+    async def test_create_workspace_link_requires_admin(
+        self, mock_get_module, mock_resolve, *mocks
+    ):
+        module = _mock_module()
+        mock_get_module.return_value = module
+        mock_resolve.return_value = "write"  # Not admin
+
+        app, _ = _make_app(_admin_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.post(
+                "/api/v2/organizations/default/registry-modules/private/default/eks/aws/workspace-links",
+                headers={**_AUTH, "Content-Type": "application/vnd.api+json"},
+                json={
+                    "data": {
+                        "type": "workspace-links",
+                        "attributes": {"workspace_id": str(uuid.uuid4())},
+                    }
+                },
+            )
+
+        assert resp.status_code == 403
+
+
+# ── Storage Key ─────────────────────────────────────────────────────
+
+
+class TestModuleOverrideKey:
+    def test_key_format(self):
+        from terrapod.storage.keys import module_override_key
+
+        key = module_override_key("abc123", "default", "eks", "aws")
+        assert key == "module_overrides/abc123/default/eks/aws.tar.gz"
+
+    def test_different_shas_produce_different_keys(self):
+        from terrapod.storage.keys import module_override_key
+
+        key1 = module_override_key("sha1", "default", "eks", "aws")
+        key2 = module_override_key("sha2", "default", "eks", "aws")
+        assert key1 != key2

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -63,6 +63,8 @@ def _mock_run(
     run.allow_empty_apply = False
     run.resource_cpu = "1"
     run.resource_memory = "2Gi"
+    run.configuration_version_id = None
+    run.module_overrides = None
     return run
 
 

--- a/web/src/app/registry/modules/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[name]/[provider]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { Upload, FolderOpen, GitBranch } from 'lucide-react'
+import { Upload, FolderOpen, GitBranch, Link2, Plus, Trash2, Search } from 'lucide-react'
 import * as Dialog from '@radix-ui/react-dialog'
 import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
@@ -177,9 +177,27 @@ export default function ModuleDetailPage() {
   // Label lockout warning
   const [lockoutWarning, setLockoutWarning] = useState('')
 
+  // Workspace links (impact analysis)
+  interface WorkspaceLink {
+    id: string
+    attributes: {
+      'workspace-id': string
+      'workspace-name': string
+      'created-at': string | null
+      'created-by': string
+    }
+  }
+  const [workspaceLinks, setWorkspaceLinks] = useState<WorkspaceLink[]>([])
+  const [linksLoading, setLinksLoading] = useState(false)
+  const [showLinkPicker, setShowLinkPicker] = useState(false)
+  const [wsSearchQuery, setWsSearchQuery] = useState('')
+  const [wsSearchResults, setWsSearchResults] = useState<{ id: string; name: string }[]>([])
+  const [linkingWs, setLinkingWs] = useState('')
+
   useEffect(() => {
     if (!getAuthState()) { router.push('/login'); return }
     loadModule()
+    loadWorkspaceLinks()
   }, [router, name, provider])
 
   usePollingInterval(!loading, 60_000, loadModule)
@@ -218,6 +236,89 @@ export default function ModuleDetailPage() {
       }
     } catch {
       // VCS connections are optional — ignore errors
+    }
+  }
+
+  async function loadWorkspaceLinks() {
+    setLinksLoading(true)
+    try {
+      const res = await apiFetch(
+        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/workspace-links`
+      )
+      if (res.ok) {
+        const data = await res.json()
+        setWorkspaceLinks(data.data || [])
+      }
+    } catch {
+      // Non-critical
+    } finally {
+      setLinksLoading(false)
+    }
+  }
+
+  async function searchWorkspaces(query: string) {
+    try {
+      const res = await apiFetch('/api/v2/organizations/default/workspaces')
+      if (res.ok) {
+        const data = await res.json()
+        const all = (data.data || []).map((ws: { id: string; attributes: { name: string } }) => ({
+          id: ws.id,
+          name: ws.attributes.name,
+        }))
+        const linked = new Set(workspaceLinks.map(l => l.attributes['workspace-id']))
+        const filtered = all.filter(
+          (ws: { id: string; name: string }) =>
+            !linked.has(ws.id) &&
+            (!query || ws.name.toLowerCase().includes(query.toLowerCase()))
+        )
+        setWsSearchResults(filtered.slice(0, 20))
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  async function handleLinkWorkspace(wsId: string) {
+    setLinkingWs(wsId)
+    setError('')
+    try {
+      const res = await apiFetch(
+        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/workspace-links`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/vnd.api+json' },
+          body: JSON.stringify({
+            data: { type: 'workspace-links', attributes: { workspace_id: wsId } },
+          }),
+        }
+      )
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.detail || `Link failed (${res.status})`)
+      }
+      setShowLinkPicker(false)
+      setWsSearchQuery('')
+      await loadWorkspaceLinks()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to link workspace')
+    } finally {
+      setLinkingWs('')
+    }
+  }
+
+  async function handleUnlinkWorkspace(linkId: string) {
+    setError('')
+    try {
+      const res = await apiFetch(
+        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/workspace-links/${linkId}`,
+        { method: 'DELETE' }
+      )
+      if (!res.ok && res.status !== 204) {
+        throw new Error(`Unlink failed (${res.status})`)
+      }
+      await loadWorkspaceLinks()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to unlink workspace')
     }
   }
 
@@ -597,6 +698,83 @@ export default function ModuleDetailPage() {
                     <span className="text-slate-400 ml-2">Last tag: {module.attributes['vcs-last-tag']}</span>
                   )}
                 </div>
+              </div>
+            )}
+
+            {/* Linked Workspaces (Impact Analysis) */}
+            {modPerms['can-update'] && (
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-5 mb-6">
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-2">
+                    <Link2 size={16} className="text-purple-400" />
+                    <h3 className="text-sm font-medium text-slate-300">Linked Workspaces</h3>
+                  </div>
+                  <button
+                    onClick={() => { setShowLinkPicker(!showLinkPicker); if (!showLinkPicker) searchWorkspaces('') }}
+                    className="text-xs text-brand-400 hover:text-brand-300 flex items-center gap-1"
+                  >
+                    <Plus size={12} />
+                    Link Workspace
+                  </button>
+                </div>
+
+                <p className="text-xs text-slate-500 mb-3">
+                  Linked workspaces receive speculative plans when PRs are opened against this module, and standard runs when new versions are published.
+                </p>
+
+                {showLinkPicker && (
+                  <div className="mb-3 p-3 bg-slate-900/50 rounded-lg border border-slate-700/30">
+                    <div className="flex items-center gap-2 mb-2">
+                      <Search size={14} className="text-slate-400" />
+                      <input
+                        type="text"
+                        value={wsSearchQuery}
+                        onChange={(e) => { setWsSearchQuery(e.target.value); searchWorkspaces(e.target.value) }}
+                        placeholder="Search workspaces..."
+                        className="flex-1 px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                      />
+                    </div>
+                    <div className="max-h-40 overflow-y-auto space-y-1">
+                      {wsSearchResults.length === 0 ? (
+                        <p className="text-xs text-slate-500 py-2 text-center">No workspaces found</p>
+                      ) : wsSearchResults.map(ws => (
+                        <button
+                          key={ws.id}
+                          onClick={() => handleLinkWorkspace(ws.id)}
+                          disabled={linkingWs === ws.id}
+                          className="w-full text-left px-2 py-1.5 rounded text-sm text-slate-300 hover:bg-slate-700/50 transition-colors disabled:opacity-50"
+                        >
+                          {ws.name}
+                          {linkingWs === ws.id && <span className="text-xs text-slate-500 ml-2">Linking...</span>}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {workspaceLinks.length === 0 ? (
+                  <p className="text-xs text-slate-500 italic">No workspaces linked yet.</p>
+                ) : (
+                  <div className="space-y-1">
+                    {workspaceLinks.map(link => (
+                      <div key={link.id} className="flex items-center justify-between px-2 py-1.5 rounded hover:bg-slate-700/30">
+                        <a
+                          href={`/workspaces/${link.attributes['workspace-id']}`}
+                          className="text-sm text-brand-400 hover:text-brand-300"
+                        >
+                          {link.attributes['workspace-name']}
+                        </a>
+                        <button
+                          onClick={() => handleUnlinkWorkspace(link.id)}
+                          className="text-slate-500 hover:text-red-400 transition-colors"
+                          title="Unlink workspace"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             )}
 

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1715,7 +1715,13 @@ function WorkspaceDetailContent() {
                             <span className="text-xs text-slate-500">plan + apply</span>
                           )}
                         </td>
-                        <td className="px-4 py-3 text-xs text-slate-400 hidden sm:table-cell">{run.attributes.source}</td>
+                        <td className="px-4 py-3 text-xs text-slate-400 hidden sm:table-cell">
+                          {run.attributes.source === 'module-test' ? (
+                            <span className="text-purple-400">module test</span>
+                          ) : run.attributes.source === 'module-publish' ? (
+                            <span className="text-purple-400">module publish</span>
+                          ) : run.attributes.source}
+                        </td>
                         <td className="px-4 py-3 text-xs text-slate-500 hidden md:table-cell">
                           {run.attributes['created-at'] ? new Date(run.attributes['created-at']).toLocaleString() : ''}
                         </td>

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -36,6 +36,7 @@ interface RunAttrs {
   'vcs-commit-sha': string | null
   'vcs-branch': string | null
   'vcs-pull-request-number': number | null
+  'module-overrides': Record<string, string> | null
   'status-timestamps': Record<string, string>
   actions: RunActions
   permissions: Record<string, boolean>
@@ -365,6 +366,20 @@ export default function RunDetailPage() {
           <div className="mb-6 p-4 bg-cyan-900/20 rounded-lg border border-cyan-800/50">
             <p className="text-sm text-cyan-300">
               This is a <strong>plan-only</strong> remote run initiated from the CLI. Apply is not available for CLI-uploaded code &mdash; only VCS-managed code can be applied.
+            </p>
+          </div>
+        )}
+
+        {/* Module override banner for module-test runs */}
+        {attrs['module-overrides'] && (
+          <div className="mb-6 p-4 bg-purple-900/20 rounded-lg border border-purple-800/50">
+            <p className="text-sm text-purple-300">
+              This run uses <strong>module overrides</strong>
+              {attrs['vcs-pull-request-number'] && <> from PR #{attrs['vcs-pull-request-number']}</>}
+              {' '}&mdash; {Object.keys(attrs['module-overrides']).map(coord => (
+                <code key={coord} className="bg-purple-900/50 px-1.5 py-0.5 rounded text-xs font-mono">{coord}</code>
+              ))}
+              {' '}will be fetched from the PR branch instead of the published registry version.
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary

- **Module-workspace linking** — new `ModuleWorkspaceLink` model with CRUD endpoints lets admins link VCS-connected modules to consuming workspaces
- **Speculative plan-only runs on module PRs** — periodic poller detects open PRs against linked modules, downloads the PR archive, uploads an override tarball to object storage, and queues plan-only runs on all linked workspaces with SHA-based deduplication
- **Registry-level module override** — the download endpoint checks `run.module_overrides` and serves the PR tarball instead of the published version, so `terraform init` transparently picks up the PR code
- **VCS commit status + PR comments** — on run completion, commit status and a PR comment with plan results are posted to the module repo
- **Version publish triggers** — when a new module version is published (tag or manual), standard runs are queued on all linked workspaces
- **Frontend** — linked workspaces section on module detail page, purple override banner on run detail, `module-test` / `module-publish` source labels on workspace runs tab

## Test plan

- [x] `make lint` passes (0 errors)
- [x] `make test` passes (588 tests, 9 new)
- [x] Migration applies cleanly in Tilt
- [x] VCS connection → module → VCS connect → tag auto-publish v1.0.0 verified
- [x] Module-workspace link CRUD (create, list, delete) via API
- [x] PR on module repo triggers speculative plan-only runs on linked workspace
- [x] Run detail shows purple module override banner with PR info
- [x] Module detail page shows linked workspaces section
- [x] Retry run preserves `module_overrides`
- [x] PR dedup works (same SHA → no duplicate runs)
- [ ] Closing PR cancels active speculative runs (next poll cycle)
- [ ] Runner downloads override tarball during plan (requires active runner)