### PR TITLE
fix(runner): guarantee log upload on every runner exit path

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -74,13 +74,16 @@ wait_for_child() {
     CHILD_PID=""
 }
 
-# --- Setup log capture ---
-# All output before terraform/tofu execution is captured so it can be
-# included in the uploaded log artifact (visible in the UI after the
-# live pod log stream ends).
-SETUP_LOG="/tmp/setup.log"
-: > "$SETUP_LOG"
-log() { echo "$@" | tee -a "$SETUP_LOG"; }
+# --- Combined log capture ---
+# All script output (setup + init + plan + apply) accumulates into a single
+# file that an EXIT trap uploads at the end, regardless of where the script
+# exits (early bin-download failure, init failure, plan failure, SIGTERM,
+# clean success). This replaces the previous pattern of per-checkpoint
+# `curl -sSf … || true` uploads that silently dropped logs whenever the
+# script exited before reaching a checkpoint.
+COMBINED_LOG="/tmp/combined.log"
+: > "$COMBINED_LOG"
+log() { echo "$@" | tee -a "$COMBINED_LOG"; }
 
 # --- Configuration ---
 TP_BACKEND="${TP_BACKEND:-terraform}"
@@ -90,6 +93,9 @@ TP_PHASE="${TP_PHASE:-plan}"
 # be several MB and the old 10s cap routinely timed out under normal network
 # conditions. Small status POSTs keep their tighter local timeouts.
 TP_UPLOAD_TIMEOUT="${TP_UPLOAD_TIMEOUT:-60}"
+# Artifact name used by upload_log() — set to "apply" when we enter the apply
+# phase so the trap writes to /artifacts/apply-log. Default is "plan".
+UPLOAD_PHASE="${TP_PHASE:-plan}"
 WORK_DIR="/workspace"
 
 mkdir -p "$WORK_DIR"
@@ -97,6 +103,42 @@ cd "$WORK_DIR"
 
 # Auth header for all API calls
 AUTH_HEADER="Authorization: Bearer $TP_AUTH_TOKEN"
+
+# --- Guaranteed log upload on exit ---
+# upload_log and an EXIT trap ensure the combined log is uploaded on every
+# exit path. Retries with linear backoff; on final failure, writes a FATAL
+# marker to the pod's own stdout/stderr so at minimum the pod log shows the
+# upload failed (visible via kubectl logs). Always returns 0 so the trap
+# never disturbs the script's real exit code.
+upload_log() {
+    _artifact="${UPLOAD_PHASE}-log"
+    if [ -z "$TP_API_URL" ] || [ -z "$TP_RUN_ID" ] || [ ! -s "$COMBINED_LOG" ]; then
+        return 0
+    fi
+    _i=1
+    while [ "$_i" -le 3 ]; do
+        if curl -sSf --max-time 30 -X PUT \
+             -H "$AUTH_HEADER" \
+             -H "Content-Type: application/octet-stream" \
+             --data-binary @"$COMBINED_LOG" \
+             "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/${_artifact}" \
+             >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep "$((_i * 2))"
+        _i=$((_i + 1))
+    done
+    _size=$(wc -c < "$COMBINED_LOG" 2>/dev/null || echo 0)
+    echo "[entrypoint] FATAL: log upload failed after 3 attempts (artifact=${_artifact}, size=${_size}B, run=${TP_RUN_ID})" >&2
+    return 0
+}
+
+on_exit() {
+    _rc=$?
+    upload_log || true
+    exit "$_rc"
+}
+trap on_exit EXIT
 
 # --- Redirect-aware curl wrapper ---
 # API endpoints return 302 redirects to presigned URLs. For cloud storage
@@ -310,16 +352,10 @@ log "[entrypoint] Running $TP_BACKEND init..."
 INIT_EXIT=0
 "$TP_BIN" init -input=false > /tmp/init.log 2>&1 || INIT_EXIT=$?
 cat /tmp/init.log
+cat /tmp/init.log >> "$COMBINED_LOG"
 if [ "$INIT_EXIT" != "0" ]; then
     log "[entrypoint] Init failed with exit code $INIT_EXIT"
-    # Upload setup + init output as plan log so it's visible in the UI
-    if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
-        cat "$SETUP_LOG" /tmp/init.log > /tmp/plan-full.log 2>/dev/null
-        curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary @/tmp/plan-full.log \
-            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/plan-log" || true
-    fi
+    # Log uploaded by on_exit trap — no explicit upload here.
     exit "$INIT_EXIT"
 fi
 
@@ -408,16 +444,10 @@ if [ "$TP_PHASE" = "plan" ]; then
             "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/plan-result" || true
     fi
 
-    # Upload plan log (best-effort) — prepend setup + init output so the full log is visible
-    if [ -n "$TP_API_URL" ] && [ -f /tmp/plan.log ]; then
-        cat "$SETUP_LOG" /tmp/init.log /tmp/plan.log > /tmp/plan-full.log 2>/dev/null
-        curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary @/tmp/plan-full.log \
-            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/plan-log" || true
-    fi
+    # Append plan.log to combined; on_exit trap uploads the combined log.
+    [ -f /tmp/plan.log ] && cat /tmp/plan.log >> "$COMBINED_LOG"
 
-    # Upload plan file (best-effort)
+    # Upload plan file (best-effort) — separate artifact, not a log.
     if [ -n "$TP_API_URL" ] && [ -f tfplan ]; then
         curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
@@ -426,6 +456,9 @@ if [ "$TP_PHASE" = "plan" ]; then
     fi
 
 elif [ "$TP_PHASE" = "apply" ]; then
