### PR TITLE
Set revisionHistoryLimit to 3 on all deployments

### DIFF
--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -10,6 +10,7 @@ spec:
   {{- if not .Values.api.autoscaling.enabled }}
   replicas: {{ .Values.api.replicas }}
   {{- end }}
+  revisionHistoryLimit: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/terrapod/templates/deployment-listener.yaml
+++ b/helm/terrapod/templates/deployment-listener.yaml
@@ -10,6 +10,7 @@ spec:
   {{- if not .Values.listener.autoscaling.enabled }}
   replicas: {{ .Values.listener.replicas }}
   {{- end }}
+  revisionHistoryLimit: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/terrapod/templates/deployment-web.yaml
+++ b/helm/terrapod/templates/deployment-web.yaml
@@ -10,6 +10,7 @@ spec:
   {{- if not .Values.web.autoscaling.enabled }}
   replicas: {{ .Values.web.replicas }}
   {{- end }}
+  revisionHistoryLimit: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Summary

- Add `revisionHistoryLimit: 3` to api, listener, and web Deployments
- Reduces old ReplicaSet accumulation from the K8s default of 10 to 3

## Test plan

- [ ] `helm template` renders correctly
- [ ] Existing old ReplicaSets beyond 3 are garbage-collected on next rollout