### PR TITLE
feat: trigger module impact poll from VCS webhooks

### DIFF
--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -99,6 +99,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
         # Module impact analysis: speculative plans for module PRs
         from terrapod.services.module_impact_service import (
+            handle_module_impact_immediate_poll,
             handle_module_test_completed,
             module_impact_poll_cycle,
         )
@@ -108,6 +109,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             interval_seconds=settings.vcs.poll_interval_seconds,
             handler=module_impact_poll_cycle,
             description="Poll VCS-connected modules for open PRs and create speculative runs",
+        )
+
+        register_trigger_handler(
+            "module_impact_immediate_poll",
+            handler=handle_module_impact_immediate_poll,
+            description="Webhook-triggered immediate module impact poll",
         )
 
         register_trigger_handler(

--- a/services/terrapod/api/routers/vcs_events.py
+++ b/services/terrapod/api/routers/vcs_events.py
@@ -77,5 +77,11 @@ async def github_webhook(request: Request) -> Response:
             {"repo": full_name},
             dedup_key=f"vcs_poll:{full_name}",
         )
+        # Also trigger module impact analysis for VCS-connected modules
+        await enqueue_trigger(
+            "module_impact_immediate_poll",
+            {"repo": full_name},
+            dedup_key=f"module_impact_poll:{full_name}",
+        )
 
     return JSONResponse(content={"message": "accepted"})

--- a/services/terrapod/services/module_impact_service.py
+++ b/services/terrapod/services/module_impact_service.py
@@ -84,6 +84,13 @@ async def _get_default_branch(conn: VCSConnection, owner: str, repo: str) -> str
 # ---------------------------------------------------------------------------
 
 
+async def handle_module_impact_immediate_poll(payload: dict) -> None:
+    """Webhook-triggered immediate module impact poll for a specific repo."""
+    repo = payload.get("repo", "unknown")
+    logger.info("Immediate module impact poll triggered by webhook", repo=repo)
+    await module_impact_poll_cycle()
+
+
 async def module_impact_poll_cycle() -> None:
     """Poll VCS-connected modules (with workspace links) for open PRs."""
     async with get_db_session() as db:

--- a/services/terrapod/services/registry_module_service.py
+++ b/services/terrapod/services/registry_module_service.py
@@ -270,28 +270,8 @@ async def get_module_download_url(
             coord = f"{namespace}/{name}/{provider}"
             override_path = run.module_overrides.get(coord)
             if override_path:
-                logger.info(
-                    "Serving module override",
-                    run_id=run_id,
-                    coord=coord,
-                    override_path=override_path,
-                )
                 presigned = await storage.presigned_get_url(override_path)
                 return presigned.url
-            else:
-                logger.info(
-                    "Module override not matched",
-                    run_id=run_id,
-                    coord=coord,
-                    overrides=run.module_overrides,
-                )
-        elif run_id:
-            logger.info(
-                "Module override lookup miss",
-                run_id=run_id,
-                run_found=run is not None,
-                has_overrides=bool(run.module_overrides) if run else False,
-            )
 
     # Normal path: look up published version
     module = await get_module(db, namespace, name, provider)


### PR DESCRIPTION
## Summary
- Webhook handler now also enqueues `module_impact_immediate_poll` alongside `vcs_immediate_poll`
- New trigger handler calls `module_impact_poll_cycle()` immediately on webhook receipt
- Modules with webhooks configured get instant PR detection instead of waiting for the 60s periodic poll
- Removes diagnostic logging from module override download path (no longer needed)