### PR TITLE
fix: grant runner tokens implicit read access to registry

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -29,6 +29,8 @@ Modules and providers use a similar three-level hierarchy (no "plan" concept):
 
 A role's `workspace_permission` maps to registry permissions: `plan` maps to `read`.
 
+**Runner tokens** receive implicit `read` access to all registry modules and providers. This allows runner Jobs to download modules and providers during `terraform init` without requiring explicit label-based permissions on each registry resource.
+
 ### Platform Permissions
 
 | Operation | Required Role |

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -131,6 +131,7 @@ Modules follow the same owner + label RBAC model as workspaces:
 - Creator becomes owner (admin permission)
 - Label-based roles grant read/write/admin
 - The `workspace_permission` on a role maps to registry permissions: `plan` maps to `read`
+- Runner tokens receive implicit `read` access (required for `terraform init` to download modules)
 
 Module API responses include a `permissions` block (`can-update`, `can-destroy`, `can-create-version`) reflecting the caller's effective access. The web UI uses these to gate editing, deletion, and version upload controls.
 

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -169,7 +169,13 @@ async def list_module_versions_cli(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Module not found")
@@ -310,7 +316,13 @@ async def show_module_endpoint(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Module not found")
@@ -332,7 +344,13 @@ async def delete_module_endpoint(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -362,7 +380,13 @@ async def update_module_endpoint(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -390,7 +414,13 @@ async def update_module_endpoint(
             and module.owner_email != user.email
         ):
             new_perm = await resolve_registry_permission(
-                db, user.email, user.roles, module.name, new_labels, module.owner_email
+                db,
+                user.email,
+                user.roles,
+                module.name,
+                new_labels,
+                module.owner_email,
+                auth_method=user.auth_method,
             )
             if new_perm is None or REGISTRY_PERMISSION_HIERARCHY.get(
                 new_perm, -1
@@ -465,7 +495,13 @@ async def create_module_version_endpoint(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "write"):
         raise HTTPException(
@@ -556,7 +592,13 @@ async def upload_module_version_endpoint(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "write"):
         raise HTTPException(
@@ -631,7 +673,13 @@ async def update_module_vcs_endpoint(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -721,7 +769,13 @@ async def list_workspace_links(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Module not found")
@@ -752,7 +806,13 @@ async def create_workspace_link(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -819,7 +879,13 @@ async def delete_workspace_link(
         raise HTTPException(status_code=404, detail="Module not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -184,7 +184,13 @@ async def _require_provider_permission(
 ) -> None:
     """Check registry permission on a provider or raise 403."""
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, provider.name, provider.labels or {}, provider.owner_email
+        db,
+        user.email,
+        user.roles,
+        provider.name,
+        provider.labels or {},
+        provider.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, required):
         raise HTTPException(
@@ -218,7 +224,13 @@ async def list_provider_versions_cli(
         raise HTTPException(status_code=404, detail="Provider not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, provider.name, provider.labels or {}, provider.owner_email
+        db,
+        user.email,
+        user.roles,
+        provider.name,
+        provider.labels or {},
+        provider.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Provider not found")
@@ -336,7 +348,13 @@ async def show_provider_endpoint(
         raise HTTPException(status_code=404, detail="Provider not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, provider.name, provider.labels or {}, provider.owner_email
+        db,
+        user.email,
+        user.roles,
+        provider.name,
+        provider.labels or {},
+        provider.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Provider not found")
@@ -379,7 +397,13 @@ async def update_provider_endpoint(
         raise HTTPException(status_code=404, detail="Provider not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, provider.name, provider.labels or {}, provider.owner_email
+        db,
+        user.email,
+        user.roles,
+        provider.name,
+        provider.labels or {},
+        provider.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -407,7 +431,13 @@ async def update_provider_endpoint(
             and provider.owner_email != user.email
         ):
             new_perm = await resolve_registry_permission(
-                db, user.email, user.roles, provider.name, new_labels, provider.owner_email
+                db,
+                user.email,
+                user.roles,
+                provider.name,
+                new_labels,
+                provider.owner_email,
+                auth_method=user.auth_method,
             )
             if new_perm is None or REGISTRY_PERMISSION_HIERARCHY.get(
                 new_perm, -1
@@ -502,7 +532,13 @@ async def list_provider_versions_endpoint(
         raise HTTPException(status_code=404, detail="Provider not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, provider.name, provider.labels or {}, provider.owner_email
+        db,
+        user.email,
+        user.roles,
+        provider.name,
+        provider.labels or {},
+        provider.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Provider not found")
@@ -582,7 +618,13 @@ async def list_provider_platforms_endpoint(
         raise HTTPException(status_code=404, detail="Provider not found")
 
     perm = await resolve_registry_permission(
-        db, user.email, user.roles, provider.name, provider.labels or {}, provider.owner_email
+        db,
+        user.email,
+        user.roles,
+        provider.name,
+        provider.labels or {},
+        provider.owner_email,
+        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Provider not found")

--- a/services/terrapod/services/registry_rbac_service.py
+++ b/services/terrapod/services/registry_rbac_service.py
@@ -46,16 +46,18 @@ async def resolve_registry_permission(
     resource_name: str,
     resource_labels: dict,
     owner_email: str,
+    auth_method: str = "",
 ) -> str | None:
     """Returns highest permission level (read/write/admin), or None.
 
     Resolution order (highest wins):
     1. Platform admin → admin
     2. Platform audit → read
-    3. Resource owner → admin
-    4. Label-based RBAC (custom roles) → mapped workspace_permission
-    5. 'everyone' role with access: everyone label → read
-    6. Default → None (no access)
+    3. Runner token → read (runners must download modules/providers to execute)
+    4. Resource owner → admin
+    5. Label-based RBAC (custom roles) → mapped workspace_permission
+    6. 'everyone' role with access: everyone label → read
+    7. Default → None (no access)
     """
     role_set = set(user_roles)
 
@@ -69,11 +71,16 @@ async def resolve_registry_permission(
     if "audit" in role_set:
         best = "read"
 
-    # 3. Owner → admin
+    # 3. Runner tokens → read (runners must download modules/providers to execute)
+    if auth_method == "runner_token":
+        if best is None:
+            best = "read"
+
+    # 4. Owner → admin
     if owner_email and owner_email == user_email:
         return "admin"
 
-    # 4. Label-based RBAC from custom roles
+    # 5. Label-based RBAC from custom roles
     custom_role_names = role_set - BUILTIN_ROLE_NAMES
     if custom_role_names:
         result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
@@ -108,7 +115,7 @@ async def resolve_registry_permission(
                 ) > REGISTRY_PERMISSION_HIERARCHY.get(best, -1):
                     best = registry_perm
 
-    # 5. 'everyone' role: if resource has label access=everyone, grant read
+    # 6. 'everyone' role: if resource has label access=everyone, grant read
     if resource_labels.get("access") == "everyone":
         if best is None:
             best = "read"

--- a/services/tests/services/test_registry_rbac.py
+++ b/services/tests/services/test_registry_rbac.py
@@ -200,6 +200,34 @@ class TestResolveRegistryPermission:
         )
         assert result is None
 
+    async def test_runner_token_gets_read(self):
+        """Runner tokens get implicit read access to download modules."""
+        db = _mock_db_with_roles()
+        result = await resolve_registry_permission(
+            db,
+            "runner@internal",
+            ["everyone"],
+            "private-module",
+            {},
+            "",
+            auth_method="runner_token",
+        )
+        assert result == "read"
+
+    async def test_runner_token_does_not_escalate_above_read(self):
+        """Runner tokens get read but don't override higher permissions."""
+        db = _mock_db_with_roles()
+        result = await resolve_registry_permission(
+            db,
+            "owner@test.com",
+            ["everyone"],
+            "my-module",
+            {},
+            "owner@test.com",
+            auth_method="runner_token",
+        )
+        assert result == "admin"
+
     async def test_only_builtin_roles_skip_db_query(self):
         db = _mock_db_with_roles()
         await resolve_registry_permission(db, "user@test.com", ["everyone"], "mod", {}, "")


### PR DESCRIPTION
## Summary

- Runner tokens only carry the `everyone` role, which has no registry permission unless modules are explicitly labelled `access: everyone`
- This caused `tofu init` to fail with "Module not found" during remote execution on the cloud-iac VCS-driven POC
- Add `auth_method` parameter to `resolve_registry_permission` and grant implicit `read` when the caller is a runner token

## Test plan

- [x] 592 tests pass (2 new for runner token registry RBAC)
- [ ] Deploy and verify VCS-driven speculative plan downloads modules successfully