### PR TITLE
fix: exclude auxiliary runs from workspace health and dashboard metrics

### DIFF
--- a/services/terrapod/api/routers/health_dashboard.py
+++ b/services/terrapod/api/routers/health_dashboard.py
@@ -12,7 +12,7 @@ from datetime import UTC, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import case, func, select
+from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
@@ -23,6 +23,14 @@ from terrapod.logging_config import get_logger
 
 router = APIRouter(prefix="/api/v2", tags=["health-dashboard"])
 logger = get_logger(__name__)
+
+
+def _primary_run_filter():
+    """Exclude auxiliary runs (module-test, speculative PR) from health metrics."""
+    return ~or_(
+        Run.source == "module-test",
+        and_(Run.plan_only.is_(True), Run.vcs_pull_request_number.isnot(None)),
+    )
 
 
 def _rfc3339(dt) -> str:
@@ -173,15 +181,17 @@ async def _get_run_health(db: AsyncSession) -> dict:
     now_utc = func.now()
     cutoff = now_utc - timedelta(hours=24)
 
+    prf = _primary_run_filter()
+
     # Current queue depth
     queued_result = await db.execute(
-        select(func.count()).select_from(Run).where(Run.status == "queued")
+        select(func.count()).select_from(Run).where(Run.status == "queued", prf)
     )
     queued = queued_result.scalar_one()
 
     # In-progress count
     in_progress_result = await db.execute(
-        select(func.count()).select_from(Run).where(Run.status.in_(["planning", "applying"]))
+        select(func.count()).select_from(Run).where(Run.status.in_(["planning", "applying"]), prf)
     )
     in_progress = in_progress_result.scalar_one()
 
@@ -191,7 +201,7 @@ async def _get_run_health(db: AsyncSession) -> dict:
             Run.status,
             func.count(),
         )
-        .where(Run.created_at >= cutoff)
+        .where(Run.created_at >= cutoff, prf)
         .group_by(Run.status)
     )
     recent_24h = {"total": 0, "applied": 0, "errored": 0, "canceled": 0}
@@ -215,6 +225,7 @@ async def _get_run_health(db: AsyncSession) -> dict:
             Run.plan_started_at.isnot(None),
             Run.plan_finished_at.isnot(None),
             Run.created_at >= cutoff,
+            prf,
         )
     )
     avg_plan_secs = plan_avg_result.scalar_one()
@@ -230,6 +241,7 @@ async def _get_run_health(db: AsyncSession) -> dict:
             Run.apply_started_at.isnot(None),
             Run.apply_finished_at.isnot(None),
             Run.created_at >= cutoff,
+            prf,
         )
     )
     avg_apply_secs = apply_avg_result.scalar_one()

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -40,7 +40,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, Response, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
@@ -67,6 +67,19 @@ logger = get_logger(__name__)
 TFP_API_VERSION = "2.6"
 TFP_APP_NAME = "Terrapod"
 X_TFE_VERSION = "v0.1.0"
+
+
+def _primary_run_filter():
+    """Filter out auxiliary runs that should not affect workspace health.
+
+    Excludes module-test runs (module impact analysis) and speculative
+    VCS PR/MR runs — these are informational and should not influence
+    the workspace's displayed status.
+    """
+    return ~or_(
+        Run.source == "module-test",
+        and_(Run.plan_only.is_(True), Run.vcs_pull_request_number.isnot(None)),
+    )
 
 
 def _rfc3339(dt: datetime | None) -> str:
@@ -391,7 +404,7 @@ async def list_workspaces(
     if ws_ids:
         latest_run_q = (
             select(Run)
-            .where(Run.workspace_id.in_(ws_ids))
+            .where(Run.workspace_id.in_(ws_ids), _primary_run_filter())
             .order_by(Run.workspace_id, Run.created_at.desc())
             .distinct(Run.workspace_id)
         )
@@ -429,9 +442,12 @@ async def show_workspace(
     if perm is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    # Load latest run for this workspace
+    # Load latest primary run for this workspace (excludes module-test / speculative PR runs)
     run_result = await db.execute(
-        select(Run).where(Run.workspace_id == ws.id).order_by(Run.created_at.desc()).limit(1)
+        select(Run)
+        .where(Run.workspace_id == ws.id, _primary_run_filter())
+        .order_by(Run.created_at.desc())
+        .limit(1)
     )
     latest_run = run_result.scalar_one_or_none()
 
@@ -596,9 +612,12 @@ async def show_workspace_by_id(
     """Show a workspace by its ID."""
     ws, perm = await _require_ws_permission(workspace_id, "read", user, db)
 
-    # Load latest run for this workspace
+    # Load latest primary run for this workspace (excludes module-test / speculative PR runs)
     run_result = await db.execute(
-        select(Run).where(Run.workspace_id == ws.id).order_by(Run.created_at.desc()).limit(1)
+        select(Run)
+        .where(Run.workspace_id == ws.id, _primary_run_filter())
+        .order_by(Run.created_at.desc())
+        .limit(1)
     )
     latest_run = run_result.scalar_one_or_none()
 

--- a/services/terrapod/services/module_impact_service.py
+++ b/services/terrapod/services/module_impact_service.py
@@ -171,6 +171,11 @@ async def _poll_module_prs(
         try:
             await _create_module_test_runs(db, storage, module, conn, owner, repo, pr)
             pr_shas[pr_num_str] = pr.head_sha
+            # Commit after each PR so runs + module_overrides are visible to
+            # listeners immediately when the SSE event fires (flush alone keeps
+            # data in the uncommitted transaction, invisible to other sessions).
+            module.vcs_last_pr_shas = pr_shas
+            await db.commit()
         except Exception:
             logger.warning(
                 "Failed to create module test runs",


### PR DESCRIPTION
## Summary

- Module-test runs (module impact analysis) and speculative VCS PR/MR runs no longer affect the workspace's displayed "latest run" status or the admin health dashboard metrics
- Adds `_primary_run_filter()` to both `tfe_v2.py` (3 latest-run queries) and `health_dashboard.py` (5 run health queries) that excludes runs where `source == "module-test"` or `plan_only AND vcs_pull_request_number IS NOT NULL`
- Fixes a race condition in `module_impact_service.py` where the SSE `run_available` event was published before `db.commit()`, making the run and its `module_overrides` invisible to listeners' separate DB sessions

## Test plan

- [x] All 607 tests pass
- [ ] Verify workspace list page shows correct latest run status (not module-test/speculative runs)
- [ ] Verify health dashboard metrics exclude auxiliary runs