### PR TITLE
fix: unify working directory and wire through to runner

### DIFF
--- a/alembic/versions/bb5e7f11d575_unify_working_directory.py
+++ b/alembic/versions/bb5e7f11d575_unify_working_directory.py
@@ -1,0 +1,46 @@
+"""Unify working directory fields.
+
+Migrate vcs_working_directory data into working_directory and drop
+vcs_working_directory column. TFE V2 only has working-directory —
+the separate vcs_working_directory was non-standard and caused the
+field to never reach the runner.
+
+Revision ID: bb5e7f11d575
+Revises: 6739dcd36d46
+Create Date: 2026-03-27
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "bb5e7f11d575"
+down_revision = "6739dcd36d46"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Copy non-empty vcs_working_directory into working_directory
+    # where working_directory is currently empty
+    op.execute(
+        """
+        UPDATE workspaces
+        SET working_directory = vcs_working_directory
+        WHERE (working_directory = '' OR working_directory IS NULL)
+          AND vcs_working_directory != ''
+          AND vcs_working_directory IS NOT NULL
+        """
+    )
+    op.drop_column("workspaces", "vcs_working_directory")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "vcs_working_directory",
+            sa.String(500),
+            nullable=False,
+            server_default="",
+        ),
+    )

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -195,10 +195,16 @@ if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
         # if extraction actually failed
         tar xzf /tmp/config.tar.gz --no-same-owner --no-same-permissions -C "$WORK_DIR" 2>/dev/null || true
 
+        # Determine the directory containing .tf files (working directory or repo root)
+        STRIP_DIR="$WORK_DIR"
+        if [ -n "${TP_WORKING_DIR:-}" ] && [ -d "$WORK_DIR/$TP_WORKING_DIR" ]; then
+            STRIP_DIR="$WORK_DIR/$TP_WORKING_DIR"
+        fi
+
         # Strip cloud {} and backend {} blocks from .tf files.
         # Uploaded configs have cloud/backend blocks that would cause recursive
         # backend use when running in remote execution mode.
-        for tf_file in "$WORK_DIR"/*.tf; do
+        for tf_file in "$STRIP_DIR"/*.tf; do
             [ -f "$tf_file" ] || continue
             awk '
             /^[[:space:]]*(cloud|backend)[[:space:]]*(\{|"[^"]*"[[:space:]]*\{)/ { depth=1; next }
@@ -207,7 +213,7 @@ if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
             ' "$tf_file" > "${tf_file}.tmp" && mv "${tf_file}.tmp" "$tf_file"
         done
         # Remove lock file — the runner resolves providers independently
-        rm -f "$WORK_DIR/.terraform.lock.hcl"
+        rm -f "$STRIP_DIR/.terraform.lock.hcl"
         log "[entrypoint] Stripped cloud/backend blocks from uploaded config"
     else
         log "[entrypoint] No configuration archive (HTTP $HTTP_CODE)"
@@ -272,6 +278,25 @@ fi
 # mirror is caching a binary on-demand from upstream.
 export TF_REGISTRY_CLIENT_TIMEOUT=30
 export TF_PROVIDER_DOWNLOAD_RETRY=3
+
+# --- Change to working directory (monorepo subdirectory support) ---
+if [ -n "${TP_WORKING_DIR:-}" ]; then
+    # Sanitize: strip leading/trailing slashes, reject path traversal
+    TP_WORKING_DIR=$(echo "$TP_WORKING_DIR" | sed 's|^/*||;s|/*$||')
+    case "$TP_WORKING_DIR" in
+        *..*)
+            log "[entrypoint] ERROR: working directory contains path traversal"
+            exit 1
+            ;;
+    esac
+    TARGET_DIR="$WORK_DIR/$TP_WORKING_DIR"
+    if [ ! -d "$TARGET_DIR" ]; then
+        log "[entrypoint] ERROR: working directory '$TP_WORKING_DIR' not found in config"
+        exit 1
+    fi
+    cd "$TARGET_DIR"
+    log "[entrypoint] Changed to working directory: $TP_WORKING_DIR"
+fi
 
 # --- Initialize ---
 log "[entrypoint] Running $TP_BACKEND init..."

--- a/provider/internal/datasources/workspace/data_source.go
+++ b/provider/internal/datasources/workspace/data_source.go
@@ -36,7 +36,6 @@ type workspaceDataSourceModel struct {
 	Labels                        types.Map    `tfsdk:"labels"`
 	VCSRepoURL                    types.String `tfsdk:"vcs_repo_url"`
 	VCSBranch                     types.String `tfsdk:"vcs_branch"`
-	VCSWorkingDirectory           types.String `tfsdk:"vcs_working_directory"`
 	VCSConnectionID               types.String `tfsdk:"vcs_connection_id"`
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
 	VarFiles                      types.List   `tfsdk:"var_files"`
@@ -75,7 +74,6 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"labels":                            computedMap("Labels."),
 			"vcs_repo_url":                      computedString("VCS repo URL."),
 			"vcs_branch":                        computedString("VCS branch."),
-			"vcs_working_directory":             computedString("VCS working directory."),
 			"vcs_connection_id":                 computedString("VCS connection ID."),
 			"agent_pool_id":                     computedString("Agent pool ID."),
 			"var_files":                         computedList("Var files for -var-file arguments."),
@@ -146,7 +144,6 @@ func readDataSourceModel(ctx context.Context, res *client.Resource, m *workspace
 	setOptionalString(&m.TerraformVersion, client.GetStringAttr(res, "terraform-version"))
 	setOptionalString(&m.VCSRepoURL, client.GetStringAttr(res, "vcs-repo-url"))
 	setOptionalString(&m.VCSBranch, client.GetStringAttr(res, "vcs-branch"))
-	setOptionalString(&m.VCSWorkingDirectory, client.GetStringAttr(res, "vcs-working-directory"))
 	setOptionalString(&m.AgentPoolID, client.GetStringAttr(res, "agent-pool-id"))
 	setOptionalString(&m.DriftStatus, client.GetStringAttr(res, "drift-status"))
 	setOptionalString(&m.DriftLastCheckedAt, client.GetStringAttr(res, "drift-last-checked-at"))

--- a/provider/internal/resources/workspace/model.go
+++ b/provider/internal/resources/workspace/model.go
@@ -24,7 +24,6 @@
 //	"labels"                            → labels              (map,    optional)
 //	"vcs-repo-url"                      → vcs_repo_url        (string, optional)
 //	"vcs-branch"                        → vcs_branch          (string, optional)
-//	"vcs-working-directory"             → vcs_working_directory (string, optional)
 //	"agent-pool-id"                     → agent_pool_id       (string, optional)
 //	"var-files"                         → var_files           (list,   optional)
 //	"drift-detection-enabled"           → drift_detection_enabled (bool, optional)
@@ -66,7 +65,6 @@ type workspaceModel struct {
 	Labels                        types.Map    `tfsdk:"labels"`
 	VCSRepoURL                    types.String `tfsdk:"vcs_repo_url"`
 	VCSBranch                     types.String `tfsdk:"vcs_branch"`
-	VCSWorkingDirectory           types.String `tfsdk:"vcs_working_directory"`
 	VCSConnectionID               types.String `tfsdk:"vcs_connection_id"`
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
 	VarFiles                      types.List   `tfsdk:"var_files"`

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -103,10 +103,6 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "Branch to track (empty = repo default).",
 				Optional:    true,
 			},
-			"vcs_working_directory": schema.StringAttribute{
-				Description: "Subdirectory within the repo.",
-				Optional:    true,
-			},
 			"vcs_connection_id": schema.StringAttribute{
 				Description: "VCS connection ID (e.g. vcs-abc123).",
 				Optional:    true,
@@ -340,9 +336,6 @@ func buildWorkspaceAttrs(m *workspaceModel) map[string]any {
 	if !m.VCSBranch.IsNull() {
 		attrs["vcs-branch"] = m.VCSBranch.ValueString()
 	}
-	if !m.VCSWorkingDirectory.IsNull() {
-		attrs["vcs-working-directory"] = m.VCSWorkingDirectory.ValueString()
-	}
 	if !m.AgentPoolID.IsNull() {
 		attrs["agent-pool-id"] = m.AgentPoolID.ValueString()
 	}
@@ -411,11 +404,6 @@ func readResourceIntoModel(ctx context.Context, res *client.Resource, m *workspa
 		m.VCSBranch = types.StringValue(v)
 	} else {
 		m.VCSBranch = types.StringNull()
-	}
-	if v := client.GetStringAttr(res, "vcs-working-directory"); v != "" {
-		m.VCSWorkingDirectory = types.StringValue(v)
-	} else {
-		m.VCSWorkingDirectory = types.StringNull()
 	}
 	if v := client.GetStringAttr(res, "agent-pool-id"); v != "" {
 		m.AgentPoolID = types.StringValue(v)

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -821,6 +821,7 @@ async def next_run(
     run_data["data"]["attributes"]["env-vars"] = env_vars
     run_data["data"]["attributes"]["terraform-vars"] = terraform_vars
     run_data["data"]["attributes"]["var-files"] = ws.var_files if ws and ws.var_files else []
+    run_data["data"]["attributes"]["working-directory"] = ws.working_directory if ws else ""
     run_data["data"]["attributes"]["phase"] = phase
 
     return JSONResponse(content=run_data)

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -128,6 +128,14 @@ def _validate_var_files(raw: object) -> list[str]:
     return result
 
 
+def _sanitize_working_directory(raw: str) -> str:
+    """Sanitize working-directory: strip leading/trailing slashes, reject traversal."""
+    v = raw.strip().strip("/")
+    if ".." in v:
+        raise HTTPException(status_code=422, detail="working-directory: path traversal not allowed")
+    return v
+
+
 _WORKSPACE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 
 
@@ -419,7 +427,6 @@ def _workspace_json(
                 "resource-memory": ws.resource_memory,
                 "vcs-repo-url": ws.vcs_repo_url,
                 "vcs-branch": ws.vcs_branch,
-                "vcs-working-directory": ws.vcs_working_directory,
                 "vcs-connection-id": f"vcs-{ws.vcs_connection_id}"
                 if ws.vcs_connection_id
                 else None,
@@ -595,7 +602,7 @@ async def create_workspace(
         auto_apply=attrs.get("auto-apply", False),
         execution_backend=attrs.get("execution-backend", settings.default_execution_backend),
         terraform_version=attrs.get("terraform-version", settings.default_terraform_version),
-        working_directory=attrs.get("working-directory", ""),
+        working_directory=_sanitize_working_directory(attrs.get("working-directory", "")),
         resource_cpu=attrs.get("resource-cpu", "1"),
         resource_memory=attrs.get("resource-memory", "2Gi"),
         labels=attrs.get("labels", {}),
@@ -604,7 +611,6 @@ async def create_workspace(
         vcs_connection_id=vcs_connection_id,
         vcs_repo_url=attrs.get("vcs-repo-url", ""),
         vcs_branch=attrs.get("vcs-branch", ""),
-        vcs_working_directory=attrs.get("vcs-working-directory", ""),
         var_files=_validate_var_files(attrs.get("var-files", [])),
         drift_detection_enabled=attrs.get(
             "drift-detection-enabled",
@@ -628,7 +634,13 @@ async def create_workspace(
 
 async def _get_workspace_by_id(workspace_id: str, db: AsyncSession) -> Workspace:
     """Look up a workspace by its ws-{uuid} ID."""
+    import uuid as _uuid
+
     ws_uuid = workspace_id.removeprefix("ws-")
+    try:
+        _uuid.UUID(ws_uuid)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Workspace not found") from None
     result = await db.execute(select(Workspace).where(Workspace.id == ws_uuid))
     ws = result.scalar_one_or_none()
     if ws is None:
@@ -774,7 +786,7 @@ async def update_workspace(
     if "terraform-version" in attrs:
         ws.terraform_version = attrs["terraform-version"]
     if "working-directory" in attrs:
-        ws.working_directory = attrs["working-directory"]
+        ws.working_directory = _sanitize_working_directory(attrs["working-directory"])
     if "resource-cpu" in attrs:
         ws.resource_cpu = attrs["resource-cpu"]
     if "resource-memory" in attrs:
@@ -818,8 +830,6 @@ async def update_workspace(
         ws.vcs_repo_url = attrs["vcs-repo-url"]
     if "vcs-branch" in attrs:
         ws.vcs_branch = attrs["vcs-branch"]
-    if "vcs-working-directory" in attrs:
-        ws.vcs_working_directory = attrs["vcs-working-directory"]
     if "var-files" in attrs:
         ws.var_files = _validate_var_files(attrs["var-files"])
     if "agent-pool-id" in attrs:

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -279,7 +279,6 @@ class Workspace(Base):
     )
     vcs_repo_url: Mapped[str] = mapped_column(String(500), nullable=False, default="")
     vcs_branch: Mapped[str] = mapped_column(String(255), nullable=False, default="")
-    vcs_working_directory: Mapped[str] = mapped_column(String(500), nullable=False, default="")
     vcs_last_commit_sha: Mapped[str] = mapped_column(String(40), nullable=False, default="")
 
     # tfvars files — passed to runner as -var-file arguments

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -57,6 +57,7 @@ def build_job_spec(
     refresh_only: bool = False,
     refresh: bool = True,
     allow_empty_apply: bool = False,
+    working_directory: str = "",
 ) -> dict:
     """Build a K8s Job spec for a run phase.
 
