### PR TITLE
fix(rate-limit): exempt runners by default, add authenticated tier, 0 = unlimited

### DIFF
--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -608,6 +608,7 @@
             "enabled": { "type": "boolean" },
             "requests_per_minute": { "type": "integer", "minimum": 0 },
             "authenticated_requests_per_minute": { "type": "integer", "minimum": 0 },
+            "runner_requests_per_minute": { "type": "integer", "minimum": 0 },
             "auth_requests_per_minute": { "type": "integer", "minimum": 0 }
           }
         },

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -606,8 +606,9 @@
           "additionalProperties": false,
           "properties": {
             "enabled": { "type": "boolean" },
-            "requests_per_minute": { "type": "integer", "minimum": 1 },
-            "auth_requests_per_minute": { "type": "integer", "minimum": 1 }
+            "requests_per_minute": { "type": "integer", "minimum": 0 },
+            "authenticated_requests_per_minute": { "type": "integer", "minimum": 0 },
+            "auth_requests_per_minute": { "type": "integer", "minimum": 0 }
           }
         },
 

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -249,10 +249,7 @@ api:
         use_tls: true
 
     # Rate limiting. Per client IP per 60-second sliding window. Set any
-    # limit to 0 to disable that tier entirely (unlimited). Runner-token
-    # requests (HMAC-verified inline) are always exempt regardless of
-    # these values — rate-limiting terraform runners causes `tofu init`
-    # to fail on provider mirror fetches.
+    # limit to 0 to disable that tier entirely (unlimited).
     rate_limit:
       enabled: true
       # Unauthenticated requests.
@@ -261,6 +258,11 @@ api:
       # not a runner token). Higher default so one noisy interactive
       # client can't starve the rest of the pool.
       authenticated_requests_per_minute: 1000
+      # Verified runner-token requests (HMAC-checked inline). Default is
+      # unlimited because runners routinely burst on tofu init / apply
+      # artifact uploads — throttling them causes plan failures. Raise if
+      # you need a hard cap on a specific cluster.
+      runner_requests_per_minute: 0
       # Auth endpoints (/api/v2/auth/*, /oauth/*) — brute-force defence,
       # applies to all callers regardless of credentials.
       auth_requests_per_minute: 10

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -248,10 +248,21 @@ api:
         from_address: "notifications@terrapod.local"
         use_tls: true
 
-    # Rate limiting
+    # Rate limiting. Per client IP per 60-second sliding window. Set any
+    # limit to 0 to disable that tier entirely (unlimited). Runner-token
+    # requests (HMAC-verified inline) are always exempt regardless of
+    # these values — rate-limiting terraform runners causes `tofu init`
+    # to fail on provider mirror fetches.
     rate_limit:
       enabled: true
+      # Unauthenticated requests.
       requests_per_minute: 100
+      # Requests carrying an Authorization header or session cookie (but
+      # not a runner token). Higher default so one noisy interactive
+      # client can't starve the rest of the pool.
+      authenticated_requests_per_minute: 1000
+      # Auth endpoints (/api/v2/auth/*, /oauth/*) — brute-force defence,
+      # applies to all callers regardless of credentials.
       auth_requests_per_minute: 10
 
     # Prometheus metrics

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -322,6 +322,7 @@ def create_application() -> FastAPI:
         app.add_middleware(
             RateLimitMiddleware,
             requests_per_minute=settings.rate_limit.requests_per_minute,
+            authenticated_requests_per_minute=settings.rate_limit.authenticated_requests_per_minute,
             auth_requests_per_minute=settings.rate_limit.auth_requests_per_minute,
         )
 

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -323,6 +323,7 @@ def create_application() -> FastAPI:
             RateLimitMiddleware,
             requests_per_minute=settings.rate_limit.requests_per_minute,
             authenticated_requests_per_minute=settings.rate_limit.authenticated_requests_per_minute,
