### PR TITLE
feat(listener): Secret-backed identity with short-lived certs and renewal coordination

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,18 +286,20 @@ The entrypoint script is at `docker/runner-entrypoint.sh`.
 All listeners follow the same flow — there is no distinction between pool types:
 
 1. An admin creates an **agent pool** via the API (e.g. "production", "dev")
-2. An admin generates a **join token** for the pool
-3. The listener is configured with `TERRAPOD_JOIN_TOKEN` and `TERRAPOD_API_URL`
-4. On startup, the listener calls `POST /api/v2/agent-pools/join` with the token
-5. The API validates the token, issues an X.509 certificate (Ed25519), and returns the listener ID, cert, and pool ID
-6. Certificates are saved to disk for restart persistence (avoiding unnecessary re-joins)
+2. An admin generates a **join token** for the pool (default: 2 uses, 1h expiry)
+3. The listener Deployment is configured with `TERRAPOD_JOIN_TOKEN` and `TERRAPOD_API_URL`
+4. On startup, each listener pod looks for a Kubernetes Secret named after the Deployment (`{release-fullname}-listener-credentials`, supplied via `TERRAPOD_CREDENTIALS_SECRET_NAME`) in its own namespace. If present and valid, it adopts the existing identity (cert, key, CA, listener-id) and skips the join entirely
+5. If no Secret exists, the pod calls `POST /api/v2/agent-pools/join` with the token. The API validates it (SHA-256 hash, expiry, `max_uses`), issues a short-lived X.509 certificate (Ed25519, 1h validity by default), and returns the listener ID, cert, and pool ID
+6. The pod writes the credentials to the Secret. If the create returns `409 AlreadyExists` (another pod won the race), the loser re-reads the Secret and adopts the winner's identity
 7. The listener authenticates subsequent API calls via `X-Terrapod-Client-Cert` header (base64-encoded PEM)
 8. The listener connects to the SSE endpoint (`GET /api/v2/listeners/{id}/events`) — a persistent outbound HTTP stream for receiving events from the API
 9. Heartbeats every 60s (300s TTL in Redis), SSE event loop handles run claims, Job status queries, log streaming, and cancellation
 
