### PR TITLE
fix: add git to runner, version display, fix X-TFE-Version format

### DIFF
--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -11,7 +11,9 @@ RUN apk upgrade --no-cache \
     curl \
     tar \
     jq \
-    unzip
+    unzip \
+    git \
+    openssh-client
 
 COPY docker/runner-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Audit Logging](audit-logging.md) | Immutable event log, query API, retention |
 | [Artifact Retention](artifact-retention.md) | Automated cleanup of old state versions, run logs, cache entries |
 | [Health Dashboard](health-dashboard.md) | Workspace health, drift status, run metrics |
+| [Runners](runners.md) | Custom runner images, private registries, Job configuration |
 | [Cloud Credentials](cloud-credentials.md) | AWS IRSA, GCP WIF, Azure WI setup |
 | [Registry](registry.md) | Private module/provider registry, caching layers |
 | [Monitoring](monitoring.md) | Prometheus metrics, scraping, recommended alerts |

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -1,0 +1,172 @@
+# Runners
+
+Runners are ephemeral Kubernetes Jobs that execute `terraform` or `tofu` plan and apply operations. The default runner image is a minimal Alpine container with `curl`, `tar`, `jq`, `unzip`, and `git` -- no terraform/tofu binary baked in. The correct version is downloaded at runtime from the [binary cache](registry.md).
+
+---
+
+## Custom Runner Images
+
+The default image covers most use cases, but you may need additional tools -- cloud CLIs (`aws`, `az`, `gcloud`), custom providers, policy tools, or language runtimes for scripts called by `local-exec` provisioners.
+
+### Building a Custom Image
+
+Base your image on the default runner and add what you need:
+
+```dockerfile
+FROM ghcr.io/mattrobinsonsre/terrapod-runner:latest
+
+USER root
+
+# Example: AWS CLI v2
+RUN apk add --no-cache gcompat \
+    && curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/awscliv2.zip /tmp/aws
+
+# Example: Azure CLI
+RUN apk add --no-cache py3-pip \
+    && pip3 install --break-system-packages azure-cli
+
+# Example: gcloud CLI
+RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz \
+    | tar -xz -C /opt \
+    && /opt/google-cloud-sdk/install.sh --quiet \
+    && ln -s /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
+
+USER 1000:1000
+```
+
+Important:
+- Switch back to `USER 1000:1000` -- runner Jobs run as non-root
+- The entrypoint (`/entrypoint.sh`) must remain unchanged -- it handles signal forwarding and graceful shutdown
+- The working directory is `/workspace` and `/tmp` is writable (both are emptyDir volumes)
+
+### Using a Custom Image
+
+Set `runners.image` in your Helm values:
+
+```yaml
+runners:
+  image:
+    repository: registry.example.com/my-org/terrapod-runner-custom
+    tag: "1.0.0"
+    pullPolicy: IfNotPresent
+```
+
+### Private Registries
+
+If your custom image is in a private registry, create a Kubernetes pull secret in the runner namespace and reference it:
+
+```bash
+kubectl -n terrapod-runners create secret docker-registry my-registry-secret \
+  --docker-server=registry.example.com \
+  --docker-username=user \
+  --docker-password=token
+```
+
+```yaml
+runners:
+  imagePullSecrets:
+    - my-registry-secret
+```
+
+Note: `runners.imagePullSecrets` is separate from `global.imagePullSecrets`. The global setting covers Helm-managed workloads (API, listener, web). Runner Jobs are created dynamically by the listener and need their own pull secrets configured here.
+
+---
+
+## Job Configuration
+
+All runner Jobs inherit the following settings from `runners.*` in Helm values:
+
+| Value | Default | Description |
+|---|---|---|
+| `runners.image.repository` | `ghcr.io/mattrobinsonsre/terrapod-runner` | Runner container image |
+| `runners.image.tag` | `""` (appVersion) | Image tag |
+| `runners.image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `runners.imagePullSecrets` | `[]` | Pull secrets for private registries |
+| `runners.nodeSelector` | `{}` | Node selector for Job pods |
+| `runners.tolerations` | `[]` | Tolerations for Job pods |
+| `runners.affinity` | `{}` | Affinity rules for Job pods |
+| `runners.podAnnotations` | `{}` | Annotations added to Job pods |
+| `runners.priorityClassName` | `""` | Priority class for Job pods |
+| `runners.topologySpreadConstraints` | `[]` | Topology spread constraints |
+| `runners.podSecurityContext` | `{}` | Pod-level security context override |
+| `runners.ttlSecondsAfterFinished` | `600` | Clean up completed Jobs after this many seconds |
+| `runners.terminationGracePeriodSeconds` | `120` | Time budget for graceful shutdown + artifact uploads |
+| `runners.tokenTTLSeconds` | `3600` | Runner token TTL (1 hour) |
+| `runners.maxTokenTTLSeconds` | `7200` | Maximum runner token TTL (2 hours) |
+| `runners.staleTimeoutSeconds` | `3600` | Mark run as errored if no Job status after this long |
+
+### Per-Workspace Resources
+
+Each workspace has `resource_cpu` and `resource_memory` settings (default: 1 CPU / 2Gi memory) that control the resource **requests** for its runner Jobs. Limits are computed as 2x the requests automatically. These are set via the workspace API or UI.
+
+---
+
+## Cloud Workload Identity
+
+Runner Jobs can assume cloud provider identities via Kubernetes ServiceAccount annotations. See [Cloud Credentials](cloud-credentials.md) for setup instructions.
+
+```yaml
+runners:
+  serviceAccount:
+    create: true
+    annotations:
+      # AWS IRSA
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/terrapod-runner
+      # OR GCP WIF
+      # iam.gke.io/gcp-service-account: runner@project.iam.gserviceaccount.com
+      # OR Azure WI
+      # azure.workload.identity/client-id: <client-id>
+  # Required for Azure WI (adds pod label)
+  azureWorkloadIdentity: false
+```
+
+---
+
+## Graceful Termination
+
+Runner Jobs implement time-budgeted graceful shutdown for spot instance preemption:
+
+1. Kubernetes sends SIGTERM to the entrypoint
+2. Entrypoint forwards **SIGINT** to terraform/tofu (HashiCorp's recommended signal for containers)
+3. Watchdog monitors the child process -- if it doesn't exit within the grace period minus 25 seconds (upload budget), SIGKILL is sent
+4. After terraform exits, artifact uploads (logs, plan, state) run with time-bounded `curl` calls
+5. **State upload is fatal** -- if state upload fails after a successful apply, the workspace is flagged as state-diverged
+
+The time budget adapts to the configured `terminationGracePeriodSeconds`. The default 120 seconds gives terraform 95 seconds to shut down gracefully and 25 seconds for artifact uploads.
+
+---
+
+## Environment Variables
+
+The entrypoint reads the following environment variables (set automatically by the listener):
+
+| Variable | Description |
+|---|---|
+| `TP_RUN_ID` | Run UUID |
+| `TP_PHASE` | `plan` or `apply` |
+| `TP_API_URL` | API base URL for artifact upload/download |
+| `TP_AUTH_TOKEN` | Short-lived runner token (from K8s Secret) |
+| `TP_VERSION` | Terraform/tofu version to download |
+| `TP_BACKEND` | `terraform` or `tofu` |
+| `TP_PLAN_ONLY` | `true` for plan-only runs |
+| `TP_WORKING_DIR` | Subdirectory within the repo to run in |
+| `TP_TARGET_ADDRS` | JSON array of `-target` addresses |
+| `TP_REPLACE_ADDRS` | JSON array of `-replace` addresses |
+| `TP_REFRESH_ONLY` | `true` for refresh-only mode |
+| `TP_REFRESH` | `false` to disable refresh |
+| `TP_ALLOW_EMPTY_APPLY` | `true` to allow empty applies |
+| `TP_TERMINATION_GRACE` | Termination grace period in seconds |
+
+Workspace variables (env and terraform) are also injected as environment variables on the Job pod.
+
+---
+
+## See Also
+
+- [Architecture](architecture.md) -- runner listener, reconciler, ARC pattern
+- [Cloud Credentials](cloud-credentials.md) -- workload identity setup
+- [Deployment](deployment.md) -- full Helm configuration reference
+- [Agent Pools](api-reference.md) -- pool and listener management

--- a/helm/terrapod/templates/configmap-runner.yaml
+++ b/helm/terrapod/templates/configmap-runner.yaml
@@ -20,6 +20,10 @@ data:
     token_ttl_seconds: {{ .Values.runners.tokenTTLSeconds }}
     max_token_ttl_seconds: {{ .Values.runners.maxTokenTTLSeconds }}
     stale_timeout_seconds: {{ .Values.runners.staleTimeoutSeconds }}
+    {{- with .Values.runners.imagePullSecrets }}
+    image_pull_secrets:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- with .Values.runners.nodeSelector }}
     node_selector:
       {{- toYaml . | nindent 6 }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -101,6 +101,7 @@
       "properties": {
         "image": { "$ref": "#/$defs/imageSpec" },
         "serverUrl": { "type": "string" },
+        "imagePullSecrets": { "type": "array", "items": { "type": "string" } },
         "nodeSelector": { "type": "object" },
         "tolerations": { "type": "array", "items": { "type": "object" } },
         "affinity": { "type": "object" },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -448,6 +448,15 @@ runners:
   # for presigned storage URLs. Defaults to http://<release>-api:8000.
   serverUrl: ""
 
+  # Image pull secrets for runner Jobs (private registries).
+  # These are separate from global.imagePullSecrets which only cover
+  # Helm-managed workloads. Runner Jobs are created dynamically by the
+  # listener and need their own pull secrets.
+  imagePullSecrets: []
+  # Example:
+  #   imagePullSecrets:
+  #     - my-registry-secret
+
   # Shared Job settings
   nodeSelector: {}
   tolerations: []

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -35,6 +35,7 @@ Endpoints:
 import asyncio
 import hashlib
 import json
+import os
 import re
 from datetime import UTC, datetime
 
@@ -66,7 +67,10 @@ logger = get_logger(__name__)
 
 TFP_API_VERSION = "2.6"
 TFP_APP_NAME = "Terrapod"
-X_TFE_VERSION = "v0.1.0"
+X_TFE_VERSION = (
+    "v202301-1"  # TFE monthly format; pre-202302 disables structured run output (unsupported)
+)
+TERRAPOD_VERSION = os.environ.get("TERRAPOD_VERSION", "dev")
 
 
 def _primary_run_filter():
@@ -245,7 +249,10 @@ async def ping() -> JSONResponse:
     Returns 200 OK with TFE-compatible headers. No auth required.
     Used by go-tfe client for initialization and version detection.
     """
-    return JSONResponse(content={}, headers=_tfe_headers())
+    return JSONResponse(
+        content={"app_name": TFP_APP_NAME, "version": TERRAPOD_VERSION},
+        headers=_tfe_headers(),
+    )
 
 
 @router.get("/account/details")

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -67,6 +67,7 @@ class RunnerConfig(BaseModel):
     priority_class_name: str = Field(default="")
     topology_spread_constraints: list[dict] = Field(default_factory=list)
     pod_security_context: dict = Field(default_factory=dict)
+    image_pull_secrets: list[str] = Field(default_factory=list)
     stale_timeout_seconds: int = Field(
         default=3600,
         description="Seconds before a run with no Job status is marked errored",

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -230,6 +230,10 @@ def build_job_spec(
 
     # Scheduling and placement from runner config
     pod_spec = job_spec["spec"]["template"]["spec"]
+
+    # Image pull secrets — for pulling custom runner images from private registries
+    if runner_config.image_pull_secrets:
+        pod_spec["imagePullSecrets"] = [{"name": s} for s in runner_config.image_pull_secrets]
     if runner_config.node_selector:
         pod_spec["nodeSelector"] = runner_config.node_selector
     if runner_config.tolerations:

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useSyncExternalStore } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, HeartPulse, FileText, BookOpen, Code, LogOut, Menu, X } from 'lucide-react'
@@ -40,6 +40,11 @@ export default function NavBar() {
   const admin = useSyncExternalStore(noopSubscribe, isAdmin, () => false)
   const adminOrAudit = useSyncExternalStore(noopSubscribe, isAdminOrAudit, () => false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [version, setVersion] = useState('')
+
+  useEffect(() => {
+    fetch('/api/v2/ping').then((r) => r.json()).then((d) => setVersion(d.version || '')).catch(() => {})
+  }, [])
 
   const handleLogout = () => {
     clearAuth()
@@ -121,6 +126,7 @@ export default function NavBar() {
             <Link href="/" className="flex items-center gap-2 mr-3 flex-shrink-0">
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
+              {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
             <div className="flex items-center gap-1 flex-wrap flex-1">
               {navLinks}
@@ -152,6 +158,7 @@ export default function NavBar() {
             <Link href="/" className="flex items-center gap-2">
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
+              {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
             <div className="flex items-center gap-1">
               <a


### PR DESCRIPTION
## Summary

Fixes #148.

- **Runner image**: add `git` and `openssh-client` to Alpine packages — modules using `git::https://` or `git::ssh://` source URLs were failing
- **Version display**: expose `TERRAPOD_VERSION` (injected from Helm `AppVersion`) in the `/api/v2/ping` response body and show it in the nav bar
- **X-TFE-Version header**: change from `v0.1.0` to `v202301-1` — the CLI parses this in `vYYYYMM-N` format for feature gating. Using pre-202302 date to correctly disable structured run output (which Terrapod does not implement)
- **Runner imagePullSecrets**: add `runners.imagePullSecrets` Helm value so custom runner images can be pulled from private registries (wired through RunnerConfig → configmap → job_template)
- **Runner docs**: new `docs/runners.md` covering custom images, Dockerfiles, private registries, Job configuration, environment variables

## Test plan

- [x] 839 tests pass
- [x] Lint clean
- [ ] Verify version appears in nav bar via Tilt
- [ ] Verify `git` and `ssh` available in runner pod