### PR TITLE
feat: tag-binding endpoints for terraform KV-tag support detection

### DIFF
--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -873,6 +873,71 @@ async def show_workspace_by_id(
     )
 
 
+@router.get("/workspaces/{workspace_id}/tag-bindings")
+async def list_workspace_tag_bindings(
+    workspace_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """List a workspace's tag bindings.
+
+    Terraform's cloud backend probes this endpoint to decide whether the TFE
+    server supports key-value workspace tags. If it 404s, terraform falls back
+    to assuming only key-only tags are supported and refuses to use map-form
+    `tags = { key = "value" }` cloud blocks for state operations.
+
+    Terrapod doesn't have a separate `tag_bindings` concept — workspace labels
+    (also used for label-based RBAC) double as TFE tag bindings. Each label
+    key/value pair is returned as one tag-binding entry.
+    """
+    ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
+
+    bindings = [
+        {
+            "type": "tag-bindings",
+            "attributes": {
+                "key": str(k),
+                "value": str(v) if v is not None else "",
+            },
+        }
+        for k, v in (ws.labels or {}).items()
+    ]
+    return JSONResponse(
+        content={"data": bindings},
+        headers=_tfe_headers(),
+    )
+
+
+@router.get("/workspaces/{workspace_id}/effective-tag-bindings")
+async def list_workspace_effective_tag_bindings(
+    workspace_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """List a workspace's effective tag bindings.
+
+    On HCP Terraform / TFE this includes tags inherited from a parent project.
+    Terrapod has no project hierarchy, so this is identical to the
+    workspace-level bindings.
+    """
+    ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
+
+    bindings = [
+        {
+            "type": "effective-tag-bindings",
+            "attributes": {
+                "key": str(k),
+                "value": str(v) if v is not None else "",
+            },
+        }
+        for k, v in (ws.labels or {}).items()
+    ]
+    return JSONResponse(
+        content={"data": bindings},
+        headers=_tfe_headers(),
+    )
+
+
 @router.patch("/workspaces/{workspace_id}")
 async def update_workspace(
     workspace_id: str = Path(...),

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -530,6 +530,97 @@ class TestPermissionsBlock:
         assert perms["can-force-unlock"] is True
 
 
+# ── Tag bindings (terraform key-value tag support probe) ───────────────
+
+
+class TestWorkspaceTagBindings:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_returns_labels_as_bindings(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "read"
+        ws = _mock_workspace(labels={"repo": "tf-aws-core", "env": "dev"})
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}/tag-bindings", headers=_AUTH)
+        assert resp.status_code == 200
+        items = resp.json()["data"]
+        # Same key/value pairs, regardless of ordering
+        assert {(i["attributes"]["key"], i["attributes"]["value"]) for i in items} == {
+            ("repo", "tf-aws-core"),
+            ("env", "dev"),
+        }
+        assert all(i["type"] == "tag-bindings" for i in items)
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_empty_labels_returns_empty_array(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "read"
+        ws = _mock_workspace(labels={})
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}/tag-bindings", headers=_AUTH)
+        # Returning 200 with [] (rather than 404) is what tells terraform's
+        # cloud backend that this server supports key-value tags.
+        assert resp.status_code == 200
+        assert resp.json() == {"data": []}
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_no_permission_blocks_access(self, mock_resolve, *mocks):
+        mock_resolve.return_value = None
+        ws = _mock_workspace()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}/tag-bindings", headers=_AUTH)
+        # 403 is fine for terraform's KV-tag-support probe — only a 404 would
+        # cause it to conclude the endpoint doesn't exist.
+        assert resp.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_effective_tag_bindings_mirrors_workspace_bindings(self, mock_resolve, *mocks):
+        # Terrapod has no project hierarchy, so effective bindings == workspace bindings
+        mock_resolve.return_value = "read"
+        ws = _mock_workspace(labels={"repo": "tf-aws-core"})
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/v2/workspaces/ws-{ws.id}/effective-tag-bindings", headers=_AUTH
+            )
+        assert resp.status_code == 200
+        items = resp.json()["data"]
+        assert items == [
+            {
+                "type": "effective-tag-bindings",
+                "attributes": {"key": "repo", "value": "tf-aws-core"},
+            }
+        ]
+
+
 # ── Cloud-block tag → label filtering ──────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds two endpoints required for terraform's cloud backend to decide that Terrapod supports key-value workspace tags:

- `GET /api/v2/workspaces/{id}/tag-bindings`
- `GET /api/v2/workspaces/{id}/effective-tag-bindings`

Both expose `Workspace.labels` as TFE-format tag bindings — the same JSONB column that already powers label-based RBAC and the cloud-block tag filter from #247.

## Why

Terraform 1.15's cloud backend probes `GET /workspaces/{id}/tag-bindings` before allowing map-form tags in the cloud block. If that 404s, it errors:

> Error loading state: backend does not support key/value tags. Try using key-only tags: your version of Terraform Enterprise does not support key-value tags. Please upgrade Terraform Enterprise to a version that supports this feature or use set type tags instead.

Reproduced against `tf-aws-core` with terraform 1.15.0-rc3 — workspace discovery via tags worked (`#247` already wires `search[tags]` / `filter[tagged]`), but state load failed at the KV-tag check.

## End-to-end behaviour after this lands

```hcl
terraform {
  cloud {
    hostname     = "terrapod.example.com"
    organization = "default"
    workspaces {
      tags = { repo = "tf-aws-core" }
    }
  }
}
```

```zsh
TF_WORKSPACE=core-stg-eu1 tofu plan -var-file=envs/stg-eu1.tfvars
```

…works without forking the config per env.

## Test plan

- [x] 4 new endpoint tests covering the populated-labels, empty-labels, no-permission, and effective-tag-bindings cases
- [x] `make test` — 1043 passed
- [x] `make lint` — clean
- [ ] Tested live with terraform 1.15.0-rc3 against `tf-aws-core` (after merge + release)