### PR TITLE
fix(vcs): stream tarballs to disk + single-flight cache to stop api OOM

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -269,8 +269,44 @@ The chart ships with a `values.schema.json` that validates all values at `helm i
 |---|---|---|
 | `api.config.vcs.enabled` | `true` | Enable VCS integration |
 | `api.config.vcs.poll_interval_seconds` | `60` | Poll interval |
+| `api.config.vcs.tmpdir` | (matches `api.ephemeralStorage.mountPath`) | Directory for streaming download/strip/upload of VCS tarballs. Falls back to system tempdir if the path doesn't exist |
+| `api.config.vcs.archive_cache_retention_days` | `7` | TTL for cached stripped tarballs in object storage. Evicted by the artifact-retention sweeper |
 | `api.config.vcs.github.existingSecret` | `""` | K8s Secret containing the GitHub webhook HMAC secret |
 | `api.config.vcs.github.existingSecretKey` | `"webhook_secret"` | Key within the Secret |
+
+#### VCS archive streaming and ephemeral storage (REQUIRED for monorepo workspaces)
+
+The VCS poller streams every workspace's tarball from GitHub/GitLab through a local file pipeline (download → strip top-level dir → upload to object storage). Without per-pod ephemeral disk, multi-hundred-MB monorepo tarballs would land in process memory and OOM-kill the api pod under multi-workspace polling.
+
+The Helm chart provisions per-pod ephemeral storage by default:
+
+```yaml
+api:
+  ephemeralStorage:
+    enabled: true
+    size: 50Gi
+    storageClass: ""     # empty = cluster default
+    mountPath: /var/lib/terrapod/tmp
+```
+
+This uses a [generic ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes) — each pod replica gets its own PVC, automatically deleted when the pod terminates. **Pick a `storageClass` whose reclaim policy is `Delete`**: with `Retain`, PersistentVolumes outlive their pods and accumulate as orphans on every restart. The cluster default is often `Retain`-flavoured (e.g. AWS EKS's `xfs-retain`, k3s's `local-path` default behaves correctly but check `kubectl get sc`).
+
+**AWS EKS example:** the EBS CSI driver ships with `gp3`/`xfs` (Delete) and `gp3-retain`/`xfs-retain` (Retain). Set `storageClass: xfs` (or `gp3`).
+
+**k3s example:** k3s ships with `local-path` as the default. It uses host-path provisioning and `Delete` reclaim — works out of the box for single-node clusters. For multi-node k3s, install a CSI driver (e.g. `longhorn`, `openebs-hostpath`) and set `storageClass` accordingly. If you can't run a CSI provisioner, set `enabled: false` and accept that you can't safely poll workspaces in repos larger than `~api.resources.limits.memory` / N replicas.
+
+**Local dev (Tilt, Rancher Desktop):** `values-local.yaml` already disables ephemeral storage. The local stack falls back to the system tempdir, which is fine for the small repos used in dev.
+
+**Cache layer:** stripped tarballs are persisted to object storage under `vcs_archives/{conn_id}/{owner}/{repo}/{sha}.tar.gz`. Multiple workspaces tracking the same `(repo, sha)` only trigger one GitHub download per cycle (single-flight in-process + storage cache across cycles + replicas). The cache is evicted by the artifact-retention sweeper after `vcs.archive_cache_retention_days` (default 7).
+
+**Sizing the ephemeral PVC:** the default 50 GiB covers fleets with monorepos up to ~500 MB and the default 10 parallel workspace polls (`_MAX_PARALLEL_WORKSPACE_POLLS = 10`). Each concurrent poll holds the raw + stripped tarball on disk (~2 × tarball size), so peak usage scales with `2 × tarball_size × parallel_polls`. Past releases used 10 GiB which was adequate for small repos but starved larger fleets — the new 50 GiB default solves that for most deployments. Sizing rule of thumb:
+
+```
+size = 4 × largest_tarball_size_MB × parallel_workspace_polls
+     + retention_days × distinct_SHAs_per_day × largest_tarball_size_MB
+```
+
+The first term covers in-flight downloads, the second covers cached stripped tarballs awaiting retention sweep. The `_ensure_tmpdir_space` sweeper kicks in below `vcs.tmpdir_min_free_bytes` (default 2 GiB) as a safety net for surprise fleet growth, but it shouldn't be the primary capacity mechanism — provision the PVC for steady state.
 
 ### Drift Detection
 

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -11,6 +11,10 @@ A step-by-step checklist for preparing a Terrapod instance for production use. E
 - [ ] **PostgreSQL is externally managed** -- RDS, Cloud SQL, Azure Database, or equivalent with automated backups and point-in-time recovery (PITR). Do not run PostgreSQL inside the Kubernetes cluster for production workloads. See [Deployment: Database](deployment.md#database).
 - [ ] **Redis is externally managed** -- ElastiCache, MemoryDB, Azure Cache, or equivalent. Redis holds ephemeral data (sessions, scheduler state, listener heartbeats) so durability is not required, but availability is. See [Deployment: Redis](deployment.md#redis).
 - [ ] **Object storage is configured** -- S3, Azure Blob, or GCS with encryption at rest enabled. Filesystem storage (PVC) is acceptable for single-replica deployments but does not support multi-replica or cross-AZ redundancy. See [Deployment: Storage Backends](deployment.md#storage-backends).
+- [ ] **API pod ephemeral storage is provisioned** -- `api.ephemeralStorage.enabled: true` (default) gives each api pod replica its own PVC for streaming VCS tarballs. The configured `storageClass` MUST have `Delete` reclaim policy, otherwise PVs accumulate as orphans on every pod restart. See [Deployment: VCS archive streaming and ephemeral storage](deployment.md#vcs-archive-streaming-and-ephemeral-storage-required-for-monorepo-workspaces).
+  - **AWS EKS**: use `xfs` or `gp3` (NOT `xfs-retain` / `gp3-retain`).
+  - **k3s (single-node)**: built-in `local-path` works out of the box.
+  - **k3s (multi-node)**: install a CSI provisioner (`longhorn`, `openebs-hostpath`) and set the storage class explicitly.
 - [ ] **TLS is enforced end-to-end** -- Ingress terminates TLS with a valid certificate, database uses `sslmode=verify-full`, Redis uses `rediss://`. See [Security Hardening: TLS](security-hardening.md#tls-configuration).
 - [ ] **DNS record points to the ingress** -- The public hostname resolves to the ingress load balancer.
 

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -44,6 +44,14 @@ Terrapod's background poller checks your VCS providers every 60 seconds (configu
 - **No inbound connections required** -- Terrapod only makes outbound HTTPS calls to VCS provider APIs, so it works behind firewalls and NATs without any ingress configuration.
 - **Webhooks are optional** (GitHub only, currently) -- if you want faster feedback (sub-second instead of up to 60s), you can configure GitHub webhooks. The webhook tells the poller to check immediately rather than waiting for the next cycle.
 
+### Streaming + caching
+
+VCS tarball downloads stream from the provider through a local file pipeline (download → strip top-level dir → upload to object storage), never buffering the whole archive in process memory. Multi-hundred-MB monorepo tarballs stay under ~10 MB of process memory. The api pod requires per-pod ephemeral storage (`api.ephemeralStorage.enabled: true`, default 10 GiB) to back this pipeline — see [Deployment: VCS archive streaming and ephemeral storage](deployment.md#vcs-archive-streaming-and-ephemeral-storage-required-for-monorepo-workspaces).
+
+Stripped tarballs are cached in object storage at `vcs_archives/{conn_id}/{owner}/{repo}/{sha}.tar.gz`. Multiple workspaces tracking the same `(repo, sha)` only trigger one provider download per cycle (single-flight in-process + storage cache across cycles). The cache is content-addressed (commit SHA = key) and evicted by the artifact-retention sweeper after `vcs.archive_cache_retention_days` (default 7).
+
+If the api pod's ephemeral PVC nears capacity (e.g. previous-pod orphans, very large concurrent downloads), the cache automatically sweeps the oldest tarball temp files older than 5 minutes before reserving more disk. Tunable via `vcs.tmpdir_min_free_bytes` (default 2 GiB).
+
 ### Provider Dispatch
 
 The `VCSProvider` protocol defines the interface for VCS operations. The poller dispatches to the correct provider based on the VCS connection's `provider` field (`github` or `gitlab`). Each provider implements:

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -174,6 +174,13 @@ data:
     vcs:
       enabled: {{ .Values.api.config.vcs.enabled }}
       poll_interval_seconds: {{ .Values.api.config.vcs.poll_interval_seconds | default 60 }}
+      # tmpdir tracks the ephemeralStorage mountPath so the VCS poller writes
+      # streamed tarballs onto the PVC, not pod memory. Override
+      # api.config.vcs.tmpdir if you remount the PVC elsewhere.
+      tmpdir: {{ .Values.api.config.vcs.tmpdir | default .Values.api.ephemeralStorage.mountPath | default "/var/lib/terrapod/tmp" | quote }}
+      {{- with .Values.api.config.vcs.archive_cache_retention_days }}
+      archive_cache_retention_days: {{ . }}
+      {{- end }}
     {{- end }}
     {{- if .Values.api.config.audit }}
     audit:

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -117,6 +117,14 @@ spec:
               mountPath: /tmp
             - name: ca-cache
               mountPath: /var/lib/terrapod/ca
+            {{- if .Values.api.ephemeralStorage.enabled }}
+            # VCS poller streams multi-hundred-MB monorepo tarballs through
+            # this path during download → strip → upload. Backed by a
+            # per-pod ephemeral PVC so we don't OOM the pod or rely on
+            # node tmpfs.
+            - name: vcs-tmpdir
+              mountPath: {{ .Values.api.ephemeralStorage.mountPath | default "/var/lib/terrapod/tmp" }}
+            {{- end }}
             {{- if eq .Values.api.config.storage.backend "filesystem" }}
             - name: storage
               mountPath: {{ .Values.api.config.storage.filesystem.root_dir }}
@@ -163,6 +171,27 @@ spec:
           emptyDir: {}
         - name: ca-cache
           emptyDir: {}
+        {{- if .Values.api.ephemeralStorage.enabled }}
+        # Generic ephemeral volume — each pod replica gets its own PVC,
+        # auto-deleted on pod removal. Used by the VCS poller to stream
+        # monorepo tarballs through (download → strip → upload) without
+        # ever materialising them in process memory.
+        - name: vcs-tmpdir
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                labels:
+                  {{- include "terrapod.labels" . | nindent 18 }}
+                  app.kubernetes.io/component: api
+              spec:
+                accessModes: ["ReadWriteOnce"]
+                {{- if .Values.api.ephemeralStorage.storageClass }}
+                storageClassName: {{ .Values.api.ephemeralStorage.storageClass | quote }}
+                {{- end }}
+                resources:
+                  requests:
+                    storage: {{ .Values.api.ephemeralStorage.size | default "10Gi" | quote }}
+        {{- end }}
         {{- if eq .Values.api.config.storage.backend "filesystem" }}
         - name: storage
           {{- if .Values.storage.filesystem.persistence.enabled }}

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -15,6 +15,12 @@ api:
   podAntiAffinity:
     enabled: false
 
+  # Tilt + Rancher Desktop don't always have a CSI provisioner that satisfies
+  # generic ephemeral volumes; the system tempdir is fine for local dev where
+  # we don't poll giant monorepos.
+  ephemeralStorage:
+    enabled: false
+
   # Dev overrides — relax security for hot reload (writable filesystem for __pycache__, .pyc)
   # Dev images use string usernames (terrapod/nextjs) which k8s can't verify as non-root
   podSecurityContext:

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -39,6 +39,7 @@
         "strategy": { "$ref": "#/$defs/strategySpec" },
         "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
         "preStopSleepSeconds": { "type": "integer", "minimum": 0 },
+        "ephemeralStorage": { "$ref": "#/$defs/ephemeralStorageSpec" },
         "podAntiAffinity": { "$ref": "#/$defs/podAntiAffinitySpec" },
         "nodeSelector": { "type": "object" },
         "tolerations": { "type": "array", "items": { "type": "object" } },
@@ -366,6 +367,17 @@
       }
     },
 
