### PR TITLE
docs: clarify that VCS module versions require semver tags

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -149,6 +149,10 @@ Instead of uploading tarballs manually, you can connect a module to a VCS reposi
 3. Push semver tags (e.g. `v1.0.0`) to the repository
 4. Terrapod's background poller detects the tag, downloads the archive, and creates the module version
 
+> **Important:** Only git tags trigger version publishing. Commits pushed to branches — including the default branch — do **not** create module versions. You must push a tag matching the configured tag pattern (default `v*`) for a new version to appear in the registry. This matches the Terraform registry convention where module versions correspond to git tags, not branch HEADs.
+>
+> If you want every merge to `main` to produce a new version automatically, set up a CI pipeline on the module repository that creates a semver tag on each merge (see example below).
+
 ### Setup via API
 
 ```zsh
@@ -220,6 +224,47 @@ registry/modules/{namespace}/{name}/{provider}/{version}.tar.gz
 ### Manual Upload Still Works
 
 Even with VCS connected, you can still upload versions directly via the API or web UI. Manually-uploaded versions will have empty `vcs-commit-sha` and `vcs-tag` fields.
+
+### Auto-Tagging via CI
+
+Since only git tags produce module versions, you may want a CI pipeline that automatically creates a semver tag when code is merged to the default branch. Here is a minimal GitHub Actions example that bumps the patch version on every merge:
+
+```yaml
+# .github/workflows/tag.yml
+name: Auto-tag on merge
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get latest tag
+        id: latest
+        run: |
+          tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          echo "tag=${tag:-v0.0.0}" >> "$GITHUB_OUTPUT"
+      - name: Bump patch version
+        id: bump
+        run: |
+          ver="${{ steps.latest.outputs.tag }}"
+          ver="${ver#v}"
+          IFS='.' read -r major minor patch <<< "$ver"
+          echo "new_tag=v${major}.${minor}.$((patch + 1))" >> "$GITHUB_OUTPUT"
+      - name: Create tag
+        run: |
+          git tag "${{ steps.bump.outputs.new_tag }}"
+          git push origin "${{ steps.bump.outputs.new_tag }}"
+```
+
+With this in place, every merge to `main` creates a new patch version tag (e.g. `v0.0.1` → `v0.0.2`), which Terrapod's poller picks up and publishes as a new module version within 60 seconds.
 
 ### Version Metadata
 

--- a/web/src/app/registry/modules/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[name]/[provider]/page.tsx
@@ -611,7 +611,7 @@ export default function ModuleDetailPage() {
             {showVcs && (
               <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-5 mb-6 space-y-4">
                 <p className="text-sm text-slate-300">
-                  Connect this module to a VCS repository. New versions will be published automatically when matching tags are pushed.
+                  Connect this module to a VCS repository. New versions are published automatically when semver tags matching the tag pattern are pushed. Branch commits alone do not create versions.
                 </p>
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -663,6 +663,7 @@ export default function ModuleDetailPage() {
                       placeholder="v*"
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                     />
+                    <p className="mt-1 text-xs text-slate-500">Only tags matching this pattern create versions (e.g. v1.0.0)</p>
                   </div>
                 </div>
 
@@ -689,15 +690,22 @@ export default function ModuleDetailPage() {
 
             {/* VCS status info when connected but section not open */}
             {isVcsSource && !showVcs && module.attributes['vcs-repo-url'] && (
-              <div className="bg-green-900/20 rounded-lg border border-green-800/30 px-4 py-3 mb-6 flex items-center gap-3">
-                <GitBranch size={16} className="text-green-400" />
-                <div className="text-sm">
-                  <span className="text-green-300">VCS connected:</span>{' '}
-                  <span className="text-slate-300 font-mono text-xs">{module.attributes['vcs-repo-url']}</span>
-                  {module.attributes['vcs-last-tag'] && (
-                    <span className="text-slate-400 ml-2">Last tag: {module.attributes['vcs-last-tag']}</span>
-                  )}
+              <div className="bg-green-900/20 rounded-lg border border-green-800/30 px-4 py-3 mb-6">
+                <div className="flex items-center gap-3">
+                  <GitBranch size={16} className="text-green-400" />
+                  <div className="text-sm">
+                    <span className="text-green-300">VCS connected:</span>{' '}
+                    <span className="text-slate-300 font-mono text-xs">{module.attributes['vcs-repo-url']}</span>
+                    {module.attributes['vcs-last-tag'] && (
+                      <span className="text-slate-400 ml-2">Last tag: {module.attributes['vcs-last-tag']}</span>
+                    )}
+                  </div>
                 </div>
+                {(module.attributes['version-statuses'] || []).length === 0 && (
+                  <p className="text-xs text-green-400/70 mt-2 ml-7">
+                    Push a semver tag (e.g. <code className="font-mono">v1.0.0</code>) matching the tag pattern to publish the first version.
+                  </p>
+                )}
               </div>
             )}
 
@@ -833,7 +841,11 @@ export default function ModuleDetailPage() {
 
             <h2 className="text-lg font-semibold text-slate-200 mb-3">Versions</h2>
             {(module.attributes['version-statuses'] || []).length === 0 ? (
-              <EmptyState message="No versions yet. Upload a module or connect VCS to get started." />
+              <EmptyState message={
+                isVcsSource
+                  ? `No versions yet. Push a semver tag matching "${module.attributes['vcs-tag-pattern'] || 'v*'}" to the connected repository to publish a version.`
+                  : 'No versions yet. Upload a module or connect VCS to get started.'
+              } />
             ) : (
               <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
                 <table className="w-full text-sm">


### PR DESCRIPTION
## Summary
- Add a callout in the VCS-Driven Module Publishing docs explaining that only git tags trigger version publishing (branch commits do not)
- Add an "Auto-Tagging via CI" section with a complete GitHub Actions example workflow
- Improve module detail page UX with context-aware hints: VCS config description, tag pattern helper text, VCS banner hint when no versions exist, and a VCS-aware empty state message

## Test plan
- [ ] Verify docs render correctly on GitHub
- [ ] Check module detail page with VCS-connected module that has no versions — should show tag hint
- [ ] Check module detail page with VCS-connected module that has versions — no extra hints
- [ ] Check VCS config panel shows updated description and tag pattern helper text