### PR TITLE
fix: add emptyDir volume for CA cache on read-only filesystem

### DIFF
--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -115,6 +115,8 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            - name: ca-cache
+              mountPath: /var/lib/terrapod/ca
             {{- if eq .Values.api.config.storage.backend "filesystem" }}
             - name: storage
               mountPath: {{ .Values.api.config.storage.filesystem.root_dir }}
@@ -158,6 +160,8 @@ spec:
           configMap:
             name: {{ include "terrapod.fullname" . }}-api-config
         - name: tmp
+          emptyDir: {}
+        - name: ca-cache
           emptyDir: {}
         {{- if eq .Values.api.config.storage.backend "filesystem" }}
         - name: storage


### PR DESCRIPTION
## Summary

- Add `ca-cache` emptyDir volume mounted at `/var/lib/terrapod/ca` in the API deployment
- Fixes startup warning `Failed to write CA cache to filesystem - [Errno 30] Read-only file system` when `readOnlyRootFilesystem: true` is set in the container security context

## Context

The API loads its internal CA from the database and caches it to `/var/lib/terrapod/ca` on startup. With `readOnlyRootFilesystem: true` (common in hardened deployments), this write fails. The fix follows the same pattern as the existing `/tmp` emptyDir.

## Test plan

- [x] `helm lint` passes
- [ ] Deploy to affected cluster and verify no startup warning