### PR TITLE
fix: pass auth_method to all registry RBAC calls

### DIFF
--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -206,7 +206,13 @@ async def download_module_cli(
     module = await get_module(db, namespace, name, provider)
     if module is not None:
         perm = await resolve_registry_permission(
-            db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+            db,
+            user.email,
+            user.roles,
+            module.name,
+            module.labels or {},
+            module.owner_email,
+            auth_method=user.auth_method,
         )
         if not has_registry_permission(perm, "read"):
             raise HTTPException(status_code=404, detail="Module version not found")
@@ -296,7 +302,13 @@ async def list_modules_endpoint(
     visible = []
     for m in modules:
         perm = await resolve_registry_permission(
-            db, user.email, user.roles, m.name, m.labels or {}, m.owner_email
+            db,
+            user.email,
+            user.roles,
+            m.name,
+            m.labels or {},
+            m.owner_email,
+            auth_method=user.auth_method,
         )
         if perm is not None:
             visible.append(_module_to_jsonapi(m, perm))
@@ -555,7 +567,13 @@ async def delete_module_version_endpoint(
     module = await get_module(db, "default", name, provider)
     if module is not None:
         perm = await resolve_registry_permission(
-            db, user.email, user.roles, module.name, module.labels or {}, module.owner_email
+            db,
+            user.email,
+            user.roles,
+            module.name,
+            module.labels or {},
+            module.owner_email,
+            auth_method=user.auth_method,
         )
         if not has_registry_permission(perm, "admin"):
             raise HTTPException(

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -280,7 +280,13 @@ async def download_provider_cli(
     provider = await get_provider(db, namespace, name)
     if provider is not None:
         perm = await resolve_registry_permission(
-            db, user.email, user.roles, provider.name, provider.labels or {}, provider.owner_email
+            db,
+            user.email,
+            user.roles,
+            provider.name,
+            provider.labels or {},
+            provider.owner_email,
+            auth_method=user.auth_method,
         )
         if not has_registry_permission(perm, "read"):
             raise HTTPException(status_code=404, detail="Provider platform not found")
@@ -329,7 +335,13 @@ async def list_providers_endpoint(
     visible = []
     for p in providers:
         perm = await resolve_registry_permission(
-            db, user.email, user.roles, p.name, p.labels or {}, p.owner_email
+            db,
+            user.email,
+            user.roles,
+            p.name,
+            p.labels or {},
+            p.owner_email,
+            auth_method=user.auth_method,
         )
         if perm is not None:
             visible.append(_provider_to_jsonapi(p, perm))


### PR DESCRIPTION
## Summary

- Five `resolve_registry_permission()` calls in the CLI protocol endpoints (module download, module list, provider download/list) were missing the `auth_method` parameter added in v0.7.6
- Runner tokens hitting these endpoints got no implicit read access, causing `tofu init` to fail with "module not found" on the download step despite the version listing working

## Test plan

- [x] All 592 tests pass
- [ ] Deploy and retrigger speculative plan on cloud-iac PR #1 — verify module download succeeds