### PR TITLE
feat: add HTML5 input validation to frontend forms

### DIFF
--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -354,6 +354,8 @@ export default function AgentPoolDetailPage() {
                   <dt className="text-xs text-slate-500">Name</dt>
                   {editing ? (
                     <input type="text" value={editName} onChange={(e) => setEditName(e.target.value)}
+                      pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                      title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                       className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                   ) : (
                     <dd className="mt-1 text-sm text-slate-200">{pool.attributes.name}</dd>
@@ -426,6 +428,8 @@ export default function AgentPoolDetailPage() {
                   <div>
                     <label htmlFor="tok-max" className="block text-sm font-medium text-slate-300 mb-1">Max Uses (optional)</label>
                     <input id="tok-max" type="number" value={tokenMaxUses} onChange={(e) => setTokenMaxUses(e.target.value)}
+                      min="1"
+                      step="1"
                       placeholder="Unlimited"
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                   </div>

--- a/web/src/app/admin/agent-pools/page.tsx
+++ b/web/src/app/admin/agent-pools/page.tsx
@@ -125,6 +125,8 @@ export default function AgentPoolsPage() {
               <div>
                 <label htmlFor="pool-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                 <input id="pool-name" type="text" value={name} onChange={(e) => setName(e.target.value)} required
+                  pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                  title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                   placeholder="aws-prod"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
               </div>

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -388,6 +388,8 @@ export default function RolesPage() {
                   <div>
                     <label htmlFor="r-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                     <input id="r-name" type="text" value={roleName} onChange={(e) => setRoleName(e.target.value)} required placeholder="developer"
+                      pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                      title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                   </div>
                   <div>
@@ -574,7 +576,7 @@ export default function RolesPage() {
                   </div>
                   <div>
                     <label htmlFor="a-email" className="block text-sm font-medium text-slate-300 mb-1">Email</label>
-                    <input id="a-email" type="text" list="email-suggestions" value={assignEmail} onChange={(e) => setAssignEmail(e.target.value)} required
+                    <input id="a-email" type="email" list="email-suggestions" value={assignEmail} onChange={(e) => setAssignEmail(e.target.value)} required
                       placeholder="user@example.com"
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                     <datalist id="email-suggestions">

--- a/web/src/app/admin/variable-sets/page.tsx
+++ b/web/src/app/admin/variable-sets/page.tsx
@@ -136,6 +136,8 @@ export default function VariableSetsPage() {
               <div>
                 <label htmlFor="vs-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                 <input id="vs-name" type="text" value={name} onChange={(e) => setName(e.target.value)} required
+                  pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                  title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                   placeholder="aws-credentials"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
               </div>

--- a/web/src/app/admin/vcs-connections/page.tsx
+++ b/web/src/app/admin/vcs-connections/page.tsx
@@ -185,6 +185,8 @@ export default function VCSConnectionsPage() {
               <div>
                 <label htmlFor="vcs-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                 <input id="vcs-name" type="text" value={name} onChange={(e) => setName(e.target.value)} required
+                  pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                  title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                   placeholder="my-github-app"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
               </div>
@@ -199,6 +201,8 @@ export default function VCSConnectionsPage() {
               <div>
                 <label htmlFor="vcs-url" className="block text-sm font-medium text-slate-300 mb-1">Server URL (optional)</label>
                 <input id="vcs-url" type="text" value={serverUrl} onChange={(e) => setServerUrl(e.target.value)}
+                  pattern="https?://.+"
+                  title="Must be an HTTP or HTTPS URL (e.g. https://github.mycompany.com)"
                   placeholder={provider === 'github' ? 'https://api.github.com' : 'https://gitlab.com'}
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
               </div>
@@ -210,12 +214,16 @@ export default function VCSConnectionsPage() {
                   <div>
                     <label htmlFor="gh-app-id" className="block text-sm font-medium text-slate-300 mb-1">App ID</label>
                     <input id="gh-app-id" type="text" value={appId} onChange={(e) => setAppId(e.target.value)} required
+                      pattern="[0-9]+"
+                      title="GitHub App ID — numeric digits only"
                       placeholder="123456"
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                   </div>
                   <div>
                     <label htmlFor="gh-install-id" className="block text-sm font-medium text-slate-300 mb-1">Installation ID</label>
                     <input id="gh-install-id" type="text" value={installationId} onChange={(e) => setInstallationId(e.target.value)} required
+                      pattern="[0-9]+"
+                      title="GitHub App Installation ID — numeric digits only"
                       placeholder="789012"
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                   </div>

--- a/web/src/app/registry/modules/page.tsx
+++ b/web/src/app/registry/modules/page.tsx
@@ -120,6 +120,8 @@ export default function ModulesPage() {
                   value={newName}
                   onChange={(e) => setNewName(e.target.value)}
                   required
+                  pattern="[a-z][a-z0-9-]*"
+                  title="Lowercase letters, numbers, and hyphens only. Must start with a lowercase letter."
                   placeholder="vpc"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 />
@@ -132,6 +134,8 @@ export default function ModulesPage() {
                   value={newProvider}
                   onChange={(e) => setNewProvider(e.target.value)}
                   required
+                  pattern="[a-z][a-z0-9-]*"
+                  title="Lowercase letters, numbers, and hyphens only. Must start with a lowercase letter."
                   placeholder="aws"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 />

--- a/web/src/app/registry/providers/page.tsx
+++ b/web/src/app/registry/providers/page.tsx
@@ -111,6 +111,8 @@ export default function ProvidersPage() {
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 required
+                pattern="[a-z][a-z0-9-]*"
+                title="Lowercase letters, numbers, and hyphens only. Must start with a lowercase letter."
                 placeholder="aws"
                 className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
               />

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1148,7 +1148,10 @@ function WorkspaceDetailContent() {
                 <div>
                   <dt className="text-xs text-slate-500">CPU Request</dt>
                   {editing ? (
-                    <input type="text" value={editCpu} onChange={(e) => setEditCpu(e.target.value)} className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                    <input type="text" value={editCpu} onChange={(e) => setEditCpu(e.target.value)}
+                      pattern="[0-9]+m|[0-9]+(\.[0-9]+)?"
+                      title="Kubernetes CPU quantity: whole cores (1, 2) or millicores (500m, 100m)"
+                      className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                   ) : (
                     <dd className="mt-1 text-sm text-slate-200">{attrs['resource-cpu']}</dd>
                   )}
@@ -1156,7 +1159,10 @@ function WorkspaceDetailContent() {
                 <div>
                   <dt className="text-xs text-slate-500">Memory Request</dt>
                   {editing ? (
-                    <input type="text" value={editMemory} onChange={(e) => setEditMemory(e.target.value)} className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                    <input type="text" value={editMemory} onChange={(e) => setEditMemory(e.target.value)}
+                      pattern="[0-9]+(Ki|Mi|Gi|Ti|Pi|Ei|k|M|G|T|P|E|m)?"
+                      title="Kubernetes memory quantity: bytes (1000) or with suffix (512Mi, 2Gi, 1Ti)"
+                      className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                   ) : (
                     <dd className="mt-1 text-sm text-slate-200">{attrs['resource-memory']}</dd>
                   )}
@@ -1176,7 +1182,10 @@ function WorkspaceDetailContent() {
                   <dt className="text-xs text-slate-500">Version</dt>
                   {editing ? (
                     <>
-                      <input type="text" list="edit-version-suggestions" value={editVersion} onChange={(e) => setEditVersion(e.target.value)} placeholder="e.g. 1.9 or 1.9.8" className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                      <input type="text" list="edit-version-suggestions" value={editVersion} onChange={(e) => setEditVersion(e.target.value)} placeholder="e.g. 1.9 or 1.9.8"
+                        pattern="[0-9]+\.[0-9]+(\.[0-9]+)?"
+                        title="Version in X.Y or X.Y.Z format (e.g. 1.9 or 1.9.8)"
+                        className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                       <datalist id="edit-version-suggestions">
                         {versionSuggestions.map(v => (
                           <option key={v} value={v} />
@@ -1238,7 +1247,10 @@ function WorkspaceDetailContent() {
                 <div>
                   <dt className="text-xs text-slate-500">VCS Repository</dt>
                   {editing ? (
-                    <input type="text" value={editVcsRepoUrl} onChange={(e) => setEditVcsRepoUrl(e.target.value)} placeholder="https://github.com/org/repo" className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                    <input type="text" value={editVcsRepoUrl} onChange={(e) => setEditVcsRepoUrl(e.target.value)} placeholder="https://github.com/org/repo"
+                      pattern="https?://.+"
+                      title="Must be an HTTP or HTTPS URL"
+                      className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                   ) : (
                     <dd className="mt-1 text-sm text-slate-200">
                       {attrs['vcs-repo-url'] ? (

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -245,6 +245,8 @@ export default function WorkspacesPage() {
                   value={newName}
                   onChange={(e) => setNewName(e.target.value)}
                   required
+                  pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                  title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                   placeholder="my-workspace"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 />
@@ -281,6 +283,8 @@ export default function WorkspacesPage() {
                   list="version-suggestions"
                   value={newVersion}
                   onChange={(e) => setNewVersion(e.target.value)}
+                  pattern="[0-9]+\.[0-9]+(\.[0-9]+)?"
+                  title="Version in X.Y or X.Y.Z format (e.g. 1.9 or 1.9.8)"
                   placeholder="e.g. 1.9 or 1.9.8"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 />
@@ -297,9 +301,12 @@ export default function WorkspacesPage() {
                   type="text"
                   value={newCpu}
                   onChange={(e) => setNewCpu(e.target.value)}
+                  pattern="[0-9]+m|[0-9]+(\.[0-9]+)?"
+                  title="Kubernetes CPU quantity: whole cores (1, 2) or millicores (500m, 100m)"
                   placeholder="1"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 />
+                <p className="mt-1 text-xs text-slate-500">e.g. 1, 0.5, 500m</p>
               </div>
               <div>
                 <label htmlFor="ws-mem" className="block text-sm font-medium text-slate-300 mb-1">Memory Request</label>
@@ -308,9 +315,12 @@ export default function WorkspacesPage() {
                   type="text"
                   value={newMemory}
                   onChange={(e) => setNewMemory(e.target.value)}
+                  pattern="[0-9]+(Ki|Mi|Gi|Ti|Pi|Ei|k|M|G|T|P|E|m)?"
+                  title="Kubernetes memory quantity: bytes (1000) or with suffix (512Mi, 2Gi, 1Ti)"
                   placeholder="2Gi"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 />
+                <p className="mt-1 text-xs text-slate-500">e.g. 2Gi, 512Mi, 1Ti</p>
               </div>
               <div className="flex items-end">
                 <label className="flex items-center gap-2 px-3 py-2 cursor-pointer">
@@ -346,6 +356,8 @@ export default function WorkspacesPage() {
                   type="text"
                   value={newVcsRepoUrl}
                   onChange={(e) => setNewVcsRepoUrl(e.target.value)}
+                  pattern="https?://.+"
+                  title="Must be an HTTP or HTTPS URL"
                   placeholder="https://github.com/org/repo"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 />


### PR DESCRIPTION
## Summary

Adds `pattern`, `title`, `min`, `step`, and `type` attributes to form inputs across the UI so users get immediate browser-native validation feedback rather than waiting for an API round-trip to discover a format error. API-side validation is unchanged — this is purely additive.

## Fields covered

| Field(s) | Validation added |
|---|---|
| Workspace, pool, role, VCS connection, variable set names | `pattern=[a-zA-Z0-9][a-zA-Z0-9_-]*` — alphanumeric, hyphens, underscores; must start with letter/number |
| Registry module name, provider name | `pattern=[a-z][a-z0-9-]*` — lowercase per Terraform registry convention |
| CPU request (workspace create + edit) | `pattern` accepts whole cores (`1`, `0.5`) or millicores (`500m`) |
| Memory request (workspace create + edit) | `pattern` accepts plain bytes or SI suffixes (`2Gi`, `512Mi`, `1Ti`) |
| Version (workspace create + edit) | `pattern=[0-9]+\.[0-9]+(\.[0-9]+)?` — `X.Y` or `X.Y.Z` format |
| VCS repository URL (create + edit), VCS server URL | `pattern=https?://.+` — HTTP/HTTPS only |
| GitHub App ID, Installation ID | `pattern=[0-9]+` — digits only |
| Agent pool token Max Uses | `min="1"`, `step="1"` (already `type="number"`) |
| Role assignment email | Changed `type="text"` → `type="email"` for native email validation |

`title` attributes are set on all patterned fields to explain the expected format in the browser's validation tooltip. Short hint text added below CPU and memory fields (`e.g. 1, 0.5, 500m`).

## What was already correct

- Notification webhook URL: already `type="url"`
- Run task webhook URL: already `type="url"`
- User passwords: already have zxcvbn strength validation
- User/owner email fields: already `type="email"`
- All dropdowns: controlled values, no free-text risk

## Files changed

- `web/src/app/workspaces/page.tsx` — create workspace form
- `web/src/app/workspaces/[id]/page.tsx` — workspace edit form
- `web/src/app/admin/vcs-connections/page.tsx` — create VCS connection
- `web/src/app/admin/agent-pools/page.tsx` — create pool
- `web/src/app/admin/agent-pools/[id]/page.tsx` — edit pool name, create token
- `web/src/app/admin/roles/page.tsx` — create role, role assignment email
- `web/src/app/admin/variable-sets/page.tsx` — create variable set
- `web/src/app/registry/modules/page.tsx` — create module
- `web/src/app/registry/providers/page.tsx` — create provider