### PR TITLE
fix: strip top-level directory from VCS module tarballs

### DIFF
--- a/services/terrapod/services/archive_utils.py
+++ b/services/terrapod/services/archive_utils.py
@@ -1,0 +1,39 @@
+"""Utilities for repacking VCS archive tarballs.
+
+GitHub and GitLab archive downloads wrap all files in a top-level directory
+(e.g. ``owner-repo-sha/``).  Terraform/tofu expects module tarballs and
+workspace configs to have .tf files at the root.  The helper here strips
+that wrapper so downloaded archives are usable as-is.
+"""
+
+import io
+import tarfile
+
+
+def strip_archive_top_level_dir(archive: bytes) -> bytes:
+    """Repack a gzipped tarball, stripping the single top-level directory.
+
+    ``owner-repo-sha/variables.tf`` becomes ``variables.tf``, etc.
+    If the archive has no common top-level directory, it is returned unchanged.
+    """
+    in_buf = io.BytesIO(archive)
+    out_buf = io.BytesIO()
+
+    with (
+        tarfile.open(fileobj=in_buf, mode="r:gz") as src,
+        tarfile.open(fileobj=out_buf, mode="w:gz") as dst,
+    ):
+        for member in src.getmembers():
+            # Strip first path component: "owner-repo-sha/file" -> "file"
+            parts = member.name.split("/", 1)
+            if len(parts) < 2 or not parts[1]:
+                continue  # skip the top-level directory entry itself
+            member.name = parts[1]
+            if member.isfile():
+                f = src.extractfile(member)
+                if f:
+                    dst.addfile(member, f)
+            else:
+                dst.addfile(member)
+
+    return out_buf.getvalue()

--- a/services/terrapod/services/module_impact_service.py
+++ b/services/terrapod/services/module_impact_service.py
@@ -29,6 +29,7 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service, run_service
+from terrapod.services.archive_utils import strip_archive_top_level_dir
 from terrapod.services.vcs_provider import PullRequest
 from terrapod.storage import get_storage
 from terrapod.storage.keys import module_override_key
@@ -235,6 +236,9 @@ async def _create_module_test_runs(
             exc_info=True,
         )
         return
+
+    # Strip top-level directory wrapper from VCS archive before storing
+    archive_bytes = strip_archive_top_level_dir(archive_bytes)
 
     # Upload override tarball (keyed by commit SHA for reuse across workspaces/retries)
     override_key = module_override_key(pr.head_sha, module.namespace, module.name, module.provider)

--- a/services/terrapod/services/registry_vcs_poller.py
+++ b/services/terrapod/services/registry_vcs_poller.py
@@ -17,6 +17,7 @@ from terrapod.db.models import RegistryModule, RegistryModuleVersion
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service
+from terrapod.services.archive_utils import strip_archive_top_level_dir
 from terrapod.storage import get_storage
 from terrapod.storage.keys import module_tarball_key
 
@@ -204,6 +205,9 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
                 exc_info=True,
             )
             continue
+
+        # Strip top-level directory wrapper from VCS archive before storing
+        archive_bytes = strip_archive_top_level_dir(archive_bytes)
 
         # Store tarball (overwrites existing if tag was moved)
         key = module_tarball_key(module.namespace, module.name, module.provider, version_str)

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -17,9 +17,6 @@ runs each poll cycle per interval. Webhook-triggered immediate polls use
 the scheduler's trigger queue with deduplication.
 """
 
-import io
-import tarfile
-
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,6 +24,7 @@ from terrapod.db.models import Run, VCSConnection, Workspace
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service, run_service
+from terrapod.services.archive_utils import strip_archive_top_level_dir
 from terrapod.services.vcs_provider import PullRequest
 from terrapod.storage import get_storage
 from terrapod.storage.keys import config_version_key
@@ -147,34 +145,7 @@ async def _resolve_branch(conn: VCSConnection, ws: Workspace, owner: str, repo: 
     return None
 
 
-def _strip_top_level_dir(archive: bytes) -> bytes:
-    """Repack a tarball, stripping the single top-level directory.
-
-    GitHub/GitLab tarballs wrap content in a directory like
-    ``owner-repo-sha/``.  The runner entrypoint extracts to /workspace
-    and expects .tf files at the root, so we strip the wrapper.
-    """
-    in_buf = io.BytesIO(archive)
-    out_buf = io.BytesIO()
-
-    with (
-        tarfile.open(fileobj=in_buf, mode="r:gz") as src,
-        tarfile.open(fileobj=out_buf, mode="w:gz") as dst,
-    ):
-        for member in src.getmembers():
-            # Strip first path component: "owner-repo-sha/file" → "file"
-            parts = member.name.split("/", 1)
-            if len(parts) < 2 or not parts[1]:
-                continue  # skip the top-level directory entry itself
-            member.name = parts[1]
-            if member.isfile():
-                f = src.extractfile(member)
-                if f:
-                    dst.addfile(member, f)
-            else:
-                dst.addfile(member)
-
-    return out_buf.getvalue()
+_strip_top_level_dir = strip_archive_top_level_dir  # alias for internal use
 
 
 async def _create_vcs_run(


### PR DESCRIPTION
## Summary

- VCS-published module tarballs were unusable because GitHub/GitLab archive downloads wrap files in a top-level directory (`owner-repo-sha/`), but terraform/tofu expects `.tf` files at the tarball root
- The workspace VCS poller already stripped this prefix for workspace configs, but the module registry VCS poller and module impact service did not
- Extracted the strip logic to a shared `archive_utils.py` module and applied it in all three archive storage paths

## Post-deployment migration

After deploying, reset `vcs_commit_sha` on all module versions to force the VCS poller to re-download and repack existing tarballs:

```sql
UPDATE registry_module_versions SET vcs_commit_sha = '' WHERE vcs_commit_sha IS NOT NULL AND vcs_commit_sha != '';
```

The next poll cycle (60s) will re-fetch all archives with the prefix stripped.

## Test plan

- [x] `make test` — 607 passed
- [ ] Deploy to mgmt, run SQL migration, verify modules are usable with `tofu init` + `tofu plan`