### PR TITLE
feat(vcs): say "Has changes" / "No changes" on commit checks

### DIFF
--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -82,8 +82,21 @@ async def _enqueue_vcs_status(run: Run, target_status: str) -> None:
 
     Only meaningful for VCS-sourced runs (those with a commit SHA).
     Posts commit status and optionally PR comments back to the provider.
+
+    Drift-detection runs are skipped — their commit SHAs are the current
+    default-branch HEAD (already merged), and posting "Has changes" /
+    "No changes" statuses there would be noise on commits that aren't
+    under review.
+
+    `has_changes` is snapshotted into the payload so the dispatcher is
+    independent of DB-commit timing (the trigger enqueue happens in the
+    same transaction as the status transition, but the dispatcher in
+    another replica may consume the trigger before the commit lands).
     """
     from terrapod.services.scheduler import enqueue_trigger
+
+    if run.is_drift_detection:
+        return
 
     try:
         await enqueue_trigger(
@@ -92,6 +105,7 @@ async def _enqueue_vcs_status(run: Run, target_status: str) -> None:
                 "run_id": str(run.id),
                 "workspace_id": str(run.workspace_id),
                 "target_status": target_status,
+                "has_changes": run.has_changes,
             },
             dedup_key=f"vcs_status:{run.id}:{target_status}",
             dedup_ttl=60,

--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -200,12 +200,12 @@ async def handle_vcs_commit_status(payload: dict) -> None:
     run_id_str = payload.get("run_id", "")
     workspace_id_str = payload.get("workspace_id", "")
     target_status = payload.get("target_status", "")
-    # has_changes is tri-state — True / False / None. The `in payload`
-    # check distinguishes "payload didn't carry it" (fall back to DB) from
-    # "payload carried None" (truly unknown).
-    payload_has_changes: bool | None = None
-    if "has_changes" in payload:
-        payload_has_changes = payload["has_changes"]
+    # has_changes is tri-state (True / False / None). We need to tell
+    # "payload didn't carry the key" (fall back to DB) apart from
+    # "payload carried None" (truly unknown — skip the fallback). A
+    # sentinel captures this without leaking `object` into the type.
+    _UNSET: object = object()
+    payload_has_changes: bool | None | object = payload.get("has_changes", _UNSET)
 
     if not run_id_str or not workspace_id_str or not target_status:
         logger.warning("Incomplete VCS status payload", payload=payload)
@@ -254,7 +254,11 @@ async def handle_vcs_commit_status(payload: dict) -> None:
         # enqueued, so it's never stale. Only fall back to the DB value
         # when the payload omits the key (older enqueuers, or a replay
         # from a queue entry written by pre-fix code).
-        has_changes = payload_has_changes if "has_changes" in payload else run.has_changes
+        has_changes: bool | None = (
+            payload_has_changes  # type: ignore[assignment]
+            if payload_has_changes is not _UNSET
+            else run.has_changes
+        )
         github_state, gitlab_state, description = _resolve_status(
             target_status, run.plan_only, has_changes
         )

--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -46,14 +46,30 @@ _COMMENT_CACHE_PREFIX = "tp:vcs_comment:"
 _COMMENT_CACHE_TTL = 7 * 24 * 3600  # 7 days
 
 
-def _resolve_status(run_status: str, plan_only: bool) -> tuple[str, str, str]:
+def _resolve_status(
+    run_status: str, plan_only: bool, has_changes: bool | None = None
+) -> tuple[str, str, str]:
     """Map run status to (github_state, gitlab_state, description).
 