-A listener can be deployed in the same cluster as the API or in a completely separate cluster — the join flow is identical. The SSE connection is outbound from the listener to the API, which works through firewalls without requiring inbound access. The Helm chart deploys a listener as a Deployment using a dedicated lightweight Docker image (`terrapod-listener`, ~225MB) that includes only the listener's dependencies (httpx, kubernetes, pydantic, structlog). The entrypoint is `python -m terrapod.runner.listener`. The listener has RBAC to create/watch/delete Jobs and Pods in the runner namespace.
+The Secret-backed identity model means a listener Deployment has **one shared identity across all pods**, surviving pod replacement and rolling updates without re-joining. See [Runners → Listener identity](runners.md#listener-identity) for the full bootstrap, renewal, and rotation lifecycle.
 
-**Multiple listener replicas** are supported for high availability. Set `listener.replicas > 1` — each pod derives a unique name by appending its Kubernetes pod name to the configured base name (`{base_name}-{pod_name}`). All replicas in a pool compete for queued runs via atomic Postgres locking (`SELECT ... FOR UPDATE SKIP LOCKED`). No leader election is required — Redis heartbeats track each listener independently, and stale records from terminated pods auto-expire after the 300s heartbeat TTL.
+A listener can be deployed in the same cluster as the API or in a completely separate cluster — the join flow is identical. The SSE connection is outbound from the listener to the API, which works through firewalls without requiring inbound access. The Helm chart deploys a listener as a Deployment using a dedicated lightweight Docker image (`terrapod-listener`, ~225MB) that includes only the listener's dependencies (httpx, kubernetes, pydantic, structlog). The entrypoint is `python -m terrapod.runner.listener`. The listener has RBAC to create/watch/delete Jobs and Pods in the runner namespace, plus scoped `get/list/watch/patch/update/delete` on its own credentials Secret.
+
+**Multiple listener replicas** are supported for high availability. Set `listener.replicas > 1` — all pods share one identity (the credentials Secret) but each derives a unique heartbeat name by appending its Kubernetes pod name to the configured base name (`{base_name}-{pod_name}`). All replicas in a pool compete for queued runs via atomic Postgres locking (`SELECT ... FOR UPDATE SKIP LOCKED`). No leader election is required — Redis heartbeats track each pod independently, and stale records from terminated pods auto-expire after the 300s heartbeat TTL.
 
 ![Agent Pool Detail](images/admin-agent-pool-detail.png)
 
@@ -330,14 +332,17 @@ Store in certificate_authority DB table (single row)
     |
     v
 Listener Join Flow:
-    1. Admin creates agent pool + join token
-    2. Listener calls POST /api/v2/agent-pools/join with the token
-    3. API validates join token (SHA-256 hash, expiry, max_uses)
-    4. API issues X.509 certificate with SAN URIs:
+    1. Admin creates agent pool + join token (default: 2 uses, 1h expiry)
+    2. Listener pod reads K8s Secret {fullname}-listener-credentials
+       - If valid cert present: adopt and skip join
+       - Otherwise: continue to step 3
+    3. Listener calls POST /api/v2/agent-pools/join with the token
+    4. API validates join token (SHA-256 hash, expiry, max_uses)
+    5. API issues short-lived X.509 certificate (1h default) with SAN URIs:
        - terrapod://listener/{name}
        - terrapod://pool/{pool_name}
-    5. Returns: listener ID, pool ID, certificate, private key, CA cert
-    6. Listener saves certs to disk for restart persistence
+    6. Returns: listener ID, pool ID, certificate, private key, CA cert
+    7. Listener writes Secret. On 409 AlreadyExists: re-read and adopt winner's identity
     |
     v
 Ongoing Authentication:
@@ -345,9 +350,13 @@ Ongoing Authentication:
     - API verifies: CA signature, expiry, CN->DB lookup, fingerprint match
     |
     v
-Certificate Renewal:
-    - At 50% of validity: POST /api/v2/listeners/{id}/renew
-    - No re-registration needed on restart if stored cert is valid
+Certificate Renewal (multi-pod safe):
+    - Each pod sleeps until cert reaches its renewal threshold
+      (validity/2 + per-pod splay 0..30s, hash of POD_NAME)
+    - Re-read the Secret first: if another pod already renewed, adopt and skip /renew
+    - Otherwise: POST /api/v2/listeners/{id}/renew (3 attempts with backoff)
+    - Write Secret with resourceVersion CAS — on conflict, re-read and adopt
+    - On /renew 401/403: clear Secret, fall back to join-token bootstrap
 ```
 
 **Source files:**

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -215,6 +215,73 @@ Workspace variables (env and terraform) are also injected as environment variabl
 
 ---
 
+## Listener Identity
+
+A listener is the long-lived Deployment that watches for runs and creates Job pods. It authenticates to the API with a short-lived X.509 certificate issued by the built-in CA. This section describes how that identity is bootstrapped, persisted, and renewed.
+
+### Deployment-level identity
+
+**Every pod in a listener Deployment shares one identity.** The cert/key/CA/listener-id live in a Kubernetes Secret named after the Deployment (`{release-fullname}-listener-credentials`) in the listener's own namespace. Multiple replicas read and write the same Secret using `resourceVersion` CAS, so pod replacement, rolling updates, and HPA scale-out never invalidate the identity. The Secret name is tied to the Deployment rather than `listener.name` so renaming the listener (changing its API-registered identity) doesn't orphan the Secret.
+
+This is intentional: scaling the Deployment must not require new join tokens or new listener registrations on the API side. From the API's perspective a single `listener.name` corresponds to a single registered listener, regardless of replica count. (Each pod still heartbeats with a unique `{base_name}-{pod_name}` so stale pods can be tracked and aged out independently.)
+
+### Bootstrap
+
+On startup each pod runs the same flow:
+
+1. Read the credentials Secret (name supplied via `TERRAPOD_CREDENTIALS_SECRET_NAME`, set by Helm to the Deployment fullname + `-credentials`). If it exists and has a valid cert/key/listener-id, adopt that identity and skip everything below.
+2. If no Secret, call `POST /api/v2/agent-pools/join` with `TERRAPOD_JOIN_TOKEN`. The API issues a short-lived cert and returns the full identity.
+3. Try to `create` the credentials Secret with that identity. On `409 AlreadyExists` another pod won the race — re-read the Secret and adopt the winner's identity instead. The cert this pod was just issued is silently dropped.
+4. If the join token is exhausted (`401`/`403`) before this pod gets a chance, the pod backs off (1, 2, 4, ... up to 30s, ~3 min total budget) and re-reads the Secret. As soon as a peer pod's bootstrap completes, the loser adopts that identity. This is why the default `max_uses: 2` is enough even for large replica counts — only the first two pods ever consume token uses, the rest discover the Secret.
+
+The default join token policy (`api.config.agent_pools.default_join_token_*`) creates tokens with `max_uses: 2` and a 1h expiry. Set either field to `null` via the API for unlimited uses or no expiry. Setting `max_uses: 1` is also fine for single-replica deployments — the bootstrap-race retry only matters when you scale up before the first pod completes.
+
+### Renewal
+
+Each pod independently runs a renewal loop:
+
+- The renewal threshold is `cert_validity_seconds / 2 + pod_splay_seconds`, where `pod_splay_seconds` is a deterministic SHA-256 hash of `POD_NAME` in the range `[0, 30)`. The splay desynchronises pods that started in lockstep so they don't all hit `/renew` simultaneously.
+- When a pod reaches its threshold, it **re-reads the Secret first**. If the cert in the Secret still has more remaining lifetime than this pod's threshold (plus a 30s skew margin), another pod has already renewed it — adopt and reset the timer.
+- Otherwise call `POST /api/v2/listeners/{id}/renew` with up to 3 attempts (exponential backoff on 5xx / network errors; immediate failure on 401/403).
+- On success, write the Secret with `resourceVersion` CAS. If another pod beat us to it (`409 Conflict`), re-read and adopt the peer's cert.
+- On `401`/`403` from `/renew`, the cert is rejected (revoked, listener deleted, etc.) — clear the Secret and fall back to the join-token bootstrap flow.
+
+The splay sits on the **renewal trigger**, not on startup. Adding sleeps to startup would fight Kubernetes scheduling and `minReadySeconds`; staggering renewal cycles is the right knob.
+
+### Configuration
+
+```yaml
+# helm/terrapod/values.yaml
+api:
+  config:
+    agent_pools:
+      # Listener cert lifetime. Lower values surface bugs faster (default 1h).
+      listener_cert_ttl_seconds: 3600
+      # Defaults applied when admins create new join tokens via the API.
+      # null = unlimited uses / no expiry.
+      default_join_token_max_uses: 2
+      default_join_token_ttl_seconds: 3600
+
+listener:
+  # Rolling update + minReadySeconds give the renewal cycles natural
+  # stagger after a deploy: maxUnavailable=1 means one pod at a time,
+  # minReadySeconds=30 spaces their POD_NAME-derived splays apart.
+  strategy:
+    maxSurge: 0
+    maxUnavailable: 1
+  minReadySeconds: 30
+```
+
+For Tilt local development, `values-local.yaml` overrides `listener_cert_ttl_seconds: 300` so a full bootstrap → renew → rotate cycle completes in a few minutes instead of an hour.
+
+### Operational notes
+
+- **Manual identity reset.** Delete the credentials Secret to force a fresh join on the next pod start: `kubectl -n terrapod delete secret {release-fullname}-listener-credentials` (find the exact name with `kubectl get secret -l app.kubernetes.io/component=listener`). This invalidates all running pods' certs on the next renewal. Rotate the join token first if the old one is no longer trusted.
+- **Listener rename.** Because the Secret name follows the Deployment, changing `listener.name` rolls the API-registered identity but keeps the same Secret — the new identity simply overwrites it on next renewal. The old listener record in the API ages out of Redis when its heartbeats stop.
+- **RBAC scope.** The listener ServiceAccount has `create` on Secrets in its own namespace and `get/list/watch/patch/update/delete` scoped by `resourceNames` to just the credentials Secret. The runner-namespace RBAC (Jobs, Pods, run-token Secrets) is separate.
+
+---
+
 ## See Also
 
 - [Architecture](architecture.md) -- runner listener, reconciler, ARC pattern

--- a/helm/terrapod/templates/_helpers.tpl
+++ b/helm/terrapod/templates/_helpers.tpl
@@ -103,6 +103,15 @@ Listener service account name.
 {{- end }}
 
 {{/*
+Listener credentials Secret name. Tied to the listener Deployment name so the
+Secret follows the Deployment's lifecycle (rename/delete cleans up naturally)
+and is unique per Helm release even if multiple releases share `listener.name`.
+*/}}
+{{- define "terrapod.listenerCredentialsSecretName" -}}
+{{- printf "%s-listener-credentials" (include "terrapod.fullname" .) -}}
+{{- end -}}
+
+{{/*
 Get the API image reference, defaulting tag to appVersion
 */}}
 {{- define "terrapod.api.image" -}}

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -179,6 +179,16 @@ data:
     audit:
       retention_days: {{ .Values.api.config.audit.retention_days | default 90 }}
     {{- end }}
+    {{- if .Values.api.config.agent_pools }}
+    agent_pools:
+      listener_cert_ttl_seconds: {{ .Values.api.config.agent_pools.listener_cert_ttl_seconds | default 3600 }}
+      {{- with .Values.api.config.agent_pools.default_join_token_max_uses }}
+      default_join_token_max_uses: {{ . }}
+      {{- end }}
+      {{- with .Values.api.config.agent_pools.default_join_token_ttl_seconds }}
+      default_join_token_ttl_seconds: {{ . }}
+      {{- end }}
+    {{- end }}
     {{- if .Values.api.config.drift_detection }}
     drift_detection:
       enabled: {{ .Values.api.config.drift_detection.enabled }}

--- a/helm/terrapod/templates/deployment-listener.yaml
+++ b/helm/terrapod/templates/deployment-listener.yaml
@@ -16,6 +16,7 @@ spec:
     rollingUpdate:
       maxSurge: {{ .Values.listener.strategy.maxSurge }}
       maxUnavailable: {{ .Values.listener.strategy.maxUnavailable }}
+  minReadySeconds: {{ .Values.listener.minReadySeconds | default 30 }}
   selector:
     matchLabels:
       {{- include "terrapod.listener.selectorLabels" . | nindent 6 }}
@@ -59,6 +60,11 @@ spec:
               value: {{ include "terrapod.runnerNamespace" . | quote }}
             - name: TERRAPOD_LISTENER_NAME
               value: {{ .Values.listener.name | default "listener" | quote }}
+            # Credentials-Secret name is tied to the listener Deployment, not
+            # to listener.name, so renaming the listener (changing its
+            # API-registered identity) doesn't orphan the Secret.
+            - name: TERRAPOD_CREDENTIALS_SECRET_NAME
+              value: {{ include "terrapod.listenerCredentialsSecretName" . | quote }}
             - name: TERRAPOD_HEALTH_PORT
               value: {{ .Values.listener.healthPort | default 8081 | quote }}
             - name: POD_NAME
@@ -67,6 +73,12 @@ spec:
                   fieldPath: metadata.name
             - name: TERRAPOD_API_URL
               value: {{ .Values.listener.apiUrl | default (printf "http://%s-api:8000" (include "terrapod.fullname" .)) | quote }}
+            # Cert TTL drives the renewal threshold (renew at 50% + splay).
+            # Must match `api.config.agent_pools.listener_cert_ttl_seconds` so
+            # pods anticipate renewal correctly. Values-local.yaml lowers
+            # this for fast iteration.
+            - name: TERRAPOD_LISTENER_CERT_TTL_SECONDS
+              value: {{ .Values.api.config.agent_pools.listener_cert_ttl_seconds | default 3600 | quote }}
             {{- if .Values.listener.existingSecret }}
             - name: TERRAPOD_JOIN_TOKEN
               valueFrom:
@@ -88,8 +100,6 @@ spec:
             - name: runner-config
               mountPath: /etc/terrapod
               readOnly: true
-            - name: certs
-              mountPath: /var/lib/terrapod/certs
             - name: tmp
               mountPath: /tmp
             {{- with .Values.listener.extraVolumeMounts }}
@@ -130,8 +140,9 @@ spec:
         - name: runner-config
           configMap:
             name: {{ include "terrapod.fullname" . }}-runner-config
-        - name: certs
-          emptyDir: {}
+        # Cert material lives in the K8s Secret named after the Deployment
+        # (TERRAPOD_CREDENTIALS_SECRET_NAME above), accessed via the K8s API
+        # by the listener — not via a volume mount.
         - name: tmp
           emptyDir: {}
         {{- with .Values.listener.extraVolumes }}

--- a/helm/terrapod/templates/rbac-listener.yaml
+++ b/helm/terrapod/templates/rbac-listener.yaml
@@ -51,4 +51,45 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "terrapod.listenerServiceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+# Credentials-Secret access in the listener's own namespace. The listener
+# stores its X.509 cert + key + CA + listener-id in this Secret and rotates
+# it via the API. Scoped to the single Secret name to limit blast radius.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "terrapod.fullname" . }}-listener-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: listener
+rules:
+  # `create` cannot be scoped to a resourceName (the resource doesn't exist
+  # yet at admission time); the rest are. The `delete` is for the rejoin
+  # path — wiping the Secret forces a fresh join-token bootstrap.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ include "terrapod.listenerCredentialsSecretName" . | quote }}
+    verbs: ["get", "list", "watch", "patch", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "terrapod.fullname" . }}-listener-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: listener
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "terrapod.fullname" . }}-listener-credentials
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "terrapod.listenerServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -51,6 +51,11 @@ api:
       # before they GA. Production defaults to "none" (GA only).
       binary_cache:
         allow_prerelease: rc
+    # Fast cert renewal cycle for Tilt — listener cert valid for 5min so the
+    # full bootstrap → renew → rotate loop is observable in a few minutes
+    # instead of an hour. Production stays at the 1h default.
+    agent_pools:
+      listener_cert_ttl_seconds: 300
     auth:
       local_enabled: true
       callback_base_url: "https://terrapod.local"

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -142,6 +142,7 @@
         "autoscaling": { "$ref": "#/$defs/autoscalingSpec" },
         "pdb": { "$ref": "#/$defs/pdbSpec" },
         "strategy": { "$ref": "#/$defs/strategySpec" },
+        "minReadySeconds": { "type": "integer", "minimum": 0 },
         "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
         "preStopSleepSeconds": { "type": "integer", "minimum": 0 },
         "podAntiAffinity": { "$ref": "#/$defs/podAntiAffinitySpec" },
@@ -567,6 +568,20 @@
           "additionalProperties": false,
           "properties": {
             "retention_days": { "type": "integer", "minimum": 1 }
+          }
+        },
+
+        "agent_pools": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "listener_cert_ttl_seconds": { "type": "integer", "minimum": 60 },
+            "default_join_token_max_uses": {
+              "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+            },
+            "default_join_token_ttl_seconds": {
+              "oneOf": [{ "type": "integer", "minimum": 60 }, { "type": "null" }]
+            }
           }
         },
 

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -238,6 +238,21 @@ api:
     audit:
       retention_days: 90
 
+    # Agent pools — listener X.509 cert TTL + join-token defaults.
+    agent_pools:
+      # Listener cert lifetime in seconds. Listeners renew at 50% of this
+      # plus a per-pod splay (0..30s). 1h is a good production default;
+      # values-local.yaml overrides to 300s so renewal cycles are
+      # observable in a few minutes.
+      listener_cert_ttl_seconds: 3600
+      # New join tokens default to 2 uses + 1h expiry — tolerates a single
+      # bootstrap-race retry across multi-replica listener Deployments
+      # without leaving the token reusable. Set per-token via the API to
+      # override (max-uses=null means unlimited; expires-at=null means
+      # no expiry).
+      default_join_token_max_uses: 2
+      default_join_token_ttl_seconds: 3600
+
     # Drift Detection — scheduled plan-only runs to detect infrastructure drift
     drift_detection:
       enabled: true
@@ -572,8 +587,13 @@ listener:
     repository: ghcr.io/mattrobinsonsre/terrapod-listener
     tag: ""  # Defaults to appVersion
     pullPolicy: IfNotPresent
-  # Base name for listener identity. Each pod appends its pod name,
-  # so the registered name becomes "{name}-{pod-name}".
+  # Listener identity. ALL pods of this Deployment share this single name —
+  # they coordinate via a K8s Secret named "{name}-credentials" in the
+  # release namespace, store the X.509 cert there, and rotate it at 50%
+  # of `runners.listenerCertTtlSeconds` plus a per-pod splay. Multiple
+  # pods running concurrently is supported; coordination uses the
+  # existing pool-level pub/sub + the run-claim DB lock + the Secret CAS
+  # for cert renewal.
   name: "listener"
   # Port for /health and /ready HTTP probe endpoints
   healthPort: 8081
@@ -622,10 +642,15 @@ listener:
     enabled: true
     maxUnavailable: 1
 
-  # Rolling update strategy — surge before killing to avoid downtime at any replica count.
+  # Rolling update strategy. maxUnavailable=1 + maxSurge=0 + minReadySeconds=30
+  # roll one pod at a time, with a 30s settle window before the next pod is
+  # touched. Combined with the per-pod cert-renewal splay this keeps cert
+  # rotation cycles across the deployment unaligned, so at most one /renew
+  # call goes through the API per cycle in steady state.
   strategy:
-    maxSurge: 1
-    maxUnavailable: 0
+    maxSurge: 0
+    maxUnavailable: 1
+  minReadySeconds: 30
 
   terminationGracePeriodSeconds: 120
   # Listeners are stateless event bridges to K8s; the API server can tolerate

--- a/services/pyproject-listener.toml
+++ b/services/pyproject-listener.toml
@@ -3,6 +3,7 @@ name = "terrapod-listener"
 version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
+    "cryptography>=46.0.5,<48.0.0",
     "httpx>=0.28",
     "kubernetes>=35.0",
     "prometheus-client>=0.24",

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -33,7 +33,9 @@ from sse_starlette.sse import EventSourceResponse
 from terrapod.api.dependencies import (
     DEFAULT_ORG,
     AuthenticatedUser,
+    ListenerIdentity,
     get_current_user,
+    get_listener_identity,
     require_admin,
 )
 from terrapod.db.session import get_db
@@ -730,14 +732,25 @@ async def listener_heartbeat(
 @router.post("/listeners/{listener_id}/renew")
 async def renew_listener_cert(
     listener_id: str = Path(...),
+    identity: ListenerIdentity = Depends(get_listener_identity),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Renew a listener's certificate.
 
-    Auth: Certificate-based (X-Terrapod-Client-Cert). For now accepts
-    any request with a valid listener ID. Still needs DB for pool lookup.
+    Auth: must present a currently-valid client cert via
+    `X-Terrapod-Client-Cert` (verified by `get_listener_identity`: CA
+    signature, expiry, listener-name lookup, fingerprint match). The
+    cert's listener id must also match the path id — a listener can
+    only renew its own cert, not another listener's.
     """
     l_uuid = uuid.UUID(listener_id.removeprefix("listener-"))
+
+    if identity.listener_id != l_uuid:
+        raise HTTPException(
+            status_code=403,
+            detail="Certificate does not match the listener id in the path",
+        )
+
     listener = await agent_pool_service.get_listener(l_uuid)
     if listener is None:
         raise HTTPException(status_code=404, detail="Listener not found")

--- a/services/terrapod/auth/ca.py
+++ b/services/terrapod/auth/ca.py
@@ -125,14 +125,17 @@ class CertificateAuthority:
         self,
         name: str,
         pool_name: str,
-        ttl_hours: int = 8760,
+        ttl_seconds: int = 3600,
     ) -> tuple[x509.Certificate, ed25519.Ed25519PrivateKey]:
         """Issue a certificate for a runner listener.
 
         Args:
             name: Listener name (used as CN).
             pool_name: Agent pool name (embedded in SAN URI).
-            ttl_hours: Certificate lifetime (default: 1 year).
+            ttl_seconds: Certificate lifetime in seconds (default: 1h).
+                Listeners renew at 50% of this lifetime plus a per-pod
+                splay; tighter values constrain how long a leaked cert
+                stays usable but increase API renewal traffic.
 
         Returns:
             Tuple of (certificate, private_key).
@@ -156,7 +159,7 @@ class CertificateAuthority:
             .public_key(public_key)
             .serial_number(x509.random_serial_number())
             .not_valid_before(now)
-            .not_valid_after(now + datetime.timedelta(hours=ttl_hours))
+            .not_valid_after(now + datetime.timedelta(seconds=ttl_seconds))
             .add_extension(
                 x509.BasicConstraints(ca=False, path_length=None),
                 critical=True,

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -433,6 +433,45 @@ class CORSConfig(BaseModel):
 # --- Rate Limiting Configuration ---
 
 
+class AgentPoolsConfig(BaseModel):
+    """Agent pool join-token defaults and listener-certificate lifetime.
+
+    Tighter defaults reduce the blast radius of a leaked join token; looser
+    defaults reduce operational noise from re-issuance on routine pod
+    restarts that miss the renewal window. Listeners renew their cert at
+    50% of `listener_cert_ttl_seconds` (plus a small per-pod splay), so
+    that value also controls how often the API reissues a fresh cert.
+    """
+
+    listener_cert_ttl_seconds: int = Field(
+        default=3600,
+        description=(
+            "Listener X.509 certificate lifetime in seconds (default 1h). "
+            "Listeners renew at 50% of TTL plus a per-pod splay, so this "
+            "drives both how fast a compromised cert ages out and how often "
+            "the API issues fresh ones. For local Tilt, override to ~300s "
+            "in values-local.yaml so a renewal cycle finishes in minutes."
+        ),
+    )
+    default_join_token_max_uses: int | None = Field(
+        default=2,
+        description=(
+            "Default max_uses on newly-created join tokens. 2 tolerates a "
+            "single bootstrap-race retry across multi-replica listener "
+            "deployments without making the token reusable indefinitely. "
+            "Per-token override is still accepted via the API."
+        ),
+    )
+    default_join_token_ttl_seconds: int | None = Field(
+        default=3600,
+        description=(
+            "Default lifetime for newly-created join tokens, in seconds. "
+            "Applied as expires_at = now() + this. Default 1h. Set to null "
+            "to default to no expiry (per-token override still accepted)."
+        ),
+    )
+
+
 class RateLimitConfig(BaseModel):
     """API rate limiting configuration.
 
@@ -624,6 +663,9 @@ class Settings(BaseSettings):
 
     # CORS
     cors: CORSConfig = Field(default_factory=CORSConfig)
+
+    # Agent Pools
+    agent_pools: AgentPoolsConfig = Field(default_factory=AgentPoolsConfig)
 
     # Rate Limiting
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)

--- a/services/terrapod/runner/identity.py
+++ b/services/terrapod/runner/identity.py
@@ -1,216 +1,625 @@
-"""Listener identity management — join via token exchange."""
+"""Listener identity — Secret-backed cert persistence with split-brain-safe rotation.
 
+Identity model
+--------------
+One listener identity per Helm release / deployment. The listener-id, cert,
+key, and CA cert all live in a single K8s Secret whose name is supplied via
+`TERRAPOD_CREDENTIALS_SECRET_NAME` (Helm wires this to the listener
+Deployment's fullname + `-credentials`) in the listener pod's own namespace.
+Multiple pods of the same deployment share that identity — they all subscribe
+to the same SSE channel, all heartbeat the same Redis key, and run-claim is
+coordinated via the existing `SELECT … FOR UPDATE SKIP LOCKED` so duplicate
+work doesn't happen.
+
+Startup flow
+------------
+1. Try to read the Secret. If found, return that identity (the renewal loop
+   will refresh the cert on the next cycle).
+2. If absent, call `/agent-pools/join` with `TERRAPOD_JOIN_TOKEN` and write
+   the response into a freshly-created Secret. If the create races (another
+   pod beat us → 409 AlreadyExists) or the API rejects the join token
+   because another pod already used it (`max_uses` exhausted), retry by
+   re-reading the Secret with backoff — the winning pod is in the middle
+   of writing it.
+
+Renewal coordination
+--------------------
+At a per-pod splay-offset within the renewal window:
+1. Re-read the Secret. If its cert is "recent enough" (would not itself need
+   renewal yet from this pod's perspective), adopt it without calling
+   `/renew`. This is what keeps cert renewal serial across the deployment in
+   steady state.
+2. Otherwise call `/renew`. On success, attempt to write the Secret with the
+   `resourceVersion` we read at step 1 — optimistic CAS. On 409 conflict
+   (another pod wrote first), drop our newly-issued cert and re-read the
+   Secret to adopt theirs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
 import os
 import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from cryptography import x509
 
 from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 
+# Secret structure — keys inside data:
+_K_TLS_CRT = "tls.crt"
+_K_TLS_KEY = "tls.key"
+_K_CA_CRT = "ca.crt"
+_K_LISTENER_ID = "listener-id"
+_K_POOL_ID = "pool-id"
+
+
+@dataclass
 class ListenerIdentity:
-    """Identity for a runner listener.
+    """Active listener identity with the cert material currently in use."""
 
-    All listeners join a pool via the API using a join token.
-    The join flow issues an X.509 certificate used for subsequent API calls.
-    Certificates are saved to disk for restart persistence.
-    """
+    listener_id: uuid.UUID
+    name: str
+    pool_id: uuid.UUID
+    api_url: str
+    certificate_pem: str
+    private_key_pem: str
+    ca_cert_pem: str
+    secret_resource_version: str | None = None
 
-    def __init__(
-        self,
-        listener_id: uuid.UUID,
-        name: str,
-        pool_id: uuid.UUID,
-        api_url: str,
-        certificate_pem: str,
-        private_key_pem: str,
-        ca_cert_pem: str,
-    ):
-        self.listener_id = listener_id
-        self.name = name
-        self.pool_id = pool_id
-        self.api_url = api_url
-        self.certificate_pem = certificate_pem
-        self.private_key_pem = private_key_pem
-        self.ca_cert_pem = ca_cert_pem
+
+# ── Public entry point ──────────────────────────────────────────────
 
 
 async def establish_identity() -> ListenerIdentity:
-    """Establish listener identity.
-
-    1. Check for saved certificates from a previous join → resume if valid
-    2. Otherwise join via TERRAPOD_JOIN_TOKEN → save certs for next restart
-    """
-    base_name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
-    pod_name = os.environ.get("POD_NAME", "")
-    name = f"{base_name}-{pod_name}" if pod_name else base_name
+    """Establish a listener identity for this pod. See module docstring."""
+    name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
     api_url = os.environ.get("TERRAPOD_API_URL", "http://localhost:8000")
+    secret_name = _credentials_secret_name(name)
+    namespace = _read_in_pod_namespace()
 
-    # Try to resume from saved certificates
-    identity = _try_resume(name, api_url)
-    if identity:
+    secret = _read_secret(secret_name, namespace)
+    if secret is not None:
+        identity = _identity_from_secret(secret, name=name, api_url=api_url)
         logger.info(
-            "Resumed from saved certificate",
+            "Resumed identity from K8s Secret",
             listener_id=str(identity.listener_id),
-            name=identity.name,
+            name=name,
+            secret=f"{namespace}/{secret_name}",
         )
         return identity
 
-    # Join via token exchange
-    return await _join_via_token(name, api_url)
+    # No Secret yet — bootstrap via join token, possibly racing other pods.
+    return await _bootstrap_via_join_token(name, api_url, secret_name, namespace)
 
 
-def _try_resume(name: str, api_url: str) -> ListenerIdentity | None:
-    """Try to resume from saved certificates on disk."""
-    cert_dir = os.environ.get("TERRAPOD_CERT_DIR", "/var/lib/terrapod/certs")
-    cert_path = os.path.join(cert_dir, "listener.crt")
-    key_path = os.path.join(cert_dir, "listener.key")
-    ca_path = os.path.join(cert_dir, "ca.crt")
-    meta_path = os.path.join(cert_dir, "identity.txt")
-
-    if not all(os.path.exists(p) for p in [cert_path, key_path, ca_path, meta_path]):
-        return None
-
-    try:
-        with open(cert_path) as f:
-            cert_pem = f.read()
-        with open(key_path) as f:
-            key_pem = f.read()
-        with open(ca_path) as f:
-            ca_pem = f.read()
-        with open(meta_path) as f:
-            lines = f.read().strip().splitlines()
-            meta = dict(line.split("=", 1) for line in lines if "=" in line)
-
-        listener_id = uuid.UUID(meta["listener_id"])
-        pool_id = uuid.UUID(meta["pool_id"])
-
-        return ListenerIdentity(
-            listener_id=listener_id,
-            name=name,
-            pool_id=pool_id,
-            api_url=api_url,
-            certificate_pem=cert_pem,
-            private_key_pem=key_pem,
-            ca_cert_pem=ca_pem,
-        )
-    except Exception as e:
-        logger.warning("Failed to resume from saved certs, will rejoin", error=str(e))
-        return None
+# ── Secret I/O ──────────────────────────────────────────────────────
 
 
-def _clear_saved_certs() -> None:
-    """Remove saved certificates to force a fresh join on next establish_identity()."""
-    cert_dir = os.environ.get("TERRAPOD_CERT_DIR", "/var/lib/terrapod/certs")
-    for filename in ("listener.crt", "listener.key", "ca.crt", "identity.txt"):
-        path = os.path.join(cert_dir, filename)
-        try:
-            os.remove(path)
-        except FileNotFoundError:
-            pass
-    logger.info("Cleared saved certificates")
+def clear_credentials_secret() -> None:
+    """Delete the credentials Secret so the next establish_identity() bootstraps fresh.
 
-
-async def _join_via_token(name: str, api_url: str) -> ListenerIdentity:
-    """Join a pool via token exchange with the API server.
-
-    Retries with exponential backoff if the API is not yet available.
+    Used by `_rejoin` after persistent 401s — the cert in the Secret has been
+    rejected by the API (e.g. Redis listener registration aged out and the
+    fingerprint check now fails). Removing the Secret forces fall-through to
+    the join-token path. Other pods sharing the deployment will see the
+    Secret vanish on their next renewal cycle and join afresh themselves —
+    that's the price of a shared identity going stale.
     """
-    import asyncio
+    from kubernetes.client.rest import ApiException
 
-    import httpx
+    name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
+    secret_name = _credentials_secret_name(name)
+    namespace = _read_in_pod_namespace()
+    api = _core_api()
+    try:
+        api.delete_namespaced_secret(name=secret_name, namespace=namespace)
+        logger.info("Cleared credentials Secret", secret=f"{namespace}/{secret_name}")
+    except ApiException as e:
+        if e.status == 404:
+            return  # already gone
+        logger.warning("Failed to clear credentials Secret", error=str(e))
 
+
+def _credentials_secret_name(listener_name: str) -> str:
+    """Resolve the credentials Secret name.
+
+    Helm sets `TERRAPOD_CREDENTIALS_SECRET_NAME` to the Deployment fullname +
+    `-credentials` so the Secret is tied to the Deployment lifecycle. Falls
+    back to `{listener_name}-credentials` for environments without Helm
+    (legacy deployments, local tests).
+    """
+    explicit = os.environ.get("TERRAPOD_CREDENTIALS_SECRET_NAME")
+    if explicit:
+        return explicit
+    return f"{listener_name}-credentials"
+
+
+def _read_in_pod_namespace() -> str:
+    """Read the pod's own namespace from the projected SA token mount."""
+    path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except OSError:
+        # Local dev fallback. Helm tests / Tilt can set TERRAPOD_LISTENER_NAMESPACE.
+        return os.environ.get("TERRAPOD_LISTENER_NAMESPACE", "terrapod")
+
+
+def _read_secret(name: str, namespace: str):
+    """Return the V1Secret or None if it doesn't exist (404)."""
+    from kubernetes.client.rest import ApiException
+
+    api = _core_api()
+    try:
+        return api.read_namespaced_secret(name=name, namespace=namespace)
+    except ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
+def _create_secret(
+    name: str,
+    namespace: str,
+    *,
+    cert: str,
+    key: str,
+    ca: str,
+    listener_id: uuid.UUID,
+    pool_id: uuid.UUID,
+):
+    """Create the credentials Secret. Raises 409 ApiException if it already exists."""
+    from kubernetes import client as k8s
+
+    api = _core_api()
+    body = k8s.V1Secret(
+        metadata=k8s.V1ObjectMeta(name=name, namespace=namespace),
+        type="Opaque",
+        string_data={
+            _K_TLS_CRT: cert,
+            _K_TLS_KEY: key,
+            _K_CA_CRT: ca,
+            _K_LISTENER_ID: str(listener_id),
+            _K_POOL_ID: str(pool_id),
+        },
+    )
+    return api.create_namespaced_secret(namespace=namespace, body=body)
+
+
+def _replace_secret(
+    name: str,
+    namespace: str,
+    *,
+    cert: str,
+    key: str,
+    ca: str,
+    listener_id: uuid.UUID,
+    pool_id: uuid.UUID,
+    resource_version: str | None,
+):
+    """Replace the Secret with optimistic concurrency on resource_version.
+
+    If `resource_version` is provided and stale, the K8s API returns 409
+    Conflict — caller must re-read and adopt the winner's cert. If None,
+    the replace is unconditional (used after a successful CAS conflict
+    where we explicitly want last-writer-wins).
+    """
+    from kubernetes import client as k8s
+
+    api = _core_api()
+    body = k8s.V1Secret(
+        metadata=k8s.V1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            resource_version=resource_version,
+        ),
+        type="Opaque",
+        string_data={
+            _K_TLS_CRT: cert,
+            _K_TLS_KEY: key,
+            _K_CA_CRT: ca,
+            _K_LISTENER_ID: str(listener_id),
+            _K_POOL_ID: str(pool_id),
+        },
+    )
+    return api.replace_namespaced_secret(name=name, namespace=namespace, body=body)
+
+
+def _core_api():
+    """Get the K8s CoreV1Api, lazily initializing the client if needed."""
+    from terrapod.runner.job_manager import _get_core_api
+
+    return _get_core_api()
+
+
+# ── Secret → identity ───────────────────────────────────────────────
+
+
+def _decode_data_field(secret, key: str) -> str:
+    """Read a field from a V1Secret's data, base64-decoded."""
+    raw = (secret.data or {}).get(key, "")
+    if not raw:
+        raise KeyError(f"Secret missing required field: {key}")
+    return base64.b64decode(raw).decode()
+
+
+def _identity_from_secret(secret, *, name: str, api_url: str) -> ListenerIdentity:
+    """Convert a V1Secret to a ListenerIdentity."""
+    return ListenerIdentity(
+        listener_id=uuid.UUID(_decode_data_field(secret, _K_LISTENER_ID)),
+        name=name,
+        pool_id=uuid.UUID(_decode_data_field(secret, _K_POOL_ID)),
+        api_url=api_url,
+        certificate_pem=_decode_data_field(secret, _K_TLS_CRT),
+        private_key_pem=_decode_data_field(secret, _K_TLS_KEY),
+        ca_cert_pem=_decode_data_field(secret, _K_CA_CRT),
+        secret_resource_version=secret.metadata.resource_version,
+    )
+
+
+# ── Bootstrap (join token) ──────────────────────────────────────────
+
+
+async def _bootstrap_via_join_token(
+    name: str, api_url: str, secret_name: str, namespace: str
+) -> ListenerIdentity:
+    """Initial join: try `/agent-pools/join`, write the Secret, retry-read on race.
+
+    Possible failure modes when N pods bootstrap simultaneously with a
+    `max_uses=2` token: the first 2 pods succeed at /join, the 3rd+ get
+    "max uses exceeded". Either way, the Secret should appear shortly —
+    the winner writes it as part of their bootstrap. Losers keep
+    re-reading the Secret with backoff until it appears.
+    """
     join_token = os.environ.get("TERRAPOD_JOIN_TOKEN", "")
     if not join_token:
         raise RuntimeError(
-            "TERRAPOD_JOIN_TOKEN is required. "
-            "Create an agent pool and generate a join token via the API, "
-            "then set the token as TERRAPOD_JOIN_TOKEN."
+            "TERRAPOD_JOIN_TOKEN is required for initial bootstrap (no Secret found). "
+            "Create a join token via the API, store it in the listener's join-token "
+            "Secret, and restart."
         )
 
-    max_retries = 30
-    backoff = 2
+    # Bound the time we'll wait for either a successful /join or for
+    # another pod's Secret to appear.
+    max_attempts = 12  # ~ 1 + 2 + 4 + 8 ... capped at 30 → ~3 min total
+    backoff = 1.0
 
-    for attempt in range(max_retries):
-        try:
-            async with httpx.AsyncClient(base_url=api_url, timeout=30) as client:
-                response = await client.post(
-                    "/api/v2/agent-pools/join",
-                    json={
-                        "join_token": join_token,
-                        "name": name,
-                    },
-                )
-                response.raise_for_status()
-                data = response.json()["data"]
-
-            listener_id = uuid.UUID(data["listener_id"])
-            pool_id = uuid.UUID(data["pool_id"])
-
-            # Save certificates and metadata to disk for restart persistence
-            _save_certs(
-                listener_id=listener_id,
-                pool_id=pool_id,
-                certificate=data["certificate"],
-                private_key=data["private_key"],
-                ca_certificate=data["ca_certificate"],
-            )
-
+    for attempt in range(max_attempts):
+        # Always re-check the Secret first — another pod may have raced ahead
+        # since our last attempt.
+        secret = _read_secret(secret_name, namespace)
+        if secret is not None:
+            identity = _identity_from_secret(secret, name=name, api_url=api_url)
             logger.info(
-                "Joined pool via token exchange",
-                listener_id=str(listener_id),
+                "Adopted credentials Secret written by another pod",
+                listener_id=str(identity.listener_id),
                 name=name,
-                pool_id=str(pool_id),
             )
+            return identity
 
-            return ListenerIdentity(
-                listener_id=listener_id,
+        # No Secret yet. Try /join.
+        try:
+            data = await _call_join(api_url, join_token, name)
+        except _JoinTokenExhausted:
+            # Another pod consumed the token's last use. The winner is
+            # writing the Secret — keep polling.
+            wait = min(backoff * (2**attempt), 30)
+            logger.info(
+                "Join token exhausted; another pod is winning. Re-reading Secret.",
+                attempt=attempt + 1,
+                wait_seconds=wait,
+            )
+            await asyncio.sleep(wait)
+            continue
+        except _JoinTransient as e:
+            # API not yet available, network blip, etc. Plain retry.
+            wait = min(backoff * (2**attempt), 30)
+            logger.warning(
+                "Transient /join failure, retrying",
+                attempt=attempt + 1,
+                wait_seconds=wait,
+                error=str(e),
+            )
+            await asyncio.sleep(wait)
+            continue
+
+        # /join succeeded — write the Secret. If another pod beat us to
+        # writing it (their /join also succeeded; max_uses>=2 makes this
+        # possible), adopt theirs and discard our cert. The losing cert
+        # remains valid until expiry but is unused.
+        try:
+            secret = _create_secret(
+                secret_name,
+                namespace,
+                cert=data["certificate"],
+                key=data["private_key"],
+                ca=data["ca_certificate"],
+                listener_id=uuid.UUID(data["listener_id"]),
+                pool_id=uuid.UUID(data["pool_id"]),
+            )
+        except _SecretAlreadyExists:
+            secret = _read_secret(secret_name, namespace)
+            if secret is None:
+                # Should be impossible — we just hit AlreadyExists.
+                continue
+            identity = _identity_from_secret(secret, name=name, api_url=api_url)
+            logger.info(
+                "Lost CAS race on Secret create; adopted winner's identity",
+                listener_id=str(identity.listener_id),
                 name=name,
-                pool_id=pool_id,
-                api_url=api_url,
-                certificate_pem=data["certificate"],
-                private_key_pem=data["private_key"],
-                ca_cert_pem=data["ca_certificate"],
             )
+            return identity
 
-        except Exception as e:
-            if attempt < max_retries - 1:
-                wait = min(backoff * (2**attempt), 60)
-                logger.warning(
-                    "Join failed, retrying",
-                    attempt=attempt + 1,
-                    wait_seconds=wait,
-                    error=str(e),
-                )
-                await asyncio.sleep(wait)
-            else:
-                raise RuntimeError(f"Failed to join pool after {max_retries} attempts: {e}") from e
+        identity = ListenerIdentity(
+            listener_id=uuid.UUID(data["listener_id"]),
+            name=name,
+            pool_id=uuid.UUID(data["pool_id"]),
+            api_url=api_url,
+            certificate_pem=data["certificate"],
+            private_key_pem=data["private_key"],
+            ca_cert_pem=data["ca_certificate"],
+            secret_resource_version=secret.metadata.resource_version,
+        )
+        logger.info(
+            "Joined pool via token, wrote credentials Secret",
+            listener_id=str(identity.listener_id),
+            name=name,
+            pool_id=str(identity.pool_id),
+        )
+        return identity
 
-    raise RuntimeError("Unreachable")
+    raise RuntimeError(
+        f"Failed to establish listener identity after {max_attempts} attempts. "
+        "Either the API is unreachable or the join token is invalid."
+    )
 
 
-def _save_certs(
-    listener_id: uuid.UUID,
-    pool_id: uuid.UUID,
-    certificate: str,
-    private_key: str,
-    ca_certificate: str,
+# ── Renewal ─────────────────────────────────────────────────────────
+
+
+def cert_not_after(cert_pem: str) -> datetime:
+    """Return the not-after timestamp on a PEM-encoded cert."""
+    return x509.load_pem_x509_certificate(cert_pem.encode()).not_valid_after_utc
+
+
+def pod_splay_seconds(pod_name: str = "", max_splay: int = 30) -> int:
+    """Deterministic 0..max_splay-1 splay value derived from pod name.
+
+    The splay offsets each pod's renewal trigger so simultaneous pod
+    starts don't all hit `/renew` at the same instant; combined with
+    the optimistic CAS on the Secret, this means only one renewal
+    actually goes through per cycle in steady state.
+    """
+    src = pod_name or os.environ.get("POD_NAME", "") or os.environ.get("HOSTNAME", "")
+    if not src:
+        return 0
+    digest = hashlib.sha256(src.encode()).digest()
+    return int.from_bytes(digest[:2], "big") % max_splay
+
+
+async def renew_loop(
+    identity_holder,
+    *,
+    secret_name: str,
+    namespace: str,
+    cert_validity_seconds: int,
+    splay_seconds: int,
 ) -> None:
-    """Save certificate material to disk for restart persistence."""
-    cert_dir = os.environ.get("TERRAPOD_CERT_DIR", "/var/lib/terrapod/certs")
-    os.makedirs(cert_dir, exist_ok=True)
+    """Keep `identity_holder.identity` fresh.
 
-    with open(os.path.join(cert_dir, "listener.crt"), "w") as f:
-        f.write(certificate)
+    `identity_holder` exposes a mutable `identity: ListenerIdentity` that
+    other listener loops read. We update it in place (well, replace it)
+    when we adopt a fresher cert from the Secret or successfully renew.
 
-    key_path = os.path.join(cert_dir, "listener.key")
-    with open(key_path, "w") as f:
-        f.write(private_key)
-    os.chmod(key_path, 0o600)
+    Step 1 of each cycle: re-read the Secret. If its cert has more remaining
+    life than our renewal threshold, adopt it without calling `/renew`. This
+    serializes renewal across pods — first pod to renew wins; the others
+    pick it up here.
 
-    with open(os.path.join(cert_dir, "ca.crt"), "w") as f:
-        f.write(ca_certificate)
+    Step 2: if the Secret cert is stale (or matches ours), we are the
+    renewer. Call `/renew`, then write the new cert with `resourceVersion`
+    CAS. On 409, drop the cert we just got and adopt the Secret's instead.
+    """
+    threshold = cert_validity_seconds // 2 + splay_seconds
+    skew = 30  # seconds
 
-    with open(os.path.join(cert_dir, "identity.txt"), "w") as f:
-        f.write(f"listener_id={listener_id}\n")
-        f.write(f"pool_id={pool_id}\n")
+    while True:
+        cert = identity_holder.identity
+        try:
+            expires = cert_not_after(cert.certificate_pem)
+        except Exception as e:
+            logger.error("Cannot parse current cert; sleeping 60s", error=str(e))
+            await asyncio.sleep(60)
+            continue
+
+        remaining = (expires - datetime.now(UTC)).total_seconds()
+        time_until_renewal = remaining - threshold
+
+        if time_until_renewal > 0:
+            await asyncio.sleep(time_until_renewal)
+            continue
+
+        # ── Step 1: maybe another pod already renewed
+        secret = _read_secret(secret_name, namespace)
+        if secret is not None:
+            try:
+                secret_cert_pem = _decode_data_field(secret, _K_TLS_CRT)
+                secret_remaining = (
+                    cert_not_after(secret_cert_pem) - datetime.now(UTC)
+                ).total_seconds()
+            except Exception:
+                secret_remaining = -1
+            if secret_remaining > threshold + skew:
+                # Adopt the freshly-renewed cert and skip /renew.
+                identity_holder.identity = _identity_from_secret(
+                    secret, name=cert.name, api_url=cert.api_url
+                )
+                logger.debug(
+                    "Adopted fresher cert from Secret; skipping /renew",
+                    secret_remaining_seconds=int(secret_remaining),
+                )
+                continue
+            current_resource_version = secret.metadata.resource_version
+        else:
+            current_resource_version = None
+
+        # ── Step 2: we're the renewer
+        new_cert = await _call_renew_with_retries(cert)
+        if new_cert is None:
+            # Transient failure (rate limit, 5xx, network). The Secret may
+            # still hold a valid-ish cert; keep using it and try again on the
+            # next cycle. Sleep a bounded interval — never go negative when
+            # we're already past expiry, and never burn-loop on rate limits.
+            sleep_for = min(max(remaining, 0), 60) + 30
+            logger.warning(
+                "Renewal failed after retries; will retry",
+                sleep_seconds=int(sleep_for),
+            )
+            await asyncio.sleep(sleep_for)
+            continue
+
+        try:
+            secret = _replace_secret(
+                secret_name,
+                namespace,
+                cert=new_cert["certificate"],
+                key=new_cert["private_key"],
+                ca=new_cert["ca_certificate"],
+                listener_id=cert.listener_id,
+                pool_id=cert.pool_id,
+                resource_version=current_resource_version,
+            )
+            identity_holder.identity = ListenerIdentity(
+                listener_id=cert.listener_id,
+                name=cert.name,
+                pool_id=cert.pool_id,
+                api_url=cert.api_url,
+                certificate_pem=new_cert["certificate"],
+                private_key_pem=new_cert["private_key"],
+                ca_cert_pem=new_cert["ca_certificate"],
+                secret_resource_version=secret.metadata.resource_version,
+            )
+            logger.info("Renewed listener cert; wrote Secret")
+        except _SecretConflict:
+            # Lost CAS race — another pod wrote first. Drop our cert,
+            # adopt theirs.
+            secret = _read_secret(secret_name, namespace)
+            if secret is not None:
+                identity_holder.identity = _identity_from_secret(
+                    secret, name=cert.name, api_url=cert.api_url
+                )
+                logger.info("Lost renewal CAS race; adopted other pod's cert")
+            else:
+                # Secret vanished — extremely unusual. Sleep and retry next loop.
+                logger.warning("Secret disappeared mid-renewal; will retry shortly")
+                await asyncio.sleep(5)
+
+
+# ── HTTP helpers ────────────────────────────────────────────────────
+
+
+class _JoinTokenExhausted(Exception):
+    """Raised when /join returns 401/403 because max_uses is exhausted."""
+
+
+class _JoinTransient(Exception):
+    """Raised on transient /join failures (5xx, network)."""
+
+
+class _SecretAlreadyExists(Exception):
+    """Raised on Secret create returning 409 AlreadyExists."""
+
+
+class _SecretConflict(Exception):
+    """Raised on Secret replace returning 409 Conflict (stale resourceVersion)."""
+
+
+async def _call_join(api_url: str, join_token: str, name: str) -> dict:
+    import httpx
+
+    async with httpx.AsyncClient(base_url=api_url, timeout=30) as client:
+        r = await client.post(
+            "/api/v2/agent-pools/join",
+            json={"join_token": join_token, "name": name},
+        )
+    if r.status_code in (401, 403):
+        # Token revoked / expired / max_uses exhausted
+        raise _JoinTokenExhausted(r.text)
+    if r.status_code >= 500 or r.status_code == 0:
+        raise _JoinTransient(f"{r.status_code}: {r.text}")
+    if r.status_code >= 400:
+        raise RuntimeError(f"/join failed: {r.status_code}: {r.text}")
+    return r.json()["data"]
+
+
+async def _call_renew_with_retries(identity: ListenerIdentity) -> dict | None:
+    """Try `/listeners/{id}/renew` up to 3 times with backoff.
+
+    Returns the new cert dict on success, or None if all attempts failed.
+    A 401/403 from the API is *not* retried — the cert is rejected, return
+    None so the caller can decide whether to fall back to join token.
+    """
+    import httpx
+
+    cert_b64 = base64.b64encode(identity.certificate_pem.encode()).decode()
+    headers = {"X-Terrapod-Client-Cert": cert_b64}
+    backoff = 1.0
+    for attempt in range(3):
+        try:
+            async with httpx.AsyncClient(base_url=identity.api_url, timeout=30) as client:
+                r = await client.post(
+                    f"/api/v2/listeners/listener-{identity.listener_id}/renew",
+                    headers=headers,
+                )
+            if r.status_code == 200:
+                return r.json()["data"]
+            if r.status_code in (401, 403):
+                logger.warning(
+                    "Renew rejected by API — cert may be revoked or listener gone",
+                    status=r.status_code,
+                    body=r.text[:200],
+                )
+                return None
+            # 429 deserves a longer wait — rate limits are per-minute so 1s
+            # backoff just hot-loops. Honor Retry-After if present.
+            if r.status_code == 429:
+                retry_after = r.headers.get("Retry-After")
+                wait = float(retry_after) if retry_after and retry_after.isdigit() else 30.0
+                logger.warning("Renew rate-limited", attempt=attempt + 1, wait_seconds=wait)
+                await asyncio.sleep(wait)
+                continue
+            # 5xx / other — fall through to retry
+            logger.warning("Renew transient failure", status=r.status_code, attempt=attempt + 1)
+        except httpx.HTTPError as e:
+            logger.warning("Renew network error", error=str(e), attempt=attempt + 1)
+        await asyncio.sleep(backoff)
+        backoff *= 2
+    return None
+
+
+# Bridge K8s ApiException → our typed exceptions so callers don't import kubernetes
+def _wrap_k8s_errors(fn):
+    def wrapper(*args, **kwargs):
+        from kubernetes.client.rest import ApiException
+
+        try:
+            return fn(*args, **kwargs)
+        except ApiException as e:
+            if e.status == 409:
+                if "AlreadyExists" in str(e.body or ""):
+                    raise _SecretAlreadyExists(str(e)) from e
+                raise _SecretConflict(str(e)) from e
+            raise
+
+    return wrapper
+
+
+_create_secret = _wrap_k8s_errors(_create_secret)
+_replace_secret = _wrap_k8s_errors(_replace_secret)

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -86,16 +86,21 @@ class RunnerListener:
     def _auth_headers(self) -> dict[str, str]:
         """Build authentication headers for API calls.
 
-        The cert header is computed once and cached — the PEM is immutable for the
-        listener's lifetime, so re-encoding it on every request just fragments the heap.
+        The cert is renewed in the background by `renew_loop`, which mutates
+        `self.identity` in place. Cache by the cert PEM identity (id() is
+        stable while the same string object is held in memory) so we
+        re-encode only on rotation, not every request.
         """
-        if not hasattr(self, "_cached_auth_headers"):
-            headers: dict[str, str] = {}
-            if self.identity and self.identity.certificate_pem:
-                cert_b64 = base64.b64encode(self.identity.certificate_pem.encode()).decode()
-                headers["X-Terrapod-Client-Cert"] = cert_b64
-            self._cached_auth_headers = headers
-        return self._cached_auth_headers
+        cert_pem = self.identity.certificate_pem if self.identity else ""
+        cached = getattr(self, "_cached_auth_headers_for_cert", None)
+        if cached is not None and cached[0] is cert_pem:
+            return cached[1]
+        headers: dict[str, str] = {}
+        if cert_pem:
+            cert_b64 = base64.b64encode(cert_pem.encode()).decode()
+            headers["X-Terrapod-Client-Cert"] = cert_b64
+        self._cached_auth_headers_for_cert = (cert_pem, headers)
+        return headers
 
     async def _establish_identity(self) -> None:
         """Establish or re-establish listener identity."""
@@ -103,9 +108,8 @@ class RunnerListener:
 
         self.identity = await establish_identity()
         self._identity_ready = True
-        # Invalidate cached auth headers so the new cert is used
-        if hasattr(self, "_cached_auth_headers"):
-            del self._cached_auth_headers
+        # Drop any cached headers so the next call re-encodes against the new cert.
+        self._cached_auth_headers_for_cert = None
 
     async def start(self) -> None:
         """Main entry point — initialize and start loops."""
@@ -135,29 +139,61 @@ class RunnerListener:
 
         try:
             # Start concurrent loops — SSE for sub-second responsiveness,
-            # poll loop as reliability fallback (~30s worst-case latency)
+            # poll loop as reliability fallback (~30s worst-case latency),
+            # cert-renewal loop to refresh the X.509 cert before it expires.
             await asyncio.gather(
                 self._health_server(),
                 self._heartbeat_loop(),
                 self._sse_loop(),
                 self._poll_loop(),
+                self._cert_renewal_loop(),
                 self._shutdown_waiter(),
             )
         finally:
             await self._http_client.aclose()
             await self._sse_client.aclose()
 
+    async def _cert_renewal_loop(self) -> None:
+        """Keep the listener's X.509 cert fresh.
+
+        Coordinates with other pods of the same listener deployment via the
+        shared K8s Secret: read first, only call /renew if no other pod has
+        rotated yet, write with resourceVersion CAS to absorb genuine ties.
+        See `terrapod.runner.identity.renew_loop` for the full algorithm.
+        """
+        from terrapod.runner.identity import (
+            _credentials_secret_name,
+            _read_in_pod_namespace,
+            pod_splay_seconds,
+            renew_loop,
+        )
+
+        cert_validity_seconds = int(os.environ.get("TERRAPOD_LISTENER_CERT_TTL_SECONDS", "3600"))
+        secret_name = _credentials_secret_name(self.identity.name)
+        namespace = _read_in_pod_namespace()
+
+        await renew_loop(
+            self,
+            secret_name=secret_name,
+            namespace=namespace,
+            cert_validity_seconds=cert_validity_seconds,
+            splay_seconds=pod_splay_seconds(),
+        )
+
     async def _rejoin(self) -> None:
-        """Force a fresh join by clearing saved certs and re-establishing identity.
+        """Force a fresh join by clearing the credentials Secret and re-establishing.
 
         Called when the listener receives persistent 401s, indicating its
-        Redis registration has expired (300s TTL) while the saved certificate
-        is still on disk. Without this, the listener loops on 401 forever.
+        Redis registration has expired (300s TTL) and the API no longer
+        recognises the cert in our credentials Secret. We drop the Secret
+        so the next `establish_identity()` falls through to the join-token
+        path; other pods of the same deployment will pick up the change
+        on their next cert renewal cycle (Secret missing → bootstrap path).
         """
-        from terrapod.runner.identity import _clear_saved_certs
+        from terrapod.runner.identity import clear_credentials_secret
 
         logger.warning("Forcing re-join due to persistent auth failures")
-        _clear_saved_certs()
+        clear_credentials_secret()
         await self._establish_identity()
 
         # Recreate HTTP clients with the new identity base URL

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -3,7 +3,7 @@
 import hashlib
 import secrets
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,6 +14,7 @@ from terrapod.auth.ca import (
     serialize_certificate,
     serialize_private_key,
 )
+from terrapod.config import settings
 from terrapod.db.models import AgentPool, AgentPoolToken, utc_now
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
@@ -95,16 +96,32 @@ def generate_join_token() -> tuple[str, str]:
     return raw, token_hash
 
 
+_UNSET = object()
+
+
 async def create_pool_token(
     db: AsyncSession,
     pool_id: uuid.UUID,
     description: str,
     created_by: str,
-    expires_at=None,
-    max_uses: int | None = None,
+    expires_at=_UNSET,
+    max_uses: int | None | object = _UNSET,
 ) -> tuple[AgentPoolToken, str]:
-    """Create a join token for an agent pool. Returns (token_record, raw_token)."""
+    """Create a join token for an agent pool. Returns (token_record, raw_token).
+
+    `expires_at` and `max_uses` default to the values from
+    `settings.agent_pools.default_join_token_*` when the caller does not
+    pass them explicitly. Pass `None` to opt this token out of the limit
+    (unlimited uses or no expiry). The sentinel default lets us
+    distinguish "caller did not specify" from "caller wants unlimited".
+    """
     raw_token, token_hash = generate_join_token()
+
+    if expires_at is _UNSET:
+        ttl = settings.agent_pools.default_join_token_ttl_seconds
+        expires_at = (datetime.now(UTC) + timedelta(seconds=ttl)) if ttl else None
+    if max_uses is _UNSET:
+        max_uses = settings.agent_pools.default_join_token_max_uses
 
     token = AgentPoolToken(
         pool_id=pool_id,
@@ -195,7 +212,11 @@ async def join_listener(
     redis = get_redis_client()
 
     # Issue certificate
-    cert, private_key = ca.issue_listener_certificate(name, pool.name)
+    cert, private_key = ca.issue_listener_certificate(
+        name,
+        pool.name,
+        ttl_seconds=settings.agent_pools.listener_cert_ttl_seconds,
+    )
     fingerprint = get_certificate_fingerprint(cert)
     now = datetime.now(UTC).isoformat()
 
@@ -360,7 +381,11 @@ async def renew_listener_certificate(
     """Renew a listener's certificate. Updates fingerprint and expiry in Redis."""
     ca = get_ca()
     redis = get_redis_client()
-    cert, private_key = ca.issue_listener_certificate(listener_name, pool.name)
+    cert, private_key = ca.issue_listener_certificate(
+        listener_name,
+        pool.name,
+        ttl_seconds=settings.agent_pools.listener_cert_ttl_seconds,
+    )
     fingerprint = get_certificate_fingerprint(cert)
 
     key = f"{_LISTENER_PREFIX}{listener_id}"

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -7,7 +7,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
-from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_admin
+from terrapod.api.dependencies import (
+    AuthenticatedUser,
+    ListenerIdentity,
+    get_current_user,
+    get_listener_identity,
+    require_admin,
+)
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -681,3 +687,100 @@ class TestDeleteListenerRBAC:
             res = await client.delete(f"/api/v2/listeners/{lid}", headers=_AUTH)
 
         assert res.status_code == 403
+
+
+# ── Renew listener cert (cert-authenticated) ────────────────────────
+
+
+def _mock_listener_identity(listener_id, name="listener-1", pool_id=None):
+    return ListenerIdentity(
+        listener_id=listener_id,
+        name=name,
+        pool_id=pool_id or uuid.uuid4(),
+        certificate_fingerprint="dead" * 16,
+        certificate_expires_at=None,
+    )
+
+
+class TestRenewListenerCert:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.renew_listener_certificate")
+    @patch("terrapod.services.agent_pool_service.get_pool")
+    @patch("terrapod.services.agent_pool_service.get_listener")
+    async def test_succeeds_when_cert_matches_path(
+        self,
+        mock_get_listener,
+        mock_get_pool,
+        mock_renew,
+        *mocks,
+    ):
+        """Cert listener_id matches the path → 200 + renewed cert returned."""
+        lid = uuid.uuid4()
+        pid = uuid.uuid4()
+        mock_get_listener.return_value = _mock_listener_dict(
+            listener_id=lid, name="listener-1", pool_id=pid
+        )
+        mock_get_pool.return_value = _mock_pool(pool_id=pid)
+        mock_renew.return_value = {
+            "certificate": "PEM",
+            "private_key": "PEM",
+            "ca_certificate": "PEM",
+            "certificate_fingerprint": "abcd",
+            "certificate_expires_at": "2026-01-01T01:00:00+00:00",
+        }
+
+        app = create_app()
+        app.dependency_overrides[get_listener_identity] = lambda: _mock_listener_identity(
+            lid, pool_id=pid
+        )
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(
+                f"/api/v2/listeners/{lid}/renew",
+                headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
+            )
+
+        assert res.status_code == 200
+        assert res.json()["data"]["certificate"] == "PEM"
+        assert mock_renew.await_count == 1
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.renew_listener_certificate")
+    async def test_rejects_path_listener_id_mismatch(self, mock_renew, *mocks):
+        """Cert authenticates as listener-A; trying to renew listener-B → 403."""
+        cert_lid = uuid.uuid4()
+        path_lid = uuid.uuid4()  # different from cert_lid
+
+        app = create_app()
+        app.dependency_overrides[get_listener_identity] = lambda: _mock_listener_identity(cert_lid)
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(
+                f"/api/v2/listeners/{path_lid}/renew",
+                headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
+            )
+
+        assert res.status_code == 403
+        assert "Certificate does not match" in res.json()["detail"]
+        # Renew was never called — auth check rejects before service layer
+        assert mock_renew.await_count == 0
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_rejects_request_without_cert_header(self, *mocks):
+        """No X-Terrapod-Client-Cert → 401 from the dep itself (no override)."""
+        app = create_app()
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(f"/api/v2/listeners/{uuid.uuid4()}/renew")
+
+        assert res.status_code == 401
+        assert "X-Terrapod-Client-Cert" in res.json()["detail"]

--- a/services/tests/auth/test_ca.py
+++ b/services/tests/auth/test_ca.py
@@ -136,13 +136,21 @@ class TestIssueListenerCertificate:
         eku = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
         assert x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH in eku.value
 
-    def test_custom_ttl(self):
+    def test_default_ttl_is_one_hour(self):
         ca = CertificateAuthority.generate()
-        cert, _ = ca.issue_listener_certificate("listener-1", "pool-1", ttl_hours=24)
+        cert, _ = ca.issue_listener_certificate("listener-1", "pool-1")
         now = datetime.datetime.now(datetime.UTC)
-        # Should expire within ~25 hours
-        assert cert.not_valid_after_utc <= now + datetime.timedelta(hours=25)
-        assert cert.not_valid_after_utc >= now + datetime.timedelta(hours=23)
+        # Default 3600s (1h)
+        assert cert.not_valid_after_utc <= now + datetime.timedelta(seconds=3610)
+        assert cert.not_valid_after_utc >= now + datetime.timedelta(seconds=3590)
+
+    def test_custom_ttl_seconds(self):
+        ca = CertificateAuthority.generate()
+        cert, _ = ca.issue_listener_certificate("listener-1", "pool-1", ttl_seconds=300)
+        now = datetime.datetime.now(datetime.UTC)
+        # 300s (5min) — the value used in local Tilt for fast renewal cycles
+        assert cert.not_valid_after_utc <= now + datetime.timedelta(seconds=310)
+        assert cert.not_valid_after_utc >= now + datetime.timedelta(seconds=290)
 
     def test_unique_keys_per_listener(self):
         ca = CertificateAuthority.generate()

--- a/services/tests/runner/test_identity.py
+++ b/services/tests/runner/test_identity.py
@@ -1,57 +1,296 @@
-"""Tests for listener identity name derivation."""
+"""Tests for listener identity — Secret-backed bootstrap, splay, /renew retries."""
 
+import base64
 import os
-from unittest.mock import patch
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from terrapod.runner import identity as identity_mod
+
+# ── pod_splay_seconds ───────────────────────────────────────────────
 
 
-class TestListenerNameDerivation:
-    """Test that listener names are correctly derived from env vars."""
+class TestPodSplaySeconds:
+    def test_deterministic_for_same_pod_name(self):
+        a = identity_mod.pod_splay_seconds("listener-7f8b9c6d4-x2k3m")
+        b = identity_mod.pod_splay_seconds("listener-7f8b9c6d4-x2k3m")
+        assert a == b
 
-    def test_name_with_pod_name(self):
-        """When POD_NAME is set, name should be base-podname."""
-        env = {
-            "TERRAPOD_LISTENER_NAME": "prod-listener",
-            "POD_NAME": "terrapod-listener-7f8b9c6d4-x2k3m",
-        }
-        with patch.dict(os.environ, env, clear=False):
-            base_name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
-            pod_name = os.environ.get("POD_NAME", "")
-            name = f"{base_name}-{pod_name}" if pod_name else base_name
+    def test_within_default_max(self):
+        v = identity_mod.pod_splay_seconds("listener-7f8b9c6d4-x2k3m")
+        assert 0 <= v < 30
 
-        assert name == "prod-listener-terrapod-listener-7f8b9c6d4-x2k3m"
+    def test_respects_custom_max(self):
+        v = identity_mod.pod_splay_seconds("listener-7f8b9c6d4-x2k3m", max_splay=10)
+        assert 0 <= v < 10
 
-    def test_name_without_pod_name(self):
-        """When POD_NAME is not set, name should be just the base name."""
-        env = {"TERRAPOD_LISTENER_NAME": "my-listener"}
-        with patch.dict(os.environ, env, clear=False):
-            # Remove POD_NAME if it exists
-            os.environ.pop("POD_NAME", None)
-            base_name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
-            pod_name = os.environ.get("POD_NAME", "")
-            name = f"{base_name}-{pod_name}" if pod_name else base_name
+    def test_different_pods_get_different_values_typically(self):
+        # Not strictly guaranteed (birthday paradox), but with 100 names
+        # the spread should cover most of 0..29.
+        names = [f"listener-{i}-x" for i in range(100)]
+        values = {identity_mod.pod_splay_seconds(n) for n in names}
+        assert len(values) >= 15  # at least half the bucket space
 
-        assert name == "my-listener"
-
-    def test_name_defaults(self):
-        """When neither env var is set, name should be 'listener'."""
+    def test_falls_back_to_zero_when_unset(self):
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("TERRAPOD_LISTENER_NAME", None)
             os.environ.pop("POD_NAME", None)
-            base_name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
-            pod_name = os.environ.get("POD_NAME", "")
-            name = f"{base_name}-{pod_name}" if pod_name else base_name
+            os.environ.pop("HOSTNAME", None)
+            assert identity_mod.pod_splay_seconds("") == 0
 
-        assert name == "listener"
 
-    def test_empty_pod_name_uses_base_only(self):
-        """When POD_NAME is empty string, name should be just the base."""
-        env = {
-            "TERRAPOD_LISTENER_NAME": "dev-listener",
-            "POD_NAME": "",
+# ── _call_renew_with_retries ────────────────────────────────────────
+
+
+def _identity():
+    return identity_mod.ListenerIdentity(
+        listener_id=uuid.uuid4(),
+        name="listener",
+        pool_id=uuid.uuid4(),
+        api_url="http://test",
+        certificate_pem="-----BEGIN CERT-----\nfoo\n-----END CERT-----\n",
+        private_key_pem="key",
+        ca_cert_pem="ca",
+    )
+
+
+class TestCallRenewWithRetries:
+    @pytest.mark.asyncio
+    async def test_returns_data_on_200(self):
+        ident = _identity()
+        new_data = {"certificate": "PEM", "private_key": "K", "ca_certificate": "CA"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": new_data}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.post.return_value = mock_response
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await identity_mod._call_renew_with_retries(ident)
+
+        assert result == new_data
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_401(self):
+        """401 means cert is rejected — no retries, return None so caller can fall back."""
+        ident = _identity()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "expired"
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.post.return_value = mock_response
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await identity_mod._call_renew_with_retries(ident)
+
+        assert result is None
+        # Single call — no retries on auth failure
+        assert mock_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_5xx_then_succeeds(self):
+        ident = _identity()
+
+        mock_500 = MagicMock(status_code=500, text="boom")
+        mock_200 = MagicMock(status_code=200)
+        mock_200.json.return_value = {"data": {"certificate": "PEM"}}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.post.side_effect = [mock_500, mock_200]
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            result = await identity_mod._call_renew_with_retries(ident)
+
+        assert result == {"certificate": "PEM"}
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_none_after_three_failures(self):
+        ident = _identity()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.post.side_effect = httpx.ConnectError("network down")
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            result = await identity_mod._call_renew_with_retries(ident)
+
+        assert result is None
+        assert mock_client.post.call_count == 3
+
+
+# ── establish_identity (bootstrap) ──────────────────────────────────
+
+
+def _v1secret(*, listener_id, pool_id, cert="PEM", key="K", ca="CA", rv="123"):
+    """Build a fake V1Secret matching the structure read_secret() returns."""
+    secret = MagicMock()
+    secret.metadata = MagicMock()
+    secret.metadata.resource_version = rv
+    secret.data = {
+        identity_mod._K_TLS_CRT: base64.b64encode(cert.encode()).decode(),
+        identity_mod._K_TLS_KEY: base64.b64encode(key.encode()).decode(),
+        identity_mod._K_CA_CRT: base64.b64encode(ca.encode()).decode(),
+        identity_mod._K_LISTENER_ID: base64.b64encode(str(listener_id).encode()).decode(),
+        identity_mod._K_POOL_ID: base64.b64encode(str(pool_id).encode()).decode(),
+    }
+    return secret
+
+
+class TestEstablishIdentity:
+    @pytest.mark.asyncio
+    async def test_resumes_from_existing_secret(self):
+        """Secret exists → return its identity without ever hitting /join."""
+        lid = uuid.uuid4()
+        pid = uuid.uuid4()
+        secret = _v1secret(listener_id=lid, pool_id=pid)
+
+        env = {"TERRAPOD_LISTENER_NAME": "core", "TERRAPOD_API_URL": "http://api"}
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch.object(identity_mod, "_read_in_pod_namespace", return_value="terrapod"),
+            patch.object(identity_mod, "_read_secret", return_value=secret),
+            patch.object(identity_mod, "_call_join", new=AsyncMock()) as mock_join,
+        ):
+            result = await identity_mod.establish_identity()
+
+        assert result.listener_id == lid
+        assert result.pool_id == pid
+        assert result.name == "core"
+        # /join was never called — Secret was the source of truth
+        mock_join.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bootstraps_via_join_token_when_secret_absent(self):
+        """No Secret → /join → create Secret → return identity."""
+        lid = str(uuid.uuid4())
+        pid = str(uuid.uuid4())
+        join_response = {
+            "listener_id": lid,
+            "pool_id": pid,
+            "certificate": "PEM",
+            "private_key": "K",
+            "ca_certificate": "CA",
         }
-        with patch.dict(os.environ, env, clear=False):
-            base_name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
-            pod_name = os.environ.get("POD_NAME", "")
-            name = f"{base_name}-{pod_name}" if pod_name else base_name
+        created_secret = _v1secret(listener_id=lid, pool_id=pid, rv="42")
 
-        assert name == "dev-listener"
+        env = {
+            "TERRAPOD_LISTENER_NAME": "core",
+            "TERRAPOD_API_URL": "http://api",
+            "TERRAPOD_JOIN_TOKEN": "the-token",
+        }
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch.object(identity_mod, "_read_in_pod_namespace", return_value="terrapod"),
+            patch.object(identity_mod, "_read_secret", return_value=None),
+            patch.object(identity_mod, "_call_join", new=AsyncMock(return_value=join_response)),
+            patch.object(identity_mod, "_create_secret", return_value=created_secret),
+        ):
+            result = await identity_mod.establish_identity()
+
+        assert str(result.listener_id) == lid
+        assert str(result.pool_id) == pid
+        assert result.secret_resource_version == "42"
+
+    @pytest.mark.asyncio
+    async def test_lost_create_race_adopts_winners_secret(self):
+        """Two pods: ours wins /join, theirs wins create → we adopt their cert."""
+        winner_lid = uuid.uuid4()
+        winner_pid = uuid.uuid4()
+        loser_join_response = {
+            "listener_id": str(uuid.uuid4()),  # we got our own listener-id from join
+            "pool_id": str(winner_pid),
+            "certificate": "LOSER_PEM",
+            "private_key": "LOSER_K",
+            "ca_certificate": "CA",
+        }
+        winner_secret = _v1secret(listener_id=winner_lid, pool_id=winner_pid, cert="WINNER_PEM")
+
+        # _read_secret returns None first (pre-join check), then the winner's secret
+        # (post-create-race re-read).
+        read_calls = iter([None, winner_secret])
+
+        env = {
+            "TERRAPOD_LISTENER_NAME": "core",
+            "TERRAPOD_API_URL": "http://api",
+            "TERRAPOD_JOIN_TOKEN": "tok",
+        }
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch.object(identity_mod, "_read_in_pod_namespace", return_value="terrapod"),
+            patch.object(
+                identity_mod, "_read_secret", side_effect=lambda *_a, **_k: next(read_calls)
+            ),
+            patch.object(
+                identity_mod, "_call_join", new=AsyncMock(return_value=loser_join_response)
+            ),
+            patch.object(
+                identity_mod,
+                "_create_secret",
+                side_effect=identity_mod._SecretAlreadyExists("409"),
+            ),
+        ):
+            result = await identity_mod.establish_identity()
+
+        # We adopted the winner's cert, not the one /join handed us
+        assert result.listener_id == winner_lid
+        assert result.certificate_pem == "WINNER_PEM"
+
+    @pytest.mark.asyncio
+    async def test_join_token_exhausted_then_secret_appears(self):
+        """Lost the /join race entirely (max_uses exhausted) → poll Secret."""
+        winner_lid = uuid.uuid4()
+        winner_pid = uuid.uuid4()
+        winner_secret = _v1secret(listener_id=winner_lid, pool_id=winner_pid)
+
+        # Start: no Secret, /join returns 401. Next attempt: Secret has appeared.
+        read_returns = iter([None, winner_secret])
+
+        env = {
+            "TERRAPOD_LISTENER_NAME": "core",
+            "TERRAPOD_API_URL": "http://api",
+            "TERRAPOD_JOIN_TOKEN": "tok",
+        }
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch.object(identity_mod, "_read_in_pod_namespace", return_value="terrapod"),
+            patch.object(
+                identity_mod, "_read_secret", side_effect=lambda *_a, **_k: next(read_returns)
+            ),
+            patch.object(
+                identity_mod,
+                "_call_join",
+                new=AsyncMock(side_effect=identity_mod._JoinTokenExhausted("401")),
+            ),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            result = await identity_mod.establish_identity()
+
+        assert result.listener_id == winner_lid
+
+    @pytest.mark.asyncio
+    async def test_no_join_token_and_no_secret_raises(self):
+        """Cold start with neither Secret nor join token → fail loudly."""
+        env = {"TERRAPOD_LISTENER_NAME": "core"}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(identity_mod, "_read_in_pod_namespace", return_value="terrapod"),
+            patch.object(identity_mod, "_read_secret", return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="TERRAPOD_JOIN_TOKEN"):
+                await identity_mod.establish_identity()

--- a/services/tests/services/test_agent_pool_service.py
+++ b/services/tests/services/test_agent_pool_service.py
@@ -1,12 +1,17 @@
 """Tests for agent pool service — join token generation and validation."""
 
 import hashlib
+import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from terrapod.services.agent_pool_service import generate_join_token, validate_join_token
+from terrapod.services.agent_pool_service import (
+    create_pool_token,
+    generate_join_token,
+    validate_join_token,
+)
 
 # ── generate_join_token ──────────────────────────────────────────────
 
@@ -152,3 +157,102 @@ class TestValidateJoinToken:
 
         result = await validate_join_token(db, raw)
         assert result is mock_record
+
+
+# ── create_pool_token defaults ──────────────────────────────────────
+
+
+def _capture_pool_token_call() -> AsyncMock:
+    """Build an AsyncSession mock that records the AgentPoolToken passed to add()."""
+    db = AsyncMock()
+    captured = {}
+
+    def add(token):
+        captured["token"] = token
+
+    db.add = MagicMock(side_effect=add)
+    db.flush = AsyncMock()
+    db._captured = captured
+    return db
+
+
+class TestCreatePoolToken:
+    @pytest.mark.asyncio
+    async def test_defaults_max_uses_to_two(self):
+        """Default max_uses comes from settings.agent_pools (2 in the bundled config)."""
+        db = _capture_pool_token_call()
+
+        await create_pool_token(
+            db,
+            pool_id=uuid.uuid4(),
+            description="test",
+            created_by="alice@example.com",
+        )
+
+        assert db._captured["token"].max_uses == 2
+
+    @pytest.mark.asyncio
+    async def test_defaults_expiry_to_one_hour_from_now(self):
+        """Default expires_at is now + default_join_token_ttl_seconds (3600)."""
+        db = _capture_pool_token_call()
+
+        before = datetime.now(UTC)
+        await create_pool_token(
+            db,
+            pool_id=uuid.uuid4(),
+            description="test",
+            created_by="alice@example.com",
+        )
+        after = datetime.now(UTC)
+
+        expires_at = db._captured["token"].expires_at
+        # Should land within (now+1h - small skew, now+1h + small skew)
+        assert before + timedelta(seconds=3590) <= expires_at <= after + timedelta(seconds=3610)
+
+    @pytest.mark.asyncio
+    async def test_explicit_max_uses_none_means_unlimited(self):
+        """Caller passing max_uses=None (vs default sentinel) opts out of the cap."""
+        db = _capture_pool_token_call()
+
+        await create_pool_token(
+            db,
+            pool_id=uuid.uuid4(),
+            description="bootstrap",
+            created_by="op@example.com",
+            max_uses=None,
+        )
+
+        assert db._captured["token"].max_uses is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_expires_at_none_means_no_expiry(self):
+        """Caller passing expires_at=None opts out of the default TTL."""
+        db = _capture_pool_token_call()
+
+        await create_pool_token(
+            db,
+            pool_id=uuid.uuid4(),
+            description="bootstrap",
+            created_by="op@example.com",
+            expires_at=None,
+        )
+
+        assert db._captured["token"].expires_at is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_values_override_defaults(self):
+        """Caller-supplied max_uses + expires_at win over the config defaults."""
+        db = _capture_pool_token_call()
+        custom_expiry = datetime.now(UTC) + timedelta(days=7)
+
+        await create_pool_token(
+            db,
+            pool_id=uuid.uuid4(),
+            description="weekly-rotated",
+            created_by="op@example.com",
+            max_uses=10,
+            expires_at=custom_expiry,
+        )
+
+        assert db._captured["token"].max_uses == 10
+        assert db._captured["token"].expires_at == custom_expiry


### PR DESCRIPTION
## Summary

- Replaces emptyDir cert persistence with a Kubernetes Secret tied to the listener Deployment so multiple pods share one identity and pod replacement preserves it
- Switches listener X.509 certs to short-lived (1h default, 300s in Tilt) with multi-pod renewal coordination via check-Secret-first + resourceVersion CAS
- Locks down `/listeners/{id}/renew` so it actually requires the listener's client cert (pre-existing bug — endpoint accepted any caller)
- Defaults new join tokens to `max_uses=2` + 1h expiry; configurable via API

## Auth model changes

| | Before | After |
|---|---|---|
| Cert validity | 1 year | 1 hour (configurable) |
| Cert persistence | emptyDir on pod | K8s Secret named `{fullname}-listener-credentials` |
| Multi-replica identity | each pod joined separately | one identity, shared Secret |
| Join token defaults | unlimited uses, no expiry | `max_uses=2`, 1h expiry |
| `/renew` auth | accepted any caller | requires matching client cert |

## Renewal coordination

Each pod renews at `validity/2 + per-pod splay (0..30s, hash of POD_NAME)`:

1. Re-read the Secret. If another pod already rotated it, adopt and skip `/renew`.
2. Otherwise call `/renew` (3 retries, 429 honors `Retry-After`) and write the Secret with `resourceVersion` CAS.
3. On 409 conflict, drop our cert and adopt the winner's.

Splay sits on the renewal trigger, not startup, so it doesn't fight K8s scheduling. Combined with `minReadySeconds=30` + `maxUnavailable=1`, rolling deploys naturally stagger renewal cycles.

## Bootstrap race handling

- Default `max_uses=2` lets the first two pods race the join cleanly. Losers see `409 AlreadyExists` on the Secret create and adopt the winner's identity.
- If the token is exhausted before a pod gets in (>2 pods cold-start), it retry-reads the Secret with exponential backoff up to ~3 min — by which time the winning pod has finished its bootstrap.

## Helm

- Listener strategy: `maxSurge=0`, `maxUnavailable=1`, `minReadySeconds=30`
- New RBAC: scoped `get/list/watch/patch/update/delete` on the credentials Secret by `resourceNames`
- New `api.config.agent_pools` block (cert TTL + token defaults) wired through values.yaml + values.schema.json
- `values-local.yaml` sets cert TTL to 300s for observable renewal cycles in Tilt
- emptyDir cert volume removed from the listener Deployment

## Verification

Run in local Tilt stack with `listener_cert_ttl_seconds: 300`:

- Fresh deploy → `/join` + Secret created
- Pod restart → `Resumed identity from K8s Secret` (no `/join`)
- Scale to 3 → all replicas adopt the existing Secret, share one `listener_id`
- Renewal cycle → only the earliest-splay pod calls `/renew`; others skip via the check-Secret-first path
- Two clean back-to-back renewals at ~150s intervals, identity stable

Test plan
- [x] Unit tests: pod splay, /renew retries (200/401/429/5xx), establish_identity (resume/bootstrap/race/exhausted/no-token)
- [x] Unit tests: pool token defaults, cert TTL conversion to seconds, /renew cert-auth check
- [x] Helm template + lint clean
- [x] `make lint` + `make test` (1062 tests)
- [x] Tilt local stack: bootstrap, restart adoption, multi-replica adoption, renewal coordination