### PR TITLE
feat(agent-pools): pool status pill on list, listener replica-count on detail

### DIFF
--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -109,7 +109,13 @@ def _validate_labels(labels: dict | None) -> dict:
     return clean
 
 
-def _pool_json(pool, listener_summary: dict | None = None, permission: str | None = None) -> dict:
+def _pool_json(pool, status: str | None = None, permission: str | None = None) -> dict:
+    """Format an AgentPool as JSON:API.
+
+    `status` is "online" if at least one live listener is registered for the pool,
+    "offline" otherwise. None means "don't include" (used by endpoints that
+    don't need to fetch listeners — e.g. create/update responses).
+    """
     attrs: dict = {
         "name": pool.name,
         "description": pool.description or "",
@@ -118,8 +124,8 @@ def _pool_json(pool, listener_summary: dict | None = None, permission: str | Non
         "created-at": _rfc3339(pool.created_at),
         "updated-at": _rfc3339(pool.updated_at),
     }
-    if listener_summary is not None:
-        attrs["listener-summary"] = listener_summary
+    if status is not None:
+        attrs["status"] = status
     if permission is not None:
         attrs["permission"] = permission
     return {
@@ -153,22 +159,30 @@ def _token_json(token, raw_token: str | None = None) -> dict:
     return result
 
 
-def _listener_json(listener: dict) -> dict:
+def _listener_json(listener: dict, replica_count: int | None = None) -> dict:
     """Format a Redis-backed listener dict as JSON:API.
 
     Accepts a dict with keys: id, name, pool_id,
     certificate_fingerprint, certificate_expires_at, created_at, last_heartbeat, etc.
+
+    `replica_count` is the number of pods currently heartbeating for this
+    listener. Pre-0.19.0 listeners that don't send `pod_name` will report 0;
+    callers should treat 0 as "unknown" rather than "no replicas".
     """
+    attrs: dict = {
+        "name": listener.get("name", ""),
+        "status": listener.get("status", "offline"),
+        "certificate-fingerprint": listener.get("certificate_fingerprint", ""),
+        "certificate-expires-at": listener.get("certificate_expires_at", ""),
+        "created-at": listener.get("created_at", ""),
+        "updated-at": listener.get("last_heartbeat", listener.get("created_at", "")),
+    }
+    if replica_count is not None:
+        attrs["replica-count"] = replica_count
     return {
         "id": f"listener-{listener['id']}",
         "type": "runner-listeners",
-        "attributes": {
-            "name": listener.get("name", ""),
-            "certificate-fingerprint": listener.get("certificate_fingerprint", ""),
-            "certificate-expires-at": listener.get("certificate_expires_at", ""),
-            "created-at": listener.get("created_at", ""),
-            "updated-at": listener.get("last_heartbeat", listener.get("created_at", "")),
-        },
+        "attributes": attrs,
         "relationships": {
             "agent-pool": {
                 "data": {"id": f"apool-{listener.get('pool_id', '')}", "type": "agent-pools"},
@@ -234,11 +248,10 @@ async def list_pools(
         if perm is None:
             continue
         listeners = await agent_pool_service.list_listeners(p.id)
-        summary = {
-            "total": len(listeners),
-            "online": sum(1 for lis in listeners if lis.get("status") == "online"),
-        }
-        result.append(_pool_json(p, listener_summary=summary, permission=perm))
+        # Any registered listener whose status field reports online → pool online.
+        # Stale listeners are auto-pruned from the pool set by list_listeners.
+        status = "online" if any(lis.get("status") == "online" for lis in listeners) else "offline"
+        result.append(_pool_json(p, status=status, permission=perm))
     return JSONResponse(content={"data": result})
 
 
@@ -278,13 +291,8 @@ async def show_pool(
     pool = await _get_pool(pool_id, db)
     perm = await _require_pool_permission(pool, user, db, "read")
     listeners = await agent_pool_service.list_listeners(pool.id)
-    summary = {
-        "total": len(listeners),
-        "online": sum(1 for lis in listeners if lis.get("status") == "online"),
-    }
-    return JSONResponse(
-        content={"data": _pool_json(pool, listener_summary=summary, permission=perm)}
-    )
+    status = "online" if any(lis.get("status") == "online" for lis in listeners) else "offline"
+    return JSONResponse(content={"data": _pool_json(pool, status=status, permission=perm)})
 
 
 @router.patch("/agent-pools/{pool_id}")
@@ -548,11 +556,27 @@ async def list_pool_listeners(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List listeners for an agent pool (requires read permission)."""
+    """List listeners for an agent pool (requires read permission).
+
+    Each listener carries a `replica-count` reflecting how many pods are
+    currently heartbeating for it. With v0.19.0's shared-identity model a
+    single listener record commonly maps to 2+ pods; this lets the UI show
+    the actual fleet size.
+    """
     pool = await _get_pool(pool_id, db)
     await _require_pool_permission(pool, user, db, "read")
     listeners = await agent_pool_service.list_listeners(pool.id)
-    return JSONResponse(content={"data": [_listener_json(lis) for lis in listeners]})
+    replica_counts = await asyncio.gather(
+        *[agent_pool_service.count_listener_replicas(lis["id"]) for lis in listeners]
+    )
+    return JSONResponse(
+        content={
+            "data": [
+                _listener_json(lis, replica_count=count)
+                for lis, count in zip(listeners, replica_counts, strict=True)
+            ]
+        }
+    )
 
 
 @router.get("/agent-pools/{pool_id}/events")
@@ -696,10 +720,15 @@ async def listener_heartbeat(
 
     capacity = body.get("capacity", 1)
     active_runs = body.get("active_runs", 0)
+    # pod_name lets us track replica count under the shared-identity model.
+    # Older clients that don't send it remain compatible — we just don't
+    # learn their replica count.
+    pod_name = body.get("pod_name") or None
 
     await agent_pool_service.heartbeat_listener(
         listener_id=str(l_uuid),
         name=listener["name"],
+        pod_name=pod_name,
         capacity=str(capacity),
         active_runs=str(active_runs),
     )

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -166,8 +166,10 @@ def _listener_json(listener: dict, replica_count: int | None = None) -> dict:
     certificate_fingerprint, certificate_expires_at, created_at, last_heartbeat, etc.
 
     `replica_count` is the number of pods currently heartbeating for this
-    listener. Pre-0.19.0 listeners that don't send `pod_name` will report 0;
-    callers should treat 0 as "unknown" rather than "no replicas".
+    listener. Pass `None` (or omit) when the listener is on a pre-0.19.0
+    image (no `tracks_pods` flag); the attribute is then omitted from the
+    response and the UI shows "—" for unknown. Passing `0` is meaningful:
+    "this listener IS tracking, but no pods are currently heartbeating".
     """
     attrs: dict = {
         "name": listener.get("name", ""),
@@ -248,9 +250,9 @@ async def list_pools(
         if perm is None:
             continue
         listeners = await agent_pool_service.list_listeners(p.id)
-        # Any registered listener whose status field reports online → pool online.
-        # Stale listeners are auto-pruned from the pool set by list_listeners.
-        status = "online" if any(lis.get("status") == "online" for lis in listeners) else "offline"
+        # `list_listeners` lazily prunes any listener whose hash has expired,
+        # so anything still in the list is heartbeating ⇒ pool is online.
+        status = "online" if listeners else "offline"
         result.append(_pool_json(p, status=status, permission=perm))
     return JSONResponse(content={"data": result})
 
@@ -291,7 +293,8 @@ async def show_pool(
     pool = await _get_pool(pool_id, db)
     perm = await _require_pool_permission(pool, user, db, "read")
     listeners = await agent_pool_service.list_listeners(pool.id)
-    status = "online" if any(lis.get("status") == "online" for lis in listeners) else "offline"
+    # See list_pools for the rationale: any listener still in the list is online.
+    status = "online" if listeners else "offline"
     return JSONResponse(content={"data": _pool_json(pool, status=status, permission=perm)})
 
 
@@ -566,14 +569,27 @@ async def list_pool_listeners(
     pool = await _get_pool(pool_id, db)
     await _require_pool_permission(pool, user, db, "read")
     listeners = await agent_pool_service.list_listeners(pool.id)
+    # Only fetch replica counts for listeners that actually track pods. A
+    # listener on a pre-0.19.0 image doesn't write per-pod keys, so its SCAN
+    # would always come back zero — and the UI should distinguish "unknown"
+    # from "0 pods heartbeating but tracking is on".
+    tracking = [lis.get("tracks_pods") == "1" for lis in listeners]
     replica_counts = await asyncio.gather(
-        *[agent_pool_service.count_listener_replicas(lis["id"]) for lis in listeners]
+        *[
+            agent_pool_service.count_listener_replicas(lis["id"])
+            for lis, tracks in zip(listeners, tracking, strict=True)
+            if tracks
+        ]
     )
+    counts_iter = iter(replica_counts)
     return JSONResponse(
         content={
             "data": [
-                _listener_json(lis, replica_count=count)
-                for lis, count in zip(listeners, replica_counts, strict=True)
+                _listener_json(
+                    lis,
+                    replica_count=next(counts_iter) if tracks else None,
+                )
+                for lis, tracks in zip(listeners, tracking, strict=True)
             ]
         }
     )

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -330,12 +330,18 @@ class RunnerListener:
                 pass
 
     async def _send_heartbeat(self) -> None:
-        """Send heartbeat via API."""
+        """Send heartbeat via API.
+
+        Includes POD_NAME so the API can track replica count for this
+        listener identity (multiple pods of one Deployment share one
+        listener_id; per-pod presence keys give the API the fleet size).
+        """
         await self._http_client.post(
             f"/api/v2/listeners/listener-{self.identity.listener_id}/heartbeat",
             json={
                 "capacity": self._max_concurrent,
                 "active_runs": self._active_launches,
+                "pod_name": os.environ.get("POD_NAME") or os.environ.get("HOSTNAME") or "",
             },
             headers=self._auth_headers(),
         )

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -335,6 +335,11 @@ class RunnerListener:
         Includes POD_NAME so the API can track replica count for this
         listener identity (multiple pods of one Deployment share one
         listener_id; per-pod presence keys give the API the fleet size).
+
+        POD_NAME is set explicitly via the Downward API by Helm. We fall
+        back to HOSTNAME, which on standard K8s runtimes equals the pod
+        name — but is not guaranteed by every CRI, so non-Helm operators
+        running this listener should set POD_NAME explicitly.
         """
         await self._http_client.post(
             f"/api/v2/listeners/listener-{self.identity.listener_id}/heartbeat",

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -357,6 +357,13 @@ async def delete_listener(listener_id: str, name: str, pool_id: str) -> None:
     Includes lazy cleanup of any per-pod presence keys so admin-driven
     listener deletion doesn't leave stragglers that could otherwise survive
     until the 180s TTL on each pod key.
+
+    Race window: a pod can heartbeat between the SCAN+DELETE pass below and
+    the listener-hash deletion in the pipeline, leaving an orphan per-pod
+    key referencing a now-deleted listener. The orphan self-heals after at
+    most 180s (its own TTL) and isn't visible anywhere — count_listener_replicas
+    is only ever called for a listener that's still in the pool index, so the
+    leak is invisible to operators. Not worth a Lua script to close.
     """
     redis = get_redis_client()
     # Per-pod keys live under a different prefix → can't go in the same pipeline
@@ -450,10 +457,19 @@ async def heartbeat_listener(
     name lookup keys, merges any updated runtime fields (status, capacity,
     active_runs), and — if `pod_name` is provided — refreshes a per-pod
     presence key used to compute replica count.
+
+    `tracks_pods=1` is set on the listener hash whenever a heartbeat carries
+    pod_name. This flag lets the API distinguish "this listener is on a
+    post-0.19.0 image, replica-count is authoritative" from "this listener
+    is on an older image, replica-count would mislead". Once set it stays set
+    for the life of the hash — older clients downstream of an upgrade can't
+    sneak in and turn off tracking.
     """
     redis = get_redis_client()
     now = datetime.now(UTC).isoformat()
     updates: dict[str, str] = {"last_heartbeat": now, "status": "online", **fields}
+    if pod_name:
+        updates["tracks_pods"] = "1"
 
     # Pipeline writes that target tp:listener:* and tp:listener_name:*. These are
     # different prefixes (different cluster slots), so transaction must stay False.

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -185,14 +185,22 @@ async def delete_pool_token(db: AsyncSession, token: AgentPoolToken) -> None:
 #
 # Listener data is ephemeral — stored in Redis with TTL, not PostgreSQL.
 # Keys:
-#   tp:listener:{id}        HASH   300s TTL  — all listener data
-#   tp:pool_listeners:{pid} SET    no TTL    — pool → listener index (lazily cleaned)
-#   tp:listener_name:{name} STRING 300s TTL  — name → ID lookup
+#   tp:listener:{id}                       HASH   300s TTL  — all listener data
+#   tp:pool_listeners:{pid}                SET    no TTL    — pool → listener index (lazily cleaned)
+#   tp:listener_name:{name}                STRING 300s TTL  — name → ID lookup
+#   tp:listener_pod:{id}:{pod_name}        STRING 180s TTL  — per-pod heartbeat presence (replica count)
 #
+# Why a separate per-pod key family: in v0.19.0 a listener Deployment shares one
+# identity (one tp:listener:{id} hash) across replicas, so the hash itself can't
+# tell us how many pods are running. Each pod's heartbeat refreshes its own
+# tp:listener_pod:{id}:{pod_name} key (TTL = 3x heartbeat interval); replica
+# count is the number of those keys still alive.
 LISTENER_TTL = 300  # seconds (refreshed on every heartbeat)
+LISTENER_POD_TTL = 180  # seconds — 3x heartbeat interval, tolerates 2 missed beats
 _LISTENER_PREFIX = "tp:listener:"
 _POOL_LISTENERS_PREFIX = "tp:pool_listeners:"
 _LISTENER_NAME_PREFIX = "tp:listener_name:"
+_LISTENER_POD_PREFIX = "tp:listener_pod:"
 
 
 async def join_listener(
@@ -344,8 +352,19 @@ async def list_listeners(pool_id: uuid.UUID) -> list[dict]:
 
 
 async def delete_listener(listener_id: str, name: str, pool_id: str) -> None:
-    """Delete a listener's Redis keys."""
+    """Delete a listener's Redis keys.
+
+    Includes lazy cleanup of any per-pod presence keys so admin-driven
+    listener deletion doesn't leave stragglers that could otherwise survive
+    until the 180s TTL on each pod key.
+    """
     redis = get_redis_client()
+    # Per-pod keys live under a different prefix → can't go in the same pipeline
+    # under cluster mode. Drain them first.
+    pod_pattern = f"{_LISTENER_POD_PREFIX}{listener_id}:*"
+    async for pod_key in redis.scan_iter(match=pod_pattern, count=100):
+        await redis.delete(pod_key)
+
     pipe = redis.pipeline(transaction=False)
     pipe.delete(f"{_LISTENER_PREFIX}{listener_id}")
     pipe.delete(f"{_LISTENER_NAME_PREFIX}{name}")
@@ -360,6 +379,14 @@ async def delete_pool_listeners(pool_id: uuid.UUID) -> None:
     member_ids = await redis.smembers(set_key)
 
     if member_ids:
+        # Per-pod keys must be drained outside the pipeline (different prefix
+        # → different cluster slot, can't share a pipeline with the listener
+        # hash deletes).
+        for lid in member_ids:
+            pod_pattern = f"{_LISTENER_POD_PREFIX}{lid}:*"
+            async for pod_key in redis.scan_iter(match=pod_pattern, count=100):
+                await redis.delete(pod_key)
+
         pipe = redis.pipeline(transaction=False)
         for lid in member_ids:
             # Get name for cleanup before deleting
@@ -411,19 +438,48 @@ async def renew_listener_certificate(
     }
 
 
-async def heartbeat_listener(listener_id: str, name: str, **fields: str) -> None:
+async def heartbeat_listener(
+    listener_id: str,
+    name: str,
+    pod_name: str | None = None,
+    **fields: str,
+) -> None:
     """Refresh listener TTL and update runtime fields.
 
-    Called by the heartbeat endpoint. Refreshes TTL on both the hash and
-    name lookup keys, and merges any updated runtime fields (status, capacity,
-    active_runs).
+    Called by the heartbeat endpoint. Refreshes TTL on the listener hash and
+    name lookup keys, merges any updated runtime fields (status, capacity,
+    active_runs), and — if `pod_name` is provided — refreshes a per-pod
+    presence key used to compute replica count.
     """
     redis = get_redis_client()
     now = datetime.now(UTC).isoformat()
     updates: dict[str, str] = {"last_heartbeat": now, "status": "online", **fields}
 
+    # Pipeline writes that target tp:listener:* and tp:listener_name:*. These are
+    # different prefixes (different cluster slots), so transaction must stay False.
     pipe = redis.pipeline(transaction=False)
     pipe.hset(f"{_LISTENER_PREFIX}{listener_id}", mapping=updates)
     pipe.expire(f"{_LISTENER_PREFIX}{listener_id}", LISTENER_TTL)
     pipe.expire(f"{_LISTENER_NAME_PREFIX}{name}", LISTENER_TTL)
+    if pod_name:
+        pipe.set(
+            f"{_LISTENER_POD_PREFIX}{listener_id}:{pod_name}",
+            now,
+            ex=LISTENER_POD_TTL,
+        )
     await pipe.execute()
+
+
+async def count_listener_replicas(listener_id: str) -> int:
+    """Return the number of pods currently heartbeating for this listener.
+
+    Counts live `tp:listener_pod:{listener_id}:*` keys. If no pods have ever
+    sent a heartbeat with `pod_name` (e.g. older listener still on a pre-0.19.0
+    image), returns 0 — caller should fall back to displaying "—".
+    """
+    redis = get_redis_client()
+    pattern = f"{_LISTENER_POD_PREFIX}{listener_id}:*"
+    count = 0
+    async for _ in redis.scan_iter(match=pattern, count=100):
+        count += 1
+    return count

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -349,8 +349,8 @@ class TestListListenersReplicaCount:
         mock_resolve.return_value = "read"
         lid_a, lid_b = uuid.uuid4(), uuid.uuid4()
         mock_list_listeners.return_value = [
-            {"id": str(lid_a), "name": "lis-a", "status": "online"},
-            {"id": str(lid_b), "name": "lis-b", "status": "online"},
+            {"id": str(lid_a), "name": "lis-a", "status": "online", "tracks_pods": "1"},
+            {"id": str(lid_b), "name": "lis-b", "status": "online", "tracks_pods": "1"},
         ]
         # 3 pods for lis-a, 1 pod for lis-b
         mock_count.side_effect = [3, 1]
@@ -364,6 +364,81 @@ class TestListListenersReplicaCount:
         by_id = {item["id"]: item["attributes"] for item in data}
         assert by_id[f"listener-{lid_a}"]["replica-count"] == 3
         assert by_id[f"listener-{lid_b}"]["replica-count"] == 1
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.count_listener_replicas", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_replica_count_omitted_when_listener_does_not_track_pods(
+        self,
+        mock_resolve,
+        mock_get_pool,
+        mock_list_listeners,
+        mock_count,
+        *mocks,
+    ):
+        """Pre-0.19.0 listeners (no tracks_pods flag) → no replica-count attr,
+        and count_listener_replicas is never called."""
+        pool = _mock_pool()
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "read"
+        lid = uuid.uuid4()
+        mock_list_listeners.return_value = [
+            {"id": str(lid), "name": "old-listener", "status": "online"},
+        ]
+
+        app, _ = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}/listeners", headers=_AUTH)
+
+        assert res.status_code == 200
+        attrs = res.json()["data"][0]["attributes"]
+        assert "replica-count" not in attrs
+        mock_count.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.count_listener_replicas", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_replica_count_included_for_mixed_listeners(
+        self,
+        mock_resolve,
+        mock_get_pool,
+        mock_list_listeners,
+        mock_count,
+        *mocks,
+    ):
+        """Mixed list: tracking listener gets replica-count, old one doesn't."""
+        pool = _mock_pool()
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "read"
+        lid_new, lid_old = uuid.uuid4(), uuid.uuid4()
+        mock_list_listeners.return_value = [
+            {"id": str(lid_new), "name": "new", "status": "online", "tracks_pods": "1"},
+            {"id": str(lid_old), "name": "old", "status": "online"},
+        ]
+        mock_count.side_effect = [2]  # only one count call expected
+
+        app, _ = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}/listeners", headers=_AUTH)
+
+        data = {item["id"]: item["attributes"] for item in res.json()["data"]}
+        assert data[f"listener-{lid_new}"]["replica-count"] == 2
+        assert "replica-count" not in data[f"listener-{lid_old}"]
+        assert mock_count.call_count == 1
 
 
 class TestShowPoolRBAC:

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -81,7 +81,7 @@ class TestListenerHeartbeat:
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
                 f"/api/v2/listeners/{lid}/heartbeat",
-                json={"capacity": 5, "active_runs": 2},
+                json={"capacity": 5, "active_runs": 2, "pod_name": "listener-abc-123"},
             )
 
         assert res.status_code == 200
@@ -92,8 +92,31 @@ class TestListenerHeartbeat:
         call_kwargs = mock_heartbeat.call_args.kwargs
         assert call_kwargs["listener_id"] == str(lid)
         assert call_kwargs["name"] == "listener-1"
+        assert call_kwargs["pod_name"] == "listener-abc-123"
         assert call_kwargs["capacity"] == "5"
         assert call_kwargs["active_runs"] == "2"
+
+    @patch("terrapod.redis.client.publish_event", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.heartbeat_listener", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_listener")
+    async def test_heartbeat_without_pod_name_passes_none(
+        self, mock_get_listener, mock_heartbeat, mock_publish
+    ):
+        """Older clients that don't send pod_name still work; pod_name comes through as None."""
+        lid = uuid.uuid4()
+        mock_get_listener.return_value = _mock_listener_dict(listener_id=lid)
+
+        app = create_app()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(
+                f"/api/v2/listeners/{lid}/heartbeat",
+                json={"capacity": 5, "active_runs": 0},
+            )
+
+        assert res.status_code == 200
+        mock_heartbeat.assert_called_once()
+        assert mock_heartbeat.call_args.kwargs["pod_name"] is None
 
     @patch("terrapod.redis.client.publish_event", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.heartbeat_listener", new_callable=AsyncMock)
@@ -207,6 +230,140 @@ class TestListPoolsRBAC:
         assert res.status_code == 200
         data = res.json()["data"]
         assert data[0]["attributes"]["permission"] == "write"
+
+
+class TestPoolStatus:
+    """Pool list/detail surfaces a status string derived from registered listeners."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "terrapod.api.routers.agent_pools.fetch_custom_roles",
+        new_callable=AsyncMock,
+    )
+    async def test_list_pools_status_online_when_listener_online(
+        self, mock_fetch_roles, mock_resolve, mock_list_pools, mock_list_listeners, *mocks
+    ):
+        pool = _mock_pool(name="busy-pool")
+        mock_list_pools.return_value = [pool]
+        mock_fetch_roles.return_value = []
+        mock_resolve.return_value = "read"
+        mock_list_listeners.return_value = [
+            {"id": str(uuid.uuid4()), "name": "lis-1", "status": "online"}
+        ]
+
+        app, _ = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+
+        assert res.status_code == 200
+        attrs = res.json()["data"][0]["attributes"]
+        assert attrs["status"] == "online"
+        # listener-summary is gone — replaced by a single status pill
+        assert "listener-summary" not in attrs
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "terrapod.api.routers.agent_pools.fetch_custom_roles",
+        new_callable=AsyncMock,
+    )
+    async def test_list_pools_status_offline_when_no_listeners(
+        self, mock_fetch_roles, mock_resolve, mock_list_pools, mock_list_listeners, *mocks
+    ):
+        pool = _mock_pool(name="quiet-pool")
+        mock_list_pools.return_value = [pool]
+        mock_fetch_roles.return_value = []
+        mock_resolve.return_value = "read"
+        mock_list_listeners.return_value = []
+
+        app, _ = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+
+        assert res.json()["data"][0]["attributes"]["status"] == "offline"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_show_pool_includes_status(
+        self, mock_resolve, mock_get_pool, mock_list_listeners, *mocks
+    ):
+        pool = _mock_pool(name="visible")
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "read"
+        mock_list_listeners.return_value = [
+            {"id": str(uuid.uuid4()), "name": "lis", "status": "online"}
+        ]
+
+        app, _ = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+
+        assert res.json()["data"]["attributes"]["status"] == "online"
+
+
+class TestListListenersReplicaCount:
+    """The /listeners endpoint enriches each listener with a replica count."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.count_listener_replicas", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    async def test_listeners_carry_replica_count(
+        self,
+        mock_resolve,
+        mock_get_pool,
+        mock_list_listeners,
+        mock_count,
+        *mocks,
+    ):
+        pool = _mock_pool()
+        mock_get_pool.return_value = pool
+        mock_resolve.return_value = "read"
+        lid_a, lid_b = uuid.uuid4(), uuid.uuid4()
+        mock_list_listeners.return_value = [
+            {"id": str(lid_a), "name": "lis-a", "status": "online"},
+            {"id": str(lid_b), "name": "lis-b", "status": "online"},
+        ]
+        # 3 pods for lis-a, 1 pod for lis-b
+        mock_count.side_effect = [3, 1]
+
+        app, _ = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}/listeners", headers=_AUTH)
+
+        assert res.status_code == 200
+        data = res.json()["data"]
+        by_id = {item["id"]: item["attributes"] for item in data}
+        assert by_id[f"listener-{lid_a}"]["replica-count"] == 3
+        assert by_id[f"listener-{lid_b}"]["replica-count"] == 1
 
 
 class TestShowPoolRBAC:

--- a/services/tests/services/test_agent_pool_service.py
+++ b/services/tests/services/test_agent_pool_service.py
@@ -295,6 +295,34 @@ class TestHeartbeatListenerPodTracking:
         assert kwargs.get("ex") == LISTENER_POD_TTL
         mock_pipe.execute.assert_awaited_once()
 
+        # tracks_pods="1" must be added to the listener hash so the API can
+        # tell this listener is on a post-0.19.0 image.
+        mock_pipe.hset.assert_called_once()
+        hset_kwargs = mock_pipe.hset.call_args.kwargs
+        mapping = hset_kwargs.get("mapping") or mock_pipe.hset.call_args.args[1]
+        assert mapping.get("tracks_pods") == "1"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_without_pod_name_does_not_set_tracks_pods(self):
+        """Without pod_name we don't claim to be tracking pods — the API
+        relies on the absence of tracks_pods to omit replica-count."""
+        mock_redis = MagicMock()
+        mock_pipe = MagicMock()
+        mock_pipe.hset = MagicMock()
+        mock_pipe.expire = MagicMock()
+        mock_pipe.set = MagicMock()
+        mock_pipe.execute = AsyncMock()
+        mock_redis.pipeline.return_value = mock_pipe
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            await heartbeat_listener(listener_id="lid-1", name="lis", capacity="5")
+
+        mapping = mock_pipe.hset.call_args.kwargs.get("mapping") or mock_pipe.hset.call_args.args[1]
+        assert "tracks_pods" not in mapping
+
     @pytest.mark.asyncio
     async def test_heartbeat_without_pod_name_skips_pod_key(self):
         """Older clients (no pod_name) still heartbeat; no per-pod key is written."""

--- a/services/tests/services/test_agent_pool_service.py
+++ b/services/tests/services/test_agent_pool_service.py
@@ -3,13 +3,16 @@
 import hashlib
 import uuid
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from terrapod.services.agent_pool_service import (
+    LISTENER_POD_TTL,
+    count_listener_replicas,
     create_pool_token,
     generate_join_token,
+    heartbeat_listener,
     validate_join_token,
 )
 
@@ -256,3 +259,103 @@ class TestCreatePoolToken:
 
         assert db._captured["token"].max_uses == 10
         assert db._captured["token"].expires_at == custom_expiry
+
+
+# ── heartbeat_listener — pod_name + replica tracking ──────────────────
+
+
+class TestHeartbeatListenerPodTracking:
+    @pytest.mark.asyncio
+    async def test_heartbeat_with_pod_name_writes_per_pod_key(self):
+        """When pod_name is supplied the heartbeat refreshes a tp:listener_pod:{lid}:{pod} TTL key."""
+        mock_redis = MagicMock()
+        # Pipeline mock: track .set() calls and provide an awaitable execute()
+        mock_pipe = MagicMock()
+        mock_pipe.hset = MagicMock()
+        mock_pipe.expire = MagicMock()
+        mock_pipe.set = MagicMock()
+        mock_pipe.execute = AsyncMock()
+        mock_redis.pipeline.return_value = mock_pipe
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            await heartbeat_listener(
+                listener_id="lid-1",
+                name="lis",
+                pod_name="lis-pod-abc",
+                capacity="5",
+            )
+
+        # The per-pod key write must use SET with TTL = LISTENER_POD_TTL
+        mock_pipe.set.assert_called_once()
+        args, kwargs = mock_pipe.set.call_args
+        assert args[0] == "tp:listener_pod:lid-1:lis-pod-abc"
+        assert kwargs.get("ex") == LISTENER_POD_TTL
+        mock_pipe.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_without_pod_name_skips_pod_key(self):
+        """Older clients (no pod_name) still heartbeat; no per-pod key is written."""
+        mock_redis = MagicMock()
+        mock_pipe = MagicMock()
+        mock_pipe.hset = MagicMock()
+        mock_pipe.expire = MagicMock()
+        mock_pipe.set = MagicMock()
+        mock_pipe.execute = AsyncMock()
+        mock_redis.pipeline.return_value = mock_pipe
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            await heartbeat_listener(listener_id="lid-1", name="lis", capacity="5")
+
+        mock_pipe.set.assert_not_called()
+
+
+# ── count_listener_replicas ───────────────────────────────────────────
+
+
+class TestCountListenerReplicas:
+    @pytest.mark.asyncio
+    async def test_counts_pod_keys_via_scan(self):
+        """Replica count is the number of tp:listener_pod:{lid}:* keys."""
+        mock_redis = MagicMock()
+
+        async def fake_scan_iter(match=None, count=None):
+            assert match == "tp:listener_pod:lid-x:*"
+            for k in (
+                "tp:listener_pod:lid-x:pod-a",
+                "tp:listener_pod:lid-x:pod-b",
+                "tp:listener_pod:lid-x:pod-c",
+            ):
+                yield k
+
+        mock_redis.scan_iter = fake_scan_iter
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            count = await count_listener_replicas("lid-x")
+
+        assert count == 3
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_pod_keys(self):
+        """No per-pod keys (e.g. listener still on pre-0.19.0 image) → 0."""
+        mock_redis = MagicMock()
+
+        async def empty_scan_iter(match=None, count=None):
+            return
+            yield  # pragma: no cover (make this an async generator)
+
+        mock_redis.scan_iter = empty_scan_iter
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            assert await count_listener_replicas("lid-empty") == 0

--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -569,8 +569,13 @@ export default function AgentPoolDetailPage() {
                           </span>
                         </td>
                         <td className="px-4 py-3 text-xs text-slate-300">
-                          {typeof l.attributes['replica-count'] === 'number' && l.attributes['replica-count'] > 0
-                            ? l.attributes['replica-count']
+                          {/* `replica-count` is omitted entirely for listeners on
+                              pre-0.19.0 images (they don't write per-pod keys, so
+                              the count would always look like 0). When present,
+                              0 is meaningful: tracking is on, no pods are
+                              currently heartbeating. */}
+                          {typeof l.attributes['replica-count'] === 'number'
+                            ? <span className={l.attributes['replica-count'] === 0 ? 'text-amber-400' : ''}>{l.attributes['replica-count']}</span>
                             : <span className="text-slate-500">—</span>}
                         </td>
                         <td className="px-4 py-3 text-xs text-slate-400 hidden md:table-cell">

--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -23,7 +23,7 @@ interface PoolAttrs {
   'owner-email': string
   permission?: string
   'created-at': string
-  'listener-summary'?: { total: number; online: number }
+  status?: 'online' | 'offline'
 }
 
 interface Pool {
@@ -50,6 +50,7 @@ interface Listener {
   attributes: {
     name: string
     status: string
+    'replica-count'?: number
     'certificate-expires-at': string | null
     'created-at': string
   }
@@ -541,20 +542,6 @@ export default function AgentPoolDetailPage() {
         {/* Listeners Tab */}
         {activeTab === 'listeners' && (
           <div>
-            {pool?.attributes['listener-summary'] && (
-              <div className="grid grid-cols-2 gap-4 mb-4">
-                <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
-                  <p className="text-xs text-slate-500 uppercase tracking-wider">Online</p>
-                  <p className={`text-2xl font-semibold mt-1 ${pool.attributes['listener-summary'].online > 0 ? 'text-green-400' : 'text-slate-500'}`}>
-                    {pool.attributes['listener-summary'].online}
-                  </p>
-                </div>
-                <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
-                  <p className="text-xs text-slate-500 uppercase tracking-wider">Total</p>
-                  <p className="text-2xl font-semibold text-slate-100 mt-1">{pool.attributes['listener-summary'].total}</p>
-                </div>
-              </div>
-            )}
             {listenersLoading ? (
               <LoadingSpinner />
             ) : listeners.length === 0 ? (
@@ -566,6 +553,7 @@ export default function AgentPoolDetailPage() {
                     <tr className="border-b border-slate-700/50">
                       <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">Name</th>
                       <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">Status</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">Replicas</th>
                       <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider hidden md:table-cell">Cert Expires</th>
                       <th className="px-4 py-3 text-right text-xs font-medium text-slate-400 uppercase tracking-wider">Actions</th>
                     </tr>
@@ -579,6 +567,11 @@ export default function AgentPoolDetailPage() {
                             <span className={`w-2 h-2 rounded-full ${l.attributes.status === 'online' ? 'bg-green-400' : 'bg-slate-500'}`} />
                             <span className="text-xs text-slate-400">{l.attributes.status}</span>
                           </span>
+                        </td>
+                        <td className="px-4 py-3 text-xs text-slate-300">
+                          {typeof l.attributes['replica-count'] === 'number' && l.attributes['replica-count'] > 0
+                            ? l.attributes['replica-count']
+                            : <span className="text-slate-500">—</span>}
                         </td>
                         <td className="px-4 py-3 text-xs text-slate-400 hidden md:table-cell">
                           {formatDate(l.attributes['certificate-expires-at'])}

--- a/web/src/app/admin/agent-pools/page.tsx
+++ b/web/src/app/admin/agent-pools/page.tsx
@@ -25,7 +25,7 @@ interface AgentPool {
     'owner-email': string
     permission?: string
     'created-at': string
-    'listener-summary'?: { total: number; online: number }
+    status?: 'online' | 'offline'
   }
 }
 
@@ -166,7 +166,7 @@ export default function AgentPoolsPage() {
                 <tr className="border-b border-slate-700/50">
                   <SortableHeader label="Name" sortKey="name" sortState={sortState} onSort={toggleSort} />
                   <SortableHeader label="Description" sortKey="description" sortState={sortState} onSort={toggleSort} className="hidden sm:table-cell" />
-                  <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider hidden md:table-cell">Listeners</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider hidden md:table-cell">Status</th>
                   <SortableHeader label="Created" sortKey="created" sortState={sortState} onSort={toggleSort} className="hidden lg:table-cell" />
                 </tr>
               </thead>
@@ -189,16 +189,14 @@ export default function AgentPoolsPage() {
                       {pool.attributes.description || '-'}
                     </td>
                     <td className="px-4 py-3 hidden md:table-cell">
-                      {pool.attributes['listener-summary'] ? (() => {
-                        const s = pool.attributes['listener-summary']
-                        return (
-                          <span className="text-xs">
-                            <span className={s.online > 0 ? 'text-green-400' : 'text-slate-500'}>{s.online}</span>
-                            <span className="text-slate-600"> / </span>
-                            <span className="text-slate-400">{s.total}</span>
-                          </span>
-                        )
-                      })() : <span className="text-xs text-slate-500">-</span>}
+                      {pool.attributes.status ? (
+                        <span className="inline-flex items-center gap-1.5">
+                          <span className={`w-2 h-2 rounded-full ${pool.attributes.status === 'online' ? 'bg-green-400' : 'bg-slate-500'}`} />
+                          <span className="text-xs text-slate-400 capitalize">{pool.attributes.status}</span>
+                        </span>
+                      ) : (
+                        <span className="text-xs text-slate-500">-</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-xs text-slate-500 hidden lg:table-cell">
                       {pool.attributes['created-at'] ? new Date(pool.attributes['created-at']).toLocaleDateString() : ''}


### PR DESCRIPTION
## Summary

The agent pools list page used to show a misleading "1/1" listener count for every pool — under v0.19.0's shared-identity model, multi-replica listener Deployments all collapse to a single listener record per pool, so the count never reflected the actual pod fleet. This PR:

- Replaces the listener count column on the pool list with a single **online/offline status pill** (pool is online if any registered listener heartbeats).
- Drops the misleading "Online/Total" stat cards on the pool detail listeners tab.
- Adds a **Replicas** column to the listener table so admins can see how many pods are actually heartbeating for each listener identity.

## Breaking change

The pool JSON drops the **`listener-summary`** attribute. The frontend (updated in this PR) is the only consumer in this repo — the Terraform provider does not read it (`grep -r listener-summary provider/` is empty). External integrators hitting the API directly that depended on this field will need to update.

The replacement attribute is `status: "online" | "offline"`.

## How replica count works

- New Redis key family `tp:listener_pod:{listener_id}:{pod_name}` with **180 s TTL** (3 × heartbeat interval, tolerates 2 missed beats).
- Each pod's heartbeat now carries `pod_name` (sourced from the Downward API `POD_NAME` env var). The API refreshes that pod's presence key on every heartbeat.
- The listener hash gains a **`tracks_pods` flag**, set the first time a heartbeat from that listener carries `pod_name`. The `/listeners` endpoint only computes replica-count for listeners with the flag set; older listeners (still on a pre-0.19.0 image) get the attribute omitted entirely.
- UI mapping:

  | replica-count | status | UI |
  |---|---|---|
  | (omitted) | — | "—" (untracked: pre-0.19.0 listener) |
  | 0 | online | "0" in amber (tracked, but no pods heartbeating — trouble) |
  | 1+ | online | the number |

## API contract changes

| Endpoint | Change |
|---|---|
| `GET /api/v2/organizations/default/agent-pools` | Pool attributes: **drop** `listener-summary`, **add** `status: "online" \| "offline"` |
| `GET /api/v2/agent-pools/{id}` | Same |
| `GET /api/v2/agent-pools/{id}/listeners` | Listener attributes: **add** optional `replica-count: int` (omitted for listeners that don't opt in via `tracks_pods`) |
| `POST /api/v2/listeners/{id}/heartbeat` | Body: **add** optional `pod_name: string`. Sets the listener-side `tracks_pods` flag when present. |

## Cluster-mode Redis safety

- Per-pod keys live under a different prefix (`tp:listener_pod:`) than the listener hash (`tp:listener:`), so they hash to different slots in cluster mode. The heartbeat pipeline already runs with `transaction=False`; the new `SET` for the per-pod key is appended to the same pipeline (cross-slot safe without MULTI/EXEC).
- Cleanup paths (`delete_listener`, `delete_pool_listeners`) drain per-pod keys outside the pipeline since SCAN+DELETE across slots can't be batched. There is a documented narrow race window where a heartbeat lands between the SCAN+DELETE pass and the listener-hash deletion, leaving an orphan per-pod key referencing a deleted listener — the orphan self-heals after at most 180 s.

## Test plan

- [x] Unit: `heartbeat_listener` writes per-pod key + `tracks_pods="1"` when `pod_name` supplied; skips both otherwise.
- [x] Unit: `count_listener_replicas` counts SCAN matches; returns 0 when empty.
- [x] API: heartbeat pod_name pass-through (with and without).
- [x] API: pool `status` is "online" when any listener registered, "offline" when none.
- [x] API: `/listeners` populates `replica-count` only for listeners with `tracks_pods="1"`; mixed-list test confirms `count_listener_replicas` is called only for tracking listeners.
- [x] `make lint` / `make test` (1074 tests) green.
- [x] `npm run build` from `web/` succeeds (Next.js prerender).
- [ ] Tilt verify: pool list shows status pill; pool detail listeners tab shows replica count = 1; scale listener Deployment to 2; replica count climbs to 2 within ~60 s.
- [ ] After release, mgmt cluster's pools should show "online" + "Replicas: 2" instead of "1/1".