### PR TITLE
fix: add UseStateForUnknown plan modifiers to provider computed attrs

### DIFF
--- a/provider/internal/resources/agent_pool/resource.go
+++ b/provider/internal/resources/agent_pool/resource.go
@@ -86,12 +86,18 @@ func (r *agentPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "A description of the agent pool.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 
 			// Read-only
 			"created_at": schema.StringAttribute{
 				Description: "Creation timestamp.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "Last update timestamp.",

--- a/provider/internal/resources/agent_pool_token/resource.go
+++ b/provider/internal/resources/agent_pool_token/resource.go
@@ -145,10 +145,16 @@ func (r *agentPoolTokenResource) Schema(_ context.Context, _ resource.SchemaRequ
 			"created_at": schema.StringAttribute{
 				Description: "Creation timestamp.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"created_by": schema.StringAttribute{
 				Description: "Email of the user who created the token.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}

--- a/provider/internal/resources/gpg_key/resource.go
+++ b/provider/internal/resources/gpg_key/resource.go
@@ -97,9 +97,17 @@ func (r *gpgKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Optional: true, Description: "Source URL.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
-			"key_id":     schema.StringAttribute{Computed: true, Description: "PGP key ID (extracted from armor)."},
-			"created_at": schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"updated_at": schema.StringAttribute{Computed: true, Description: "Update timestamp."},
+			"key_id": schema.StringAttribute{
+				Computed: true, Description: "PGP key ID (extracted from armor).",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true, Description: "Update timestamp.",
+			},
 		},
 	}
 }

--- a/provider/internal/resources/module_workspace_link/resource.go
+++ b/provider/internal/resources/module_workspace_link/resource.go
@@ -54,9 +54,16 @@ func (r *moduleWorkspaceLinkResource) Schema(_ context.Context, _ resource.Schem
 			},
 			"workspace_name": schema.StringAttribute{
 				Computed: true, Description: "Workspace name.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"created_at": schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"created_by": schema.StringAttribute{Computed: true, Description: "Creator email."},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_by": schema.StringAttribute{
+				Computed: true, Description: "Creator email.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }

--- a/provider/internal/resources/notification_configuration/resource.go
+++ b/provider/internal/resources/notification_configuration/resource.go
@@ -71,9 +71,16 @@ func (r *notificationConfigResource) Schema(_ context.Context, _ resource.Schema
 				Optional: true, ElementType: types.StringType,
 				Description: "Email addresses (for email destination type).",
 			},
-			"has_token": schema.BoolAttribute{Computed: true, Description: "Whether a token is configured."},
-			"created_at": schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"updated_at": schema.StringAttribute{Computed: true, Description: "Update timestamp."},
+			"has_token": schema.BoolAttribute{
+				Computed: true, Description: "Whether a token is configured.",
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true, Description: "Update timestamp.",
+			},
 		},
 	}
 }

--- a/provider/internal/resources/registry_module/resource.go
+++ b/provider/internal/resources/registry_module/resource.go
@@ -105,12 +105,28 @@ func (r *registryModuleResource) Schema(_ context.Context, _ resource.SchemaRequ
 			"vcs_repo_url":      schema.StringAttribute{Optional: true, Description: "VCS repo URL."},
 			"vcs_branch":        schema.StringAttribute{Optional: true, Description: "VCS branch."},
 			"vcs_tag_pattern":   schema.StringAttribute{Optional: true, Description: "VCS tag pattern (e.g. v*)."},
-			"namespace":         schema.StringAttribute{Computed: true, Description: "Namespace (always default)."},
-			"status":            schema.StringAttribute{Computed: true, Description: "Module status."},
-			"owner_email":       schema.StringAttribute{Computed: true, Description: "Owner email."},
-			"source":            schema.StringAttribute{Computed: true, Description: "Source (upload or vcs)."},
-			"created_at":        schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"updated_at":        schema.StringAttribute{Computed: true, Description: "Update timestamp."},
+			"namespace": schema.StringAttribute{
+				Computed: true, Description: "Namespace (always default).",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"status": schema.StringAttribute{
+				Computed: true, Description: "Module status.",
+			},
+			"owner_email": schema.StringAttribute{
+				Computed: true, Description: "Owner email.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"source": schema.StringAttribute{
+				Computed: true, Description: "Source (upload or vcs).",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true, Description: "Update timestamp.",
+			},
 		},
 	}
 }

--- a/provider/internal/resources/registry_provider/resource.go
+++ b/provider/internal/resources/registry_provider/resource.go
@@ -82,10 +82,21 @@ func (r *registryProviderResource) Schema(_ context.Context, _ resource.SchemaRe
 				Optional: true, ElementType: types.StringType,
 				Description: "Labels for RBAC evaluation.",
 			},
-			"namespace":   schema.StringAttribute{Computed: true, Description: "Namespace (always default)."},
-			"owner_email": schema.StringAttribute{Computed: true, Description: "Owner email."},
-			"created_at":  schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"updated_at":  schema.StringAttribute{Computed: true, Description: "Update timestamp."},
+			"namespace": schema.StringAttribute{
+				Computed: true, Description: "Namespace (always default).",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"owner_email": schema.StringAttribute{
+				Computed: true, Description: "Owner email.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true, Description: "Update timestamp.",
+			},
 		},
 	}
 }

