### PR TITLE
fix: resolve infinite render loop in navbar

### DIFF
--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -36,11 +36,9 @@ function NavLink({
 
 export default function NavBar() {
   const router = useRouter()
-  const roles = useSyncExternalStore(
-    () => () => {},  // no-op subscribe — localStorage doesn't change mid-session
-    () => ({ admin: isAdmin(), adminOrAudit: isAdminOrAudit() }),  // client
-    () => ({ admin: false, adminOrAudit: false }),  // server
-  )
+  const noopSubscribe = () => () => {}
+  const admin = useSyncExternalStore(noopSubscribe, isAdmin, () => false)
+  const adminOrAudit = useSyncExternalStore(noopSubscribe, isAdminOrAudit, () => false)
   const [menuOpen, setMenuOpen] = useState(false)
 
   const handleLogout = () => {
@@ -72,7 +70,7 @@ export default function NavBar() {
         <Activity size={16} />
         Sessions
       </NavLink>
-      {roles.admin && (
+      {admin && (
         <>
           <NavLink href="/admin/binary-cache" onClick={closeMenu}>
             <HardDrive size={16} />
@@ -104,7 +102,7 @@ export default function NavBar() {
           </NavLink>
         </>
       )}
-      {roles.adminOrAudit && (
+      {adminOrAudit && (
         <NavLink href="/admin/audit-log" onClick={closeMenu}>
           <FileText size={16} />
           Audit Log


### PR DESCRIPTION
## Summary

- `useSyncExternalStore` `getSnapshot` was returning a new object `{ admin, adminOrAudit }` on every call
- `Object.is()` always returns `false` for distinct objects, so React thought the store changed every render → infinite loop (React error #185)
- Split into two separate `useSyncExternalStore` calls returning primitive booleans — `Object.is(true, true)` is `true`, so no loop
- Preserves the hydration mismatch fix from v0.8.2 (`useSyncExternalStore` with server snapshot)

## Impact

**Production is broken** —  shows "This page couldn't load" due to this infinite loop crash.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] CI passes (lint + build)
- [ ] Page loads without React error #185
- [ ] Admin nav links still appear for admin users (hydration fix preserved)