### PR TITLE
feat: filter workspace list by cloud-block tags (matched against labels)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -157,6 +157,24 @@ resource "null_resource" "hello" {
 
 > Note: The `terraform {}` block syntax is used by both OpenTofu and Terraform. No changes are needed when switching between them.
 
+If you'd rather select a workspace at run time (typical when a single repo backs several environments) replace `name` with `tags`. Tags are matched against the workspace's labels — see the [RBAC docs](rbac.md#labels-are-also-tags) for details.
+
+```hcl
+workspaces {
+  tags = ["core"]                    # any workspace whose labels include "core"
+  # or, for an exact match:
+  tags = { repo = "tf-aws-core" }
+}
+```
+
+Then pick a specific workspace per invocation:
+
+```zsh
+TF_WORKSPACE=core-stg-eu1 tofu plan
+# or
+tofu workspace select core-stg-eu1
+```
+
 If you have not already run `tofu login`:
 
 ```zsh

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -295,6 +295,37 @@ curl -X PATCH https://terrapod.example.com/api/v2/workspaces/ws-{id} \
 - Owners have `admin` permission on their workspace
 - Only a platform admin can change workspace ownership
 
+### Labels are also Tags
+
+Workspace labels do double duty: alongside their primary role in label-based RBAC, they also stand in for TFE's "workspace tags" concept on the CLI. The `cloud { workspaces { tags = ... } }` block in your `.tf` config is matched against the same `labels` map.
+
+```hcl
+terraform {
+  cloud {
+    hostname     = "terrapod.example.com"
+    organization = "default"
+
+    workspaces {
+      tags = ["core"]                    # all workspaces with label key "core"
+      # or
+      tags = { repo = "tf-aws-core" }    # all workspaces with label repo=tf-aws-core
+    }
+  }
+}
+```
+
+Both forms are accepted:
+
+| Form | Example | Matches |
+|---|---|---|
+| List, bare key | `tags = ["core"]` | workspaces with label key `core` (any value) |
+| List, key=value | `tags = ["env=prod"]` | workspaces with `env: prod` exactly |
+| Map | `tags = { env = "prod" }` | workspaces with `env: prod` exactly |
+
+Pick the workspace at run time with `terraform workspace select <name>` or the `TF_WORKSPACE` environment variable. This is how a single repo with multiple environments (e.g. `core-dev-eu1`, `core-stg-eu1`, `core-prod-eu1`) can use one `cloud {}` block and pick the env per CLI invocation.
+
+The web UI displays this field as **"Labels (tags)"** to make the dual purpose explicit.
+
 ---
 
 ## Self-Lockout Protection on Label Changes

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -575,6 +575,61 @@ def _workspace_json(
     }
 
 
+def _parse_tag_filters(request: Request) -> list[tuple[str, str | None]]:
+    """Extract cloud-block tag filters from a workspace-list request.
+
+    The terraform/tofu CLI's `cloud { workspaces { tags = ... } }` block emits two
+    query-parameter shapes depending on whether `tags` is a list or a map:
+
+      - list form  `tags = ["core", "env=prod"]`
+            -> `?search[tags]=core,env=prod`
+            (each comma-separated token is either a bare key or `key=value`)
+
+      - map form   `tags = { env = "prod" }`
+            -> `?filter[tagged][0][key]=env&filter[tagged][0][value]=prod`
+
+    Terrapod doesn't have a separate "tags" concept on workspaces; instead each
+    tag is matched against `Workspace.labels` (which is also the source of
+    label-based RBAC). A bare key matches any workspace that has that label key
+    set; `key=value` matches an exact label entry.
+
+    Returns a list of `(key, value)` tuples where `value` is `None` for
+    key-only matches.
+    """
+    filters: list[tuple[str, str | None]] = []
+
+    # List form: search[tags]=a,b,c=d
+    raw_tags = request.query_params.get("search[tags]", "")
+    if raw_tags:
+        for token in raw_tags.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            if "=" in token:
+                k, v = token.split("=", 1)
+                filters.append((k.strip(), v.strip()))
+            else:
+                filters.append((token, None))
+
+    # Map form: filter[tagged][N][key|value]=...
+    indexed: dict[int, dict[str, str]] = {}
+    for qk, qv in request.query_params.multi_items():
+        m = re.match(r"^filter\[tagged\]\[(\d+)\]\[(key|value)\]$", qk)
+        if not m:
+            continue
+        idx = int(m.group(1))
+        indexed.setdefault(idx, {})[m.group(2)] = qv
+    for idx in sorted(indexed):
+        entry = indexed[idx]
+        key = entry.get("key", "").strip()
+        if not key:
+            continue
+        value = entry.get("value")
+        filters.append((key, value.strip() if value is not None else None))
+
+    return filters
+
+
 @router.get("/organizations/default/workspaces")
 async def list_workspaces(
     user: AuthenticatedUser = Depends(get_current_user),
@@ -589,6 +644,15 @@ async def list_workspaces(
     search_name = request.query_params.get("search[name]", "") if request else ""
     if search_name:
         query = query.where(Workspace.name.ilike(f"%{search_name}%"))
+
+    # Cloud-block tag filtering. Tags are matched against Workspace.labels —
+    # see _parse_tag_filters for the dual-form parsing.
+    if request is not None:
+        for k, v in _parse_tag_filters(request):
+            if v is None:
+                query = query.where(Workspace.labels.has_key(k))  # noqa: W601
+            else:
+                query = query.where(Workspace.labels.contains({k: v}))
 
     result = await db.execute(query)
     workspaces = result.scalars().all()

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -528,3 +528,105 @@ class TestPermissionsBlock:
         assert perms["can-queue-run"] is True
         assert perms["can-lock"] is True
         assert perms["can-force-unlock"] is True
+
+
+# ── Cloud-block tag → label filtering ──────────────────────────────────
+
+
+class TestParseTagFilters:
+    """Unit tests for the cloud-block `tags` query parameter parser."""
+
+    def _req(self, query: str):
+        from urllib.parse import urlencode
+
+        from starlette.requests import Request
+
+        if isinstance(query, dict):
+            query = urlencode(query, doseq=True)
+        scope = {"type": "http", "query_string": query.encode("ascii"), "headers": []}
+        return Request(scope)
+
+    def test_no_tag_params_returns_empty(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        assert _parse_tag_filters(self._req("")) == []
+        assert _parse_tag_filters(self._req("search%5Bname%5D=foo")) == []
+
+    def test_list_form_bare_keys(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        # search[tags]=core,internal -> two key-only entries
+        out = _parse_tag_filters(self._req("search%5Btags%5D=core,internal"))
+        assert out == [("core", None), ("internal", None)]
+
+    def test_list_form_key_value(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        # search[tags]=env=prod,team=platform
+        out = _parse_tag_filters(self._req("search%5Btags%5D=env=prod,team=platform"))
+        assert out == [("env", "prod"), ("team", "platform")]
+
+    def test_list_form_mixed(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        out = _parse_tag_filters(self._req("search%5Btags%5D=core,env=prod"))
+        assert out == [("core", None), ("env", "prod")]
+
+    def test_list_form_strips_whitespace(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        out = _parse_tag_filters(self._req("search%5Btags%5D=%20core%20,%20env=prod%20"))
+        assert out == [("core", None), ("env", "prod")]
+
+    def test_list_form_skips_empty_tokens(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        out = _parse_tag_filters(self._req("search%5Btags%5D=,core,,internal,"))
+        assert out == [("core", None), ("internal", None)]
+
+    def test_map_form_single(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        # filter[tagged][0][key]=env&filter[tagged][0][value]=prod
+        q = "filter%5Btagged%5D%5B0%5D%5Bkey%5D=env&filter%5Btagged%5D%5B0%5D%5Bvalue%5D=prod"
+        out = _parse_tag_filters(self._req(q))
+        assert out == [("env", "prod")]
+
+    def test_map_form_multiple_indexed(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        # Two indexed entries; ensure they're returned in numeric (not insertion) order
+        q = (
+            "filter%5Btagged%5D%5B1%5D%5Bkey%5D=team"
+            "&filter%5Btagged%5D%5B1%5D%5Bvalue%5D=platform"
+            "&filter%5Btagged%5D%5B0%5D%5Bkey%5D=env"
+            "&filter%5Btagged%5D%5B0%5D%5Bvalue%5D=prod"
+        )
+        out = _parse_tag_filters(self._req(q))
+        assert out == [("env", "prod"), ("team", "platform")]
+
+    def test_map_form_missing_value_treated_as_key_only(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        # value omitted -> key-only filter (matches any value)
+        q = "filter%5Btagged%5D%5B0%5D%5Bkey%5D=core"
+        out = _parse_tag_filters(self._req(q))
+        assert out == [("core", None)]
+
+    def test_map_form_empty_key_skipped(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        q = "filter%5Btagged%5D%5B0%5D%5Bkey%5D=&filter%5Btagged%5D%5B0%5D%5Bvalue%5D=prod"
+        out = _parse_tag_filters(self._req(q))
+        assert out == []
+
+    def test_combined_list_and_map_forms(self):
+        from terrapod.api.routers.tfe_v2 import _parse_tag_filters
+
+        q = (
+            "search%5Btags%5D=core"
+            "&filter%5Btagged%5D%5B0%5D%5Bkey%5D=env"
+            "&filter%5Btagged%5D%5B0%5D%5Bvalue%5D=prod"
+        )
+        out = _parse_tag_filters(self._req(q))
+        assert out == [("core", None), ("env", "prod")]

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1384,7 +1384,12 @@ function WorkspaceDetailContent() {
                   </div>
                 )}
                 <div className="sm:col-span-2">
-                  <dt className="text-xs text-slate-500 mb-1">Labels</dt>
+                  <dt
+                    className="text-xs text-slate-500 mb-1"
+                    title='Workspace labels do double duty: label-based RBAC matching, and as the "tags" matched by terraform/tofu cloud { workspaces { tags = ... } } blocks.'
+                  >
+                    Labels (tags)
+                  </dt>
                   {editing && perms['can-update'] ? (
                     <LabelsEditor labels={editLabels} onChange={setEditLabels} />
                   ) : (


### PR DESCRIPTION
## Summary

`GET /api/v2/organizations/default/workspaces` now accepts the two query-parameter shapes the terraform/tofu CLI emits when the cloud block uses `tags` instead of a single `name`:

- list form `tags = ["core", "env=prod"]` → `search[tags]=core,env=prod`
- map form `tags = { env = "prod" }` → `filter[tagged][0][key]=env&filter[tagged][0][value]=prod`

Tags are matched against `Workspace.labels` — the same JSONB column used by label-based RBAC. Bare keys match any value; `key=value` forms match exactly. Multiple tags are AND-ed.

## Why

A single root module like `tf-aws-core` backs ~7 environments, each with its own Terrapod workspace. With only `name = "..."` supported, the cloud block could only point at a single workspace, blocking CLI-driven operations across envs. With tags, one config picks the workspace at run time via `TF_WORKSPACE` or `terraform workspace select`.

## Behaviour

```hcl
terraform {
  cloud {
    hostname     = "terrapod.example.com"
    organization = "default"
    workspaces {
      tags = ["core"]                    # all workspaces with label key "core"
      # or
      tags = { repo = "tf-aws-core" }    # exact match on label
    }
  }
}
```

```zsh
TF_WORKSPACE=core-stg-eu1 tofu plan
# or
tofu workspace select core-stg-eu1
```

## Docs + UX

- `docs/rbac.md` gains a "Labels are also Tags" subsection
- `docs/getting-started.md` shows the tag form alongside the named form
- The workspace overview in the web UI now labels the field **"Labels (tags)"** with a tooltip explaining the dual purpose

## Test plan

- [x] 11 new parser unit tests covering both forms, mixed forms, ordering, whitespace, empty tokens, key-only entries
- [x] `make test` — 1039 passed
- [x] `make lint` — clean
- [ ] After deploy, `tofu init` against a `cloud { workspaces { tags = ["core"] } }` block lists the matching workspaces