### PR TITLE
feat: tiered allow_prerelease policy for binary cache

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -608,7 +608,22 @@ api:
         enabled: true
         terraform_mirror_url: "https://releases.hashicorp.com/terraform"
         tofu_mirror_url: "https://github.com/opentofu/opentofu/releases/download"
+        allow_prerelease: none    # none | rc | beta | alpha | dev
 ```
+
+### Pre-release versions (`allow_prerelease`)
+
+Controls whether terraform / tofu **pre-release** builds (alpha, beta, rc, dev) can be cached, listed, and served. The value names the *lowest* tier accepted — everything more stable is also allowed:
+
+| Policy | Accepted tiers |
+|---|---|
+| `none` (default) | GA only |
+| `rc` | GA + rc |
+| `beta` | GA + rc + beta |
+| `alpha` | GA + rc + beta + alpha |
+| `dev` | everything |
+
+Requesting a version whose tier is not permitted returns HTTP 400 with a clear message. Production deployments should leave this at `none`. Dev / staging deployments can set `rc` (or `beta`) to try upcoming releases — e.g. Terraform 1.15 release candidates or OpenTofu 1.12 betas — before they GA.
 
 ### API Endpoints
 

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -165,6 +165,9 @@ data:
         {{- if .Values.api.config.registry.binary_cache.tofu_mirror_url }}
         tofu_mirror_url: {{ .Values.api.config.registry.binary_cache.tofu_mirror_url | quote }}
         {{- end }}
+        {{- if .Values.api.config.registry.binary_cache.allow_prerelease }}
+        allow_prerelease: {{ .Values.api.config.registry.binary_cache.allow_prerelease | quote }}
+        {{- end }}
       {{- end }}
     {{- end }}
     {{- if .Values.api.config.vcs }}

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -46,6 +46,11 @@ api:
         platforms:
           - os: darwin
             arch: arm64
+      # Allow RC-tier pre-release terraform/tofu binaries in local dev so we
+      # can try upcoming releases (e.g. terraform 1.15-rc, tofu 1.12-beta)
+      # before they GA. Production defaults to "none" (GA only).
+      binary_cache:
+        allow_prerelease: rc
     auth:
       local_enabled: true
       callback_base_url: "https://terrapod.local"

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -532,7 +532,11 @@
               "properties": {
                 "enabled": { "type": "boolean" },
                 "terraform_mirror_url": { "type": "string" },
-                "tofu_mirror_url": { "type": "string" }
+                "tofu_mirror_url": { "type": "string" },
+                "allow_prerelease": {
+                  "type": "string",
+                  "enum": ["none", "rc", "beta", "alpha", "dev"]
+                }
               }
             }
           }

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -197,6 +197,13 @@ api:
         enabled: true
         terraform_mirror_url: "https://releases.hashicorp.com/terraform"
         tofu_mirror_url: "https://github.com/opentofu/opentofu/releases/download"
+        # Lowest pre-release tier to accept for terraform/tofu CLI version
+        # resolution + caching. One of: none, rc, beta, alpha, dev.
+        # 'none' (default) permits only GA releases. 'rc' allows release
+        # candidates and GA. 'dev' allows everything. Set to 'rc' or 'beta'
+        # in dev/staging to try upcoming releases like terraform 1.15-rc or
+        # tofu 1.12-beta before they GA.
+        allow_prerelease: none
 
     # GPG signing key for provider registry
     # ASCII-armored GPG private key. If set, used to sign all provider SHA256SUMS.

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -6,7 +6,7 @@ Non-secret configuration loaded from YAML file, secrets from environment variabl
 
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field, PostgresDsn, RedisDsn
@@ -338,6 +338,15 @@ class BinaryCacheConfig(BaseModel):
     enabled: bool = Field(default=True)
     terraform_mirror_url: str = Field(default="https://releases.hashicorp.com/terraform")
     tofu_mirror_url: str = Field(default="https://github.com/opentofu/opentofu/releases/download")
+    allow_prerelease: Literal["none", "rc", "beta", "alpha", "dev"] = Field(
+        default="none",
+        description="Lowest pre-release tier to accept for terraform/tofu CLI version "
+        "resolution and caching. The value names the LEAST stable tier allowed; every "
+        "more-stable tier is also allowed. 'none' (default) permits only GA releases. "
+        "'rc' allows release candidates and GA. 'dev' allows everything. "
+        "Intended for dev/staging deployments trying upcoming releases such as "
+        "terraform 1.15-rc or tofu 1.12-beta.",
+    )
 
 
 class RegistryConfig(BaseModel):

--- a/services/terrapod/services/binary_cache_service.py
+++ b/services/terrapod/services/binary_cache_service.py
@@ -30,6 +30,67 @@ VALID_ARCH = {"amd64", "arm64", "arm", "386"}
 _VERSION_CACHE_PREFIX = "tp:version_resolve"
 _VERSION_CACHE_TTL = 3600  # 1 hour
 
+# Pre-release stability tiers, least → most stable.
+# Both terraform and tofu use these suffixes (tofu does not emit "dev").
+_PRERELEASE_TAGS = ("dev", "alpha", "beta", "rc")
+_STABILITY_RANK = {"dev": 1, "alpha": 2, "beta": 3, "rc": 4, "stable": 5}
+# Floor imposed by the allow_prerelease policy value — the lowest rank accepted.
+_POLICY_FLOOR = {
+    "none": _STABILITY_RANK["stable"],
+    "rc": _STABILITY_RANK["rc"],
+    "beta": _STABILITY_RANK["beta"],
+    "alpha": _STABILITY_RANK["alpha"],
+    "dev": _STABILITY_RANK["dev"],
+}
+
+
+def _parse_stability(version: str) -> str:
+    """Return the stability tier of a version string.
+
+    Returns 'stable' for GA versions (e.g. '1.15.0'), or the matching
+    pre-release tier name (e.g. 'rc' for '1.15.0-rc2').
+    """
+    for tag in _PRERELEASE_TAGS:
+        if f"-{tag}" in version:
+            return tag
+    return "stable"
+
+
+def _is_version_allowed(version: str, policy: str) -> bool:
+    """True if `version` satisfies the pre-release `policy`."""
+    return _STABILITY_RANK[_parse_stability(version)] >= _POLICY_FLOOR.get(
+        policy, _STABILITY_RANK["stable"]
+    )
+
+
+def _version_sort_key(v: str) -> tuple:
+    """Sort key giving correct ordering across stable + pre-release versions.
+
+    Orders: 1.15.0 > 1.15.0-rc2 > 1.15.0-rc1 > 1.15.0-beta1 > 1.15.0-alpha2.
+    Base x.y.z components compare first; within the same base, stability rank
+    then intra-tier number decide.
+    """
+    base = v
+    tier_rank = _STABILITY_RANK["stable"]
+    tier_num = 0
+    for tag in _PRERELEASE_TAGS:
+        marker = f"-{tag}"
+        idx = v.find(marker)
+        if idx != -1:
+            base = v[:idx]
+            suffix = v[idx + len(marker) :]
+            tier_rank = _STABILITY_RANK[tag]
+            try:
+                tier_num = int(suffix) if suffix else 0
+            except ValueError:
+                tier_num = 0
+            break
+    try:
+        base_parts = tuple(int(x) for x in base.split("."))
+    except ValueError:
+        base_parts = (0,)
+    return base_parts + (tier_rank, tier_num)
+
 
 async def get_or_cache_binary(
     db: AsyncSession,
@@ -49,6 +110,14 @@ async def get_or_cache_binary(
         raise ValueError(f"Invalid OS: {os_}. Must be one of {VALID_OS}")
     if arch not in VALID_ARCH:
         raise ValueError(f"Invalid arch: {arch}. Must be one of {VALID_ARCH}")
+
+    policy = settings.registry.binary_cache.allow_prerelease
+    if not _is_version_allowed(version, policy):
+        raise ValueError(
+            f"Pre-release version {version!r} is not allowed by the current "
+            f"binary_cache.allow_prerelease policy ({policy!r}). Set the "
+            f"policy to 'rc', 'beta', 'alpha', or 'dev' to permit it."
+        )
 
     # Check cache
     cached = await _get_cached(db, tool, version, os_, arch)
@@ -184,8 +253,8 @@ async def list_available_versions(tool: str) -> list[str]:
     else:
         versions = await _fetch_tofu_versions()
 
-    # Sort descending
-    versions.sort(key=lambda v: [int(x) for x in v.split(".")], reverse=True)
+    # Sort descending (stability-aware so pre-release versions sort correctly)
+    versions.sort(key=_version_sort_key, reverse=True)
 
     # Add major.minor shortcuts (deduplicated, in order)
     shortcuts: list[str] = []
@@ -215,40 +284,49 @@ async def list_available_versions(tool: str) -> list[str]:
 
 
 async def _fetch_terraform_versions() -> list[str]:
-    """Fetch stable terraform versions from releases.hashicorp.com."""
+    """Fetch terraform versions from releases.hashicorp.com.
+
+    Filters by the configured allow_prerelease policy: stable-only by default,
+    or includes rc/beta/alpha/dev tiers down to the configured floor.
+    """
     url = "https://releases.hashicorp.com/terraform/index.json"
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.get(url)
         resp.raise_for_status()
         data = resp.json()
 
+    policy = settings.registry.binary_cache.allow_prerelease
     versions = []
     for v in data.get("versions", {}):
-        if any(tag in v for tag in ("-alpha", "-beta", "-rc", "-dev")):
+        if not _is_version_allowed(v, policy):
             continue
-        parts = v.split(".")
+        parts = v.split("-")[0].split(".")
         if len(parts) >= 3:
             versions.append(v)
     return versions
 
 
 async def _fetch_tofu_versions() -> list[str]:
-    """Fetch stable tofu versions from GitHub releases."""
+    """Fetch tofu versions from GitHub releases.
+
+    Filters by the configured allow_prerelease policy. GitHub's
+    `prerelease` flag is the authoritative signal for pre-release status;
+    the policy is applied on top of it.
+    """
     url = "https://api.github.com/repos/opentofu/opentofu/releases"
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.get(url, params={"per_page": 100})
         resp.raise_for_status()
         releases = resp.json()
 
+    policy = settings.registry.binary_cache.allow_prerelease
     versions = []
     for release in releases:
-        if release.get("prerelease", False):
-            continue
         tag = release.get("tag_name", "")
         version = tag.lstrip("v")
-        if any(t in version for t in ("-alpha", "-beta", "-rc")):
+        if not _is_version_allowed(version, policy):
             continue
-        parts = version.split(".")
+        parts = version.split("-")[0].split(".")
         if len(parts) >= 3:
             versions.append(version)
     return versions
@@ -319,9 +397,14 @@ async def resolve_version(tool: str, partial_version: str) -> str:
 
 
 async def _resolve_terraform_version(partial: str) -> str:
-    """Resolve partial terraform version via releases.hashicorp.com index."""
+    """Resolve partial terraform version via releases.hashicorp.com index.
+
+    Honors the allow_prerelease policy: pre-release versions are only
+    considered when explicitly permitted.
+    """
     url = "https://releases.hashicorp.com/terraform/index.json"
     prefix = f"{partial}."
+    policy = settings.registry.binary_cache.allow_prerelease
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.get(url)
@@ -331,25 +414,29 @@ async def _resolve_terraform_version(partial: str) -> str:
     versions = data.get("versions", {})
     matching = []
     for v in versions:
-        if v.startswith(prefix):
-            # Skip pre-release versions
-            if any(tag in v for tag in ("-alpha", "-beta", "-rc", "-dev")):
-                continue
-            matching.append(v)
+        if not v.startswith(prefix):
+            continue
+        if not _is_version_allowed(v, policy):
+            continue
+        matching.append(v)
 
     if not matching:
-        logger.warning("No matching terraform version found", partial=partial)
+        logger.warning("No matching terraform version found", partial=partial, policy=policy)
         return partial
 
-    # Sort by version parts and return the latest
-    matching.sort(key=lambda v: [int(x) for x in v.split(".")])
+    matching.sort(key=_version_sort_key)
     return matching[-1]
 
 
 async def _resolve_tofu_version(partial: str) -> str:
-    """Resolve partial tofu version via GitHub releases API."""
+    """Resolve partial tofu version via GitHub releases API.
+
+    Honors the allow_prerelease policy: pre-release versions are only
+    considered when explicitly permitted.
+    """
     url = "https://api.github.com/repos/opentofu/opentofu/releases"
     prefix = f"v{partial}."
+    policy = settings.registry.binary_cache.allow_prerelease
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.get(url, params={"per_page": 100})
@@ -359,18 +446,18 @@ async def _resolve_tofu_version(partial: str) -> str:
     matching = []
     for release in releases:
         tag = release.get("tag_name", "")
-        if tag.startswith(prefix) and not release.get("prerelease", False):
-            # Strip the 'v' prefix
-            version = tag.lstrip("v")
-            if any(t in version for t in ("-alpha", "-beta", "-rc")):
-                continue
-            matching.append(version)
+        if not tag.startswith(prefix):
+            continue
+        version = tag.lstrip("v")
+        if not _is_version_allowed(version, policy):
+            continue
+        matching.append(version)
 
     if not matching:
-        logger.warning("No matching tofu version found", partial=partial)
+        logger.warning("No matching tofu version found", partial=partial, policy=policy)
         return partial
 
-    matching.sort(key=lambda v: [int(x) for x in v.split(".")])
+    matching.sort(key=_version_sort_key)
     return matching[-1]
 
 

--- a/services/tests/services/test_binary_cache_service.py
+++ b/services/tests/services/test_binary_cache_service.py
@@ -1,0 +1,188 @@
+"""Tests for binary cache pre-release handling."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.services.binary_cache_service import (
+    _is_version_allowed,
+    _parse_stability,
+    _version_sort_key,
+    get_or_cache_binary,
+)
+
+
+class TestParseStability:
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            ("1.15.0", "stable"),
+            ("1.14.8", "stable"),
+            ("1.0.0", "stable"),
+            ("1.15.0-rc1", "rc"),
+            ("1.15.0-rc2", "rc"),
+            ("1.12.0-beta1", "beta"),
+            ("1.15.0-alpha1", "alpha"),
+            ("1.15.0-alpha2", "alpha"),
+            ("1.15.0-dev", "dev"),
+        ],
+    )
+    def test_parses_tier(self, version: str, expected: str) -> None:
+        assert _parse_stability(version) == expected
+
+
+class TestIsVersionAllowed:
+    """Policy naming: the value is the LEAST stable tier accepted."""
+
+    @pytest.mark.parametrize(
+        "policy,allowed,denied",
+        [
+            (
+                "none",
+                ["1.15.0", "1.14.8"],
+                ["1.15.0-rc2", "1.15.0-beta1", "1.15.0-alpha1", "1.15.0-dev"],
+            ),
+            (
+                "rc",
+                ["1.15.0", "1.15.0-rc2"],
+                ["1.15.0-beta1", "1.15.0-alpha1", "1.15.0-dev"],
+            ),
+            (
+                "beta",
+                ["1.15.0", "1.15.0-rc2", "1.12.0-beta1"],
+                ["1.15.0-alpha1", "1.15.0-dev"],
+            ),
+            (
+                "alpha",
+                ["1.15.0", "1.15.0-rc2", "1.12.0-beta1", "1.15.0-alpha1"],
+                ["1.15.0-dev"],
+            ),
+            (
+                "dev",
+                ["1.15.0", "1.15.0-rc2", "1.12.0-beta1", "1.15.0-alpha1", "1.15.0-dev"],
+                [],
+            ),
+        ],
+    )
+    def test_policy_admits_expected_tiers(
+        self, policy: str, allowed: list[str], denied: list[str]
+    ) -> None:
+        for v in allowed:
+            assert _is_version_allowed(v, policy), f"{v} should be allowed by policy={policy}"
+        for v in denied:
+            assert not _is_version_allowed(v, policy), f"{v} should be denied by policy={policy}"
+
+    def test_unknown_policy_falls_back_to_stable_only(self) -> None:
+        assert _is_version_allowed("1.15.0", "bogus")
+        assert not _is_version_allowed("1.15.0-rc2", "bogus")
+
+
+class TestVersionSortKey:
+    """Sort key orders versions semver-ish with stability rank applied."""
+
+    def test_stable_before_rc_before_beta_before_alpha_before_dev(self) -> None:
+        versions = [
+            "1.15.0-dev",
+            "1.15.0-alpha1",
+            "1.15.0-alpha2",
+            "1.15.0-beta1",
+            "1.15.0-rc1",
+            "1.15.0-rc2",
+            "1.15.0",
+        ]
+        shuffled = list(reversed(versions))
+        shuffled.sort(key=_version_sort_key)
+        assert shuffled == versions
+
+    def test_patch_versions_sort_above_pre_releases_of_next_minor(self) -> None:
+        # 1.14.8 (stable) < 1.15.0-alpha1: higher minor beats stable
+        got = sorted(["1.14.8", "1.15.0-alpha1"], key=_version_sort_key)
+        assert got == ["1.14.8", "1.15.0-alpha1"]
+
+    def test_all_stable_sort_in_patch_order(self) -> None:
+        got = sorted(
+            ["1.14.8", "1.14.10", "1.14.9", "1.15.0"],
+            key=_version_sort_key,
+        )
+        assert got == ["1.14.8", "1.14.9", "1.14.10", "1.15.0"]
+
+    def test_rc_numbers_within_tier_sort_by_integer(self) -> None:
+        got = sorted(
+            ["1.15.0-rc10", "1.15.0-rc2", "1.15.0-rc1"],
+            key=_version_sort_key,
+        )
+        assert got == ["1.15.0-rc1", "1.15.0-rc2", "1.15.0-rc10"]
+
+    def test_handles_bare_dev_without_number(self) -> None:
+        # "-dev" with no trailing number should not blow up
+        got = sorted(["1.15.0", "1.15.0-dev"], key=_version_sort_key)
+        assert got == ["1.15.0-dev", "1.15.0"]
+
+
+class TestGetOrCacheBinaryGatesPrereleases:
+    """Integration-ish: confirm the policy is enforced at the service entry point."""
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.binary_cache_service.settings")
+    async def test_rejects_rc_when_policy_is_none(self, mock_settings: MagicMock) -> None:
+        mock_settings.registry.binary_cache.allow_prerelease = "none"
+        db = AsyncMock()
+        storage = AsyncMock()
+        with pytest.raises(ValueError, match="Pre-release version"):
+            await get_or_cache_binary(db, storage, "terraform", "1.15.0-rc2", "linux", "amd64")
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.binary_cache_service.settings")
+    async def test_rejects_beta_when_policy_is_rc(self, mock_settings: MagicMock) -> None:
+        mock_settings.registry.binary_cache.allow_prerelease = "rc"
+        db = AsyncMock()
+        storage = AsyncMock()
+        with pytest.raises(ValueError, match="Pre-release version"):
+            await get_or_cache_binary(db, storage, "tofu", "1.12.0-beta1", "linux", "amd64")
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.binary_cache_service._get_cached", new_callable=AsyncMock)
+    @patch("terrapod.services.binary_cache_service.settings")
+    async def test_accepts_rc_when_policy_is_rc(
+        self,
+        mock_settings: MagicMock,
+        mock_get_cached: AsyncMock,
+    ) -> None:
+        # With policy=rc, a -rc version must pass the gate. Stub out the cache
+        # lookup with a sentinel so the function short-circuits before any DB
+        # or storage I/O.
+        mock_settings.registry.binary_cache.allow_prerelease = "rc"
+        sentinel = MagicMock()
+        sentinel.last_accessed_at = None
+        mock_get_cached.return_value = sentinel
+
+        db = AsyncMock()
+        storage = AsyncMock()
+        presigned = MagicMock()
+        presigned.url = "https://example/presigned"
+        storage.presigned_get_url = AsyncMock(return_value=presigned)
+
+        url = await get_or_cache_binary(db, storage, "terraform", "1.15.0-rc2", "linux", "amd64")
+        assert url == "https://example/presigned"
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.binary_cache_service._get_cached", new_callable=AsyncMock)
+    @patch("terrapod.services.binary_cache_service.settings")
+    async def test_always_accepts_stable_regardless_of_policy(
+        self,
+        mock_settings: MagicMock,
+        mock_get_cached: AsyncMock,
+    ) -> None:
+        mock_settings.registry.binary_cache.allow_prerelease = "none"
+        sentinel = MagicMock()
+        sentinel.last_accessed_at = None
+        mock_get_cached.return_value = sentinel
+
+        db = AsyncMock()
+        storage = AsyncMock()
+        presigned = MagicMock()
+        presigned.url = "https://example/presigned"
+        storage.presigned_get_url = AsyncMock(return_value=presigned)
+
+        url = await get_or_cache_binary(db, storage, "terraform", "1.14.8", "linux", "amd64")
+        assert url == "https://example/presigned"


### PR DESCRIPTION
## Summary

Adds a `registry.binary_cache.allow_prerelease` setting that gates whether terraform/tofu **pre-release** builds (alpha, beta, rc, dev) can be cached, listed, and served.

The value names the **least stable** tier accepted; every more-stable tier is also allowed:

| Policy | Accepted tiers |
|---|---|
| `none` (default) | GA only |
| `rc` | GA + rc |
| `beta` | GA + rc + beta |
| `alpha` | GA + rc + beta + alpha |
| `dev` | everything |

Production defaults to `none`, so upstream pre-releases can't accidentally be pinned. `values-local.yaml` sets `rc` so local dev can consume Terraform 1.15-rc and OpenTofu 1.12-beta (both of which add dynamic module `source` / `version` support via `const = true` input variables) before they GA.

## Motivation

We want to prototype dynamic module version selection — same root module for dev/stg/prod, different module versions per env — in `tf-dev-eu1-core`. That feature requires Terraform 1.15 and OpenTofu 1.12, both currently in rc/beta. Having a Helm-level flag to permit those pre-releases gives us a controlled on-ramp: off in prod, on in dev.

## Changes

- `config.py`: `BinaryCacheConfig.allow_prerelease` as `Literal[\"none\", \"rc\", \"beta\", \"alpha\", \"dev\"]`
- `binary_cache_service.py`: new `_parse_stability` / `_is_version_allowed` / `_version_sort_key` helpers; enforcement at `get_or_cache_binary`; policy applied in `_fetch_*` + `_resolve_*` so list and partial-version resolution respect the policy
- Also fixes a pre-existing sort bug: `[int(x) for x in v.split(\".\")]` crashed on pre-release strings — new `_version_sort_key` handles both stable and pre-release versions
- Helm: `values.yaml` default (`none`), `values-local.yaml` override (`rc`), `values.schema.json` enum, `configmap-api.yaml` render
- Docs: `docs/registry.md` + `CLAUDE.md`

## Tests

- 4 new test classes (30+ assertions) covering tier parsing, policy matrix across all 5 tiers, stability-aware sort (including edge cases like bare `-dev`), and service-level gate enforcement
- `make test`: 950 passed (was 946)
- `make lint`: all clean
- `helm lint`: clean
- Local stack smoke: API pod loads `allow_prerelease = rc` from values-local.yaml as expected

## Test plan

- [ ] CI green
- [ ] Once merged + released, enable in wrapper chart (follow-up MR on internal repo)