### PR TITLE
chore(helm): raise api memory default 1Gi → 2Gi

### DIFF
--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -49,12 +49,21 @@ api:
     annotations: {}
 
   resources:
+    # Request/limit ratios deliberately tight: CPU ≤ 2× request,
+    # memory = request (Guaranteed QoS). Wide bands cause noisy-neighbour
+    # evictions on memory and unpredictable throttling on CPU.
+    #
+    # Memory raised from 1Gi after the parallel VCS poller (v0.17.2,
+    # PR #233) started holding up to 10 concurrent per-workspace archive
+    # buffers + AsyncSession + httpx clients per cycle. Steady-state RSS
+    # sits around 700-800Mi on moderate deployments and Python doesn't
+    # return heap to the OS, so 1Gi was prone to OOMKill under load.
     requests:
-      cpu: 250m
-      memory: 512Mi
+      cpu: 500m
+      memory: 2Gi
     limits:
       cpu: "1"
-      memory: 1Gi
+      memory: 2Gi
 
   autoscaling:
     # Disabled by default — filesystem storage does not support multi-replica.


### PR DESCRIPTION
Bumps API resource defaults so the request/limit ratios fit the pattern (CPU ≤ 2×, memory = request → Guaranteed QoS).

## Why

After v0.17.2 shipped (parallel VCS poller, #233), one of two API replicas on our mgmt cluster was OOMKilled under normal load. The new poller holds up to \`_MAX_PARALLEL_WORKSPACE_POLLS = 10\` concurrent per-workspace contexts — each with:

- downloaded + repacked archive buffer (multi-MB for larger repos)
- AsyncSession (+ eager-loaded workspace attrs)
- \`httpx.AsyncClient\` with its own connection pool
- GitHub response JSON being parsed

Peak memory is genuinely higher than in the serial era. Python doesn't return heap to the OS aggressively, so steady-state RSS on a moderate deployment (5 VCS workspaces, 20+ open PRs per repo) sits around 700-800 MiB and grazes the 1 GiB ceiling.

## Change

\`\`\`yaml
# before
requests: { cpu: 250m, memory: 512Mi }
limits:   { cpu: \"1\",  memory: 1Gi }
# after
requests: { cpu: 500m, memory: 2Gi }
limits:   { cpu: \"1\",  memory: 2Gi }
\`\`\`

- **Memory**: request = limit → Guaranteed QoS. No eviction risk from overcommit, no OOM surprises.
- **CPU**: 2× burst ratio (500m → 1). Tight enough to avoid unpredictable throttling.
- Single-worker uvicorn still caps at 1 core, so the CPU limit is correct.

## Alternatives considered

1. Drop \`_MAX_PARALLEL_WORKSPACE_POLLS\` from 10 → 5. Lowers peak memory but reduces parallelism benefit on larger deployments.
2. Rework the poller to stream archives through to object storage instead of buffering. Bigger change; worth doing eventually.
3. Just bump the memory limit without raising request (what I started with). Satisfies the OOM fix but leaves a 4× burst ratio that can bite under noisy-neighbour pressure.

Going with the request-and-limit bump — least invasive runtime change, predictable scheduling.

## Test plan

- [ ] CI green
- [ ] \`helm lint\` passes (ran locally, clean)