### PR TITLE
feat: add trigger prefixes for VCS subdirectory filtering

### DIFF
--- a/alembic/versions/49bb8c2d2fb3_add_workspace_trigger_prefixes.py
+++ b/alembic/versions/49bb8c2d2fb3_add_workspace_trigger_prefixes.py
@@ -1,0 +1,31 @@
+"""Add workspace trigger_prefixes column.
+
+Revision ID: 49bb8c2d2fb3
+Revises: bb5e7f11d575
+Create Date: 2026-03-27
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY
+
+revision = "49bb8c2d2fb3"
+down_revision = "bb5e7f11d575"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "trigger_prefixes",
+            ARRAY(sa.String(255)),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "trigger_prefixes")

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -303,7 +303,55 @@ curl -X POST https://terrapod.example.com/api/v2/organizations/default/workspace
 | `vcs-repo-url` | Repository URL (HTTPS or SSH format) | (required) |
 | `vcs-branch` | Branch to track | Repo's default branch |
 | `working-directory` | Subdirectory containing Terraform files | Repository root |
+| `trigger-prefixes` | Directories that trigger runs (overrides working directory filtering) | `[]` (uses working directory) |
 | `vcs-connection` (relationship) | VCS connection to use for authentication | (required) |
+
+### Trigger Prefixes
+
+By default, when a workspace has a `working-directory` set, only commits that change files within that directory trigger runs. This works well for simple layouts, but breaks down in monorepos where shared modules live outside the working directory.
+
+**`trigger-prefixes`** lets you specify exactly which directories should trigger runs. When set, it **replaces** (not appends to) the default working directory filtering.
+
+**Default behaviour (no trigger prefixes):**
+- `working-directory: "environments/dev"` → only changes in `environments/dev/` trigger runs
+
+**With trigger prefixes:**
+- `trigger-prefixes: ["environments/dev", "modules"]` → changes in `environments/dev/` OR `modules/` trigger runs
+
+**Example — monorepo with shared modules:**
+
+```
+repo/
+  environments/
+    dev/          ← workspace working directory
+      main.tf     ← references ../../modules/vpc
+    staging/
+  modules/
+    vpc/          ← shared module
+    rds/
+```
+
+```zsh
+curl -X PATCH https://terrapod.example.com/api/v2/workspaces/ws-XXXX \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN" \
+  -H "Content-Type: application/vnd.api+json" \
+  -d '{
+    "data": {
+      "type": "workspaces",
+      "attributes": {
+        "trigger-prefixes": ["environments/dev", "modules"]
+      }
+    }
+  }'
+```
+
+Now commits to `modules/vpc/main.tf` will trigger runs for this workspace.
+
+**Notes:**
+- Maximum 20 entries
+- Paths are normalized (leading/trailing slashes stripped)
+- When `trigger-prefixes` is set, the working directory is NOT automatically included — add it explicitly if needed
+- Set to `[]` (empty list) to revert to default working directory filtering
 
 ### Supported URL Formats
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -140,6 +140,29 @@ def _sanitize_working_directory(raw: str) -> str:
     return v
 
 
+def _validate_trigger_prefixes(raw: object) -> list[str]:
+    """Validate and sanitize trigger-prefixes input.
+
+    Each entry is normalized the same way as working-directory (strip slashes,
+    reject traversal).  Max 20 entries.
+    """
+    if not isinstance(raw, list):
+        raise HTTPException(status_code=422, detail="trigger-prefixes must be a list of strings")
+    if len(raw) > 20:
+        raise HTTPException(status_code=422, detail="trigger-prefixes: maximum 20 entries")
+    result: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            raise HTTPException(status_code=422, detail="trigger-prefixes entries must be strings")
+        v = _sanitize_working_directory(entry)
+        if not v:
+            raise HTTPException(
+                status_code=422, detail="trigger-prefixes entries must be non-empty"
+            )
+        result.append(v)
+    return result
+
+
 _WORKSPACE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 
 
@@ -438,6 +461,7 @@ def _workspace_json(
                 if ws.vcs_connection_id
                 else None,
                 "var-files": ws.var_files or [],
+                "trigger-prefixes": ws.trigger_prefixes or [],
                 "drift-detection-enabled": ws.drift_detection_enabled,
                 "drift-detection-interval-seconds": ws.drift_detection_interval_seconds,
                 "drift-last-checked-at": _rfc3339(ws.drift_last_checked_at),
@@ -619,6 +643,7 @@ async def create_workspace(
         vcs_repo_url=attrs.get("vcs-repo-url", ""),
         vcs_branch=attrs.get("vcs-branch", ""),
         var_files=_validate_var_files(attrs.get("var-files", [])),
+        trigger_prefixes=_validate_trigger_prefixes(attrs.get("trigger-prefixes", [])),
         drift_detection_enabled=attrs.get(
             "drift-detection-enabled",
             True if vcs_connection_id else False,
@@ -839,6 +864,8 @@ async def update_workspace(
         ws.vcs_branch = attrs["vcs-branch"]
     if "var-files" in attrs:
         ws.var_files = _validate_var_files(attrs["var-files"])
+    if "trigger-prefixes" in attrs:
+        ws.trigger_prefixes = _validate_trigger_prefixes(attrs["trigger-prefixes"])
     if "agent-pool-id" in attrs:
         import uuid as _uuid
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -286,6 +286,11 @@ class Workspace(Base):
         ARRAY(String(500)), nullable=False, server_default="{}"
     )
 
+    # VCS trigger prefixes — directories that trigger runs (overrides working_directory filtering)
+    trigger_prefixes: Mapped[list[str]] = mapped_column(
+        ARRAY(String(255)), nullable=False, server_default="{}"
+    )
+
     # Drift detection
     drift_detection_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     drift_detection_interval_seconds: Mapped[int] = mapped_column(

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -84,14 +84,16 @@ async def _get_changed_files(
     return await github_service.get_changed_files(conn, owner, repo, base_sha, head_sha)
 
 
-def _changes_affect_directory(changed_files: list[str], working_directory: str) -> bool:
-    """Check if any changed files fall within the workspace's working directory.
+def _changes_affect_prefixes(changed_files: list[str], prefixes: list[str]) -> bool:
+    """Check if any changed files fall within any of the given directory prefixes.
 
-    Uses strict prefix matching: only files starting with "{working_directory}/"
-    are considered relevant. Root-level files don't trigger subdirectory workspaces.
+    Uses strict prefix matching: only files starting with "{prefix}/" are
+    considered relevant. Root-level files don't trigger subdirectory workspaces.
     """