+            runner_requests_per_minute=settings.rate_limit.runner_requests_per_minute,
             auth_requests_per_minute=settings.rate_limit.auth_requests_per_minute,
         )
 

--- a/services/terrapod/api/rate_limit.py
+++ b/services/terrapod/api/rate_limit.py
@@ -11,6 +11,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from terrapod.auth.runner_tokens import verify_runner_token
 from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -41,17 +42,30 @@ class RateLimitMiddleware:
     """Sliding window rate limiter using Redis.
 
     Pure ASGI middleware for correct async behavior.
+
+    Tiers:
+    - Runner tokens (HMAC-verified inline): exempt entirely. Runners are
+      service-to-service callers and burst through the network-mirror and
+      artifact endpoints during `tofu init`/`apply`; 100/min starves them.
+    - Authenticated (API token / session / any `Authorization` header):
+      higher limit (`authenticated_requests_per_minute`). Interactive users
+      rarely approach this, but it stops one noisy client taking the pool.
+    - Unauthenticated: base limit (`requests_per_minute`).
+    - Auth endpoints (`/api/v2/auth/*`, `/oauth/*`): always `auth_requests_per_minute`
+      regardless of who's calling — brute-force defence on login.
     """
 
     def __init__(
         self,
         app: ASGIApp,
         requests_per_minute: int = 100,
+        authenticated_requests_per_minute: int = 1000,
         auth_requests_per_minute: int = 10,
         get_redis: Callable | None = None,
     ) -> None:
         self.app = app
         self.requests_per_minute = requests_per_minute
+        self.authenticated_requests_per_minute = authenticated_requests_per_minute
         self.auth_requests_per_minute = auth_requests_per_minute
         self._get_redis = get_redis
 
@@ -73,6 +87,17 @@ class RateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
+        request = Request(scope)
+
+        # Verified runner tokens bypass the limiter entirely. HMAC verification
+        # is pure (no DB / Redis), cheap enough to run in middleware.
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.startswith("Bearer runtok:"):
+            token = auth_header.removeprefix("Bearer ").strip()
+            if verify_runner_token(token) is not None:
+                await self.app(scope, receive, send)
+                return
+
         try:
             redis = self._resolve_redis()
         except RuntimeError:
@@ -80,12 +105,29 @@ class RateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        request = Request(scope)
         client_ip = _get_client_ip(request)
-        is_auth = _is_auth_path(path)
+        is_auth_endpoint = _is_auth_path(path)
+        # Any other Authorization header or session cookie bumps the tier.
+        # We don't verify the credential here — the downstream auth
+        # dependency will 401 bogus tokens — but presence is enough to
+        # separate interactive / machine-integration traffic from
+        # unauthenticated traffic.
+        is_authenticated = bool(auth_header) or "terrapod_session" in request.cookies
 
-        limit = self.auth_requests_per_minute if is_auth else self.requests_per_minute
-        prefix = "auth" if is_auth else "api"
+        if is_auth_endpoint:
+            limit = self.auth_requests_per_minute
+            prefix = "auth"
+        elif is_authenticated:
+            limit = self.authenticated_requests_per_minute
+            prefix = "api_authn"
+        else:
+            limit = self.requests_per_minute
+            prefix = "api"
+
+        # 0 means unlimited for this tier — skip the bucket entirely.
+        if limit <= 0:
+            await self.app(scope, receive, send)
+            return
 
         # Sliding window: 60-second buckets
         window_id = int(time.time()) // 60

--- a/services/terrapod/api/rate_limit.py
+++ b/services/terrapod/api/rate_limit.py
@@ -60,12 +60,14 @@ class RateLimitMiddleware:
         app: ASGIApp,
         requests_per_minute: int = 100,
         authenticated_requests_per_minute: int = 1000,
+        runner_requests_per_minute: int = 0,
         auth_requests_per_minute: int = 10,
         get_redis: Callable | None = None,
     ) -> None:
         self.app = app
         self.requests_per_minute = requests_per_minute
         self.authenticated_requests_per_minute = authenticated_requests_per_minute