-    Special case: 'planned' status depends on whether the run is plan-only.
+    Plan-only 'planned' runs use the plan's has_changes flag to produce a
+    descriptive message ("Has changes" / "No changes") instead of the generic
+    "Plan finished". The check still reports success in both cases — only the
+    text differs. Non-plan-only 'planned' runs keep the awaiting-confirmation
+    pending state, annotated with has-changes when known. When has_changes
+    is None (older runs, pre-plan statuses) the description falls back to
+    the bare form.
     """
     if run_status == "planned":
+        # A no-op plan is effectively done — nothing to apply, nothing to
+        # confirm. Report success regardless of plan_only.
+        if has_changes is False:
+            return ("success", "success", "No changes")
         if plan_only:
+            if has_changes is True:
+                return ("success", "success", "Has changes")
             return ("success", "success", "Plan finished")
+        if has_changes is True:
+            return ("pending", "running", "Has changes, awaiting confirmation")
         return ("pending", "running", "Plan complete, awaiting confirmation")
     return _STATUS_MAP.get(run_status, ("pending", "pending", run_status))
 
@@ -68,7 +84,7 @@ def _build_comment_body(
     run_url: str,
 ) -> str:
     """Build the markdown body for a PR/MR comment."""
-    github_state, _, description = _resolve_status(run_status, plan_only)
+    github_state, _, description = _resolve_status(run_status, plan_only, has_changes)
     emoji = _STATUS_EMOJI.get(run_status, ":grey_question:")
 
     has_changes_line = ""
@@ -225,8 +241,12 @@ async def handle_vcs_commit_status(payload: dict) -> None:
 
         owner, repo = parsed
 
-        # Resolve status
-        github_state, gitlab_state, description = _resolve_status(target_status, run.plan_only)
+        # Resolve status. `has_changes` is set on the run by the runner
+        # when the plan finishes; None means unknown (pre-plan statuses,
+        # or older runs before the field existed).
+        github_state, gitlab_state, description = _resolve_status(
+            target_status, run.plan_only, run.has_changes
+        )
 
         # Build target URL
         target_url = ""

--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -83,31 +83,28 @@ def _build_comment_body(
     has_changes: bool | None,
     run_url: str,
 ) -> str:
-    """Build the markdown body for a PR/MR comment."""
+    """Build the markdown body for a PR/MR comment.
+
+    `has_changes` is consumed by ``_resolve_status`` to form the status
+    description ("Has changes" / "No changes"); we don't append a second
+    has-changes line, which used to be redundant with the description.
+    """
     github_state, _, description = _resolve_status(run_status, plan_only, has_changes)
     emoji = _STATUS_EMOJI.get(run_status, ":grey_question:")
 
-    has_changes_line = ""
-    if run_status == "planned" and has_changes is not None:
-        if has_changes:
-            has_changes_line = "Plan has changes — review in Terrapod."
-        else:
-            has_changes_line = "No changes detected."
-
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    lines = [
-        f"<!-- terrapod:ws:{workspace_id} -->",
-        f"### Terrapod — {workspace_name}",
-        "",
-        f"**Status:** {emoji} {description}",
-        f"**Run:** [{run_id}]({run_url})",
-    ]
-    if has_changes_line:
-        lines.append(has_changes_line)
-    lines += ["", f"*Updated {now}*"]
-
-    return "\n".join(lines)
+    return "\n".join(
+        [
+            f"<!-- terrapod:ws:{workspace_id} -->",
+            f"### Terrapod — {workspace_name}",
+            "",
+            f"**Status:** {emoji} {description}",
+            f"**Run:** [{run_id}]({run_url})",
+            "",
+            f"*Updated {now}*",
+        ]
+    )
 
 
 def _comment_marker(workspace_id: str) -> str:
@@ -194,10 +191,21 @@ async def handle_vcs_commit_status(payload: dict) -> None:
     """Handle a VCS commit status trigger.
 
     Posts commit status and optionally a PR/MR comment.
