### PR TITLE
fix: add ws- prefix to workspace-id in workspace-links response

### DIFF
--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -764,7 +764,7 @@ def _link_to_jsonapi(link: ModuleWorkspaceLink) -> dict:
         "id": str(link.id),
         "type": "workspace-links",
         "attributes": {
-            "workspace-id": str(link.workspace_id),
+            "workspace-id": f"ws-{link.workspace_id}",
             "workspace-name": ws.name if ws else "",
             "created-at": link.created_at.isoformat() if link.created_at else None,
             "created-by": link.created_by,


### PR DESCRIPTION
## Summary

- Fix inconsistent workspace-id in workspace-links API response — was returning raw UUID while all other workspace ID references use the `ws-` prefix
- Caused `Provider produced inconsistent result after apply` error when using `terrapod_module_workspace_link` with a workspace ID from `terrapod_workspace.id`

## Test plan

- [ ] CI green
- [ ] `terraform apply` on terrapod-config creates workspace link without error