### PR TITLE
feat(web): add VCS settings to workspace UI

### DIFF
--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -312,6 +312,9 @@ def _workspace_json(
                 "vcs-repo-url": ws.vcs_repo_url,
                 "vcs-branch": ws.vcs_branch,
                 "vcs-working-directory": ws.vcs_working_directory,
+                "vcs-connection-id": f"vcs-{ws.vcs_connection_id}"
+                if ws.vcs_connection_id
+                else None,
                 "var-files": ws.var_files or [],
                 "drift-detection-enabled": ws.drift_detection_enabled,
                 "drift-detection-interval-seconds": ws.drift_detection_interval_seconds,
@@ -321,6 +324,7 @@ def _workspace_json(
                 "latest-run": latest_run_attr,
                 "agent-pool-id": f"apool-{ws.agent_pool_id}" if ws.agent_pool_id else None,
                 "agent-pool-name": ws.agent_pool.name if ws.agent_pool else None,
+                "vcs-connection-name": ws.vcs_connection.name if ws.vcs_connection else None,
                 "labels": ws.labels or {},
                 "owner-email": ws.owner_email,
                 "created-at": _rfc3339(ws.created_at),

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -274,6 +274,9 @@ class Workspace(Base):
         ForeignKey("vcs_connections.id", ondelete="SET NULL"),
         nullable=True,
     )
+    vcs_connection: Mapped["VCSConnection | None"] = relationship(
+        "VCSConnection", foreign_keys=[vcs_connection_id], lazy="joined"
+    )
     vcs_repo_url: Mapped[str] = mapped_column(String(500), nullable=False, default="")
     vcs_branch: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     vcs_working_directory: Mapped[str] = mapped_column(String(500), nullable=False, default="")

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -40,6 +40,7 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.vcs_branch = ""
     ws.vcs_working_directory = ""
     ws.vcs_connection_id = None
+    ws.vcs_connection = None
     ws.labels = {}
     ws.owner_email = "test@example.com"
     ws.drift_detection_enabled = overrides.get("drift_detection_enabled", False)

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -73,6 +73,7 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.id = ws_id or uuid.uuid4()
     ws.name = name
     ws.vcs_connection_id = None
+    ws.vcs_connection = None
     ws.vcs_repo_url = ""
     return ws
 

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -53,6 +53,7 @@ def _mock_workspace(
     ws.labels = labels or {}
     ws.owner_email = owner_email
     ws.vcs_connection_id = None
+    ws.vcs_connection = None
     ws.vcs_repo_url = ""
     ws.vcs_branch = ""
     ws.vcs_working_directory = ""

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -45,6 +45,8 @@ interface WorkspaceAttrs {
   'var-files': string[]
   'vcs-repo-url': string
   'vcs-branch': string
+  'vcs-connection-id': string | null
+  'vcs-connection-name': string | null
   'drift-detection-enabled': boolean
   'drift-detection-interval-seconds': number
   'drift-last-checked-at': string
@@ -190,11 +192,18 @@ function WorkspaceDetailContent() {
   const [editOwner, setEditOwner] = useState('')
   const [editVarFiles, setEditVarFiles] = useState<string[]>([])
   const [newVarFile, setNewVarFile] = useState('')
+  const [editVcsConnectionId, setEditVcsConnectionId] = useState<string | null>(null)
+  const [editVcsRepoUrl, setEditVcsRepoUrl] = useState('')
+  const [editVcsBranch, setEditVcsBranch] = useState('')
   const [saving, setSaving] = useState(false)
 
   // Agent pools
   const [agentPools, setAgentPools] = useState<AgentPool[]>([])
   const [poolsLoaded, setPoolsLoaded] = useState(false)
+
+  // VCS connections
+  const [vcsConnections, setVcsConnections] = useState<{ id: string; attributes: { name: string; provider: string } }[]>([])
+  const [vcsConnectionsLoaded, setVcsConnectionsLoaded] = useState(false)
 
   // Version suggestions
   const [versionSuggestions, setVersionSuggestions] = useState<string[]>([])
@@ -537,11 +546,20 @@ function WorkspaceDetailContent() {
     setEditOwner(workspace.attributes['owner-email'] || '')
     setEditVarFiles(workspace.attributes['var-files'] || [])
     setNewVarFile('')
+    setEditVcsConnectionId(workspace.attributes['vcs-connection-id'] || null)
+    setEditVcsRepoUrl(workspace.attributes['vcs-repo-url'] || '')
+    setEditVcsBranch(workspace.attributes['vcs-branch'] || '')
     setEditing(true)
     if (!poolsLoaded) {
       apiFetch('/api/v2/organizations/default/agent-pools').then(res => res.ok ? res.json() : { data: [] }).then(data => {
         setAgentPools(data.data || [])
         setPoolsLoaded(true)
+      }).catch(() => {})
+    }
+    if (!vcsConnectionsLoaded) {
+      apiFetch('/api/v2/organizations/default/vcs-connections').then(res => res.ok ? res.json() : { data: [] }).then(data => {
+        setVcsConnections(data.data || [])
+        setVcsConnectionsLoaded(true)
       }).catch(() => {})
     }
     const backend = workspace.attributes['execution-backend'] || 'tofu'
@@ -576,9 +594,16 @@ function WorkspaceDetailContent() {
               'terraform-version': editVersion,
               'agent-pool-id': editPoolId,
               'var-files': editVarFiles,
+              'vcs-repo-url': editVcsRepoUrl,
+              'vcs-branch': editVcsBranch,
               labels: editLabels,
               ...(isAdmin() ? { 'owner-email': editOwner } : {}),
               ...(force ? { force: true } : {}),
+            },
+            relationships: {
+              'vcs-connection': {
+                data: editVcsConnectionId ? { id: editVcsConnectionId, type: 'vcs-connections' } : null,
+              },
             },
           },
         }),
@@ -1191,6 +1216,43 @@ function WorkspaceDetailContent() {
                     <input type="email" value={editOwner} onChange={(e) => setEditOwner(e.target.value)} placeholder="user@example.com" className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                   ) : (
                     <dd className="mt-1 text-sm text-slate-200">{attrs['owner-email'] || 'None'}</dd>
+                  )}
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">VCS Connection</dt>
+                  {editing ? (
+                    <select
+                      value={editVcsConnectionId || ''}
+                      onChange={(e) => setEditVcsConnectionId(e.target.value || null)}
+                      className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    >
+                      <option value="">None</option>
+                      {vcsConnections.map((c) => (
+                        <option key={c.id} value={c.id}>{c.attributes.name} ({c.attributes.provider})</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">{attrs['vcs-connection-name'] || 'None'}</dd>
+                  )}
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">VCS Repository</dt>
+                  {editing ? (
+                    <input type="text" value={editVcsRepoUrl} onChange={(e) => setEditVcsRepoUrl(e.target.value)} placeholder="https://github.com/org/repo" className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">
+                      {attrs['vcs-repo-url'] ? (
+                        <a href={attrs['vcs-repo-url']} target="_blank" rel="noopener noreferrer" className="text-brand-400 hover:text-brand-300">{attrs['vcs-repo-url']}</a>
+                      ) : 'None'}
+                    </dd>
+                  )}
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">VCS Branch</dt>
+                  {editing ? (
+                    <input type="text" value={editVcsBranch} onChange={(e) => setEditVcsBranch(e.target.value)} placeholder="main (default)" className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">{attrs['vcs-branch'] || 'Default'}</dd>
                   )}
                 </div>
                 <div className="sm:col-span-2">

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -54,11 +54,18 @@ export default function WorkspacesPage() {
   const [newVersion, setNewVersion] = useState('1.9')
   const [newCpu, setNewCpu] = useState('1')
   const [newMemory, setNewMemory] = useState('2Gi')
+  const [newVcsConnectionId, setNewVcsConnectionId] = useState('')
+  const [newVcsRepoUrl, setNewVcsRepoUrl] = useState('')
+  const [newVcsBranch, setNewVcsBranch] = useState('')
   const [creating, setCreating] = useState(false)
 
   // Version suggestions
   const [versionSuggestions, setVersionSuggestions] = useState<string[]>([])
   const [versionsBackend, setVersionsBackend] = useState('')
+
+  // VCS connections
+  const [vcsConnections, setVcsConnections] = useState<{ id: string; attributes: { name: string; provider: string } }[]>([])
+  const [vcsConnectionsLoaded, setVcsConnectionsLoaded] = useState(false)
 
   type WsSortKey = 'name' | 'mode' | 'resources' | 'status' | 'created'
 
@@ -118,6 +125,15 @@ export default function WorkspacesPage() {
     loadWorkspaces()
   }, []))
 
+  // Load VCS connections when form opens
+  useEffect(() => {
+    if (!showCreate || vcsConnectionsLoaded) return
+    apiFetch('/api/v2/organizations/default/vcs-connections')
+      .then(res => res.ok ? res.json() : { data: [] })
+      .then(data => { setVcsConnections(data.data || []); setVcsConnectionsLoaded(true) })
+      .catch(() => {})
+  }, [showCreate, vcsConnectionsLoaded])
+
   // Fetch version suggestions when backend changes and form is open
   useEffect(() => {
     if (!showCreate || newBackend === versionsBackend) return
@@ -163,7 +179,16 @@ export default function WorkspacesPage() {
               'auto-apply': newAutoApply,
               'resource-cpu': newCpu,
               'resource-memory': newMemory,
+              'vcs-repo-url': newVcsRepoUrl,
+              'vcs-branch': newVcsBranch,
             },
+            ...(newVcsConnectionId ? {
+              relationships: {
+                'vcs-connection': {
+                  data: { id: newVcsConnectionId, type: 'vcs-connections' },
+                },
+              },
+            } : {}),
           },
         }),
       })
