### PR TITLE
feat(drift): dismiss action to clear drift status without toggling detection (closes #220)

### DIFF
--- a/docs/drift-detection.md
+++ b/docs/drift-detection.md
@@ -103,6 +103,30 @@ The status is updated after each drift run completes. The mapping from run outco
 | `errored` | — | `errored` |
 | `canceled` / `discarded` | — | No update |
 
+### Dismissing drift
+
+When a workspace shows `drifted` or `errored` status — for example after you've acknowledged the drift and plan to reconcile it through a real apply — you can clear the reported state without disabling scheduled drift detection.
+
+**UI**: click the "Dismiss" link next to the drift-status badge on the workspace overview.
+
+**API**:
+
+```http
+POST /api/v2/workspaces/{workspace_id}/actions/dismiss-drift
+```
+
+Effect:
+
+- `drift_status` → `""` (unchecked)
+- `drift_last_checked_at` → `null`
+- `drift_detection_enabled` — **unchanged** (scheduled checks continue)
+
+The next scheduled check repopulates the status from current infrastructure reality. If drift is still present, the status flips back to `drifted`.
+
+Idempotent: dismissing a workspace that isn't currently reporting drift is a no-op.
+
+Requires `plan` permission on the workspace.
+
 ---
 
 ## Skipping Logic

--- a/services/terrapod/api/routers/workspace_extensions.py
+++ b/services/terrapod/api/routers/workspace_extensions.py
@@ -4,8 +4,9 @@ These endpoints are NOT part of the TFE V2 API specification. They provide
 Terrapod-specific functionality consumed by the web UI.
 
 Endpoints:
-    GET /api/v2/workspace-events — SSE stream for workspace list updates
-    GET /api/v2/workspaces/{workspace_id}/vcs-refs — list VCS branches/tags
+    GET  /api/v2/workspace-events — SSE stream for workspace list updates
+    GET  /api/v2/workspaces/{workspace_id}/vcs-refs — list VCS branches/tags
+    POST /api/v2/workspaces/{workspace_id}/actions/dismiss-drift — clear drift status
 """
 
 import asyncio
@@ -119,5 +120,58 @@ async def list_vcs_refs(
             "branches": branches,
             "tags": tags,
             "default-branch": default_branch,
+        }
+    )
+
+
+@router.post("/workspaces/{workspace_id}/actions/dismiss-drift")
+async def dismiss_drift(
+    workspace_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Clear the workspace's transient drift_status without disabling drift detection.
+
+    Sets `drift_status = ""` and `drift_last_checked_at = null`. Leaves
+    `drift_detection_enabled` unchanged — scheduled checks continue to run.
+    The next scheduled check will repopulate the state from the current
+    infrastructure reality.
+
+    Idempotent: dismissing when no drift is currently reported is a no-op.
+
+    Requires `plan` permission on the workspace (same level as lock/unlock —
+    a transient state reset, not a configuration mutation).
+    """
+    from terrapod.api.routers.tfe_v2 import _get_workspace_by_id
+
+    ws = await _get_workspace_by_id(workspace_id, db)
+    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    if not has_permission(perm, "plan"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Requires plan permission on workspace",
+        )
+
+    ws.drift_status = ""
+    ws.drift_last_checked_at = None
+    await db.commit()
+
+    logger.info(
+        "Drift status dismissed",
+        workspace=ws.name,
+        user=user.email,
+    )
+
+    return JSONResponse(
+        content={
+            "data": {
+                "id": f"ws-{ws.id}",
+                "type": "workspaces",
+                "attributes": {
+                    "drift-status": ws.drift_status,
+                    "drift-last-checked-at": None,
+                    "drift-detection-enabled": ws.drift_detection_enabled,
+                },
+            }
         }
     )

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -223,3 +223,97 @@ class TestRunDriftAttributes:
         attrs = resp.json()["data"]["attributes"]
         assert attrs["is-drift-detection"] is True
         assert attrs["has-changes"] is True
+
+
+# ── Dismiss drift action ─────────────────────────────────────────────────
+
+
+class TestDismissDriftAction:
+    """POST /workspaces/{id}/actions/dismiss-drift clears transient drift state."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission")
+    async def test_dismiss_drift_clears_state_and_keeps_detection_enabled(
+        self, mock_resolve, *mocks
+    ):
+        """drift_status and drift_last_checked_at reset; drift_detection_enabled unchanged."""
+        mock_resolve.return_value = "plan"
+        ws = _mock_workspace(
+            drift_detection_enabled=True,
+            drift_status="drifted",
+            drift_last_checked_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        )
+
+        app, mock_db = _make_app(_user())
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/v2/workspaces/ws-{ws.id}/actions/dismiss-drift",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 200
+        assert ws.drift_status == ""
+        assert ws.drift_last_checked_at is None
+        # Detection itself must NOT be touched — scheduled checks continue
+        assert ws.drift_detection_enabled is True
+        body = resp.json()["data"]["attributes"]
+        assert body["drift-status"] == ""
+        assert body["drift-last-checked-at"] is None
+        assert body["drift-detection-enabled"] is True
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission")
+    async def test_dismiss_drift_requires_plan_permission(self, mock_resolve, *mocks):
+        """Read-only users cannot dismiss drift."""
+        mock_resolve.return_value = "read"
+        ws = _mock_workspace(drift_status="drifted")
+
+        app, mock_db = _make_app(_user())
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/v2/workspaces/ws-{ws.id}/actions/dismiss-drift",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 403
+        # State must not have changed
+        assert ws.drift_status == "drifted"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission")
+    async def test_dismiss_drift_is_idempotent(self, mock_resolve, *mocks):
+        """Dismissing a workspace with no drift reported is a no-op (still 200)."""
+        mock_resolve.return_value = "plan"
+        ws = _mock_workspace(
+            drift_detection_enabled=True,
+            drift_status="",
+            drift_last_checked_at=None,
+        )
+
+        app, mock_db = _make_app(_user())
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/v2/workspaces/ws-{ws.id}/actions/dismiss-drift",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 200
+        assert ws.drift_status == ""

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -282,6 +282,7 @@ function WorkspaceDetailContent() {
   // Drift detection
   const [savingDrift, setSavingDrift] = useState(false)
   const [checkingDrift, setCheckingDrift] = useState(false)
+  const [dismissingDrift, setDismissingDrift] = useState(false)
 
   // Delete confirmation
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -754,6 +755,26 @@ function WorkspaceDetailContent() {
       setError(err instanceof Error ? err.message : 'Failed to queue drift check')
     } finally {
       setCheckingDrift(false)
+    }
+  }
+
+  async function handleDismissDrift() {
+    setDismissingDrift(true)
+    setError('')
+    try {
+      const res = await apiFetch(
+        `/api/v2/workspaces/${workspaceId}/actions/dismiss-drift`,
+        { method: 'POST' }
+      )
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.detail || `Failed to dismiss drift (${res.status})`)
+      }
+      await loadWorkspace()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to dismiss drift')
+    } finally {
+      setDismissingDrift(false)
     }
   }
 
@@ -1580,10 +1601,20 @@ function WorkspaceDetailContent() {
                 </div>
                 <div>
                   <dt className="text-xs text-slate-500">Status</dt>
-                  <dd className="mt-1">
+                  <dd className="mt-1 flex items-center gap-2">
                     <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${driftStatusBadge(attrs['drift-status']).cls}`}>
                       {driftStatusBadge(attrs['drift-status']).label}
                     </span>
+                    {perms['can-queue-run'] && (attrs['drift-status'] === 'drifted' || attrs['drift-status'] === 'errored') && (
+                      <button
+                        onClick={handleDismissDrift}
+                        disabled={dismissingDrift}
+                        title="Clear the reported drift state. The next scheduled check will repopulate it from reality."
+                        className="text-xs text-slate-400 hover:text-slate-200 disabled:text-slate-600 transition-colors"
+                      >
+                        {dismissingDrift ? 'Dismissing…' : 'Dismiss'}
+                      </button>
+                    )}
                   </dd>
                 </div>
                 <div>


### PR DESCRIPTION
## Summary

Closes #220. Adds a one-click way to clear a workspace's drift status (the red/amber banner on the workspace overview) without the side effect of turning scheduled drift detection off and back on.

## API

```http
POST /api/v2/workspaces/{workspace_id}/actions/dismiss-drift
```

Effect:

- `drift_status` → `""`
- `drift_last_checked_at` → `null`
- `drift_detection_enabled` — **unchanged**

The next scheduled check repopulates the status from current infrastructure reality. If the drift is still there, it'll come right back — dismiss acknowledges the *currently reported* state, it doesn't mute future detection.

Permission: `plan` on the workspace (same level as lock/unlock — a transient state reset, not a config change). Idempotent.

Lives in `workspace_extensions.py` per CLAUDE.md's rule that `tfe_v2.py` only carries TFE V2 standard endpoints.

## UI

Small "Dismiss" link next to the drift-status badge on the workspace overview. Visible only to users with `can-queue-run` permission and only when the status is `drifted` or `errored` (nothing to dismiss otherwise).

## Tests

3 new API tests in `test_drift_detection.py`:

- `test_dismiss_drift_clears_state_and_keeps_detection_enabled` — happy path; asserts `drift_detection_enabled` is NOT touched
- `test_dismiss_drift_requires_plan_permission` — read-only user gets 403; state not mutated
- `test_dismiss_drift_is_idempotent` — dismissing clean state returns 200 with no change

**976 tests pass** (was 973). Lint clean.