### PR TITLE
fix: persist live-streamed logs when runner upload fails

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1087,11 +1087,8 @@ async def _serve_log(
     try:
         data = await storage.get(log_key)
     except ObjectNotFoundError:
-        if phase_done:
-            # Phase finished but no log — return empty complete stream
-            return Response(content=_STX + _ETX, media_type="text/plain")
-
-        # Try live-streamed data from Redis
+        # Try live-streamed data from Redis (available for both in-progress
+        # and recently-completed runs where the Job didn't upload final logs)
         try:
             from terrapod.redis.client import LOG_STREAM_PREFIX, get_redis_client
 
@@ -1102,10 +1099,15 @@ async def _serve_log(
                 if isinstance(live_data, str):
                     live_data = live_data.encode()
                 data = live_data
+            elif phase_done:
+                # Phase finished, no log in storage or Redis — empty stream
+                return Response(content=_STX + _ETX, media_type="text/plain")
             else:
                 # Still running, no log yet — return empty (client retries)
                 return Response(content=b"", media_type="text/plain")
         except Exception:
+            if phase_done:
+                return Response(content=_STX + _ETX, media_type="text/plain")
             return Response(content=b"", media_type="text/plain")
 
     if strip_ansi:

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -27,6 +27,45 @@ logger = get_logger(__name__)
 STALE_TIMEOUT = timedelta(hours=1)
 
 
+async def _persist_live_log_if_missing(run: Run, phase: str) -> None:
+    """Promote live-streamed log from Redis to object storage if the runner
+    didn't upload its own final log.  This prevents log loss when a Job fails
+    before the entrypoint's log upload step (or when the upload itself fails).
+    """
+    from terrapod.redis.client import LOG_STREAM_PREFIX, get_redis_client
+    from terrapod.storage import get_storage
+    from terrapod.storage.keys import apply_log_key, plan_log_key
+    from terrapod.storage.protocol import ObjectNotFoundError
+
+    storage = get_storage()
+    ws_id = str(run.workspace_id)
+    run_id = str(run.id)
+    log_key = plan_log_key(ws_id, run_id) if phase == "plan" else apply_log_key(ws_id, run_id)
+
+    # Check if runner already uploaded the final log
+    try:
+        await storage.get(log_key)
+        return  # Already in storage — nothing to do
+    except ObjectNotFoundError:
+        pass
+
+    # Promote Redis live log to storage
+    try:
+        redis = get_redis_client()
+        live_data = await redis.get(f"{LOG_STREAM_PREFIX}{run.id}:{phase}")
+        if live_data:
+            if isinstance(live_data, str):
+                live_data = live_data.encode()
+            await storage.put(log_key, live_data)
+            logger.info(
+                "Persisted live log from Redis to storage",
+                run_id=run_id,
+                phase=phase,
+            )
+    except Exception as e:
+        logger.warning("Failed to persist live log", run_id=run_id, error=str(e))
+
+
 async def reconcile_runs() -> None:
     """Drive run state transitions based on Job outcomes.
 
@@ -112,6 +151,9 @@ async def _handle_succeeded(db: AsyncSession, run: Run) -> None:
     """Handle a succeeded Job."""
     from terrapod.services import run_service, run_task_service
 
+    phase = "plan" if run.status == "planning" else "apply"
+    await _persist_live_log_if_missing(run, phase)
+
     if run.status == "planning":
         # Check post_plan task stage
         ts = await run_task_service.create_task_stage(db, run.id, run.workspace_id, "post_plan")
@@ -156,6 +198,9 @@ async def _handle_succeeded(db: AsyncSession, run: Run) -> None:
 async def _handle_failed(db: AsyncSession, run: Run, error_message: str) -> None:
     """Handle a failed or deleted Job."""
     from terrapod.services import run_service
+
+    phase = "plan" if run.status == "planning" else "apply"
+    await _persist_live_log_if_missing(run, phase)
 
     run = await run_service.transition_run(db, run, "errored", error_message=error_message)
 

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -124,10 +124,16 @@ class TestReconcileOne:
 # ── _handle_succeeded ─────────────────────────────────────────────────
 
 
+_PERSIST_PATCH = "terrapod.services.run_reconciler._persist_live_log_if_missing"
+
+
 class TestHandleSucceeded:
+    @patch(_PERSIST_PATCH, new_callable=AsyncMock)
     @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)
     @patch("terrapod.services.run_service.transition_run", new_callable=AsyncMock)
-    async def test_plan_succeeded_transitions_to_planned(self, mock_transition, mock_stage):
+    async def test_plan_succeeded_transitions_to_planned(
+        self, mock_transition, mock_stage, mock_persist
+    ):
         db = AsyncMock()
         run = _mock_run(status="planning")
         mock_stage.return_value = None
@@ -136,10 +142,14 @@ class TestHandleSucceeded:
         await _handle_succeeded(db, run)
 
         mock_transition.assert_called_once_with(db, run, "planned")
+        mock_persist.assert_called_once_with(run, "plan")
 
+    @patch(_PERSIST_PATCH, new_callable=AsyncMock)
     @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)
     @patch("terrapod.services.run_service.transition_run", new_callable=AsyncMock)
-    async def test_plan_with_auto_apply_transitions_to_confirmed(self, mock_transition, mock_stage):
+    async def test_plan_with_auto_apply_transitions_to_confirmed(
+        self, mock_transition, mock_stage, mock_persist
+    ):
         db = AsyncMock()
         run = _mock_run(status="planning", auto_apply=True)
         mock_stage.return_value = None
@@ -154,9 +164,10 @@ class TestHandleSucceeded:
         assert mock_transition.call_args_list[0].args[2] == "planned"
         assert mock_transition.call_args_list[1].args[2] == "confirmed"
 
+    @patch(_PERSIST_PATCH, new_callable=AsyncMock)
     @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)
     @patch("terrapod.services.run_service.transition_run", new_callable=AsyncMock)
-    async def test_plan_only_unlocks_workspace(self, mock_transition, mock_stage):
+    async def test_plan_only_unlocks_workspace(self, mock_transition, mock_stage, mock_persist):
         db = AsyncMock()
         run = _mock_run(status="planning", plan_only=True)
         mock_stage.return_value = None
@@ -172,8 +183,9 @@ class TestHandleSucceeded:
         assert ws.locked is False
         assert ws.lock_id is None
 
+    @patch(_PERSIST_PATCH, new_callable=AsyncMock)
     @patch("terrapod.services.run_service.transition_run", new_callable=AsyncMock)
-    async def test_apply_succeeded_transitions_to_applied(self, mock_transition):
+    async def test_apply_succeeded_transitions_to_applied(self, mock_transition, mock_persist):
         db = AsyncMock()
         run = _mock_run(status="applying")
         mock_transition.return_value = run
@@ -185,12 +197,14 @@ class TestHandleSucceeded:
 
         mock_transition.assert_called_once_with(db, run, "applied")
         assert ws.locked is False
+        mock_persist.assert_called_once_with(run, "apply")
 
+    @patch(_PERSIST_PATCH, new_callable=AsyncMock)
     @patch("terrapod.services.run_task_service.resolve_stage", new_callable=AsyncMock)
     @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)
     @patch("terrapod.services.run_service.transition_run", new_callable=AsyncMock)
     async def test_post_plan_task_stage_failed_errors_run(
-        self, mock_transition, mock_create_stage, mock_resolve
+        self, mock_transition, mock_create_stage, mock_resolve, mock_persist
     ):
         db = AsyncMock()
         run = _mock_run(status="planning")
@@ -211,8 +225,9 @@ class TestHandleSucceeded:
 
 
 class TestHandleFailed:
+    @patch(_PERSIST_PATCH, new_callable=AsyncMock)
     @patch("terrapod.services.run_service.transition_run", new_callable=AsyncMock)
-    async def test_transitions_to_errored(self, mock_transition):
+    async def test_transitions_to_errored(self, mock_transition, mock_persist):
         db = AsyncMock()
         run = _mock_run(status="planning")
         mock_transition.return_value = run
@@ -224,6 +239,7 @@ class TestHandleFailed:
 
         mock_transition.assert_called_once_with(db, run, "errored", error_message="Job failed")
         assert ws.locked is False
+        mock_persist.assert_called_once_with(run, "plan")
 
 
 # ── _check_stale ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Log serving (`_serve_log`) now checks Redis live stream data before returning empty when a phase is complete — previously it short-circuited to empty when `phase_done` was true
- Reconciler promotes Redis live log to object storage on terminal state transitions when the runner's own log upload is missing, preventing log loss after Redis 300s TTL expires
- Both fixes are server-side (reconciler-driven), not dependent on UX fetching logs

## Test plan

- [x] All 592 tests pass
- [ ] Trigger a failing run and verify log output appears in the UI