### PR TITLE
fix: UUIDv7 job name collision on concurrent runs

### DIFF
--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -77,7 +77,7 @@ def build_job_spec(
     if not namespace:
         namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
 
-    run_short = run_id[:8]
+    run_short = run_id[:16]
     job_name = f"tprun-{run_short}-{phase}"
 
     # Resolve the default runner definition for setup_script

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -377,7 +377,7 @@ class RunnerListener:
             {"key": v["key"], "value": v["value"]} for v in attrs.get("terraform-vars", [])
         ]
 
-        run_short = run_id[:8]
+        run_short = run_id[:16]
         auth_secret_name = f"tprun-{run_short}-auth"
 
         spec = build_job_spec(
@@ -539,7 +539,7 @@ class RunnerListener:
         from terrapod.runner.job_manager import _get_core_api
 
         namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
-        run_short = run_id[:8]
+        run_short = run_id[:16]
         secret_name = f"tprun-{run_short}-auth"
 
         secret = k8s_client.V1Secret(


### PR DESCRIPTION
## Summary

- UUIDv7 encodes the timestamp in the first 48 bits (12 hex chars), so two runs created in the same millisecond share the first 8 hex chars
- This caused K8s Job creation to fail with 409 Conflict when two runs (branch push + PR speculative) were queued simultaneously — both generated job name `tprun-{same_prefix}-plan`
- Extend the run ID prefix from 8 to 16 chars to include the `rand_a` portion of UUIDv7

## Test plan

- [x] 590 tests pass
- [ ] Queue two runs simultaneously on the same workspace — both should get unique job names