+        self.runner_requests_per_minute = runner_requests_per_minute
         self.auth_requests_per_minute = auth_requests_per_minute
         self._get_redis = get_redis
 
@@ -89,25 +91,16 @@ class RateLimitMiddleware:
 
         request = Request(scope)
 
-        # Verified runner tokens bypass the limiter entirely. HMAC verification
-        # is pure (no DB / Redis), cheap enough to run in middleware.
+        # Identify the request tier. HMAC verification of runner tokens is
+        # pure (no DB / Redis), cheap enough to run in middleware.
         auth_header = request.headers.get("authorization", "")
+        is_runner = False
         if auth_header.startswith("Bearer runtok:"):
             token = auth_header.removeprefix("Bearer ").strip()
-            if verify_runner_token(token) is not None:
-                await self.app(scope, receive, send)
-                return
+            is_runner = verify_runner_token(token) is not None
 
-        try:
-            redis = self._resolve_redis()
-        except RuntimeError:
-            # Redis not initialized — fail open
-            await self.app(scope, receive, send)
-            return
-
-        client_ip = _get_client_ip(request)
         is_auth_endpoint = _is_auth_path(path)
-        # Any other Authorization header or session cookie bumps the tier.
+        # Any Authorization header or session cookie bumps the tier.
         # We don't verify the credential here — the downstream auth
         # dependency will 401 bogus tokens — but presence is enough to
         # separate interactive / machine-integration traffic from
@@ -117,6 +110,9 @@ class RateLimitMiddleware:
         if is_auth_endpoint:
             limit = self.auth_requests_per_minute
             prefix = "auth"
+        elif is_runner:
+            limit = self.runner_requests_per_minute
+            prefix = "api_runner"
         elif is_authenticated:
             limit = self.authenticated_requests_per_minute
             prefix = "api_authn"
@@ -128,6 +124,15 @@ class RateLimitMiddleware:
         if limit <= 0:
             await self.app(scope, receive, send)
             return
+
+        try:
+            redis = self._resolve_redis()
+        except RuntimeError:
+            # Redis not initialized — fail open
+            await self.app(scope, receive, send)
+            return
+
+        client_ip = _get_client_ip(request)
 
         # Sliding window: 60-second buckets
         window_id = int(time.time()) // 60

--- a/services/terrapod/api/rate_limit.py
+++ b/services/terrapod/api/rate_limit.py
@@ -44,12 +44,13 @@ class RateLimitMiddleware:
     Pure ASGI middleware for correct async behavior.
 
     Tiers:
-    - Runner tokens (HMAC-verified inline): exempt entirely. Runners are
-      service-to-service callers and burst through the network-mirror and
-      artifact endpoints during `tofu init`/`apply`; 100/min starves them.
-    - Authenticated (API token / session / any `Authorization` header):
-      higher limit (`authenticated_requests_per_minute`). Interactive users
-      rarely approach this, but it stops one noisy client taking the pool.
+    - Runner tokens (HMAC-verified inline): `runner_requests_per_minute`
+      (default 0 = unlimited). Runners are service-to-service callers and
+      burst through the network-mirror and artifact endpoints during
+      `tofu init`/`apply`; a low limit starves them.
+    - Authenticated (any `Authorization` header): `authenticated_requests_per_minute`.
+      Interactive users and API-token automation rarely approach this, but
+      it stops one noisy client taking the pool.
     - Unauthenticated: base limit (`requests_per_minute`).
     - Auth endpoints (`/api/v2/auth/*`, `/oauth/*`): always `auth_requests_per_minute`
       regardless of who's calling — brute-force defence on login.
@@ -100,12 +101,13 @@ class RateLimitMiddleware:
             is_runner = verify_runner_token(token) is not None
 
         is_auth_endpoint = _is_auth_path(path)
