### PR TITLE
fix: allow confirm/apply for UI-queued runs on VCS-connected workspaces

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -255,7 +255,7 @@ async def _fetch_vcs_config(
     archive = _strip_top_level_dir(archive)
 
     cv = await run_service.create_configuration_version(
-        db, workspace_id=ws.id, source="tfe-api", auto_queue_runs=False
+        db, workspace_id=ws.id, source="vcs", auto_queue_runs=False
     )
     await db.flush()
 
@@ -285,21 +285,15 @@ async def create_run(
 
     ws = await _get_workspace(ws_id, db)
 
-    # CLI-initiated runs on VCS-connected remote workspaces: plan is allowed,
-    # apply is not — VCS is the source of truth. Non-VCS ("CLI-driven") remote
+    # CLI-initiated runs on VCS-connected agent workspaces: plan is allowed,
+    # apply is not — VCS is the source of truth. Non-VCS ("CLI-driven") agent
     # workspaces allow both plan and apply from the CLI.
-    # The guard only applies when a configuration version is being uploaded
-    # (CLI workflow). Runs without a CV (UI-queued, VCS, drift) get code from VCS.
+    # The guard fires when a configuration version is provided (CLI upload).
+    # Runs without a CV (UI-queued) will fetch code from VCS downstream.
     plan_only = attrs.get("plan-only", False)
-    source = attrs.get("source", "tfe-api")
     cv_data = relationships.get("configuration-version", {}).get("data", {})
     has_cv = bool(cv_data.get("id", "") if cv_data else "")
-    if (
-        ws.execution_mode == "agent"
-        and ws.vcs_connection_id is not None
-        and source not in ("vcs", "drift-detection")
-        and has_cv
-    ):
+    if ws.execution_mode == "agent" and ws.vcs_connection_id is not None and has_cv:
         if not plan_only:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -347,7 +341,7 @@ async def create_run(
         is_destroy=attrs.get("is-destroy", False),
         auto_apply=attrs.get("auto-apply"),
         plan_only=plan_only,
-        source=attrs.get("source", "tfe-api"),
+        source="tfe-api",
         terraform_version=attrs.get("terraform-version", ""),
         configuration_version_id=cv_uuid,
         created_by=user.email,
@@ -445,7 +439,13 @@ async def confirm_run(
 
     # Block apply for CLI-uploaded code on VCS-connected agent workspaces.
     # Destroy runs are exempt — they don't depend on uploaded code.
-    if run.source not in ("vcs", "drift-detection") and not run.is_destroy:
+    # Runs with vcs_commit_sha were fetched from VCS (UI-queued or poller)
+    # and are safe to apply even if source is "tfe-api".
+    if (
+        run.source not in ("vcs", "drift-detection")
+        and not run.is_destroy
+        and not run.vcs_commit_sha
+    ):
         ws = await db.get(Workspace, run.workspace_id)
         if ws and ws.execution_mode == "agent" and ws.vcs_connection_id is not None:
             raise HTTPException(

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -458,6 +458,40 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    async def test_create_apply_blocked_even_with_spoofed_vcs_source(self, mock_resolve, *mocks):
+        """Remote + VCS + CLI CV + source='vcs' spoofed → still 422."""
+        mock_resolve.return_value = "write"
+        ws = _mock_workspace()
+        ws.execution_mode = "agent"
+        ws.vcs_connection_id = uuid.uuid4()
+
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        cv_id = uuid.uuid4()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/runs",
+                json={
+                    "data": {
+                        "attributes": {"plan-only": False, "source": "vcs"},
+                        "relationships": {
+                            "workspace": {"data": {"id": f"ws-{ws.id}"}},
+                            "configuration-version": {"data": {"id": f"cv-{cv_id}"}},
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "VCS-connected" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.resolve_workspace_permission")
@@ -568,6 +602,37 @@ class TestCLIApplyGuard:
             )
         assert resp.status_code == 422
         assert "VCS-connected" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.confirm_run")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_confirm_allowed_for_ui_queued_vcs_run(
+        self, mock_get_run, mock_resolve, mock_confirm, *mocks
+    ):
+        """Confirm UI-queued run on VCS-connected workspace → 200 (code from VCS)."""
+        mock_resolve.return_value = "write"
+        run = _mock_run(status="planned")
+        run.vcs_commit_sha = "abc123"  # Code was fetched from VCS
+        mock_get_run.return_value = run
+        confirmed = _mock_run(status="confirmed")
+        mock_confirm.return_value = confirmed
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        ws.execution_mode = "agent"
+        ws.vcs_connection_id = uuid.uuid4()
+
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/v2/runs/run-{run.id}/actions/apply",
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")


### PR DESCRIPTION
## Summary

- The `confirm_run` guard blocked ALL non-VCS source runs on VCS-connected agent workspaces, including UI-queued runs that fetched their code from VCS via `_fetch_vcs_config`
- The `create_run` endpoint trusted the client-supplied `source` attribute, allowing a caller to spoof `source: "vcs"` with a CLI-uploaded CV to bypass the apply guard
- The CV created by `_fetch_vcs_config` was incorrectly labelled `source="tfe-api"` when the code came from VCS

### Fix

- **Confirm guard**: now also checks `run.vcs_commit_sha` — runs that fetched code from VCS have this set server-side by `_fetch_vcs_config`, CLI-uploaded runs don't
- **Create guard**: no longer checks `source` from the client — the guard fires based on `has_cv` (whether the client uploaded a configuration version). Source is hardcoded to `"tfe-api"` for all API-created runs
- **CV source**: `_fetch_vcs_config` now sets `source="vcs"` on the configuration version it creates
- **New tests**: UI-queued VCS run confirm (200), source spoofing attack (422)

### Security analysis

| Attack vector | Result |
|---|---|
| CLI upload + `source: "vcs"` spoofed | Blocked — source ignored, `has_cv` triggers guard |
| CLI upload + `source: "drift-detection"` spoofed | Blocked — same reason |
| UI-queued run (no CV, VCS code fetched) | Allowed — `vcs_commit_sha` set server-side |
| `vcs_commit_sha` injection via request body | Not possible — field is never read from client attrs |

## Test plan

- [x] 876 tests pass
- [x] Lint clean
- [x] Source spoofing test added
- [x] UI-queued VCS confirm test added