### PR TITLE
feat(ui): workspace list pool column + run-linked status pill; tighten cancel gate

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -48,6 +48,13 @@ from terrapod.storage.protocol import ObjectNotFoundError
 router = APIRouter(prefix="/api/v2", tags=["runs"])
 logger = get_logger(__name__)
 
+# States where cancellation is a sensible action — the run is actively
+# moving through the pipeline. `planned` (awaiting user confirm/discard)
+# is deliberately excluded: the right actions there are confirm/discard,
+# not cancel. Terminal states (applied/errored/discarded/canceled) aren't
+# here because there's nothing left running.
+_CANCELABLE_STATES = frozenset({"pending", "queued", "planning", "confirmed", "applying"})
+
 
 def _rfc3339(dt) -> str:
     if dt is None:
@@ -111,15 +118,17 @@ def _run_json(
                     and not run.auto_apply
                     and not run.plan_only,
                     "is-discardable": run.status == "planned" and not run.plan_only,
-                    "is-cancelable": run.status not in run_service.TERMINAL_STATES
-                    and not (run.plan_only and run.status == "planned"),
+                    # Cancel only applies to in-progress states. In particular
+                    # `planned` (awaiting confirmation) is NOT cancelable —
+                    # the user should confirm or discard. Terminal states
+                    # aren't cancelable either (nothing running).
+                    "is-cancelable": run.status in _CANCELABLE_STATES,
                     "is-retryable": run.status in run_service.TERMINAL_STATES
                     or (run.plan_only and run.status == "planned"),
                 },
                 "permissions": {
                     "can-apply": run.status == "planned" and not run.plan_only,
-                    "can-cancel": run.status not in run_service.TERMINAL_STATES
-                    and not (run.plan_only and run.status == "planned"),
+                    "can-cancel": run.status in _CANCELABLE_STATES,
                     "can-discard": run.status == "planned" and not run.plan_only,
                     "can-retry": run.status in run_service.TERMINAL_STATES
                     or (run.plan_only and run.status == "planned"),

--- a/services/terrapod/services/module_impact_service.py
+++ b/services/terrapod/services/module_impact_service.py
@@ -212,7 +212,7 @@ async def _cancel_stale_module_runs(
         )
         for stale_run in result.scalars().all():
             try:
-                await run_service.cancel_run(db, stale_run)
+                await run_service.cancel_run(db, stale_run, force=True)
                 logger.info(
                     "Canceled stale module-test run",
                     run_id=str(stale_run.id),
@@ -330,7 +330,7 @@ async def _create_module_test_runs(
         )
         for stale_run in result.scalars().all():
             try:
-                await run_service.cancel_run(db, stale_run)
+                await run_service.cancel_run(db, stale_run, force=True)
             except Exception:
                 pass
 

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -447,10 +447,30 @@ async def discard_run(db: AsyncSession, run: Run) -> Run:
     return await transition_run(db, run, "discarded")
 
 
-async def cancel_run(db: AsyncSession, run: Run) -> Run:
-    """Cancel a run."""
+# User-cancelable states: only in-progress. `planned` is awaiting user
+# confirm/discard and should be resolved that way — cancelling a
+# planned-awaiting-confirm run leaves the workspace in an ambiguous state
+# (plan exists, nothing applied, no record of user decision). Terminal
+# states have nothing left to cancel.
+#
+# Internal callers (vcs_poller, module_impact) legitimately cancel stale
+# `planned` speculative runs when a newer commit supersedes them; they
+# pass `force=True` below to bypass the user-action gate.
+CANCELABLE_STATES = frozenset({"pending", "queued", "planning", "confirmed", "applying"})
+
+
+async def cancel_run(db: AsyncSession, run: Run, *, force: bool = False) -> Run:
+    """Cancel a run.
+
+    By default only in-progress states (`CANCELABLE_STATES`) are cancelable.
+    Pass `force=True` to bypass that check — only for internal callers
+    that need to cancel superseded `planned` runs as part of cleanup.
+    Terminal states are always rejected.
+    """
     if run.status in TERMINAL_STATES:
         raise ValueError(f"Cannot cancel run in terminal state '{run.status}'")
+    if not force and run.status not in CANCELABLE_STATES:
+        raise ValueError(f"Cannot cancel run in state '{run.status}'")
     # Unlock workspace
     workspace = await db.get(Workspace, run.workspace_id)
     if workspace and workspace.locked:

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -411,7 +411,7 @@ async def _poll_workspace_prs(
         )
         for stale_run in stale_result.scalars().all():
             try:
-                await run_service.cancel_run(db, stale_run)
+                await run_service.cancel_run(db, stale_run, force=True)
                 logger.info(
                     "Canceled stale PR run",
                     run_id=str(stale_run.id),

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
@@ -371,7 +372,53 @@ class TestRunJsonSerialization:
         actions = resp.json()["data"]["attributes"]["actions"]
         assert actions["is-confirmable"] is True
         assert actions["is-discardable"] is True
-        assert actions["is-cancelable"] is True
+        # A `planned` run (awaiting confirm/discard) is intentionally NOT
+        # cancelable — the right actions are confirm or discard. Cancel
+        # only applies to in-progress states.
+        assert actions["is-cancelable"] is False
+
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            ("pending", True),
+            ("queued", True),
+            ("planning", True),
+            ("confirmed", True),
+            ("applying", True),
+            ("planned", False),  # awaiting confirm/discard
+            ("applied", False),  # terminal
+            ("errored", False),  # terminal
+            ("canceled", False),  # terminal
+            ("discarded", False),  # terminal
+        ],
+    )
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_is_cancelable_by_status(
+        self,
+        mock_get_run,
+        mock_resolve,
+        mock_init_db,
+        mock_init_redis,
+        mock_init_storage,
+        status: str,
+        expected: bool,
+    ):
+        """Cancelable flips per run state — only in-progress states allow cancel."""
+        mock_resolve.return_value = "read"
+        run = _mock_run(status=status, auto_apply=False)
+        mock_get_run.return_value = run
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        assert resp.json()["data"]["attributes"]["actions"]["is-cancelable"] is expected
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -38,6 +38,7 @@ interface Workspace {
     locked: boolean
     'resource-cpu': string
     'resource-memory': string
+    'agent-pool-name': string | null
     'drift-detection-enabled': boolean
     'drift-status': string
     'state-diverged': boolean
@@ -82,31 +83,45 @@ export default function WorkspacesPage() {
   const [agentPools, setAgentPools] = useState<{ id: string; attributes: { name: string } }[]>([])
   const [agentPoolsLoaded, setAgentPoolsLoaded] = useState(false)
 
-  type WsSortKey = 'name' | 'mode' | 'resources' | 'status' | 'created'
+  type WsSortKey = 'name' | 'mode' | 'pool' | 'resources' | 'status' | 'created'
 
-  function resolveStatus(ws: Workspace): { label: string; color: string; priority: number } {
+  // Resolved status. `runId` is the run that *defined* the status — set
+  // when the status comes from `latest-run`. For workspace-level
+  // conditions (state-diverged, vcs-error, drifted, no-runs) there's
+  // no single defining run so runId stays null and the pill doesn't
+  // link anywhere.
+  function resolveStatus(ws: Workspace): {
+    label: string
+    color: string
+    priority: number
+    runId: string | null
+  } {
     const drift = ws.attributes['drift-status']
     const run = ws.attributes['latest-run']
 
-    if (ws.attributes['state-diverged']) return { label: 'State Diverged', color: 'red', priority: 0 }
-    if (ws.attributes['vcs-last-error']) return { label: 'VCS Error', color: 'red', priority: 0 }
-    if (drift === 'drifted') return { label: 'Drifted', color: 'amber', priority: 1 }
+    if (ws.attributes['state-diverged'])
+      return { label: 'State Diverged', color: 'red', priority: 0, runId: null }
+    if (ws.attributes['vcs-last-error'])
+      return { label: 'VCS Error', color: 'red', priority: 0, runId: null }
+    if (drift === 'drifted')
+      return { label: 'Drifted', color: 'amber', priority: 1, runId: null }
     if (run) {
       const s = run.status
       const planOnly = run['plan-only']
-      if (s === 'errored') return { label: 'Errored', color: 'red', priority: 2 }
-      if (s === 'planned' && !planOnly) return { label: 'Needs Confirm', color: 'amber', priority: 3 }
-      if (s === 'planning') return { label: 'Planning', color: 'blue', priority: 4 }
-      if (s === 'applying') return { label: 'Applying', color: 'blue', priority: 4 }
-      if (s === 'confirmed') return { label: 'Confirmed', color: 'blue', priority: 4 }
-      if (s === 'queued') return { label: 'Queued', color: 'blue', priority: 4 }
-      if (s === 'pending') return { label: 'Pending', color: 'slate', priority: 5 }
-      if (s === 'applied') return { label: 'Applied', color: 'green', priority: 6 }
-      if (s === 'planned' && planOnly) return { label: 'Planned', color: 'green', priority: 7 }
-      if (s === 'canceled') return { label: 'Canceled', color: 'slate', priority: 8 }
-      if (s === 'discarded') return { label: 'Discarded', color: 'slate', priority: 8 }
+      const runId = run.id
+      if (s === 'errored') return { label: 'Errored', color: 'red', priority: 2, runId }
+      if (s === 'planned' && !planOnly) return { label: 'Needs Confirm', color: 'amber', priority: 3, runId }
+      if (s === 'planning') return { label: 'Planning', color: 'blue', priority: 4, runId }
+      if (s === 'applying') return { label: 'Applying', color: 'blue', priority: 4, runId }
+      if (s === 'confirmed') return { label: 'Confirmed', color: 'blue', priority: 4, runId }
+      if (s === 'queued') return { label: 'Queued', color: 'blue', priority: 4, runId }
+      if (s === 'pending') return { label: 'Pending', color: 'slate', priority: 5, runId }
+      if (s === 'applied') return { label: 'Applied', color: 'green', priority: 6, runId }
+      if (s === 'planned' && planOnly) return { label: 'Planned', color: 'green', priority: 7, runId }
+      if (s === 'canceled') return { label: 'Canceled', color: 'slate', priority: 8, runId }
+      if (s === 'discarded') return { label: 'Discarded', color: 'slate', priority: 8, runId }
     }
-    return { label: '\u2014', color: 'gray', priority: 9 }
+    return { label: '\u2014', color: 'gray', priority: 9, runId: null }
   }
 
   const badgeColors: Record<string, string> = {
@@ -124,6 +139,7 @@ export default function WorkspacesPage() {
       switch (key) {
         case 'name': return item.attributes.name
         case 'mode': return item.attributes['execution-mode']
+        case 'pool': return item.attributes['agent-pool-name'] || ''
         case 'resources': return item.attributes['resource-cpu']
         case 'status': return resolveStatus(item).label
         case 'created': return item.attributes['created-at']
@@ -474,9 +490,10 @@ export default function WorkspacesPage() {
                 <tr className="border-b border-slate-700/50">
                   <SortableHeader label="Name" sortKey="name" sortState={sortState} onSort={toggleSort} />
                   <SortableHeader label="Mode" sortKey="mode" sortState={sortState} onSort={toggleSort} className="hidden sm:table-cell" />
-                  <SortableHeader label="Resources" sortKey="resources" sortState={sortState} onSort={toggleSort} className="hidden md:table-cell" />
+                  <SortableHeader label="Pool" sortKey="pool" sortState={sortState} onSort={toggleSort} className="hidden md:table-cell" />
+                  <SortableHeader label="Resources" sortKey="resources" sortState={sortState} onSort={toggleSort} className="hidden lg:table-cell" />
                   <SortableHeader label="Status" sortKey="status" sortState={sortState} onSort={toggleSort} className="hidden lg:table-cell" />
-                  <SortableHeader label="Created" sortKey="created" sortState={sortState} onSort={toggleSort} className="hidden lg:table-cell" />
+                  <SortableHeader label="Created" sortKey="created" sortState={sortState} onSort={toggleSort} className="hidden xl:table-cell" />
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-700/30">
@@ -497,19 +514,31 @@ export default function WorkspacesPage() {
                     </td>
                     <td className="px-4 py-3 hidden md:table-cell">
                       <span className="text-xs text-slate-400">
+                        {ws.attributes['agent-pool-name'] || '\u2014'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 hidden lg:table-cell">
+                      <span className="text-xs text-slate-400">
                         {ws.attributes['resource-cpu']} CPU / {ws.attributes['resource-memory']}
                       </span>
                     </td>
                     <td className="px-4 py-3 hidden lg:table-cell">
                       {status.color === 'gray' ? (
                         <span className="text-xs text-slate-500">{status.label}</span>
+                      ) : status.runId ? (
+                        <Link
+                          href={`/workspaces/${ws.id}/runs/${status.runId}`}
+                          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium hover:opacity-80 transition-opacity ${badgeColors[status.color]}`}
+                        >
+                          {status.label}
+                        </Link>
                       ) : (
                         <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors[status.color]}`}>
                           {status.label}
                         </span>
                       )}
                     </td>
-                    <td className="px-4 py-3 hidden lg:table-cell">
+                    <td className="px-4 py-3 hidden xl:table-cell">
                       <span className="text-xs text-slate-500">
                         {ws.attributes['created-at'] ? new Date(ws.attributes['created-at']).toLocaleDateString() : ''}
                       </span>


### PR DESCRIPTION
Three small UX/correctness tweaks bundled:

## Workspace list page

### 1. New \`Pool\` column

Agent pool name is now visible in the workspace list, between Mode and Resources. Sortable. The backend was already serialising \`agent-pool-name\` in the workspace response — it just wasn't shown.

Breakpoint gating was shuffled one notch so narrow screens continue to drop the less-critical columns first: Pool at \`md:\`, Resources + Status at \`lg:\`, Created at \`xl:\`.

### 2. Status pill → run link

Clicking the status pill now navigates to the run that defined the status, for run-derived statuses:

- Errored, Needs Confirm, Planning, Applying, Confirmed, Queued, Pending, Applied, Planned, Canceled, Discarded → link to \`/workspaces/{id}/runs/{latest-run.id}\`

For workspace-level conditions the pill stays non-clickable — there's no single \"defining run\":

- State Diverged (workspace-level flag)
- VCS Error (polling-cycle failure, not a run)
- Drifted (drift-detection-run-id isn't surfaced in the workspace response)

These three conditions are already surfaced as banners on the workspace overview, which is where the user needs to go.

\`resolveStatus\` now returns a \`runId\` field alongside label/color/priority; the UI renders a \`<Link>\` when \`runId\` is non-null and a plain \`<span>\` otherwise.

## Cancel action gating

A \`planned\` run that's awaiting user confirm/discard (i.e. not plan_only) currently shows a Cancel button in the UI. That's the wrong action — Cancel on a planned-awaiting-confirm run leaves the workspace in an ambiguous state (plan exists, nothing applied, no record of a user decision). The user should Confirm or Discard.

- \`runs.py\`: \`is-cancelable\` / \`can-cancel\` now gated on a new \`_CANCELABLE_STATES = {pending, queued, planning, confirmed, applying}\` frozenset rather than \`status not in TERMINAL_STATES\`.
- \`run_service.cancel_run\`: mirrors the restriction by default; internal callers (\`vcs_poller\` superseding stale PR runs, \`module_impact_service\` cleanup) opt in via a new \`force=True\` kwarg since they legitimately need to cancel stale \`planned\` speculative runs.

## Tests

- Updated the existing \`test_actions_block\` expectation: a \`planned\` run is no longer cancelable.
- Added a parametrised \`test_is_cancelable_by_status\` that pins the cancelable/not-cancelable decision for every run status (10 cases).

Full suite: 1028 pass.

## Test plan

- [ ] Speculative plan + visual check on mgmt UI: Pool column shows up at md+, status pill is a link for run-derived statuses, non-clickable for state-diverged / vcs-error / drifted.
- [ ] Cancel button absent on a planned-awaiting-confirm run; present on an in-progress run.
- [ ] Stale PR commits still auto-cancel prior speculative plans (vcs_poller path — force=True).