@@ -178,6 +203,9 @@ export default function WorkspacesPage() {
       setNewAutoApply(false)
       setNewCpu('1')
       setNewMemory('2Gi')
+      setNewVcsConnectionId('')
+      setNewVcsRepoUrl('')
+      setNewVcsBranch('')
       setShowCreate(false)
       await loadWorkspaces()
     } catch (err) {
@@ -294,6 +322,44 @@ export default function WorkspacesPage() {
                   />
                   <span className="text-sm text-slate-300">Auto Apply</span>
                 </label>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              <div>
+                <label htmlFor="ws-vcs-conn" className="block text-sm font-medium text-slate-300 mb-1">VCS Connection</label>
+                <select
+                  id="ws-vcs-conn"
+                  value={newVcsConnectionId}
+                  onChange={(e) => setNewVcsConnectionId(e.target.value)}
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                >
+                  <option value="">None</option>
+                  {vcsConnections.map((c) => (
+                    <option key={c.id} value={c.id}>{c.attributes.name} ({c.attributes.provider})</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="ws-vcs-repo" className="block text-sm font-medium text-slate-300 mb-1">VCS Repository URL</label>
+                <input
+                  id="ws-vcs-repo"
+                  type="text"
+                  value={newVcsRepoUrl}
+                  onChange={(e) => setNewVcsRepoUrl(e.target.value)}
+                  placeholder="https://github.com/org/repo"
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                />
+              </div>
+              <div>
+                <label htmlFor="ws-vcs-branch" className="block text-sm font-medium text-slate-300 mb-1">VCS Branch</label>
+                <input
+                  id="ws-vcs-branch"
+                  type="text"
+                  value={newVcsBranch}
+                  onChange={(e) => setNewVcsBranch(e.target.value)}
+                  placeholder="main (default)"
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                />
               </div>
             </div>
             <button


### PR DESCRIPTION
## Summary

- Add VCS Connection, Repository URL, and Branch fields to workspace detail settings (read + edit mode)
- Add VCS Connection, Repository URL, and Branch fields to the create workspace form
- Add `vcs-connection-id` and `vcs-connection-name` convenience attributes to workspace API response
- Add `vcs_connection` relationship on Workspace model (lazy joined)

Previously VCS settings could only be configured via API — they were invisible in the UI.

## Test plan
- [ ] Workspace detail shows VCS Connection name, repo URL (as link), and branch in read mode
- [ ] Edit mode shows dropdowns/inputs for all three VCS fields
- [ ] Saving VCS settings persists correctly
- [ ] Create workspace form includes VCS fields
- [ ] Clearing VCS connection (set to None) disconnects VCS