### PR TITLE
fix: await _strip_top_level_dir on UI-queued VCS runs

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -264,7 +264,7 @@ async def _fetch_vcs_config(
             raise HTTPException(status_code=422, detail="Cannot get branch HEAD SHA")
 
     archive = await _download_archive(conn, owner, repo, sha)
-    archive = _strip_top_level_dir(archive)
+    archive = await _strip_top_level_dir(archive)
 
     cv = await run_service.create_configuration_version(
         db, workspace_id=ws.id, source="vcs", auto_queue_runs=False


### PR DESCRIPTION
## Summary

500 on `POST /api/v2/runs` from the UI when a VCS-connected workspace queues a run without uploading code:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Body, value: <coroutine object
strip_archive_top_level_dir_async at 0x…>, type: <class 'coroutine'>,
valid types: <class 'bytes'>, <class 'bytearray'>, file-like object
```

\`runs.py:267\` was missing an \`await\`. \`_strip_top_level_dir\` aliases the async helper (\`asyncio.to_thread\` over multi-MB tar bytes), so the call returned a coroutine instead of bytes. That coroutine reached \`storage.put()\` → boto3 → ParamValidationError.

Sibling callers (\`module_impact_service\`, \`registry_vcs_poller\`, \`vcs_poller\`) already await it correctly — this was the only stale call site.

## Scope

Surfaces only on the **UI "Queue run"** path against VCS-connected workspaces. Unaffected:
- VCS-poll-driven runs (used the correct call site)
- CLI-uploaded configuration versions (skips the fetch entirely)
- Plan-only runs from the UI on VCS workspaces (same code path — also broken; same fix)

## Test plan

- [x] \`make test\` — 1043 pass
- [x] \`make lint\` — clean
- [ ] After release, click "Queue run" on \`terrapod-config\` (the workspace that originally surfaced this) and confirm a 201 with a queued run

## Regression test

Not added in this PR — covering the call site requires mocking ~8 collaborators (\`_download_archive\`, \`_get_branch_sha\`, \`_resolve_branch\`, \`_parse_repo_url\`, \`_strip_top_level_dir\`, \`storage.put\`, \`run_service.create_configuration_version\`, \`run_service.mark_configuration_uploaded\`). The fix is obvious; the test scaffolding is not. Worth a follow-up to add a targeted unit test for \`_fetch_vcs_config\`.