### PR TITLE
fix: pass -destroy flag to runner for destroy runs

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -371,6 +371,9 @@ if [ "$TP_PHASE" = "plan" ]; then
     if [ "${TP_REFRESH:-true}" = "false" ]; then
         PLAN_ARGS="$PLAN_ARGS -refresh=false"
     fi
+    if [ "${TP_DESTROY:-false}" = "true" ]; then
+        PLAN_ARGS="$PLAN_ARGS -destroy"
+    fi
     : > /tmp/plan.log
     "$TP_BIN" plan $PLAN_ARGS "$@" > /tmp/plan.log 2>&1 &
     CHILD_PID=$!

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -57,6 +57,7 @@ def build_job_spec(
     refresh_only: bool = False,
     refresh: bool = True,
     allow_empty_apply: bool = False,
+    is_destroy: bool = False,
     working_directory: str = "",
 ) -> dict:
     """Build a K8s Job spec for a run phase.
@@ -119,6 +120,8 @@ def build_job_spec(
         container_env.append({"name": "TP_REFRESH", "value": "false"})
     if allow_empty_apply:
         container_env.append({"name": "TP_ALLOW_EMPTY_APPLY", "value": "true"})
+    if is_destroy:
+        container_env.append({"name": "TP_DESTROY", "value": "true"})
     if working_directory:
         container_env.append({"name": "TP_WORKING_DIR", "value": working_directory})
 

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -491,6 +491,7 @@ class RunnerListener:
             refresh_only=attrs.get("refresh-only", False),
             refresh=attrs.get("refresh", True),
             allow_empty_apply=attrs.get("allow-empty-apply", False),
+            is_destroy=attrs.get("is-destroy", False),
             working_directory=attrs.get("working-directory", ""),
         )
 

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -538,7 +538,7 @@ export default function RunDetailPage() {
         {attrs['is-destroy'] && (
           <div className="mb-6 p-4 bg-red-900/20 rounded-lg border border-red-800/50">
             <p className="text-sm text-red-300">
-              This is a <strong>destroy</strong> run &mdash; all managed resources will be destroyed when applied.
+              This is a <strong>destroy</strong>{' '}run &mdash; all managed resources will be destroyed when applied.
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary

- The `is_destroy` attribute was stored on the run model and included in the API response to the listener, but was never forwarded to the runner Job as an environment variable. Destroy runs executed a normal plan instead of a destroy plan.
- Fix missing space in the destroy run warning banner ("destroyrun" → "destroy run")

Relates to #158

## Changes

- `job_template.py`: Add `is_destroy` param → `TP_DESTROY=true` env var
- `listener.py`: Pass `is-destroy` from run attrs to `build_job_spec`
- `runner-entrypoint.sh`: Add `-destroy` to plan args when `TP_DESTROY=true`
- `runs/[runId]/page.tsx`: Add `{' '}` after `</strong>` in destroy banner

## Test plan

- [x] 876 tests pass
- [ ] Queue a destroy run and verify plan output includes `-destroy`
- [ ] Confirm apply completes and resources are destroyed