+    "ephemeralStorageSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "mountPath": { "type": "string" }
+      }
+    },
+
     "apiConfig": {
       "type": "object",
       "additionalProperties": false,
@@ -552,6 +564,8 @@
           "properties": {
             "enabled": { "type": "boolean" },
             "poll_interval_seconds": { "type": "integer", "minimum": 1 },
+            "tmpdir": { "type": "string" },
+            "archive_cache_retention_days": { "type": "integer", "minimum": 0 },
             "github": {
               "type": "object",
               "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -336,6 +336,33 @@ api:
   # has slower endpoint convergence.
   preStopSleepSeconds: 30
 
+  # Per-pod ephemeral storage for VCS archive streaming. Each api pod replica
+  # gets its own PVC (generic ephemeral volume → auto-deleted on pod removal).
+  # Required because the VCS poller streams multi-hundred-MB monorepo tarballs
+  # through this path during download → strip → upload; without it the api
+  # pod OOM-kills under multi-workspace polling of the same repo.
+  #
+  # Sizing: each concurrent workspace poll holds raw + stripped tarball on
+  # disk simultaneously (~2× tarball size). With the default 10 parallel
+  # workspace polls and a 500 MB monorepo, peak usage is ~10 GB just for
+  # in-flight downloads — plus the cached stripped tarballs from prior
+  # cycles waiting for the retention sweeper. 50 GiB is the safe default;
+  # bump it for fleets with bigger monorepos or more parallel workspaces.
+  #
+  # Disable only if you can guarantee no large monorepo workspaces (e.g. tests,
+  # local dev — values-local.yaml does this). The poller will fall back to the
+  # system tempdir, but tmpfs-backed /tmp on most images is too small.
+  ephemeralStorage:
+    enabled: true
+    size: 50Gi
+    # Empty string = cluster default StorageClass. Some default classes (e.g.
+    # k3s-rancher-default with `Retain` reclaim, or AWS EKS's `xfs-retain`)
+    # leave PVs hanging around after the pod dies, which defeats "ephemeral".
+    # Set this to a class with `Delete` reclaim policy. See docs/deployment.md
+    # for k3s + AWS guidance.
+    storageClass: ""
+    mountPath: /var/lib/terrapod/tmp
+
   # Pod anti-affinity spreads replicas across nodes (required) and AZs (preferred).
   # Disable on single-node clusters. Set 'affinity' to override with custom rules.
   podAntiAffinity:

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -223,16 +223,14 @@ async def _fetch_vcs_config(
 
     Returns (cv_id, commit_sha, ref_name).
     """
+    from terrapod.services.vcs_archive_cache import VCSArchiveCache
     from terrapod.services.vcs_poller import (
-        _download_archive,
         _get_branch_sha,
         _list_tags,
         _parse_repo_url,
         _resolve_branch,
-        _strip_top_level_dir,
+        _stream_cv_upload_from_cache,
     )
-    from terrapod.storage import get_storage
-    from terrapod.storage.keys import config_version_key
 
     conn = await db.get(VCSConnection, ws.vcs_connection_id)
     if not conn or conn.status != "active":
@@ -253,7 +251,7 @@ async def _fetch_vcs_config(
             if tag_match:
                 sha = tag_match["sha"]
             else:
-                # Treat as raw SHA — download_archive accepts any git ref
+                # Treat as raw SHA — providers accept any git ref
                 sha = ref_override
     else:
         ref_name = await _resolve_branch(conn, ws, owner, repo) or ""
@@ -263,17 +261,20 @@ async def _fetch_vcs_config(
         if not sha:
             raise HTTPException(status_code=422, detail="Cannot get branch HEAD SHA")
 
-    archive = await _download_archive(conn, owner, repo, sha)
-    archive = await _strip_top_level_dir(archive)
+    # Streaming + storage cache: tarball never lands in process memory, and
+    # subsequent UI fetches at the same SHA hit the cache (storage `head()`)
+    # instead of re-downloading from GitHub. Single-shot cache instance is
+    # fine here — the in-process single-flight only matters when multiple
+    # workspaces poll the same SHA concurrently.
+    cache = VCSArchiveCache()
+    cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha)
 
     cv = await run_service.create_configuration_version(
         db, workspace_id=ws.id, source="vcs", auto_queue_runs=False
     )
     await db.flush()
 
-    storage = get_storage()
-    key = config_version_key(str(ws.id), str(cv.id))
-    await storage.put(key, archive, content_type="application/x-tar")
+    await _stream_cv_upload_from_cache(cache_storage_key, ws.id, cv.id)
 
     cv = await run_service.mark_configuration_uploaded(db, cv)
 

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -384,6 +384,38 @@ class VCSConfig(BaseModel):
         default=60, description="Polling interval in seconds for VCS changes"
     )
     github: GitHubWebhookConfig = Field(default_factory=GitHubWebhookConfig)
+    tmpdir: str = Field(
+        default="/var/lib/terrapod/tmp",
+        description=(
+            "Directory for temporary VCS archive files (raw + stripped tarballs). "
+            "Should point at an ephemeral PVC mount in production — multi-hundred-MB "
+            "monorepo tarballs land here during streaming download/strip/upload, "
+            "and a node tmpfs typically isn't large enough. The Helm chart provisions "
+            "this via `api.ephemeralStorage` and mounts it at this path. Falls back "
+            "to the system tempdir at runtime if the path doesn't exist (suitable for "
+            "tests and local dev)."
+        ),
+    )
+    archive_cache_retention_days: int = Field(
+        default=7,
+        description=(
+            "TTL for cached VCS archive tarballs in object storage. Stripped "
+            "tarballs are content-addressed by commit SHA so they're safe to "
+            "cache for the lifetime of any in-flight runs that reference them. "
+            "Evicted by the artifact-retention sweeper."
+        ),
+    )
+    tmpdir_min_free_bytes: int = Field(
+        default=2 * 1024**3,  # 2 GiB
+        description=(
+            "Minimum free space in `tmpdir` before each VCS download. If free "
+            "space drops below this, the cache evicts the oldest orphan temp "
+            "tarballs (anything older than 5 minutes that didn't get cleaned "
+            "up by its NamedTemporaryFile context — e.g. a previous pod crash) "
+            "until we hit the threshold or run out of candidates. Stops the "
+            "ephemeral PVC from filling up and breaking subsequent polls."
+        ),
+    )
 
 
 # --- Drift Detection Configuration ---

--- a/services/terrapod/services/archive_utils.py
+++ b/services/terrapod/services/archive_utils.py
@@ -2,8 +2,15 @@
 
 GitHub and GitLab archive downloads wrap all files in a top-level directory
 (e.g. ``owner-repo-sha/``).  Terraform/tofu expects module tarballs and
-workspace configs to have .tf files at the root.  The helper here strips
+workspace configs to have .tf files at the root.  The helpers here strip
 that wrapper so downloaded archives are usable as-is.
+
+Two interfaces:
+- bytes-in/bytes-out (legacy, used by the registry path) — buffers the full
+  tarball in memory, only safe for small archives.
+- file-in/file-out (preferred for VCS poll cycles) — uses sequential streaming
+  tarfile mode (``r|gz`` / ``w|gz``) so a multi-hundred-MB monorepo tarball
+  never lands in process memory.
 """
 
 import asyncio
@@ -48,3 +55,42 @@ def strip_archive_top_level_dir(archive: bytes) -> bytes:
                 dst.addfile(member)
 
     return out_buf.getvalue()
+
+
+async def strip_archive_top_level_dir_file_async(src_path: str, dst_path: str) -> None:
+    """Async wrapper around the file-to-file streaming strip.
+
+    Use this for VCS-poll-cycle archives where the input may be hundreds of
+    MB. The sync helper runs in a thread so the asyncio loop isn't blocked.
+    """
+    await asyncio.to_thread(strip_archive_top_level_dir_file, src_path, dst_path)
+
+
+def strip_archive_top_level_dir_file(src_path: str, dst_path: str) -> None:
+    """Repack a gzipped tarball file-to-file, stripping the single top-level directory.
+
+    Uses tarfile streaming mode (``r|gz`` for read, ``w|gz`` for write) which
+    processes entries sequentially without building an in-memory index. Memory
+    use is bounded by the per-entry buffer (one file at a time), so a 300 MB
+    monorepo tarball costs single-digit MB of RAM rather than 300+ MB.
+
+    Same path-rewrite contract as ``strip_archive_top_level_dir``: the first
+    path component (``owner-repo-sha/``) is dropped from every member name.
+    """
+    with (
+        open(src_path, "rb") as src_f,
+        open(dst_path, "wb") as dst_f,
+        tarfile.open(fileobj=src_f, mode="r|gz") as src,
+        tarfile.open(fileobj=dst_f, mode="w|gz") as dst,
+    ):
+        for member in src:
+            parts = member.name.split("/", 1)
+            if len(parts) < 2 or not parts[1]:
+                continue  # skip the top-level directory entry itself
+            member.name = parts[1]
+            if member.isfile():
+                f = src.extractfile(member)
+                if f:
+                    dst.addfile(member, f)
+            else:
+                dst.addfile(member)

--- a/services/terrapod/services/artifact_retention_service.py
+++ b/services/terrapod/services/artifact_retention_service.py
@@ -64,6 +64,11 @@ async def artifact_retention_cycle() -> None:
             ("provider_cache", _cleanup_provider_cache, cfg.provider_cache_retention_days),
             ("binary_cache", _cleanup_binary_cache, cfg.binary_cache_retention_days),
             ("module_overrides", _cleanup_module_overrides, cfg.module_overrides_retention_days),
+            (
+                "vcs_archives",
+                _cleanup_vcs_archives,
+                settings.vcs.archive_cache_retention_days,
+            ),
         ]
 
         for category, handler, threshold in categories:
@@ -389,5 +394,71 @@ async def _cleanup_module_overrides(
     if deleted:
         await db.commit()
         RETENTION_DELETED.labels(category="module_overrides").inc(deleted)
+
+    return deleted
+
+
+async def _cleanup_vcs_archives(
+    db: AsyncSession,
+    storage: ObjectStore,
+    retention_days: int,
+    batch_size: int,
+) -> int:
+    """Delete cached VCS archive tarballs older than retention_days.
+
+    VCS archives are cached in object storage at
+    ``vcs_archives/{conn_id}/{owner}/{repo}/{sha}.tar.gz``. They have no DB
+    table — entries are content-addressed by commit SHA, so we list the prefix
+    and use each object's `last_modified` timestamp directly. No `db.commit()`
+    is needed because no relational state changes.
+
+    `db` is unused here but kept on the signature to match the other handlers.
+
+    Scaling: `list_prefix` returns ALL entries under the prefix in one call.
+    For typical fleets (≤100 monorepos × ≤10 unique SHAs per workspace per
+    week) this is well under 10k keys. If a deployment grows past that, the
+    handler logs a warning so operators can move to a DB-tracked index;
+    until then this single-call approach keeps the contract simple.
+    """
+    from terrapod.api.metrics import RETENTION_DELETED
+
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+    deleted = 0
+    _LIST_WARN_THRESHOLD = 10_000
+
+    try:
+        entries = await storage.list_prefix("vcs_archives/")
+    except Exception:
+        logger.warning("Failed to list vcs_archives prefix", exc_info=True)
+        return 0
+
+    if len(entries) >= _LIST_WARN_THRESHOLD:
+        logger.warning(
+            "vcs_archives prefix has many entries; consider DB-tracked index",
+            entry_count=len(entries),
+            threshold=_LIST_WARN_THRESHOLD,
+        )
+
+    # Oldest first so we evict the longest-stale entries first if we hit the batch cap.
+    entries.sort(key=lambda m: m.last_modified)
+    for meta in entries:
+        if meta.last_modified >= cutoff:
+            # Sorted oldest first; once we see anything still in retention,
+            # everything after is also in retention.
+            break
+        if deleted >= batch_size:
+            break
+        try:
+            await storage.delete(meta.key)
+            deleted += 1
+        except Exception:
+            logger.warning(
+                "Failed to delete VCS archive from storage",
+                key=meta.key,
+                exc_info=True,
+            )
+
+    if deleted:
+        RETENTION_DELETED.labels(category="vcs_archives").inc(deleted)
 
     return deleted

--- a/services/terrapod/services/github_service.py
+++ b/services/terrapod/services/github_service.py
@@ -315,6 +315,11 @@ async def download_repo_archive(conn: VCSConnection, owner: str, repo: str, ref:
     """Download a repository tarball for a given ref (branch, tag, or SHA).
 
     Uses GitHub's tarball endpoint which returns a redirect to a CDN URL.
+
+    Loads the full tarball into process memory. Safe for small registry
+    archives but DANGEROUS for full monorepo poll-cycle archives — the api
+    pod will OOM under enough concurrent workspace polls. Use
+    `download_repo_archive_to_file` for the VCS-poll path.
     """
     token = await get_installation_token(conn)
     api_url = _api_url(conn)
@@ -327,6 +332,53 @@ async def download_repo_archive(conn: VCSConnection, owner: str, repo: str, ref:
     )
     resp.raise_for_status()
     return resp.content
+
+
+async def download_repo_archive_to_file(
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    ref: str,
+    dest_path: str,
+    *,
+    chunk_size: int = 1 << 20,  # 1 MiB
+    timeout: float = 300.0,
+) -> int:
+    """Stream a repository tarball directly to a local file path.
+
+    Avoids buffering the full archive in process memory — chunks land on
+    disk as they arrive over the wire, so a 500 MB tarball uses ~chunk_size
+    of RAM regardless of repo size. Returns the total bytes written.
+
+    Retry policy: none. Transport errors propagate to the caller. The VCS
+    poller reruns every `vcs.poll_interval_seconds` (default 60s), so a
+    transient network hiccup is naturally retried by the next cycle. We
+    deliberately don't retry inline because mid-stream retries are unsafe
+    (no resumable offset against the GitHub tarball endpoint) and pre-byte
+    retries would just duplicate the cycle's own retry cadence.
+    """
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+    url = f"{api_url}/repos/{owner}/{repo}/tarball/{ref}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    bytes_written = 0
+    async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
+        async with client.stream("GET", url, headers=headers) as resp:
+            resp.raise_for_status()
+            with open(dest_path, "wb") as f:
+                async for chunk in resp.aiter_bytes(chunk_size=chunk_size):
+                    if not chunk:
+                        continue
+                    # Disk write is sync; offload to a thread so we don't
+                    # block the event loop on every chunk.
+                    await asyncio.to_thread(f.write, chunk)
+                    bytes_written += len(chunk)
+    return bytes_written
 
 
 async def list_open_pull_requests(

--- a/services/terrapod/services/gitlab_service.py
+++ b/services/terrapod/services/gitlab_service.py
@@ -4,6 +4,7 @@ Authenticates via Project/Group Access Token (stored on the VCSConnection).
 Supports GitLab.com and self-hosted GitLab instances.
 """
 
+import asyncio
 from urllib.parse import quote as url_quote
 
 import httpx
@@ -72,7 +73,12 @@ async def get_default_branch(conn: VCSConnection, owner: str, repo: str) -> str 
 
 
 async def download_archive(conn: VCSConnection, owner: str, repo: str, ref: str) -> bytes:
-    """Download repository tarball at a given ref."""
+    """Download repository tarball at a given ref.
+
+    Buffers the full tarball into process memory. See the github_service
+    counterpart — use `download_archive_to_file` for the VCS-poll-cycle
+    path to avoid OOMing the api pod on large monorepos.
+    """
     api = _api_url(conn)
     project = _project_path(owner, repo)
 
@@ -84,6 +90,48 @@ async def download_archive(conn: VCSConnection, owner: str, repo: str, ref: str)
         )
         resp.raise_for_status()
         return resp.content
+
+
+async def download_archive_to_file(
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    ref: str,
+    dest_path: str,
+    *,
+    chunk_size: int = 1 << 20,  # 1 MiB
+    timeout: float = 300.0,
+) -> int:
+    """Stream a project tarball directly to a local file path.
+
+    Avoids buffering the full archive in process memory — chunks land on
+    disk as they arrive. Returns total bytes written.
+
+    Retry policy: none. Same rationale as the github counterpart — the VCS
+    poller reruns every `vcs.poll_interval_seconds`, so transport errors
+    here are naturally retried by the next cycle. Mid-stream retries
+    against the GitLab archive endpoint aren't resumable.
+    """
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+    url = f"{api}/projects/{project}/repository/archive.tar.gz"
+
+    bytes_written = 0
+    async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
+        async with client.stream(
+            "GET",
+            url,
+            params={"sha": ref},
+            headers=_headers(conn),
+        ) as resp:
+            resp.raise_for_status()
+            with open(dest_path, "wb") as f:
+                async for chunk in resp.aiter_bytes(chunk_size=chunk_size):
+                    if not chunk:
+                        continue
+                    await asyncio.to_thread(f.write, chunk)
+                    bytes_written += len(chunk)
+    return bytes_written
 
 
 async def list_open_prs(

--- a/services/terrapod/services/vcs_archive_cache.py
+++ b/services/terrapod/services/vcs_archive_cache.py
@@ -1,0 +1,394 @@
+"""Single-flight VCS tarball cache for poll cycles.
+
+Why this exists
+---------------
+Without coordination, every workspace that polls a VCS repo at a given
+commit SHA does its own GitHub/GitLab tarball download — even when the
+SHA is identical across workspaces (typical with multiple workspaces in
+one mono-repo). With N workspaces tracking a single mono-repo at the
+same SHA, that means N simultaneous downloads + N in-memory buffers per
+poll cycle. For non-trivial repos (hundreds of MB), the api pod runs
+out of memory and gets OOM-killed.
+
+The cache solves this with two layers:
+
+1. **In-process single-flight** — concurrent workspace polls within ONE
+   replica's poll cycle coalesce on a single download. First requestor
+   takes a per-key `asyncio.Lock`; the others wait, then either pull from
+   the in-memory dict or read the now-populated storage cache.
+
+2. **Object storage cache** — stripped tarballs persisted at
+   `vcs_archives/{conn_id}/{owner}/{repo}/{sha}.tar.gz`. Survives across
+   poll cycles and replicas. The artifact-retention sweeper evicts entries
+   older than `vcs.archive_cache_retention_days`.
+
+Multi-replica safety
+--------------------
+- The distributed scheduler guarantees only one replica runs `poll_cycle`
+  per interval, so the in-process lock layer is sufficient for that path.
+- The runs.py UI vcs-ref override path runs in request handlers on any
+  replica. The in-process lock won't dedup cross-replica requests there,
+  but the storage `head()` check plus the partial-failure cleanup in
+  `_download_strip_upload` keeps the cache consistent: cloud backends
+  (S3 multipart-complete, Azure commit-block-list, GCS resumable finalize)
+  are atomic on success, and the filesystem backend's non-atomic write is
+  caught by the try/except and the partial entry deleted. Worst case: two
+  replicas do the same download once and overwrite the same content-
+  addressed key with byte-identical content.
+
+Memory profile
+--------------
+Bounded by per-chunk buffers (1 MiB stream chunk + tarfile per-member
+buffer). A 500 MB tarball stays under ~10 MB of process memory at any
+moment; the rest lives on the api pod's ephemeral PVC.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import time as time_mod
+from contextlib import asynccontextmanager
+
+from terrapod.config import settings
+from terrapod.db.models import VCSConnection
+from terrapod.logging_config import get_logger
+from terrapod.services import github_service, gitlab_service
+from terrapod.services.archive_utils import strip_archive_top_level_dir_file_async
+from terrapod.storage import get_storage
+from terrapod.storage.keys import vcs_archive_key
+from terrapod.storage.protocol import ObjectNotFoundError
+
+logger = get_logger(__name__)
+
+# Orphan temp files newer than this are presumed to belong to an in-flight
+# operation in another coroutine — never delete them. 5 minutes covers the
+# longest plausible streaming download/upload (200+ MB tarball over a slow
+# link) plus headroom for a stuck operation that hasn't yet errored out.
+_ORPHAN_AGE_SECONDS = 300
+
+
+def _resolve_tmpdir() -> str | None:
+    """Return the configured VCS tmpdir if it exists, else None.
+
+    None falls back to the system tempdir at the call site — appropriate
+    for tests and local dev without an ephemeral PVC mount.
+    """
+    configured = settings.vcs.tmpdir
+    if configured and os.path.isdir(configured):
+        return configured
+    return None
+
+
+def _free_bytes(path: str) -> int:
+    """Return free bytes on the filesystem containing `path`."""
+    stat = os.statvfs(path)
+    return stat.f_bavail * stat.f_frsize
+
+
+def _ensure_tmpdir_space(tmpdir: str | None) -> None:
+    """Best-effort: free up space in `tmpdir` if free space is below threshold.
+
+    Scans for orphan tarball-like temp files older than `_ORPHAN_AGE_SECONDS`
+    (anything actively being used should be younger), deletes oldest first
+    until we hit `vcs.tmpdir_min_free_bytes` free or run out of candidates.
+
+    A previous pod crash can leave NamedTemporaryFile orphans behind even
+    though the file descriptors went away — those files keep their disk
+    blocks until something deletes them. Without this sweep the PVC fills
+    up over time and every subsequent download fails with ENOSPC.
+
+    Best-effort: failures here are logged and swallowed. The actual
+    download will surface a real ENOSPC if there's still no space.
+    """
+    if tmpdir is None:
+        # System tempdir — assume the OS handles its own cleanup
+        return
+    try:
+        free = _free_bytes(tmpdir)
+    except OSError as e:
+        logger.warning("statvfs failed on tmpdir; skipping space check", path=tmpdir, error=str(e))
+        return
+    threshold = settings.vcs.tmpdir_min_free_bytes
+    if free >= threshold:
+        return
+
+    logger.warning(
+        "VCS tmpdir below free-space threshold; sweeping orphan tarballs",
+        path=tmpdir,
+        free_bytes=free,
+        threshold_bytes=threshold,
+    )
+
+    cutoff = time_mod.time() - _ORPHAN_AGE_SECONDS
+    candidates: list[tuple[float, str]] = []
+    try:
+        for entry in os.scandir(tmpdir):
+            if not entry.is_file(follow_symlinks=False):
+                continue
+            name = entry.name
+            # Only sweep files that look like our tarballs — avoid nuking
+            # anything else mounted into this directory by accident.
+            if not name.endswith(".tar.gz"):
+                continue
+            try:
+                mtime = entry.stat(follow_symlinks=False).st_mtime
+            except OSError:
+                continue
+            if mtime < cutoff:
+                candidates.append((mtime, entry.path))
+    except OSError as e:
+        logger.warning("scandir failed on tmpdir", path=tmpdir, error=str(e))
+        return
+
+    candidates.sort()  # oldest first
+    deleted = 0
+    bytes_freed = 0
+    for _mtime, path in candidates:
+        try:
+            sz = os.path.getsize(path)
+            os.unlink(path)
+            deleted += 1
+            bytes_freed += sz
+        except OSError:
+            continue
+        try:
+            free = _free_bytes(tmpdir)
+        except OSError:
+            break
+        if free >= threshold:
+            break
+
+    logger.info(
+        "VCS tmpdir sweep complete",
+        path=tmpdir,
+        deleted_files=deleted,
+        bytes_freed=bytes_freed,
+        free_bytes_after=free,
+    )
+
+
+async def _stream_download_to_file(
+    conn: VCSConnection, owner: str, repo: str, sha: str, dest_path: str
+) -> int:
+    """Dispatch to the appropriate provider's streaming download."""
+    if conn.provider == "gitlab":
+        return await gitlab_service.download_archive_to_file(conn, owner, repo, sha, dest_path)
+    return await github_service.download_repo_archive_to_file(conn, owner, repo, sha, dest_path)
+
+
+async def _file_chunks(path: str, chunk_size: int = 1 << 20):
+    """Async-iterate a file's contents in `chunk_size` chunks.
+
+    Read I/O happens in a thread so the event loop isn't blocked on each
+    read. The file handle lives in this generator's frame for the lifetime
+    of the consumer — if the consumer aborts mid-iteration the handle
+    closes via the generator's `with` block on GC.
+    """
+
+    def _read(f):  # noqa: ANN001
+        return f.read(chunk_size)
+
+    f = await asyncio.to_thread(open, path, "rb")
+    try:
+        while True:
+            chunk = await asyncio.to_thread(_read, f)
+            if not chunk:
+                return
+            yield chunk
+    finally:
+        await asyncio.to_thread(f.close)
+
+
+class VCSArchiveCache:
+    """Single-flight cache for VCS archive tarballs.
+
+    Construct one instance per logical work unit (poll cycle / immediate-poll
+    trigger / one UI request). DO NOT reuse across cycles — `_known` grows
+    without bound, and stale entries can mask cross-replica cache
+    invalidations (e.g. an admin manually deleting a `vcs_archives/...` key
+    via the artifact-retention sweeper).
+    """
+
+    def __init__(self) -> None:
+        # Maps cache_key → storage_key (where the stripped tarball lives).
+        self._known: dict[str, str] = {}
+        # Per-cache-key locks for single-flight. We never delete entries
+        # from this dict — the lock object itself is cheap and sticking
+        # around for the cache lifetime is fine.
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _key_lock(self, cache_key: str) -> asyncio.Lock:
+        """Get-or-create the per-key lock.
+
+        `dict.setdefault` is atomic under the GIL, and asyncio coroutines
+        don't preempt at non-await points, so this is safe to call without
+        a meta-lock.
+        """
+        return self._locks.setdefault(cache_key, asyncio.Lock())
+
+    async def get_or_fetch(
+        self,
+        conn: VCSConnection,
+        owner: str,
+        repo: str,
+        sha: str,
+    ) -> str:
+        """Ensure the stripped tarball for (conn, owner, repo, sha) is in storage.
+
+        Returns the storage key. Concurrent calls for the same (conn, sha)
+        coalesce — exactly one performs the download, the others wait and
+        re-use the result.
+        """
+        cache_key = f"{conn.id}:{owner}/{repo}@{sha}"
+        if cache_key in self._known:
+            return self._known[cache_key]
+
+        lock = self._key_lock(cache_key)
+        async with lock:
+            # Re-check after acquiring the lock — peer may have populated.
+            if cache_key in self._known:
+                return self._known[cache_key]
+
+            storage_key = vcs_archive_key(str(conn.id), owner, repo, sha)
+            storage = get_storage()
+
+            # Storage cache hit (previous cycle or another replica wrote it).
+            try:
+                await storage.head(storage_key)
+                self._known[cache_key] = storage_key
+                logger.debug(
+                    "VCS archive storage-cache hit",
+                    connection_id=str(conn.id),
+                    owner=owner,
+                    repo=repo,
+                    sha=sha[:8],
+                )
+                return storage_key
+            except ObjectNotFoundError:
+                pass
+
+            # Miss → download, strip, upload.
+            await self._download_strip_upload(conn, owner, repo, sha, storage_key)
+            self._known[cache_key] = storage_key
+            return storage_key
+
+    async def _download_strip_upload(
+        self,
+        conn: VCSConnection,
+        owner: str,
+        repo: str,
+        sha: str,
+        storage_key: str,
+    ) -> None:
+        """Stream from VCS → strip → upload to object storage. No memory buffer.
+
+        Transactional w.r.t. the storage cache: if `put_stream` raises after
+        partially uploading, we best-effort `delete(storage_key)` so a future
+        `head()` won't return OK on a truncated tarball. Without this, a
+        corrupt entry would be silently served to subsequent workspaces and
+        the runner would fail with a cryptic tarball error far from the
+        upload site.
+        """
+        storage = get_storage()
+        tmpdir = _resolve_tmpdir()
+        # Sweep stale orphans before reserving more disk. statvfs is cheap;
+        # the sweep only does real work when we're below the threshold.
+        await asyncio.to_thread(_ensure_tmpdir_space, tmpdir)
+
+        with (
+            tempfile.NamedTemporaryFile(suffix=".raw.tar.gz", dir=tmpdir) as raw_f,
+            tempfile.NamedTemporaryFile(suffix=".stripped.tar.gz", dir=tmpdir) as stripped_f,
+        ):
+            raw_path = raw_f.name
+            stripped_path = stripped_f.name
+
+            bytes_in = await _stream_download_to_file(conn, owner, repo, sha, raw_path)
+            await strip_archive_top_level_dir_file_async(raw_path, stripped_path)
+            bytes_out = await asyncio.to_thread(os.path.getsize, stripped_path)
+
+            try:
+                await storage.put_stream(
+                    storage_key,
+                    _file_chunks(stripped_path),
+                    content_type="application/x-tar",
+                )
+            except Exception as e:
+                # Partial upload: a future head() might return OK on a
+                # truncated key. Best-effort delete so the cache stays
+                # consistent. We swallow secondary errors — re-raise the
+                # original.
+                logger.warning(
+                    "VCS archive upload failed; deleting partial cache entry",
+                    storage_key=storage_key,
+                    error=str(e),
+                )
+                try:
+                    await storage.delete(storage_key)
+                except Exception:
+                    logger.warning(
+                        "Best-effort cache delete also failed; cache may hold corrupt entry until TTL",
+                        storage_key=storage_key,
+                        exc_info=True,
+                    )
+                raise
+
+            logger.info(
+                "Cached VCS archive",
+                connection_id=str(conn.id),
+                owner=owner,
+                repo=repo,
+                sha=sha[:8],
+                raw_bytes=bytes_in,
+                stripped_bytes=bytes_out,
+                storage_key=storage_key,
+            )
+
+
+@asynccontextmanager
+async def materialize_archive(storage_key: str):
+    """Stream a cached archive from storage into a local temp file.
+
+    Yields the path to a temp file containing the stripped tarball.
+    Caller can read it (e.g. for further processing) or stream-upload it
+    elsewhere. The temp file is unlinked on context exit regardless of
+    whether the caller errored.
+
+    Uses `mkstemp` (single fd we own) rather than `NamedTemporaryFile`
+    which opens its own write handle that we'd otherwise ignore. The fd
+    is wrapped in a buffered `BufferedWriter` (`os.fdopen`) so chunk
+    writes loop internally to handle short writes — the bare `os.write(2)`
+    syscall can transfer fewer bytes than requested under disk pressure
+    or signal interruption, which would silently truncate the cached
+    tarball. All file I/O is dispatched to threads to keep the event
+    loop unblocked.
+
+    Used by the per-workspace config-version path: each workspace needs
+    the same stripped tarball but at a different storage key, and we
+    don't have a server-side copy primitive in our protocol — so we
+    materialise once and stream-upload to the target key.
+    """
+    storage = get_storage()
+    tmpdir = _resolve_tmpdir()
+    await asyncio.to_thread(_ensure_tmpdir_space, tmpdir)
+
+    fd, path = await asyncio.to_thread(tempfile.mkstemp, suffix=".tar.gz", dir=tmpdir)
+    # Wrap the fd in a buffered file object so .write() handles short
+    # writes for us. fdopen takes ownership of the fd; closing the
+    # BufferedWriter closes the underlying fd.
+    f = await asyncio.to_thread(os.fdopen, fd, "wb")
+    try:
+        try:
+            async for chunk in await storage.get_stream(storage_key):
+                if not chunk:
+                    continue
+                await asyncio.to_thread(f.write, chunk)
+        finally:
+            await asyncio.to_thread(f.close)
+        yield path
+    finally:
+        try:
+            await asyncio.to_thread(os.unlink, path)
+        except FileNotFoundError:
+            pass

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -35,6 +35,7 @@ from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service, run_service
 from terrapod.services.archive_utils import strip_archive_top_level_dir_async
+from terrapod.services.vcs_archive_cache import VCSArchiveCache, materialize_archive
 from terrapod.services.vcs_provider import PullRequest
 from terrapod.storage import get_storage
 from terrapod.storage.keys import config_version_key
@@ -178,6 +179,26 @@ async def _resolve_branch(conn: VCSConnection, ws: Workspace, owner: str, repo: 
 _strip_top_level_dir = strip_archive_top_level_dir_async  # alias for internal use
 
 
+async def _stream_cv_upload_from_cache(
+    cache_storage_key: str, workspace_id: uuid.UUID, cv_id: uuid.UUID
+) -> None:
+    """Materialise a cached VCS archive and stream-upload it to the workspace CV key.
+
+    Uses temp files end-to-end — never holds the tarball in process memory.
+    """
+    storage = get_storage()
+    cv_key = config_version_key(str(workspace_id), str(cv_id))
+
+    async with materialize_archive(cache_storage_key) as path:
+        from terrapod.services.vcs_archive_cache import _file_chunks
+
+        await storage.put_stream(
+            cv_key,
+            _file_chunks(path),
+            content_type="application/x-tar",
+        )
+
+
 async def _create_vcs_run(
     db: AsyncSession,
     ws: Workspace,
@@ -190,8 +211,14 @@ async def _create_vcs_run(
     speculative: bool = False,
     pr_number: int | None = None,
     message: str = "",
+    cache: VCSArchiveCache | None = None,
 ) -> Run | None:
-    """Download archive, create ConfigurationVersion and Run.
+    """Download archive (via cache + streaming), create ConfigurationVersion and Run.
+
+    The `cache` argument coalesces concurrent downloads of the same (conn, sha)
+    across workspace polls in the same cycle. Pass None when this path is
+    invoked one-shot (e.g. UI-queued runs); a fresh cache instance is built
+    internally so the streaming pipeline still applies.
 
     Defensive dedup: if a run already exists for this (workspace, sha, branch,
     pr_number), return None rather than creating a duplicate. This catches
@@ -220,19 +247,19 @@ async def _create_vcs_run(
         )
         return None
 
+    if cache is None:
+        cache = VCSArchiveCache()
+
     try:
-        archive = await _download_archive(conn, owner, repo, sha)
+        cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha)
     except Exception as e:
         logger.error(
-            "Failed to download repo archive",
+            "Failed to fetch repo archive into cache",
             workspace=ws.name,
             ref=sha[:8],
             error=str(e),
         )
         return None
-
-    # VCS tarballs have a top-level directory wrapper — strip it
-    archive = await _strip_top_level_dir(archive)
 
     cv = await run_service.create_configuration_version(
         db,
@@ -243,9 +270,17 @@ async def _create_vcs_run(
     )
     await db.flush()
 
-    storage = get_storage()
-    key = config_version_key(str(ws.id), str(cv.id))
-    await storage.put(key, archive, content_type="application/x-tar")
+    try:
+        await _stream_cv_upload_from_cache(cache_storage_key, ws.id, cv.id)
+    except Exception as e:
+        logger.error(
+            "Failed to materialise cached archive into config version",
+            workspace=ws.name,
+            ref=sha[:8],
+            cache_key=cache_storage_key,
+            error=str(e),
+        )
+        return None
 
     cv = await run_service.mark_configuration_uploaded(db, cv)
 
@@ -275,6 +310,7 @@ async def _poll_workspace_branch(
     owner: str,
     repo: str,
     branch: str,
+    cache: VCSArchiveCache | None = None,
 ) -> None:
     """Check the tracked branch for new commits and create a run."""
     sha = await _get_branch_sha(conn, owner, repo, branch)
@@ -362,6 +398,7 @@ async def _poll_workspace_branch(
         sha,
         branch,
         message=f"Triggered by commit {sha[:8]} on {branch}",
+        cache=cache,
     )
 
     if run:
@@ -383,6 +420,7 @@ async def _poll_workspace_prs(
     owner: str,
     repo: str,
     branch: str,
+    cache: VCSArchiveCache | None = None,
 ) -> None:
     """Check open PRs/MRs targeting the tracked branch for speculative plans."""
     prs = await _list_open_prs(conn, owner, repo, branch)
@@ -477,6 +515,7 @@ async def _poll_workspace_prs(
             speculative=True,
             pr_number=pr.number,
             message=f"Speculative plan for PR #{pr.number}: {pr.title}",
+            cache=cache,
         )
 
         if run:
@@ -491,8 +530,17 @@ async def _poll_workspace_prs(
             )
 
 
-async def _poll_workspace(db: AsyncSession, ws: Workspace) -> None:
-    """Poll a single workspace: check branch for pushes and PRs for speculative plans."""
+async def _poll_workspace(
+    db: AsyncSession,
+    ws: Workspace,
+    cache: VCSArchiveCache | None = None,
+) -> None:
+    """Poll a single workspace: check branch for pushes and PRs for speculative plans.
+
+    `cache` coalesces concurrent (conn, sha) downloads across workspaces in the
+    same poll cycle. Pass None for one-shot calls; a fresh cache is built inside
+    `_create_vcs_run` so streaming + per-call disk-temp behaviour still applies.
+    """
     if not ws.vcs_repo_url or not ws.vcs_connection_id:
         return
 
@@ -529,10 +577,10 @@ async def _poll_workspace(db: AsyncSession, ws: Workspace) -> None:
 
     try:
         # 1. Check tracked branch for new commits → real runs
-        await _poll_workspace_branch(db, ws, conn, owner, repo, branch)
+        await _poll_workspace_branch(db, ws, conn, owner, repo, branch, cache)
 
         # 2. Check open PRs/MRs targeting the tracked branch → speculative plans
-        await _poll_workspace_prs(db, ws, conn, owner, repo, branch)
+        await _poll_workspace_prs(db, ws, conn, owner, repo, branch, cache)
 
         # Success: update last-polled timestamp and clear any previous error
         ws.vcs_last_polled_at = utc_now()
@@ -558,19 +606,26 @@ async def _poll_workspace(db: AsyncSession, ws: Workspace) -> None:
 _MAX_PARALLEL_WORKSPACE_POLLS = 10
 
 
-async def _poll_workspace_owned(ws_id: uuid.UUID, semaphore: asyncio.Semaphore) -> None:
+async def _poll_workspace_owned(
+    ws_id: uuid.UUID,
+    semaphore: asyncio.Semaphore,
+    cache: VCSArchiveCache | None = None,
+) -> None:
     """Poll a single workspace in its own DB session, bounded by a semaphore.
 
     Each parallel poll needs its own session — AsyncSession is not safe to
     share across concurrent coroutines. Errors are caught and logged here
     so one workspace's failure doesn't sink the whole cycle.
+
+    `cache` is shared across all workspaces in this cycle so concurrent polls
+    of the same (conn, sha) coalesce on a single tarball download.
     """
     async with semaphore, get_db_session() as db:
         ws = await db.get(Workspace, ws_id)
         if ws is None:
             return
         try:
-            await _poll_workspace(db, ws)
+            await _poll_workspace(db, ws, cache)
             await db.commit()
         except Exception as e:
             logger.error(
@@ -672,9 +727,12 @@ async def poll_cycle() -> None:
 
     logger.debug("VCS poll cycle", workspace_count=len(workspace_ids))
 
+    # One cache instance per cycle — coalesces concurrent (conn, sha) tarball
+    # downloads across all workspace polls in this cycle.
+    cache = VCSArchiveCache()
     semaphore = asyncio.Semaphore(_MAX_PARALLEL_WORKSPACE_POLLS)
     await asyncio.gather(
-        *[_poll_workspace_owned(wid, semaphore) for wid in workspace_ids],
+        *[_poll_workspace_owned(wid, semaphore, cache) for wid in workspace_ids],
         return_exceptions=True,
     )
 
@@ -717,9 +775,12 @@ async def handle_immediate_poll(payload: dict) -> None:
         workspace_count=len(workspace_ids),
     )
 
+    # Webhook-triggered polls also share one cache instance — same coalescing
+    # benefit when multiple workspaces map to the same repo.
+    cache = VCSArchiveCache()
     semaphore = asyncio.Semaphore(_MAX_PARALLEL_WORKSPACE_POLLS)
     await asyncio.gather(
-        *[_poll_workspace_owned(wid, semaphore) for wid in workspace_ids],
+        *[_poll_workspace_owned(wid, semaphore, cache) for wid in workspace_ids],
         return_exceptions=True,
     )
 

--- a/services/terrapod/storage/keys.py
+++ b/services/terrapod/storage/keys.py
@@ -121,3 +121,18 @@ def platform_provider_shasums_sig_key(version: str) -> str:
 def module_override_key(commit_sha: str, namespace: str, name: str, provider: str) -> str:
     """Key for a module override tarball (keyed by commit SHA for reuse across runs)."""
     return f"module_overrides/{commit_sha}/{namespace}/{name}/{provider}.tar.gz"
+
+
+# --- VCS Archive Cache ---
+
+
+def vcs_archive_key(connection_id: str, owner: str, repo: str, sha: str) -> str:
+    """Key for a cached, top-level-stripped VCS archive tarball.
+
+    Scoped by `connection_id` so two VCS connections that happen to point
+    at the same repo (e.g. one Terrapod app + one personal app for testing)
+    can't see each other's cache entries. Content is content-addressed by
+    commit SHA — same SHA = same tarball, safe to share across workspaces
+    using the same connection.
+    """
+    return f"vcs_archives/{connection_id}/{owner}/{repo}/{sha}.tar.gz"

--- a/services/tests/services/test_artifact_retention_service.py
+++ b/services/tests/services/test_artifact_retention_service.py
@@ -13,6 +13,7 @@ from terrapod.services.artifact_retention_service import (
     _cleanup_provider_cache,
     _cleanup_run_artifacts,
     _cleanup_state_versions,
+    _cleanup_vcs_archives,
     artifact_retention_cycle,
 )
 
@@ -459,3 +460,84 @@ class TestArtifactRetentionCycle:
             await artifact_retention_cycle()
             mock_sv.assert_not_called()
             mock_ra.assert_not_called()
+
+
+# ── _cleanup_vcs_archives ────────────────────────────────────────────
+
+
+def _make_object_meta(key: str, last_modified):
+    """Build an ObjectMeta-shaped MagicMock for storage.list_prefix() returns."""
+    meta = MagicMock()
+    meta.key = key
+    meta.last_modified = last_modified
+    return meta
+
+
+class TestCleanupVCSArchives:
+    @pytest.mark.asyncio
+    async def test_deletes_old_entries_only(self):
+        now = datetime.now(UTC)
+        old = _make_object_meta("vcs_archives/c1/owner/repo/old.tar.gz", now - timedelta(days=10))
+        recent = _make_object_meta(
+            "vcs_archives/c1/owner/repo/recent.tar.gz", now - timedelta(days=2)
+        )
+        storage = AsyncMock()
+        storage.list_prefix = AsyncMock(return_value=[old, recent])
+        storage.delete = AsyncMock()
+        db = AsyncMock()
+
+        deleted = await _cleanup_vcs_archives(db, storage, retention_days=7, batch_size=100)
+
+        assert deleted == 1
+        storage.delete.assert_awaited_once_with(old.key)
+
+    @pytest.mark.asyncio
+    async def test_evicts_oldest_first_when_capped_by_batch_size(self):
+        now = datetime.now(UTC)
+        ages = [now - timedelta(days=d) for d in (30, 20, 15, 10)]
+        # All four are past the 7-day cutoff; with batch_size=2 we expect the
+        # oldest two (days=30, days=20) deleted, the newer two left for next cycle.
+        entries = [
+            _make_object_meta(f"vcs_archives/c1/owner/repo/sha{i}.tar.gz", a)
+            for i, a in enumerate(ages)
+        ]
+        storage = AsyncMock()
+        storage.list_prefix = AsyncMock(return_value=entries)
+        storage.delete = AsyncMock()
+        db = AsyncMock()
+
+        deleted = await _cleanup_vcs_archives(db, storage, retention_days=7, batch_size=2)
+
+        assert deleted == 2
+        deleted_keys = [c.args[0] for c in storage.delete.await_args_list]
+        # Oldest first: sha0 (30 days), sha1 (20 days)
+        assert deleted_keys == [entries[0].key, entries[1].key]
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_list_prefix_fails(self):
+        storage = AsyncMock()
+        storage.list_prefix = AsyncMock(side_effect=RuntimeError("storage backend down"))
+        storage.delete = AsyncMock()
+        db = AsyncMock()
+
+        deleted = await _cleanup_vcs_archives(db, storage, retention_days=7, batch_size=100)
+
+        assert deleted == 0
+        storage.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swallows_individual_delete_failure_and_continues(self):
+        now = datetime.now(UTC)
+        old1 = _make_object_meta("vcs_archives/c1/repo/a.tar.gz", now - timedelta(days=10))
+        old2 = _make_object_meta("vcs_archives/c1/repo/b.tar.gz", now - timedelta(days=9))
+        storage = AsyncMock()
+        storage.list_prefix = AsyncMock(return_value=[old1, old2])
+        # First delete fails, second succeeds — we should still count the
+        # successful one and proceed.
+        storage.delete = AsyncMock(side_effect=[RuntimeError("transient"), None])
+        db = AsyncMock()
+
+        deleted = await _cleanup_vcs_archives(db, storage, retention_days=7, batch_size=100)
+
+        assert deleted == 1
+        assert storage.delete.await_count == 2

--- a/services/tests/services/test_vcs_archive_cache.py
+++ b/services/tests/services/test_vcs_archive_cache.py
@@ -1,0 +1,629 @@
+"""Tests for VCSArchiveCache — single-flight + storage caching of VCS tarballs."""
+
+import asyncio
+import io
+import os
+import tarfile
+import time as time_mod
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.services.archive_utils import strip_archive_top_level_dir_file
+from terrapod.services.vcs_archive_cache import (
+    VCSArchiveCache,
+    _ensure_tmpdir_space,
+    materialize_archive,
+)
+from terrapod.storage.protocol import ObjectNotFoundError
+
+
+def _mock_conn(provider="github", id_=None):
+    conn = MagicMock()
+    conn.id = id_ or uuid.uuid4()
+    conn.provider = provider
+    conn.status = "active"
+    return conn
+
+
+# ── strip_archive_top_level_dir_file ───────────────────────────────────
+
+
+def _make_tarball(members: dict[str, bytes]) -> bytes:
+    """Build a gzipped tar with the given {path: content} members."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for path, content in members.items():
+            info = tarfile.TarInfo(name=path)
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _list_tarball_members(data: bytes) -> dict[str, bytes]:
+    out = {}
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            f = tf.extractfile(member)
+            out[member.name] = f.read() if f else b""
+    return out
+
+
+class TestStripArchiveTopLevelDirFile:
+    def test_strips_top_level_directory(self, tmp_path):
+        """A `markupai-repo-abc/` wrapper is removed from every member name."""
+        src = tmp_path / "in.tar.gz"
+        dst = tmp_path / "out.tar.gz"
+        src.write_bytes(
+            _make_tarball(
+                {
+                    "markupai-repo-abc123/": b"",
+                    "markupai-repo-abc123/main.tf": b"resource {}\n",
+                    "markupai-repo-abc123/sub/vars.tf": b"variable {}\n",
+                }
+            )
+        )
+
+        strip_archive_top_level_dir_file(str(src), str(dst))
+        members = _list_tarball_members(dst.read_bytes())
+
+        assert "markupai-repo-abc123" not in members
+        assert "main.tf" in members
+        assert members["main.tf"] == b"resource {}\n"
+        assert "sub/vars.tf" in members
+
+    def test_handles_empty_archive(self, tmp_path):
+        """An empty (member-less) tarball produces an empty output."""
+        src = tmp_path / "in.tar.gz"
+        dst = tmp_path / "out.tar.gz"
+        src.write_bytes(_make_tarball({}))
+
+        strip_archive_top_level_dir_file(str(src), str(dst))
+        members = _list_tarball_members(dst.read_bytes())
+        assert members == {}
+
+    def test_does_not_buffer_full_archive_in_memory(self, tmp_path):
+        """Smoke test: a moderately large archive completes without erroring.
+
+        Real OOM behaviour is hard to assert in a unit test — the value of
+        this test is just confirming the streaming path produces correct
+        output for non-trivial input sizes.
+        """
+        # 50 members @ 64KB each = ~3.2MB uncompressed
+        big_blob = b"x" * (64 * 1024)
+        members = {f"repo-abc/file_{i}.txt": big_blob for i in range(50)}
+        src = tmp_path / "in.tar.gz"
+        dst = tmp_path / "out.tar.gz"
+        src.write_bytes(_make_tarball(members))
+
+        strip_archive_top_level_dir_file(str(src), str(dst))
+        out_members = _list_tarball_members(dst.read_bytes())
+        assert len(out_members) == 50
+        assert all(v == big_blob for v in out_members.values())
+
+
+# ── VCSArchiveCache: storage cache hit ─────────────────────────────────
+
+
+class TestVCSArchiveCacheStorageHit:
+    @pytest.mark.asyncio
+    async def test_storage_cache_hit_skips_download(self):
+        """If head() returns OK, we don't touch GitHub or the strip pipeline."""
+        cache = VCSArchiveCache()
+        conn = _mock_conn()
+
+        mock_storage = MagicMock()
+        mock_storage.head = AsyncMock(return_value=MagicMock())  # exists
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache.VCSArchiveCache._download_strip_upload",
+                new_callable=AsyncMock,
+            ) as mock_dsu,
+        ):
+            key = await cache.get_or_fetch(conn, "owner", "repo", "abc123")
+
+        assert key.startswith("vcs_archives/")
+        assert "abc123" in key
+        mock_storage.head.assert_awaited_once()
+        mock_dsu.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_in_process_dict_caches_across_calls(self):
+        """A second call for the same (conn, sha) skips even the head() call."""
+        cache = VCSArchiveCache()
+        conn = _mock_conn()
+
+        mock_storage = MagicMock()
+        mock_storage.head = AsyncMock(return_value=MagicMock())
+
+        with patch(
+            "terrapod.services.vcs_archive_cache.get_storage",
+            return_value=mock_storage,
+        ):
+            key1 = await cache.get_or_fetch(conn, "owner", "repo", "abc123")
+            key2 = await cache.get_or_fetch(conn, "owner", "repo", "abc123")
+
+        assert key1 == key2
+        # head() called once — second call took the in-memory short-circuit
+        mock_storage.head.assert_awaited_once()
+
+
+# ── VCSArchiveCache: cache miss → download → upload ────────────────────
+
+
+class TestVCSArchiveCacheMiss:
+    @pytest.mark.asyncio
+    async def test_miss_runs_download_strip_upload(self, tmp_path):
+        """On head() miss, the cache invokes the streaming download/strip/upload pipeline."""
+        cache = VCSArchiveCache()
+        conn = _mock_conn(provider="github")
+
+        mock_storage = MagicMock()
+        mock_storage.head = AsyncMock(side_effect=ObjectNotFoundError("missing"))
+        mock_storage.put_stream = AsyncMock(return_value=MagicMock())
+
+        # Stub the GH download to write a known tarball to dest_path
+        async def fake_download(_conn, _o, _r, _sha, dest_path, **_kw):
+            data = _make_tarball({"prefix-abc/main.tf": b"resource {}\n"})
+            with open(dest_path, "wb") as f:
+                f.write(data)
+            return len(data)
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "terrapod.services.github_service.download_repo_archive_to_file",
+                side_effect=fake_download,
+            ),
+        ):
+            key = await cache.get_or_fetch(conn, "owner", "repo", "abc123")
+
+        assert key.startswith("vcs_archives/")
+        mock_storage.put_stream.assert_awaited_once()
+        # Chunks arg is an async iterator — exhaust it to confirm content was streamed
+        kwargs = mock_storage.put_stream.call_args.kwargs
+        assert kwargs.get("content_type") == "application/x-tar"
+
+
+# ── VCSArchiveCache: single-flight under concurrency ───────────────────
+
+
+class TestVCSArchiveCacheSingleFlight:
+    @pytest.mark.asyncio
+    async def test_concurrent_get_or_fetch_coalesce_one_download(self, tmp_path):
+        """Five concurrent callers for the same (conn, sha) trigger one download."""
+        cache = VCSArchiveCache()
+        conn = _mock_conn(provider="github")
+
+        mock_storage = MagicMock()
+        mock_storage.head = AsyncMock(side_effect=ObjectNotFoundError("missing"))
+        mock_storage.put_stream = AsyncMock(return_value=MagicMock())
+
+        download_calls = 0
+        download_started = asyncio.Event()
+        download_can_finish = asyncio.Event()
+
+        async def slow_download(_conn, _o, _r, _sha, dest_path, **_kw):
+            nonlocal download_calls
+            download_calls += 1
+            download_started.set()
+            await download_can_finish.wait()
+            data = _make_tarball({"x/main.tf": b"resource {}\n"})
+            with open(dest_path, "wb") as f:
+                f.write(data)
+            return len(data)
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "terrapod.services.github_service.download_repo_archive_to_file",
+                side_effect=slow_download,
+            ),
+        ):
+            # Fire 5 concurrent fetches before letting the first download finish
+            tasks = [
+                asyncio.create_task(cache.get_or_fetch(conn, "owner", "repo", "abc123"))
+                for _ in range(5)
+            ]
+            await download_started.wait()
+            # Give the other 4 tasks a chance to queue up on the lock
+            await asyncio.sleep(0.05)
+            download_can_finish.set()
+            keys = await asyncio.gather(*tasks)
+
+        assert download_calls == 1
+        assert len(set(keys)) == 1  # all callers got the same storage key
+
+    @pytest.mark.asyncio
+    async def test_different_shas_do_not_block_each_other(self, tmp_path):
+        """Concurrent calls for different SHAs both proceed in parallel."""
+        cache = VCSArchiveCache()
+        conn = _mock_conn(provider="github")
+
+        mock_storage = MagicMock()
+        mock_storage.head = AsyncMock(side_effect=ObjectNotFoundError("missing"))
+        mock_storage.put_stream = AsyncMock(return_value=MagicMock())
+
+        active = 0
+        max_concurrent = 0
+
+        async def fake_download(_conn, _o, _r, _sha, dest_path, **_kw):
+            nonlocal active, max_concurrent
+            active += 1
+            max_concurrent = max(max_concurrent, active)
+            await asyncio.sleep(0.05)
+            data = _make_tarball({"x/main.tf": b"x"})
+            with open(dest_path, "wb") as f:
+                f.write(data)
+            active -= 1
+            return len(data)
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "terrapod.services.github_service.download_repo_archive_to_file",
+                side_effect=fake_download,
+            ),
+        ):
+            await asyncio.gather(
+                cache.get_or_fetch(conn, "owner", "repo", "sha-a"),
+                cache.get_or_fetch(conn, "owner", "repo", "sha-b"),
+                cache.get_or_fetch(conn, "owner", "repo", "sha-c"),
+            )
+
+        assert max_concurrent >= 2  # different SHAs ran in parallel
+
+
+# ── VCSArchiveCache: dispatch by provider ──────────────────────────────
+
+
+class TestEnsureTmpdirSpace:
+    """`_ensure_tmpdir_space` evicts old orphan temp tarballs when free space is low."""
+
+    def test_no_sweep_when_above_threshold(self, tmp_path):
+        """If statvfs shows enough free space, we don't touch any files."""
+        keep = tmp_path / "ancient.raw.tar.gz"
+        keep.write_bytes(b"x" * 1024)
+        old_mtime = time_mod.time() - 10_000
+        os.utime(keep, (old_mtime, old_mtime))
+
+        # Pretend there's tons of free space so the threshold check passes.
+        # Use settings.vcs.tmpdir_min_free_bytes default (~2 GiB) and a fake
+        # statvfs returning more than that.
+        with patch("terrapod.services.vcs_archive_cache._free_bytes", return_value=10 * 1024**3):
+            _ensure_tmpdir_space(str(tmp_path))
+
+        assert keep.exists()  # not deleted because we were above threshold
+
+    def test_sweeps_oldest_orphans_when_low(self, tmp_path):
+        """Below threshold, the oldest orphan tarballs get deleted first."""
+        old1 = tmp_path / "old1.raw.tar.gz"
+        old2 = tmp_path / "old2.stripped.tar.gz"
+        new_in_use = tmp_path / "fresh.raw.tar.gz"
+        unrelated = tmp_path / "DO_NOT_TOUCH.txt"
+
+        for p in (old1, old2, new_in_use, unrelated):
+            p.write_bytes(b"x" * 1024)
+
+        # old1 + old2 well past the 5-min orphan age; new_in_use is fresh.
+        # unrelated isn't a tarball — must never be deleted.
+        cutoff = time_mod.time() - 600
+        os.utime(old1, (cutoff, cutoff))
+        os.utime(old2, (cutoff + 1, cutoff + 1))  # slightly newer than old1
+        # new_in_use has its default (now) mtime
+
+        # First _free_bytes call shows below threshold; subsequent calls
+        # also show below threshold so the loop keeps deleting.
+        with patch(
+            "terrapod.services.vcs_archive_cache._free_bytes",
+            return_value=1024,  # 1 KB free << 2 GiB threshold
+        ):
+            _ensure_tmpdir_space(str(tmp_path))
+
+        # Both old orphans deleted; in-use and unrelated survive.
+        assert not old1.exists()
+        assert not old2.exists()
+        assert new_in_use.exists()
+        assert unrelated.exists()
+
+    def test_skips_when_tmpdir_is_none(self):
+        """No-op when caller passed None (system tempdir fallback path)."""
+        # Should not raise, should not call statvfs
+        with patch("terrapod.services.vcs_archive_cache._free_bytes") as mock_free:
+            _ensure_tmpdir_space(None)
+        mock_free.assert_not_called()
+
+    def test_does_not_delete_files_younger_than_orphan_age(self, tmp_path):
+        """A recent file (mtime within the last 5 minutes) is presumed in-flight."""
+        recent = tmp_path / "recent.raw.tar.gz"
+        recent.write_bytes(b"x" * 1024)
+        # mtime is "now" by default — well within the 5-min window
+
+        with patch(
+            "terrapod.services.vcs_archive_cache._free_bytes",
+            return_value=1024,  # below threshold
+        ):
+            _ensure_tmpdir_space(str(tmp_path))
+
+        # Even though we're below threshold, we don't touch in-flight files
+        assert recent.exists()
+
+
+class TestVCSArchiveCacheProviderDispatch:
+    @pytest.mark.asyncio
+    async def test_gitlab_uses_gitlab_streaming_download(self, tmp_path):
+        cache = VCSArchiveCache()
+        conn = _mock_conn(provider="gitlab")
+
+        mock_storage = MagicMock()
+        mock_storage.head = AsyncMock(side_effect=ObjectNotFoundError("missing"))
+        mock_storage.put_stream = AsyncMock(return_value=MagicMock())
+
+        async def fake_download(_conn, _o, _r, _sha, dest_path, **_kw):
+            data = _make_tarball({"x/main.tf": b"x"})
+            with open(dest_path, "wb") as f:
+                f.write(data)
+            return len(data)
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "terrapod.services.gitlab_service.download_archive_to_file",
+                side_effect=fake_download,
+            ) as mock_gl,
+            patch(
+                "terrapod.services.github_service.download_repo_archive_to_file",
+                new_callable=AsyncMock,
+            ) as mock_gh,
+        ):
+            await cache.get_or_fetch(conn, "owner", "repo", "abc123")
+
+        mock_gl.assert_awaited_once()
+        mock_gh.assert_not_called()
+
+
+# ── VCSArchiveCache: transactional upload (partial failure cleanup) ─────
+
+
+class TestVCSArchiveCachePartialUploadCleanup:
+    @pytest.mark.asyncio
+    async def test_put_stream_failure_deletes_partial_cache_entry(self, tmp_path):
+        """If put_stream raises, we delete the storage_key so a future
+        head() doesn't return OK on a truncated tarball."""
+        cache = VCSArchiveCache()
+        conn = _mock_conn(provider="github")
+
+        mock_storage = MagicMock()
+        mock_storage.head = AsyncMock(side_effect=ObjectNotFoundError("missing"))
+        mock_storage.put_stream = AsyncMock(side_effect=RuntimeError("network died mid-upload"))
+        mock_storage.delete = AsyncMock()
+
+        async def fake_download(_conn, _o, _r, _sha, dest_path, **_kw):
+            data = _make_tarball({"x/main.tf": b"x"})
+            with open(dest_path, "wb") as f:
+                f.write(data)
+            return len(data)
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "terrapod.services.github_service.download_repo_archive_to_file",
+                side_effect=fake_download,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="network died"):
+                await cache.get_or_fetch(conn, "owner", "repo", "abc123")
+
+        # Partial upload key must be cleaned up
+        mock_storage.delete.assert_awaited_once()
+        deleted_key = mock_storage.delete.call_args.args[0]
+        assert deleted_key.startswith("vcs_archives/")
+        assert "abc123" in deleted_key
+
+    @pytest.mark.asyncio
+    async def test_failure_does_not_pollute_in_memory_cache(self, tmp_path):
+        """A raised exception from `_download_strip_upload` must not populate
+        the in-memory `_known` dict, so the next call retries cleanly."""
+        cache = VCSArchiveCache()
+        conn = _mock_conn(provider="github")
+
+        mock_storage = MagicMock()
+        mock_storage.head = AsyncMock(side_effect=ObjectNotFoundError("missing"))
+        mock_storage.put_stream = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_storage.delete = AsyncMock()
+
+        async def fake_download(_conn, _o, _r, _sha, dest_path, **_kw):
+            data = _make_tarball({"x/main.tf": b"x"})
+            with open(dest_path, "wb") as f:
+                f.write(data)
+            return len(data)
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "terrapod.services.github_service.download_repo_archive_to_file",
+                side_effect=fake_download,
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                await cache.get_or_fetch(conn, "owner", "repo", "abc123")
+
+        cache_key = f"{conn.id}:owner/repo@abc123"
+        assert cache_key not in cache._known
+
+
+# ── materialize_archive ─────────────────────────────────────────────────
+
+
+class TestMaterializeArchive:
+    @pytest.mark.asyncio
+    async def test_streams_storage_key_to_local_temp_file(self, tmp_path):
+        """The yielded path contains exactly the bytes streamed from storage."""
+        payload = _make_tarball({"a.tf": b"a", "b.tf": b"bb"})
+
+        async def chunks():
+            # Split into 2 chunks to exercise the loop
+            yield payload[: len(payload) // 2]
+            yield payload[len(payload) // 2 :]
+
+        mock_storage = MagicMock()
+        mock_storage.get_stream = AsyncMock(return_value=chunks())
+
+        observed: dict[str, bytes] = {}
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+        ):
+            async with materialize_archive("vcs_archives/foo/owner/repo/abc.tar.gz") as path:
+                # Caller would normally stream-upload from path; we just read it
+                with open(path, "rb") as f:
+                    observed["bytes"] = f.read()
+                observed["existed"] = os.path.exists(path)
+                observed["path"] = path
+
+        # Inside-context: file existed; afterwards: deleted
+        assert observed["existed"]
+        assert observed["bytes"] == payload
+        assert not os.path.exists(observed["path"])
+
+    @pytest.mark.asyncio
+    async def test_unlinks_temp_file_even_when_consumer_raises(self, tmp_path):
+        """Caller error inside the `async with` must not leak the temp file.
+
+        CodeQL's py/unreachable-statement rule mis-models exception flow when
+        a `raise` sits inside a context manager whose body the analyser can't
+        see (the `@asynccontextmanager` generator). Using a plain
+        try/except + nullable variable, written sequentially, keeps the
+        control-flow graph explicit enough to satisfy the analyser without
+        sacrificing test clarity.
+        """
+
+        async def chunks():
+            yield b"some bytes"
+
+        mock_storage = MagicMock()
+        mock_storage.get_stream = AsyncMock(return_value=chunks())
+
+        observed_path: str | None = None
+        observed_error: BaseException | None = None
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+        ):
+            try:
+                async with materialize_archive("vcs_archives/foo.tar.gz") as path:
+                    observed_path = path
+                    raise RuntimeError("caller blew up")
+            except RuntimeError as e:
+                observed_error = e
+
+        assert observed_path is not None
+        assert observed_error is not None
+        assert "caller blew up" in str(observed_error)
+        assert not os.path.exists(observed_path)
+
+    @pytest.mark.asyncio
+    async def test_handles_large_chunks_via_buffered_writer(self, tmp_path):
+        """The fdopen-wrapped writer must handle multi-MB chunks without truncation.
+
+        Past versions used a bare `os.write(fd, b)` which can short-write
+        under disk pressure (`write(2)` is allowed to transfer fewer bytes
+        than requested). Using `os.fdopen(fd, "wb")` wraps the fd in a
+        BufferedWriter whose `.write()` loops internally, guaranteeing the
+        full chunk lands on disk.
+
+        We assert correctness on a non-trivial chunk size — exact
+        short-write behaviour is hard to provoke deterministically, but
+        this guards against regressions where someone reverts to bare
+        `os.write` and breaks correctness on real-world chunk sizes.
+        """
+        # 4 MiB chunk — large enough that on a real system, a single
+        # write(2) syscall might not transfer it all in one go.
+        large_chunk = b"X" * (4 * 1024 * 1024)
+        payload = large_chunk + b"Y" * 1024
+
+        async def chunks():
+            yield large_chunk
+            yield b"Y" * 1024
+
+        mock_storage = MagicMock()
+        mock_storage.get_stream = AsyncMock(return_value=chunks())
+
+        with (
+            patch(
+                "terrapod.services.vcs_archive_cache.get_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "terrapod.services.vcs_archive_cache._resolve_tmpdir",
+                return_value=str(tmp_path),
+            ),
+        ):
+            async with materialize_archive("vcs_archives/large.tar.gz") as path:
+                with open(path, "rb") as f:
+                    written = f.read()
+
+        assert len(written) == len(payload)
+        assert written == payload

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -519,14 +519,17 @@ class TestCreateVcsRunDedup:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=dedup_result)
 
