### PR TITLE
fix: map UI confirm action to TFE V2 /actions/apply endpoint

### DIFF
--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -384,7 +384,9 @@ export default function RunDetailPage() {
     setActionLoading(action)
     setError('')
     try {
-      const res = await apiFetch(`/api/v2/runs/${runId}/actions/${action}`, { method: 'POST' })
+      // TFE V2 API uses "apply" to confirm a planned run
+      const apiAction = action === 'confirm' ? 'apply' : action
+      const res = await apiFetch(`/api/v2/runs/${runId}/actions/${apiAction}`, { method: 'POST' })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
         throw new Error(data.detail || `Failed to ${action} run`)


### PR DESCRIPTION
## Summary

The "Confirm & Apply" button was posting to `/api/v2/runs/{id}/actions/confirm`, which doesn't exist. The TFE V2 API uses `/actions/apply` to confirm a planned run (confusing naming, but that's the contract). One-line fix to map `confirm` → `apply` in the frontend action handler.

## Root Cause

The `handleAction` function constructs the URL by interpolating the action name directly into the path. `discard`, `cancel`, and `retry` all match their API endpoints, but `confirm` doesn't — the TFE V2 API uses `apply` for this action.

## Test plan

- [ ] CI passes
- [ ] Manually verify Confirm & Apply works on a planned run

Fixes #140