### PR TITLE
fix(listener): cert renewal race + surface silent failures + close auth gaps

### DIFF
--- a/services/terrapod/api/dependencies.py
+++ b/services/terrapod/api/dependencies.py
@@ -319,7 +319,9 @@ async def authenticate_listener(request: Request) -> "ListenerIdentity":
         )
 
     fingerprint = get_certificate_fingerprint(cert)
-    if not await agent_pool_service.is_fingerprint_valid(listener["id"], fingerprint):
+    if not await agent_pool_service.is_fingerprint_valid(
+        listener["id"], fingerprint, listener=listener
+    ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Certificate fingerprint not registered",
@@ -496,7 +498,9 @@ async def get_listener_identity(
 
     # Verify fingerprint match
     fingerprint = get_certificate_fingerprint(cert)
-    if not await agent_pool_service.is_fingerprint_valid(listener["id"], fingerprint):
+    if not await agent_pool_service.is_fingerprint_valid(
+        listener["id"], fingerprint, listener=listener
+    ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Certificate fingerprint not registered",

--- a/services/terrapod/api/dependencies.py
+++ b/services/terrapod/api/dependencies.py
@@ -319,11 +319,10 @@ async def authenticate_listener(request: Request) -> "ListenerIdentity":
         )
 
     fingerprint = get_certificate_fingerprint(cert)
-    stored_fp = listener.get("certificate_fingerprint", "")
-    if stored_fp and fingerprint != stored_fp:
+    if not await agent_pool_service.is_fingerprint_valid(listener["id"], fingerprint):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Certificate fingerprint mismatch",
+            detail="Certificate fingerprint not registered",
         )
 
     return ListenerIdentity(
@@ -497,11 +496,10 @@ async def get_listener_identity(
 
     # Verify fingerprint match
     fingerprint = get_certificate_fingerprint(cert)
-    stored_fp = listener.get("certificate_fingerprint", "")
-    if stored_fp and fingerprint != stored_fp:
+    if not await agent_pool_service.is_fingerprint_valid(listener["id"], fingerprint):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Certificate fingerprint mismatch",
+            detail="Certificate fingerprint not registered",
         )
 
     return ListenerIdentity(

--- a/services/terrapod/api/metrics.py
+++ b/services/terrapod/api/metrics.py
@@ -231,6 +231,27 @@ LISTENER_JOINS = Counter(
     ["pool_name"],
 )
 
+LISTENER_LAUNCH_FAILURES = Counter(
+    "terrapod_listener_launch_failures_total",
+    (
+        "Pre-Job launch failures reported by listeners. Increments when a "
+        "listener PATCHes a run to `errored` from `planning`/`applying` while "
+        "the run still has no `job_name` — i.e. the listener claimed the run "
+        "but couldn't get as far as launching the K8s Job (auth failure on "
+        "/runner-token, create_job exception, auth Secret create failure)."
+    ),
+)
+
+LISTENER_PRELAUNCH_TIMEOUTS = Counter(
+    "terrapod_listener_prelaunch_timeouts_total",
+    (
+        "Reconciler timed out a run that was claimed but never had a Job "
+        "launched. Counterpart to launch_failures: the listener didn't even "
+        "manage to PATCH the failure (its cert was rejected, or it crashed). "
+        "Backstop signal for silent listener failures."
+    ),
+)
+
 
 # ---------------------------------------------------------------------------
 # Retention metrics

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -23,7 +23,7 @@ import asyncio
 import json
 import re
 import uuid
-from datetime import UTC
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request
 from fastapi.responses import JSONResponse
@@ -159,6 +159,53 @@ def _token_json(token, raw_token: str | None = None) -> dict:
     return result
 
 
+def _derive_listener_status(listener: dict) -> str:
+    """Derive a truthful status from listener Redis state + cert expiry.
+
+    Heartbeats blindly write `status: "online"` regardless of cert validity.
+    A listener whose cert has expired keeps heartbeating but every cert-auth
+    call (renew, runner-token, runs/next, job-launched, etc.) returns 401 —
+    it's not actually working. Reflect that in the API/UI by downgrading the
+    status to "cert-expired" so operators can spot it instead of trusting a
+    misleading "online".
+
+    Returns one of: "online", "cert-expired", "offline".
+    """
+    raw_status = listener.get("status", "offline")
+    expires_at = listener.get("certificate_expires_at", "")
+    if not expires_at:
+        return raw_status
+    try:
+        # `fromisoformat` accepts both `+00:00` and `Z` suffix in 3.13+.
+        expiry = datetime.fromisoformat(expires_at)
+    except ValueError:
+        return raw_status
+    if expiry.tzinfo is None:
+        expiry = expiry.replace(tzinfo=UTC)
+    if expiry < datetime.now(UTC):
+        return "cert-expired"
+    return raw_status
+
+
+def _derive_pool_status(listeners: list[dict]) -> str:
+    """Pool-level health derived from member listeners.
+
+    - `online`     — at least one listener has a non-expired cert
+    - `degraded`   — listeners exist but ALL have cert-expired (the listeners
+                     are heartbeating but can't authenticate any cert-protected
+                     call → no runs will execute)
+    - `offline`    — no listeners
+    """
+    if not listeners:
+        return "offline"
+    statuses = [_derive_listener_status(item) for item in listeners]
+    if any(s == "online" for s in statuses):
+        return "online"
+    if all(s == "cert-expired" for s in statuses):
+        return "degraded"
+    return "offline"
+
+
 def _listener_json(listener: dict, replica_count: int | None = None) -> dict:
     """Format a Redis-backed listener dict as JSON:API.
 
@@ -170,10 +217,14 @@ def _listener_json(listener: dict, replica_count: int | None = None) -> dict:
     image (no `tracks_pods` flag); the attribute is then omitted from the
     response and the UI shows "—" for unknown. Passing `0` is meaningful:
     "this listener IS tracking, but no pods are currently heartbeating".
+
+    `status` is computed from `_derive_listener_status` so a heartbeating
+    listener with an expired cert appears as `cert-expired` rather than the
+    misleading `online` written by the heartbeat path.
     """
     attrs: dict = {
         "name": listener.get("name", ""),
-        "status": listener.get("status", "offline"),
+        "status": _derive_listener_status(listener),
         "certificate-fingerprint": listener.get("certificate_fingerprint", ""),
         "certificate-expires-at": listener.get("certificate_expires_at", ""),
         "created-at": listener.get("created_at", ""),
@@ -250,9 +301,11 @@ async def list_pools(
         if perm is None:
             continue
         listeners = await agent_pool_service.list_listeners(p.id)
-        # `list_listeners` lazily prunes any listener whose hash has expired,
-        # so anything still in the list is heartbeating ⇒ pool is online.
-        status = "online" if listeners else "offline"
+        # `list_listeners` lazily prunes any listener whose hash has expired.
+        # Anything still in the list is heartbeating, but heartbeat alone is
+        # not enough — a listener with an expired cert keeps heartbeating but
+        # 401s every authenticated call, so we cross-check cert expiry too.
+        status = _derive_pool_status(listeners)
         result.append(_pool_json(p, status=status, permission=perm))
     return JSONResponse(content={"data": result})
 
@@ -293,8 +346,7 @@ async def show_pool(
     pool = await _get_pool(pool_id, db)
     perm = await _require_pool_permission(pool, user, db, "read")
     listeners = await agent_pool_service.list_listeners(pool.id)
-    # See list_pools for the rationale: any listener still in the list is online.
-    status = "online" if listeners else "offline"
+    status = _derive_pool_status(listeners)
     return JSONResponse(content={"data": _pool_json(pool, status=status, permission=perm)})
 
 
@@ -727,9 +779,21 @@ async def listener_events(
 async def listener_heartbeat(
     listener_id: str = Path(...),
     body: dict = Body(...),
+    identity: ListenerIdentity = Depends(get_listener_identity),
 ) -> JSONResponse:
-    """Listener heartbeat — refreshes TTL and updates runtime fields in Redis."""
+    """Listener heartbeat — refreshes TTL and updates runtime fields in Redis.
+
+    Auth: must present a valid client cert. Without this, anyone could keep
+    a dead listener "online" by spamming heartbeats — masking the very cert
+    failure that took it offline. The cert's listener-id must also match the
+    path id (a listener can only heartbeat itself).
+    """
     l_uuid = uuid.UUID(listener_id.removeprefix("listener-"))
+    if identity.listener_id != l_uuid:
+        raise HTTPException(
+            status_code=403,
+            detail="Certificate does not match the listener id in the path",
+        )
     listener = await agent_pool_service.get_listener(l_uuid)
     if listener is None:
         raise HTTPException(status_code=404, detail="Listener not found")

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -35,7 +35,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
-from terrapod.api.dependencies import AuthenticatedUser, get_current_user, get_listener_identity
+from terrapod.api.dependencies import (
+    AuthenticatedUser,
+    ListenerIdentity,
+    get_current_user,
+    get_listener_identity,
+)
 from terrapod.db.models import Run, StateVersion, VCSConnection, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -829,13 +834,24 @@ async def run_events_stream(
 @router.get("/listeners/{listener_id}/runs/next")
 async def next_run(
     listener_id: str = Path(...),
+    identity: ListenerIdentity = Depends(get_listener_identity),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Poll for the next queued run assigned to this listener.
 
+    Auth: must present a valid client cert whose listener-id matches the
+    path. Without this, anyone with a listener-id could claim runs out from
+    under the real listener and gather their resolved variables (which
+    include sensitive workspace vars).
+
     Returns 204 No Content if no run is available.
     """
     l_uuid = uuid.UUID(listener_id.removeprefix("listener-"))
+    if identity.listener_id != l_uuid:
+        raise HTTPException(
+            status_code=403,
+            detail="Certificate does not match the listener id in the path",
+        )
     listener = await agent_pool_service.get_listener(l_uuid)
     if listener is None:
         raise HTTPException(status_code=404, detail="Listener not found")
@@ -880,13 +896,19 @@ async def update_run_status(
     listener_id: str = Path(...),
     run_id: str = Path(...),
     body: dict = Body(...),
+    identity: ListenerIdentity = Depends(get_listener_identity),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Listener reports run status update."""
     run = await _get_run(run_id, db)
 
-    # Verify this listener owns the run
+    # Verify this listener owns the run AND its cert matches the path
     l_uuid = uuid.UUID(listener_id.removeprefix("listener-"))
+    if identity.listener_id != l_uuid:
+        raise HTTPException(
+            status_code=403,
+            detail="Certificate does not match the listener id in the path",
+        )
     if run.listener_id != l_uuid:
         raise HTTPException(status_code=403, detail="Run not assigned to this listener")
 
@@ -896,6 +918,20 @@ async def update_run_status(
 
     if not target_status:
         raise HTTPException(status_code=422, detail="status is required")
+
+    # Listener is reporting a pre-launch failure if it's transitioning a run
+    # from planning/applying → errored while job_name is still NULL (no Job
+    # was ever created). Surface that in metrics so we can alert on bursts of
+    # listener failures (auth / K8s outage / secret-create) without grepping
+    # logs across replicas.
+    if (
+        target_status == "errored"
+        and run.job_name is None
+        and run.status in ("planning", "applying")
+    ):
+        from terrapod.api.metrics import LISTENER_LAUNCH_FAILURES
+
+        LISTENER_LAUNCH_FAILURES.inc()
 
     # Set has_changes before transition (so it's visible in drift handler)
     if has_changes is not None:
@@ -975,6 +1011,7 @@ async def report_job_launched(
     listener_id: str = Path(...),
     run_id: str = Path(...),
     body: dict = Body(...),
+    identity: ListenerIdentity = Depends(get_listener_identity),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Listener reports Job creation for a run.
@@ -986,6 +1023,11 @@ async def report_job_launched(
     run = await _get_run(run_id, db)
 
     l_uuid = uuid.UUID(listener_id.removeprefix("listener-"))
+    if identity.listener_id != l_uuid:
+        raise HTTPException(
+            status_code=403,
+            detail="Certificate does not match the listener id in the path",
+        )
     if run.listener_id != l_uuid:
         raise HTTPException(status_code=403, detail="Run not assigned to this listener")
 
@@ -1006,6 +1048,7 @@ async def report_job_status(
     listener_id: str = Path(...),
     run_id: str = Path(...),
     body: dict = Body(...),
+    identity: ListenerIdentity = Depends(get_listener_identity),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Listener reports Job status in response to a check_job_status event.
@@ -1014,6 +1057,12 @@ async def report_job_status(
     queries K8s for the Job status and POSTs the result here. The reconciler
     picks up the status from Redis on its next cycle.
     """
+    l_uuid = uuid.UUID(listener_id.removeprefix("listener-"))
+    if identity.listener_id != l_uuid:
+        raise HTTPException(
+            status_code=403,
+            detail="Certificate does not match the listener id in the path",
+        )
     run = await _get_run(run_id, db)
 
     job_status = body.get("status", "")
@@ -1035,6 +1084,7 @@ async def upload_log_stream(
     run_id: str = Path(...),
     phase: str = Query("plan"),
     request: Request = ...,
+    identity: ListenerIdentity = Depends(get_listener_identity),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Listener uploads live pod log data for an in-progress run.
@@ -1048,6 +1098,12 @@ async def upload_log_stream(
     log data from being stored under the apply phase key when the run has
     already transitioned.
     """
+    l_uuid = uuid.UUID(listener_id.removeprefix("listener-"))
+    if identity.listener_id != l_uuid:
+        raise HTTPException(
+            status_code=403,
+            detail="Certificate does not match the listener id in the path",
+        )
     run = await _get_run(run_id, db)
     if phase not in ("plan", "apply"):
         phase = "plan" if run.status == "planning" else "apply"

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -74,6 +74,17 @@ class RunnerConfig(BaseModel):
         default=3600,
         description="Seconds before a run with no Job status is marked errored",
     )
+    launch_timeout_seconds: int = Field(
+        default=300,
+        description=(
+            "Seconds before a claimed run with NO job_name is marked errored. "
+            "Distinct from stale_timeout: this catches the 'listener claimed "
+            "the run but never launched a Job' failure mode (e.g. /runner-token "
+            "401, K8s API outage at create_job time). Shorter default than "
+            "stale_timeout because 'no Job launched after 5 min' is a clear "
+            "failure signal, whereas a long-running Job with no status is not."
+        ),
+    )
 
 
 def load_runner_config(path: str = "/etc/terrapod/runners.yaml") -> RunnerConfig:

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -192,7 +192,18 @@ class RunnerListener:
         """
         from terrapod.runner.identity import clear_credentials_secret
 
-        logger.warning("Forcing re-join due to persistent auth failures")
+        # Error-level: this is an operator-actionable signal. Persistent auth
+        # failures usually mean the cert in our Secret no longer matches what
+        # the API has registered (Redis fingerprint key expired, listener
+        # registration aged out, or — pre-fix — a renewal race wrote the
+        # wrong fingerprint). The rejoin path consumes a join-token use, so
+        # repeated rejoins eventually exhaust max_uses and we'll start
+        # failing closed. Worth a SEV level in your log alerts.
+        logger.error(
+            "Forcing re-join due to persistent auth failures",
+            listener_id=str(self.identity.listener_id) if self.identity else "<unknown>",
+            name=self.identity.name if self.identity else "<unknown>",
+        )
         clear_credentials_secret()
         await self._establish_identity()
 
@@ -535,12 +546,26 @@ class RunnerListener:
             self._active_launches -= 1
 
     async def _launch_run(self, run_id: str, attrs: dict) -> None:
-        """Build and launch a K8s Job for a claimed run, then report back."""
+        """Build and launch a K8s Job for a claimed run, then report back.
+
+        Any pre-Job failure (token request, Job create, auth Secret create)
+        must transition the run to `errored` via the API — otherwise the run
+        sits forever in `planning`/`applying` because the reconciler skips
+        runs without a `job_name`. The reconciler's `launch_timeout` is the
+        backstop, but surfacing the actual error here gives operators an
+        immediate signal at the API instead of a generic timeout 5 min later.
+        """
         from terrapod.runner.job_manager import create_job, get_job_uid
         from terrapod.runner.job_template import build_job_spec
 
         phase = attrs.get("phase", "plan")
-        runner_token = await self._get_runner_token(run_id)
+
+        try:
+            runner_token = await self._get_runner_token(run_id)
+        except Exception as e:
+            logger.error("Failed to fetch runner token", run_id=run_id, error=str(e))
+            await self._report_launch_failed(run_id, f"Could not obtain runner token: {e}")
+            return
 
         env_vars = [{"key": v["key"], "value": v["value"]} for v in attrs.get("env-vars", [])]
         terraform_vars = [
@@ -578,6 +603,7 @@ class RunnerListener:
             job_name = await create_job(spec)
         except Exception as e:
             logger.error("Failed to create Job", run_id=run_id, error=str(e))
+            await self._report_launch_failed(run_id, f"Failed to create K8s Job: {e}")
             return
 
         # Create auth Secret with ownerReference to the Job
@@ -586,6 +612,8 @@ class RunnerListener:
             await self._create_auth_secret(run_id, runner_token, job_name, job_uid)
         except Exception as e:
             logger.error("Failed to create auth secret", run_id=run_id, error=str(e))
+            await self._report_launch_failed(run_id, f"Failed to create runner auth Secret: {e}")
+            return
 
         # Report Job launched to the API
         try:
@@ -597,6 +625,11 @@ class RunnerListener:
             )
         except Exception as e:
             logger.error("Failed to report job-launched", run_id=run_id, error=str(e))
+            # Don't error the run here — the Job is genuinely running. The
+            # reconciler will time it out via stale_timeout if status reports
+            # never arrive, but a transient HTTP blip here shouldn't kill an
+            # otherwise-healthy plan/apply.
+            return
 
         logger.info(
             "Job launched",
@@ -604,6 +637,33 @@ class RunnerListener:
             phase=phase,
             job=job_name,
         )
+
+    async def _report_launch_failed(self, run_id: str, error_message: str) -> None:
+        """Mark a run errored when the listener can't launch its Job.
+
+        Best-effort: if this PATCH itself fails (e.g. our cert is being
+        rejected — the very condition that caused the launch failure), the
+        reconciler's launch_timeout is the safety net. Don't let a failed
+        report-failure call cascade and break the listener's event loop.
+        """
+        try:
+            await self._http_client.patch(
+                f"/api/v2/listeners/listener-{self.identity.listener_id}/runs/run-{run_id}",
+                json={"status": "errored", "error_message": error_message},
+                headers=self._auth_headers(),
+            )
+            logger.info(
+                "Reported launch failure to API",
+                run_id=run_id,
+                error_message=error_message,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to report launch failure (reconciler will time out)",
+                run_id=run_id,
+                error=str(e),
+                original_error=error_message,
+            )
 
     async def _handle_check_job_status(self, data: dict) -> None:
         """Query K8s for Job status and POST the result back to the API."""

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -237,15 +237,52 @@ async def _register_fingerprint(listener_id: str, fingerprint: str, ttl: int) ->
     await redis.setex(f"{_LISTENER_FP_PREFIX}{listener_id}:{fingerprint}", ttl, "1")
 
 
-async def is_fingerprint_valid(listener_id: str, fingerprint: str) -> bool:
+async def is_fingerprint_valid(
+    listener_id: str, fingerprint: str, listener: dict | None = None
+) -> bool:
     """Return True if `fingerprint` is registered for `listener_id`.
 
     Cert-auth's source of truth — replaces the previous single-value equality
     check on the listener hash field. Tolerates concurrent renewals issuing
     multiple valid certs at once.
+
+    Migration fallback: when this code first deploys, listeners that joined
+    under the old scheme have no `tp:listener_fp:*` key — only a fingerprint
+    on their listener hash. Without a fallback, every existing listener
+    would 401 on its next heartbeat / renew / runner-token call, triggering
+    a fleet-wide rejoin storm at deploy time. Pass the listener dict so we
+    can fall back to the legacy field, and self-heal by writing the new
+    key on first match. After the first request from each existing listener
+    the fallback path stops being exercised; new joins / renews never need
+    it because they call `_register_fingerprint` directly.
     """
     redis = get_redis_client()
-    return bool(await redis.exists(f"{_LISTENER_FP_PREFIX}{listener_id}:{fingerprint}"))
+    new_key = f"{_LISTENER_FP_PREFIX}{listener_id}:{fingerprint}"
+    if await redis.exists(new_key):
+        return True
+
+    if listener is not None and listener.get("certificate_fingerprint") == fingerprint:
+        # Self-heal: register in the new key family so subsequent requests
+        # take the fast path. TTL is derived from the legacy
+        # `certificate_expires_at` field; on missing / unparseable values
+        # fall back to a conservative 1-hour ceiling — the next renewal
+        # will refresh it.
+        ttl = 3600
+        expires_at = listener.get("certificate_expires_at", "")
+        if expires_at:
+            try:
+                expiry = datetime.fromisoformat(expires_at)
+                if expiry.tzinfo is None:
+                    expiry = expiry.replace(tzinfo=UTC)
+                remaining = int((expiry - datetime.now(UTC)).total_seconds())
+                if remaining > 60:
+                    ttl = remaining + 60
+            except ValueError:
+                pass
+        await redis.setex(new_key, ttl, "1")
+        return True
+
+    return False
 
 
 async def join_listener(

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -189,18 +189,63 @@ async def delete_pool_token(db: AsyncSession, token: AgentPoolToken) -> None:
 #   tp:pool_listeners:{pid}                SET    no TTL    — pool → listener index (lazily cleaned)
 #   tp:listener_name:{name}                STRING 300s TTL  — name → ID lookup
 #   tp:listener_pod:{id}:{pod_name}        STRING 180s TTL  — per-pod heartbeat presence (replica count)
+#   tp:listener_fp:{id}:{fingerprint}      STRING ~cert TTL — accepted cert fingerprints
 #
 # Why a separate per-pod key family: in v0.19.0 a listener Deployment shares one
 # identity (one tp:listener:{id} hash) across replicas, so the hash itself can't
 # tell us how many pods are running. Each pod's heartbeat refreshes its own
 # tp:listener_pod:{id}:{pod_name} key (TTL = 3x heartbeat interval); replica
 # count is the number of those keys still alive.
+#
+# Why a separate per-fingerprint key family: when N pods race on /renew at the
+# same moment, the API issues N distinct certs but the K8s Secret CAS only lets
+# one win — the others adopt the winner from the Secret. If auth tracked a
+# single "current" fingerprint, the cert that won the Secret might not be the
+# one whose fingerprint is in Redis (last-writer-wins on the hash field), and
+# every subsequent cert-auth call would 401 with "fingerprint mismatch". By
+# storing each issued fingerprint as its own TTL'd key and auth doing EXISTS,
+# all certs we issued remain valid until they actually expire — concurrent
+# renewals stop being a coordination problem.
 LISTENER_TTL = 300  # seconds (refreshed on every heartbeat)
 LISTENER_POD_TTL = 180  # seconds — 3x heartbeat interval, tolerates 2 missed beats
 _LISTENER_PREFIX = "tp:listener:"
 _POOL_LISTENERS_PREFIX = "tp:pool_listeners:"
 _LISTENER_NAME_PREFIX = "tp:listener_name:"
 _LISTENER_POD_PREFIX = "tp:listener_pod:"
+_LISTENER_FP_PREFIX = "tp:listener_fp:"
+
+
+def _fingerprint_ttl(cert) -> int:
+    """TTL to apply to a fingerprint registration key.
+
+    Cert validity plus 60s buffer. The 60s slack absorbs minor clock skew
+    between the API server and Redis so we never reject a still-valid cert
+    because its fingerprint key expired a moment too early.
+    """
+    remaining = (cert.not_valid_after_utc - datetime.now(UTC)).total_seconds()
+    return max(60, int(remaining) + 60)
+
+
+async def _register_fingerprint(listener_id: str, fingerprint: str, ttl: int) -> None:
+    """Register an accepted cert fingerprint for a listener.
+
+    Multiple fingerprints may be live concurrently (e.g. two pods both
+    successfully called /renew within the same window). Cert-auth treats
+    any registered fingerprint as valid until its key expires.
+    """
+    redis = get_redis_client()
+    await redis.setex(f"{_LISTENER_FP_PREFIX}{listener_id}:{fingerprint}", ttl, "1")
+
+
+async def is_fingerprint_valid(listener_id: str, fingerprint: str) -> bool:
+    """Return True if `fingerprint` is registered for `listener_id`.
+
+    Cert-auth's source of truth — replaces the previous single-value equality
+    check on the listener hash field. Tolerates concurrent renewals issuing
+    multiple valid certs at once.
+    """
+    redis = get_redis_client()
+    return bool(await redis.exists(f"{_LISTENER_FP_PREFIX}{listener_id}:{fingerprint}"))
 
 
 async def join_listener(
@@ -226,6 +271,7 @@ async def join_listener(
         ttl_seconds=settings.agent_pools.listener_cert_ttl_seconds,
     )
     fingerprint = get_certificate_fingerprint(cert)
+    fp_ttl = _fingerprint_ttl(cert)
     now = datetime.now(UTC).isoformat()
 
     # Check if listener already exists (re-join after restart)
@@ -247,6 +293,7 @@ async def join_listener(
         await redis.expire(f"{_LISTENER_NAME_PREFIX}{name}", LISTENER_TTL)
         # Ensure pool set membership (may have changed pools)
         await redis.sadd(f"{_POOL_LISTENERS_PREFIX}{pool.id}", listener_id)
+        await _register_fingerprint(listener_id, fingerprint, fp_ttl)
         logger.info(
             "Listener re-joined (updated existing)",
             listener=name,
@@ -274,6 +321,7 @@ async def join_listener(
         await redis.setex(f"{_LISTENER_NAME_PREFIX}{name}", LISTENER_TTL, listener_id)
         # Pool index
         await redis.sadd(f"{_POOL_LISTENERS_PREFIX}{pool.id}", listener_id)
+        await _register_fingerprint(listener_id, fingerprint, fp_ttl)
         logger.info(
             "Listener joined",
             listener=name,
@@ -366,11 +414,14 @@ async def delete_listener(listener_id: str, name: str, pool_id: str) -> None:
     leak is invisible to operators. Not worth a Lua script to close.
     """
     redis = get_redis_client()
-    # Per-pod keys live under a different prefix → can't go in the same pipeline
-    # under cluster mode. Drain them first.
+    # Per-pod and per-fingerprint keys live under different prefixes → can't go
+    # in the same pipeline under cluster mode. Drain them first.
     pod_pattern = f"{_LISTENER_POD_PREFIX}{listener_id}:*"
     async for pod_key in redis.scan_iter(match=pod_pattern, count=100):
         await redis.delete(pod_key)
+    fp_pattern = f"{_LISTENER_FP_PREFIX}{listener_id}:*"
+    async for fp_key in redis.scan_iter(match=fp_pattern, count=100):
+        await redis.delete(fp_key)
 
     pipe = redis.pipeline(transaction=False)
     pipe.delete(f"{_LISTENER_PREFIX}{listener_id}")
@@ -386,13 +437,16 @@ async def delete_pool_listeners(pool_id: uuid.UUID) -> None:
     member_ids = await redis.smembers(set_key)
 
     if member_ids:
-        # Per-pod keys must be drained outside the pipeline (different prefix
-        # → different cluster slot, can't share a pipeline with the listener
-        # hash deletes).
+        # Per-pod + per-fingerprint keys must be drained outside the pipeline
+        # (different prefix → different cluster slot, can't share a pipeline
+        # with the listener hash deletes).
         for lid in member_ids:
             pod_pattern = f"{_LISTENER_POD_PREFIX}{lid}:*"
             async for pod_key in redis.scan_iter(match=pod_pattern, count=100):
                 await redis.delete(pod_key)
+            fp_pattern = f"{_LISTENER_FP_PREFIX}{lid}:*"
+            async for fp_key in redis.scan_iter(match=fp_pattern, count=100):
+                await redis.delete(fp_key)
 
         pipe = redis.pipeline(transaction=False)
         for lid in member_ids:
@@ -412,7 +466,15 @@ async def renew_listener_certificate(
     listener_name: str,
     pool: AgentPool,
 ) -> dict:
-    """Renew a listener's certificate. Updates fingerprint and expiry in Redis."""
+    """Renew a listener's certificate. Registers the new fingerprint in Redis.
+
+    Concurrent /renew calls (one per listener pod racing within the same
+    window) all succeed — each registers its own fingerprint key, and all
+    are accepted by cert-auth until they expire. The K8s Secret CAS on
+    the listener side picks one cert to actually use; the others stay
+    valid-but-unused. The hash's `certificate_fingerprint` field is
+    updated for UI display only — not load-bearing for auth.
+    """
     ca = get_ca()
     redis = get_redis_client()
     cert, private_key = ca.issue_listener_certificate(
@@ -421,6 +483,8 @@ async def renew_listener_certificate(
         ttl_seconds=settings.agent_pools.listener_cert_ttl_seconds,
     )
     fingerprint = get_certificate_fingerprint(cert)
+
+    await _register_fingerprint(listener_id, fingerprint, _fingerprint_ttl(cert))
 
     key = f"{_LISTENER_PREFIX}{listener_id}"
     await redis.hset(

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -71,15 +71,17 @@ async def reconcile_runs() -> None:
     """Drive run state transitions based on Job outcomes.
 
     This is the main entry point, called every 2s by the scheduler.
+
+    Picks up two cohorts:
+    1. planning/applying with job_name set — drive on Job status reports
+    2. planning/applying with NO job_name set — the listener claimed the run
+       but never reported job-launched (auth failure, K8s outage at create
+       time, listener died mid-launch). Without picking these up they sit
+       indefinitely. `_check_stale` applies a shorter `launch_timeout` to
+       this cohort so failures surface in minutes, not hours.
     """
     async with get_db_session() as db:
-        # Find runs in planning/applying with job_name set
-        result = await db.execute(
-            select(Run).where(
-                Run.status.in_(["planning", "applying"]),
-                Run.job_name.isnot(None),
-            )
-        )
+        result = await db.execute(select(Run).where(Run.status.in_(["planning", "applying"])))
         runs = list(result.scalars().all())
 
         if not runs:
@@ -103,6 +105,13 @@ async def _reconcile_one(db: AsyncSession, run: Run) -> None:
     from terrapod.redis.client import get_job_status_from_redis, publish_listener_event
 
     phase = "plan" if run.status == "planning" else "apply"
+
+    # If no Job has been launched yet (listener never POSTed job-launched),
+    # there's nothing for listeners to query — skip the SSE round-trip and
+    # rely on the launch_timeout in _check_stale.
+    if run.job_name is None:
+        await _check_stale(db, run)
+        return
 
     # Publish check_job_status event to the pool's listener channel
     if run.pool_id:
@@ -215,15 +224,39 @@ async def _handle_failed(db: AsyncSession, run: Run, error_message: str) -> None
 
 
 async def _check_stale(db: AsyncSession, run: Run) -> None:
-    """Check if a run is stale (stuck without Job status for too long)."""
+    """Check if a run is stale (stuck without Job status / Job launch for too long).
+
+    Two timeouts apply, depending on what stage the run is stuck at:
+    - **launch_timeout** (default 5 min) — run has no `job_name` yet. Listener
+      claimed it but never POSTed `job-launched`. Catches /runner-token auth
+      failures, K8s outages at create time, listener crashes mid-launch.
+    - **stale_timeout** (default 1 h) — Job exists but reports no status.
+      Catches dead listeners that stopped reporting, lost SSE channels,
+      pods that never produced output. Looser default because a long
+      `terraform plan` legitimately produces no extra status.
+    """
     phase_start = run.plan_started_at if run.status == "planning" else run.apply_started_at
     if phase_start is None:
         return
 
     cfg = load_runner_config()
-    stale_timeout = timedelta(seconds=cfg.stale_timeout_seconds)
+    if run.job_name is None:
+        timeout = timedelta(seconds=cfg.launch_timeout_seconds)
+        message_prefix = "Run stuck pre-launch"
+    else:
+        timeout = timedelta(seconds=cfg.stale_timeout_seconds)
+        message_prefix = "Run stale"
 
     now = datetime.now(UTC)
-    if now - phase_start > stale_timeout:
-        await _handle_failed(db, run, f"Run stale — no Job status for >{stale_timeout}")
-        logger.warning("Stale run errored", run_id=str(run.id), status=run.status)
+    if now - phase_start > timeout:
+        await _handle_failed(db, run, f"{message_prefix} — no progress for >{timeout}")
+        if run.job_name is None:
+            from terrapod.api.metrics import LISTENER_PRELAUNCH_TIMEOUTS
+
+            LISTENER_PRELAUNCH_TIMEOUTS.inc()
+        logger.warning(
+            "Stale run errored",
+            run_id=str(run.id),
+            status=run.status,
+            had_job=run.job_name is not None,
+        )

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -1,7 +1,7 @@
 """Tests for agent pool endpoints including RBAC gating."""
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import ASGITransport, AsyncClient
@@ -68,6 +68,14 @@ def _mock_listener_dict(listener_id=None, name="listener-1", pool_id=None):
 
 
 class TestListenerHeartbeat:
+    """Heartbeat must be cert-authenticated.
+
+    Without auth, an attacker (or a misconfigured listener) could keep a
+    dead listener "online" by spamming heartbeats — masking a cert auth
+    failure that would otherwise mark the listener offline. The cert's
+    listener-id must also match the path id.
+    """
+
     @patch("terrapod.redis.client.publish_event", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.heartbeat_listener", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_listener")
@@ -77,11 +85,13 @@ class TestListenerHeartbeat:
         mock_get_listener.return_value = listener
 
         app = create_app()
+        app.dependency_overrides[get_listener_identity] = lambda: _mock_listener_identity(lid)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
                 f"/api/v2/listeners/{lid}/heartbeat",
                 json={"capacity": 5, "active_runs": 2, "pod_name": "listener-abc-123"},
+                headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
 
         assert res.status_code == 200
@@ -107,11 +117,13 @@ class TestListenerHeartbeat:
         mock_get_listener.return_value = _mock_listener_dict(listener_id=lid)
 
         app = create_app()
+        app.dependency_overrides[get_listener_identity] = lambda: _mock_listener_identity(lid)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
                 f"/api/v2/listeners/{lid}/heartbeat",
                 json={"capacity": 5, "active_runs": 0},
+                headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
 
         assert res.status_code == 200
@@ -129,11 +141,13 @@ class TestListenerHeartbeat:
         mock_get_listener.return_value = listener
 
         app = create_app()
+        app.dependency_overrides[get_listener_identity] = lambda: _mock_listener_identity(lid)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
                 f"/api/v2/listeners/{lid}/heartbeat",
                 json={"capacity": 3, "active_runs": 1},
+                headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
 
         assert res.status_code == 200
@@ -147,6 +161,21 @@ class TestListenerHeartbeat:
     async def test_heartbeat_not_found(self, mock_get_listener):
         mock_get_listener.return_value = None
 
+        lid = uuid.uuid4()
+        app = create_app()
+        app.dependency_overrides[get_listener_identity] = lambda: _mock_listener_identity(lid)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(
+                f"/api/v2/listeners/{lid}/heartbeat",
+                json={"capacity": 1},
+                headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
+            )
+
+        assert res.status_code == 404
+
+    async def test_heartbeat_without_cert_returns_401(self):
+        """No client cert header → 401 from get_listener_identity."""
         app = create_app()
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
@@ -155,7 +184,24 @@ class TestListenerHeartbeat:
                 json={"capacity": 1},
             )
 
-        assert res.status_code == 404
+        assert res.status_code == 401
+
+    async def test_heartbeat_cert_listener_id_mismatch_returns_403(self):
+        """Cert authenticates as listener A but URL targets listener B → 403."""
+        cert_lid = uuid.uuid4()
+        path_lid = uuid.uuid4()
+
+        app = create_app()
+        app.dependency_overrides[get_listener_identity] = lambda: _mock_listener_identity(cert_lid)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.post(
+                f"/api/v2/listeners/{path_lid}/heartbeat",
+                json={"capacity": 1},
+                headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
+            )
+
+        assert res.status_code == 403
 
 
 class TestListPoolsRBAC:
@@ -321,6 +367,112 @@ class TestPoolStatus:
             res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
 
         assert res.json()["data"]["attributes"]["status"] == "online"
+
+
+# ── Truthful pool/listener status (cert-expiry cross-check) ──────────
+
+
+class TestDeriveListenerStatus:
+    """Cross-check heartbeat-reported status against cert expiry.
+
+    The heartbeat path blindly writes `status: "online"` regardless of cert
+    validity. A listener whose cert has expired keeps heartbeating but every
+    cert-authenticated call (claim run, renew, runner-token, etc.) 401s — it
+    isn't actually working. The derived status must reflect that.
+    """
+
+    def test_online_when_cert_valid(self):
+        from terrapod.api.routers.agent_pools import _derive_listener_status
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        listener = {"status": "online", "certificate_expires_at": future}
+        assert _derive_listener_status(listener) == "online"
+
+    def test_cert_expired_when_expiry_in_past(self):
+        from terrapod.api.routers.agent_pools import _derive_listener_status
+
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        listener = {"status": "online", "certificate_expires_at": past}
+        assert _derive_listener_status(listener) == "cert-expired"
+
+    def test_falls_back_to_raw_status_when_no_expiry_field(self):
+        """Older listeners may not populate the field — preserve the raw value."""
+        from terrapod.api.routers.agent_pools import _derive_listener_status
+
+        assert _derive_listener_status({"status": "offline"}) == "offline"
+        assert _derive_listener_status({"status": "online"}) == "online"
+
+    def test_falls_back_to_raw_status_on_unparseable_expiry(self):
+        from terrapod.api.routers.agent_pools import _derive_listener_status
+
+        listener = {"status": "online", "certificate_expires_at": "garbage"}
+        assert _derive_listener_status(listener) == "online"
+
+
+class TestDerivePoolStatus:
+    def test_offline_when_no_listeners(self):
+        from terrapod.api.routers.agent_pools import _derive_pool_status
+
+        assert _derive_pool_status([]) == "offline"
+
+    def test_online_when_any_listener_healthy(self):
+        from terrapod.api.routers.agent_pools import _derive_pool_status
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        listeners = [
+            {"status": "online", "certificate_expires_at": past},  # cert-expired
+            {"status": "online", "certificate_expires_at": future},  # online
+        ]
+        assert _derive_pool_status(listeners) == "online"
+
+    def test_degraded_when_all_certs_expired(self):
+        """All listeners heartbeating but every cert is past expiry → pool can't run anything."""
+        from terrapod.api.routers.agent_pools import _derive_pool_status
+
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        listeners = [
+            {"status": "online", "certificate_expires_at": past},
+            {"status": "online", "certificate_expires_at": past},
+        ]
+        assert _derive_pool_status(listeners) == "degraded"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
+    @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "terrapod.api.routers.agent_pools.fetch_custom_roles",
+        new_callable=AsyncMock,
+    )
+    async def test_list_pools_returns_degraded_when_all_certs_expired(
+        self, mock_fetch_roles, mock_resolve, mock_list_pools, mock_list_listeners, *mocks
+    ):
+        """End-to-end: heartbeating listener with expired cert surfaces as `degraded` at /agent-pools."""
+        pool = _mock_pool(name="dying-pool")
+        mock_list_pools.return_value = [pool]
+        mock_fetch_roles.return_value = []
+        mock_resolve.return_value = "read"
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        mock_list_listeners.return_value = [
+            {
+                "id": str(uuid.uuid4()),
+                "name": "lis",
+                "status": "online",
+                "certificate_expires_at": past,
+            }
+        ]
+
+        app, _ = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+
+        assert res.json()["data"][0]["attributes"]["status"] == "degraded"
 
 
 class TestListListenersReplicaCount:

--- a/services/tests/api/test_auth_dependency.py
+++ b/services/tests/api/test_auth_dependency.py
@@ -246,7 +246,7 @@ class TestGetListenerIdentity:
             "certificate_fingerprint": fp_b,  # whichever got hset last
         }
 
-        async def fake_is_valid(_lid, fp):
+        async def fake_is_valid(_lid, fp, listener=None):
             return fp in (fp_a, fp_b)
 
         with (
@@ -344,7 +344,7 @@ class TestAuthenticateListener:
             "certificate_fingerprint": fp_b,
         }
 
-        async def fake_is_valid(_lid, fp):
+        async def fake_is_valid(_lid, fp, listener=None):
             return fp in (fp_a, fp_b)
 
         request_a = MagicMock()

--- a/services/tests/api/test_auth_dependency.py
+++ b/services/tests/api/test_auth_dependency.py
@@ -1,5 +1,7 @@
-"""Tests for the unified auth dependency (session + API token)."""
+"""Tests for the unified auth dependency (session + API token + listener cert)."""
 
+import base64
+import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -8,9 +10,16 @@ from fastapi.security import HTTPAuthorizationCredentials
 
 from terrapod.api.dependencies import (
     AuthenticatedUser,
+    authenticate_listener,
     get_current_user,
+    get_listener_identity,
     require_admin,
     require_admin_or_audit,
+)
+from terrapod.auth.ca import (
+    CertificateAuthority,
+    get_certificate_fingerprint,
+    serialize_certificate,
 )
 
 
@@ -189,3 +198,202 @@ class TestRequireAdminOrAudit:
             await require_admin_or_audit(user=user)
 
         assert exc_info.value.status_code == 403
+
+
+# ── Listener certificate auth ──────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def _test_ca() -> CertificateAuthority:
+    """Module-scoped CA so we don't pay 30 cert-generations per test."""
+    return CertificateAuthority.generate()
+
+
+def _cert_header(cert) -> str:
+    """Encode a cert as the X-Terrapod-Client-Cert header value."""
+    return base64.b64encode(serialize_certificate(cert)).decode()
+
+
+class TestGetListenerIdentity:
+    """Cert auth must accept any fingerprint registered in Redis, not just one.
+
+    Concurrent /renew calls register multiple valid fingerprints. Auth treats
+    each as independently valid until the per-fingerprint key TTLs out. This
+    is the regression test for the scenario where pod A and pod B both renew
+    in the same window and one of their certs ends up unused — but both must
+    still authenticate, otherwise the listener fleet 401-loops itself.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_renewals_both_authenticate(self, _test_ca):
+        """Two certs issued seconds apart must both pass cert-auth."""
+        listener_name = "listener-1"
+        listener_id = str(uuid.uuid4())
+        pool_id = str(uuid.uuid4())
+
+        cert_a, _ = _test_ca.issue_listener_certificate(listener_name, "pool-1")
+        cert_b, _ = _test_ca.issue_listener_certificate(listener_name, "pool-1")
+        fp_a = get_certificate_fingerprint(cert_a)
+        fp_b = get_certificate_fingerprint(cert_b)
+        assert fp_a != fp_b  # different keys → different fingerprints
+
+        # Redis state: both fingerprints registered (the bug fix). The hash
+        # carries the latest fingerprint for UI display only — auth ignores it.
+        listener_dict = {
+            "id": listener_id,
+            "name": listener_name,
+            "pool_id": pool_id,
+            "certificate_fingerprint": fp_b,  # whichever got hset last
+        }
+
+        async def fake_is_valid(_lid, fp):
+            return fp in (fp_a, fp_b)
+
+        with (
+            patch("terrapod.auth.ca.get_ca", return_value=_test_ca),
+            patch(
+                "terrapod.services.agent_pool_service.get_listener_by_name",
+                AsyncMock(return_value=listener_dict),
+            ),
+            patch(
+                "terrapod.services.agent_pool_service.is_fingerprint_valid",
+                side_effect=fake_is_valid,
+            ),
+        ):
+            id_a = await get_listener_identity(_cert_header(cert_a))
+            id_b = await get_listener_identity(_cert_header(cert_b))
+
+        assert str(id_a.listener_id) == listener_id
+        assert str(id_b.listener_id) == listener_id
+        assert id_a.certificate_fingerprint == fp_a
+        assert id_b.certificate_fingerprint == fp_b
+
+    @pytest.mark.asyncio
+    async def test_unregistered_fingerprint_rejected(self, _test_ca):
+        """A CA-signed cert whose fingerprint is not registered → 401.
+
+        Defends against a stale cert from a prior listener instance whose
+        Redis registration has aged out, or a forged cert (signed by another
+        instance of the same CA) that was never issued by this server.
+        """
+        listener_name = "listener-1"
+        cert, _ = _test_ca.issue_listener_certificate(listener_name, "pool-1")
+
+        with (
+            patch("terrapod.auth.ca.get_ca", return_value=_test_ca),
+            patch(
+                "terrapod.services.agent_pool_service.get_listener_by_name",
+                AsyncMock(
+                    return_value={
+                        "id": str(uuid.uuid4()),
+                        "name": listener_name,
+                        "pool_id": str(uuid.uuid4()),
+                    }
+                ),
+            ),
+            patch(
+                "terrapod.services.agent_pool_service.is_fingerprint_valid",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_listener_identity(_cert_header(cert))
+
+        assert exc_info.value.status_code == 401
+        assert "not registered" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_listener_not_in_redis_rejected(self, _test_ca):
+        """Cert authenticates against CA but listener has no Redis registration."""
+        cert, _ = _test_ca.issue_listener_certificate("ghost", "pool-1")
+
+        with (
+            patch("terrapod.auth.ca.get_ca", return_value=_test_ca),
+            patch(
+                "terrapod.services.agent_pool_service.get_listener_by_name",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_listener_identity(_cert_header(cert))
+
+        assert exc_info.value.status_code == 401
+
+
+class TestAuthenticateListener:
+    """Same coverage as get_listener_identity but for the SSE-path variant.
+
+    `authenticate_listener` is the Request-based form used by SSE handlers
+    (it must not hold a DB session for the streaming lifetime). Same cert
+    handling, same fingerprint check — keep them in lockstep.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_renewals_both_authenticate(self, _test_ca):
+        listener_name = "listener-1"
+        listener_id = str(uuid.uuid4())
+        cert_a, _ = _test_ca.issue_listener_certificate(listener_name, "pool-1")
+        cert_b, _ = _test_ca.issue_listener_certificate(listener_name, "pool-1")
+        fp_a = get_certificate_fingerprint(cert_a)
+        fp_b = get_certificate_fingerprint(cert_b)
+
+        listener_dict = {
+            "id": listener_id,
+            "name": listener_name,
+            "pool_id": str(uuid.uuid4()),
+            "certificate_fingerprint": fp_b,
+        }
+
+        async def fake_is_valid(_lid, fp):
+            return fp in (fp_a, fp_b)
+
+        request_a = MagicMock()
+        request_a.headers = {"x-terrapod-client-cert": _cert_header(cert_a)}
+        request_b = MagicMock()
+        request_b.headers = {"x-terrapod-client-cert": _cert_header(cert_b)}
+
+        with (
+            patch("terrapod.auth.ca.get_ca", return_value=_test_ca),
+            patch(
+                "terrapod.services.agent_pool_service.get_listener_by_name",
+                AsyncMock(return_value=listener_dict),
+            ),
+            patch(
+                "terrapod.services.agent_pool_service.is_fingerprint_valid",
+                side_effect=fake_is_valid,
+            ),
+        ):
+            id_a = await authenticate_listener(request_a)
+            id_b = await authenticate_listener(request_b)
+
+        assert id_a.certificate_fingerprint == fp_a
+        assert id_b.certificate_fingerprint == fp_b
+
+    @pytest.mark.asyncio
+    async def test_unregistered_fingerprint_rejected(self, _test_ca):
+        cert, _ = _test_ca.issue_listener_certificate("listener-1", "pool-1")
+        request = MagicMock()
+        request.headers = {"x-terrapod-client-cert": _cert_header(cert)}
+
+        with (
+            patch("terrapod.auth.ca.get_ca", return_value=_test_ca),
+            patch(
+                "terrapod.services.agent_pool_service.get_listener_by_name",
+                AsyncMock(
+                    return_value={
+                        "id": str(uuid.uuid4()),
+                        "name": "listener-1",
+                        "pool_id": str(uuid.uuid4()),
+                    }
+                ),
+            ),
+            patch(
+                "terrapod.services.agent_pool_service.is_fingerprint_valid",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await authenticate_listener(request)
+
+        assert exc_info.value.status_code == 401
+        assert "not registered" in exc_info.value.detail.lower()

--- a/services/tests/services/test_agent_pool_service.py
+++ b/services/tests/services/test_agent_pool_service.py
@@ -447,13 +447,15 @@ class TestFingerprintRegistration:
             assert await is_fingerprint_valid("lid-x", "fp-stale") is False
 
     @pytest.mark.asyncio
-    async def test_concurrent_renewals_both_remain_valid(self):
-        """Two pods race on /renew → both fingerprints are independently registered.
+    async def test_two_distinct_fingerprints_can_coexist(self):
+        """Independent keys → two issued fingerprints both authenticate.
 
-        Whichever cert wins the K8s Secret CAS becomes the active one in use,
-        but the loser's cert MUST also auth successfully — otherwise a pod
-        that adopted the winner's cert would 401 and the listener fleet would
-        lock itself out for the rest of the cert lifetime.
+        This is the structural property that makes concurrent /renew safe:
+        each registration writes its own key, so the K8s-Secret CAS can pick
+        either cert and the loser's fingerprint stays auth-valid until it
+        TTLs out — no fingerprint-mismatch 401s. Earlier name hinted at
+        a concurrency test but no actual race is exercised; the property
+        is "two registrations don't interfere".
         """
         registered = set()
 
@@ -511,3 +513,125 @@ class TestFingerprintRegistration:
         cert = MagicMock()
         cert.not_valid_after_utc = datetime.now(UTC) - timedelta(seconds=600)
         assert _fingerprint_ttl(cert) >= 60
+
+
+class TestFingerprintMigrationFallback:
+    """Auth must keep working for listeners that joined before this PR.
+
+    Pre-fix listeners only have their fingerprint on the legacy
+    `certificate_fingerprint` hash field — no `tp:listener_fp:*` key. Without
+    a fallback, the moment this code deploys every existing listener would
+    401 on its next call (heartbeat, renew, runner-token, runs/next), trigger
+    SSE 401s, force a rejoin, and consume join-token uses. A fleet-wide
+    rejoin storm is the exact failure mode this PR is meant to prevent.
+
+    The fallback accepts the legacy field on first request and self-heals
+    by writing the new key, so the slow path is exercised at most once per
+    listener per cert lifetime.
+    """
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_legacy_field_when_new_key_missing(self):
+        mock_redis = MagicMock()
+        # No tp:listener_fp:* key exists — this listener pre-dates the PR.
+        mock_redis.exists = AsyncMock(return_value=0)
+        mock_redis.setex = AsyncMock()
+
+        listener = {
+            "id": "lid-legacy",
+            "certificate_fingerprint": "fp-legacy",
+            "certificate_expires_at": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+        }
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            assert await is_fingerprint_valid("lid-legacy", "fp-legacy", listener=listener) is True
+
+    @pytest.mark.asyncio
+    async def test_fallback_self_heals_to_new_key_family(self):
+        """First fallback request must register the fingerprint going forward."""
+        mock_redis = MagicMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+        mock_redis.setex = AsyncMock()
+
+        listener = {
+            "id": "lid-legacy",
+            "certificate_fingerprint": "fp-legacy",
+            "certificate_expires_at": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+        }
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            await is_fingerprint_valid("lid-legacy", "fp-legacy", listener=listener)
+
+        # New-style key was written so the next call hits the fast path.
+        mock_redis.setex.assert_awaited_once()
+        args = mock_redis.setex.await_args.args
+        assert args[0] == f"{_LISTENER_FP_PREFIX}lid-legacy:fp-legacy"
+        assert args[2] == "1"
+        # TTL ≈ remaining cert lifetime + 60s buffer (~3660s for 1h cert).
+        assert args[1] > 3000
+
+    @pytest.mark.asyncio
+    async def test_fallback_rejects_wrong_fingerprint(self):
+        """Legacy listener fingerprint of A — presenting cert B is still rejected.
+
+        Defends against an attacker who knows the listener-id but presents a
+        different (CA-signed) cert hoping the fallback will accept anything.
+        """
+        mock_redis = MagicMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+        mock_redis.setex = AsyncMock()
+
+        listener = {
+            "id": "lid-legacy",
+            "certificate_fingerprint": "fp-legacy",
+            "certificate_expires_at": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+        }
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            assert (
+                await is_fingerprint_valid("lid-legacy", "fp-different", listener=listener) is False
+            )
+
+        mock_redis.setex.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fallback_uses_safe_default_ttl_when_expiry_unparseable(self):
+        """Garbled/missing certificate_expires_at must not crash — use 1h default."""
+        mock_redis = MagicMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+        mock_redis.setex = AsyncMock()
+
+        listener = {
+            "id": "lid-x",
+            "certificate_fingerprint": "fp",
+            "certificate_expires_at": "not-a-real-date",
+        }
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            assert await is_fingerprint_valid("lid-x", "fp", listener=listener) is True
+
+        assert mock_redis.setex.await_args.args[1] == 3600
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_without_listener_dict(self):
+        """Old call shape (no listener arg) → no fallback → False as before."""
+        mock_redis = MagicMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            assert await is_fingerprint_valid("lid-x", "fp") is False

--- a/services/tests/services/test_agent_pool_service.py
+++ b/services/tests/services/test_agent_pool_service.py
@@ -8,11 +8,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from terrapod.services.agent_pool_service import (
+    _LISTENER_FP_PREFIX,
     LISTENER_POD_TTL,
+    _fingerprint_ttl,
+    _register_fingerprint,
     count_listener_replicas,
     create_pool_token,
     generate_join_token,
     heartbeat_listener,
+    is_fingerprint_valid,
     validate_join_token,
 )
 
@@ -387,3 +391,123 @@ class TestCountListenerReplicas:
             return_value=mock_redis,
         ):
             assert await count_listener_replicas("lid-empty") == 0
+
+
+# ── Per-fingerprint registration (regression: cert renewal race) ──────
+
+
+class TestFingerprintRegistration:
+    """Each issued cert registers its fingerprint as its own TTL'd key.
+
+    The previous design tracked a single "current" fingerprint on the listener
+    hash. When N listener pods all called /renew within the same window, the
+    API issued N distinct certs but the K8s Secret CAS picked one — leaving
+    Redis pointing at a fingerprint that wasn't necessarily the cert all pods
+    actually used. Subsequent cert-auth calls 401'd with "fingerprint mismatch".
+
+    The fix: store each issued fingerprint under its own key. Auth does EXISTS
+    instead of equality. Concurrent renewals all stay valid until they expire.
+    """
+
+    @pytest.mark.asyncio
+    async def test_register_writes_setex_with_namespaced_key(self):
+        mock_redis = MagicMock()
+        mock_redis.setex = AsyncMock()
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            await _register_fingerprint("lid-x", "fp-abc", 600)
+
+        mock_redis.setex.assert_awaited_once_with(f"{_LISTENER_FP_PREFIX}lid-x:fp-abc", 600, "1")
+
+    @pytest.mark.asyncio
+    async def test_is_valid_true_when_key_exists(self):
+        mock_redis = MagicMock()
+        mock_redis.exists = AsyncMock(return_value=1)
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            assert await is_fingerprint_valid("lid-x", "fp-abc") is True
+
+        mock_redis.exists.assert_awaited_once_with(f"{_LISTENER_FP_PREFIX}lid-x:fp-abc")
+
+    @pytest.mark.asyncio
+    async def test_is_valid_false_when_key_absent(self):
+        mock_redis = MagicMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            assert await is_fingerprint_valid("lid-x", "fp-stale") is False
+
+    @pytest.mark.asyncio
+    async def test_concurrent_renewals_both_remain_valid(self):
+        """Two pods race on /renew → both fingerprints are independently registered.
+
+        Whichever cert wins the K8s Secret CAS becomes the active one in use,
+        but the loser's cert MUST also auth successfully — otherwise a pod
+        that adopted the winner's cert would 401 and the listener fleet would
+        lock itself out for the rest of the cert lifetime.
+        """
+        registered = set()
+
+        mock_redis = MagicMock()
+
+        async def fake_setex(key, ttl, value):
+            registered.add(key)
+
+        async def fake_exists(key):
+            return 1 if key in registered else 0
+
+        mock_redis.setex = fake_setex
+        mock_redis.exists = fake_exists
+
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            # Two concurrent renewals → two distinct fingerprints registered.
+            await _register_fingerprint("lid-x", "fp-pod-a", 600)
+            await _register_fingerprint("lid-x", "fp-pod-b", 600)
+
+            # Both must auth successfully regardless of which won the K8s
+            # Secret CAS on the listener side.
+            assert await is_fingerprint_valid("lid-x", "fp-pod-a") is True
+            assert await is_fingerprint_valid("lid-x", "fp-pod-b") is True
+
+        # And a rogue cert never registered must still be rejected.
+        with patch(
+            "terrapod.services.agent_pool_service.get_redis_client",
+            return_value=mock_redis,
+        ):
+            assert await is_fingerprint_valid("lid-x", "fp-not-issued") is False
+
+    def test_ttl_buffer_against_clock_skew(self):
+        """The fingerprint key TTL is cert lifetime + 60s buffer.
+
+        The buffer prevents the rare case where Redis evicts the fingerprint
+        key a moment before the cert's not-after, causing a still-valid cert
+        to fail auth. 60s is enough for any realistic API↔Redis clock skew.
+        """
+        cert = MagicMock()
+        cert.not_valid_after_utc = datetime.now(UTC) + timedelta(seconds=600)
+        ttl = _fingerprint_ttl(cert)
+        # Should be ~660s (600 + 60 buffer); allow slack for test wall-clock drift.
+        assert 650 <= ttl <= 670
+
+    def test_ttl_floor_at_60_for_already_expired(self):
+        """An expired cert still gets a 60s floor so we don't pass 0/negative TTL.
+
+        Redis SETEX rejects a 0 or negative TTL with a runtime error. Better
+        to register the fingerprint briefly (it'll be rejected by the
+        not-after check in dependencies.py anyway) than crash the renewal.
+        """
+        cert = MagicMock()
+        cert.not_valid_after_utc = datetime.now(UTC) - timedelta(seconds=600)
+        assert _fingerprint_ttl(cert) >= 60

--- a/services/tests/services/test_listener.py
+++ b/services/tests/services/test_listener.py
@@ -221,3 +221,61 @@ class TestConcurrentSafety:
         )
 
         assert len(claims) >= 5  # Both paths contributed
+
+
+# ── Launch failure reporting ─────────────────────────────────────────
+
+
+class TestLaunchFailureReporting:
+    """Pre-Job failures must be reported to the API so the run errors out fast.
+
+    Without this, /runner-token 401 / create_job exception / etc. would leave
+    the run in `planning` until the reconciler's launch_timeout (5 min). Active
+    reporting from the listener gives operators an immediate, accurate error
+    message at the API rather than a generic timeout 5 min later.
+    """
+
+    async def test_runner_token_failure_reports_errored(self, fresh_shutdown_event):
+        listener = _make_listener(fresh_shutdown_event)
+        listener._get_runner_token = AsyncMock(side_effect=RuntimeError("401 Unauthorized"))
+        listener._http_client = AsyncMock()
+
+        await listener._launch_run("abc-123", {"phase": "plan"})
+
+        listener._http_client.patch.assert_awaited_once()
+        kwargs = listener._http_client.patch.await_args.kwargs
+        body = kwargs["json"]
+        assert body["status"] == "errored"
+        assert "runner token" in body["error_message"].lower()
+        assert "401" in body["error_message"]
+
+    async def test_create_job_failure_reports_errored(self, fresh_shutdown_event):
+        listener = _make_listener(fresh_shutdown_event)
+        listener._get_runner_token = AsyncMock(return_value="runtok:xyz")
+        listener._http_client = AsyncMock()
+        listener.runner_config = MagicMock()
+
+        with (
+            patch("terrapod.runner.job_template.build_job_spec", return_value={"kind": "Job"}),
+            patch(
+                "terrapod.runner.job_manager.create_job",
+                AsyncMock(side_effect=RuntimeError("kubernetes API down")),
+            ),
+        ):
+            await listener._launch_run("abc-123", {"phase": "plan"})
+
+        listener._http_client.patch.assert_awaited_once()
+        body = listener._http_client.patch.await_args.kwargs["json"]
+        assert body["status"] == "errored"
+        assert (
+            "k8s job" in body["error_message"].lower() or "create" in body["error_message"].lower()
+        )
+
+    async def test_report_failure_swallows_patch_errors(self, fresh_shutdown_event):
+        """Best-effort: a failed PATCH must not crash the listener event loop."""
+        listener = _make_listener(fresh_shutdown_event)
+        listener._http_client = AsyncMock()
+        listener._http_client.patch = AsyncMock(side_effect=RuntimeError("network down"))
+
+        # Must not raise
+        await listener._report_launch_failed("abc-123", "boom")

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -249,7 +249,9 @@ class TestCheckStale:
     @patch("terrapod.services.run_reconciler.load_runner_config")
     @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
     async def test_stale_plan_gets_errored(self, mock_handle, mock_config):
-        mock_config.return_value = MagicMock(stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS)
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS, launch_timeout_seconds=300
+        )
         db = AsyncMock()
         run = _mock_run(
             status="planning",
@@ -266,7 +268,9 @@ class TestCheckStale:
     @patch("terrapod.services.run_reconciler.load_runner_config")
     @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
     async def test_stale_apply_gets_errored(self, mock_handle, mock_config):
-        mock_config.return_value = MagicMock(stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS)
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS, launch_timeout_seconds=300
+        )
         db = AsyncMock()
         run = _mock_run(
             status="applying",
@@ -282,7 +286,9 @@ class TestCheckStale:
     @patch("terrapod.services.run_reconciler.load_runner_config")
     @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
     async def test_not_stale_yet(self, mock_handle, mock_config):
-        mock_config.return_value = MagicMock(stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS)
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS, launch_timeout_seconds=300
+        )
         db = AsyncMock()
         run = _mock_run(
             status="planning",
@@ -296,7 +302,9 @@ class TestCheckStale:
     @patch("terrapod.services.run_reconciler.load_runner_config")
     @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
     async def test_no_phase_start_skips_check(self, mock_handle, mock_config):
-        mock_config.return_value = MagicMock(stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS)
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS, launch_timeout_seconds=300
+        )
         db = AsyncMock()
         run = _mock_run(status="planning", plan_started_at=None)
 
@@ -309,7 +317,9 @@ class TestCheckStale:
     async def test_custom_timeout_from_config(self, mock_handle, mock_config):
         """Stale timeout is read from RunnerConfig, not hardcoded."""
         custom_timeout = 300  # 5 minutes
-        mock_config.return_value = MagicMock(stale_timeout_seconds=custom_timeout)
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=custom_timeout, launch_timeout_seconds=300
+        )
         db = AsyncMock()
         # 10 minutes ago — stale with 5m timeout, NOT stale with default 1h
         run = _mock_run(
@@ -321,3 +331,109 @@ class TestCheckStale:
 
         mock_handle.assert_called_once()
         assert "stale" in mock_handle.call_args.args[2].lower()
+
+
+# ── launch_timeout (no job_name) cohort ──────────────────────────────
+
+
+class TestCheckStaleLaunchTimeout:
+    """Runs that were claimed but never had a Job launched.
+
+    The listener can claim a run (transitioning it to planning/applying with
+    listener_id set) but then fail to actually create the K8s Job — auth
+    failure on /runner-token, K8s outage at create_job time, listener crash
+    mid-launch. Without picking these up they sit indefinitely. The shorter
+    launch_timeout (default 5 min) catches them quickly.
+    """
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_pre_launch_run_errors_after_launch_timeout(self, mock_handle, mock_config):
+        mock_config.return_value = MagicMock(stale_timeout_seconds=3600, launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            job_name=None,  # never launched
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=10),  # > 5 min
+        )
+
+        await _check_stale(db, run)
+
+        mock_handle.assert_called_once()
+        assert "pre-launch" in mock_handle.call_args.args[2].lower()
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_pre_launch_timeout_increments_metric(self, mock_handle, mock_config):
+        """Backstop counter for silent listener failures must fire on pre-launch timeout."""
+        from terrapod.api.metrics import LISTENER_PRELAUNCH_TIMEOUTS
+
+        mock_config.return_value = MagicMock(stale_timeout_seconds=3600, launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            job_name=None,
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=10),
+        )
+
+        before = LISTENER_PRELAUNCH_TIMEOUTS._value.get()
+        await _check_stale(db, run)
+        after = LISTENER_PRELAUNCH_TIMEOUTS._value.get()
+
+        assert after == before + 1
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_pre_launch_run_within_window_not_errored(self, mock_handle, mock_config):
+        """Same condition as above but only 2 min in — under the 5m launch_timeout."""
+        mock_config.return_value = MagicMock(stale_timeout_seconds=3600, launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            job_name=None,
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=2),
+        )
+
+        await _check_stale(db, run)
+
+        mock_handle.assert_not_called()
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_running_job_uses_stale_timeout_not_launch_timeout(
+        self, mock_handle, mock_config
+    ):
+        """A run with job_name set must use stale_timeout (1h), not launch_timeout (5m).
+
+        Otherwise legitimate long plans would get killed at 5 min just because
+        the Job hasn't reported intermediate status.
+        """
+        mock_config.return_value = MagicMock(stale_timeout_seconds=3600, launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            job_name="tprun-abc123-plan",  # Job exists
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=20),  # >5m, <1h
+        )
+
+        await _check_stale(db, run)
+
+        mock_handle.assert_not_called()
+
+
+class TestReconcileOneWithoutJobName:
+    """Pre-launch runs (no job_name) skip the SSE round-trip and go straight to stale check."""
+
+    @patch("terrapod.redis.client.get_job_status_from_redis", new_callable=AsyncMock)
+    @patch("terrapod.redis.client.publish_listener_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_reconciler._check_stale", new_callable=AsyncMock)
+    async def test_no_job_name_skips_publish(self, mock_check_stale, mock_publish, mock_status):
+        """No SSE check_job_status published — there's no Job for listeners to query."""
+        db = AsyncMock()
+        run = _mock_run(job_name=None)
+
+        await _reconcile_one(db, run)
+
+        mock_publish.assert_not_called()
+        mock_status.assert_not_called()
+        mock_check_stale.assert_called_once()

--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -23,7 +23,30 @@ interface PoolAttrs {
   'owner-email': string
   permission?: string
   'created-at': string
-  status?: 'online' | 'offline'
+  status?: 'online' | 'offline' | 'degraded'
+}
+
+function statusDotClass(status: string | undefined): string {
+  if (status === 'online') return 'bg-green-400'
+  if (status === 'cert-expired') return 'bg-red-400'
+  if (status === 'degraded') return 'bg-amber-400'
+  return 'bg-slate-500'
+}
+
+function statusTitle(status: string | undefined): string | undefined {
+  if (status === 'cert-expired') return 'Listener is heartbeating but its certificate has expired — every cert-authenticated call (claim run, renew, runner-token) will fail. Most likely cause: the API never registered the latest cert, or the cert TTL elapsed before renewal.'
+  if (status === 'degraded') return 'Listeners are heartbeating but their certificates have expired — runs will fail to launch.'
+  return undefined
+}
+
+function defaultExpiryLocal(): string {
+  // Mirror the server's default_join_token_ttl_seconds (3600s = 1h) and format
+  // as a value the <input type="datetime-local"> accepts: "YYYY-MM-DDTHH:mm"
+  // in the browser's local TZ. The form submits this back as a local datetime
+  // and the API parses it as TZ-aware.
+  const d = new Date(Date.now() + 60 * 60 * 1000)
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 interface Pool {
@@ -86,8 +109,13 @@ export default function AgentPoolDetailPage() {
   const [tokensLoading, setTokensLoading] = useState(false)
   const [showCreateToken, setShowCreateToken] = useState(false)
   const [tokenDesc, setTokenDesc] = useState('')
-  const [tokenMaxUses, setTokenMaxUses] = useState('')
-  const [tokenExpiry, setTokenExpiry] = useState('')
+  // Prepopulate to mirror the server-side defaults
+  // (settings.agent_pools.default_join_token_max_uses=2, default_join_token_ttl_seconds=3600).
+  // An empty form submitted as-is would still get these defaults applied at the
+  // API, but blank inputs imply "no default" to the user — show what they'll
+  // actually get so the choice is informed.
+  const [tokenMaxUses, setTokenMaxUses] = useState('2')
+  const [tokenExpiry, setTokenExpiry] = useState(() => defaultExpiryLocal())
   const [creatingToken, setCreatingToken] = useState(false)
   const [createdToken, setCreatedToken] = useState<string | null>(null)
 
@@ -231,8 +259,8 @@ export default function AgentPoolDetailPage() {
       const data = await res.json()
       setCreatedToken(data.data?.attributes?.token || null)
       setTokenDesc('')
-      setTokenMaxUses('')
-      setTokenExpiry('')
+      setTokenMaxUses('2')
+      setTokenExpiry(defaultExpiryLocal())
       setShowCreateToken(false)
       await loadTokens()
     } catch (err) {
@@ -470,17 +498,18 @@ export default function AgentPoolDetailPage() {
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                   </div>
                   <div>
-                    <label htmlFor="tok-max" className="block text-sm font-medium text-slate-300 mb-1">Max Uses (optional)</label>
+                    <label htmlFor="tok-max" className="block text-sm font-medium text-slate-300 mb-1">Max Uses</label>
                     <input id="tok-max" type="number" value={tokenMaxUses} onChange={(e) => setTokenMaxUses(e.target.value)}
                       min="1"
                       step="1"
-                      placeholder="Unlimited"
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
+                    <p className="mt-1 text-xs text-slate-500">Default 2 — tolerates one bootstrap-race retry across listener replicas.</p>
                   </div>
                   <div>
-                    <label htmlFor="tok-exp" className="block text-sm font-medium text-slate-300 mb-1">Expires At (optional)</label>
+                    <label htmlFor="tok-exp" className="block text-sm font-medium text-slate-300 mb-1">Expires At</label>
                     <input id="tok-exp" type="datetime-local" value={tokenExpiry} onChange={(e) => setTokenExpiry(e.target.value)}
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
+                    <p className="mt-1 text-xs text-slate-500">Default 1 hour from now.</p>
                   </div>
                 </div>
                 <button type="submit" disabled={creatingToken}
@@ -563,8 +592,8 @@ export default function AgentPoolDetailPage() {
                       <tr key={l.id} className="hover:bg-slate-700/20 transition-colors">
                         <td className="px-4 py-3 text-sm text-slate-200">{l.attributes.name}</td>
                         <td className="px-4 py-3">
-                          <span className="flex items-center gap-1.5">
-                            <span className={`w-2 h-2 rounded-full ${l.attributes.status === 'online' ? 'bg-green-400' : 'bg-slate-500'}`} />
+                          <span className="flex items-center gap-1.5" title={statusTitle(l.attributes.status)}>
+                            <span className={`w-2 h-2 rounded-full ${statusDotClass(l.attributes.status)}`} />
                             <span className="text-xs text-slate-400">{l.attributes.status}</span>
                           </span>
                         </td>

--- a/web/src/app/admin/agent-pools/page.tsx
+++ b/web/src/app/admin/agent-pools/page.tsx
@@ -25,11 +25,17 @@ interface AgentPool {
     'owner-email': string
     permission?: string
     'created-at': string
-    status?: 'online' | 'offline'
+    status?: 'online' | 'offline' | 'degraded'
   }
 }
 
 type PoolSortKey = 'name' | 'description' | 'created'
+
+function statusDotClass(status: string | undefined): string {
+  if (status === 'online') return 'bg-green-400'
+  if (status === 'degraded') return 'bg-amber-400'
+  return 'bg-slate-500'
+}
 
 export default function AgentPoolsPage() {
   const router = useRouter()
@@ -190,8 +196,8 @@ export default function AgentPoolsPage() {
                     </td>
                     <td className="px-4 py-3 hidden md:table-cell">
                       {pool.attributes.status ? (
-                        <span className="inline-flex items-center gap-1.5">
-                          <span className={`w-2 h-2 rounded-full ${pool.attributes.status === 'online' ? 'bg-green-400' : 'bg-slate-500'}`} />
+                        <span className="inline-flex items-center gap-1.5" title={pool.attributes.status === 'degraded' ? 'Listeners are heartbeating but their certificates have expired — runs will fail to launch.' : undefined}>
+                          <span className={`w-2 h-2 rounded-full ${statusDotClass(pool.attributes.status)}`} />
                           <span className="text-xs text-slate-400 capitalize">{pool.attributes.status}</span>
                         </span>
                       ) : (


### PR DESCRIPTION
## Summary

Five overlapping bugs in the listener / agent-pool path that combined to make a single botched cert renewal lock the listener fleet out for the rest of a cert's lifetime, while the UI happily reported "online":

1. **Cert renewal race (P0)** — concurrent `/renew` calls left Redis fingerprint and the K8s Secret cert in disagreement → 401 on every cert-authenticated call until cert expiry.
2. **Silent run failures (P0)** — `/runner-token` 401s and other pre-Job failures were swallowed. Runs sat in `planning` for an hour with no signal.
3. **Listener auth gaps (P1)** — `/heartbeat`, `/runs/next`, `/job-launched`, `/job-status`, `PATCH /runs/{id}`, `/log-stream` accepted any caller. A broken listener kept "heartbeating online" while every cert-authed call 401'd; anyone with a listener-id could claim runs and read resolved sensitive variables.
4. **Misleading pool/listener status (P1)** — heartbeat path wrote `status: online` regardless of cert validity. UI showed online for listeners that couldn't authenticate any cert call.
5. **Failure signaling (P2)** — no counters or operator-actionable signal when a listener rejoins after persistent auth failures or fails to launch a Job.

Plus one UX bug spotted along the way:
6. **Join-token form** — pre-populates with the server-side defaults (max-uses=2, 1h expiry) so admins see what they'll actually get.

## Renewal race detail

When N listener pods all hit the renewal threshold at the same time:
- The **API side** (`agent_pool_service.renew_listener_certificate`) issued a fresh cert per call and unconditionally `HSET` the new fingerprint onto the listener hash. Last write wins.
- The **listener side** (`runner/identity.renew_loop`) wrote the new cert to a shared K8s Secret with `resourceVersion` CAS. One pod's cert wins; the others adopt the winner.

These two coordination mechanisms aren't joined up. If pod A wins the K8s Secret CAS but pod B was the last to update Redis, every subsequent cert-auth call presents pod A's cert against Redis fingerprint B and 401s with "fingerprint mismatch". The listener swallows the 401, retries until the on-disk cert expires, then bootstraps via the join token. By that point the run that was queued on the listener has been silently sitting in `planning` for hours.

Confirmed in production (Loki on a prod cluster): two `/renew` calls landed 10 ms apart, after which every cert-auth call from that listener returned 401 until the next bootstrap.

### Fix

Replace the single `certificate_fingerprint` hash field with a per-fingerprint TTL'd Redis key:

  tp:listener_fp:{listener_id}:{fingerprint}  → "1"  (TTL = cert lifetime + 60s)

- `join_listener` and `renew_listener_certificate` register the new fingerprint
- Cert-auth (`get_listener_identity`, `authenticate_listener`) does `EXISTS` instead of equality
- The hash's `certificate_fingerprint` field is kept for UI display only

Concurrent /renew calls each register their own fingerprint. Both certs are independently valid until their TTLs expire. The K8s Secret CAS still serializes which cert is _actively used_, but the loser cert no longer triggers spurious 401s in the meantime.

### Backwards-compat at deploy time

A naive flip from "compare equality" → "EXISTS" would 401 every listener that joined under the old scheme — their cert was registered on the legacy hash field, no `tp:listener_fp:*` key exists. `is_fingerprint_valid` now accepts the listener dict, falls back to the legacy field if the new key is missing, and **self-heals** by writing the new key with a TTL derived from `certificate_expires_at`. After the first request from each pre-existing listener the fallback path stops being exercised.

## Other fixes

| Concern | Change |
|---|---|
| Silent run failures (listener) | `_launch_run` PATCHes the run to `errored` with the actual error on `/runner-token` / `create_job` / `_create_auth_secret` failure |
| Silent run failures (reconciler) | New `launch_timeout_seconds` (default 300s) for runs claimed but never had a Job launched. Reconciler now picks up runs without `job_name` and times them out |
| Auth gaps | `Depends(get_listener_identity)` added to `/heartbeat`, `/runs/next`, `/job-launched`, `/job-status`, `/log-stream`, `PATCH /runs/{id}` with cert-listener-id == path-listener-id check |
| Misleading status | `_derive_listener_status` cross-checks cert expiry, returns `cert-expired` for heartbeating-but-broken listeners. `_derive_pool_status` returns `degraded` when all listeners are cert-expired. Frontend renders both with explanatory tooltips |
| Failure signaling | Counters `terrapod_listener_launch_failures_total` and `terrapod_listener_prelaunch_timeouts_total`; rejoin log bumped to error level with listener-id |
| Token form UX | Pre-populates `Max Uses` (2) and `Expires At` (now+1h) with server defaults |

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1130 passing (+23 new)
- [x] `helm template ./helm/terrapod -f helm/terrapod/values-local.yaml` clean
- [x] Frontend `npm run build` succeeds (lightningcss native binary issue is environmental, build passes against unmodified main)

Test coverage:
- Concurrent-renewal regression in service + dependencies layer (two distinct fingerprints registered, both auth pass)
- **Migration fallback**: legacy listener auth succeeds, self-heals to new key family, rejects wrong fingerprint, handles malformed expiry, preserves old call shape
- Launch failure reporting from listener side (runner-token failure, K8s create failure)
- Pre-launch timeout in reconciler (no `job_name` cohort) + counter increment
- Heartbeat auth gating (no cert → 401, mismatched cert → 403)
- Status derivation for cert-expired and degraded across listener and pool