### PR TITLE
fix: provider mirror index.json must return all upstream versions

### DIFF
--- a/services/terrapod/services/provider_cache_service.py
+++ b/services/terrapod/services/provider_cache_service.py
@@ -64,9 +64,9 @@ async def get_or_fetch_versions(
         return {"versions": {}}
 
     # Check Redis cache first
-    from terrapod.redis.client import get_redis
+    from terrapod.redis.client import get_redis_client
 
-    redis = get_redis()
+    redis = get_redis_client()
     cache_key = _index_redis_key(hostname, namespace, type_)
     cached = await redis.get(cache_key)
     if cached:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4537,9 +4537,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

- The network mirror's `index.json` was returning only locally-cached binary versions instead of all versions available upstream
- This caused `tofu init` / `terraform init` to fail with "no available releases match the given constraints" when the requested version hadn't been previously cached as a binary (e.g. `>= 5.80` with only `6.37.0` cached)
- Now fetches the full version list from upstream, cached in Redis with 24h TTL

## Test plan

- [x] `make test` — 607 passed
- [ ] Deploy, test locally with `TF_CLI_CONFIG_FILE` pointing at the mirror — verify all upstream versions appear in `index.json`
- [ ] Push to cloud-iac PR to trigger e2e VCS run