### PR TITLE
feat(ui): smart filter on workspace list page (name + labels)

### DIFF
--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback, useMemo } from 'react'
+import { Suspense, useEffect, useState, useCallback, useMemo } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import NavBar from '@/components/nav-bar'
@@ -51,7 +51,9 @@ interface Workspace {
   }
 }
 
-export default function WorkspacesPage() {
+// Wrapped in <Suspense> at the bottom — `useSearchParams()` triggers Next.js's
+// CSR bailout, and without a boundary the whole page fails to build statically.
+function WorkspacesPageInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
@@ -632,5 +634,13 @@ export default function WorkspacesPage() {
         )}
       </main>
     </>
+  )
+}
+
+export default function WorkspacesPage() {
+  return (
+    <Suspense fallback={<><NavBar /><main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto"><LoadingSpinner /></main></>}>
+      <WorkspacesPageInner />
+    </Suspense>
   )
 }

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
@@ -13,6 +13,7 @@ import { getAuthState } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
 import { useWorkspaceListEvents } from '@/lib/use-workspace-list-events'
+import { matchWorkspace, parseFilterQuery, removeTerm, serializeFilter } from '@/lib/workspace-filter'
 
 interface LatestRun {
   id: string
@@ -46,14 +47,40 @@ interface Workspace {
     'health-conditions': HealthCondition[]
     'latest-run': LatestRun | null
     'created-at': string
+    labels?: Record<string, string> | null
   }
 }
 
 export default function WorkspacesPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+
+  // Filter input. Tokens are space-separated; bare words match the workspace
+  // name (case-insensitive substring), `key:value` / `key=value` match a
+  // label exactly, and `key:` / `key=` matches any workspace that has the
+  // label key set. Mirrored to the URL via ?q=… so refresh + share work.
+  const [filterInput, setFilterInput] = useState(searchParams.get('q') || '')
+  const parsedFilter = useMemo(() => parseFilterQuery(filterInput), [filterInput])
+
+  // Sync the input back to the URL whenever the parsed shape changes.
+  useEffect(() => {
+    const serialized = serializeFilter(parsedFilter)
+    const current = searchParams.get('q') || ''
+    if (serialized === current) return
+    const params = new URLSearchParams(Array.from(searchParams.entries()))
+    if (serialized) params.set('q', serialized)
+    else params.delete('q')
+    const qs = params.toString()
+    router.replace(qs ? `/workspaces?${qs}` : '/workspaces', { scroll: false })
+  }, [parsedFilter, router, searchParams])
+
+  const filteredWorkspaces = useMemo(
+    () => (parsedFilter.terms.length === 0 ? workspaces : workspaces.filter(ws => matchWorkspace(ws, parsedFilter))),
+    [workspaces, parsedFilter],
+  )
 
   // Create form
   const [showCreate, setShowCreate] = useState(false)
@@ -134,7 +161,7 @@ export default function WorkspacesPage() {
   }
 
   const { sortedItems: sortedWorkspaces, sortState, toggleSort } = useSortable<Workspace, WsSortKey>(
-    workspaces, 'name', 'asc',
+    filteredWorkspaces, 'name', 'asc',
     useCallback((item: Workspace, key: WsSortKey) => {
       switch (key) {
         case 'name': return item.attributes.name
@@ -479,10 +506,63 @@ export default function WorkspacesPage() {
           )
         })()}
 
+        {!loading && workspaces.length > 0 && (
+          <div className="mb-4">
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={filterInput}
+                onChange={e => setFilterInput(e.target.value)}
+                placeholder='Filter by name or label — e.g. "eu1" or "env:prod" or "repo:tf-aws-core eu1"'
+                aria-label="Filter workspaces"
+                className="flex-1 px-3 py-2 rounded-lg bg-slate-800/50 border border-slate-700/50 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-brand-500"
+              />
+              {parsedFilter.terms.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setFilterInput('')}
+                  className="px-3 py-2 rounded-lg text-sm text-slate-400 hover:text-slate-200 transition-colors"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            {parsedFilter.terms.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-2">
+                {parsedFilter.terms.map((term, i) => {
+                  const label =
+                    term.kind === 'name'
+                      ? `name: ${term.value}`
+                      : term.value === null
+                        ? `${term.key}: (any)`
+                        : `${term.key}: ${term.value}`
+                  return (
+                    <button
+                      type="button"
+                      key={`${i}-${label}`}
+                      onClick={() => setFilterInput(serializeFilter(removeTerm(parsedFilter, i)))}
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-slate-700/50 text-slate-300 hover:bg-slate-700 transition-colors"
+                      title="Remove this term"
+                    >
+                      <span>{label}</span>
+                      <span aria-hidden className="text-slate-500">×</span>
+                    </button>
+                  )
+                })}
+                <span className="text-xs text-slate-500 self-center">
+                  Showing {filteredWorkspaces.length} of {workspaces.length}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
         {loading ? (
           <LoadingSpinner />
         ) : workspaces.length === 0 ? (
           <EmptyState message="No workspaces yet. Create one to get started." />
+        ) : filteredWorkspaces.length === 0 ? (
+          <EmptyState message="No workspaces match this filter." />
         ) : (
           <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
             <table className="w-full">

--- a/web/src/lib/workspace-filter.ts
+++ b/web/src/lib/workspace-filter.ts
@@ -1,0 +1,84 @@
+// Pure helpers for the workspace-list filter input.
+//
+// The input is a single text box that mixes name substrings and label
+// predicates separated by whitespace. Each token is either:
+//
+//   - bare word          → name substring match (case-insensitive)
+//   - "key:value"        → label predicate (case-sensitive exact match)
+//   - "key=value"        → same as key:value
+//   - "key:" / "key="    → label key-only predicate (any value, including empty)
+//
+// All terms are AND-ed: a workspace matches when every name term appears in
+// its name AND every label predicate matches one of its labels.
+
+export interface NameTerm {
+  kind: 'name'
+  value: string
+}
+
+export interface LabelTerm {
+  kind: 'label'
+  key: string
+  value: string | null // null = any-value match
+}
+
+export type FilterTerm = NameTerm | LabelTerm
+
+export interface ParsedFilter {
+  terms: FilterTerm[]
+}
+
+const SEPARATOR = /[:=]/
+
+export function parseFilterQuery(input: string): ParsedFilter {
+  const terms: FilterTerm[] = []
+  for (const raw of input.split(/\s+/)) {
+    const token = raw.trim()
+    if (!token) continue
+    const sep = token.search(SEPARATOR)
+    if (sep < 0) {
+      terms.push({ kind: 'name', value: token })
+      continue
+    }
+    const key = token.slice(0, sep).trim()
+    if (!key) continue // ":foo" or "=foo" with no key — skip
+    const rest = token.slice(sep + 1)
+    terms.push({ kind: 'label', key, value: rest === '' ? null : rest })
+  }
+  return { terms }
+}
+
+export function serializeFilter(parsed: ParsedFilter): string {
+  return parsed.terms
+    .map(t => {
+      if (t.kind === 'name') return t.value
+      return t.value === null ? `${t.key}:` : `${t.key}:${t.value}`
+    })
+    .join(' ')
+}
+
+export function removeTerm(parsed: ParsedFilter, index: number): ParsedFilter {
+  return { terms: parsed.terms.filter((_, i) => i !== index) }
+}
+
+export interface MatchableWorkspace {
+  attributes: {
+    name: string
+    labels?: Record<string, string> | null
+  }
+}
+
+export function matchWorkspace(ws: MatchableWorkspace, parsed: ParsedFilter): boolean {
+  const name = ws.attributes.name.toLowerCase()
+  const labels = ws.attributes.labels || {}
+  for (const term of parsed.terms) {
+    if (term.kind === 'name') {
+      if (!name.includes(term.value.toLowerCase())) return false
+    } else if (term.value === null) {
+      if (!Object.prototype.hasOwnProperty.call(labels, term.key)) return false
+    } else if (labels[term.key] !== term.value) {
+      return false
+    }
+  }
+  return true
+}


### PR DESCRIPTION
## Summary

Adds a single text input above the workspace table that filters the list as you type. Tokens are space-separated:

| Token | Match |
|---|---|
| `eu1` | name substring (case-insensitive) |
| `env:prod` | exact label match |
| `env=prod` | same |
| `env:` or `env=` | any value, label key just has to be set |

Multiple terms are AND-ed. Active terms render as removable chips below the input. The current filter is mirrored to `?q=…` so refresh/share works.

## Why client-side?

The workspace list endpoint already returns the full `labels` map for every visible workspace, and the result is RBAC-filtered server-side. For the deployment scale we target (single-org, low-hundreds of workspaces) all filtering happens in the browser — no extra API calls, no debounce, instant feedback.

If we ever paginate the list endpoint we'll need to flip to server-side filtering — the parser stays the same, only the apply changes. Tracked mentally; no work needed today.

## Test plan

- [x] `make lint` — clean (frontend + type-check)
- [ ] Manual: `eu1`, `env:prod`, `repo:tf-aws-core eu1`, `core env=prod` all narrow correctly
- [ ] Manual: refresh with `?q=env:prod` repopulates the input and the chips
- [ ] Manual: × on a chip removes that one term; "Clear" wipes everything
- [ ] Manual: filtering everything out shows the "No workspaces match this filter" empty state