+
+    ``has_changes`` is expected to be present in the payload — the enqueuer
+    snapshots it at the moment of status transition so we don't depend on
+    when the run row's ``has_changes`` column lands in the DB (a trigger
+    consumed by another replica can otherwise outrun the commit).
     """
     run_id_str = payload.get("run_id", "")
     workspace_id_str = payload.get("workspace_id", "")
     target_status = payload.get("target_status", "")
+    # has_changes is tri-state — True / False / None. The `in payload`
+    # check distinguishes "payload didn't carry it" (fall back to DB) from
+    # "payload carried None" (truly unknown).
+    payload_has_changes: bool | None = None
+    if "has_changes" in payload:
+        payload_has_changes = payload["has_changes"]
 
     if not run_id_str or not workspace_id_str or not target_status:
         logger.warning("Incomplete VCS status payload", payload=payload)
@@ -241,11 +249,14 @@ async def handle_vcs_commit_status(payload: dict) -> None:
 
         owner, repo = parsed
 
-        # Resolve status. `has_changes` is set on the run by the runner
-        # when the plan finishes; None means unknown (pre-plan statuses,
-        # or older runs before the field existed).
+        # Prefer the payload-carried has_changes — it was snapshotted at
+        # the moment of the status transition, before the trigger was
+        # enqueued, so it's never stale. Only fall back to the DB value
+        # when the payload omits the key (older enqueuers, or a replay
+        # from a queue entry written by pre-fix code).
+        has_changes = payload_has_changes if "has_changes" in payload else run.has_changes
         github_state, gitlab_state, description = _resolve_status(
-            target_status, run.plan_only, run.has_changes
+            target_status, run.plan_only, has_changes
         )
 
         # Build target URL
@@ -298,7 +309,7 @@ async def handle_vcs_commit_status(payload: dict) -> None:
                 run_id=f"run-{run.id}",
                 run_status=target_status,
                 plan_only=run.plan_only,
-                has_changes=run.has_changes,
+                has_changes=has_changes,
                 run_url=run_url,
             )
             await _find_or_create_comment(

--- a/services/tests/services/test_vcs_status_dispatcher.py
+++ b/services/tests/services/test_vcs_status_dispatcher.py
@@ -1,6 +1,14 @@
 """Tests for VCS commit-status resolution — has-changes descriptions."""
 
-from terrapod.services.vcs_status_dispatcher import _resolve_status
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.services.vcs_status_dispatcher import (
+    _build_comment_body,
+    _resolve_status,
+)
 
 
 class TestResolveStatusPlanned:
@@ -59,3 +67,95 @@ class TestResolveStatusNonPlanned:
         gh, _, desc = _resolve_status("queued", plan_only=False, has_changes=None)
         assert gh == "pending"
         assert desc == "Waiting for runner"
+
+
+class TestBuildCommentBody:
+    """The PR comment body should not duplicate has-changes info — the
+    description line already carries it; a second sentence saying the
+    same thing is noise."""
+
+    def test_has_changes_description_and_no_duplicate_sentence(self):
+        body = _build_comment_body(
+            workspace_name="sls-prod-us1",
+            workspace_id=str(uuid.uuid4()),
+            run_id="run-abc",
+            run_status="planned",
+            plan_only=True,
+            has_changes=True,
+            run_url="https://terrapod.example/workspaces/x/runs/y",
+        )
+        assert "Has changes" in body
+        assert "review in Terrapod" not in body  # old redundant line
+        assert "No changes detected" not in body
+
+    def test_no_changes_description_and_no_duplicate_sentence(self):
+        body = _build_comment_body(
+            workspace_name="sls-prod-us1",
+            workspace_id=str(uuid.uuid4()),
+            run_id="run-abc",
+            run_status="planned",
+            plan_only=True,
+            has_changes=False,
+            run_url="https://terrapod.example/x",
+        )
+        assert "No changes" in body
+        assert "No changes detected" not in body  # old redundant line
+
+
+class TestEnqueueVcsStatus:
+    """_enqueue_vcs_status must carry has_changes in the payload (closing
+    the commit-vs-enqueue race) and must skip drift runs."""
+
+    @pytest.mark.asyncio
+    async def test_has_changes_put_in_payload(self):
+        from terrapod.services.run_service import _enqueue_vcs_status
+
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.workspace_id = uuid.uuid4()
+        run.has_changes = True
+        run.is_drift_detection = False
+
+        with patch("terrapod.services.scheduler.enqueue_trigger", new=AsyncMock()) as mock_enq:
+            await _enqueue_vcs_status(run, "planned")
+
+        mock_enq.assert_awaited_once()
+        # enqueue_trigger(name, payload, dedup_key=..., dedup_ttl=...)
+        _, payload = mock_enq.await_args.args
+        assert payload["has_changes"] is True
+        assert payload["target_status"] == "planned"
+
+    @pytest.mark.asyncio
+    async def test_has_changes_none_still_carried_in_payload(self):
+        """Payload should always carry the key — even when None — so the
+        dispatcher can distinguish 'explicitly unknown' from 'payload was
+        written by an older enqueuer that didn't carry it at all'."""
+        from terrapod.services.run_service import _enqueue_vcs_status
+
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.workspace_id = uuid.uuid4()
+        run.has_changes = None
+        run.is_drift_detection = False
+
+        with patch("terrapod.services.scheduler.enqueue_trigger", new=AsyncMock()) as mock_enq:
+            await _enqueue_vcs_status(run, "planning")
+
+        _, payload = mock_enq.await_args.args
+        assert "has_changes" in payload
+        assert payload["has_changes"] is None
+
+    @pytest.mark.asyncio
+    async def test_drift_runs_do_not_enqueue(self):
+        from terrapod.services.run_service import _enqueue_vcs_status
+
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.workspace_id = uuid.uuid4()
+        run.has_changes = True
+        run.is_drift_detection = True
+
+        with patch("terrapod.services.scheduler.enqueue_trigger", new=AsyncMock()) as mock_enq:
+            await _enqueue_vcs_status(run, "planned")
+
+        mock_enq.assert_not_awaited()

--- a/services/tests/services/test_vcs_status_dispatcher.py
+++ b/services/tests/services/test_vcs_status_dispatcher.py
@@ -1,0 +1,61 @@
+"""Tests for VCS commit-status resolution — has-changes descriptions."""
+
+from terrapod.services.vcs_status_dispatcher import _resolve_status
+
+
+class TestResolveStatusPlanned:
+    """The `planned` status description depends on plan_only and has_changes."""
+
+    def test_plan_only_with_changes(self):
+        gh, gl, desc = _resolve_status("planned", plan_only=True, has_changes=True)
+        assert gh == "success"
+        assert gl == "success"
+        assert desc == "Has changes"
+
+    def test_plan_only_no_changes(self):
+        gh, gl, desc = _resolve_status("planned", plan_only=True, has_changes=False)
+        assert gh == "success"
+        assert gl == "success"
+        assert desc == "No changes"
+
+    def test_plan_only_unknown_changes_falls_back(self):
+        """When has_changes is None the description stays generic."""
+        gh, gl, desc = _resolve_status("planned", plan_only=True, has_changes=None)
+        assert gh == "success"
+        assert desc == "Plan finished"
+
+    def test_apply_run_with_changes_awaiting_confirmation(self):
+        gh, gl, desc = _resolve_status("planned", plan_only=False, has_changes=True)
+        assert gh == "pending"
+        assert gl == "running"
+        assert desc == "Has changes, awaiting confirmation"
+
+    def test_apply_run_no_changes_is_success_not_pending(self):
+        """No changes = nothing to apply = nothing to confirm. Success, not pending."""
+        gh, gl, desc = _resolve_status("planned", plan_only=False, has_changes=False)
+        assert gh == "success"
+        assert gl == "success"
+        assert desc == "No changes"
+
+    def test_apply_run_unknown_changes_generic(self):
+        _, _, desc = _resolve_status("planned", plan_only=False, has_changes=None)
+        assert desc == "Plan complete, awaiting confirmation"
+
+
+class TestResolveStatusNonPlanned:
+    """Other statuses are unaffected by has_changes."""
+
+    def test_applied(self):
+        gh, gl, desc = _resolve_status("applied", plan_only=False, has_changes=True)
+        assert gh == "success"
+        assert desc == "Apply complete"
+
+    def test_errored(self):
+        gh, _, desc = _resolve_status("errored", plan_only=True, has_changes=None)
+        assert gh == "failure"
+        assert desc == "Run failed"
+
+    def test_queued(self):
+        gh, _, desc = _resolve_status("queued", plan_only=False, has_changes=None)
+        assert gh == "pending"
+        assert desc == "Waiting for runner"


### PR DESCRIPTION
## Why

VCS commit status for a finished plan said \"Plan finished\" regardless of whether the plan actually diffed. That makes the PR check an information-free tick — you have to click through to Terrapod to find out if there's anything to review.

## Change

Plumb the run's \`has_changes\` flag (already set by the runner when the plan finishes) through \`_resolve_status\` in the VCS status dispatcher so the description reflects reality.

| Run type | \`has_changes\` | State | Description |
|---|---|---|---|
| Plan-only (PR) | True | success | \`Has changes\` |
| Plan-only (PR) | False | success | \`No changes\` |
| Plan-only (PR) | None | success | \`Plan finished\` (fallback for older runs) |
| Apply run | True | pending | \`Has changes, awaiting confirmation\` |
| Apply run | False | **success** | \`No changes\` |
| Apply run | None | pending | \`Plan complete, awaiting confirmation\` |

### Non-plan-only check transitions

For apply runs the check row now goes:

\`planning(pending) → planned(success, \"No changes\") OR planned(pending, \"Has changes, awaiting confirmation\") → applying(pending) → applied(success)\`

The \"apply run + no changes\" cell used to be pending; it now reports success because a no-op plan has nothing to apply and nothing to confirm — leaving it pending is incoherent. This is the only GitHub state change. Green → yellow → green is intentional for the apply-with-changes path; if anything downstream (required checks, dashboards) relies on monotonic success/pending, flag it before merging.

## has_changes payload snapshot (limited race fix)

The \`vcs_commit_status\` trigger used to look up \`run.has_changes\` from the DB. If another replica consumed the trigger before the transaction that set \`has_changes\` landed, it would read NULL and render the generic \"Plan finished\" fallback. The enqueuer now snapshots \`has_changes\` into the trigger payload; the dispatcher uses the payload value when present and falls back to the DB column only for queue entries written by pre-fix code.

Note: this only closes the race for \`has_changes\`. The dispatcher still reads \`run.plan_only\`, \`run.vcs_commit_sha\`, \`run.vcs_pull_request_number\` from the DB; those fields are all populated at run creation and never mutated, so they don't have a window where they could be stale. If the run row genuinely isn't visible yet, the \`run is None\` guard short-circuits and the status post is dropped — the dedup key prevents a duplicate re-enqueue for 60 s, so that status change is lost. Not introduced by this PR, not claimed to be fixed here.

## Drift runs skip VCS status

\`_enqueue_vcs_status\` now early-returns for \`is_drift_detection=True\` runs. Drift runs target the current default-branch HEAD (already merged) — posting \"Has changes\" / \"No changes\" check statuses on merged commits is noise on commits that aren't under review. Drift still flows through notifications and SSE (unchanged).

## Comment body cleanup

Dropped the redundant \"Plan has changes — review in Terrapod\" / \"No changes detected\" follow-up line in \`_build_comment_body\`. The status description above it now carries the same information.

## Tests

\`tests/services/test_vcs_status_dispatcher.py\` — new file, covers:
- Each \`_resolve_status\` branch (plan-only / apply × True / False / None × planned)
- Representative non-planned statuses (applied / errored / queued)
- \`_build_comment_body\` non-redundancy on the \"has changes\" and \"no changes\" paths
- \`_enqueue_vcs_status\` carries \`has_changes\` in payload (True and None)
- \`_enqueue_vcs_status\` skips drift runs

Full suite: 997 pass.

## Test plan

- [ ] CI green
- [ ] Release + deploy
- [ ] Verify on an SLS PR plan that \"Has changes\" / \"No changes\" shows on the GitHub check row
- [ ] Confirm PR comment no longer has a duplicate has-changes line
- [ ] Confirm drift-detection runs don't post check statuses