### PR TITLE
chore(tests): drop unused fake_owned_poll in provider-dispatch test

### DIFF
--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -801,11 +801,6 @@ class TestPollCycleParallel:
         mock_ctx.__aenter__ = AsyncMock(return_value=mock_db)
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
 
-        polled: list[uuid.UUID] = []
-
-        async def fake_owned_poll(ws_id, semaphore):
-            polled.append(ws_id)
-
         # Call the inner helper directly (bypassing handle_immediate_poll's
         # SQL-side provider filter) so we can verify the Python-side
         # parser dispatch behaves correctly on a mixed row set.


### PR DESCRIPTION
Closes the code-scanning alert at https://github.com/mattrobinsonsre/terrapod/security/code-scanning/118.

The test was introduced alongside the parallel-poll rewrite but calls `_select_workspace_ids` directly — `_poll_workspace_owned` is never invoked from this path, so `fake_owned_poll` and its `polled` list were unused.