-    prefix = working_directory.rstrip("/") + "/"
-    return any(f.startswith(prefix) for f in changed_files)
+    if not prefixes:
+        return False
+    normalized = [p.rstrip("/") + "/" for p in prefixes]
+    return any(f.startswith(n) for f in changed_files for n in normalized)
 
 
 async def _list_branches(conn: VCSConnection, owner: str, repo: str) -> list[dict[str, str]]:
@@ -235,7 +237,7 @@ async def _poll_workspace_branch(
             workspace=ws.name,
             repo=f"{owner}/{repo}",
             branch=branch,
-            error=str(e),
+            error=repr(e),
         )
         return
 
@@ -263,15 +265,21 @@ async def _poll_workspace_branch(
     )
 
     # VCS subdirectory filtering: skip runs when changes don't affect the workspace
-    if ws.working_directory and ws.vcs_last_commit_sha:
+    effective_prefixes = (
+        ws.trigger_prefixes
+        if ws.trigger_prefixes
+        else ([ws.working_directory] if ws.working_directory else [])
+    )
+    if effective_prefixes and ws.vcs_last_commit_sha:
         try:
             changed = await _get_changed_files(conn, owner, repo, ws.vcs_last_commit_sha, sha)
             # None means truncated — create run unconditionally
-            if changed is not None and not _changes_affect_directory(changed, ws.working_directory):
+            if changed is not None and not _changes_affect_prefixes(changed, effective_prefixes):
                 logger.info(
-                    "Skipping run — no changes in working directory",
+                    "Skipping run — no changes match trigger prefixes",
                     workspace=ws.name,
-                    working_directory=ws.working_directory,
+                    trigger_prefixes=effective_prefixes,
+                    changed_files=changed[:20],
                     changed_files_count=len(changed),
                 )
                 ws.vcs_last_commit_sha = sha
