### PR TITLE
fix(drift): publish drift_status_change to per-workspace SSE channel

### DIFF
--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -294,10 +294,20 @@ async def handle_drift_run_completed(payload: dict) -> None:
             run_id=run_id,
         )
 
-        # Publish drift status change to SSE channels
+        # Publish drift status change to SSE channels.
+        #
+        # The workspace LIST page subscribes to WORKSPACE_LIST_EVENTS_CHANNEL,
+        # the admin dashboard to ADMIN_EVENTS_CHANNEL, and the workspace DETAIL
+        # page to tp:run_events:{workspace_id}. When a drift run completes we
+        # need to notify all three — without the per-workspace publish below,
+        # the detail page only sees the earlier run_status_change event (fired
+        # when the run transitioned to `planned`, before this handler ran) and
+        # so its loadWorkspace() call reads the stale drift_status. Publishing
+        # here too triggers a second refresh that picks up the updated status.
         try:
             from terrapod.redis.client import (
                 ADMIN_EVENTS_CHANNEL,
+                RUN_EVENTS_PREFIX,
                 WORKSPACE_LIST_EVENTS_CHANNEL,
                 publish_event,
             )
@@ -311,6 +321,7 @@ async def handle_drift_run_completed(payload: dict) -> None:
             )
             await publish_event(ADMIN_EVENTS_CHANNEL, drift_payload)
             await publish_event(WORKSPACE_LIST_EVENTS_CHANNEL, drift_payload)
+            await publish_event(f"{RUN_EVENTS_PREFIX}{ws.id}", drift_payload)
         except Exception as e:
             logger.debug("Failed to publish drift event", error=str(e))
 

--- a/services/tests/services/test_drift_detection_service.py
+++ b/services/tests/services/test_drift_detection_service.py
@@ -249,7 +249,10 @@ class TestHandleDriftRunCompleted:
     async def test_publishes_drift_status_change_event(
         self, mock_run_svc, mock_session, mock_notif, mock_publish
     ):
-        """Drift status change publishes to admin and workspace list channels."""
+        """Drift status change publishes to admin, workspace-list, AND the
+        per-workspace run_events channel (the last is what the workspace
+        detail page listens to — without it the UI stays stale until a
+        manual reload)."""
         from terrapod.services.drift_detection_service import handle_drift_run_completed
 
         run = _mock_run(status="planned", has_changes=True)
@@ -268,8 +271,9 @@ class TestHandleDriftRunCompleted:
             }
         )
 
-        # Should publish to both admin and workspace list channels
-        assert mock_publish.call_count == 2
         channels = [call.args[0] for call in mock_publish.call_args_list]
         assert "tp:admin_events" in channels
         assert "tp:workspace_list_events" in channels
+        # The one that fixes the detail-page-stays-stale bug
+        assert f"tp:run_events:{ws.id}" in channels
+        assert mock_publish.call_count == 3


### PR DESCRIPTION
## Summary

The workspace detail page stayed on stale "no drift" status until a manual reload after a drift run completed — even though the drift_run_completed handler was correctly writing `drift_status`.

## Root cause

1. Run transitions `planning → planned` → publishes `run_status_change` to `tp:run_events:{workspace_id}`. The detail page listens here and calls `loadWorkspace()` — but at that instant `drift_status` hasn't been updated yet (that happens in the async `drift_run_completed` handler that fires separately).
2. The `drift_run_completed` handler writes `ws.drift_status` and publishes `drift_status_change` — but only to `ADMIN_EVENTS_CHANNEL` and `WORKSPACE_LIST_EVENTS_CHANNEL`. The detail page doesn't subscribe to either.
3. User sees a stale badge until F5.

## Fix

Publish the `drift_status_change` event to `tp:run_events:{workspace_id}` as well. The detail page's `useRunEvents` hook is event-agnostic — any event on the channel triggers a `loadWorkspace()`, which now reads the freshly-updated `drift_status`.

## Tests

Updated the existing `test_publishes_drift_status_change_event` to assert all three channels get the publish. **976 tests pass.**