### PR TITLE
feat: show workspace name on run detail page

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -65,6 +65,7 @@ def _rfc3339(dt) -> str:
 def _run_json(
     run: Run,
     *,
+    workspace_name: str = "",
     workspace_has_vcs: bool = False,
     state_version_id: str | None = None,
 ) -> dict:
@@ -94,6 +95,7 @@ def _run_json(
                 "allow-empty-apply": run.allow_empty_apply,
                 "is-drift-detection": run.is_drift_detection,
                 "has-changes": run.has_changes,
+                "workspace-name": workspace_name,
                 "workspace-has-vcs": workspace_has_vcs,
                 "module-overrides": run.module_overrides,
                 "vcs-commit-sha": run.vcs_commit_sha,
@@ -382,7 +384,11 @@ async def create_run(
     await db.refresh(run)
 
     return JSONResponse(
-        content=_run_json(run, workspace_has_vcs=ws.vcs_connection_id is not None),
+        content=_run_json(
+            run,
+            workspace_name=ws.name,
+            workspace_has_vcs=ws.vcs_connection_id is not None,
+        ),
         status_code=201,
     )
 
@@ -408,6 +414,7 @@ async def show_run(
     return JSONResponse(
         content=_run_json(
             run,
+            workspace_name=ws.name if ws else "",
             workspace_has_vcs=bool(ws and ws.vcs_connection_id),
             state_version_id=sv_id,
         ),
@@ -433,7 +440,12 @@ async def list_workspace_runs(
     runs = await run_service.list_workspace_runs(db, ws.id, page_number, page_size)
     has_vcs = ws.vcs_connection_id is not None
     return JSONResponse(
-        content={"data": [_run_json(r, workspace_has_vcs=has_vcs)["data"] for r in runs]}
+        content={
+            "data": [
+                _run_json(r, workspace_name=ws.name, workspace_has_vcs=has_vcs)["data"]
+                for r in runs
+            ]
+        }
     )
 
 

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -153,7 +153,9 @@ class TestRunJsonModuleOverrides:
         mock_get_run.return_value = run
         mock_resolve.return_value = "read"
 
-        app, _ = _make_app(_admin_user())
+        mock_db = AsyncMock()
+        mock_db.get.return_value = _mock_workspace(ws_id=run.workspace_id)
+        app, _ = _make_app(_admin_user(), mock_db=mock_db)
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
 

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -38,6 +38,7 @@ interface RunAttrs {
   'vcs-commit-sha': string | null
   'vcs-branch': string | null
   'vcs-pull-request-number': number | null
+  'workspace-name': string
   'workspace-has-vcs': boolean
   'module-overrides': Record<string, string> | null
   'status-timestamps': Record<string, string>
@@ -507,12 +508,16 @@ export default function RunDetailPage() {
       <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto">
         <div className="mb-4">
           <Link href={`/workspaces/${workspaceId}?tab=runs`} className="text-sm text-slate-400 hover:text-slate-200">
-            &larr; Back to workspace
+            &larr; Back to {attrs['workspace-name'] || 'workspace'}
           </Link>
         </div>
 
         <PageHeader
-          title={`Run ${run.id.replace(/^run-/, '').split('-').pop()}`}
+          title={
+            attrs['workspace-name']
+              ? `${attrs['workspace-name']} — run ${run.id.replace(/^run-/, '').split('-').pop()}`
+              : `Run ${run.id.replace(/^run-/, '').split('-').pop()}`
+          }
           description={attrs.message || `${attrs.source} run`}
           actions={
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Add `workspace-name` to the run JSON payload served by `GET /api/v2/runs/{id}`, `POST .../runs`, and `GET .../workspaces/{id}/runs`.
- Use it on the run detail page: the header title now reads `{workspace} — run {shortId}`, and the back link reads `← Back to {workspace}`.

Landing on a run URL directly (e.g. from a notification or bookmark) previously showed only the short run id with no indication of which workspace the run belonged to.

## Test plan

- [x] `make test` — 1028 passed
- [x] `make lint` — clean
- [ ] Verify on a deployed instance: run detail page shows workspace name in title and back link