### PR TITLE
feat: add extraEnv and extraEnvFrom for runner Jobs

### DIFF
--- a/docs/runners.md
+++ b/docs/runners.md
@@ -75,6 +75,55 @@ Note: `runners.imagePullSecrets` is separate from `global.imagePullSecrets`. The
 
 ---
 
+## Injecting Environment Variables
+
+There are two ways to get environment variables into runner Jobs:
+
+### Workspace Variables (per-workspace)
+
+Set variables on individual workspaces via the UI or API. Variables with `category=env` are injected as container environment variables. Sensitive variables are masked in API responses but the actual value is passed to the runner. Variable sets can share the same variables across multiple workspaces.
+
+### Helm Values (global, all runners)
+
+Use `runners.extraEnv` for individual env vars (literal values or from Secrets/ConfigMaps) and `runners.extraEnvFrom` to inject all keys from a Secret or ConfigMap:
+
+```yaml
+runners:
+  # Individual env vars
+  extraEnv:
+    - name: AWS_DEFAULT_REGION
+      value: eu-west-1
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: aws-credentials
+          key: access-key-id
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: aws-credentials
+          key: secret-access-key
+
+  # Bulk inject all keys from a Secret or ConfigMap
+  extraEnvFrom:
+    - secretRef:
+        name: aws-credentials
+    - configMapRef:
+        name: runner-config
+```
+
+Create the Secret in the runner namespace:
+
+```bash
+kubectl -n terrapod-runners create secret generic aws-credentials \
+  --from-literal=access-key-id=AKIA... \
+  --from-literal=secret-access-key=...
+```
+
+Helm-injected env vars apply to **all** runner Jobs globally. Use workspace variables when different workspaces need different credentials.
+
+---
+
 ## Job Configuration
 
 All runner Jobs inherit the following settings from `runners.*` in Helm values:
@@ -85,6 +134,8 @@ All runner Jobs inherit the following settings from `runners.*` in Helm values:
 | `runners.image.tag` | `""` (appVersion) | Image tag |
 | `runners.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `runners.imagePullSecrets` | `[]` | Pull secrets for private registries |
+| `runners.extraEnv` | `[]` | Extra env vars for all runner Jobs |
+| `runners.extraEnvFrom` | `[]` | Inject env vars from Secrets/ConfigMaps |
 | `runners.nodeSelector` | `{}` | Node selector for Job pods |
 | `runners.tolerations` | `[]` | Tolerations for Job pods |
 | `runners.affinity` | `{}` | Affinity rules for Job pods |

--- a/helm/terrapod/templates/configmap-runner.yaml
+++ b/helm/terrapod/templates/configmap-runner.yaml
@@ -51,4 +51,12 @@ data:
     pod_security_context:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.runners.extraEnv }}
+    extra_env:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.runners.extraEnvFrom }}
+    extra_env_from:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -102,6 +102,8 @@
         "image": { "$ref": "#/$defs/imageSpec" },
         "serverUrl": { "type": "string" },
         "imagePullSecrets": { "type": "array", "items": { "type": "string" } },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "extraEnvFrom": { "type": "array", "items": { "type": "object" } },
         "nodeSelector": { "type": "object" },
         "tolerations": { "type": "array", "items": { "type": "object" } },
         "affinity": { "type": "object" },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -457,6 +457,28 @@ runners:
   #   imagePullSecrets:
   #     - my-registry-secret
 
+  # Extra environment variables injected into all runner Jobs.
+  # Supports literal values and valueFrom (secretKeyRef, configMapKeyRef).
+  extraEnv: []
+  # Example:
+  #   extraEnv:
+  #     - name: AWS_DEFAULT_REGION
+  #       value: eu-west-1
+  #     - name: AWS_ACCESS_KEY_ID
+  #       valueFrom:
+  #         secretKeyRef:
+  #           name: aws-credentials
+  #           key: access-key-id
+
+  # Inject all keys from Secrets or ConfigMaps as env vars on runner Jobs.
+  extraEnvFrom: []
+  # Example:
+  #   extraEnvFrom:
+  #     - secretRef:
+  #         name: aws-credentials
+  #     - configMapRef:
+  #         name: runner-config
+
   # Shared Job settings
   nodeSelector: {}
   tolerations: []

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -68,6 +68,8 @@ class RunnerConfig(BaseModel):
     topology_spread_constraints: list[dict] = Field(default_factory=list)
     pod_security_context: dict = Field(default_factory=dict)
     image_pull_secrets: list[str] = Field(default_factory=list)
+    extra_env: list[dict] = Field(default_factory=list)
+    extra_env_from: list[dict] = Field(default_factory=list)
     stale_timeout_seconds: int = Field(
         default=3600,
         description="Seconds before a run with no Job status is marked errored",

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -138,6 +138,10 @@ def build_job_spec(
     for var in terraform_vars:
         container_env.append({"name": f"TF_VAR_{var['key']}", "value": var["value"]})
 
+    # Extra env vars from runner config (Helm values → runners.extraEnv)
+    for extra in runner_config.extra_env:
+        container_env.append(extra)
+
     # Image config
     image = runner_config.image.repository
     if runner_config.image.tag:
@@ -221,6 +225,12 @@ def build_job_spec(
             },
         },
     }
+
+    # envFrom — inject all keys from Secrets/ConfigMaps as env vars
+    if runner_config.extra_env_from:
+        job_spec["spec"]["template"]["spec"]["containers"][0]["envFrom"] = (
+            runner_config.extra_env_from
+        )
 
     # Service account (CSP identity) — from global runner config (Helm values)
     if runner_config.service_account_name:


### PR DESCRIPTION
## Summary

Addresses #150.

Adds `runners.extraEnv` and `runners.extraEnvFrom` Helm values so operators can inject environment variables into all runner Jobs globally — either as literal values, from Kubernetes Secrets via `secretKeyRef`, or bulk from Secrets/ConfigMaps via `envFrom`.

This lets users provide cloud credentials (AWS access keys, Azure service principal, GCP credentials) to runners via K8s Secrets rather than storing them in Terrapod's workspace variable system.

### Changes

- **`services/terrapod/config.py`**: add `extra_env` and `extra_env_from` fields to `RunnerConfig`
- **`services/terrapod/runner/job_template.py`**: append `extra_env` to container env list, set `envFrom` on container when `extra_env_from` is configured
- **`helm/terrapod/values.yaml`**: add `runners.extraEnv` and `runners.extraEnvFrom` with examples
- **`helm/terrapod/templates/configmap-runner.yaml`**: render new fields into `runners.yaml`
- **`helm/terrapod/values.schema.json`**: add schema entries
- **`docs/runners.md`**: new section on environment variable injection (workspace vars vs Helm)

### Example

```yaml
runners:
  extraEnvFrom:
    - secretRef:
        name: aws-credentials
```

## Test plan

- [x] 839 tests pass
- [x] Lint clean
- [ ] Verify with Tilt: runner Jobs pick up extra env vars