--- a/provider/internal/resources/role/resource.go
+++ b/provider/internal/resources/role/resource.go
@@ -42,6 +42,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -137,10 +138,16 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"built_in": schema.BoolAttribute{
 				Description: "Whether this is a built-in role.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				Description: "Creation timestamp.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "Last update timestamp.",

--- a/provider/internal/resources/role_assignment/resource.go
+++ b/provider/internal/resources/role_assignment/resource.go
@@ -114,6 +114,9 @@ func (r *roleAssignmentResource) Schema(_ context.Context, _ resource.SchemaRequ
 			"created_at": schema.StringAttribute{
 				Description: "Creation timestamp.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}

--- a/provider/internal/resources/run_task/resource.go
+++ b/provider/internal/resources/run_task/resource.go
@@ -64,9 +64,16 @@ func (r *runTaskResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional: true, Sensitive: true,
 				Description: "HMAC signing key (write-only).",
 			},
-			"has_hmac_key": schema.BoolAttribute{Computed: true, Description: "Whether an HMAC key is configured."},
-			"created_at":   schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"updated_at":   schema.StringAttribute{Computed: true, Description: "Update timestamp."},
+			"has_hmac_key": schema.BoolAttribute{
+				Computed: true, Description: "Whether an HMAC key is configured.",
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true, Description: "Update timestamp.",
+			},
 		},
 	}
 }

--- a/provider/internal/resources/run_trigger/resource.go
+++ b/provider/internal/resources/run_trigger/resource.go
@@ -45,11 +45,16 @@ func (r *runTriggerResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"workspace_name": schema.StringAttribute{
 				Computed: true, Description: "Destination workspace name.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"sourceable_name": schema.StringAttribute{
 				Computed: true, Description: "Source workspace name.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"created_at": schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }

--- a/provider/internal/resources/user/resource.go
+++ b/provider/internal/resources/user/resource.go
@@ -123,6 +123,9 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"created_at": schema.StringAttribute{
 				Description: "Creation timestamp.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "Last update timestamp.",

--- a/provider/internal/resources/variable/resource.go
+++ b/provider/internal/resources/variable/resource.go
@@ -69,8 +69,13 @@ func (r *variableResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"version_id": schema.StringAttribute{
 				Computed: true, Description: "Version identifier.",
 			},
-			"created_at": schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"updated_at": schema.StringAttribute{Computed: true, Description: "Update timestamp."},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true, Description: "Update timestamp.",
+			},
 		},
 	}
 }

--- a/provider/internal/resources/variable_set/resource.go
+++ b/provider/internal/resources/variable_set/resource.go
@@ -104,8 +104,13 @@ func (r *variableSetResource) Schema(_ context.Context, _ resource.SchemaRequest
 			"workspace_count": schema.Int64Attribute{
 				Computed: true, Description: "Number of workspaces assigned to this set.",
 			},
-			"created_at": schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"updated_at": schema.StringAttribute{Computed: true, Description: "Update timestamp."},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true, Description: "Update timestamp.",
+			},
 		},
 	}
 }

--- a/provider/internal/resources/variable_set_variable/resource.go
+++ b/provider/internal/resources/variable_set_variable/resource.go
@@ -119,8 +119,13 @@ func (r *variableSetVariableResource) Schema(_ context.Context, _ resource.Schem
 			"version_id": schema.StringAttribute{
 				Computed: true, Description: "Version identifier.",
 			},
-			"created_at": schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-			"updated_at": schema.StringAttribute{Computed: true, Description: "Update timestamp."},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true, Description: "Update timestamp.",
+			},
 		},
 	}
 }

--- a/provider/internal/resources/vcs_connection/resource.go
+++ b/provider/internal/resources/vcs_connection/resource.go
@@ -119,6 +119,7 @@ func (r *vcsConnectionResource) Schema(_ context.Context, _ resource.SchemaReque
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
@@ -165,14 +166,23 @@ func (r *vcsConnectionResource) Schema(_ context.Context, _ resource.SchemaReque
 			"github_account_login": schema.StringAttribute{
 				Description: "The GitHub account login (for GitHub connections).",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"github_account_type": schema.StringAttribute{
 				Description: "The GitHub account type (for GitHub connections).",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				Description: "Creation timestamp.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "Last update timestamp.",

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -72,11 +74,17 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "The Terraform/OpenTofu version to use.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"working_directory": schema.StringAttribute{
 				Description: "Working directory relative to the repo root.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"resource_cpu": schema.StringAttribute{
 				Description: "CPU request for runner Jobs (K8s format, e.g. '1').",
@@ -120,17 +128,26 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "Enable drift detection for this workspace. Defaults to true for VCS-connected workspaces, false otherwise.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"drift_detection_interval_seconds": schema.Int64Attribute{
 				Description: "Interval in seconds between drift detection checks.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 
 			// Read-only
 			"owner_email": schema.StringAttribute{
 				Description: "Email of the workspace owner.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"drift_status": schema.StringAttribute{
 				Description: "Current drift status.",
@@ -147,6 +164,9 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"created_at": schema.StringAttribute{
 				Description: "Creation timestamp.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "Last update timestamp.",


### PR DESCRIPTION
## Summary

- Add `UseStateForUnknown` plan modifiers to stable/immutable computed attributes across all 17 provider resource types
- Eliminates noisy `(known after apply)` diffs on `created_at`, `owner_email`, `namespace`, `key_id`, etc. during plan and import
- Volatile attributes (`updated_at`, `locked`, `status`, `use_count`, etc.) deliberately excluded — these must be re-read from the API

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] CI green (provider lint + test)
- [ ] `terraform plan` on terrapod-config shows clean diff for stable attrs after import