-        with patch("terrapod.services.vcs_poller._download_archive") as mock_dl:
+        with patch(
+            "terrapod.services.vcs_archive_cache.VCSArchiveCache.get_or_fetch",
+            new_callable=AsyncMock,
+        ) as mock_fetch:
             run = await _create_vcs_run(
                 mock_db, ws, conn, "org", "repo", "bbb222", "main", message="test"
             )
 
         assert run is None
         # We must bail before wasting bandwidth on the archive download
-        mock_dl.assert_not_called()
+        mock_fetch.assert_not_called()
 
     async def test_dedup_distinguishes_pr_number(self):
         """A PR-scoped run must not dedup against a branch-push run with the same SHA."""
@@ -541,12 +544,13 @@ class TestCreateVcsRunDedup:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=dedup_result)
 
-        # Simulate the archive download failing so we don't need to mock the whole
-        # create-run chain — the assertion is that dedup passed (download was tried).
+        # Simulate the archive fetch failing so we don't need to mock the whole
+        # create-run chain — the assertion is that dedup passed (cache was tried).
         with patch(
-            "terrapod.services.vcs_poller._download_archive",
+            "terrapod.services.vcs_archive_cache.VCSArchiveCache.get_or_fetch",
+            new_callable=AsyncMock,
             side_effect=RuntimeError("stop here"),
-        ) as mock_dl:
+        ) as mock_fetch:
             run = await _create_vcs_run(
                 mock_db,
                 ws,
@@ -559,8 +563,8 @@ class TestCreateVcsRunDedup:
                 message="test",
             )
 
