### PR TITLE
feat: add label-based RBAC for agent pools

### DIFF
--- a/alembic/versions/ad9e14fa1469_add_agent_pool_rbac.py
+++ b/alembic/versions/ad9e14fa1469_add_agent_pool_rbac.py
@@ -27,7 +27,9 @@ def upgrade() -> None:
         sa.Column("pool_permission", sa.String(20), nullable=False, server_default="read"),
     )
 
-    # Backward compat: existing pools get access=everyone
+    # Backward compat: existing pools get access=everyone so they remain
+    # visible to all users after upgrade. Newly created pools get {} (empty)
+    # by default — admins must set labels explicitly for RBAC visibility.
     op.execute('UPDATE agent_pools SET labels = \'{"access": "everyone"}\'')
 
 

--- a/alembic/versions/ad9e14fa1469_add_agent_pool_rbac.py
+++ b/alembic/versions/ad9e14fa1469_add_agent_pool_rbac.py
@@ -1,0 +1,37 @@
+"""Add agent pool RBAC (labels, owner_email, pool_permission).
+
+Adds label-based RBAC to agent pools, mirroring the existing workspace
+and registry RBAC patterns. Pools get labels + owner_email for permission
+resolution, and roles get pool_permission for fine-grained access control.
+
+Existing pools default to access=everyone so they remain visible to all
+users after the migration.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "ad9e14fa1469"
+down_revision = "cc6a19db3ee3"
+
+
+def upgrade() -> None:
+    # AgentPool additions
+    op.add_column("agent_pools", sa.Column("labels", JSONB, nullable=False, server_default="{}"))
+    op.add_column("agent_pools", sa.Column("owner_email", sa.String(255), nullable=True))
+
+    # Role addition
+    op.add_column(
+        "roles",
+        sa.Column("pool_permission", sa.String(20), nullable=False, server_default="read"),
+    )
+
+    # Backward compat: existing pools get access=everyone
+    op.execute('UPDATE agent_pools SET labels = \'{"access": "everyone"}\'')
+
+
+def downgrade() -> None:
+    op.drop_column("roles", "pool_permission")
+    op.drop_column("agent_pools", "owner_email")
+    op.drop_column("agent_pools", "labels")

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -31,15 +31,38 @@ A role's `workspace_permission` maps to registry permissions: `plan` maps to `re
 
 **Runner tokens** receive implicit `read` access to all registry modules and providers. This allows runner Jobs to download modules and providers during `terraform init` without requiring explicit label-based permissions on each registry resource.
 
+### Pool Permission Levels
+
+Agent pools use a three-level hierarchy (separate from workspace permissions):
+
+| Level | Grants |
+|---|---|
+| **read** | View pool, list listeners |
+| **write** | read + assign pool to workspaces |
+| **admin** | write + manage tokens, update/delete pool |
+
+Each custom role has a `pool_permission` field (default: `read`) that is independent of `workspace_permission`. Assigning a pool to a workspace requires **both** `write` on the pool **and** `admin` on the workspace.
+
+Pool permission resolution follows the same order as workspace permissions:
+
+1. **Platform admin** → `admin` on all pools
+2. **Platform audit** → `read` on all pools
+3. **Pool owner** (`pool.owner_email == user.email`) → `admin`
+4. **Label-based RBAC** — custom roles matched against pool labels using `pool_permission`
+5. **`everyone` role** — pools with label `access: everyone` → `read`
+6. **Default** → no access (pool is invisible)
+
 ### Platform Permissions
 
 | Operation | Required Role |
 |---|---|
 | Manage roles and assignments | `admin` |
 | Manage VCS connections | `admin` |
-| Manage agent pools and tokens | `admin` |
+| Create agent pools | `admin` |
+| Manage agent pool tokens, update/delete pool | Pool `admin` (owner, platform admin, or role-based) |
 | Binary/module/provider cache admin | `admin` |
-| View roles, VCS connections, agent pools | `admin` or `audit` |
+| View roles, VCS connections | `admin` or `audit` |
+| View agent pools | Any authenticated user (filtered by pool RBAC) |
 | Create workspaces | Any authenticated user (creator becomes owner) |
 | Create registry modules/providers | Any authenticated user (creator becomes owner) |
 | Variable sets (create/update/delete) | `admin` |
@@ -130,6 +153,7 @@ curl -X POST https://terrapod.example.com/api/v2/roles \
 | `name` | string | Unique role name (lowercase, alphanumeric + hyphens) |
 | `description` | string | Human-readable description |
 | `workspace-permission` | string | One of: `read`, `plan`, `write`, `admin` |
+| `pool-permission` | string | One of: `read`, `write`, `admin` (default: `read`) |
 | `allow-labels` | object | Label key-value pairs that grant access |
 | `allow-names` | array | Explicit workspace names that grant access |
 | `deny-labels` | object | Label key-value pairs that deny access (overrides allow) |

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -18,7 +18,8 @@ test.describe('Admin access control', () => {
     // Admin-only links should not be visible
     await expect(userPage.locator('nav >> text=Roles')).not.toBeVisible();
     await expect(userPage.locator('nav >> text=Users')).not.toBeVisible();
-    await expect(userPage.locator('nav >> text=Agent Pools')).not.toBeVisible();
+    // Agent Pools is visible to all users (RBAC-filtered server-side)
+    await expect(userPage.locator('nav >> text=Agent Pools')).toBeVisible();
   });
 
   test('admin can access roles page', async ({ adminPage }) => {

--- a/provider/internal/datasources/agent_pool/data_source.go
+++ b/provider/internal/datasources/agent_pool/data_source.go
@@ -93,10 +93,10 @@ func (d *agentPoolDataSource) Read(ctx context.Context, req datasource.ReadReque
 			config.Name = types.StringValue(client.GetStringAttr(&r, "name"))
 			config.Description = types.StringValue(client.GetStringAttr(&r, "description"))
 
-			// Labels
+			// Labels — treat empty map {} as valid (not null)
 			if rawLabels, ok := r.Attributes["labels"]; ok && len(rawLabels) > 0 {
 				var labels map[string]string
-				if err := json.Unmarshal(rawLabels, &labels); err == nil && len(labels) > 0 {
+				if err := json.Unmarshal(rawLabels, &labels); err == nil {
 					val, d := types.MapValueFrom(ctx, types.StringType, labels)
 					resp.Diagnostics.Append(d...)
 					config.Labels = val

--- a/provider/internal/datasources/agent_pool/data_source.go
+++ b/provider/internal/datasources/agent_pool/data_source.go
@@ -6,6 +6,7 @@ package agent_pool
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -25,6 +26,8 @@ type agentPoolDataSourceModel struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
+	Labels      types.Map    `tfsdk:"labels"`
+	OwnerEmail  types.String `tfsdk:"owner_email"`
 	CreatedAt   types.String `tfsdk:"created_at"`
 	UpdatedAt   types.String `tfsdk:"updated_at"`
 }
@@ -44,6 +47,8 @@ func (d *agentPoolDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"id":          schema.StringAttribute{Computed: true, Description: "Agent pool ID."},
 			"name":        schema.StringAttribute{Required: true, Description: "Agent pool name."},
 			"description": schema.StringAttribute{Computed: true, Description: "Description."},
+			"labels":      schema.MapAttribute{Computed: true, ElementType: types.StringType, Description: "Pool labels for RBAC."},
+			"owner_email": schema.StringAttribute{Computed: true, Description: "Pool owner email."},
 			"created_at":  schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
 			"updated_at":  schema.StringAttribute{Computed: true, Description: "Update timestamp."},
 		},
@@ -87,6 +92,27 @@ func (d *agentPoolDataSource) Read(ctx context.Context, req datasource.ReadReque
 			config.ID = types.StringValue(r.ID)
 			config.Name = types.StringValue(client.GetStringAttr(&r, "name"))
 			config.Description = types.StringValue(client.GetStringAttr(&r, "description"))
+
+			// Labels
+			if rawLabels, ok := r.Attributes["labels"]; ok && len(rawLabels) > 0 {
+				var labels map[string]string
+				if err := json.Unmarshal(rawLabels, &labels); err == nil && len(labels) > 0 {
+					val, d := types.MapValueFrom(ctx, types.StringType, labels)
+					resp.Diagnostics.Append(d...)
+					config.Labels = val
+				} else {
+					config.Labels = types.MapNull(types.StringType)
+				}
+			} else {
+				config.Labels = types.MapNull(types.StringType)
+			}
+
+			if v := client.GetStringAttr(&r, "owner-email"); v != "" {
+				config.OwnerEmail = types.StringValue(v)
+			} else {
+				config.OwnerEmail = types.StringNull()
+			}
+
 			config.CreatedAt = types.StringValue(client.GetStringAttr(&r, "created-at"))
 			config.UpdatedAt = types.StringValue(client.GetStringAttr(&r, "updated-at"))
 			resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)

--- a/provider/internal/resources/agent_pool/resource.go
+++ b/provider/internal/resources/agent_pool/resource.go
@@ -293,10 +293,11 @@ func readAgentPoolIntoModel(ctx context.Context, res *client.Resource, m *agentP
 		m.Description = types.StringNull()
 	}
 
-	// Labels
+	// Labels — treat empty map {} as a valid value (not null) to avoid
+	// unnecessary Terraform diffs between config `labels = {}` and state `null`.
 	if raw, ok := res.Attributes["labels"]; ok && len(raw) > 0 {
 		var labels map[string]string
-		if err := json.Unmarshal(raw, &labels); err == nil && len(labels) > 0 {
+		if err := json.Unmarshal(raw, &labels); err == nil {
 			val, d := types.MapValueFrom(ctx, types.StringType, labels)
 			diags.Append(d...)
 			m.Labels = val

--- a/provider/internal/resources/agent_pool/resource.go
+++ b/provider/internal/resources/agent_pool/resource.go
@@ -13,6 +13,8 @@
 //
 //	"name"                 -> name                 (string, required)
 //	"description"          -> description          (string, optional)
+//	"labels"               -> labels               (map[string]string, optional)
+//	"owner-email"          -> owner_email          (string, optional)
 //
 // Read-only attributes:
 //
@@ -24,6 +26,7 @@ package agent_pool
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -48,6 +51,8 @@ type agentPoolModel struct {
 	// Writable attributes
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
+	Labels      types.Map    `tfsdk:"labels"`
+	OwnerEmail  types.String `tfsdk:"owner_email"`
 
 	// Read-only attributes
 	CreatedAt types.String `tfsdk:"created_at"`
@@ -89,6 +94,17 @@ func (r *agentPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+			},
+			"labels": schema.MapAttribute{
+				Description: "Labels for RBAC-based access control.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"owner_email": schema.StringAttribute{
+				Description: "Email of the pool owner (granted admin permission).",
+				Optional:    true,
+				Computed:    true,
 			},
 
 			// Read-only
@@ -146,7 +162,7 @@ func (r *agentPoolResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	readAgentPoolIntoModel(res, &plan)
+	readAgentPoolIntoModel(ctx, res, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -173,7 +189,7 @@ func (r *agentPoolResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	readAgentPoolIntoModel(res, &state)
+	readAgentPoolIntoModel(ctx, res, &state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -210,7 +226,7 @@ func (r *agentPoolResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	readAgentPoolIntoModel(res, &plan)
+	readAgentPoolIntoModel(ctx, res, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -241,11 +257,23 @@ func buildAgentPoolAttrs(m *agentPoolModel) map[string]any {
 		attrs["description"] = m.Description.ValueString()
 	}
 
+	if !m.Labels.IsNull() && !m.Labels.IsUnknown() {
+		labels := map[string]string{}
+		for k, v := range m.Labels.Elements() {
+			labels[k] = v.(types.String).ValueString()
+		}
+		attrs["labels"] = labels
+	}
+
+	if !m.OwnerEmail.IsNull() && !m.OwnerEmail.IsUnknown() {
+		attrs["owner-email"] = m.OwnerEmail.ValueString()
+	}
+
 	return attrs
 }
 
 // readAgentPoolIntoModel populates the Terraform model from a JSON:API resource.
-func readAgentPoolIntoModel(res *client.Resource, m *agentPoolModel) {
+func readAgentPoolIntoModel(ctx context.Context, res *client.Resource, m *agentPoolModel) {
 	m.ID = types.StringValue(res.ID)
 	m.Name = types.StringValue(client.GetStringAttr(res, "name"))
 
@@ -253,6 +281,26 @@ func readAgentPoolIntoModel(res *client.Resource, m *agentPoolModel) {
 		m.Description = types.StringValue(v)
 	} else {
 		m.Description = types.StringNull()
+	}
+
+	// Labels
+	if raw, ok := res.Attributes["labels"]; ok && len(raw) > 0 {
+		var labels map[string]string
+		if err := json.Unmarshal(raw, &labels); err == nil && len(labels) > 0 {
+			val, _ := types.MapValueFrom(ctx, types.StringType, labels)
+			m.Labels = val
+		} else {
+			m.Labels = types.MapNull(types.StringType)
+		}
+	} else {
+		m.Labels = types.MapNull(types.StringType)
+	}
+
+	// Owner email
+	if v := client.GetStringAttr(res, "owner-email"); v != "" {
+		m.OwnerEmail = types.StringValue(v)
+	} else {
+		m.OwnerEmail = types.StringNull()
 	}
 
 	m.CreatedAt = types.StringValue(client.GetStringAttr(res, "created-at"))

--- a/provider/internal/resources/agent_pool/resource.go
+++ b/provider/internal/resources/agent_pool/resource.go
@@ -29,9 +29,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -100,11 +102,17 @@ func (r *agentPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"owner_email": schema.StringAttribute{
 				Description: "Email of the pool owner (granted admin permission).",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 
 			// Read-only
@@ -162,7 +170,7 @@ func (r *agentPoolResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	readAgentPoolIntoModel(ctx, res, &plan)
+	resp.Diagnostics.Append(readAgentPoolIntoModel(ctx, res, &plan)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -189,7 +197,7 @@ func (r *agentPoolResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	readAgentPoolIntoModel(ctx, res, &state)
+	resp.Diagnostics.Append(readAgentPoolIntoModel(ctx, res, &state)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -226,7 +234,7 @@ func (r *agentPoolResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	readAgentPoolIntoModel(ctx, res, &plan)
+	resp.Diagnostics.Append(readAgentPoolIntoModel(ctx, res, &plan)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -273,7 +281,9 @@ func buildAgentPoolAttrs(m *agentPoolModel) map[string]any {
 }
 
 // readAgentPoolIntoModel populates the Terraform model from a JSON:API resource.
-func readAgentPoolIntoModel(ctx context.Context, res *client.Resource, m *agentPoolModel) {
+func readAgentPoolIntoModel(ctx context.Context, res *client.Resource, m *agentPoolModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	m.ID = types.StringValue(res.ID)
 	m.Name = types.StringValue(client.GetStringAttr(res, "name"))
 
@@ -287,7 +297,8 @@ func readAgentPoolIntoModel(ctx context.Context, res *client.Resource, m *agentP
 	if raw, ok := res.Attributes["labels"]; ok && len(raw) > 0 {
 		var labels map[string]string
 		if err := json.Unmarshal(raw, &labels); err == nil && len(labels) > 0 {
-			val, _ := types.MapValueFrom(ctx, types.StringType, labels)
+			val, d := types.MapValueFrom(ctx, types.StringType, labels)
+			diags.Append(d...)
 			m.Labels = val
 		} else {
 			m.Labels = types.MapNull(types.StringType)
@@ -305,4 +316,6 @@ func readAgentPoolIntoModel(ctx context.Context, res *client.Resource, m *agentP
 
 	m.CreatedAt = types.StringValue(client.GetStringAttr(res, "created-at"))
 	m.UpdatedAt = types.StringValue(client.GetStringAttr(res, "updated-at"))
+
+	return diags
 }

--- a/provider/internal/resources/role/resource.go
+++ b/provider/internal/resources/role/resource.go
@@ -23,6 +23,7 @@
 //	"deny-labels"                   → deny_labels          (map[string]string, optional)
 //	"deny-names"                    → deny_names           (list of strings, optional)
 //	"workspace-permission"          → workspace_permission (string, required: read/plan/write/admin)
+//	"pool-permission"               → pool_permission      (string, optional: read/write/admin, default "read")
 //
 // Read-only attributes:
 //
@@ -67,6 +68,7 @@ type roleModel struct {
 	DenyLabels          types.Map    `tfsdk:"deny_labels"`
 	DenyNames           types.List   `tfsdk:"deny_names"`
 	WorkspacePermission types.String `tfsdk:"workspace_permission"`
+	PoolPermission      types.String `tfsdk:"pool_permission"`
 
 	// Read-only attributes
 	BuiltIn   types.Bool   `tfsdk:"built_in"`
@@ -130,8 +132,13 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				ElementType: types.StringType,
 			},
 			"workspace_permission": schema.StringAttribute{
-				Description: "Permission level: read, plan, write, or admin.",
+				Description: "Workspace permission level: read, plan, write, or admin.",
 				Required:    true,
+			},
+			"pool_permission": schema.StringAttribute{
+				Description: "Agent pool permission level: read, write, or admin. Defaults to read.",
+				Optional:    true,
+				Computed:    true,
 			},
 
 			// Read-only
@@ -288,6 +295,10 @@ func buildRoleAttrs(m *roleModel) map[string]any {
 		"workspace-permission": m.WorkspacePermission.ValueString(),
 	}
 
+	if !m.PoolPermission.IsNull() && !m.PoolPermission.IsUnknown() {
+		attrs["pool-permission"] = m.PoolPermission.ValueString()
+	}
+
 	if !m.Description.IsNull() {
 		attrs["description"] = m.Description.ValueString()
 	}
@@ -382,6 +393,11 @@ func readRoleIntoModel(ctx context.Context, res *roleResponseData, m *roleModel)
 	m.Name = types.StringValue(res.Name)
 
 	m.WorkspacePermission = types.StringValue(getStringFromMap(res.Attributes, "workspace-permission"))
+	if v := getStringFromMap(res.Attributes, "pool-permission"); v != "" {
+		m.PoolPermission = types.StringValue(v)
+	} else {
+		m.PoolPermission = types.StringValue("read")
+	}
 	m.BuiltIn = types.BoolValue(getBoolFromMap(res.Attributes, "built-in"))
 	m.CreatedAt = types.StringValue(getStringFromMap(res.Attributes, "created-at"))
 	m.UpdatedAt = types.StringValue(getStringFromMap(res.Attributes, "updated-at"))

--- a/provider/internal/resources/role/resource.go
+++ b/provider/internal/resources/role/resource.go
@@ -139,6 +139,9 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Description: "Agent pool permission level: read, write, or admin. Defaults to read.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 
 			// Read-only

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -40,6 +40,7 @@ from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service
 from terrapod.services.pool_rbac_service import (
+    POOL_PERMISSION_HIERARCHY,
     fetch_custom_roles,
     has_pool_permission,
     resolve_pool_permission,
@@ -283,7 +284,7 @@ async def update_pool(
 ) -> JSONResponse:
     """Update an agent pool (requires admin permission on pool)."""
     pool = await _get_pool(pool_id, db)
-    await _require_pool_permission(pool, user, db, "admin")
+    perm = await _require_pool_permission(pool, user, db, "admin")
 
     attrs = body.get("data", {}).get("attributes", {})
 
@@ -299,6 +300,41 @@ async def update_pool(
     labels_arg = _UNSET
     if "labels" in attrs:
         labels_arg = _validate_labels(attrs["labels"]) if attrs["labels"] else {}
+
+    # Self-lockout check: warn if label/owner change would reduce user's access.
+    # Platform admins are immune (their access doesn't depend on labels/owner).
+    if "admin" not in set(user.roles) and not attrs.get("force"):
+        new_labels = labels_arg if labels_arg is not _UNSET else (pool.labels or {})
+        new_owner = (owner_arg or None) if owner_arg is not _UNSET else pool.owner_email
+        if new_labels != (pool.labels or {}) or new_owner != pool.owner_email:
+            new_perm = await resolve_pool_permission(
+                db,
+                user_email=user.email,
+                user_roles=user.roles,
+                pool_name=attrs.get("name") or pool.name,
+                pool_labels=new_labels,
+                owner_email=new_owner or "",
+            )
+            if new_perm is None or POOL_PERMISSION_HIERARCHY.get(
+                new_perm, -1
+            ) < POOL_PERMISSION_HIERARCHY.get(perm, -1):
+                new_level = new_perm or "none"
+                return JSONResponse(
+                    status_code=409,
+                    content={
+                        "errors": [
+                            {
+                                "status": "409",
+                                "title": "Label/owner change would reduce your access",
+                                "detail": (
+                                    f"This change would reduce your access from "
+                                    f"{perm} to {new_level} on this pool. "
+                                    f'Re-submit with "force": true to confirm.'
+                                ),
+                            }
+                        ]
+                    },
+                )
 
     pool = await agent_pool_service.update_pool(
         db,

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -38,6 +38,7 @@ from terrapod.api.dependencies import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service
+from terrapod.services.pool_rbac_service import has_pool_permission, resolve_pool_permission
 
 router = APIRouter(prefix="/api/v2", tags=["agent-pools"])
 logger = get_logger(__name__)
@@ -49,15 +50,19 @@ def _rfc3339(dt) -> str:
     return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _pool_json(pool, listener_summary: dict | None = None) -> dict:
+def _pool_json(pool, listener_summary: dict | None = None, permission: str | None = None) -> dict:
     attrs: dict = {
         "name": pool.name,
         "description": pool.description or "",
+        "labels": pool.labels or {},
+        "owner-email": pool.owner_email or "",
         "created-at": _rfc3339(pool.created_at),
         "updated-at": _rfc3339(pool.updated_at),
     }
     if listener_summary is not None:
         attrs["listener-summary"] = listener_summary
+    if permission is not None:
+        attrs["permission"] = permission
     return {
         "id": f"apool-{pool.id}",
         "type": "agent-pools",
@@ -121,6 +126,29 @@ async def _get_pool(pool_id: str, db: AsyncSession):
     return pool
 
 
+async def _require_pool_permission(
+    pool, user: AuthenticatedUser, db: AsyncSession, required: str
+) -> str:
+    """Resolve user's pool permission and require at least `required` level.
+
+    Returns the effective permission. Raises 404 if no access, 403 if
+    insufficient.
+    """
+    perm = await resolve_pool_permission(
+        db,
+        user_email=user.email,
+        user_roles=user.roles,
+        pool_name=pool.name,
+        pool_labels=pool.labels or {},
+        owner_email=pool.owner_email or "",
+    )
+    if perm is None:
+        raise HTTPException(status_code=404, detail="Agent pool not found")
+    if not has_pool_permission(perm, required):
+        raise HTTPException(status_code=403, detail=f"Requires {required} permission on pool")
+    return perm
+
+
 # ── Agent Pools ──────────────────────────────────────────────────────────
 
 
@@ -129,16 +157,26 @@ async def list_pools(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List all agent pools."""
+    """List agent pools visible to the current user (RBAC-filtered)."""
     pools = await agent_pool_service.list_pools(db)
     result = []
     for p in pools:
+        perm = await resolve_pool_permission(
+            db,
+            user_email=user.email,
+            user_roles=user.roles,
+            pool_name=p.name,
+            pool_labels=p.labels or {},
+            owner_email=p.owner_email or "",
+        )
+        if perm is None:
+            continue
         listeners = await agent_pool_service.list_listeners(p.id)
         summary = {
             "total": len(listeners),
             "online": sum(1 for lis in listeners if lis.get("status") == "online"),
         }
-        result.append(_pool_json(p, listener_summary=summary))
+        result.append(_pool_json(p, listener_summary=summary, permission=perm))
     return JSONResponse(content={"data": result})
 
 
@@ -159,11 +197,13 @@ async def create_pool(
         db,
         name=name,
         description=attrs.get("description", ""),
+        labels=attrs.get("labels", {}),
+        owner_email=attrs.get("owner-email") or user.email,
     )
     await db.commit()
     await db.refresh(pool)
 
-    return JSONResponse(content={"data": _pool_json(pool)}, status_code=201)
+    return JSONResponse(content={"data": _pool_json(pool, permission="admin")}, status_code=201)
 
 
 @router.get("/agent-pools/{pool_id}")
@@ -172,25 +212,29 @@ async def show_pool(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Show an agent pool."""
+    """Show an agent pool (requires read permission)."""
     pool = await _get_pool(pool_id, db)
+    perm = await _require_pool_permission(pool, user, db, "read")
     listeners = await agent_pool_service.list_listeners(pool.id)
     summary = {
         "total": len(listeners),
         "online": sum(1 for lis in listeners if lis.get("status") == "online"),
     }
-    return JSONResponse(content={"data": _pool_json(pool, listener_summary=summary)})
+    return JSONResponse(
+        content={"data": _pool_json(pool, listener_summary=summary, permission=perm)}
+    )
 
 
 @router.patch("/agent-pools/{pool_id}")
 async def update_pool(
     pool_id: str = Path(...),
     body: dict = Body(...),
-    user: AuthenticatedUser = Depends(require_admin),
+    user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Update an agent pool (admin only)."""
+    """Update an agent pool (requires admin permission on pool)."""
     pool = await _get_pool(pool_id, db)
+    await _require_pool_permission(pool, user, db, "admin")
 
     attrs = body.get("data", {}).get("attributes", {})
     pool = await agent_pool_service.update_pool(
@@ -198,21 +242,24 @@ async def update_pool(
         pool,
         name=attrs.get("name"),
         description=attrs.get("description"),
+        labels=attrs.get("labels"),
+        owner_email=attrs.get("owner-email"),
     )
     await db.commit()
     await db.refresh(pool)
 
-    return JSONResponse(content={"data": _pool_json(pool)})
+    return JSONResponse(content={"data": _pool_json(pool, permission="admin")})
 
 
 @router.delete("/agent-pools/{pool_id}", status_code=204)
 async def delete_pool(
     pool_id: str = Path(...),
-    user: AuthenticatedUser = Depends(require_admin),
+    user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    """Delete an agent pool (admin only)."""
+    """Delete an agent pool (requires admin permission on pool)."""
     pool = await _get_pool(pool_id, db)
+    await _require_pool_permission(pool, user, db, "admin")
     # Clean up all listener Redis keys for this pool before DB delete
     await agent_pool_service.delete_pool_listeners(pool.id)
     await agent_pool_service.delete_pool(db, pool)
@@ -225,11 +272,12 @@ async def delete_pool(
 @router.get("/agent-pools/{pool_id}/tokens")
 async def list_pool_tokens(
     pool_id: str = Path(...),
-    user: AuthenticatedUser = Depends(require_admin),
+    user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List join tokens for an agent pool."""
+    """List join tokens for an agent pool (requires admin on pool)."""
     pool = await _get_pool(pool_id, db)
+    await _require_pool_permission(pool, user, db, "admin")
     tokens = await agent_pool_service.list_pool_tokens(db, pool.id)
     return JSONResponse(content={"data": [_token_json(t) for t in tokens]})
 
@@ -238,11 +286,12 @@ async def list_pool_tokens(
 async def create_pool_token(
     pool_id: str = Path(...),
     body: dict = Body(...),
-    user: AuthenticatedUser = Depends(require_admin),
+    user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Create a join token for an agent pool."""
+    """Create a join token for an agent pool (requires admin on pool)."""
     pool = await _get_pool(pool_id, db)
+    await _require_pool_permission(pool, user, db, "admin")
 
     attrs = body.get("data", {}).get("attributes", {})
 
@@ -266,11 +315,12 @@ async def create_pool_token(
 async def delete_pool_token(
     pool_id: str = Path(...),
     token_id: str = Path(...),
-    user: AuthenticatedUser = Depends(require_admin),
+    user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    """Delete/revoke a join token."""
+    """Delete/revoke a join token (requires admin on pool)."""
     pool = await _get_pool(pool_id, db)
+    await _require_pool_permission(pool, user, db, "admin")
     token_uuid = uuid.UUID(token_id.removeprefix("at-"))
 
     from sqlalchemy import select
@@ -387,8 +437,9 @@ async def list_pool_listeners(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List listeners for an agent pool."""
+    """List listeners for an agent pool (requires read permission)."""
     pool = await _get_pool(pool_id, db)
+    await _require_pool_permission(pool, user, db, "read")
     listeners = await agent_pool_service.list_listeners(pool.id)
     return JSONResponse(content={"data": [_listener_json(lis) for lis in listeners]})
 
@@ -408,11 +459,10 @@ async def pool_events(
     from terrapod.redis.client import POOL_EVENTS_PREFIX, subscribe_channel
 
     user = await authenticate_request(request)
-    if "admin" not in user.roles:
-        raise HTTPException(status_code=403, detail="Admin access required")
 
     async with get_db_session() as db:
         pool = await _get_pool(pool_id, db)
+        await _require_pool_permission(pool, user, db, "read")
         pool_uuid = str(pool.id)
 
     channel = f"{POOL_EVENTS_PREFIX}{pool_uuid}"
@@ -446,16 +496,21 @@ async def pool_events(
 @router.delete("/listeners/{listener_id}", status_code=204)
 async def delete_listener(
     listener_id: str = Path(...),
-    user: AuthenticatedUser = Depends(require_admin),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> None:
-    """Delete a listener (admin only)."""
+    """Delete a listener (requires admin permission on pool)."""
     l_uuid = uuid.UUID(listener_id.removeprefix("listener-"))
     listener = await agent_pool_service.get_listener(l_uuid)
     if listener is None:
         raise HTTPException(status_code=404, detail="Listener not found")
-    await agent_pool_service.delete_listener(
-        listener["id"], listener["name"], listener.get("pool_id", "")
-    )
+    # Resolve pool to check admin permission
+    pool_id_str = listener.get("pool_id", "")
+    if pool_id_str:
+        pool = await agent_pool_service.get_pool(db, uuid.UUID(pool_id_str))
+        if pool:
+            await _require_pool_permission(pool, user, db, "admin")
+    await agent_pool_service.delete_listener(listener["id"], listener["name"], pool_id_str)
 
 
 # ── SSE Event Channel ────────────────────────────────────────────────────

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -21,6 +21,7 @@ Endpoints:
 
 import asyncio
 import json
+import re
 import uuid
 from datetime import UTC
 
@@ -38,7 +39,11 @@ from terrapod.api.dependencies import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service
-from terrapod.services.pool_rbac_service import has_pool_permission, resolve_pool_permission
+from terrapod.services.pool_rbac_service import (
+    fetch_custom_roles,
+    has_pool_permission,
+    resolve_pool_permission,
+)
 
 router = APIRouter(prefix="/api/v2", tags=["agent-pools"])
 logger = get_logger(__name__)
@@ -50,12 +55,24 @@ def _rfc3339(dt) -> str:
     return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _validate_owner_email(email: str | None) -> str | None:
+    """Validate owner_email looks like an email address. Returns the email or raises 422."""
+    if not email:
+        return None
+    if not _EMAIL_RE.match(email):
+        raise HTTPException(status_code=422, detail="owner-email must be a valid email address")
+    return email
+
+
 def _pool_json(pool, listener_summary: dict | None = None, permission: str | None = None) -> dict:
     attrs: dict = {
         "name": pool.name,
         "description": pool.description or "",
         "labels": pool.labels or {},
-        "owner-email": pool.owner_email or "",
+        "owner-email": pool.owner_email or None,
         "created-at": _rfc3339(pool.created_at),
         "updated-at": _rfc3339(pool.updated_at),
     }
@@ -159,6 +176,8 @@ async def list_pools(
 ) -> JSONResponse:
     """List agent pools visible to the current user (RBAC-filtered)."""
     pools = await agent_pool_service.list_pools(db)
+    # Pre-fetch custom roles once to avoid N+1 queries
+    custom_roles = await fetch_custom_roles(db, user.roles)
     result = []
     for p in pools:
         perm = await resolve_pool_permission(
@@ -168,6 +187,7 @@ async def list_pools(
             pool_name=p.name,
             pool_labels=p.labels or {},
             owner_email=p.owner_email or "",
+            preloaded_roles=custom_roles,
         )
         if perm is None:
             continue
@@ -198,7 +218,7 @@ async def create_pool(
         name=name,
         description=attrs.get("description", ""),
         labels=attrs.get("labels", {}),
-        owner_email=attrs.get("owner-email") or user.email,
+        owner_email=_validate_owner_email(attrs.get("owner-email")) or user.email,
     )
     await db.commit()
     await db.refresh(pool)
@@ -243,7 +263,7 @@ async def update_pool(
         name=attrs.get("name"),
         description=attrs.get("description"),
         labels=attrs.get("labels"),
-        owner_email=attrs.get("owner-email"),
+        owner_email=_validate_owner_email(attrs.get("owner-email")),
     )
     await db.commit()
     await db.refresh(pool)
@@ -506,9 +526,17 @@ async def delete_listener(
         raise HTTPException(status_code=404, detail="Listener not found")
     # Resolve pool to check admin permission
     pool_id_str = listener.get("pool_id", "")
-    if pool_id_str:
+    if not pool_id_str:
+        # Orphaned listener — require platform admin to clean up
+        if "admin" not in set(user.roles):
+            raise HTTPException(status_code=403, detail="Admin access required")
+    else:
         pool = await agent_pool_service.get_pool(db, uuid.UUID(pool_id_str))
-        if pool:
+        if pool is None:
+            # Pool deleted but listener Redis key persists — require platform admin
+            if "admin" not in set(user.roles):
+                raise HTTPException(status_code=403, detail="Admin access required")
+        else:
             await _require_pool_permission(pool, user, db, "admin")
     await agent_pool_service.delete_listener(listener["id"], listener["name"], pool_id_str)
 

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -67,6 +67,35 @@ def _validate_owner_email(email: str | None) -> str | None:
     return email
 
 
+_MAX_LABELS = 50
+_MAX_LABEL_KEY_LEN = 63
+_MAX_LABEL_VALUE_LEN = 255
+
+
+def _validate_labels(labels: dict | None) -> dict:
+    """Validate labels are string key-value pairs within size limits."""
+    if not labels:
+        return {}
+    if not isinstance(labels, dict):
+        raise HTTPException(status_code=422, detail="labels must be an object")
+    if len(labels) > _MAX_LABELS:
+        raise HTTPException(status_code=422, detail=f"labels cannot exceed {_MAX_LABELS} entries")
+    clean: dict[str, str] = {}
+    for k, v in labels.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise HTTPException(status_code=422, detail="label keys and values must be strings")
+        if len(k) > _MAX_LABEL_KEY_LEN:
+            raise HTTPException(
+                status_code=422, detail=f"label key exceeds {_MAX_LABEL_KEY_LEN} characters"
+            )
+        if len(v) > _MAX_LABEL_VALUE_LEN:
+            raise HTTPException(
+                status_code=422, detail=f"label value exceeds {_MAX_LABEL_VALUE_LEN} characters"
+            )
+        clean[k] = v
+    return clean
+
+
 def _pool_json(pool, listener_summary: dict | None = None, permission: str | None = None) -> dict:
     attrs: dict = {
         "name": pool.name,
@@ -217,7 +246,7 @@ async def create_pool(
         db,
         name=name,
         description=attrs.get("description", ""),
-        labels=attrs.get("labels", {}),
+        labels=_validate_labels(attrs.get("labels")),
         owner_email=_validate_owner_email(attrs.get("owner-email")) or user.email,
     )
     await db.commit()
@@ -257,13 +286,27 @@ async def update_pool(
     await _require_pool_permission(pool, user, db, "admin")
 
     attrs = body.get("data", {}).get("attributes", {})
+
+    # Distinguish "key absent" (don't change) from "key present with null/empty" (clear it).
+    # Use _UNSET sentinel so we can detect when a key was not provided at all.
+    _UNSET = object()
+
+    owner_arg = _UNSET
+    if "owner-email" in attrs:
+        raw_owner = attrs["owner-email"]
+        owner_arg = _validate_owner_email(raw_owner) if raw_owner else ""
+
+    labels_arg = _UNSET
+    if "labels" in attrs:
+        labels_arg = _validate_labels(attrs["labels"]) if attrs["labels"] else {}
+
     pool = await agent_pool_service.update_pool(
         db,
         pool,
         name=attrs.get("name"),
         description=attrs.get("description"),
-        labels=attrs.get("labels"),
-        owner_email=_validate_owner_email(attrs.get("owner-email")),
+        labels=labels_arg if labels_arg is not _UNSET else None,
+        owner_email=owner_arg if owner_arg is not _UNSET else None,
     )
     await db.commit()
     await db.refresh(pool)

--- a/services/terrapod/api/routers/roles.py
+++ b/services/terrapod/api/routers/roles.py
@@ -30,6 +30,7 @@ router = APIRouter(prefix="/api/v2", tags=["roles"])
 logger = get_logger(__name__)
 
 VALID_PERMISSIONS = {"read", "plan", "write", "admin"}
+VALID_POOL_PERMISSIONS = {"read", "write", "admin"}
 
 
 def _rfc3339(dt) -> str:
@@ -49,6 +50,7 @@ def _role_json(role: Role) -> dict:
             "deny-labels": role.deny_labels,
             "deny-names": role.deny_names,
             "workspace-permission": role.workspace_permission,
+            "pool-permission": role.pool_permission,
             "built-in": False,
             "created-at": _rfc3339(role.created_at),
             "updated-at": _rfc3339(role.updated_at),
@@ -67,6 +69,7 @@ def _builtin_role_json(name: str, info: dict) -> dict:
             "deny-labels": {},
             "deny-names": [],
             "workspace-permission": "admin" if name == "admin" else "read",
+            "pool-permission": "admin" if name == "admin" else "read",
             "built-in": True,
             "created-at": "",
             "updated-at": "",
@@ -117,6 +120,10 @@ async def create_role(
     if ws_perm not in VALID_PERMISSIONS:
         raise HTTPException(status_code=422, detail=f"Invalid workspace-permission: {ws_perm}")
 
+    pool_perm = attrs.get("pool-permission", "read")
+    if pool_perm not in VALID_POOL_PERMISSIONS:
+        raise HTTPException(status_code=422, detail=f"Invalid pool-permission: {pool_perm}")
+
     role = Role(
         name=name,
         description=attrs.get("description", ""),
@@ -125,6 +132,7 @@ async def create_role(
         deny_labels=attrs.get("deny-labels", {}),
         deny_names=attrs.get("deny-names", []),
         workspace_permission=ws_perm,
+        pool_permission=pool_perm,
     )
     db.add(role)
     await db.commit()
@@ -186,6 +194,11 @@ async def update_role(
         if ws_perm not in VALID_PERMISSIONS:
             raise HTTPException(status_code=422, detail=f"Invalid workspace-permission: {ws_perm}")
         role.workspace_permission = ws_perm
+    if "pool-permission" in attrs:
+        pool_perm = attrs["pool-permission"]
+        if pool_perm not in VALID_POOL_PERMISSIONS:
+            raise HTTPException(status_code=422, detail=f"Invalid pool-permission: {pool_perm}")
+        role.pool_permission = pool_perm
 
     await db.commit()
     await db.refresh(role)

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -50,6 +50,8 @@ from terrapod.api.dependencies import (
 from terrapod.db.models import Run, StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
+from terrapod.services import agent_pool_service as _agent_pool_service
+from terrapod.services.pool_rbac_service import has_pool_permission, resolve_pool_permission
 from terrapod.services.workspace_rbac_service import (
     PERMISSION_HIERARCHY,
     has_permission,
@@ -686,13 +688,8 @@ async def create_workspace(
         import uuid as _uuid
 
         agent_pool_id = _uuid.UUID(str(pool_val).removeprefix("apool-"))
-        from terrapod.services import agent_pool_service
-        from terrapod.services.pool_rbac_service import (
-            has_pool_permission,
-            resolve_pool_permission,
-        )
 
-        target_pool = await agent_pool_service.get_pool(db, agent_pool_id)
+        target_pool = await _agent_pool_service.get_pool(db, agent_pool_id)
         if target_pool is None:
             raise HTTPException(status_code=404, detail="Agent pool not found")
         pool_perm = await resolve_pool_permission(
@@ -923,13 +920,7 @@ async def update_workspace(
         else:
             new_pool_id = _uuid.UUID(str(pool_val).removeprefix("apool-"))
             # Check write permission on target pool
-            from terrapod.services import agent_pool_service
-            from terrapod.services.pool_rbac_service import (
-                has_pool_permission,
-                resolve_pool_permission,
-            )
-
-            target_pool = await agent_pool_service.get_pool(db, new_pool_id)
+            target_pool = await _agent_pool_service.get_pool(db, new_pool_id)
             if target_pool is None:
                 raise HTTPException(status_code=404, detail="Agent pool not found")
             pool_perm = await resolve_pool_permission(

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -679,13 +679,35 @@ async def create_workspace(
 
     from terrapod.config import settings
 
-    # Resolve agent pool ID from attributes
+    # Resolve agent pool ID from attributes (requires write permission on pool)
     agent_pool_id = None
     pool_val = attrs.get("agent-pool-id")
     if pool_val:
         import uuid as _uuid
 
         agent_pool_id = _uuid.UUID(str(pool_val).removeprefix("apool-"))
+        from terrapod.services import agent_pool_service
+        from terrapod.services.pool_rbac_service import (
+            has_pool_permission,
+            resolve_pool_permission,
+        )
+
+        target_pool = await agent_pool_service.get_pool(db, agent_pool_id)
+        if target_pool is None:
+            raise HTTPException(status_code=404, detail="Agent pool not found")
+        pool_perm = await resolve_pool_permission(
+            db,
+            user_email=user.email,
+            user_roles=user.roles,
+            pool_name=target_pool.name,
+            pool_labels=target_pool.labels or {},
+            owner_email=target_pool.owner_email or "",
+        )
+        if not has_pool_permission(pool_perm, "write"):
+            raise HTTPException(
+                status_code=403,
+                detail="Requires write permission on agent pool",
+            )
 
     execution_mode = attrs.get("execution-mode", "local")
     if execution_mode not in ("local", "agent"):
@@ -899,7 +921,31 @@ async def update_workspace(
         if pool_val is None:
             ws.agent_pool_id = None
         else:
-            ws.agent_pool_id = _uuid.UUID(str(pool_val).removeprefix("apool-"))
+            new_pool_id = _uuid.UUID(str(pool_val).removeprefix("apool-"))
+            # Check write permission on target pool
+            from terrapod.services import agent_pool_service
+            from terrapod.services.pool_rbac_service import (
+                has_pool_permission,
+                resolve_pool_permission,
+            )
+
+            target_pool = await agent_pool_service.get_pool(db, new_pool_id)
+            if target_pool is None:
+                raise HTTPException(status_code=404, detail="Agent pool not found")
+            pool_perm = await resolve_pool_permission(
+                db,
+                user_email=user.email,
+                user_roles=user.roles,
+                pool_name=target_pool.name,
+                pool_labels=target_pool.labels or {},
+                owner_email=target_pool.owner_email or "",
+            )
+            if not has_pool_permission(pool_perm, "write"):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Requires write permission on agent pool",
+                )
+            ws.agent_pool_id = new_pool_id
     if "drift-detection-enabled" in attrs:
         ws.drift_detection_enabled = attrs["drift-detection-enabled"]
         # Reset drift status when disabling drift detection

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -700,6 +700,8 @@ async def create_workspace(
             pool_labels=target_pool.labels or {},
             owner_email=target_pool.owner_email or "",
         )
+        if pool_perm is None:
+            raise HTTPException(status_code=404, detail="Agent pool not found")
         if not has_pool_permission(pool_perm, "write"):
             raise HTTPException(
                 status_code=403,
@@ -931,6 +933,8 @@ async def update_workspace(
                 pool_labels=target_pool.labels or {},
                 owner_email=target_pool.owner_email or "",
             )
+            if pool_perm is None:
+                raise HTTPException(status_code=404, detail="Agent pool not found")
             if not has_pool_permission(pool_perm, "write"):
                 raise HTTPException(
                     status_code=403,

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -190,7 +190,9 @@ class AgentPool(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # RBAC
-    labels: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
+    labels: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, default=dict, server_default="{}", nullable=False
+    )
     owner_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -99,6 +99,9 @@ class Role(Base):
     workspace_permission: Mapped[str] = mapped_column(
         String(20), nullable=False, default="read"
     )  # read, plan, write, admin
+    pool_permission: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="read", server_default="read"
+    )  # read, write, admin
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, nullable=False
@@ -185,6 +188,10 @@ class AgentPool(Base):
     )
     name: Mapped[str] = mapped_column(String(63), unique=True, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # RBAC
+    labels: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
+    owner_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, nullable=False

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -74,7 +74,7 @@ async def update_pool(
     if labels is not None:
         pool.labels = labels
     if owner_email is not None:
-        pool.owner_email = owner_email
+        pool.owner_email = owner_email or None  # empty string clears
     await db.flush()
     return pool
 

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -25,11 +25,15 @@ async def create_pool(
     db: AsyncSession,
     name: str,
     description: str = "",
+    labels: dict | None = None,
+    owner_email: str | None = None,
 ) -> AgentPool:
     """Create a new agent pool."""
     pool = AgentPool(
         name=name,
         description=description,
+        labels=labels or {},
+        owner_email=owner_email,
     )
     db.add(pool)
     await db.flush()
@@ -59,12 +63,18 @@ async def update_pool(
     pool: AgentPool,
     name: str | None = None,
     description: str | None = None,
+    labels: dict | None = None,
+    owner_email: str | None = None,
 ) -> AgentPool:
     """Update an agent pool."""
     if name is not None:
         pool.name = name
     if description is not None:
         pool.description = description
+    if labels is not None:
+        pool.labels = labels
+    if owner_email is not None:
+        pool.owner_email = owner_email
     await db.flush()
     return pool
 

--- a/services/terrapod/services/pool_rbac_service.py
+++ b/services/terrapod/services/pool_rbac_service.py
@@ -8,6 +8,8 @@ Permission hierarchy: read < write < admin
 Resolution order: platform admin > audit > owner > label RBAC > everyone > none
 """
 
+from __future__ import annotations
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -20,15 +22,6 @@ logger = get_logger(__name__)
 
 POOL_PERMISSION_HIERARCHY = {"read": 0, "write": 1, "admin": 2}
 
-# Map workspace_permission values to pool permission levels.
-# "plan" has no meaning for pools → maps to "read".
-_WS_PERM_TO_POOL = {
-    "read": "read",
-    "plan": "read",
-    "write": "write",
-    "admin": "admin",
-}
-
 
 def has_pool_permission(effective: str | None, required: str) -> bool:
     """Check if effective permission meets the required level."""
@@ -39,6 +32,22 @@ def has_pool_permission(effective: str | None, required: str) -> bool:
     )
 
 
+async def fetch_custom_roles(
+    db: AsyncSession,
+    user_roles: list[str],
+) -> list[Role]:
+    """Fetch custom (non-builtin) Role objects for the given role names.
+
+    Use this to pre-load roles once before calling resolve_pool_permission
+    in a loop, passing the result as ``preloaded_roles`` to avoid N+1 queries.
+    """
+    custom_names = set(user_roles) - BUILTIN_ROLE_NAMES
+    if not custom_names:
+        return []
+    result = await db.execute(select(Role).where(Role.name.in_(custom_names)))
+    return list(result.scalars().all())
+
+
 async def resolve_pool_permission(
     db: AsyncSession,
     user_email: str,
@@ -46,6 +55,8 @@ async def resolve_pool_permission(
     pool_name: str,
     pool_labels: dict,
     owner_email: str | None,
+    *,
+    preloaded_roles: list[Role] | None = None,
 ) -> str | None:
     """Returns highest permission level (read/write/admin), or None.
 
@@ -56,6 +67,9 @@ async def resolve_pool_permission(
     4. Label-based RBAC (custom roles) → pool_permission field on role
     5. 'everyone' role with access: everyone label → read
     6. Default → None (no access)
+
+    Pass ``preloaded_roles`` (from :func:`fetch_custom_roles`) to skip the
+    per-call DB query — useful when resolving permissions for many pools.
     """
     role_set = set(user_roles)
 
@@ -76,8 +90,11 @@ async def resolve_pool_permission(
     # 4. Label-based RBAC from custom roles (uses pool_permission, not workspace_permission)
     custom_role_names = role_set - BUILTIN_ROLE_NAMES
     if custom_role_names:
-        result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
-        roles = list(result.scalars().all())
+        if preloaded_roles is not None:
+            roles = preloaded_roles
+        else:
+            result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
+            roles = list(result.scalars().all())
 
         for role in roles:
             # Check deny first

--- a/services/terrapod/services/pool_rbac_service.py
+++ b/services/terrapod/services/pool_rbac_service.py
@@ -1,0 +1,116 @@
+"""Agent-pool-specific RBAC permission resolution.
+
+Resolves the highest permission level a user has on an agent pool
+using the same label-based model as workspaces and registry resources
+but with a simpler three-level hierarchy (no "plan" for pools).
+
+Permission hierarchy: read < write < admin
+Resolution order: platform admin > audit > owner > label RBAC > everyone > none
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.auth.builtin_roles import BUILTIN_ROLE_NAMES
+from terrapod.db.models import Role
+from terrapod.logging_config import get_logger
+from terrapod.services.rbac_service import matches_labels, merge_labels
+
+logger = get_logger(__name__)
+
+POOL_PERMISSION_HIERARCHY = {"read": 0, "write": 1, "admin": 2}
+
+# Map workspace_permission values to pool permission levels.
+# "plan" has no meaning for pools → maps to "read".
+_WS_PERM_TO_POOL = {
+    "read": "read",
+    "plan": "read",
+    "write": "write",
+    "admin": "admin",
+}
+
+
+def has_pool_permission(effective: str | None, required: str) -> bool:
+    """Check if effective permission meets the required level."""
+    if effective is None:
+        return False
+    return POOL_PERMISSION_HIERARCHY.get(effective, -1) >= POOL_PERMISSION_HIERARCHY.get(
+        required, 99
+    )
+
+
+async def resolve_pool_permission(
+    db: AsyncSession,
+    user_email: str,
+    user_roles: list[str],
+    pool_name: str,
+    pool_labels: dict,
+    owner_email: str | None,
+) -> str | None:
+    """Returns highest permission level (read/write/admin), or None.
+
+    Resolution order (highest wins):
+    1. Platform admin → admin
+    2. Platform audit → read
+    3. Pool owner → admin
+    4. Label-based RBAC (custom roles) → pool_permission field on role
+    5. 'everyone' role with access: everyone label → read
+    6. Default → None (no access)
+    """
+    role_set = set(user_roles)
+
+    # 1. Platform admin
+    if "admin" in role_set:
+        return "admin"
+
+    best: str | None = None
+
+    # 2. Platform audit → read
+    if "audit" in role_set:
+        best = "read"
+
+    # 3. Owner → admin
+    if owner_email and owner_email == user_email:
+        return "admin"
+
+    # 4. Label-based RBAC from custom roles (uses pool_permission, not workspace_permission)
+    custom_role_names = role_set - BUILTIN_ROLE_NAMES
+    if custom_role_names:
+        result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
+        roles = list(result.scalars().all())
+
+        for role in roles:
+            # Check deny first
+            deny_labels: dict[str, set[str]] = {}
+            merge_labels(deny_labels, role.deny_labels)
+            deny_names = set(role.deny_names)
+
+            if pool_name in deny_names:
+                continue
+            if matches_labels(pool_labels, deny_labels):
+                continue
+
+            # Check allow
+            allow_labels: dict[str, set[str]] = {}
+            merge_labels(allow_labels, role.allow_labels)
+            allow_names = set(role.allow_names)
+
+            matched = False
+            if pool_name in allow_names:
+                matched = True
+            elif matches_labels(pool_labels, allow_labels):
+                matched = True
+
+            if matched:
+                pool_perm = role.pool_permission
+                if best is None or POOL_PERMISSION_HIERARCHY.get(
+                    pool_perm, -1
+                ) > POOL_PERMISSION_HIERARCHY.get(best, -1):
+                    best = pool_perm
+
+    # 5. 'everyone' role: if pool has label access=everyone, grant read
+    if pool_labels.get("access") == "everyone":
+        if best is None:
+            best = "read"
+
+    return best

--- a/services/terrapod/services/pool_rbac_service.py
+++ b/services/terrapod/services/pool_rbac_service.py
@@ -91,7 +91,7 @@ async def resolve_pool_permission(
     custom_role_names = role_set - BUILTIN_ROLE_NAMES
     if custom_role_names:
         if preloaded_roles is not None:
-            roles = preloaded_roles
+            roles = [r for r in preloaded_roles if r.name in custom_role_names]
         else:
             result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
             roles = list(result.scalars().all())

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -1,14 +1,50 @@
-"""Tests for agent pool heartbeat endpoint."""
+"""Tests for agent pool endpoints including RBAC gating."""
 
 import uuid
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_admin
+from terrapod.db.session import get_db
 
 _BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+def _user(email="test@example.com", roles=None):
+    return AuthenticatedUser(
+        email=email,
+        display_name="Test",
+        roles=roles or ["everyone"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _mock_pool(pool_id=None, name="test-pool", labels=None, owner_email=None):
+    pool = MagicMock()
+    pool.id = pool_id or uuid.uuid4()
+    pool.name = name
+    pool.description = "A test pool"
+    pool.labels = labels or {}
+    pool.owner_email = owner_email
+    pool.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    pool.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return pool
+
+
+def _make_app(user, mock_db=None, is_admin=False):
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    if is_admin:
+        app.dependency_overrides[require_admin] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app, mock_db
 
 
 def _mock_listener_dict(listener_id=None, name="listener-1", pool_id=None):
@@ -91,3 +127,376 @@ class TestListenerHeartbeat:
             )
 
         assert res.status_code == 404
+
+
+class TestListPoolsRBAC:
+    """Pool listing is RBAC-filtered: only pools the user has read access to."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "terrapod.api.routers.agent_pools.fetch_custom_roles",
+        new_callable=AsyncMock,
+    )
+    async def test_list_pools_filters_by_rbac(
+        self, mock_fetch_roles, mock_resolve, mock_list_pools, mock_list_listeners, *mocks
+    ):
+        """User only sees pools they have permission on."""
+        pool_visible = _mock_pool(name="visible-pool", labels={"env": "dev"})
+        pool_hidden = _mock_pool(name="hidden-pool", labels={"env": "prod"})
+        mock_list_pools.return_value = [pool_visible, pool_hidden]
+        mock_fetch_roles.return_value = []
+        mock_list_listeners.return_value = []
+
+        # First pool: read access; second pool: no access
+        mock_resolve.side_effect = ["read", None]
+
+        user = _user(roles=["everyone"])
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+
+        assert res.status_code == 200
+        data = res.json()["data"]
+        assert len(data) == 1
+        assert data[0]["attributes"]["name"] == "visible-pool"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "terrapod.api.routers.agent_pools.fetch_custom_roles",
+        new_callable=AsyncMock,
+    )
+    async def test_list_pools_returns_permission(
+        self, mock_fetch_roles, mock_resolve, mock_list_pools, mock_list_listeners, *mocks
+    ):
+        """Response includes the user's effective permission on each pool."""
+        pool = _mock_pool(name="my-pool")
+        mock_list_pools.return_value = [pool]
+        mock_fetch_roles.return_value = []
+        mock_list_listeners.return_value = []
+        mock_resolve.return_value = "write"
+
+        user = _user(roles=["pool-writer"])
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+
+        assert res.status_code == 200
+        data = res.json()["data"]
+        assert data[0]["attributes"]["permission"] == "write"
+
+
+class TestShowPoolRBAC:
+    """Show pool requires read permission."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_show_pool_with_read(
+        self, mock_resolve, mock_get_pool, mock_list_listeners, *mocks
+    ):
+        pool = _mock_pool(name="visible", labels={"env": "dev"}, owner_email="owner@test.com")
+        mock_get_pool.return_value = pool
+        mock_list_listeners.return_value = []
+        mock_resolve.return_value = "read"
+
+        user = _user()
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+
+        assert res.status_code == 200
+        attrs = res.json()["data"]["attributes"]
+        assert attrs["name"] == "visible"
+        assert attrs["labels"] == {"env": "dev"}
+        assert attrs["owner-email"] == "owner@test.com"
+        assert attrs["permission"] == "read"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_show_pool_no_access_returns_404(self, mock_resolve, mock_get_pool, *mocks):
+        """Pool invisible to user returns 404 (not 403)."""
+        pool = _mock_pool(name="secret")
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = None
+
+        user = _user()
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+
+        assert res.status_code == 404
+
+
+class TestCreatePoolRBAC:
+    """Pool creation is admin-only and accepts labels/owner."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.create_pool", new_callable=AsyncMock)
+    async def test_create_pool_with_labels_and_owner(self, mock_create, *mocks):
+        pool = _mock_pool(
+            name="new-pool",
+            labels={"env": "prod", "team": "sre"},
+            owner_email="sre@example.com",
+        )
+        mock_create.return_value = pool
+
+        user = _user(email="admin@example.com", roles=["admin"])
+        app, mock_db = _make_app(user, is_admin=True)
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(
+                "/api/v2/organizations/default/agent-pools",
+                json={
+                    "data": {
+                        "type": "agent-pools",
+                        "attributes": {
+                            "name": "new-pool",
+                            "labels": {"env": "prod", "team": "sre"},
+                            "owner-email": "sre@example.com",
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 201
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["labels"] == {"env": "prod", "team": "sre"}
+        assert call_kwargs["owner_email"] == "sre@example.com"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.create_pool", new_callable=AsyncMock)
+    async def test_create_pool_invalid_owner_email_422(self, mock_create, *mocks):
+        user = _user(email="admin@example.com", roles=["admin"])
+        app, mock_db = _make_app(user, is_admin=True)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(
+                "/api/v2/organizations/default/agent-pools",
+                json={
+                    "data": {
+                        "type": "agent-pools",
+                        "attributes": {
+                            "name": "bad-pool",
+                            "owner-email": "not-an-email",
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 422
+        assert "owner-email" in res.json()["detail"]
+
+
+class TestUpdatePoolRBAC:
+    """Pool update requires admin permission on the pool."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_update_pool_with_labels(self, mock_resolve, mock_get_pool, mock_update, *mocks):
+        pool = _mock_pool(name="my-pool", labels={"env": "dev"})
+        updated_pool = _mock_pool(name="my-pool", labels={"env": "prod"})
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "admin"
+        mock_update.return_value = updated_pool
+
+        user = _user(email="owner@example.com")
+        app, mock_db = _make_app(user)
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/agent-pools/apool-{pool.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "labels": {"env": "prod"},
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_update_pool_write_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
+        """Write permission is insufficient for pool update — admin required."""
+        pool = _mock_pool(name="restricted")
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "write"
+
+        user = _user()
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/agent-pools/apool-{pool.id}",
+                json={"data": {"attributes": {"description": "updated"}}},
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 403
+
+
+class TestDeletePoolRBAC:
+    """Pool delete requires admin permission on the pool."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.delete_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.agent_pool_service.delete_pool_listeners",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_delete_pool_with_admin(
+        self, mock_resolve, mock_get_pool, mock_del_listeners, mock_del_pool, *mocks
+    ):
+        pool = _mock_pool()
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "admin"
+
+        user = _user(email="owner@example.com")
+        app, mock_db = _make_app(user)
+        mock_db.commit = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.delete(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+
+        assert res.status_code == 204
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_delete_pool_no_access_returns_404(self, mock_resolve, mock_get_pool, *mocks):
+        pool = _mock_pool()
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = None
+
+        user = _user()
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.delete(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+
+        assert res.status_code == 404
+
+
+class TestDeleteListenerRBAC:
+    """Listener delete requires admin on pool, or platform admin when pool can't be resolved."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.services.agent_pool_service.delete_listener",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_listener")
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_delete_listener_with_pool_admin(
+        self, mock_resolve, mock_get_listener, mock_get_pool, mock_del, *mocks
+    ):
+        pool = _mock_pool()
+        lid = uuid.uuid4()
+        listener = _mock_listener_dict(listener_id=lid, pool_id=pool.id)
+        mock_get_listener.return_value = listener
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "admin"
+
+        user = _user()
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.delete(f"/api/v2/listeners/{lid}", headers=_AUTH)
+
+        assert res.status_code == 204
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.get_listener")
+    async def test_delete_listener_no_pool_non_admin_403(self, mock_get_listener, *mocks):
+        """When pool can't be resolved, non-admin gets 403."""
+        lid = uuid.uuid4()
+        listener = _mock_listener_dict(listener_id=lid)
+        listener["pool_id"] = ""
+        mock_get_listener.return_value = listener
+
+        user = _user(roles=["everyone"])
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.delete(f"/api/v2/listeners/{lid}", headers=_AUTH)
+
+        assert res.status_code == 403

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -448,6 +448,159 @@ class TestDeletePoolRBAC:
         assert res.status_code == 404
 
 
+class TestTokenEndpointRBAC:
+    """Token endpoints require admin permission — read-only gets 403."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_list_tokens_read_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
+        """User with read permission cannot list pool tokens."""
+        pool = _mock_pool()
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "read"
+
+        user = _user()
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}/tokens", headers=_AUTH)
+
+        assert res.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_create_token_read_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
+        """User with read permission cannot create pool tokens."""
+        pool = _mock_pool()
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "read"
+
+        user = _user()
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(
+                f"/api/v2/agent-pools/apool-{pool.id}/tokens",
+                json={"data": {"attributes": {"description": "test"}}},
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 403
+
+
+class TestUpdatePoolSelfLockout:
+    """Self-lockout protection prevents accidental access loss."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_label_change_reducing_access_returns_409(
+        self, mock_resolve, mock_get_pool, *mocks
+    ):
+        """Changing labels that would reduce user's access returns 409."""
+        pool = _mock_pool(name="my-pool", labels={"team": "sre"})
+        mock_get_pool.return_value = pool
+        # First call: current permission check → admin
+        # Second call: simulated new permission → None (locked out)
+        mock_resolve.side_effect = ["admin", None]
+
+        user = _user(email="user@example.com", roles=["sre-role"])
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/agent-pools/apool-{pool.id}",
+                json={"data": {"attributes": {"labels": {"team": "other"}}}},
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 409
+        assert "reduce your access" in res.json()["errors"][0]["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_force_bypasses_lockout_check(
+        self, mock_resolve, mock_get_pool, mock_update, *mocks
+    ):
+        """Setting force: true bypasses the self-lockout check."""
+        pool = _mock_pool(name="my-pool", labels={"team": "sre"})
+        updated_pool = _mock_pool(name="my-pool", labels={"team": "other"})
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "admin"
+        mock_update.return_value = updated_pool
+
+        user = _user(email="user@example.com", roles=["sre-role"])
+        app, mock_db = _make_app(user)
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/agent-pools/apool-{pool.id}",
+                json={"data": {"attributes": {"labels": {"team": "other"}, "force": True}}},
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_platform_admin_immune_to_lockout(
+        self, mock_resolve, mock_get_pool, mock_update, *mocks
+    ):
+        """Platform admins skip the self-lockout check entirely."""
+        pool = _mock_pool(name="my-pool", labels={"team": "sre"})
+        updated_pool = _mock_pool(name="my-pool", labels={})
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "admin"
+        mock_update.return_value = updated_pool
+
+        user = _user(email="admin@example.com", roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/agent-pools/apool-{pool.id}",
+                json={"data": {"attributes": {"labels": {}}}},
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200
+
+
 class TestDeleteListenerRBAC:
     """Listener delete requires admin on pool, or platform admin when pool can't be resolved."""
 
@@ -481,6 +634,34 @@ class TestDeleteListenerRBAC:
             res = await client.delete(f"/api/v2/listeners/{lid}", headers=_AUTH)
 
         assert res.status_code == 204
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_listener")
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_delete_listener_read_only_returns_403(
+        self, mock_resolve, mock_get_listener, mock_get_pool, *mocks
+    ):
+        """User with read permission cannot delete listeners."""
+        pool = _mock_pool()
+        lid = uuid.uuid4()
+        listener = _mock_listener_dict(listener_id=lid, pool_id=pool.id)
+        mock_get_listener.return_value = listener
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "read"
+
+        user = _user()
+        app, _ = _make_app(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.delete(f"/api/v2/listeners/{lid}", headers=_AUTH)
+
+        assert res.status_code == 403
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -95,6 +95,28 @@ class TestListRoles:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
+    async def test_list_includes_pool_permission(self, *mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        role = _mock_role("pool-role")
+        role.pool_permission = "write"
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [role]
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/v2/roles", headers=_AUTH)
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        custom_entry = next(r for r in data if r["name"] == "pool-role")
+        assert custom_entry["attributes"]["pool-permission"] == "write"
+        # Built-in admin should have pool-permission: admin
+        admin_entry = next(r for r in data if r["name"] == "admin")
+        assert admin_entry["attributes"]["pool-permission"] == "admin"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
     async def test_audit_can_list(self, *mocks):
         user = _user(roles=["audit"])
         app, mock_db = _make_app(user)
@@ -222,6 +244,59 @@ class TestCreateRole:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
+    async def test_create_with_pool_permission(self, *mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/roles",
+                json={
+                    "data": {
+                        "name": "pool-admin-role",
+                        "attributes": {
+                            "workspace-permission": "read",
+                            "pool-permission": "admin",
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 201
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_invalid_pool_permission_rejected(self, *mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/roles",
+                json={
+                    "data": {
+                        "name": "bad-pool",
+                        "attributes": {
+                            "workspace-permission": "read",
+                            "pool-permission": "superadmin",
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
     async def test_create_requires_admin(self, *mocks):
         user = _user(roles=["audit"])
         app, _ = _make_app(user)
@@ -269,6 +344,44 @@ class TestShowRole:
             resp = await c.get("/api/v2/roles/my-role", headers=_AUTH)
         assert resp.status_code == 200
         assert resp.json()["data"]["attributes"]["workspace-permission"] == "write"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_show_role_includes_pool_permission(self, *mocks):
+        role = _mock_role("pool-role")
+        role.pool_permission = "write"
+        app, mock_db = _make_app(_user(roles=["admin"]))
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = role
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/v2/roles/pool-role", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attributes"]["pool-permission"] == "write"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_show_builtin_admin_has_pool_permission_admin(self, *mocks):
+        app, _ = _make_app(_user(roles=["admin"]))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/v2/roles/admin", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attributes"]["pool-permission"] == "admin"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_show_builtin_everyone_has_pool_permission_read(self, *mocks):
+        app, _ = _make_app(_user(roles=["admin"]))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/v2/roles/everyone", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attributes"]["pool-permission"] == "read"
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -37,6 +37,7 @@ def _mock_role(name="dev-team", ws_perm="read"):
     role.deny_labels = {}
     role.deny_names = []
     role.workspace_permission = ws_perm
+    role.pool_permission = "read"
     role.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     role.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return role

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -84,10 +84,10 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.services.pool_rbac_service.resolve_pool_permission",
+        "terrapod.api.routers.tfe_v2.resolve_pool_permission",
         new_callable=AsyncMock,
     )
-    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
         "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
         new_callable=AsyncMock,
@@ -132,10 +132,10 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.services.pool_rbac_service.resolve_pool_permission",
+        "terrapod.api.routers.tfe_v2.resolve_pool_permission",
         new_callable=AsyncMock,
     )
-    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
         "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
         new_callable=AsyncMock,
@@ -215,10 +215,10 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.services.pool_rbac_service.resolve_pool_permission",
+        "terrapod.api.routers.tfe_v2.resolve_pool_permission",
         new_callable=AsyncMock,
     )
-    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
         "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
         new_callable=AsyncMock,

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -1,0 +1,259 @@
+"""Tests for workspace agent pool assignment with pool RBAC gating."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+def _user(email="test@example.com", roles=None):
+    return AuthenticatedUser(
+        email=email,
+        display_name="Test",
+        roles=roles or ["everyone"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _mock_workspace(ws_id=None, pool_id=None):
+    ws = MagicMock()
+    ws.id = ws_id or uuid.uuid4()
+    ws.name = "test-ws"
+    ws.execution_mode = "agent"
+    ws.auto_apply = False
+    ws.execution_backend = "tofu"
+    ws.terraform_version = "1.11"
+    ws.working_directory = ""
+    ws.locked = False
+    ws.lock_id = None
+    ws.agent_pool_id = pool_id
+    ws.agent_pool = None
+    ws.resource_cpu = "1"
+    ws.resource_memory = "2Gi"
+    ws.labels = {}
+    ws.owner_email = "test@example.com"
+    ws.vcs_connection_id = None
+    ws.vcs_connection = None
+    ws.vcs_repo_url = ""
+    ws.vcs_branch = ""
+    ws.vcs_last_commit_sha = ""
+    ws.vcs_last_polled_at = None
+    ws.vcs_last_error = None
+    ws.vcs_last_error_at = None
+    ws.var_files = []
+    ws.trigger_prefixes = []
+    ws.drift_detection_enabled = False
+    ws.drift_detection_interval_seconds = 86400
+    ws.drift_last_checked_at = None
+    ws.drift_status = ""
+    ws.state_diverged = False
+    ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return ws
+
+
+def _mock_pool(pool_id=None, name="test-pool", labels=None, owner_email=None):
+    pool = MagicMock()
+    pool.id = pool_id or uuid.uuid4()
+    pool.name = name
+    pool.labels = labels or {}
+    pool.owner_email = owner_email
+    return pool
+
+
+def _make_app(user, mock_db=None):
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app, mock_db
+
+
+class TestWorkspacePoolAssignment:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.services.pool_rbac_service.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_assign_pool_with_write_permission(
+        self, mock_ws_perm, mock_get_pool, mock_pool_perm, *mocks
+    ):
+        """User with write on pool can assign it to workspace."""
+        user = _user(roles=["everyone", "pool-writer"])
+        pool = _mock_pool(name="prod-pool")
+        ws = _mock_workspace()
+
+        mock_ws_perm.return_value = "admin"
+        mock_get_pool.return_value = pool
+        mock_pool_perm.return_value = "write"
+
+        app, mock_db = _make_app(user)
+
+        # Mock workspace lookup
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "agent-pool-id": f"apool-{pool.id}",
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.services.pool_rbac_service.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_assign_pool_without_write_permission_403(
+        self, mock_ws_perm, mock_get_pool, mock_pool_perm, *mocks
+    ):
+        """User without write on pool gets 403."""
+        user = _user(roles=["everyone"])
+        pool = _mock_pool(name="restricted-pool")
+        ws = _mock_workspace()
+
+        mock_ws_perm.return_value = "admin"
+        mock_get_pool.return_value = pool
+        mock_pool_perm.return_value = "read"  # Only read, not write
+
+        app, mock_db = _make_app(user)
+
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "agent-pool-id": f"apool-{pool.id}",
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 403
+        assert "write permission" in res.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_clear_pool_no_permission_check(self, mock_ws_perm, *mocks):
+        """Clearing pool (setting null) does not require pool permission."""
+        user = _user(roles=["everyone"])
+        ws = _mock_workspace(pool_id=uuid.uuid4())
+
+        mock_ws_perm.return_value = "admin"
+
+        app, mock_db = _make_app(user)
+
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "agent-pool-id": None,
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.services.pool_rbac_service.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_platform_admin_bypasses_pool_check(
+        self, mock_ws_perm, mock_get_pool, mock_pool_perm, *mocks
+    ):
+        """Platform admin can assign any pool."""
+        user = _user(email="admin@example.com", roles=["admin"])
+        pool = _mock_pool(name="restricted-pool")
+        ws = _mock_workspace()
+
+        mock_ws_perm.return_value = "admin"
+        mock_get_pool.return_value = pool
+        mock_pool_perm.return_value = "admin"  # admin resolves to admin
+
+        app, mock_db = _make_app(user)
+
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "agent-pool-id": f"apool-{pool.id}",
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200

--- a/services/tests/services/test_pool_rbac_service.py
+++ b/services/tests/services/test_pool_rbac_service.py
@@ -1,0 +1,191 @@
+"""Tests for pool RBAC — permission resolution, owner, pool_permission field."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from terrapod.services.pool_rbac_service import (
+    POOL_PERMISSION_HIERARCHY,
+    has_pool_permission,
+    resolve_pool_permission,
+)
+
+
+def _make_role(
+    *,
+    name="custom-role",
+    pool_permission="read",
+    allow_labels=None,
+    allow_names=None,
+    deny_labels=None,
+    deny_names=None,
+):
+    role = MagicMock()
+    role.name = name
+    role.pool_permission = pool_permission
+    role.allow_labels = allow_labels or {}
+    role.allow_names = allow_names or []
+    role.deny_labels = deny_labels or {}
+    role.deny_names = deny_names or []
+    return role
+
+
+def _mock_db_with_roles(roles):
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = roles
+    db.execute.return_value = result
+    return db
+
+
+class TestHasPoolPermission:
+    def test_admin_meets_all(self):
+        for required in POOL_PERMISSION_HIERARCHY:
+            assert has_pool_permission("admin", required) is True
+
+    def test_read_only_meets_read(self):
+        assert has_pool_permission("read", "read") is True
+        assert has_pool_permission("read", "write") is False
+        assert has_pool_permission("read", "admin") is False
+
+    def test_write_meets_read_and_write(self):
+        assert has_pool_permission("write", "read") is True
+        assert has_pool_permission("write", "write") is True
+        assert has_pool_permission("write", "admin") is False
+
+    def test_none_meets_nothing(self):
+        for required in POOL_PERMISSION_HIERARCHY:
+            assert has_pool_permission(None, required) is False
+
+
+class TestResolvePoolPermission:
+    @pytest.mark.asyncio
+    async def test_admin_gets_admin(self):
+        db = AsyncMock()
+        result = await resolve_pool_permission(db, "admin@test.com", ["admin"], "my-pool", {}, None)
+        assert result == "admin"
+
+    @pytest.mark.asyncio
+    async def test_audit_gets_read(self):
+        db = _mock_db_with_roles([])
+        result = await resolve_pool_permission(db, "user@test.com", ["audit"], "my-pool", {}, None)
+        assert result == "read"
+
+    @pytest.mark.asyncio
+    async def test_owner_gets_admin(self):
+        db = _mock_db_with_roles([])
+        result = await resolve_pool_permission(
+            db, "owner@test.com", ["everyone"], "my-pool", {}, "owner@test.com"
+        )
+        assert result == "admin"
+
+    @pytest.mark.asyncio
+    async def test_label_based_access_uses_pool_permission(self):
+        """Custom roles use pool_permission field, not workspace_permission."""
+        role = _make_role(pool_permission="write", allow_labels={"env": ["prod"]})
+        db = _mock_db_with_roles([role])
+        result = await resolve_pool_permission(
+            db, "user@test.com", ["custom-role"], "prod-pool", {"env": "prod"}, None
+        )
+        assert result == "write"
+
+    @pytest.mark.asyncio
+    async def test_deny_label_blocks(self):
+        role = _make_role(
+            pool_permission="write",
+            allow_labels={"env": ["prod"]},
+            deny_labels={"restricted": ["true"]},
+        )
+        db = _mock_db_with_roles([role])
+        result = await resolve_pool_permission(
+            db,
+            "user@test.com",
+            ["custom-role"],
+            "prod-pool",
+            {"env": "prod", "restricted": "true"},
+            None,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_deny_name_blocks(self):
+        role = _make_role(
+            pool_permission="write",
+            allow_labels={"env": ["prod"]},
+            deny_names=["secret-pool"],
+        )
+        db = _mock_db_with_roles([role])
+        result = await resolve_pool_permission(
+            db,
+            "user@test.com",
+            ["custom-role"],
+            "secret-pool",
+            {"env": "prod"},
+            None,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_everyone_access_label(self):
+        db = _mock_db_with_roles([])
+        result = await resolve_pool_permission(
+            db,
+            "user@test.com",
+            ["everyone"],
+            "public-pool",
+            {"access": "everyone"},
+            None,
+        )
+        assert result == "read"
+
+    @pytest.mark.asyncio
+    async def test_no_access_default(self):
+        db = _mock_db_with_roles([])
+        result = await resolve_pool_permission(
+            db, "user@test.com", ["everyone"], "private-pool", {}, None
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_highest_permission_wins(self):
+        role_reader = _make_role(
+            name="reader", pool_permission="read", allow_labels={"env": ["prod"]}
+        )
+        role_writer = _make_role(
+            name="writer", pool_permission="admin", allow_labels={"env": ["prod"]}
+        )
+        db = _mock_db_with_roles([role_reader, role_writer])
+        result = await resolve_pool_permission(
+            db,
+            "user@test.com",
+            ["reader", "writer"],
+            "prod-pool",
+            {"env": "prod"},
+            None,
+        )
+        assert result == "admin"
+
+    @pytest.mark.asyncio
+    async def test_name_based_access(self):
+        role = _make_role(pool_permission="write", allow_names=["special-pool"])
+        db = _mock_db_with_roles([role])
+        result = await resolve_pool_permission(
+            db, "user@test.com", ["custom-role"], "special-pool", {}, None
+        )
+        assert result == "write"
+
+    @pytest.mark.asyncio
+    async def test_owner_empty_string_does_not_match(self):
+        """Empty owner_email should not grant admin."""
+        db = _mock_db_with_roles([])
+        result = await resolve_pool_permission(db, "user@test.com", ["everyone"], "my-pool", {}, "")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_owner_none_does_not_match(self):
+        """None owner_email should not grant admin."""
+        db = _mock_db_with_roles([])
+        result = await resolve_pool_permission(
+            db, "user@test.com", ["everyone"], "my-pool", {}, None
+        )
+        assert result is None

--- a/services/tests/services/test_pool_rbac_service.py
+++ b/services/tests/services/test_pool_rbac_service.py
@@ -236,3 +236,20 @@ class TestResolvePoolPermission:
         )
         assert result == "admin"
         db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preloaded_roles_filtered_by_user_roles(self):
+        """Preloaded roles not held by the user are ignored."""
+        role_held = _make_role(name="held-role", pool_permission="read", allow_names=["my-pool"])
+        role_other = _make_role(name="other-role", pool_permission="admin", allow_names=["my-pool"])
+        db = AsyncMock()
+        result = await resolve_pool_permission(
+            db,
+            "user@test.com",
+            ["held-role"],  # user only holds held-role, not other-role
+            "my-pool",
+            {},
+            None,
+            preloaded_roles=[role_held, role_other],
+        )
+        assert result == "read"  # only held-role's permission, not other-role's admin

--- a/services/tests/services/test_pool_rbac_service.py
+++ b/services/tests/services/test_pool_rbac_service.py
@@ -189,3 +189,50 @@ class TestResolvePoolPermission:
             db, "user@test.com", ["everyone"], "my-pool", {}, None
         )
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_audit_with_custom_role_elevation(self):
+        """Audit user with a custom role granting write gets write (not just read)."""
+        role = _make_role(pool_permission="write", allow_labels={"env": ["prod"]})
+        db = _mock_db_with_roles([role])
+        result = await resolve_pool_permission(
+            db,
+            "auditor@test.com",
+            ["audit", "custom-role"],
+            "prod-pool",
+            {"env": "prod"},
+            None,
+        )
+        assert result == "write"
+
+    @pytest.mark.asyncio
+    async def test_audit_without_matching_role_gets_read(self):
+        """Audit user with a custom role that doesn't match still gets read from audit."""
+        role = _make_role(pool_permission="write", allow_labels={"env": ["staging"]})
+        db = _mock_db_with_roles([role])
+        result = await resolve_pool_permission(
+            db,
+            "auditor@test.com",
+            ["audit", "custom-role"],
+            "prod-pool",
+            {"env": "prod"},
+            None,
+        )
+        assert result == "read"
+
+    @pytest.mark.asyncio
+    async def test_preloaded_roles_skips_db_query(self):
+        """When preloaded_roles is passed, no DB query should be made."""
+        role = _make_role(pool_permission="admin", allow_names=["my-pool"])
+        db = AsyncMock()
+        result = await resolve_pool_permission(
+            db,
+            "user@test.com",
+            ["custom-role"],
+            "my-pool",
+            {},
+            None,
+            preloaded_roles=[role],
+        )
+        assert result == "admin"
+        db.execute.assert_not_called()

--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -9,6 +9,7 @@ import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { ConnectionStatus } from '@/components/connection-status'
+import { LabelsEditor } from '@/components/labels-editor'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { usePoolEvents } from '@/lib/use-pool-events'
@@ -18,6 +19,9 @@ interface PoolAttrs {
   name: string
   description: string
   'is-default': boolean
+  labels: Record<string, string>
+  'owner-email': string
+  permission?: string
   'created-at': string
   'listener-summary'?: { total: number; online: number }
 }
@@ -68,6 +72,8 @@ export default function AgentPoolDetailPage() {
   const [editing, setEditing] = useState(false)
   const [editName, setEditName] = useState('')
   const [editDesc, setEditDesc] = useState('')
+  const [editLabels, setEditLabels] = useState<Record<string, string>>({})
+  const [editOwner, setEditOwner] = useState('')
   const [saving, setSaving] = useState(false)
 
   // Delete pool
@@ -103,7 +109,6 @@ export default function AgentPoolDetailPage() {
 
   useEffect(() => {
     if (!getAuthState()) { router.push('/login'); return }
-    if (!isAdmin()) { router.push('/'); return }
     loadPool()
   }, [router, loadPool])
 
@@ -153,6 +158,8 @@ export default function AgentPoolDetailPage() {
     if (!pool) return
     setEditName(pool.attributes.name)
     setEditDesc(pool.attributes.description || '')
+    setEditLabels(pool.attributes.labels || {})
+    setEditOwner(pool.attributes['owner-email'] || '')
     setEditing(true)
   }
 
@@ -170,6 +177,8 @@ export default function AgentPoolDetailPage() {
             attributes: {
               name: editName,
               description: editDesc,
+              labels: editLabels,
+              'owner-email': editOwner || null,
             },
           },
         }),
@@ -266,9 +275,12 @@ export default function AgentPoolDetailPage() {
     })
   }
 
+  const poolPerm = pool?.attributes.permission || 'read'
+  const isPoolAdmin = poolPerm === 'admin'
+
   const tabs: { key: Tab; label: string }[] = [
     { key: 'settings', label: 'Settings' },
-    { key: 'tokens', label: 'Tokens' },
+    ...(isPoolAdmin ? [{ key: 'tokens' as Tab, label: 'Tokens' }] : []),
     { key: 'listeners', label: 'Listeners' },
   ]
 
@@ -339,7 +351,7 @@ export default function AgentPoolDetailPage() {
             <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-6">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm font-medium text-slate-300">Pool Settings</h3>
-                {!editing ? (
+                {isPoolAdmin && (!editing ? (
                   <button onClick={startEditing} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
                 ) : (
                   <div className="flex gap-2">
@@ -348,7 +360,7 @@ export default function AgentPoolDetailPage() {
                       {saving ? 'Saving...' : 'Save'}
                     </button>
                   </div>
-                )}
+                ))}
               </div>
               <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
@@ -375,10 +387,40 @@ export default function AgentPoolDetailPage() {
                   <dt className="text-xs text-slate-500">Created</dt>
                   <dd className="mt-1 text-sm text-slate-200">{formatDate(pool.attributes['created-at'])}</dd>
                 </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Owner</dt>
+                  {editing ? (
+                    <input type="email" value={editOwner} onChange={(e) => setEditOwner(e.target.value)}
+                      placeholder="user@example.com"
+                      className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">{pool.attributes['owner-email'] || '-'}</dd>
+                  )}
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Your Permission</dt>
+                  <dd className="mt-1">
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                      poolPerm === 'admin' ? 'bg-purple-900/50 text-purple-300' :
+                      poolPerm === 'write' ? 'bg-blue-900/50 text-blue-300' :
+                      'bg-slate-700/50 text-slate-300'
+                    }`}>{poolPerm}</span>
+                  </dd>
+                </div>
+                <div className="sm:col-span-2">
+                  <dt className="text-xs text-slate-500 mb-1">Labels</dt>
+                  <dd>
+                    <LabelsEditor
+                      labels={editing ? editLabels : (pool.attributes.labels || {})}
+                      onChange={editing ? setEditLabels : undefined}
+                      readOnly={!editing}
+                    />
+                  </dd>
+                </div>
               </dl>
             </div>
 
-            {!pool.attributes['is-default'] && (
+            {isPoolAdmin && !pool.attributes['is-default'] && (
               <div className="bg-slate-800/50 rounded-lg border border-red-900/30 p-6">
                 <div className="flex items-center justify-between">
                   <div>

--- a/web/src/app/admin/agent-pools/page.tsx
+++ b/web/src/app/admin/agent-pools/page.tsx
@@ -9,6 +9,7 @@ import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
+import { LabelsEditor } from '@/components/labels-editor'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
@@ -20,6 +21,9 @@ interface AgentPool {
     name: string
     description: string
     'is-default': boolean
+    labels: Record<string, string>
+    'owner-email': string
+    permission?: string
     'created-at': string
     'listener-summary'?: { total: number; online: number }
   }
@@ -37,6 +41,7 @@ export default function AgentPoolsPage() {
   const [showCreate, setShowCreate] = useState(false)
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
+  const [createLabels, setCreateLabels] = useState<Record<string, string>>({})
   const [creating, setCreating] = useState(false)
 
   const poolAccessor = useCallback((item: AgentPool, key: PoolSortKey) => {
@@ -53,7 +58,6 @@ export default function AgentPoolsPage() {
 
   useEffect(() => {
     if (!getAuthState()) { router.push('/login'); return }
-    if (!isAdmin()) { router.push('/'); return }
     loadPools()
   }, [router])
 
@@ -80,6 +84,7 @@ export default function AgentPoolsPage() {
     try {
       const attrs: Record<string, unknown> = { name }
       if (description) attrs.description = description
+      if (Object.keys(createLabels).length > 0) attrs.labels = createLabels
 
       const res = await apiFetch('/api/v2/organizations/default/agent-pools', {
         method: 'POST',
@@ -92,6 +97,7 @@ export default function AgentPoolsPage() {
       }
       setName('')
       setDescription('')
+      setCreateLabels({})
       setShowCreate(false)
       await loadPools()
     } catch (err) {
@@ -108,14 +114,14 @@ export default function AgentPoolsPage() {
         <PageHeader
           title="Agent Pools"
           description="Manage runner agent pools and their listeners"
-          actions={
+          actions={isAdmin() ? (
             <button
               onClick={() => setShowCreate(!showCreate)}
               className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors btn-smoke"
             >
               {showCreate ? 'Cancel' : 'New Pool'}
             </button>
-          }
+          ) : undefined}
         />
 
         {error && <ErrorBanner message={error} />}
@@ -137,6 +143,10 @@ export default function AgentPoolsPage() {
                   placeholder="Production AWS runners"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
               </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1">Labels</label>
+              <LabelsEditor labels={createLabels} onChange={setCreateLabels} />
             </div>
             <button type="submit" disabled={creating}
               className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors">

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -20,6 +20,7 @@ interface Role {
     description: string
     'built-in': boolean
     'workspace-permission': string | null
+    'pool-permission': string | null
     'allow-labels': Record<string, string>
     'allow-names': string[]
     'deny-labels': Record<string, string>
@@ -64,6 +65,7 @@ export default function RolesPage() {
   const [roleAllowLabels, setRoleAllowLabels] = useState('')
   const [roleAllowNames, setRoleAllowNames] = useState('')
   const [roleDenyLabels, setRoleDenyLabels] = useState('')
+  const [rolePoolPermission, setRolePoolPermission] = useState('read')
   const [roleDenyNames, setRoleDenyNames] = useState('')
   const [creatingRole, setCreatingRole] = useState(false)
 
@@ -74,6 +76,7 @@ export default function RolesPage() {
   const [editRoleAllowLabels, setEditRoleAllowLabels] = useState('')
   const [editRoleAllowNames, setEditRoleAllowNames] = useState('')
   const [editRoleDenyLabels, setEditRoleDenyLabels] = useState('')
+  const [editRolePoolPermission, setEditRolePoolPermission] = useState('read')
   const [editRoleDenyNames, setEditRoleDenyNames] = useState('')
   const [savingRole, setSavingRole] = useState(false)
 
@@ -176,6 +179,7 @@ export default function RolesPage() {
         name: roleName,
         description: roleDesc,
         'workspace-permission': rolePermission,
+        'pool-permission': rolePoolPermission,
       }
       if (roleAllowLabels.trim()) attrs['allow-labels'] = parseLabels(roleAllowLabels)
       if (roleAllowNames.trim()) attrs['allow-names'] = roleAllowNames.split(',').map((s) => s.trim()).filter(Boolean)
@@ -195,6 +199,7 @@ export default function RolesPage() {
       setRoleName('')
       setRoleDesc('')
       setRolePermission('read')
+      setRolePoolPermission('read')
       setRoleAllowLabels('')
       setRoleAllowNames('')
       setRoleDenyLabels('')
@@ -212,6 +217,7 @@ export default function RolesPage() {
     setEditingRole(role.name)
     setEditRoleDesc(role.attributes.description || '')
     setEditRolePermission(role.attributes['workspace-permission'] || 'read')
+    setEditRolePoolPermission(role.attributes['pool-permission'] || 'read')
     setEditRoleAllowLabels(formatLabels(role.attributes['allow-labels'] || {}))
     setEditRoleAllowNames((role.attributes['allow-names'] || []).join(', '))
     setEditRoleDenyLabels(formatLabels(role.attributes['deny-labels'] || {}))
@@ -227,6 +233,7 @@ export default function RolesPage() {
       const attrs: Record<string, unknown> = {
         description: editRoleDesc,
         'workspace-permission': editRolePermission,
+        'pool-permission': editRolePoolPermission,
         'allow-labels': parseLabels(editRoleAllowLabels),
         'allow-names': editRoleAllowNames.split(',').map((s) => s.trim()).filter(Boolean),
         'deny-labels': parseLabels(editRoleDenyLabels),
@@ -384,7 +391,7 @@ export default function RolesPage() {
 
             {showCreateRole && (
               <form onSubmit={handleCreateRole} className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6 space-y-3">
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
                   <div>
                     <label htmlFor="r-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                     <input id="r-name" type="text" value={roleName} onChange={(e) => setRoleName(e.target.value)} required placeholder="developer"
@@ -403,10 +410,19 @@ export default function RolesPage() {
                     </select>
                   </div>
                   <div>
-                    <label htmlFor="r-desc" className="block text-sm font-medium text-slate-300 mb-1">Description</label>
-                    <input id="r-desc" type="text" value={roleDesc} onChange={(e) => setRoleDesc(e.target.value)} placeholder="Developer access"
-                      className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
+                    <label htmlFor="r-pool-perm" className="block text-sm font-medium text-slate-300 mb-1">Pool Permission</label>
+                    <select id="r-pool-perm" value={rolePoolPermission} onChange={(e) => setRolePoolPermission(e.target.value)}
+                      className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent">
+                      <option value="read">read</option>
+                      <option value="write">write</option>
+                      <option value="admin">admin</option>
+                    </select>
                   </div>
+                </div>
+                <div>
+                  <label htmlFor="r-desc" className="block text-sm font-medium text-slate-300 mb-1">Description</label>
+                  <input id="r-desc" type="text" value={roleDesc} onChange={(e) => setRoleDesc(e.target.value)} placeholder="Developer access"
+                    className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
@@ -466,11 +482,20 @@ export default function RolesPage() {
                                 className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                             </div>
                             <div>
-                              <label className="block text-xs text-slate-500 mb-1">Permission</label>
+                              <label className="block text-xs text-slate-500 mb-1">Workspace Permission</label>
                               <select value={editRolePermission} onChange={(e) => setEditRolePermission(e.target.value)}
                                 className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500">
                                 <option value="read">read</option>
                                 <option value="plan">plan</option>
+                                <option value="write">write</option>
+                                <option value="admin">admin</option>
+                              </select>
+                            </div>
+                            <div>
+                              <label className="block text-xs text-slate-500 mb-1">Pool Permission</label>
+                              <select value={editRolePoolPermission} onChange={(e) => setEditRolePoolPermission(e.target.value)}
+                                className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500">
+                                <option value="read">read</option>
                                 <option value="write">write</option>
                                 <option value="admin">admin</option>
                               </select>
@@ -507,7 +532,12 @@ export default function RolesPage() {
                               )}
                               {a['workspace-permission'] && (
                                 <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${permissionBadge(a['workspace-permission'])}`}>
-                                  {a['workspace-permission']}
+                                  ws: {a['workspace-permission']}
+                                </span>
+                              )}
+                              {a['pool-permission'] && (
+                                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${permissionBadge(a['pool-permission'])}`}>
+                                  pool: {a['pool-permission']}
                                 </span>
                               )}
                             </div>

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -535,7 +535,7 @@ export default function RolesPage() {
                                   ws: {a['workspace-permission']}
                                 </span>
                               )}
-                              {a['pool-permission'] && (
+                              {a['pool-permission'] && a['pool-permission'] !== 'read' && (
                                 <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${permissionBadge(a['pool-permission'])}`}>
                                   pool: {a['pool-permission']}
                                 </span>

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -65,7 +65,7 @@ interface WorkspaceAttrs {
 
 interface AgentPool {
   id: string
-  attributes: { name: string }
+  attributes: { name: string; permission?: string }
 }
 
 interface Workspace {
@@ -584,7 +584,8 @@ function WorkspaceDetailContent() {
     setEditing(true)
     if (!poolsLoaded) {
       apiFetch('/api/v2/organizations/default/agent-pools').then(res => res.ok ? res.json() : { data: [] }).then(data => {
-        setAgentPools(data.data || [])
+        const allPools: AgentPool[] = data.data || []
+        setAgentPools(allPools.filter(p => p.attributes.permission === 'write' || p.attributes.permission === 'admin'))
         setPoolsLoaded(true)
       }).catch(() => {})
     }

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -75,6 +75,10 @@ export default function NavBar() {
         <Activity size={16} />
         Sessions
       </NavLink>
+      <NavLink href="/admin/agent-pools" onClick={closeMenu}>
+        <Server size={16} />
+        Agent Pools
+      </NavLink>
       {admin && (
         <>
           <NavLink href="/admin/binary-cache" onClick={closeMenu}>
@@ -92,10 +96,6 @@ export default function NavBar() {
           <NavLink href="/admin/roles" onClick={closeMenu}>
             <Shield size={16} />
             Roles
-          </NavLink>
-          <NavLink href="/admin/agent-pools" onClick={closeMenu}>
-            <Server size={16} />
-            Agent Pools
           </NavLink>
           <NavLink href="/admin/variable-sets" onClick={closeMenu}>
             <Variable size={16} />


### PR DESCRIPTION
## Summary

- Adds three-level RBAC (read/write/admin) to agent pools, mirroring existing workspace and registry patterns
- Pool assignment on workspaces now requires `write` permission on the target pool (+ `admin` on workspace)
- Pool list, detail, and management endpoints are RBAC-gated instead of admin-only
- Frontend: labels editor on pool create/edit, pool permission badges on roles, filtered pool picker on workspaces

## Motivation

Agent pools control which K8s clusters runners execute in, and the IRSA/WIF identity attached to runner ServiceAccounts grants cloud provider access. Previously, any user with `admin` permission on a workspace could assign it to any pool — potentially escalating their cloud access. This closes that gap by requiring explicit pool-level authorization.

Closes #202

## Changes

### Backend
- **Migration**: `labels` (JSONB) and `owner_email` on `agent_pools`; `pool_permission` on `roles`
- **pool_rbac_service.py** (new): Permission resolution matching workspace/registry pattern — platform admin/audit, owner, label RBAC, everyone fallback
- **agent_pools.py**: All endpoints RBAC-gated (read for list/show/listeners, admin for update/delete/tokens)
- **tfe_v2.py**: Pool write check on workspace create + update when setting `agent-pool-id`
- **roles.py**: `pool-permission` attribute in role CRUD and responses

### Frontend
- Pool detail: labels editor (using existing `LabelsEditor` component), owner editing, permission badge
- Pool create form: labels editor
- Roles page: pool permission badge + selector in create/edit forms
- Workspace pool picker: filtered to pools with write/admin permission
- Nav bar: agent pools link visible to all users (list is RBAC-filtered server-side)

### Terraform Provider
- `terrapod_agent_pool` resource/data source: `labels` (map), `owner_email` attributes
- `terrapod_role` resource: `pool_permission` attribute

### Documentation
- `docs/rbac.md`: Pool permission levels, resolution order, platform permissions update

## Test plan

- [x] 898 unit tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] Playwright UI testing against local Tilt stack:
  - Login, navigate to agent pools list
  - Pool detail shows owner, permission badge, labels
  - Create role with pool-permission selector (read/write/admin)
  - Workspace create: agent pool picker shows pools filtered by write permission
  - Labels editor on pool create/edit forms