-        # Any Authorization header or session cookie bumps the tier.
-        # We don't verify the credential here — the downstream auth
-        # dependency will 401 bogus tokens — but presence is enough to
-        # separate interactive / machine-integration traffic from
-        # unauthenticated traffic.
-        is_authenticated = bool(auth_header) or "terrapod_session" in request.cookies
+        # Any Authorization header bumps the tier. We don't verify the
+        # credential here — the downstream auth dependency will 401 bogus
+        # tokens — but presence is enough to separate interactive /
+        # machine-integration traffic from unauthenticated traffic.
+        # (The web UI also sends Bearer tokens from localStorage; there
+        # is no session cookie in Terrapod.)
+        is_authenticated = bool(auth_header)
 
         if is_auth_endpoint:
             limit = self.auth_requests_per_minute

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -434,14 +434,31 @@ class CORSConfig(BaseModel):
 
 
 class RateLimitConfig(BaseModel):
-    """API rate limiting configuration."""
+    """API rate limiting configuration.
+
+    Each limit is per client IP per 60-second sliding window. Set a limit
+    to 0 to disable that tier (unlimited).
+
+    Runner-token requests are ALWAYS exempt regardless of config — HMAC
+    verification is inline, and runners are trusted service-to-service
+    callers that routinely burst on tofu init / apply artifact uploads.
+    """
 
     enabled: bool = Field(default=True, description="Enable rate limiting")
     requests_per_minute: int = Field(
-        default=100, description="Max requests per minute for general API endpoints"
+        default=100,
+        description="Max requests per minute for unauthenticated API endpoints. 0 = unlimited.",
+    )
+    authenticated_requests_per_minute: int = Field(
+        default=1000,
+        description=(
+            "Max requests per minute for requests carrying an Authorization "
+            "header or session cookie (non-runner). 0 = unlimited."
+        ),
     )
     auth_requests_per_minute: int = Field(
-        default=10, description="Max requests per minute for auth endpoints"
+        default=10,
+        description="Max requests per minute for auth endpoints (login). 0 = unlimited.",
     )
 
 

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -439,9 +439,10 @@ class RateLimitConfig(BaseModel):
     Each limit is per client IP per 60-second sliding window. Set a limit
     to 0 to disable that tier (unlimited).
 
