### PR TITLE
fix(vcs): scope commit status context per workspace

### DIFF
--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -233,6 +233,11 @@ async def handle_vcs_commit_status(payload: dict) -> None:
         if settings.external_url:
             target_url = f"{settings.external_url.rstrip('/')}/workspaces/{ws.id}/runs/{run.id}"
 
+        # Scope context to the workspace so multiple workspaces linked to the
+        # same PR (e.g. module-impact fan-out) each get a distinct check,
+        # rather than clobbering each other.
+        context = f"terrapod/{ws.name}"
+
         # Post commit status
         try:
             if conn.provider == "gitlab":
@@ -244,6 +249,7 @@ async def handle_vcs_commit_status(payload: dict) -> None:
                     state=gitlab_state,
                     description=description,
                     target_url=target_url,
+                    context=context,
                 )
             else:
                 await github_service.create_commit_status(
@@ -254,6 +260,7 @@ async def handle_vcs_commit_status(payload: dict) -> None:
                     state=github_state,
                     description=description,
                     target_url=target_url,
+                    context=context,
                 )
         except Exception as e:
             logger.warning(


### PR DESCRIPTION
## Problem

When multiple workspaces are linked to the same PR (for example via `terrapod_module_workspace_link` causing module-impact fan-out, or a single repo driving multiple workspaces) every workspace's run posted GitHub commit status with the same default context `"terrapod"`. GitHub dedups checks by context, so only the last workspace's result remained visible — the others were silently overwritten.

Concretely observed on [markupai/tf-aws-core#2](https://github.com/markupai/tf-aws-core/pull/2) where `dev-eu1-core` and `mai-dev-us1-core` both plan speculatively for every PR but only one "terrapod" check ever appeared.

## Fix

In `vcs_status_dispatcher.handle_vcs_commit_status`, build the context as `terrapod/<workspace-name>` and pass it through to both `github_service.create_commit_status` and `gitlab_service.create_commit_status` (both already accept a `context` parameter).

Result: each linked workspace gets its own independently-tracked check row.

## Compatibility

The single-workspace case simply switches from context `terrapod` to `terrapod/<ws-name>`. Any branch protection rule that requires `terrapod` as a status check will need to be updated to match the new context. Call this out in release notes for v0.16.x.