### PR TITLE
feat: add refresh button to run log panel

### DIFF
--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -187,7 +187,7 @@ function LogPanel({
           </button>
         </div>
         <div className="flex items-center gap-2">
-          {onRefresh && !isStreaming && (
+          {onRefresh && (
             <button
               onClick={onRefresh}
               className="px-2.5 py-1 text-xs rounded font-medium bg-slate-700 text-slate-400 hover:text-slate-200 transition-colors inline-flex items-center gap-1"


### PR DESCRIPTION
## Summary
- Adds a refresh button to the plan/apply log toolbar so users can re-fetch logs without reloading the page
- Hidden during active streaming (SSE handles live updates)