### PR TITLE
feat: add application-level Prometheus metrics

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Health Dashboard](health-dashboard.md) | Workspace health, drift status, run metrics |
 | [Cloud Credentials](cloud-credentials.md) | AWS IRSA, GCP WIF, Azure WI setup |
 | [Registry](registry.md) | Private module/provider registry, caching layers |
+| [Monitoring](monitoring.md) | Prometheus metrics, scraping, recommended alerts |
 | [Deployment](deployment.md) | Production Helm deployment, storage backends, scaling |
 | [API Reference](api-reference.md) | All API endpoints with examples |
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,269 @@
+# Monitoring
+
+Terrapod exposes Prometheus metrics from two components: the **API server** (FastAPI) and the **web frontend** (Next.js). Metrics cover HTTP requests, run lifecycle, scheduler health, VCS polling, storage operations, authentication, caching, and infrastructure errors.
+
+---
+
+## Enabling Metrics
+
+Metrics are gated by a single Helm value:
+
+```yaml
+api:
+  config:
+    metrics:
+      enabled: true
+```
+
+When enabled:
+
+- The **API** serves `/metrics` on its main port (8000) and registers HTTP request middleware for automatic request counting and duration tracking.
+- The **web frontend** starts a separate metrics server on port **9091** via a Next.js `instrumentation.ts` hook. This port is added to the web Deployment and Service only when metrics are enabled.
+
+---
+
+## Security
+
+The `/metrics` endpoints are **not exposed via the public ingress**:
+
+- **API**: The BFF middleware only proxies `/api/*`, `/.well-known/*`, `/oauth/*`, `/v1/*`. The API's `/metrics` is never reachable from the internet.
+- **Web**: Metrics are served on a **separate port** (9091). The ingress only routes to the web's main port (3000), so metrics are never reachable from the public URL.
+
+Metrics are only reachable via **internal Service scraping** (Prometheus ServiceMonitor, `kubectl port-forward`, or direct pod access).
+
+---
+
+## Scraping
+
+### ServiceMonitor (Prometheus Operator)
+
+When both `metrics.enabled` and `metrics.serviceMonitor.enabled` are true, Terrapod creates ServiceMonitors for the API and web services:
+
+```yaml
+api:
+  config:
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+        interval: "30s"    # scrape interval (default 30s)
+        labels: {}         # extra labels for ServiceMonitor selection
+```
+
+The listener Deployment has a separate PodMonitor (`podmonitor-listener.yaml`), also gated by `metrics.enabled`.
+
+| Component | Port | Path | ServiceMonitor |
+|---|---|---|---|
+| API | 8000 | `/metrics` | `servicemonitor-api.yaml` |
+| Web | 9091 | `/metrics` | `servicemonitor-web.yaml` |
+| Listener | (pod) | `/metrics` | `podmonitor-listener.yaml` |
+
+### Annotation-Based Discovery
+
+When metrics are enabled, Terrapod adds standard `prometheus.io/*` annotations to API and web pods:
+
+| Component | `prometheus.io/scrape` | `prometheus.io/port` | `prometheus.io/path` |
+|---|---|---|---|
+| API | `"true"` | `8000` | `/metrics` |
+| Web | `"true"` | `9091` | `/metrics` |
+
+These annotations are used by Prometheus configurations that rely on `kubernetes_sd_configs` with annotation-based relabeling (the older, non-Operator pattern). If you're using ServiceMonitors (Prometheus Operator), the annotations are harmless but redundant.
+
+### Manual Scrape Config
+
+If not using the Prometheus Operator:
+
+```yaml
+scrape_configs:
+  - job_name: terrapod-api
+    kubernetes_sd_configs:
+      - role: service
+        namespaces:
+          names: [terrapod]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name]
+        regex: terrapod-api
+        action: keep
+    metrics_path: /metrics
+
+  - job_name: terrapod-web
+    kubernetes_sd_configs:
+      - role: service
+        namespaces:
+          names: [terrapod]
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name]
+        regex: terrapod-web
+        action: keep
+      - source_labels: [__meta_kubernetes_service_port_name]
+        regex: metrics
+        action: keep
+    metrics_path: /metrics
+```
+
+---
+
+## Metrics Reference
+
+### HTTP (API)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_http_requests_total` | Counter | method, path_template, status | Total HTTP requests |
+| `terrapod_http_request_duration_seconds` | Histogram | method, path_template, status | Request duration |
+
+### Runs
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_runs_created_total` | Counter | source, plan_only | Runs created |
+| `terrapod_runs_transitioned_total` | Counter | from_status, to_status | Run state transitions |
+| `terrapod_runs_terminal_total` | Counter | status | Runs reaching terminal state |
+| `terrapod_run_plan_duration_seconds` | Histogram | status | Plan phase duration |
+| `terrapod_run_apply_duration_seconds` | Histogram | status | Apply phase duration |
+
+### Scheduler
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_scheduler_task_executions_total` | Counter | task, status | Periodic task executions |
+| `terrapod_scheduler_task_duration_seconds` | Histogram | task | Periodic task duration |
+| `terrapod_scheduler_trigger_enqueued_total` | Counter | type | Triggers enqueued |
+| `terrapod_scheduler_trigger_deduplicated_total` | Counter | type | Triggers skipped (dedup) |
+| `terrapod_scheduler_trigger_processed_total` | Counter | type, status | Triggers processed |
+
+### VCS
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_vcs_poll_duration_seconds` | Histogram | provider | Poll cycle duration |
+| `terrapod_vcs_commits_detected_total` | Counter | provider | New commits detected |
+| `terrapod_vcs_prs_detected_total` | Counter | provider | New PRs/MRs detected |
+| `terrapod_vcs_runs_created_total` | Counter | provider, type | Runs created by VCS poller |
+| `terrapod_vcs_webhook_received_total` | Counter | provider | Webhook events received |
+
+### Storage
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_storage_operations_total` | Counter | operation, status | Storage operations |
+| `terrapod_storage_operation_duration_seconds` | Histogram | operation | Storage operation duration |
+| `terrapod_storage_errors_total` | Counter | operation | Storage errors |
+
+### Auth
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_auth_login_total` | Counter | provider, outcome | Login attempts |
+| `terrapod_auth_failures_total` | Counter | method, reason | Authentication failures |
+
+### Cache
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_binary_cache_requests_total` | Counter | tool, result | Binary cache requests (hit/miss) |
+| `terrapod_provider_cache_requests_total` | Counter | result | Provider cache requests (hit/miss) |
+
+### Infrastructure
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_db_errors_total` | Counter | operation | Database errors |
+| `terrapod_redis_errors_total` | Counter | operation | Redis errors |
+
+### State
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_state_versions_created_total` | Counter | -- | State versions created |
+| `terrapod_state_lock_conflicts_total` | Counter | -- | Lock conflicts (409) |
+
+### Listeners
+
+Listener metrics are emitted by the **API server** (not the listener itself), since the API receives all heartbeats and join requests. This avoids needing a separate scrape target on the listener.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_listener_heartbeats_total` | Counter | pool_id | Heartbeats received from listeners |
+| `terrapod_listener_joins_total` | Counter | pool_name | Listener join events |
+
+### Web (Next.js)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `terrapod_web_page_requests_total` | Counter | path | Page/route handler requests |
+| `terrapod_web_metrics_scrapes_total` | Counter | -- | Metrics endpoint scrapes |
+| Node.js default metrics | various | -- | GC, event loop, memory (via prom-client) |
+
+---
+
+## Recommended Alerts
+
+### High Error Rate
+
+```yaml
+- alert: TerrapodHighErrorRate
+  expr: |
+    sum(rate(terrapod_http_requests_total{status=~"5.."}[5m]))
+    / sum(rate(terrapod_http_requests_total[5m])) > 0.05
+  for: 5m
+  annotations:
+    summary: "Terrapod API error rate above 5%"
+```
+
+### Stuck Runs
+
+```yaml
+- alert: TerrapodStuckRuns
+  expr: |
+    increase(terrapod_runs_transitioned_total{to_status=~"planning|applying"}[30m]) > 0
+    unless increase(terrapod_runs_terminal_total[30m]) > 0
+  for: 30m
+  annotations:
+    summary: "Runs entering planning/applying but none reaching terminal state"
+```
+
+### Scheduler Stalls
+
+```yaml
+- alert: TerrapodSchedulerStall
+  expr: |
+    increase(terrapod_scheduler_task_executions_total{task="run_reconciler"}[5m]) == 0
+  for: 5m
+  annotations:
+    summary: "Run reconciler has not executed in 5 minutes"
+```
+
+### Storage Errors
+
+```yaml
+- alert: TerrapodStorageErrors
+  expr: rate(terrapod_storage_errors_total[5m]) > 0
+  for: 5m
+  annotations:
+    summary: "Storage backend errors detected"
+```
+
+### Database/Redis Errors
+
+```yaml
+- alert: TerrapodInfraErrors
+  expr: |
+    rate(terrapod_db_errors_total[5m]) > 0.1
+    or rate(terrapod_redis_errors_total[5m]) > 0.1
+  for: 5m
+  annotations:
+    summary: "Database or Redis errors detected"
+```
+
+### Cache Miss Rate
+
+```yaml
+- alert: TerrapodHighCacheMissRate
+  expr: |
+    sum(rate(terrapod_binary_cache_requests_total{result="miss"}[1h]))
+    / sum(rate(terrapod_binary_cache_requests_total[1h])) > 0.5
+  for: 1h
+  annotations:
+    summary: "Binary cache miss rate above 50% over the last hour"
+```

--- a/helm/terrapod/Chart.yaml
+++ b/helm/terrapod/Chart.yaml
@@ -16,5 +16,7 @@ home: https://github.com/mattrobinsonsre/terrapod
 sources:
   - https://github.com/mattrobinsonsre/terrapod
 
+icon: https://raw.githubusercontent.com/mattrobinsonsre/terrapod/main/web/public/logo.svg
+
 maintainers:
   - name: Matt Robinson

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -23,6 +23,11 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-api.yaml") . | sha256sum }}
+        {{- if .Values.api.config.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+        {{- end }}
         {{- with .Values.api.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/terrapod/templates/deployment-web.yaml
+++ b/helm/terrapod/templates/deployment-web.yaml
@@ -21,9 +21,16 @@ spec:
       {{- include "terrapod.web.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.web.podAnnotations }}
+      {{- if or .Values.api.config.metrics.enabled .Values.web.podAnnotations }}
       annotations:
+        {{- if .Values.api.config.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9091"
+        prometheus.io/path: "/metrics"
+        {{- end }}
+        {{- with .Values.web.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "terrapod.web.selectorLabels" . | nindent 8 }}
@@ -50,6 +57,11 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+            {{- if .Values.api.config.metrics.enabled }}
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+            {{- end }}
           env:
             - name: API_URL
               value: "http://{{ include "terrapod.fullname" . }}-api:8000"

--- a/helm/terrapod/templates/service-web.yaml
+++ b/helm/terrapod/templates/service-web.yaml
@@ -17,6 +17,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.api.config.metrics.enabled }}
+    - port: 9091
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "terrapod.web.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/terrapod/templates/servicemonitor-web.yaml
+++ b/helm/terrapod/templates/servicemonitor-web.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.web.enabled }}
+{{- if and .Values.api.config.metrics.enabled .Values.api.config.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "terrapod.fullname" . }}-web
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+    {{- with .Values.api.config.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "terrapod.web.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.api.config.metrics.serviceMonitor.interval | default "30s" }}
+{{- end }}
+{{- end }}

--- a/services/terrapod/api/dependencies.py
+++ b/services/terrapod/api/dependencies.py
@@ -21,6 +21,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from terrapod.api.metrics import AUTH_FAILURES
 from terrapod.auth.api_tokens import validate_api_token
 from terrapod.auth.sessions import (
     Session,
@@ -161,6 +162,15 @@ async def get_current_user(
                 provider_name=session.provider_name,
                 auth_method="session",
             )
+
+    if credentials is not None:
+        _tok = credentials.credentials
+        if _tok.startswith("runtok:"):
+            AUTH_FAILURES.labels(method="runner_token", reason="invalid_or_expired").inc()
+        else:
+            AUTH_FAILURES.labels(method="bearer", reason="invalid_or_expired").inc()
+    else:
+        AUTH_FAILURES.labels(method="none", reason="missing").inc()
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,

--- a/services/terrapod/api/metrics.py
+++ b/services/terrapod/api/metrics.py
@@ -1,13 +1,20 @@
 """Prometheus metrics instrumentation for the Terrapod API server.
 
-Provides HTTP request counter/histogram and a /metrics endpoint.
-Only active when settings.metrics.enabled is True.
+Provides HTTP request counter/histogram, application-level metrics,
+and a /metrics endpoint.  Only active when settings.metrics.enabled is True.
+
+All metric objects are defined centrally here and imported at
+instrumentation points (1-2 lines each).
 """
 
 import time
 
 from fastapi import Request, Response
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+# ---------------------------------------------------------------------------
+# HTTP request metrics
+# ---------------------------------------------------------------------------
 
 REQUEST_COUNT = Counter(
     "terrapod_http_requests_total",
@@ -19,6 +26,209 @@ REQUEST_DURATION = Histogram(
     "terrapod_http_request_duration_seconds",
     "HTTP request duration in seconds",
     ["method", "path_template", "status"],
+)
+
+# ---------------------------------------------------------------------------
+# Run lifecycle metrics
+# ---------------------------------------------------------------------------
+
+RUNS_CREATED = Counter(
+    "terrapod_runs_created_total",
+    "Total runs created",
+    ["source", "plan_only"],
+)
+
+RUNS_TRANSITIONED = Counter(
+    "terrapod_runs_transitioned_total",
+    "Total run state transitions",
+    ["from_status", "to_status"],
+)
+
+RUNS_TERMINAL = Counter(
+    "terrapod_runs_terminal_total",
+    "Total runs reaching terminal state",
+    ["status"],
+)
+
+RUN_PLAN_DURATION = Histogram(
+    "terrapod_run_plan_duration_seconds",
+    "Duration of run plan phase in seconds",
+    ["status"],
+)
+
+RUN_APPLY_DURATION = Histogram(
+    "terrapod_run_apply_duration_seconds",
+    "Duration of run apply phase in seconds",
+    ["status"],
+)
+
+# ---------------------------------------------------------------------------
+# Scheduler metrics
+# ---------------------------------------------------------------------------
+
+SCHEDULER_TASK_EXECUTIONS = Counter(
+    "terrapod_scheduler_task_executions_total",
+    "Total periodic task executions",
+    ["task", "status"],
+)
+
+SCHEDULER_TASK_DURATION = Histogram(
+    "terrapod_scheduler_task_duration_seconds",
+    "Duration of periodic task executions in seconds",
+    ["task"],
+)
+
+SCHEDULER_TRIGGER_ENQUEUED = Counter(
+    "terrapod_scheduler_trigger_enqueued_total",
+    "Total triggers enqueued",
+    ["type"],
+)
+
+SCHEDULER_TRIGGER_DEDUPLICATED = Counter(
+    "terrapod_scheduler_trigger_deduplicated_total",
+    "Total triggers deduplicated (skipped)",
+    ["type"],
+)
+
+SCHEDULER_TRIGGER_PROCESSED = Counter(
+    "terrapod_scheduler_trigger_processed_total",
+    "Total triggers processed",
+    ["type", "status"],
+)
+
+# ---------------------------------------------------------------------------
+# VCS metrics
+# ---------------------------------------------------------------------------
+
+VCS_POLL_DURATION = Histogram(
+    "terrapod_vcs_poll_duration_seconds",
+    "Duration of VCS poll cycle in seconds",
+    ["provider"],
+)
+
+VCS_COMMITS_DETECTED = Counter(
+    "terrapod_vcs_commits_detected_total",
+    "Total new commits detected by VCS poller",
+    ["provider"],
+)
+
+VCS_PRS_DETECTED = Counter(
+    "terrapod_vcs_prs_detected_total",
+    "Total new PRs/MRs detected by VCS poller",
+    ["provider"],
+)
+
+VCS_RUNS_CREATED = Counter(
+    "terrapod_vcs_runs_created_total",
+    "Total runs created by VCS poller",
+    ["provider", "type"],
+)
+
+VCS_WEBHOOK_RECEIVED = Counter(
+    "terrapod_vcs_webhook_received_total",
+    "Total VCS webhook events received",
+    ["provider"],
+)
+
+# ---------------------------------------------------------------------------
+# Storage metrics
+# ---------------------------------------------------------------------------
+
+STORAGE_OPERATIONS = Counter(
+    "terrapod_storage_operations_total",
+    "Total storage operations",
+    ["operation", "status"],
+)
+
+STORAGE_OPERATION_DURATION = Histogram(
+    "terrapod_storage_operation_duration_seconds",
+    "Duration of storage operations in seconds",
+    ["operation"],
+)
+
+STORAGE_ERRORS = Counter(
+    "terrapod_storage_errors_total",
+    "Total storage operation errors",
+    ["operation"],
+)
+
+# ---------------------------------------------------------------------------
+# Auth metrics
+# ---------------------------------------------------------------------------
+
+AUTH_LOGIN = Counter(
+    "terrapod_auth_login_total",
+    "Total login attempts",
+    ["provider", "outcome"],
+)
+
+AUTH_FAILURES = Counter(
+    "terrapod_auth_failures_total",
+    "Total authentication failures",
+    ["method", "reason"],
+)
+
+# ---------------------------------------------------------------------------
+# Cache metrics
+# ---------------------------------------------------------------------------
+
+BINARY_CACHE_REQUESTS = Counter(
+    "terrapod_binary_cache_requests_total",
+    "Total binary cache requests",
+    ["tool", "result"],
+)
+
+PROVIDER_CACHE_REQUESTS = Counter(
+    "terrapod_provider_cache_requests_total",
+    "Total provider cache requests",
+    ["result"],
+)
+
+# ---------------------------------------------------------------------------
+# Infrastructure error metrics
+# ---------------------------------------------------------------------------
+
+DB_ERRORS = Counter(
+    "terrapod_db_errors_total",
+    "Total database errors",
+    ["operation"],
+)
+
+REDIS_ERRORS = Counter(
+    "terrapod_redis_errors_total",
+    "Total Redis errors",
+    ["operation"],
+)
+
+# ---------------------------------------------------------------------------
+# State metrics
+# ---------------------------------------------------------------------------
+
+STATE_VERSIONS_CREATED = Counter(
+    "terrapod_state_versions_created_total",
+    "Total state versions created",
+)
+
+STATE_LOCK_CONFLICTS = Counter(
+    "terrapod_state_lock_conflicts_total",
+    "Total state lock conflicts (409)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Listener metrics (emitted from API, not from the listener itself)
+# ---------------------------------------------------------------------------
+
+LISTENER_HEARTBEATS = Counter(
+    "terrapod_listener_heartbeats_total",
+    "Total listener heartbeats received",
+    ["pool_id"],
+)
+
+LISTENER_JOINS = Counter(
+    "terrapod_listener_joins_total",
+    "Total listener joins",
+    ["pool_name"],
 )
 
 

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -308,8 +308,10 @@ async def join_listener(
     result = await agent_pool_service.join_listener(pool, token, name, db)
     await db.commit()
 
+    from terrapod.api.metrics import LISTENER_JOINS
     from terrapod.redis.client import POOL_EVENTS_PREFIX, publish_event
 
+    LISTENER_JOINS.labels(pool_name=pool.name).inc()
     await publish_event(
         f"{POOL_EVENTS_PREFIX}{pool.id}",
         json.dumps({"event": "listener_joined", "listener_name": name}),
@@ -348,8 +350,10 @@ async def join_listener_by_token(
     result["pool_id"] = str(pool.id)
     await db.commit()
 
+    from terrapod.api.metrics import LISTENER_JOINS
     from terrapod.redis.client import POOL_EVENTS_PREFIX, publish_event
 
+    LISTENER_JOINS.labels(pool_name=pool.name).inc()
     await publish_event(
         f"{POOL_EVENTS_PREFIX}{pool.id}",
         json.dumps({"event": "listener_joined", "listener_name": name}),
@@ -509,6 +513,10 @@ async def listener_heartbeat(
         capacity=str(capacity),
         active_runs=str(active_runs),
     )
+
+    from terrapod.api.metrics import LISTENER_HEARTBEATS
+
+    LISTENER_HEARTBEATS.labels(pool_id=listener.get("pool_id", "unknown")).inc()
 
     # Publish heartbeat event to admin dashboard + pool SSE channels
     try:

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -945,6 +945,10 @@ async def create_state_version(
     await db.commit()
     await db.refresh(sv)
 
+    from terrapod.api.metrics import STATE_VERSIONS_CREATED
+
+    STATE_VERSIONS_CREATED.inc()
+
     logger.info("State version created", workspace=ws.name, serial=serial, sv_id=str(sv.id))
 
     from terrapod.redis.client import publish_workspace_event
@@ -1043,6 +1047,9 @@ async def lock_workspace(
     lock_id = lock_info.get("ID", f"lock-{user.email}")
 
     if ws.locked:
+        from terrapod.api.metrics import STATE_LOCK_CONFLICTS
+
+        STATE_LOCK_CONFLICTS.inc()
         raise HTTPException(
             status_code=409, detail=f'workspace already locked (lock ID: "{ws.lock_id}")'
         )

--- a/services/terrapod/api/routers/vcs_events.py
+++ b/services/terrapod/api/routers/vcs_events.py
@@ -65,6 +65,9 @@ async def github_webhook(request: Request) -> Response:
         return JSONResponse(content={"message": "ignored"})
 
     if event_type in ("push", "pull_request"):
+        from terrapod.api.metrics import VCS_WEBHOOK_RECEIVED
+
+        VCS_WEBHOOK_RECEIVED.labels(provider="github").inc()
         logger.info(
             "Webhook event received",
             event_type=event_type,

--- a/services/terrapod/db/session.py
+++ b/services/terrapod/db/session.py
@@ -81,6 +81,9 @@ async def get_db() -> AsyncGenerator[AsyncSession]:
             yield session
             await session.commit()
         except Exception:
+            from terrapod.api.metrics import DB_ERRORS
+
+            DB_ERRORS.labels(operation="session").inc()
             await session.rollback()
             raise
 
@@ -100,6 +103,9 @@ async def get_db_session() -> AsyncGenerator[AsyncSession]:
             yield session
             await session.commit()
         except Exception:
+            from terrapod.api.metrics import DB_ERRORS
+
+            DB_ERRORS.labels(operation="session").inc()
             await session.rollback()
             raise
 

--- a/services/terrapod/redis/client.py
+++ b/services/terrapod/redis/client.py
@@ -67,6 +67,9 @@ async def get_redis_health() -> bool:
         await _redis.ping()
         return True
     except Exception as e:
+        from terrapod.api.metrics import REDIS_ERRORS
+
+        REDIS_ERRORS.labels(operation="health_check").inc()
         logger.error("Redis health check failed", error=str(e))
         return False
 

--- a/services/terrapod/services/binary_cache_service.py
+++ b/services/terrapod/services/binary_cache_service.py
@@ -10,6 +10,7 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from terrapod.api.metrics import BINARY_CACHE_REQUESTS
 from terrapod.config import settings
 from terrapod.db.models import CachedBinary
 from terrapod.logging_config import get_logger
@@ -50,11 +51,13 @@ async def get_or_cache_binary(
     # Check cache
     cached = await _get_cached(db, tool, version, os_, arch)
     if cached is not None:
+        BINARY_CACHE_REQUESTS.labels(tool=tool, result="hit").inc()
         key = binary_cache_key(tool, version, os_, arch)
         presigned = await storage.presigned_get_url(key)
         return presigned.url
 
     # Cache miss — fetch from upstream
+    BINARY_CACHE_REQUESTS.labels(tool=tool, result="miss").inc()
     logger.info(
         "Binary cache miss, fetching from upstream",
         tool=tool,

--- a/services/terrapod/services/provider_cache_service.py
+++ b/services/terrapod/services/provider_cache_service.py
@@ -19,6 +19,7 @@ import httpx
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from terrapod.api.metrics import PROVIDER_CACHE_REQUESTS
 from terrapod.config import settings
 from terrapod.db.models import CachedProviderPackage
 from terrapod.logging_config import get_logger
@@ -153,6 +154,11 @@ async def get_or_fetch_platforms(
                 delete(CachedProviderPackage).where(CachedProviderPackage.id.in_(stale_ids))
             )
             await db.flush()
+
+    if cached_platforms:
+        PROVIDER_CACHE_REQUESTS.labels(result="hit").inc()
+    else:
+        PROVIDER_CACHE_REQUESTS.labels(result="miss").inc()
 
     # --- Tier 2: check Redis for upstream metadata ---
     meta = await _get_cached_metadata(hostname, namespace, type_, version)

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -6,6 +6,13 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from terrapod.api.metrics import (
+    RUN_APPLY_DURATION,
+    RUN_PLAN_DURATION,
+    RUNS_CREATED,
+    RUNS_TERMINAL,
+    RUNS_TRANSITIONED,
+)
 from terrapod.db.models import (
     ConfigurationVersion,
     Run,
@@ -237,6 +244,8 @@ async def create_run(
     db.add(run)
     await db.flush()
 
+    RUNS_CREATED.labels(source=source, plan_only=str(plan_only)).inc()
+
     logger.info(
         "Run created",
         run_id=str(run.id),
@@ -303,6 +312,16 @@ async def transition_run(
         run.apply_finished_at = now
 
     await db.flush()
+
+    RUNS_TRANSITIONED.labels(from_status=old_status, to_status=target_status).inc()
+    if target_status in TERMINAL_STATES:
+        RUNS_TERMINAL.labels(status=target_status).inc()
+    if run.plan_started_at and run.plan_finished_at and target_status in ("planned", "errored"):
+        duration = (run.plan_finished_at - run.plan_started_at).total_seconds()
+        RUN_PLAN_DURATION.labels(status=target_status).observe(duration)
+    if run.apply_started_at and run.apply_finished_at and target_status in ("applied", "errored"):
+        duration = (run.apply_finished_at - run.apply_started_at).total_seconds()
+        RUN_APPLY_DURATION.labels(status=target_status).observe(duration)
 
     logger.info(
         "Run transitioned",

--- a/services/terrapod/services/scheduler.py
+++ b/services/terrapod/services/scheduler.py
@@ -31,6 +31,13 @@ import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
+from terrapod.api.metrics import (
+    SCHEDULER_TASK_DURATION,
+    SCHEDULER_TASK_EXECUTIONS,
+    SCHEDULER_TRIGGER_DEDUPLICATED,
+    SCHEDULER_TRIGGER_ENQUEUED,
+    SCHEDULER_TRIGGER_PROCESSED,
+)
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
 
@@ -164,6 +171,7 @@ async def enqueue_trigger(
         dedup_redis_key = f"{PREFIX}:trigger:{dedup_key}"
         added = await redis.set(dedup_redis_key, "1", nx=True, ex=dedup_ttl)
         if not added:
+            SCHEDULER_TRIGGER_DEDUPLICATED.labels(type=trigger_type).inc()
             logger.debug("Trigger deduplicated", type=trigger_type, dedup_key=dedup_key)
             return False
 
@@ -176,6 +184,7 @@ async def enqueue_trigger(
         }
     )
     await redis.lpush(f"{PREFIX}:triggers", item)
+    SCHEDULER_TRIGGER_ENQUEUED.labels(type=trigger_type).inc()
     logger.info("Trigger enqueued", type=trigger_type, dedup_key=dedup_key)
     return True
 
@@ -206,9 +215,12 @@ async def _run_periodic_loop(
         try:
             if await try_claim_periodic(task.name, task.interval_seconds):
                 logger.debug("Claimed periodic task", task=task.name)
+                start = time.monotonic()
                 try:
                     await task.handler()
+                    SCHEDULER_TASK_EXECUTIONS.labels(task=task.name, status="success").inc()
                 except Exception as e:
+                    SCHEDULER_TASK_EXECUTIONS.labels(task=task.name, status="error").inc()
                     logger.error(
                         "Periodic task failed",
                         task=task.name,
@@ -216,6 +228,7 @@ async def _run_periodic_loop(
                         exc_info=e,
                     )
                 finally:
+                    SCHEDULER_TASK_DURATION.labels(task=task.name).observe(time.monotonic() - start)
                     await mark_completed(task.name)
         except Exception as e:
             logger.error("Scheduler claim error", task=task.name, error=str(e))
@@ -254,7 +267,9 @@ async def _run_trigger_consumer(shutdown: asyncio.Event) -> None:
                 logger.info("Executing trigger", type=trigger_type)
                 try:
                     await handler_def.handler(payload)
+                    SCHEDULER_TRIGGER_PROCESSED.labels(type=trigger_type, status="success").inc()
                 except Exception as e:
+                    SCHEDULER_TRIGGER_PROCESSED.labels(type=trigger_type, status="error").inc()
                     logger.error(
                         "Trigger handler failed",
                         type=trigger_type,

--- a/services/terrapod/services/sso_service.py
+++ b/services/terrapod/services/sso_service.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from terrapod.api.metrics import AUTH_LOGIN
 from terrapod.auth.claims_mapper import map_claims_to_roles
 from terrapod.auth.recent_users import record_recent_user
 from terrapod.auth.sso import AuthenticatedIdentity
@@ -65,8 +66,10 @@ async def process_login(
         result = await db.execute(select(User).where(User.email == identity.email))
         user = result.scalar_one_or_none()
         if not user:
+            AUTH_LOGIN.labels(provider=identity.provider_name, outcome="user_not_found").inc()
             raise ValueError("User not found")
         if not user.is_active:
+            AUTH_LOGIN.labels(provider=identity.provider_name, outcome="disabled").inc()
             raise ValueError("User account is disabled")
         # Update last_login_at
         from terrapod.db.models import utc_now
@@ -105,6 +108,8 @@ async def process_login(
         await record_recent_user(identity.provider_name, identity.email, identity.display_name)
     except Exception:
         logger.debug("Failed to record recent user", exc_info=True)
+
+    AUTH_LOGIN.labels(provider=identity.provider_name, outcome="success").inc()
 
     return LoginResult(
         email=identity.email,

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -17,9 +17,17 @@ runs each poll cycle per interval. Webhook-triggered immediate polls use
 the scheduler's trigger queue with deduplication.
 """
 
+import time as time_mod
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from terrapod.api.metrics import (
+    VCS_COMMITS_DETECTED,
+    VCS_POLL_DURATION,
+    VCS_PRS_DETECTED,
+    VCS_RUNS_CREATED,
+)
 from terrapod.db.models import Run, VCSConnection, Workspace
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
@@ -243,6 +251,8 @@ async def _poll_workspace_branch(
     if sha == ws.vcs_last_commit_sha:
         return
 
+    VCS_COMMITS_DETECTED.labels(provider=conn.provider).inc()
+
     logger.info(
         "New commit detected",
         workspace=ws.name,
@@ -288,6 +298,7 @@ async def _poll_workspace_branch(
     )
 
     if run:
+        VCS_RUNS_CREATED.labels(provider=conn.provider, type="push").inc()
         ws.vcs_last_commit_sha = sha
         await db.commit()
 
@@ -358,6 +369,8 @@ async def _poll_workspace_prs(
                     error=str(e),
                 )
 
+        VCS_PRS_DETECTED.labels(provider=conn.provider).inc()
+
         logger.info(
             "New PR commit detected",
             workspace=ws.name,
@@ -406,6 +419,7 @@ async def _poll_workspace_prs(
         )
 
         if run:
+            VCS_RUNS_CREATED.labels(provider=conn.provider, type="pr").inc()
             await db.commit()
             logger.info(
                 "Speculative run created for PR",
@@ -459,6 +473,7 @@ async def poll_cycle() -> None:
     Called by the distributed scheduler as a periodic task. Only one
     replica runs this per interval across the entire deployment.
     """
+    start = time_mod.monotonic()
     async with get_db_session() as db:
         result = await db.execute(
             select(Workspace).where(
@@ -469,6 +484,7 @@ async def poll_cycle() -> None:
         workspaces = result.scalars().all()
 
         if not workspaces:
+            VCS_POLL_DURATION.labels(provider="all").observe(time_mod.monotonic() - start)
             return
 
         logger.debug("VCS poll cycle", workspace_count=len(workspaces))
@@ -483,6 +499,8 @@ async def poll_cycle() -> None:
                     error=str(e),
                     exc_info=e,
                 )
+
+    VCS_POLL_DURATION.labels(provider="all").observe(time_mod.monotonic() - start)
 
 
 async def handle_immediate_poll(payload: dict) -> None:

--- a/services/terrapod/storage/__init__.py
+++ b/services/terrapod/storage/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from terrapod.config import StorageBackend, settings
 from terrapod.logging_config import get_logger
-from terrapod.storage.protocol import ObjectStore
+from terrapod.storage.protocol import InstrumentedStore, ObjectStore
 
 logger = get_logger(__name__)
 
@@ -76,6 +76,10 @@ async def init_storage() -> None:
                 presigned_url_expiry_seconds=cfg.gcs.presigned_url_expiry_seconds,
             )
             logger.info("Storage initialized", backend="gcs", bucket=cfg.gcs.bucket)
+
+    # Wrap with metrics instrumentation when enabled
+    if _store is not None and settings.metrics.enabled:
+        _store = InstrumentedStore(_store)  # type: ignore[assignment]
 
 
 async def close_storage() -> None:

--- a/services/terrapod/storage/protocol.py
+++ b/services/terrapod/storage/protocol.py
@@ -2,9 +2,11 @@
 Object storage protocol and types for Terrapod.
 
 Defines the ObjectStore Protocol that all storage backends must satisfy,
-along with shared data types and exceptions.
+along with shared data types, exceptions, and an instrumented wrapper
+that emits Prometheus metrics for all operations.
 """
 
+import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -231,3 +233,168 @@ class ObjectStore(Protocol):
     async def close(self) -> None:
         """Release any resources held by the backend."""
         ...
+
+
+# --- Instrumented Wrapper ---
+
+
+class InstrumentedStore:
+    """Wrapper that emits Prometheus metrics for all storage operations.
+
+    Delegates to a concrete ObjectStore implementation and records
+    operation count, duration, and errors.
+    """
+
+    def __init__(self, inner: ObjectStore) -> None:
+        self._inner = inner
+
+    def _record(self, operation: str, start: float, error: bool = False) -> None:
+        from terrapod.api.metrics import (
+            STORAGE_ERRORS,
+            STORAGE_OPERATION_DURATION,
+            STORAGE_OPERATIONS,
+        )
+
+        duration = time.monotonic() - start
+        status = "error" if error else "ok"
+        STORAGE_OPERATIONS.labels(operation=operation, status=status).inc()
+        STORAGE_OPERATION_DURATION.labels(operation=operation).observe(duration)
+        if error:
+            STORAGE_ERRORS.labels(operation=operation).inc()
+
+    async def put(
+        self,
+        key: str,
+        data: bytes,
+        content_type: str = "application/octet-stream",
+        metadata: dict[str, str] | None = None,
+    ) -> ObjectMeta:
+        start = time.monotonic()
+        try:
+            result = await self._inner.put(key, data, content_type, metadata)
+            self._record("put", start)
+            return result
+        except Exception:
+            self._record("put", start, error=True)
+            raise
+
+    async def put_stream(
+        self,
+        key: str,
+        chunks: AsyncIterator[bytes],
+        content_type: str = "application/octet-stream",
+        metadata: dict[str, str] | None = None,
+    ) -> ObjectMeta:
+        start = time.monotonic()
+        try:
+            result = await self._inner.put_stream(key, chunks, content_type, metadata)
+            self._record("put_stream", start)
+            return result
+        except Exception:
+            self._record("put_stream", start, error=True)
+            raise
+
+    async def get(self, key: str) -> bytes:
+        start = time.monotonic()
+        try:
+            result = await self._inner.get(key)
+            self._record("get", start)
+            return result
+        except ObjectNotFoundError:
+            self._record("get", start)  # not an error, just not found
+            raise
+        except Exception:
+            self._record("get", start, error=True)
+            raise
+
+    async def get_stream(
+        self,
+        key: str,
+        chunk_size: int = 256 * 1024,
+    ) -> AsyncIterator[bytes]:
+        start = time.monotonic()
+        try:
+            stream = self._inner.get_stream(key, chunk_size)
+            self._record("get_stream", start)
+            async for chunk in stream:
+                yield chunk
+        except ObjectNotFoundError:
+            self._record("get_stream", start)
+            raise
+        except Exception:
+            self._record("get_stream", start, error=True)
+            raise
+
+    async def delete(self, key: str) -> None:
+        start = time.monotonic()
+        try:
+            await self._inner.delete(key)
+            self._record("delete", start)
+        except Exception:
+            self._record("delete", start, error=True)
+            raise
+
+    async def exists(self, key: str) -> bool:
+        start = time.monotonic()
+        try:
+            result = await self._inner.exists(key)
+            self._record("exists", start)
+            return result
+        except Exception:
+            self._record("exists", start, error=True)
+            raise
+
+    async def head(self, key: str) -> ObjectMeta:
+        start = time.monotonic()
+        try:
+            result = await self._inner.head(key)
+            self._record("head", start)
+            return result
+        except ObjectNotFoundError:
+            self._record("head", start)
+            raise
+        except Exception:
+            self._record("head", start, error=True)
+            raise
+
+    async def list_prefix(self, prefix: str) -> list[ObjectMeta]:
+        start = time.monotonic()
+        try:
+            result = await self._inner.list_prefix(prefix)
+            self._record("list_prefix", start)
+            return result
+        except Exception:
+            self._record("list_prefix", start, error=True)
+            raise
+
+    async def presigned_get_url(
+        self,
+        key: str,
+        expiry_seconds: int | None = None,
+    ) -> PresignedURL:
+        start = time.monotonic()
+        try:
+            result = await self._inner.presigned_get_url(key, expiry_seconds)
+            self._record("presigned_get_url", start)
+            return result
+        except Exception:
+            self._record("presigned_get_url", start, error=True)
+            raise
+
+    async def presigned_put_url(
+        self,
+        key: str,
+        content_type: str = "application/octet-stream",
+        expiry_seconds: int | None = None,
+    ) -> PresignedURL:
+        start = time.monotonic()
+        try:
+            result = await self._inner.presigned_put_url(key, content_type, expiry_seconds)
+            self._record("presigned_put_url", start)
+            return result
+        except Exception:
+            self._record("presigned_put_url", start, error=True)
+            raise
+
+    async def close(self) -> None:
+        await self._inner.close()

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "fflate": "^0.8.2",
         "lucide-react": "^0.577.0",
         "next": "^16.2.1",
+        "prom-client": "^15.1.3",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "react-hot-toast": "^2.6.0",
@@ -1385,6 +1386,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -2016,13 +2026,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
-      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
@@ -2341,13 +2344,6 @@
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
       }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
-      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -3259,6 +3255,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.4",
@@ -6369,6 +6371,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7157,6 +7172,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/tinyglobby": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "fflate": "^0.8.2",
     "lucide-react": "^0.577.0",
     "next": "^16.2.1",
+    "prom-client": "^15.1.3",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-hot-toast": "^2.6.0",

--- a/web/src/instrumentation.ts
+++ b/web/src/instrumentation.ts
@@ -1,0 +1,30 @@
+/**
+ * Next.js instrumentation hook — runs once on server startup.
+ *
+ * Starts a tiny HTTP server on port 9091 that serves Prometheus
+ * metrics. This keeps metrics on a separate port from the main
+ * Next.js server (3000), so the ingress never exposes them.
+ * Prometheus scrapes this port via the ServiceMonitor.
+ */
+
+import http from 'node:http'
+
+export async function register() {
+  // Only run on the Node.js server, not Edge Runtime
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return
+
+  const { registry, webMetricsScrapes } = await import('@/lib/metrics')
+
+  const METRICS_PORT = parseInt(process.env.METRICS_PORT || '9091', 10)
+
+  const server = http.createServer(async (_req, res) => {
+    webMetricsScrapes.inc()
+    const metrics = await registry.metrics()
+    res.writeHead(200, { 'Content-Type': registry.contentType })
+    res.end(metrics)
+  })
+
+  server.listen(METRICS_PORT, () => {
+    console.log(`Metrics server listening on port ${METRICS_PORT}`)
+  })
+}

--- a/web/src/lib/metrics.ts
+++ b/web/src/lib/metrics.ts
@@ -1,0 +1,35 @@
+/**
+ * Prometheus metrics for the Terrapod web frontend.
+ *
+ * Uses prom-client (server-side only). Provides default Node.js
+ * runtime metrics (GC, event loop, memory) and custom counters
+ * for tracking web-specific events.
+ *
+ * Note: The Next.js middleware runs in the Edge Runtime and cannot
+ * use prom-client. BFF proxy request timing is tracked on the API
+ * side via its HTTP middleware. Web metrics focus on frontend
+ * server health and page-level events.
+ */
+
+import client from 'prom-client'
+
+// Use a custom registry to avoid polluting the default
+export const registry = new client.Registry()
+
+registry.setDefaultLabels({ app: 'terrapod-web' })
+
+// Collect default Node.js metrics (GC, event loop, memory)
+client.collectDefaultMetrics({ register: registry })
+
+export const webPageRequests = new client.Counter({
+  name: 'terrapod_web_page_requests_total',
+  help: 'Total page/route handler requests served by Next.js server',
+  labelNames: ['path'] as const,
+  registers: [registry],
+})
+
+export const webMetricsScrapes = new client.Counter({
+  name: 'terrapod_web_metrics_scrapes_total',
+  help: 'Total /metrics endpoint scrapes',
+  registers: [registry],
+})


### PR DESCRIPTION
## Summary

- Add ~30 Prometheus metrics across the API server covering run lifecycle, scheduler health, VCS polling, storage operations, authentication, caching, infrastructure errors, state management, and listener activity
- Add web frontend metrics via `prom-client` on a separate port (9091) using Next.js `instrumentation.ts` hook — metrics are never exposed through the public ingress
- Add `InstrumentedStore` wrapper for storage metrics without modifying individual backends (S3, Azure, GCS, filesystem)
- Add `prometheus.io/*` pod annotations (gated by `metrics.enabled`) for annotation-based Prometheus discovery
- Add web ServiceMonitor for Prometheus Operator scraping
- Add `docs/monitoring.md` with full metrics reference, scraping config, security model, and recommended alerts
- Add chart icon to `Chart.yaml`

## Metrics Categories

| Category | Metrics | Instrumentation Points |
|---|---|---|
| HTTP | request count + duration | middleware (existing) |
| Runs | created, transitioned, terminal, plan/apply duration | run_service |
| Scheduler | task executions, duration, triggers enqueued/deduped/processed | scheduler |
| VCS | poll duration, commits/PRs detected, runs created, webhooks | vcs_poller, vcs_events |
| Storage | operations, duration, errors | InstrumentedStore wrapper |
| Auth | login outcomes, auth failures | sso_service, dependencies |
| Cache | binary cache hit/miss, provider cache hit/miss | cache services |
| Infrastructure | DB errors, Redis errors | db/session, redis/client |
| State | versions created, lock conflicts | tfe_v2 |
| Listeners | heartbeats received, joins | agent_pools (emitted from API) |
| Web | page requests, scrape count, Node.js defaults | instrumentation.ts |

## Security

- API `/metrics` is never reachable from the internet (BFF only proxies `/api/*`, `/.well-known/*`, `/oauth/*`, `/v1/*`)
- Web metrics are on a separate port (9091) — ingress only routes to port 3000

## Test plan

- [x] `make lint` — all linters pass (ruff, eslint, tsc)
- [x] `make test` — 612 tests pass
- [x] `helm lint` — chart validates
- [x] `npx tsc --noEmit` — TypeScript clean
- [x] Tilt: verify `kubectl port-forward svc/terrapod-api 8000 -n terrapod` → `curl localhost:8000/metrics` shows new metrics
- [x] Tilt: verify `kubectl port-forward svc/terrapod-web 9091:9091 -n terrapod` → `curl localhost:9091/metrics` shows web metrics
- [x] Verify `curl https://terrapod.local/metrics` returns 404/503 (not exposed)