@@ -281,7 +289,7 @@ async def _poll_workspace_branch(
             logger.warning(
                 "Failed to get changed files, creating run anyway",
                 workspace=ws.name,
-                error=str(e),
+                error=repr(e),
             )
 
     run = await _create_vcs_run(
@@ -379,20 +387,25 @@ async def _poll_workspace_prs(
         )
 
         # VCS subdirectory filtering for PRs: compare PR head against tracked branch
-        if ws.working_directory and ws.vcs_last_commit_sha:
+        pr_prefixes = (
+            ws.trigger_prefixes
+            if ws.trigger_prefixes
+            else ([ws.working_directory] if ws.working_directory else [])
+        )
+        if pr_prefixes and ws.vcs_last_commit_sha:
             try:
                 changed = await _get_changed_files(
                     conn, owner, repo, ws.vcs_last_commit_sha, pr.head_sha
                 )
                 # None means truncated — create run unconditionally
-                if changed is not None and not _changes_affect_directory(
-                    changed, ws.working_directory
-                ):
+                if changed is not None and not _changes_affect_prefixes(changed, pr_prefixes):
                     logger.info(
-                        "Skipping PR run — no changes in working directory",
+                        "Skipping PR run — no changes match trigger prefixes",
                         workspace=ws.name,
                         pr_number=pr.number,
-                        working_directory=ws.working_directory,
+                        trigger_prefixes=pr_prefixes,
+                        changed_files=changed[:20],
+                        changed_files_count=len(changed),
                     )
                     continue
             except Exception as e:
@@ -400,7 +413,7 @@ async def _poll_workspace_prs(
                     "Failed to get changed files for PR, creating run anyway",
                     workspace=ws.name,
                     pr_number=pr.number,
-                    error=str(e),
+                    error=repr(e),
                 )
 
         run = await _create_vcs_run(

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -50,6 +50,7 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.execution_backend = overrides.get("execution_backend", "tofu")
     ws.agent_pool = None
     ws.var_files = []
+    ws.trigger_prefixes = []
     ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return ws

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -57,6 +57,7 @@ def _mock_workspace(
     ws.vcs_repo_url = ""
     ws.vcs_branch = ""
     ws.var_files = []
+    ws.trigger_prefixes = []
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400
     ws.drift_last_checked_at = None

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -12,6 +12,7 @@ def _mock_workspace(**overrides):
     ws.vcs_repo_url = overrides.get("vcs_repo_url", "https://github.com/org/repo")
     ws.vcs_branch = overrides.get("vcs_branch", "main")
     ws.working_directory = overrides.get("working_directory", "")
+    ws.trigger_prefixes = overrides.get("trigger_prefixes", [])
     ws.vcs_last_commit_sha = overrides.get("vcs_last_commit_sha", "aaa111")
     ws.locked = False
     ws.auto_apply = False
@@ -35,44 +36,54 @@ def _mock_connection(**overrides):
     return conn
 
 
-class TestChangesAffectDirectory:
-    """Unit tests for _changes_affect_directory helper."""
+class TestChangesAffectPrefixes:
+    """Unit tests for _changes_affect_prefixes helper."""
 
-    def test_file_in_subdirectory_matches(self):
-        from terrapod.services.vcs_poller import _changes_affect_directory
+    def test_single_prefix_matches(self):
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
 
-        assert _changes_affect_directory(["infra/main.tf", "README.md"], "infra") is True
+        assert _changes_affect_prefixes(["infra/main.tf", "README.md"], ["infra"]) is True
 
-    def test_file_not_in_subdirectory(self):
-        from terrapod.services.vcs_poller import _changes_affect_directory
+    def test_multiple_prefixes_any_match(self):
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
 
-        assert _changes_affect_directory(["app/main.py", "README.md"], "infra") is False
+        assert _changes_affect_prefixes(["modules/vpc/main.tf"], ["infra", "modules"]) is True
 
-    def test_root_file_does_not_match(self):
-        from terrapod.services.vcs_poller import _changes_affect_directory
+    def test_no_prefix_matches(self):
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
 
-        assert _changes_affect_directory(["main.tf"], "infra") is False
+        assert _changes_affect_prefixes(["app/main.py", "README.md"], ["infra"]) is False
 
-    def test_nested_subdirectory_matches(self):
-        from terrapod.services.vcs_poller import _changes_affect_directory
+    def test_empty_prefix_list(self):
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
 
-        assert _changes_affect_directory(["infra/prod/main.tf"], "infra") is True
+        assert _changes_affect_prefixes(["infra/main.tf"], []) is False
 
-    def test_prefix_collision_does_not_match(self):
-        """'infra-old/main.tf' should NOT match working_directory='infra'."""
-        from terrapod.services.vcs_poller import _changes_affect_directory
+    def test_prefix_collision(self):
+        """'infra-old/main.tf' should NOT match prefix 'infra'."""
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
 
-        assert _changes_affect_directory(["infra-old/main.tf"], "infra") is False
+        assert _changes_affect_prefixes(["infra-old/main.tf"], ["infra"]) is False
 
     def test_trailing_slash_stripped(self):
-        from terrapod.services.vcs_poller import _changes_affect_directory
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
 
-        assert _changes_affect_directory(["infra/main.tf"], "infra/") is True
+        assert _changes_affect_prefixes(["infra/main.tf"], ["infra/"]) is True
 
     def test_empty_changed_files(self):
-        from terrapod.services.vcs_poller import _changes_affect_directory
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
 
-        assert _changes_affect_directory([], "infra") is False
+        assert _changes_affect_prefixes([], ["infra"]) is False
+
+    def test_nested_subdirectory_matches(self):
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
+
+        assert _changes_affect_prefixes(["infra/prod/main.tf"], ["infra"]) is True
+
+    def test_root_file_does_not_match(self):
+        from terrapod.services.vcs_poller import _changes_affect_prefixes
+
+        assert _changes_affect_prefixes(["main.tf"], ["infra"]) is False
 
 
 class TestPollWorkspaceBranchFiltering:
@@ -215,3 +226,80 @@ class TestPollWorkspaceBranchFiltering:
         await _poll_workspace_branch(mock_db, ws, conn, "org", "repo", "main")
 
         mock_create.assert_called_once()
+
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._get_branch_sha")
+    async def test_uses_trigger_prefixes_over_working_dir(
+        self, mock_sha, mock_changed, mock_create
+    ):
+        """When trigger_prefixes is set, it overrides working_directory for filtering."""
+        from terrapod.services.vcs_poller import _poll_workspace_branch
+
+        ws = _mock_workspace(
+            working_directory="infra",
+            trigger_prefixes=["modules"],
+            vcs_last_commit_sha="aaa111",
+        )
+        conn = _mock_connection()
+        mock_sha.return_value = "bbb222"
+        mock_changed.return_value = ["modules/vpc/main.tf"]
+        mock_run = MagicMock()
+        mock_run.id = uuid.uuid4()
+        mock_create.return_value = mock_run
+
+        mock_db = AsyncMock()
+        await _poll_workspace_branch(mock_db, ws, conn, "org", "repo", "main")
+
+        # Change is in modules/ which matches trigger_prefixes, even though
+        # it's outside working_directory ("infra")
+        mock_create.assert_called_once()
+
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._get_branch_sha")
+    async def test_trigger_prefix_matches_outside_working_dir(
+        self, mock_sha, mock_changed, mock_create
+    ):
+        """Trigger prefixes can match directories outside the working directory."""
+        from terrapod.services.vcs_poller import _poll_workspace_branch
+
+        ws = _mock_workspace(
+            working_directory="environments/dev",
+            trigger_prefixes=["environments/dev", "modules"],
+            vcs_last_commit_sha="aaa111",
+        )
+        conn = _mock_connection()
+        mock_sha.return_value = "bbb222"
+        mock_changed.return_value = ["modules/vpc/main.tf"]
+        mock_run = MagicMock()
+        mock_run.id = uuid.uuid4()
+        mock_create.return_value = mock_run
+
+        mock_db = AsyncMock()
+        await _poll_workspace_branch(mock_db, ws, conn, "org", "repo", "main")
+
+        mock_create.assert_called_once()
+
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._get_branch_sha")
+    async def test_trigger_prefixes_skip_when_no_match(self, mock_sha, mock_changed, mock_create):
+        """When trigger_prefixes is set but no files match, skip the run."""
+        from terrapod.services.vcs_poller import _poll_workspace_branch
+
+        ws = _mock_workspace(
+            working_directory="environments/dev",
+            trigger_prefixes=["environments/dev", "modules"],
+            vcs_last_commit_sha="aaa111",
+        )
+        conn = _mock_connection()
+        mock_sha.return_value = "bbb222"
+        mock_changed.return_value = ["environments/staging/main.tf", "README.md"]
+
+        mock_db = AsyncMock()
+        await _poll_workspace_branch(mock_db, ws, conn, "org", "repo", "main")
+
+        mock_create.assert_not_called()
+        assert ws.vcs_last_commit_sha == "bbb222"
+        mock_db.commit.assert_called_once()

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -43,6 +43,7 @@ interface WorkspaceAttrs {
   labels: Record<string, string>
   'owner-email': string
   'var-files': string[]
+  'trigger-prefixes': string[]
   'vcs-repo-url': string
   'vcs-branch': string
   'vcs-connection-id': string | null
@@ -194,6 +195,8 @@ function WorkspaceDetailContent() {
   const [editOwner, setEditOwner] = useState('')
   const [editVarFiles, setEditVarFiles] = useState<string[]>([])
   const [newVarFile, setNewVarFile] = useState('')
+  const [editTriggerPrefixes, setEditTriggerPrefixes] = useState<string[]>([])
+  const [newTriggerPrefix, setNewTriggerPrefix] = useState('')
   const [editWorkingDir, setEditWorkingDir] = useState('')
   const [editVcsConnectionId, setEditVcsConnectionId] = useState<string | null>(null)
   const [editVcsRepoUrl, setEditVcsRepoUrl] = useState('')
@@ -551,6 +554,8 @@ function WorkspaceDetailContent() {
     setEditOwner(workspace.attributes['owner-email'] || '')
     setEditVarFiles(workspace.attributes['var-files'] || [])
     setNewVarFile('')
+    setEditTriggerPrefixes(workspace.attributes['trigger-prefixes'] || [])
+    setNewTriggerPrefix('')
     setEditWorkingDir(workspace.attributes['working-directory'] || '')
     setEditVcsConnectionId(workspace.attributes['vcs-connection-id'] || null)
     setEditVcsRepoUrl(workspace.attributes['vcs-repo-url'] || '')
@@ -602,6 +607,7 @@ function WorkspaceDetailContent() {
               'agent-pool-id': editPoolId,
               'working-directory': editWorkingDir,
               'var-files': editVarFiles,
+              'trigger-prefixes': editTriggerPrefixes,
               'vcs-repo-url': editVcsRepoUrl,
               'vcs-branch': editVcsBranch,
               labels: editLabels,
@@ -1363,6 +1369,66 @@ function WorkspaceDetailContent() {
                         </div>
                       ) : (
                         <span className="text-slate-500">None</span>
+                      )}
+                    </dd>
+                  )}
+                </div>
+                <div className="sm:col-span-2">
+                  <dt className="text-xs text-slate-500 mb-1">Trigger Prefixes</dt>
+                  {editing && perms['can-update'] ? (
+                    <div className="space-y-2">
+                      <p className="text-xs text-slate-400">Directories that trigger runs. Overrides working directory filtering when set.</p>
+                      {editTriggerPrefixes.map((f, i) => (
+                        <div key={f} className="flex items-center gap-2">
+                          <code className="text-sm text-slate-200 bg-slate-700 px-2 py-0.5 rounded flex-1 truncate">{f}</code>
+                          <button
+                            onClick={() => setEditTriggerPrefixes(editTriggerPrefixes.filter((_, j) => j !== i))}
+                            className="text-xs text-red-400 hover:text-red-300"
+                          >Remove</button>
+                        </div>
+                      ))}
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="text"
+                          value={newTriggerPrefix}
+                          onChange={(e) => setNewTriggerPrefix(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' && newTriggerPrefix.trim()) {
+                              e.preventDefault()
+                              const v = newTriggerPrefix.trim().replace(/^\/|\/$/g, '')
+                              if (v && !editTriggerPrefixes.includes(v)) {
+                                setEditTriggerPrefixes([...editTriggerPrefixes, v])
+                              }
+                              setNewTriggerPrefix('')
+                            }
+                          }}
+                          placeholder="e.g. modules"
+                          className="flex-1 px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                        />
+                        <button
+                          onClick={() => {
+                            if (newTriggerPrefix.trim()) {
+                              const v = newTriggerPrefix.trim().replace(/^\/|\/$/g, '')
+                              if (v && !editTriggerPrefixes.includes(v)) {
+                                setEditTriggerPrefixes([...editTriggerPrefixes, v])
+                              }
+                              setNewTriggerPrefix('')
+                            }
+                          }}
+                          className="text-xs text-brand-400 hover:text-brand-300"
+                        >Add</button>
+                      </div>
+                    </div>
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">
+                      {(attrs['trigger-prefixes'] || []).length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {attrs['trigger-prefixes'].map((f) => (
+                            <code key={f} className="bg-slate-700 px-2 py-0.5 rounded text-xs">{f}</code>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-slate-500">None (uses working directory)</span>
                       )}
                     </dd>
                   )}


### PR DESCRIPTION
## Summary

- Add `trigger-prefixes` workspace attribute for monorepo VCS filtering — allows specifying multiple directories that trigger runs, replacing the default single working-directory filter
- Fix empty error strings in VCS poller logs (`str(e)` → `repr(e)`)
- Log changed file paths when skipping a run for easier debugging

## Changes

- **Database**: New `trigger_prefixes` ARRAY column on workspaces with Alembic migration
- **API**: Validation, serialization, create and update support for `trigger-prefixes`
- **VCS poller**: `_changes_affect_directory()` → `_changes_affect_prefixes()` with multi-prefix support; effective prefixes computed as `trigger_prefixes || [working_directory]`
- **Frontend**: Chip-list editor in workspace settings (same pattern as var-files)
- **Docs**: New "Trigger Prefixes" section in VCS integration docs with monorepo example
- **Tests**: 10 new/updated tests for multi-prefix filtering logic

## Test plan

- [x] `make test` — 844 tests pass
- [x] `make lint` — clean (Python + TypeScript)
- [x] `helm lint` — clean
- [x] Tilt local stack — migration, API, UI all verified via Playwright:
  - Add prefixes → save → read back correctly
  - Re-edit loads saved values
  - Remove individual prefixes
  - Empty list shows "None (uses working directory)"

Closes #152