### PR TITLE
fix(vcs-cache): drop erroneous await on get_stream() async generator

### DIFF
--- a/services/terrapod/services/vcs_archive_cache.py
+++ b/services/terrapod/services/vcs_archive_cache.py
@@ -380,7 +380,14 @@ async def materialize_archive(storage_key: str):
     f = await asyncio.to_thread(os.fdopen, fd, "wb")
     try:
         try:
-            async for chunk in await storage.get_stream(storage_key):
+            # `storage.get_stream` is an async generator (uses `yield` under
+            # the hood across S3/Azure/GCS/filesystem backends), so calling
+            # it returns the iterator directly — DO NOT `await` it. Awaiting
+            # an async-generator object raises `TypeError: 'async_generator'
+            # object can't be awaited`. AsyncMock-based unit tests don't
+            # surface this because the mock's `return_value` is itself
+            # awaitable; only the real backends bite.
+            async for chunk in storage.get_stream(storage_key):
                 if not chunk:
                     continue
                 await asyncio.to_thread(f.write, chunk)

--- a/services/tests/services/test_vcs_archive_cache.py
+++ b/services/tests/services/test_vcs_archive_cache.py
@@ -506,16 +506,25 @@ class TestVCSArchiveCachePartialUploadCleanup:
 class TestMaterializeArchive:
     @pytest.mark.asyncio
     async def test_streams_storage_key_to_local_temp_file(self, tmp_path):
-        """The yielded path contains exactly the bytes streamed from storage."""
+        """The yielded path contains exactly the bytes streamed from storage.
+
+        IMPORTANT: production storage backends implement `get_stream` as an
+        async generator (uses `yield` internally) — calling it returns the
+        iterator directly, no `await` needed. We mock that shape with a
+        plain attribute pointing at an async-gen function, NOT an
+        `AsyncMock(return_value=...)`. The latter is awaitable and would
+        hide the production bug where `await storage.get_stream(...)`
+        raises `TypeError: 'async_generator' object can't be awaited`.
+        """
         payload = _make_tarball({"a.tf": b"a", "b.tf": b"bb"})
 
-        async def chunks():
+        async def get_stream(_key):
             # Split into 2 chunks to exercise the loop
             yield payload[: len(payload) // 2]
             yield payload[len(payload) // 2 :]
 
         mock_storage = MagicMock()
-        mock_storage.get_stream = AsyncMock(return_value=chunks())
+        mock_storage.get_stream = get_stream
 
         observed: dict[str, bytes] = {}
 
@@ -553,11 +562,11 @@ class TestMaterializeArchive:
         sacrificing test clarity.
         """
 
-        async def chunks():
+        async def get_stream(_key):
             yield b"some bytes"
 
         mock_storage = MagicMock()
-        mock_storage.get_stream = AsyncMock(return_value=chunks())
+        mock_storage.get_stream = get_stream  # async generator, NOT AsyncMock
 
         observed_path: str | None = None
         observed_error: BaseException | None = None
@@ -604,12 +613,12 @@ class TestMaterializeArchive:
         large_chunk = b"X" * (4 * 1024 * 1024)
         payload = large_chunk + b"Y" * 1024
 
-        async def chunks():
+        async def get_stream(_key):
             yield large_chunk
             yield b"Y" * 1024
 
         mock_storage = MagicMock()
-        mock_storage.get_stream = AsyncMock(return_value=chunks())
+        mock_storage.get_stream = get_stream  # async generator, NOT AsyncMock
 
         with (
             patch(


### PR DESCRIPTION
## Symptom

After v0.20.0 deployed, the cache successfully writes a stripped tarball (\`\"Cached VCS archive\"\` log fires for the new SHA), but every consumer of \`materialize_archive\` errors with:

\`\`\`
'async_generator' object can't be awaited
\`\`\`

Result: speculative runs are not created for any new SHA. The streaming + cache path was untested against real storage backends; AsyncMock-shaped unit tests hid the bug.

## Root cause

\`storage.get_stream(key)\` is an **async generator** across all four backends (S3 / Azure / GCS / filesystem) — it uses \`yield\` internally. Calling it returns the iterator directly; you do NOT \`await\` it.

\`vcs_archive_cache.py\` had:

\`\`\`python
async for chunk in await storage.get_stream(storage_key):
                  ^^^^^ wrong
\`\`\`

The unit test masked it via \`AsyncMock(return_value=chunks())\` — AsyncMock makes the call awaitable (and returns the iterator on await), so the test passed against a contract the real backends don't honor.

## Fix

1. Drop the \`await\` in \`materialize_archive\`.
2. Update the three \`materialize_archive\` tests to use a real \`async def get_stream(_key): yield ...\` shape — same contract the real backends provide. AsyncMock is no longer used for \`get_stream\` in any of these tests.

## Test plan

- [x] \`make lint\` clean
- [x] \`make test\` 1096 pass (test changes are tighter — production semantics now exercised)
- [ ] After merge + tag v0.20.1 + wrapper bump: confirm \`Speculative run created for PR\` log lines appear, and the GitHub PR checks tab shows the terrapod statuses on the latest SHA.