### PR TITLE
fix(runner): increase artifact upload timeout 10s→60s (configurable via TP_UPLOAD_TIMEOUT)

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -86,6 +86,10 @@ log() { echo "$@" | tee -a "$SETUP_LOG"; }
 TP_BACKEND="${TP_BACKEND:-terraform}"
 TP_VERSION="${TP_VERSION:-1.9.8}"
 TP_PHASE="${TP_PHASE:-plan}"
+# Timeout (seconds) for artifact uploads — logs, plan file, state. These can
+# be several MB and the old 10s cap routinely timed out under normal network
+# conditions. Small status POSTs keep their tighter local timeouts.
+TP_UPLOAD_TIMEOUT="${TP_UPLOAD_TIMEOUT:-60}"
 WORK_DIR="/workspace"
 
 mkdir -p "$WORK_DIR"
@@ -311,7 +315,7 @@ if [ "$INIT_EXIT" != "0" ]; then
     # Upload setup + init output as plan log so it's visible in the UI
     if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
         cat "$SETUP_LOG" /tmp/init.log > /tmp/plan-full.log 2>/dev/null
-        curl -sSf --max-time 10 -X PUT -H "$AUTH_HEADER" \
+        curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @/tmp/plan-full.log \
             "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/plan-log" || true
@@ -407,7 +411,7 @@ if [ "$TP_PHASE" = "plan" ]; then
     # Upload plan log (best-effort) — prepend setup + init output so the full log is visible
     if [ -n "$TP_API_URL" ] && [ -f /tmp/plan.log ]; then
         cat "$SETUP_LOG" /tmp/init.log /tmp/plan.log > /tmp/plan-full.log 2>/dev/null
-        curl -sSf --max-time 10 -X PUT -H "$AUTH_HEADER" \
+        curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @/tmp/plan-full.log \
             "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/plan-log" || true
@@ -415,7 +419,7 @@ if [ "$TP_PHASE" = "plan" ]; then
 
     # Upload plan file (best-effort)
     if [ -n "$TP_API_URL" ] && [ -f tfplan ]; then
-        curl -sSf --max-time 10 -X PUT -H "$AUTH_HEADER" \
+        curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @tfplan \
             "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/plan-file" || true
@@ -447,7 +451,7 @@ elif [ "$TP_PHASE" = "apply" ]; then
     # Upload apply log (best-effort, bounded by --max-time) — prepend setup + init output
     if [ -n "$TP_API_URL" ] && [ -f /tmp/apply.log ]; then
         cat "$SETUP_LOG" /tmp/init.log /tmp/apply.log > /tmp/apply-full.log 2>/dev/null
-        curl -sSf --max-time 10 -X PUT -H "$AUTH_HEADER" \
+        curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @/tmp/apply-full.log \
             "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/apply-log" || \
@@ -456,7 +460,7 @@ elif [ "$TP_PHASE" = "apply" ]; then
 
     # Upload new state (FATAL — missing state = infrastructure/state divergence)
     if [ -n "$TP_API_URL" ] && [ -f terraform.tfstate ]; then
-        if ! curl -sSf --max-time 15 -X PUT -H "$AUTH_HEADER" \
+        if ! curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @terraform.tfstate \
             "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/state"; then


### PR DESCRIPTION
## Summary

Observed on a real apply run (`run-019daf7e-fb1c-...` on `dev-eu1-core`): the combined setup + init + apply log timed out the 10s curl cap even though the apply itself succeeded cleanly. User-visible symptom:

```
[entrypoint] WARNING: apply log upload failed
[entrypoint] Phase apply completed with exit code 0
```

…and a log truncated at "Modifications complete" in the Terrapod UI, with no further post-apply context.

Root cause: `curl -sSf --max-time 10` was tight enough that even a plain multi-MB log upload over normal network conditions could exceed it. The failure mode is silent data loss (log truncation) on successful applies.

## Fix

Introduce `TP_UPLOAD_TIMEOUT` env var (default **60s**) and apply it to all artifact PUTs:

| Endpoint | Was | Now |
|---|---|---|
| `/artifacts/plan-log` (init failure path) | 10s | `$TP_UPLOAD_TIMEOUT` |
| `/artifacts/plan-log` (normal plan) | 10s | `$TP_UPLOAD_TIMEOUT` |
| `/artifacts/plan-file` | 10s | `$TP_UPLOAD_TIMEOUT` |
| `/artifacts/apply-log` | 10s | `$TP_UPLOAD_TIMEOUT` |
| `/artifacts/state` | 15s | `$TP_UPLOAD_TIMEOUT` |

Small status POSTs (`/plan-result`, `/state-diverged`) keep their tight local timeouts (10s, 5s) — those are <1 KB JSON payloads that should always be fast and whose semantics are "signal, not data transfer".

## Test plan

- [x] `bash -n` on the modified entrypoint
- [ ] On the next apply through a real Terrapod runner, confirm the apply log reaches the UI in full with no `WARNING: apply log upload failed` line. (Will exercise on the next scheduled run of `dev-eu1-core`.)