@@ -118,6 +119,8 @@ def build_job_spec(
         container_env.append({"name": "TP_REFRESH", "value": "false"})
     if allow_empty_apply:
         container_env.append({"name": "TP_ALLOW_EMPTY_APPLY", "value": "true"})
+    if working_directory:
+        container_env.append({"name": "TP_WORKING_DIR", "value": working_directory})
 
     # Termination grace period — passed to entrypoint for time-budgeted shutdown
     container_env.append(

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -429,6 +429,7 @@ class RunnerListener:
             refresh_only=attrs.get("refresh-only", False),
             refresh=attrs.get("refresh", True),
             allow_empty_apply=attrs.get("allow-empty-apply", False),
+            working_directory=attrs.get("working-directory", ""),
         )
 
         namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -263,17 +263,15 @@ async def _poll_workspace_branch(
     )
 
     # VCS subdirectory filtering: skip runs when changes don't affect the workspace
-    if ws.vcs_working_directory and ws.vcs_last_commit_sha:
+    if ws.working_directory and ws.vcs_last_commit_sha:
         try:
             changed = await _get_changed_files(conn, owner, repo, ws.vcs_last_commit_sha, sha)
             # None means truncated — create run unconditionally
-            if changed is not None and not _changes_affect_directory(
-                changed, ws.vcs_working_directory
-            ):
+            if changed is not None and not _changes_affect_directory(changed, ws.working_directory):
                 logger.info(
                     "Skipping run — no changes in working directory",
                     workspace=ws.name,
-                    working_directory=ws.vcs_working_directory,
+                    working_directory=ws.working_directory,
                     changed_files_count=len(changed),
                 )
                 ws.vcs_last_commit_sha = sha
@@ -381,20 +379,20 @@ async def _poll_workspace_prs(
         )
 
         # VCS subdirectory filtering for PRs: compare PR head against tracked branch
-        if ws.vcs_working_directory and ws.vcs_last_commit_sha:
+        if ws.working_directory and ws.vcs_last_commit_sha:
             try:
                 changed = await _get_changed_files(
                     conn, owner, repo, ws.vcs_last_commit_sha, pr.head_sha
                 )
                 # None means truncated — create run unconditionally
                 if changed is not None and not _changes_affect_directory(
-                    changed, ws.vcs_working_directory
+                    changed, ws.working_directory
                 ):
                     logger.info(
                         "Skipping PR run — no changes in working directory",
                         workspace=ws.name,
                         pr_number=pr.number,
-                        working_directory=ws.vcs_working_directory,
+                        working_directory=ws.working_directory,
                     )
                     continue
             except Exception as e:

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -38,7 +38,6 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.resource_memory = "2Gi"
     ws.vcs_repo_url = ""
     ws.vcs_branch = ""
-    ws.vcs_working_directory = ""
     ws.vcs_connection_id = None
     ws.vcs_connection = None
     ws.labels = {}

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -56,7 +56,6 @@ def _mock_workspace(
     ws.vcs_connection = None
     ws.vcs_repo_url = ""
     ws.vcs_branch = ""
-    ws.vcs_working_directory = ""
     ws.var_files = []
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -11,7 +11,7 @@ def _mock_workspace(**overrides):
     ws.vcs_connection_id = overrides.get("vcs_connection_id", uuid.uuid4())
     ws.vcs_repo_url = overrides.get("vcs_repo_url", "https://github.com/org/repo")
     ws.vcs_branch = overrides.get("vcs_branch", "main")
-    ws.vcs_working_directory = overrides.get("vcs_working_directory", "")
+    ws.working_directory = overrides.get("working_directory", "")
     ws.vcs_last_commit_sha = overrides.get("vcs_last_commit_sha", "aaa111")
     ws.locked = False
     ws.auto_apply = False
@@ -88,7 +88,7 @@ class TestPollWorkspaceBranchFiltering:
         from terrapod.services.vcs_poller import _poll_workspace_branch
 
         ws = _mock_workspace(
-            vcs_working_directory="terraform/prod",
+            working_directory="terraform/prod",
             vcs_last_commit_sha="aaa111",
         )
         conn = _mock_connection()
@@ -110,7 +110,7 @@ class TestPollWorkspaceBranchFiltering:
         from terrapod.services.vcs_poller import _poll_workspace_branch
 
         ws = _mock_workspace(
-            vcs_working_directory="terraform/prod",
+            working_directory="terraform/prod",
             vcs_last_commit_sha="aaa111",
         )
         conn = _mock_connection()
@@ -134,7 +134,7 @@ class TestPollWorkspaceBranchFiltering:
         """When no working_directory set, always create run (no file check)."""
         from terrapod.services.vcs_poller import _poll_workspace_branch
 
-        ws = _mock_workspace(vcs_working_directory="", vcs_last_commit_sha="aaa111")
+        ws = _mock_workspace(working_directory="", vcs_last_commit_sha="aaa111")
         conn = _mock_connection()
         mock_sha.return_value = "bbb222"
         mock_run = MagicMock()
@@ -155,7 +155,7 @@ class TestPollWorkspaceBranchFiltering:
         from terrapod.services.vcs_poller import _poll_workspace_branch
 
         ws = _mock_workspace(
-            vcs_working_directory="infra",
+            working_directory="infra",
             vcs_last_commit_sha="",
         )
         conn = _mock_connection()
@@ -178,7 +178,7 @@ class TestPollWorkspaceBranchFiltering:
         from terrapod.services.vcs_poller import _poll_workspace_branch
 
         ws = _mock_workspace(
-            vcs_working_directory="infra",
+            working_directory="infra",
             vcs_last_commit_sha="aaa111",
         )
         conn = _mock_connection()
@@ -201,7 +201,7 @@ class TestPollWorkspaceBranchFiltering:
         from terrapod.services.vcs_poller import _poll_workspace_branch
 
         ws = _mock_workspace(
-            vcs_working_directory="infra",
+            working_directory="infra",
             vcs_last_commit_sha="aaa111",
         )
         conn = _mock_connection()

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -194,6 +194,7 @@ function WorkspaceDetailContent() {
   const [editOwner, setEditOwner] = useState('')
   const [editVarFiles, setEditVarFiles] = useState<string[]>([])
   const [newVarFile, setNewVarFile] = useState('')
+  const [editWorkingDir, setEditWorkingDir] = useState('')
   const [editVcsConnectionId, setEditVcsConnectionId] = useState<string | null>(null)
   const [editVcsRepoUrl, setEditVcsRepoUrl] = useState('')
   const [editVcsBranch, setEditVcsBranch] = useState('')
@@ -550,6 +551,7 @@ function WorkspaceDetailContent() {
     setEditOwner(workspace.attributes['owner-email'] || '')
     setEditVarFiles(workspace.attributes['var-files'] || [])
     setNewVarFile('')
+    setEditWorkingDir(workspace.attributes['working-directory'] || '')
     setEditVcsConnectionId(workspace.attributes['vcs-connection-id'] || null)
     setEditVcsRepoUrl(workspace.attributes['vcs-repo-url'] || '')
     setEditVcsBranch(workspace.attributes['vcs-branch'] || '')
@@ -598,6 +600,7 @@ function WorkspaceDetailContent() {
               'execution-backend': editBackend,
               'terraform-version': editVersion,
               'agent-pool-id': editPoolId,
+              'working-directory': editWorkingDir,
               'var-files': editVarFiles,
               'vcs-repo-url': editVcsRepoUrl,
               'vcs-branch': editVcsBranch,
@@ -1221,7 +1224,12 @@ function WorkspaceDetailContent() {
                 </div>
                 <div>
                   <dt className="text-xs text-slate-500">Working Directory</dt>
-                  <dd className="mt-1 text-sm text-slate-200">{attrs['working-directory'] || '/'}</dd>
+                  {editing ? (
+                    <input type="text" value={editWorkingDir} onChange={(e) => setEditWorkingDir(e.target.value)} placeholder="e.g. environments/dev"
+                      className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">{attrs['working-directory'] || '/'}</dd>
+                  )}
                 </div>
                 <div>
                   <dt className="text-xs text-slate-500">Agent Pool</dt>

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -54,6 +54,7 @@ export default function WorkspacesPage() {
   const [newVersion, setNewVersion] = useState('1.11')
   const [newCpu, setNewCpu] = useState('1')
   const [newMemory, setNewMemory] = useState('2Gi')
+  const [newWorkingDir, setNewWorkingDir] = useState('')
   const [newVcsConnectionId, setNewVcsConnectionId] = useState('')
   const [newVcsRepoUrl, setNewVcsRepoUrl] = useState('')
   const [newVcsBranch, setNewVcsBranch] = useState('')
@@ -179,6 +180,7 @@ export default function WorkspacesPage() {
               'auto-apply': newAutoApply,
               'resource-cpu': newCpu,
               'resource-memory': newMemory,
+              'working-directory': newWorkingDir,
               'vcs-repo-url': newVcsRepoUrl,
               'vcs-branch': newVcsBranch,
             },
@@ -203,6 +205,7 @@ export default function WorkspacesPage() {
       setNewAutoApply(false)
       setNewCpu('1')
       setNewMemory('2Gi')
+      setNewWorkingDir('')
       setNewVcsConnectionId('')
       setNewVcsRepoUrl('')
       setNewVcsBranch('')
@@ -332,6 +335,18 @@ export default function WorkspacesPage() {
                   />
                   <span className="text-sm text-slate-300">Auto Apply</span>
                 </label>
+              </div>
+              <div>
+                <label htmlFor="ws-workdir" className="block text-sm font-medium text-slate-300 mb-1">Working Directory</label>
+                <input
+                  id="ws-workdir"
+                  type="text"
+                  value={newWorkingDir}
+                  onChange={(e) => setNewWorkingDir(e.target.value)}
+                  placeholder="e.g. environments/dev"
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                />
+                <p className="mt-1 text-xs text-slate-500">Subdirectory within repo containing .tf files</p>
               </div>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">


### PR DESCRIPTION
## Summary

- **Unify working directory fields** — dropped non-standard `vcs_working_directory` column, unified on TFE V2 `working-directory`. Data migration preserves existing values. The field now flows through the full chain: API `next_run()` → listener → Job `TP_WORKING_DIR` env var → entrypoint `cd` into subdirectory
- **Fix SQLAlchemy error leak** — UUID validation in `_get_workspace_by_id()` prevents raw `DataError` from leaking when workspace name is used instead of ID
- **Input sanitization** — strips leading/trailing slashes, rejects path traversal (`..`) in both API and entrypoint (defense in depth)
- **UI** — working directory is now editable in workspace create form and settings page
- **Provider** — removed `vcs_working_directory` from Terraform resource and data source schemas

Closes #143

## Test plan

- [x] `make test` — 839 tests pass
- [x] `make lint` — clean (Python + frontend + TypeScript)
- [x] `helm lint` — passes
- [x] Tilt verification: migration applied, API response shape correct, PATCH works
- [x] Playwright: verified create form has working directory field, edit mode shows editable input
- [x] Runner verification: queued run → Job has `TP_WORKING_DIR=environments/dev` → entrypoint attempts cd (errors correctly when subdir missing in config)
- [x] Error leak: `GET /api/v2/workspaces/dev` returns 404 (not 500)