### PR TITLE
fix: show run creator and dismiss drift banner on detection disable

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -105,6 +105,7 @@ def _run_json(
                 },
                 "created-at": _rfc3339(run.created_at),
                 "updated-at": _rfc3339(run.updated_at),
+                "created-by": run.created_by or "",
                 "actions": {
                     "is-confirmable": run.status == "planned"
                     and not run.auto_apply

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -450,7 +450,7 @@ def _compute_health_conditions(ws: Workspace) -> list[dict]:
             }
         )
 
-    if ws.drift_status == "drifted":
+    if ws.drift_detection_enabled and ws.drift_status == "drifted":
         conditions.append(
             {
                 "code": "drifted",
@@ -461,7 +461,7 @@ def _compute_health_conditions(ws: Workspace) -> list[dict]:
             }
         )
 
-    if ws.drift_status == "errored":
+    if ws.drift_detection_enabled and ws.drift_status == "errored":
         conditions.append(
             {
                 "code": "drift_errored",
@@ -902,6 +902,10 @@ async def update_workspace(
             ws.agent_pool_id = _uuid.UUID(str(pool_val).removeprefix("apool-"))
     if "drift-detection-enabled" in attrs:
         ws.drift_detection_enabled = attrs["drift-detection-enabled"]
+        # Reset drift status when disabling drift detection
+        if not ws.drift_detection_enabled:
+            ws.drift_status = ""
+            ws.drift_last_checked_at = None
     if "drift-detection-interval-seconds" in attrs:
         ws.drift_detection_interval_seconds = _clamp_drift_interval(
             attrs["drift-detection-interval-seconds"]

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -207,6 +207,7 @@ class TestRunDriftAttributes:
         run.resource_cpu = "1"
         run.resource_memory = "2Gi"
         run.module_overrides = None
+        run.created_by = "test@example.com"
 
         ws = _mock_workspace(ws_id=ws_id)
 

--- a/services/tests/api/test_health_conditions.py
+++ b/services/tests/api/test_health_conditions.py
@@ -87,19 +87,37 @@ class TestComputeHealthConditions:
         from terrapod.api.routers.tfe_v2 import _compute_health_conditions
 
         ws = _mock_workspace(drift_status="drifted")
+        ws.drift_detection_enabled = True
         conditions = _compute_health_conditions(ws)
         assert len(conditions) == 1
         assert conditions[0]["code"] == "drifted"
         assert conditions[0]["severity"] == "warning"
 
+    def test_drifted_hidden_when_detection_disabled(self):
+        from terrapod.api.routers.tfe_v2 import _compute_health_conditions
+
+        ws = _mock_workspace(drift_status="drifted")
+        ws.drift_detection_enabled = False
+        conditions = _compute_health_conditions(ws)
+        assert conditions == []
+
     def test_drift_errored(self):
         from terrapod.api.routers.tfe_v2 import _compute_health_conditions
 
         ws = _mock_workspace(drift_status="errored")
+        ws.drift_detection_enabled = True
         conditions = _compute_health_conditions(ws)
         assert len(conditions) == 1
         assert conditions[0]["code"] == "drift_errored"
         assert conditions[0]["severity"] == "warning"
+
+    def test_drift_errored_hidden_when_detection_disabled(self):
+        from terrapod.api.routers.tfe_v2 import _compute_health_conditions
+
+        ws = _mock_workspace(drift_status="errored")
+        ws.drift_detection_enabled = False
+        conditions = _compute_health_conditions(ws)
+        assert conditions == []
 
     def test_multiple_conditions_simultaneously(self):
         from terrapod.api.routers.tfe_v2 import _compute_health_conditions
@@ -111,6 +129,7 @@ class TestComputeHealthConditions:
             execution_mode="agent",
             agent_pool_id=None,
         )
+        ws.drift_detection_enabled = True
         conditions = _compute_health_conditions(ws)
         codes = {c["code"] for c in conditions}
         assert codes == {"state_diverged", "no_agent_pool", "vcs_error", "drifted"}

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -123,6 +123,7 @@ def _mock_run(
     run.resource_cpu = "1"
     run.resource_memory = "2Gi"
     run.configuration_version_id = None
+    run.created_by = "test@example.com"
     return run
 
 

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -65,6 +65,7 @@ def _mock_run(
     run.resource_memory = "2Gi"
     run.configuration_version_id = None
     run.module_overrides = None
+    run.created_by = "test@example.com"
     return run
 
 

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -318,7 +318,7 @@ function WorkspaceDetailContent() {
   const [deleteRtId, setDeleteRtId] = useState<string | null>(null)
 
   // Sorting for runs tab
-  type RunSortKey = 'id' | 'status' | 'type' | 'source' | 'created-at'
+  type RunSortKey = 'id' | 'status' | 'type' | 'source' | 'created-by' | 'created-at'
   const { sortedItems: sortedRuns, sortState: runSortState, toggleSort: toggleRunSort } = useSortable<RunItem, RunSortKey>(
     runs, 'created-at', 'desc',
     useCallback((item: RunItem, key: RunSortKey) => {
@@ -327,6 +327,7 @@ function WorkspaceDetailContent() {
         case 'status': return item.attributes.status
         case 'type': return item.attributes['is-destroy'] ? 'destroy' : item.attributes['plan-only'] ? 'plan only' : 'plan + apply'
         case 'source': return item.attributes.source
+        case 'created-by': return item.attributes['created-by'] || ''
         case 'created-at': return item.attributes['created-at']
       }
     }, []),

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -94,6 +94,7 @@ interface RunItem {
     'plan-only': boolean
     'is-destroy': boolean
     'created-at': string
+    'created-by': string
     'plan-started-at': string | null
     'apply-finished-at': string | null
     actions?: {
@@ -1953,6 +1954,7 @@ function WorkspaceDetailContent() {
                       <SortableHeader label="Status" sortKey="status" sortState={runSortState} onSort={toggleRunSort} />
                       <SortableHeader label="Type" sortKey="type" sortState={runSortState} onSort={toggleRunSort} className="hidden sm:table-cell" />
                       <SortableHeader label="Source" sortKey="source" sortState={runSortState} onSort={toggleRunSort} className="hidden sm:table-cell" />
+                      <SortableHeader label="Triggered By" sortKey="created-by" sortState={runSortState} onSort={toggleRunSort} className="hidden lg:table-cell" />
                       <SortableHeader label="Created" sortKey="created-at" sortState={runSortState} onSort={toggleRunSort} className="hidden md:table-cell" />
                     </tr>
                   </thead>
@@ -1994,6 +1996,9 @@ function WorkspaceDetailContent() {
                           ) : run.attributes.source === 'module-publish' ? (
                             <span className="text-purple-400">module publish</span>
                           ) : run.attributes.source}
+                        </td>
+                        <td className="px-4 py-3 text-xs text-slate-400 hidden lg:table-cell">
+                          {run.attributes['created-by'] || <span className="text-slate-600">&mdash;</span>}
                         </td>
                         <td className="px-4 py-3 text-xs text-slate-500 hidden md:table-cell">
                           {run.attributes['created-at'] ? new Date(run.attributes['created-at']).toLocaleString() : ''}

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -41,6 +41,7 @@ interface RunAttrs {
   'workspace-has-vcs': boolean
   'module-overrides': Record<string, string> | null
   'status-timestamps': Record<string, string>
+  'created-by': string
   actions: RunActions
   permissions: Record<string, boolean>
 }
@@ -636,6 +637,12 @@ export default function RunDetailPage() {
               <dt className="text-xs text-slate-500">Plan Only</dt>
               <dd className="mt-1 text-sm text-slate-200">{attrs['plan-only'] ? 'Yes' : 'No'}</dd>
             </div>
+            {attrs['created-by'] && (
+              <div>
+                <dt className="text-xs text-slate-500">Triggered By</dt>
+                <dd className="mt-1 text-sm text-slate-200">{attrs['created-by']}</dd>
+              </div>
+            )}
             <div>
               <dt className="text-xs text-slate-500">Created</dt>
               <dd className="mt-1 text-sm text-slate-200">{formatTimestamp(attrs['created-at'])}</dd>


### PR DESCRIPTION
## Summary

- **Show who triggered a run (#183)** — adds `created-by` attribute to the run API response. Displayed as "Triggered By" in both the run detail metadata section and the run list table on the workspace page.
- **Dismiss drift banner when detection disabled (#184)** — resets `drift_status` and `drift_last_checked_at` when drift detection is toggled off. Also gates drift health conditions on `drift_detection_enabled` so stale banners never show.

Closes #183, closes #184

## Test plan

- [x] All 878 tests pass
- [ ] Verify "Triggered By" appears on run detail page for runs created by a user
- [ ] Verify "Triggered By" column appears in workspace runs list
- [ ] Verify disabling drift detection clears the "Infrastructure drift detected" health banner
- [ ] Verify re-enabling drift detection starts fresh (status unchecked)