### PR TITLE
feat(ui): jump to apply tab when user clicks Confirm & Apply

### DIFF
--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -470,6 +470,11 @@ export default function RunDetailPage() {
           return
         }
       }
+      // Confirm = applies — jump straight to the apply tab so the user sees
+      // the apply log streaming instead of the plan log they were just on.
+      if (action === 'confirm') {
+        switchSection('apply')
+      }
       await loadRun()
     } catch (err) {
       setError(err instanceof Error ? err.message : `Failed to ${action} run`)


### PR DESCRIPTION
## Summary

After clicking **Confirm & Apply** on a planned run, the user is left staring at the (now-finished) plan log instead of the apply log that's about to start streaming. Tiny change: switch to the apply tab as part of the confirm action so the next thing the user sees is the apply log streaming.

Reuses the existing `switchSection()` helper that the tab buttons already call — URL gets `?tab=apply` just like a manual click would.

## Test plan

- [x] `make lint` clean, `npm run build` clean
- [ ] Manual: queue an apply on a non-auto-apply workspace, click Confirm & Apply, observe URL gains `?tab=apply` and the apply log starts streaming below
- [ ] Manual: clicking Discard or Cancel does NOT switch tabs (only confirm does)