-        assert run is None  # Download failed, returns None
-        mock_dl.assert_called_once()  # But dedup let us through — the key assertion
+        assert run is None  # Fetch failed, returns None
+        mock_fetch.assert_called_once()  # But dedup let us through — the key assertion
 
 
 # ── poll_cycle parallelism + repo-scoped immediate polls ─────────────
@@ -593,7 +597,7 @@ class TestPollCycleParallel:
         max_in_flight: list[int] = [0]
         entered = 0
 
-        async def fake_owned_poll(ws_id, semaphore):
+        async def fake_owned_poll(ws_id, semaphore, cache=None):
             import asyncio as _a
 
             nonlocal entered
@@ -665,7 +669,7 @@ class TestPollCycleParallel:
 
         polled: list[uuid.UUID] = []
 
-        async def fake_owned_poll(ws_id, semaphore):
+        async def fake_owned_poll(ws_id, semaphore, cache=None):
             polled.append(ws_id)
 
         with (
@@ -710,7 +714,7 @@ class TestPollCycleParallel:
 
         polled: list[uuid.UUID] = []
 
-        async def fake_owned_poll(ws_id, semaphore):
+        async def fake_owned_poll(ws_id, semaphore, cache=None):
             polled.append(ws_id)
 
         with (
@@ -754,7 +758,7 @@ class TestPollCycleParallel:
 
         polled: list[uuid.UUID] = []
 
-        async def fake_owned_poll(ws_id, semaphore):
+        async def fake_owned_poll(ws_id, semaphore, cache=None):
             polled.append(ws_id)
 
         with (


### PR DESCRIPTION
## Symptoms

API pods OOM-killed (exit 137) on every VCS poll cycle when multiple workspaces track the same multi-hundred-MB monorepo. With N workspaces tracking one repo, each cycle made N simultaneous full-tarball downloads + held them in process memory simultaneously — easily over the 2Gi pod limit. Pod death loses the in-flight cycle, the other replica picks it up and OOMs again. End result: PR speculative plans never complete in a window where the user isn't pushing new commits.

## Root cause

`download_repo_archive(...) -> bytes` returns the full tarball as a Python `bytes` object — `resp.content`. The strip step then doubles that (input + repacked output), so peak memory was `2 × tarball_size × N concurrent workspaces`. Plus N× the GitHub API quota usage when N workspaces all polled the same repo at the same SHA.

## Fix

Three layered changes — all needed for the scenario to recover cleanly.

### 1. Streaming pipeline (the OOM fix)

- New `download_repo_archive_to_file` (github + gitlab): streams `httpx` response chunks straight to a local file.
- New `strip_archive_top_level_dir_file`: file-to-file streaming strip via `tarfile r|gz` / `w|gz` modes. Sequential per-member processing, no in-memory index.
- `_create_vcs_run` and the runs.py UI `vcs-ref` override path now run the full streaming pipeline (download → temp file → strip → temp file → `storage.put_stream`). A 500 MB tarball stays under ~10 MB of process memory; the rest lives on the api pod's ephemeral PVC.

### 2. Single-flight cache (the duplicate-download fix)

- New `VCSArchiveCache` module:
  - **In-process `asyncio.Lock` per (conn, sha)** — concurrent workspace polls within one cycle coalesce on a single download.
  - **Object-storage cache** at `vcs_archives/{conn_id}/{owner}/{repo}/{sha}.tar.gz` — survives across cycles + replicas. `head()` check before download means re-polling the same SHA hits the cache.
- One cache per `poll_cycle`, one per `handle_immediate_poll`, threaded through `_poll_workspace` → `_poll_workspace_branch` / `_poll_workspace_prs` → `_create_vcs_run`.
- runs.py UI path uses a one-shot cache — sparse requests, the storage layer still gives cross-replica dedup.

### 3. Per-pod ephemeral storage (the prerequisite)

- New `api.ephemeralStorage` Helm block (default `enabled: true`, `size: 10Gi`). Generic ephemeral volume → each api pod replica gets its own PVC, auto-deleted on pod removal.
- Pick a `storageClass` whose reclaim policy is **`Delete`** (e.g. on AWS EBS CSI: `xfs` or `gp3` — NOT `xfs-retain`). Cluster default is often `Retain`-flavoured and that leaks PVs on every pod restart.
- `values-local.yaml` overrides `enabled: false` for Tilt + rancher-desktop where the CSI provisioner is unreliable.
- New `vcs.tmpdir` config wires the api's tempdir to the PVC mountpoint.

### 4. Disk-full protection

`_ensure_tmpdir_space` runs before each download. If free space is below `vcs.tmpdir_min_free_bytes` (default 2 GiB), sweeps oldest orphan `.tar.gz` temp files older than 5 minutes until we recover the threshold. Handles the case where a previous-pod crash leaves `NamedTemporaryFile` orphans behind.

### 5. Cache lifecycle

`_cleanup_vcs_archives` in the artifact-retention sweeper evicts tarballs older than `vcs.archive_cache_retention_days` (default 7) using `storage.list_prefix` — content-addressed entries don't need a DB table.

## Multi-replica safety

- Scheduler invariant: one replica per `poll_cycle` interval, so the in-process lock layer is sufficient there.
- Storage cache (atomic `head`/`put_stream` on a content-addressed key) handles the rare cross-replica race in the UI path.

## Documentation

- `docs/deployment.md`: new "VCS archive streaming and ephemeral storage" subsection — config reference, AWS EKS + k3s (single-node / multi-node) storage class guidance, cache layer.
- `docs/production-checklist.md`: ephemeral storage + storage-class as a Go-Live checklist item.
- `docs/vcs-integration.md`: streaming + caching architecture note.

## Test plan

- [x] `make lint` clean.
- [x] `make test`: 1087 tests pass (+13 new).
- [x] `helm lint` clean (default + `values-local.yaml`).
- [x] `helm template` shows the `vcs-tmpdir` ephemeral volume + mount in deployment-api.yaml.
- [x] `npm run build` from `web/` succeeds.
- [ ] Tilt verify: api pod stays under memory limit while polling a fixture monorepo; second cycle for same SHA hits the storage cache (look for `VCS archive storage-cache hit` log).
- [ ] After release: bump operator wrapper chart, set `api.ephemeralStorage.storageClass: <Delete-reclaim class>`, watch the api pod stop OOM-killing.