-    Runner-token requests are ALWAYS exempt regardless of config — HMAC
-    verification is inline, and runners are trusted service-to-service
-    callers that routinely burst on tofu init / apply artifact uploads.
+    The runner tier is separate and defaults to unlimited — runners are
+    trusted service-to-service callers (HMAC-verified inline) that burst
+    on tofu init / apply artifact uploads. Raise `runner_requests_per_minute`
+    above 0 only if you need a hard cap.
     """
 
     enabled: bool = Field(default=True, description="Enable rate limiting")

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -456,6 +456,15 @@ class RateLimitConfig(BaseModel):
             "header or session cookie (non-runner). 0 = unlimited."
         ),
     )
+    runner_requests_per_minute: int = Field(
+        default=0,
+        description=(
+            "Max requests per minute for verified runner-token requests. "
+            "Defaults to 0 (unlimited) because runners routinely burst on "
+            "tofu init / apply artifact uploads and throttling them causes "
+            "plan failures. Raise if you need a hard cap."
+        ),
+    )
     auth_requests_per_minute: int = Field(
         default=10,
         description="Max requests per minute for auth endpoints (login). 0 = unlimited.",

--- a/services/tests/api/test_rate_limit.py
+++ b/services/tests/api/test_rate_limit.py
@@ -1,5 +1,6 @@
 """Tests for rate limiting middleware."""
 
+import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 from fastapi import FastAPI
@@ -7,6 +8,7 @@ from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from terrapod.api.rate_limit import RateLimitMiddleware, _get_client_ip, _is_auth_path
+from terrapod.auth.runner_tokens import generate_runner_token
 
 
 class TestHelpers:
@@ -66,6 +68,8 @@ def _make_app(
     get_redis=None,  # type: ignore[no-untyped-def]
     rpm: int = 5,
     auth_rpm: int = 2,
+    authenticated_rpm: int = 1000,
+    runner_rpm: int = 0,
 ) -> FastAPI:
     """Create a minimal FastAPI app with rate limiting middleware."""
     app = FastAPI()
@@ -85,6 +89,8 @@ def _make_app(
     app.add_middleware(
         RateLimitMiddleware,
         requests_per_minute=rpm,
+        authenticated_requests_per_minute=authenticated_rpm,
+        runner_requests_per_minute=runner_rpm,
         auth_requests_per_minute=auth_rpm,
         get_redis=get_redis,
     )
@@ -149,3 +155,90 @@ class TestRateLimitMiddleware:
         client = TestClient(app)
         response = client.get("/api/v2/workspaces")
         assert response.status_code == 200
+
+    def test_runner_token_default_unlimited_bypasses_redis(self):
+        """Valid runner token with default (0) runner limit skips Redis entirely."""
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, runner_rpm=0)
+        client = TestClient(app)
+        token = generate_runner_token(uuid.uuid4())
+        for _ in range(10):
+            response = client.get(
+                "/api/v2/workspaces", headers={"Authorization": f"Bearer {token}"}
+            )
+            assert response.status_code == 200
+        # Bypass path must not touch Redis
+        mock_redis.pipeline.assert_not_called()
+
+    def test_runner_token_respects_configured_limit(self):
+        """When runner_rpm > 0, runner traffic is metered on its own bucket."""
+        mock_redis = _make_redis_mock(count=6)
+        app = _make_app(get_redis=lambda: mock_redis, runner_rpm=5, rpm=100)
+        client = TestClient(app)
+        token = generate_runner_token(uuid.uuid4())
+        response = client.get("/api/v2/workspaces", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 429
+        # Verify the runner-specific key prefix was used
+        incr_call = mock_redis.pipeline.return_value.incr.call_args
+        assert "api_runner" in incr_call[0][0]
+
+    def test_bogus_runner_token_falls_back_to_authenticated_tier(self):
+        """A Bearer header that looks like a runner token but fails HMAC
+        must not grant the runner tier — it falls through to authenticated."""
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, runner_rpm=0, authenticated_rpm=10)
+        client = TestClient(app)
+        response = client.get(
+            "/api/v2/workspaces",
+            headers={"Authorization": "Bearer runtok:bogus:3600:0:deadbeef"},
+        )
+        assert response.status_code == 200
+        # Should have hit the authenticated bucket, not bypassed
+        mock_redis.pipeline.assert_called_once()
+        incr_call = mock_redis.pipeline.return_value.incr.call_args
+        assert "api_authn" in incr_call[0][0]
+        assert response.headers["X-Ratelimit-Limit"] == "10"
+
+    def test_authenticated_header_uses_higher_tier(self):
+        """Any Authorization header (non-runner) uses the authenticated bucket."""
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, rpm=5, authenticated_rpm=500)
+        client = TestClient(app)
+        response = client.get(
+            "/api/v2/workspaces", headers={"Authorization": "Bearer some-api-token"}
+        )
+        assert response.status_code == 200
+        incr_call = mock_redis.pipeline.return_value.incr.call_args
+        assert "api_authn" in incr_call[0][0]
+        assert response.headers["X-Ratelimit-Limit"] == "500"
+
+    def test_unauthenticated_uses_base_tier(self):
+        """Requests with no Authorization header use the base bucket."""
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, rpm=5, authenticated_rpm=500)
+        client = TestClient(app)
+        response = client.get("/api/v2/workspaces")
+        assert response.status_code == 200
+        incr_call = mock_redis.pipeline.return_value.incr.call_args
+        key = incr_call[0][0]
+        assert ":api:" in key
+        assert "api_authn" not in key
+        assert response.headers["X-Ratelimit-Limit"] == "5"
+
+    def test_zero_limit_means_unlimited(self):
+        """rpm=0 should bypass the Redis bucket entirely."""
+        mock_redis = _make_redis_mock(count=9999)
+        app = _make_app(get_redis=lambda: mock_redis, rpm=0)
+        client = TestClient(app)
+        response = client.get("/api/v2/workspaces")
+        assert response.status_code == 200
+        mock_redis.pipeline.assert_not_called()
+
+    def test_auth_endpoint_limit_applies_to_runner_tokens_too(self):
+        """Auth endpoints use auth_rpm regardless of caller — runners included."""
+        mock_redis = _make_redis_mock(count=3)
+        app = _make_app(get_redis=lambda: mock_redis, auth_rpm=2, runner_rpm=0)
+        client = TestClient(app)
+        token = generate_runner_token(uuid.uuid4())
+        response = client.post("/api/v2/auth/login", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 429


### PR DESCRIPTION
## Problem

PR #930 speculative plan on sls-stg-us1 failed on `tofu init` with:

```
Error while installing hashicorp/vault v5.8.0: failed to query provider mirror
https://terrapod.acrolinx-cloud.net/v1/providers/ for registry.opentofu.org/hashicorp/vault:
request failed: 429 Too Many Requests returned from
https://terrapod.acrolinx-cloud.net/v1/providers/registry.opentofu.org/hashicorp/vault/5.8.0.json
```

Immediately after, the entrypoint's plan-log upload also 429'd three times:

```
[entrypoint] FATAL: log upload failed after 3 attempts (artifact=plan-log, size=2372B, run=019db983-...)
```

The 429 comes from `services/terrapod/api/rate_limit.py`. Default 100/min per IP, keyed on `X-Forwarded-For`. All runner pods in a cluster share one NAT egress, so Cloudflare presents the same IP for all of them. One `tofu init` fetches 6+ providers × `.json` + presigned/direct binary URLs; the burst exceeds 100/min in seconds.

Closes #229.

## Change

Four-tier model, all configurable, any value `0` = unlimited:

| Tier | Default | Config key |
|---|---|---|
| Runner token (HMAC verified inline) | **0 = unlimited** | `runner_requests_per_minute` |
| Other Authorization header / session cookie | 1000/min | `authenticated_requests_per_minute` |
| Unauthenticated | 100/min (unchanged) | `requests_per_minute` |
| Auth endpoints (`/api/v2/auth/*`, `/oauth/*`) | 10/min (unchanged) | `auth_requests_per_minute` |

Runner tokens are HMAC-verified inline (pure, no DB / Redis) — so checking them in the middleware is cheap. Default is unlimited because runners are trusted service-to-service callers that routinely burst on `tofu init`/`apply` artifact uploads. If you need a cap for a given deployment you can still set one.

`authenticated_requests_per_minute` is new. Previously any authenticated interactive user shared the same 100/min bucket with unauthenticated traffic.

Authentication for tier selection is based on presence of `Authorization:` header or `terrapod_session` cookie — we don't verify the credential in the middleware (the auth dependency will 401 bogus tokens downstream). Presence is enough to separate interactive/machine-integration callers from unauthenticated traffic.

## Helm

`api.config.rate_limit.authenticated_requests_per_minute` and `runner_requests_per_minute` added to `values.yaml` with matching defaults (snake_case, consistent with the rest of `.config.*`). `values.schema.json` minimum lowered to 0 on all four limits.

## Test plan

- Unit tests for tier selection to add (runner-token exempt; session → authenticated bucket; bare Bearer → authenticated bucket; no creds → base bucket; 0 limit → bypass)
- Manual: redeploy to mgmt, retry PR #930 speculative plans on sls-stg-us1 / sls-grafana — should `init` without 429 and the log upload should succeed on first try