### PR TITLE
fix(local): nginx ingress class, web memory limit, and build cache

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -74,6 +74,7 @@ docker_build(
     'terrapod-api',
     context='.',
     dockerfile='docker/Dockerfile.api',
+    cache_from=['terrapod-api:latest'],
     live_update=[
         sync('./services/terrapod', '/app/terrapod'),
         sync('./alembic', '/app/alembic'),

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -54,8 +54,8 @@ api:
         default_provider: "auth0"
         oidc:
           - name: "auth0"
-            issuer_url: "https://dev-zqwrse0xlal03qiu.us.auth0.com/"
-            client_id: "AymR3SnEXQAdKE0t5NUPezczpcgpcXK5"
+            issuer_url: "https://dev-1234.us.auth0.com/"
+            client_id: "abc123"
             scopes:
               - openid
               - profile
@@ -97,17 +97,26 @@ web:
     periodSeconds: 10
     timeoutSeconds: 10
 
+  extraVolumeMounts:
+    - name: next-cache
+      mountPath: /app/.next
+
+  extraVolumes:
+    - name: next-cache
+      emptyDir: {}
+
   resources:
     requests:
       cpu: 200m
       memory: 512Mi
     limits:
       cpu: "1"
-      memory: 1Gi
+      memory: 2Gi
 
 # Ingress — BFF through web frontend, mkcert TLS
 ingress:
   enabled: true
+  className: nginx
   hostname: terrapod.local
   tls: true
 


### PR DESCRIPTION
- Add className: nginx to local ingress so Docker Desktop's nginx controller picks up the Ingress resource without manual annotation
- Raise web pod memory limit 1Gi → 2Gi to prevent OOMKilled on Next.js cold starts under Tilt
- Mount an emptyDir for .next build cache so the web container doesn't compete with the read-only filesystem
- Add cache_from to Tiltfile docker_build so Tilt reuses the locally-built image layer cache instead of re-pulling on each run
- Replace hardcoded Auth0 dev credentials with placeholder values; developers should set their own in a local override or .env