+    # From here on, the trap uploads to /artifacts/apply-log rather than plan-log.
+    UPLOAD_PHASE="apply"
+
     # Download plan file from plan phase
     if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
         log "[entrypoint] Downloading plan file from plan phase..."
@@ -448,15 +481,8 @@ elif [ "$TP_PHASE" = "apply" ]; then
     wait_for_child
     kill "$TAIL_PID" 2>/dev/null; wait "$TAIL_PID" 2>/dev/null || true
 
-    # Upload apply log (best-effort, bounded by --max-time) — prepend setup + init output
-    if [ -n "$TP_API_URL" ] && [ -f /tmp/apply.log ]; then
-        cat "$SETUP_LOG" /tmp/init.log /tmp/apply.log > /tmp/apply-full.log 2>/dev/null
-        curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary @/tmp/apply-full.log \
-            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/apply-log" || \
-            echo "[entrypoint] WARNING: apply log upload failed"
-    fi
+    # Append apply.log to combined; on_exit trap uploads the combined log.
+    [ -f /tmp/apply.log ] && cat /tmp/apply.log >> "$COMBINED_LOG"
 
     # Upload new state (FATAL — missing state = infrastructure/state divergence)
     if [ -n "$TP_API_URL" ] && [ -f terraform.tfstate ]; then

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -580,8 +580,20 @@ class RunnerListener:
             )
             if not logs:
                 return
-        except Exception:
-            return  # Pod may not have logs yet
+        except Exception as e:
+            # Pod may not have logs yet (container still starting) — this is
+            # expected for the first few events after Job launch. But we MUST
+            # log so that repeated failures are diagnosable; previously this
+            # was a bare `except: return` which silenced permanent failures
+            # (auth, RBAC, wrong namespace, etc.) indistinguishably from the
+            # benign "logs not ready" case.
+            logger.debug(
+                "Failed to read pod logs (may be starting up)",
+                run_id=run_id,
+                job=job_name,
+                error=str(e),
+            )
+            return
 
         # Encode once — avoid holding both str and bytes simultaneously
         log_bytes = logs.encode() if isinstance(logs, str) else logs
@@ -598,8 +610,17 @@ class RunnerListener:
                     "Content-Type": "application/octet-stream",
                 },
             )
-        except Exception:
-            pass  # Best-effort log streaming
+        except Exception as e:
+            # Best-effort log streaming — runner-entrypoint uploads the full
+            # combined log via the on_exit trap, so live-stream failure isn't
+            # fatal. But log it at warning: if this happens every cycle we
+            # want it surfaced, not silently swallowed.
+            logger.warning(
+                "Failed to PUT log stream",
+                run_id=run_id,
+                job=job_name,
+                error=str(e),
+            )
 
     async def _handle_cancel_job(self, data: dict) -> None:
         """Delete a K8s Job for a canceled run."""


### PR DESCRIPTION
## Problem

Runner logs failed to appear in the Terrapod UX for two runs today — both pods ran and errored (exit 22 on a nonexistent tofu 1.12 tarball; exit 1 on a git module fetch with `No user exists for uid 1000`), and their logs were clearly available via `kubectl logs`, but `/artifacts/plan-log` was empty on the API side.

Root cause: the entrypoint uploaded logs only at specific checkpoints — after `init` succeeds/fails, after `plan` finishes, after `apply` finishes. Each upload was `curl -sSf ... || true`, so failures silently dropped, and any exit *before* a checkpoint (binary download, config fetch, signal, an unrelated `set -e` trigger) skipped upload entirely.

This is at least the second time we've had to fix log-loss. This time we want an invariant rather than another checkpoint.

## Fix — entrypoint

Collapse the three per-checkpoint uploads into one `EXIT` trap that fires on every exit path:

- `COMBINED_LOG=/tmp/combined.log` accumulates every piece of output (setup + init + plan + apply) as each phase completes.
- `upload_log()` PUTs the combined log to `/artifacts/{plan,apply}-log` with 3 retries + linear backoff; final failure prints a `FATAL` line to stderr so the pod log still shows that upload died.
- `on_exit` captures `$?` before calling `upload_log`, then re-`exit`s with the original code — the K8s Job's exit status remains truthful (reconciler/UX still see `exit 1` vs `exit 22` vs `exit 137`).
- `UPLOAD_PHASE` flips to `apply` at the top of the apply branch so the same trap writes to the correct artifact URL.

Works on every exit path: early binary-download failure, init failure, plan failure, apply failure, `SIGTERM`, even `set -e` killing the script somewhere unexpected.

## Fix — listener

`_handle_stream_logs` had two bare `except: return/pass` blocks that made permanent failures (RBAC, wrong namespace, API 5xx) indistinguishable from the benign "pod still starting" case. Both now log — `debug` for the K8s read (noisy when pods are starting, but visible with log-level bump) and `warning` for the PUT back (genuinely unexpected, should never be silent).

With the entrypoint trap guarantee, live-stream failures are no longer fatal to log visibility — they're defence-in-depth. But we still want diagnostic signal when they happen repeatedly.

## Compatibility

- No public API change. No chart change. Just runner image + listener image.
- Existing live-stream path continues to work when SSE is healthy — the trap uploads at exit.  The reconciler's `_persist_live_log_if_missing` becomes a third-line fallback rather than the primary path.

## Test plan

- Release v0.16.4 and redeploy to mgmt via wrapper chart bump.
- Re-queue the stuck `sls-*` runs — first plan should fail to download a module (unrelated issue) but the **log should appear in the UX** showing exactly that failure.