### PR TITLE
fix(listener): re-join on 404 from listener-scoped endpoints

### DIFF
--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -322,7 +322,21 @@ class RunnerListener:
                 await self._sse_connect()
                 consecutive_401s = 0  # successful connection resets counter
             except httpx.HTTPStatusError as e:
-                if e.response.status_code == 401:
+                if e.response.status_code == 404:
+                    # API doesn't recognise our listener-id: Redis TTL expired
+                    # (e.g. during an API outage). Immediate re-join — 404 is
+                    # unambiguous, unlike a single 401 flap.
+                    logger.warning(
+                        "Listener ID unknown to API (stale registration) — re-joining",
+                        listener_id=str(self.identity.listener_id),
+                    )
+                    try:
+                        await self._rejoin()
+                        consecutive_401s = 0
+                        continue
+                    except Exception as rejoin_err:
+                        logger.error("Re-join failed", error=str(rejoin_err))
+                elif e.response.status_code == 401:
                     consecutive_401s += 1
                     if consecutive_401s >= _REJOIN_THRESHOLD:
                         try:
@@ -396,6 +410,10 @@ class RunnerListener:
         drop or buffer the connection. This loop ensures bounded worst-case
         latency (~30s) by periodically checking for available work regardless
         of SSE state.
+
+        A 404 from a listener-scoped endpoint means the API no longer has our
+        registration (Redis TTL expired during an outage) — triggers re-join
+        to recover a fresh identity without requiring a pod restart.
         """
         while not _shutdown.is_set():
             try:
@@ -406,6 +424,18 @@ class RunnerListener:
 
             try:
                 await self._handle_run_available()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    logger.warning(
+                        "Listener ID unknown to API (stale registration) — re-joining",
+                        listener_id=str(self.identity.listener_id),
+                    )
+                    try:
+                        await self._rejoin()
+                    except Exception as rejoin_err:
+                        logger.error("Re-join failed", error=str(rejoin_err))
+                else:
+                    logger.warning("Poll fallback failed", error=str(e))
             except Exception as e:
                 logger.warning("Poll fallback failed", error=str(e))
 


### PR DESCRIPTION
## Problem

When the mgmt Terrapod API was unavailable long enough for Redis listener registrations to expire (300s TTL), listener pods kept polling `/api/v2/listeners/{id}/runs/next` with their pre-outage listener-id and got `404 Not Found` every time. They never re-registered. Runs queued for those pools sat in `queued` forever.

Observed today on `mai-dev-us1-services1-terrapod-listener`: a run queued at 08:42 was still `queued` at 09:52, and the listener log showed the same 404 every ~30s for the same stale ID. Restarting the listener deployment fixed it — listener went through a fresh join, got a new ID, and the queued run was claimed within seconds.

## Root cause

`services/terrapod/runner/listener.py`:

- `_sse_loop` re-joined on consecutive `401` (cert rejected) but not on `404` (ID unknown).
- `_poll_loop` (SSE fallback) logged 404 at warning and retried with the same stale ID, forever.

Symmetry gap: both 401 and 404 mean "this identity is no longer valid, get a new one," but only 401 triggered re-join.

## Fix

Treat 404 on listener-scoped endpoints as a stale-identity signal and trigger `_rejoin()` in both loops. Immediate rather than threshold-gated, because 404 is unambiguous (unlike a single 401 flap which could be a transient cert issue).

## Test

Can't easily reproduce the Redis TTL expiry condition in CI. Manually validated during the incident:

1. mai-dev-us1 listener in the broken state: run `019db980` queued for 70 min, listener logs 404 every 30s.
2. Before this fix I had to `kubectl rollout restart` the deployment to unstick it.
3. With this fix, the listener would self-heal — no manual intervention required.

Closes #226.