### PR TITLE
feat(workspaces): status filter dropdown + reserved label keys

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -314,19 +314,21 @@ A small set of label keys are reserved as **virtual filter fields** in the works
 | Reserved key | Maps to | Filter status |
 |---|---|---|
 | `status` | derived run status (`errored`, `needs-confirm`, `drifted`, `applied`, …) | implemented |
-| `pool` | `agent_pool_name` | reserved (future virtual) |
-| `mode` | `execution_mode` (`local`/`agent`) | reserved (future virtual) |
-| `backend` | `execution_backend` (`tofu`/`terraform`) | reserved (future virtual) |
-| `owner` | `owner_email` | reserved (future virtual) |
-| `drift` | `drift_status` (`drifted`/`in_sync`/`never_checked`) | reserved (future virtual) |
-| `version` | `terraform_version` | reserved (future virtual) |
-| `vcs` | true if the workspace has a VCS connection | reserved (future virtual) |
-| `locked` | `locked` boolean | reserved (future virtual) |
-| `branch` | `vcs_branch` | reserved (future virtual) |
+| `pool` | `agent_pool_name` | reserved (planned virtual) |
+| `mode` | `execution_mode` (`local`/`agent`) | reserved (planned virtual) |
+| `backend` | `execution_backend` (`tofu`/`terraform`) | reserved (planned virtual) |
+| `owner` | `owner_email` | reserved (planned virtual) |
+| `drift` | `drift_status` (`drifted`/`in_sync`/`never_checked`) | reserved (planned virtual) |
+| `version` | `terraform_version` | reserved (planned virtual) |
+| `vcs` | `true`/`false` — has VCS connection | reserved (planned virtual) |
+| `locked` | `true`/`false` — currently locked | reserved (planned virtual) |
+| `branch` | `vcs_branch` | reserved (planned virtual) |
 
-If you have an existing label with one of these keys (from a deployment that pre-dates this restriction), reads and existing rows continue to work, but the next create or update of that resource that includes the reserved key in its `labels` field will be rejected. Migrate by renaming — for example, swap `pool: shared` for `team-pool: shared` (or simply drop it if the same data is already on `agent_pool_id`).
+The set is intentionally aggressive: reserving a key today is near-zero cost (no virtual implementation required), but adding a reservation later — once the key is in customer use as a literal label — is a migration.
 
-The list lives in `terrapod.services.label_validation.RESERVED_LABEL_KEYS`. Adding to it is a behaviour change for any deployment with existing labels using the new key.
+If you have an existing label with one of the reserved keys, reads and existing rows continue to work, but the next create or update of that resource that includes the reserved key in its `labels` field will be rejected with a 422 that names the offending key. Migrate by renaming — for example, swap `version: 1.11` for `tf-version: 1.11` (or drop it if the same data is already on `terraform_version`).
+
+The list lives in `terrapod.services.label_validation.RESERVED_LABEL_KEYS`. Adding to it is a behaviour change for any deployment with existing labels using the new key — update both the constant and this table together.
 
 ### Labels are also Tags
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -295,6 +295,39 @@ curl -X PATCH https://terrapod.example.com/api/v2/workspaces/ws-{id} \
 - Owners have `admin` permission on their workspace
 - Only a platform admin can change workspace ownership
 
+### Label Limits
+
+Labels are validated at the API on workspace, agent pool, and registry module/provider create or update. The API returns **422 Unprocessable Entity** if any of the following limits are violated:
+
+| Limit | Value |
+|---|---|
+| Maximum labels per resource | 50 |
+| Maximum label key length | 63 characters |
+| Maximum label value length | 255 characters |
+
+Keys and values must be strings.
+
+### Reserved Label Keys
+
+A small set of label keys are reserved as **virtual filter fields** in the workspace-list filter UI. A filter term like `status:errored` resolves against a workspace's derived status, not against a literal label called `status`. To keep that filter language unambiguous, these keys cannot be used as literal labels — the API rejects them on create and update with 422.
+
+| Reserved key | Maps to | Filter status |
+|---|---|---|
+| `status` | derived run status (`errored`, `needs-confirm`, `drifted`, `applied`, …) | implemented |
+| `pool` | `agent_pool_name` | reserved (future virtual) |
+| `mode` | `execution_mode` (`local`/`agent`) | reserved (future virtual) |
+| `backend` | `execution_backend` (`tofu`/`terraform`) | reserved (future virtual) |
+| `owner` | `owner_email` | reserved (future virtual) |
+| `drift` | `drift_status` (`drifted`/`in_sync`/`never_checked`) | reserved (future virtual) |
+| `version` | `terraform_version` | reserved (future virtual) |
+| `vcs` | true if the workspace has a VCS connection | reserved (future virtual) |
+| `locked` | `locked` boolean | reserved (future virtual) |
+| `branch` | `vcs_branch` | reserved (future virtual) |
+
+If you have an existing label with one of these keys (from a deployment that pre-dates this restriction), reads and existing rows continue to work, but the next create or update of that resource that includes the reserved key in its `labels` field will be rejected. Migrate by renaming — for example, swap `pool: shared` for `team-pool: shared` (or simply drop it if the same data is already on `agent_pool_id`).
+
+The list lives in `terrapod.services.label_validation.RESERVED_LABEL_KEYS`. Adding to it is a behaviour change for any deployment with existing labels using the new key.
+
 ### Labels are also Tags
 
 Workspace labels do double duty: alongside their primary role in label-based RBAC, they also stand in for TFE's "workspace tags" concept on the CLI. The `cloud { workspaces { tags = ... } }` block in your `.tf` config is matched against the same `labels` map.

--- a/services/terrapod/api/labels.py
+++ b/services/terrapod/api/labels.py
@@ -1,0 +1,29 @@
+"""FastAPI helper that translates label-validation errors to HTTP 422.
+
+The pure validator lives in `terrapod.services.label_validation` and is
+web-framework-agnostic. Routers should import the wrapper here so they
+get a single-call surface that raises `HTTPException` directly.
+"""
+
+from fastapi import HTTPException
+
+from terrapod.services.label_validation import (
+    LabelValidationError,
+)
+from terrapod.services.label_validation import (
+    validate_labels as _validate_labels,
+)
+
+
+def validate_labels(labels: dict | None) -> dict:
+    """Validate labels and translate any `LabelValidationError` to HTTP 422.
+
+    Routers calling this get the same shape as the underlying validator
+    (clean dict in, clean dict out) but with HTTP semantics on failure.
+    Any other exception type (programmer error, etc.) propagates
+    untranslated so the global exception handler can log it as a 500.
+    """
+    try:
+        return _validate_labels(labels)
+    except LabelValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -41,6 +41,7 @@ from terrapod.api.dependencies import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service
+from terrapod.services.label_validation import validate_labels as _validate_labels
 from terrapod.services.pool_rbac_service import (
     POOL_PERMISSION_HIERARCHY,
     fetch_custom_roles,
@@ -78,35 +79,6 @@ def _validate_owner_email(email: str | None) -> str | None:
     if not _EMAIL_RE.match(email):
         raise HTTPException(status_code=422, detail="owner-email must be a valid email address")
     return email
-
-
-_MAX_LABELS = 50
-_MAX_LABEL_KEY_LEN = 63
-_MAX_LABEL_VALUE_LEN = 255
-
-
-def _validate_labels(labels: dict | None) -> dict:
-    """Validate labels are string key-value pairs within size limits."""
-    if not labels:
-        return {}
-    if not isinstance(labels, dict):
-        raise HTTPException(status_code=422, detail="labels must be an object")
-    if len(labels) > _MAX_LABELS:
-        raise HTTPException(status_code=422, detail=f"labels cannot exceed {_MAX_LABELS} entries")
-    clean: dict[str, str] = {}
-    for k, v in labels.items():
-        if not isinstance(k, str) or not isinstance(v, str):
-            raise HTTPException(status_code=422, detail="label keys and values must be strings")
-        if len(k) > _MAX_LABEL_KEY_LEN:
-            raise HTTPException(
-                status_code=422, detail=f"label key exceeds {_MAX_LABEL_KEY_LEN} characters"
-            )
-        if len(v) > _MAX_LABEL_VALUE_LEN:
-            raise HTTPException(
-                status_code=422, detail=f"label value exceeds {_MAX_LABEL_VALUE_LEN} characters"
-            )
-        clean[k] = v
-    return clean
 
 
 def _pool_json(pool, status: str | None = None, permission: str | None = None) -> dict:

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -38,10 +38,10 @@ from terrapod.api.dependencies import (
     get_listener_identity,
     require_admin,
 )
+from terrapod.api.labels import validate_labels as _validate_labels
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service
-from terrapod.services.label_validation import validate_labels as _validate_labels
 from terrapod.services.pool_rbac_service import (
     POOL_PERMISSION_HIERARCHY,
     fetch_custom_roles,

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -36,6 +36,7 @@ from terrapod.api.dependencies import AuthenticatedUser, get_current_user, requi
 from terrapod.db.models import ModuleWorkspaceLink, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
+from terrapod.services.label_validation import validate_labels
 from terrapod.services.registry_module_service import (
     create_module,
     create_module_version,
@@ -249,7 +250,7 @@ async def create_module_endpoint(
 
     module = await create_module(db, "default", attrs.name, attrs.provider)
     module.owner_email = user.email
-    module.labels = attrs.labels
+    module.labels = validate_labels(attrs.labels)
 
     # Apply VCS fields if provided
     if attrs.vcs_connection_id:
@@ -417,7 +418,9 @@ async def update_module_endpoint(
         module.owner_email = attrs["owner-email"]
 
     if "labels" in attrs:
-        new_labels = attrs["labels"]
+        # Validate up-front (size limits + reserved-key check). Raises 422
+        # before any self-lockout logic.
+        new_labels = validate_labels(attrs["labels"])
         # Self-lockout check: warn if label change would reduce user's access
         if (
             new_labels != (module.labels or {})

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -33,10 +33,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_non_runner
+from terrapod.api.labels import validate_labels
 from terrapod.db.models import ModuleWorkspaceLink, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services.label_validation import validate_labels
 from terrapod.services.registry_module_service import (
     create_module,
     create_module_version,

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -35,9 +35,9 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_non_runner
+from terrapod.api.labels import validate_labels
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services.label_validation import validate_labels
 from terrapod.services.platform_provider_service import (
     get_download_info as platform_get_download_info,
 )

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -37,6 +37,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_non_runner
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
+from terrapod.services.label_validation import validate_labels
 from terrapod.services.platform_provider_service import (
     get_download_info as platform_get_download_info,
 )
@@ -314,7 +315,7 @@ async def create_provider_endpoint(
 
     provider = await create_provider(db, "default", attrs.name)
     provider.owner_email = user.email
-    provider.labels = attrs.labels
+    provider.labels = validate_labels(attrs.labels)
     await db.commit()
 
     logger.info("Registry provider created", name=attrs.name, owner=user.email)
@@ -434,7 +435,9 @@ async def update_provider_endpoint(
         provider.owner_email = attrs["owner-email"]
 
     if "labels" in attrs:
-        new_labels = attrs["labels"]
+        # Validate up-front (size limits + reserved-key check). Raises 422
+        # before any self-lockout logic.
+        new_labels = validate_labels(attrs["labels"])
         # Self-lockout check: warn if label change would reduce user's access
         if (
             new_labels != (provider.labels or {})

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -47,11 +47,11 @@ from terrapod.api.dependencies import (
     get_current_user,
     require_non_runner,
 )
+from terrapod.api.labels import validate_labels
 from terrapod.db.models import Run, StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service as _agent_pool_service
-from terrapod.services.label_validation import validate_labels
 from terrapod.services.pool_rbac_service import has_pool_permission, resolve_pool_permission
 from terrapod.services.workspace_rbac_service import (
     PERMISSION_HIERARCHY,

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -51,6 +51,7 @@ from terrapod.db.models import Run, StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service as _agent_pool_service
+from terrapod.services.label_validation import validate_labels
 from terrapod.services.pool_rbac_service import has_pool_permission, resolve_pool_permission
 from terrapod.services.workspace_rbac_service import (
     PERMISSION_HIERARCHY,
@@ -788,7 +789,7 @@ async def create_workspace(
         working_directory=_sanitize_working_directory(attrs.get("working-directory", "")),
         resource_cpu=attrs.get("resource-cpu", "1"),
         resource_memory=attrs.get("resource-memory", "2Gi"),
-        labels=attrs.get("labels", {}),
+        labels=validate_labels(attrs.get("labels", {})),
         owner_email=user.email,
         agent_pool_id=agent_pool_id,
         vcs_connection_id=vcs_connection_id,
@@ -1000,7 +1001,10 @@ async def update_workspace(
     if "resource-memory" in attrs:
         ws.resource_memory = attrs["resource-memory"]
     if "labels" in attrs:
-        new_labels = attrs["labels"]
+        # Validate up-front (size limits + reserved-key check). Raises 422
+        # before any self-lockout logic so the error path stays simple and
+        # the user gets a clear message naming the offending key.
+        new_labels = validate_labels(attrs["labels"])
         # Self-lockout check: warn if label change would reduce user's access
         # Platform admins and owners are immune (their access doesn't depend on labels)
         if (

--- a/services/terrapod/services/label_validation.py
+++ b/services/terrapod/services/label_validation.py
@@ -7,20 +7,28 @@ filter terms like `status:errored` resolve against a workspace's derived
 status, not against a literal label called `status`. Allowing literal labels
 with reserved keys would make the filter ambiguous.
 
+This module is web-framework-agnostic: it raises `ValueError` on violations
+so it can be called from FastAPI routers, CLI tools, migration scripts, or
+background tasks. Routers translate `ValueError` to HTTP 422 via the wrapper
+in `terrapod.api.labels`.
+
 Keep `RESERVED_LABEL_KEYS` in lockstep with the filter parser in
 `web/src/lib/workspace-filter.ts`. Each reserved key listed here either is
-already implemented as a virtual filter term, or is reserved for an upcoming
+already implemented as a virtual filter term, or is reserved for a planned
 one — see `docs/rbac.md` for the user-facing list.
 """
-
-from fastapi import HTTPException
 
 MAX_LABELS = 50
 MAX_LABEL_KEY_LEN = 63
 MAX_LABEL_VALUE_LEN = 255
 
 # Reserved label keys: derived workspace attributes that are (or will be)
-# exposed as virtual filter fields.
+# exposed as virtual filter fields. We're aggressive about reservations
+# because the cost of reserving a key today is near-zero (no virtual
+# implementation required) but the cost of NOT reserving and later wanting
+# the key as a virtual is a migration. Boolean predicates (`vcs`, `locked`)
+# will resolve as `key:true` / `key:false` when implemented; `version` will
+# match against `terraform_version` once we have a value comparison plan.
 #
 # CHANGE-CONTROL: adding to this set is a behaviour change for any deployment
 # that already has labels with the new key. Update `docs/rbac.md` and the
@@ -41,39 +49,42 @@ RESERVED_LABEL_KEYS: frozenset[str] = frozenset(
 )
 
 
+class LabelValidationError(ValueError):
+    """Raised when a labels payload fails shape, size, or reserved-key checks.
+
+    A `ValueError` subclass so callers using a bare `except ValueError`
+    still catch it; the explicit type lets routers translate to HTTP 422
+    without catching unrelated `ValueError`s.
+    """
+
+
 def validate_labels(labels: dict | None) -> dict:
     """Validate labels: shape, size limits, and reserved-key check.
 
-    Returns a clean dict (or {} for None/empty input). Raises HTTPException
-    422 with a specific detail message on any violation.
+    Returns a clean dict (or {} for None/empty input). Raises
+    `LabelValidationError` (a `ValueError`) with a user-readable message
+    on any violation. The caller is responsible for translating to an
+    HTTP status code — see `terrapod.api.labels.validate_labels_or_422`
+    for the FastAPI helper.
     """
     if not labels:
         return {}
     if not isinstance(labels, dict):
-        raise HTTPException(status_code=422, detail="labels must be an object")
+        raise LabelValidationError("labels must be an object")
     if len(labels) > MAX_LABELS:
-        raise HTTPException(status_code=422, detail=f"labels cannot exceed {MAX_LABELS} entries")
+        raise LabelValidationError(f"labels cannot exceed {MAX_LABELS} entries")
     clean: dict[str, str] = {}
     for k, v in labels.items():
         if not isinstance(k, str) or not isinstance(v, str):
-            raise HTTPException(status_code=422, detail="label keys and values must be strings")
+            raise LabelValidationError("label keys and values must be strings")
         if len(k) > MAX_LABEL_KEY_LEN:
-            raise HTTPException(
-                status_code=422,
-                detail=f"label key exceeds {MAX_LABEL_KEY_LEN} characters",
-            )
+            raise LabelValidationError(f"label key exceeds {MAX_LABEL_KEY_LEN} characters")
         if len(v) > MAX_LABEL_VALUE_LEN:
-            raise HTTPException(
-                status_code=422,
-                detail=f"label value exceeds {MAX_LABEL_VALUE_LEN} characters",
-            )
+            raise LabelValidationError(f"label value exceeds {MAX_LABEL_VALUE_LEN} characters")
         if k in RESERVED_LABEL_KEYS:
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    f'label key "{k}" is reserved for filter syntax. '
-                    f"Reserved keys: {', '.join(sorted(RESERVED_LABEL_KEYS))}."
-                ),
+            raise LabelValidationError(
+                f'label key "{k}" is reserved for filter syntax. '
+                f"Reserved keys: {', '.join(sorted(RESERVED_LABEL_KEYS))}."
             )
         clean[k] = v
     return clean

--- a/services/terrapod/services/label_validation.py
+++ b/services/terrapod/services/label_validation.py
@@ -1,0 +1,79 @@
+"""Shared validation for labels on workspaces, agent pools, registry modules/providers.
+
+Labels are arbitrary string→string maps used by the label-based RBAC system
+and exposed in the workspace-list filter UI. To keep the filter language
+unambiguous, a small set of label keys are reserved for *virtual* fields —
+filter terms like `status:errored` resolve against a workspace's derived
+status, not against a literal label called `status`. Allowing literal labels
+with reserved keys would make the filter ambiguous.
+
+Keep `RESERVED_LABEL_KEYS` in lockstep with the filter parser in
+`web/src/lib/workspace-filter.ts`. Each reserved key listed here either is
+already implemented as a virtual filter term, or is reserved for an upcoming
+one — see `docs/rbac.md` for the user-facing list.
+"""
+
+from fastapi import HTTPException
+
+MAX_LABELS = 50
+MAX_LABEL_KEY_LEN = 63
+MAX_LABEL_VALUE_LEN = 255
+
+# Reserved label keys: derived workspace attributes that are (or will be)
+# exposed as virtual filter fields.
+#
+# CHANGE-CONTROL: adding to this set is a behaviour change for any deployment
+# that already has labels with the new key. Update `docs/rbac.md` and the
+# frontend filter parser comment when extending.
+RESERVED_LABEL_KEYS: frozenset[str] = frozenset(
+    {
+        "status",  # derived run status (errored, needs-confirm, drifted, …)
+        "pool",  # agent_pool_name
+        "mode",  # execution_mode (local/agent)
+        "backend",  # execution_backend (tofu/terraform)
+        "owner",  # owner_email
+        "drift",  # drift_status
+        "version",  # terraform_version
+        "vcs",  # has VCS connection
+        "locked",  # locked boolean
+        "branch",  # vcs_branch
+    }
+)
+
+
+def validate_labels(labels: dict | None) -> dict:
+    """Validate labels: shape, size limits, and reserved-key check.
+
+    Returns a clean dict (or {} for None/empty input). Raises HTTPException
+    422 with a specific detail message on any violation.
+    """
+    if not labels:
+        return {}
+    if not isinstance(labels, dict):
+        raise HTTPException(status_code=422, detail="labels must be an object")
+    if len(labels) > MAX_LABELS:
+        raise HTTPException(status_code=422, detail=f"labels cannot exceed {MAX_LABELS} entries")
+    clean: dict[str, str] = {}
+    for k, v in labels.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise HTTPException(status_code=422, detail="label keys and values must be strings")
+        if len(k) > MAX_LABEL_KEY_LEN:
+            raise HTTPException(
+                status_code=422,
+                detail=f"label key exceeds {MAX_LABEL_KEY_LEN} characters",
+            )
+        if len(v) > MAX_LABEL_VALUE_LEN:
+            raise HTTPException(
+                status_code=422,
+                detail=f"label value exceeds {MAX_LABEL_VALUE_LEN} characters",
+            )
+        if k in RESERVED_LABEL_KEYS:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f'label key "{k}" is reserved for filter syntax. '
+                    f"Reserved keys: {', '.join(sorted(RESERVED_LABEL_KEYS))}."
+                ),
+            )
+        clean[k] = v
+    return clean

--- a/services/tests/api/test_labels_wrapper.py
+++ b/services/tests/api/test_labels_wrapper.py
@@ -1,0 +1,40 @@
+"""Tests for the FastAPI wrapper that translates LabelValidationError → HTTP 422."""
+
+import pytest
+from fastapi import HTTPException
+
+from terrapod.api.labels import validate_labels
+
+
+class TestValidateLabelsWrapper:
+    def test_clean_input_returns_dict(self):
+        assert validate_labels({"env": "prod"}) == {"env": "prod"}
+
+    def test_none_returns_empty_dict(self):
+        assert validate_labels(None) == {}
+
+    def test_reserved_key_translated_to_422(self):
+        """LabelValidationError → HTTPException with status 422 and the
+        original detail message preserved (so the user sees which key)."""
+        with pytest.raises(HTTPException) as exc:
+            validate_labels({"status": "live"})
+        assert exc.value.status_code == 422
+        assert "status" in exc.value.detail
+        assert "reserved" in exc.value.detail.lower()
+
+    def test_size_limit_translated_to_422(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_labels({"k": "x" * 1000})
+        assert exc.value.status_code == 422
+
+    def test_other_exceptions_propagate(self):
+        """Non-LabelValidationError exceptions must NOT be caught — they
+        indicate programmer error and should reach the global handler.
+        Today the validator can't raise anything else, but the wrapper
+        contract should keep that promise."""
+
+        from unittest.mock import patch
+
+        with patch("terrapod.api.labels._validate_labels", side_effect=RuntimeError("oops")):
+            with pytest.raises(RuntimeError):
+                validate_labels({"env": "prod"})

--- a/services/tests/services/test_label_validation.py
+++ b/services/tests/services/test_label_validation.py
@@ -1,0 +1,117 @@
+"""Tests for shared label validation (size limits + reserved-key check)."""
+
+import pytest
+from fastapi import HTTPException
+
+from terrapod.services.label_validation import (
+    MAX_LABEL_KEY_LEN,
+    MAX_LABEL_VALUE_LEN,
+    MAX_LABELS,
+    RESERVED_LABEL_KEYS,
+    validate_labels,
+)
+
+
+class TestShape:
+    def test_none_returns_empty_dict(self):
+        assert validate_labels(None) == {}
+
+    def test_empty_dict_returns_empty_dict(self):
+        assert validate_labels({}) == {}
+
+    def test_non_dict_input_raises_422(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_labels(["not", "a", "dict"])
+        assert exc.value.status_code == 422
+
+    def test_clean_dict_passes_through(self):
+        labels = {"env": "prod", "team": "platform"}
+        assert validate_labels(labels) == labels
+
+
+class TestSizeLimits:
+    def test_too_many_labels_rejected(self):
+        labels = {f"k{i}": "v" for i in range(MAX_LABELS + 1)}
+        with pytest.raises(HTTPException) as exc:
+            validate_labels(labels)
+        assert exc.value.status_code == 422
+        assert str(MAX_LABELS) in exc.value.detail
+
+    def test_max_labels_exactly_passes(self):
+        labels = {f"k{i}": "v" for i in range(MAX_LABELS)}
+        assert validate_labels(labels) == labels
+
+    def test_long_key_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_labels({"k" * (MAX_LABEL_KEY_LEN + 1): "v"})
+        assert exc.value.status_code == 422
+        assert "label key" in exc.value.detail
+
+    def test_long_value_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_labels({"k": "v" * (MAX_LABEL_VALUE_LEN + 1)})
+        assert exc.value.status_code == 422
+        assert "label value" in exc.value.detail
+
+    def test_non_string_key_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_labels({123: "v"})
+        assert exc.value.status_code == 422
+
+    def test_non_string_value_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_labels({"k": 123})
+        assert exc.value.status_code == 422
+
+
+class TestReservedKeys:
+    """Reserved keys are virtual filter fields — labels with those keys
+    would collide with filter syntax and are rejected at the API.
+    """
+
+    @pytest.mark.parametrize("reserved", sorted(RESERVED_LABEL_KEYS))
+    def test_each_reserved_key_rejected(self, reserved):
+        with pytest.raises(HTTPException) as exc:
+            validate_labels({reserved: "any-value"})
+        assert exc.value.status_code == 422
+        assert reserved in exc.value.detail
+        # Error message must list the full reserved set so admins can
+        # learn the restriction without grepping the source.
+        for key in RESERVED_LABEL_KEYS:
+            assert key in exc.value.detail
+
+    def test_reserved_keys_locked_in(self):
+        """The 10 keys are documented (rbac.md) and depended on by the
+        frontend filter parser. Lock the set to flag any drift in review."""
+        assert RESERVED_LABEL_KEYS == frozenset(
+            {
+                "status",
+                "pool",
+                "mode",
+                "backend",
+                "owner",
+                "drift",
+                "version",
+                "vcs",
+                "locked",
+                "branch",
+            }
+        )
+
+    def test_clean_keys_alongside_reserved_still_rejected(self):
+        """Mixed input with one reserved key still 422s — no partial accept."""
+        with pytest.raises(HTTPException):
+            validate_labels({"env": "prod", "status": "live"})
+
+    def test_non_reserved_keys_pass(self):
+        """Common label conventions (env, team, repo, …) must still work —
+        they're how customers organise workspaces today."""
+        labels = {
+            "env": "prod",
+            "team": "platform",
+            "repo": "tf-aws-core",
+            "scope": "core",
+            "region": "eu-west-1",
+            "managed-by": "terrapod-provider",
+        }
+        assert validate_labels(labels) == labels

--- a/services/tests/services/test_label_validation.py
+++ b/services/tests/services/test_label_validation.py
@@ -1,13 +1,13 @@
-"""Tests for shared label validation (size limits + reserved-key check)."""
+"""Tests for the pure label validator (size limits + reserved-key check)."""
 
 import pytest
-from fastapi import HTTPException
 
 from terrapod.services.label_validation import (
     MAX_LABEL_KEY_LEN,
     MAX_LABEL_VALUE_LEN,
     MAX_LABELS,
     RESERVED_LABEL_KEYS,
+    LabelValidationError,
     validate_labels,
 )
 
@@ -19,70 +19,70 @@ class TestShape:
     def test_empty_dict_returns_empty_dict(self):
         assert validate_labels({}) == {}
 
-    def test_non_dict_input_raises_422(self):
-        with pytest.raises(HTTPException) as exc:
+    def test_non_dict_input_raises(self):
+        with pytest.raises(LabelValidationError):
             validate_labels(["not", "a", "dict"])
-        assert exc.value.status_code == 422
 
     def test_clean_dict_passes_through(self):
         labels = {"env": "prod", "team": "platform"}
         assert validate_labels(labels) == labels
 
+    def test_value_error_subtype(self):
+        """LabelValidationError must be a ValueError so callers using a
+        bare `except ValueError` still catch it."""
+        with pytest.raises(ValueError):
+            validate_labels({"status": "live"})
+
 
 class TestSizeLimits:
     def test_too_many_labels_rejected(self):
         labels = {f"k{i}": "v" for i in range(MAX_LABELS + 1)}
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(LabelValidationError) as exc:
             validate_labels(labels)
-        assert exc.value.status_code == 422
-        assert str(MAX_LABELS) in exc.value.detail
+        assert str(MAX_LABELS) in str(exc.value)
 
     def test_max_labels_exactly_passes(self):
         labels = {f"k{i}": "v" for i in range(MAX_LABELS)}
         assert validate_labels(labels) == labels
 
     def test_long_key_rejected(self):
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(LabelValidationError) as exc:
             validate_labels({"k" * (MAX_LABEL_KEY_LEN + 1): "v"})
-        assert exc.value.status_code == 422
-        assert "label key" in exc.value.detail
+        assert "label key" in str(exc.value)
 
     def test_long_value_rejected(self):
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(LabelValidationError) as exc:
             validate_labels({"k": "v" * (MAX_LABEL_VALUE_LEN + 1)})
-        assert exc.value.status_code == 422
-        assert "label value" in exc.value.detail
+        assert "label value" in str(exc.value)
 
     def test_non_string_key_rejected(self):
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(LabelValidationError):
             validate_labels({123: "v"})
-        assert exc.value.status_code == 422
 
     def test_non_string_value_rejected(self):
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(LabelValidationError):
             validate_labels({"k": 123})
-        assert exc.value.status_code == 422
 
 
 class TestReservedKeys:
     """Reserved keys are virtual filter fields — labels with those keys
-    would collide with filter syntax and are rejected at the API.
+    would collide with filter syntax and are rejected by the validator.
     """
 
     @pytest.mark.parametrize("reserved", sorted(RESERVED_LABEL_KEYS))
     def test_each_reserved_key_rejected(self, reserved):
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(LabelValidationError) as exc:
             validate_labels({reserved: "any-value"})
-        assert exc.value.status_code == 422
-        assert reserved in exc.value.detail
+        msg = str(exc.value)
+        assert reserved in msg
         # Error message must list the full reserved set so admins can
         # learn the restriction without grepping the source.
         for key in RESERVED_LABEL_KEYS:
-            assert key in exc.value.detail
+            assert key in msg
 
     def test_reserved_keys_locked_in(self):
-        """The 10 keys are documented (rbac.md) and depended on by the
-        frontend filter parser. Lock the set to flag any drift in review."""
+        """The set is documented in rbac.md and depended on by the frontend
+        filter parser. Lock it to flag any drift in review."""
         assert RESERVED_LABEL_KEYS == frozenset(
             {
                 "status",
@@ -99,13 +99,14 @@ class TestReservedKeys:
         )
 
     def test_clean_keys_alongside_reserved_still_rejected(self):
-        """Mixed input with one reserved key still 422s — no partial accept."""
-        with pytest.raises(HTTPException):
+        """Mixed input with one reserved key still rejects — no partial accept."""
+        with pytest.raises(LabelValidationError):
             validate_labels({"env": "prod", "status": "live"})
 
     def test_non_reserved_keys_pass(self):
         """Common label conventions (env, team, repo, …) must still work —
-        they're how customers organise workspaces today."""
+        they're how customers organise workspaces today.
+        """
         labels = {
             "env": "prod",
             "team": "platform",

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useEffect, useState, useCallback, useMemo } from 'react'
+import { Suspense, useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import NavBar from '@/components/nav-bar'
@@ -14,8 +14,6 @@ import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
 import { useWorkspaceListEvents } from '@/lib/use-workspace-list-events'
 import {
-  STATUS_FILTER_ERRORED,
-  STATUS_FILTER_NEEDS_CONFIRM,
   hasStatusTerm,
   matchWorkspace,
   parseFilterQuery,
@@ -23,6 +21,26 @@ import {
   serializeFilter,
   toggleStatusTerm,
 } from '@/lib/workspace-filter'
+
+// Status options for the filter dropdown — kept in lockstep with `resolveStatus`
+// below so the kebab-case filter value matches what the server-side derived
+// status would be. Order: most operationally interesting first.
+const STATUS_FILTER_OPTIONS: Array<{ value: string; label: string; dot: string }> = [
+  { value: 'errored', label: 'Errored', dot: 'bg-red-400' },
+  { value: 'needs-confirm', label: 'Needs Confirm', dot: 'bg-amber-400' },
+  { value: 'state-diverged', label: 'State Diverged', dot: 'bg-red-400' },
+  { value: 'vcs-error', label: 'VCS Error', dot: 'bg-red-400' },
+  { value: 'drifted', label: 'Drifted', dot: 'bg-amber-400' },
+  { value: 'planning', label: 'Planning', dot: 'bg-blue-400' },
+  { value: 'applying', label: 'Applying', dot: 'bg-blue-400' },
+  { value: 'confirmed', label: 'Confirmed', dot: 'bg-blue-400' },
+  { value: 'queued', label: 'Queued', dot: 'bg-blue-400' },
+  { value: 'applied', label: 'Applied', dot: 'bg-green-400' },
+  { value: 'planned', label: 'Planned', dot: 'bg-green-400' },
+  { value: 'pending', label: 'Pending', dot: 'bg-slate-500' },
+  { value: 'canceled', label: 'Canceled', dot: 'bg-slate-500' },
+  { value: 'discarded', label: 'Discarded', dot: 'bg-slate-500' },
+]
 
 interface LatestRun {
   id: string
@@ -75,6 +93,28 @@ function WorkspacesPageInner() {
   // label key set. Mirrored to the URL via ?q=… so refresh + share work.
   const [filterInput, setFilterInput] = useState(searchParams.get('q') || '')
   const parsedFilter = useMemo(() => parseFilterQuery(filterInput), [filterInput])
+
+  // Status dropdown state. Closes on outside-click and Escape — same pattern
+  // used for the run-actions menu so the page feels consistent.
+  const [statusMenuOpen, setStatusMenuOpen] = useState(false)
+  const statusMenuRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!statusMenuOpen) return
+    const onClick = (e: MouseEvent) => {
+      if (statusMenuRef.current && !statusMenuRef.current.contains(e.target as Node)) {
+        setStatusMenuOpen(false)
+      }
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setStatusMenuOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [statusMenuOpen])
 
   // Sync the input back to the URL whenever the parsed shape changes.
   useEffect(() => {
@@ -529,13 +569,19 @@ function WorkspacesPageInner() {
         })()}
 
         {!loading && workspaces.length > 0 && (() => {
-          const erroredActive = hasStatusTerm(parsedFilter, STATUS_FILTER_ERRORED)
-          const needsConfirmActive = hasStatusTerm(parsedFilter, STATUS_FILTER_NEEDS_CONFIRM)
-          // Counts shown on the buttons answer "would clicking this find anything?".
-          // Cheap to compute on the unfiltered list — keeps the buttons honest if
-          // the filter input changes but these statuses are no longer present.
-          const erroredCount = workspaces.filter(w => resolveStatus(w).filter === STATUS_FILTER_ERRORED).length
-          const needsConfirmCount = workspaces.filter(w => resolveStatus(w).filter === STATUS_FILTER_NEEDS_CONFIRM).length
+          // Per-status counts on the unfiltered workspace list — answers
+          // "what would I find if I picked this option?" before clicking.
+          // Compute once; the dropdown is closed most of the time so this
+          // stays cheap.
+          const statusCounts: Record<string, number> = {}
+          for (const ws of workspaces) {
+            const f = resolveStatus(ws).filter
+            if (f) statusCounts[f] = (statusCounts[f] || 0) + 1
+          }
+          const activeStatusValues = parsedFilter.terms
+            .filter(t => t.kind === 'status')
+            .map(t => (t as { kind: 'status'; value: string }).value)
+          const activeCount = activeStatusValues.length
           return (
             <div className="mb-4">
               <div className="flex items-center gap-2">
@@ -547,6 +593,66 @@ function WorkspacesPageInner() {
                   aria-label="Filter workspaces"
                   className="flex-1 px-3 py-2 rounded-lg bg-slate-800/50 border border-slate-700/50 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-brand-500"
                 />
+                {/* Status dropdown — single entry point for all status presets.
+                    Picks any combination via toggle; the existing chips below
+                    show what's active and let the user remove individually. */}
+                <div className="relative" ref={statusMenuRef}>
+                  <button
+                    type="button"
+                    aria-haspopup="menu"
+                    aria-expanded={statusMenuOpen}
+                    onClick={() => setStatusMenuOpen(o => !o)}
+                    className={
+                      'inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium border transition-colors ' +
+                      (activeCount > 0
+                        ? 'bg-slate-700/60 text-slate-100 border-slate-600'
+                        : 'bg-slate-800/50 text-slate-300 border-slate-700/50 hover:bg-slate-700/60')
+                    }
+                  >
+                    <span>Status</span>
+                    {activeCount > 0 && (
+                      <span className="inline-flex items-center justify-center min-w-5 px-1.5 rounded-full text-[10px] font-semibold bg-brand-600 text-white">
+                        {activeCount}
+                      </span>
+                    )}
+                    <svg className={'w-3 h-3 transition-transform ' + (statusMenuOpen ? 'rotate-180' : '')} viewBox="0 0 12 12" fill="currentColor" aria-hidden>
+                      <path d="M3 4.5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                  {statusMenuOpen && (
+                    <div
+                      role="menu"
+                      className="absolute right-0 z-10 mt-1 w-64 rounded-lg bg-slate-800 border border-slate-700 shadow-xl py-1 max-h-96 overflow-y-auto"
+                    >
+                      {STATUS_FILTER_OPTIONS.map(opt => {
+                        const active = hasStatusTerm(parsedFilter, opt.value)
+                        const count = statusCounts[opt.value] || 0
+                        return (
+                          <button
+                            key={opt.value}
+                            type="button"
+                            role="menuitemcheckbox"
+                            aria-checked={active}
+                            onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, opt.value)))}
+                            className={
+                              'w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors ' +
+                              (active ? 'bg-slate-700/60 text-slate-100' : 'text-slate-300 hover:bg-slate-700/40')
+                            }
+                          >
+                            {/* Checkmark rail keeps the option labels aligned whether
+                                checked or not. */}
+                            <span className="w-3 inline-flex justify-center text-brand-400">
+                              {active ? '✓' : ''}
+                            </span>
+                            <span className={'w-1.5 h-1.5 rounded-full ' + opt.dot} />
+                            <span className="flex-1 text-left">{opt.label}</span>
+                            <span className={'text-xs ' + (count > 0 ? 'text-slate-400' : 'text-slate-600')}>{count}</span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
                 {parsedFilter.terms.length > 0 && (
                   <button
                     type="button"
@@ -556,40 +662,6 @@ function WorkspacesPageInner() {
                     Clear
                   </button>
                 )}
-              </div>
-              <div className="flex flex-wrap gap-2 mt-2">
-                <button
-                  type="button"
-                  onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, STATUS_FILTER_ERRORED)))}
-                  aria-pressed={erroredActive}
-                  className={
-                    'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-colors ' +
-                    (erroredActive
-                      ? 'bg-red-900/60 text-red-200 ring-1 ring-red-500/40'
-                      : 'bg-slate-800/50 text-slate-300 hover:bg-slate-700/60')
-                  }
-                  title={erroredActive ? 'Remove the errored filter' : 'Show only workspaces with a failed latest run'}
-                >
-                  <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-                  <span>Errored</span>
-                  <span className="text-[10px] text-slate-400">{erroredCount}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, STATUS_FILTER_NEEDS_CONFIRM)))}
-                  aria-pressed={needsConfirmActive}
-                  className={
-                    'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-colors ' +
-                    (needsConfirmActive
-                      ? 'bg-amber-900/60 text-amber-200 ring-1 ring-amber-500/40'
-                      : 'bg-slate-800/50 text-slate-300 hover:bg-slate-700/60')
-                  }
-                  title={needsConfirmActive ? 'Remove the needs-confirm filter' : 'Show only workspaces with an apply waiting for confirmation'}
-                >
-                  <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
-                  <span>Needs Confirm</span>
-                  <span className="text-[10px] text-slate-400">{needsConfirmCount}</span>
-                </button>
               </div>
               {parsedFilter.terms.length > 0 && (
                 <div className="flex flex-wrap gap-2 mt-2">

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -13,7 +13,16 @@ import { getAuthState } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
 import { useWorkspaceListEvents } from '@/lib/use-workspace-list-events'
-import { matchWorkspace, parseFilterQuery, removeTerm, serializeFilter } from '@/lib/workspace-filter'
+import {
+  STATUS_FILTER_ERRORED,
+  STATUS_FILTER_NEEDS_CONFIRM,
+  hasStatusTerm,
+  matchWorkspace,
+  parseFilterQuery,
+  removeTerm,
+  serializeFilter,
+  toggleStatusTerm,
+} from '@/lib/workspace-filter'
 
 interface LatestRun {
   id: string
@@ -79,10 +88,18 @@ function WorkspacesPageInner() {
     router.replace(qs ? `/workspaces?${qs}` : '/workspaces', { scroll: false })
   }, [parsedFilter, router, searchParams])
 
-  const filteredWorkspaces = useMemo(
-    () => (parsedFilter.terms.length === 0 ? workspaces : workspaces.filter(ws => matchWorkspace(ws, parsedFilter))),
-    [workspaces, parsedFilter],
-  )
+  const filteredWorkspaces = useMemo(() => {
+    if (parsedFilter.terms.length === 0) return workspaces
+    return workspaces.filter(ws => {
+      // Status terms need the resolved status; pass it conditionally so
+      // workspaces without a status (— display) don't accidentally match
+      // an empty `status:` predicate.
+      const resolved = resolveStatus(ws)
+      return matchWorkspace(ws, parsedFilter, resolved.filter ?? undefined)
+    })
+    // resolveStatus is a stateless closure over `ws` — safe to omit from deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaces, parsedFilter])
 
   // Create form
   const [showCreate, setShowCreate] = useState(false)
@@ -118,39 +135,42 @@ function WorkspacesPageInner() {
   // when the status comes from `latest-run`. For workspace-level
   // conditions (state-diverged, vcs-error, drifted, no-runs) there's
   // no single defining run so runId stays null and the pill doesn't
-  // link anywhere.
+  // link anywhere. `filter` is the kebab-case lowercase token used by the
+  // `status:` filter predicate; kept alongside the display label so the
+  // two never drift out of sync.
   function resolveStatus(ws: Workspace): {
     label: string
     color: string
     priority: number
     runId: string | null
+    filter: string | null
   } {
     const drift = ws.attributes['drift-status']
     const run = ws.attributes['latest-run']
 
     if (ws.attributes['state-diverged'])
-      return { label: 'State Diverged', color: 'red', priority: 0, runId: null }
+      return { label: 'State Diverged', color: 'red', priority: 0, runId: null, filter: 'state-diverged' }
     if (ws.attributes['vcs-last-error'])
-      return { label: 'VCS Error', color: 'red', priority: 0, runId: null }
+      return { label: 'VCS Error', color: 'red', priority: 0, runId: null, filter: 'vcs-error' }
     if (drift === 'drifted')
-      return { label: 'Drifted', color: 'amber', priority: 1, runId: null }
+      return { label: 'Drifted', color: 'amber', priority: 1, runId: null, filter: 'drifted' }
     if (run) {
       const s = run.status
       const planOnly = run['plan-only']
       const runId = run.id
-      if (s === 'errored') return { label: 'Errored', color: 'red', priority: 2, runId }
-      if (s === 'planned' && !planOnly) return { label: 'Needs Confirm', color: 'amber', priority: 3, runId }
-      if (s === 'planning') return { label: 'Planning', color: 'blue', priority: 4, runId }
-      if (s === 'applying') return { label: 'Applying', color: 'blue', priority: 4, runId }
-      if (s === 'confirmed') return { label: 'Confirmed', color: 'blue', priority: 4, runId }
-      if (s === 'queued') return { label: 'Queued', color: 'blue', priority: 4, runId }
-      if (s === 'pending') return { label: 'Pending', color: 'slate', priority: 5, runId }
-      if (s === 'applied') return { label: 'Applied', color: 'green', priority: 6, runId }
-      if (s === 'planned' && planOnly) return { label: 'Planned', color: 'green', priority: 7, runId }
-      if (s === 'canceled') return { label: 'Canceled', color: 'slate', priority: 8, runId }
-      if (s === 'discarded') return { label: 'Discarded', color: 'slate', priority: 8, runId }
+      if (s === 'errored') return { label: 'Errored', color: 'red', priority: 2, runId, filter: 'errored' }
+      if (s === 'planned' && !planOnly) return { label: 'Needs Confirm', color: 'amber', priority: 3, runId, filter: 'needs-confirm' }
+      if (s === 'planning') return { label: 'Planning', color: 'blue', priority: 4, runId, filter: 'planning' }
+      if (s === 'applying') return { label: 'Applying', color: 'blue', priority: 4, runId, filter: 'applying' }
+      if (s === 'confirmed') return { label: 'Confirmed', color: 'blue', priority: 4, runId, filter: 'confirmed' }
+      if (s === 'queued') return { label: 'Queued', color: 'blue', priority: 4, runId, filter: 'queued' }
+      if (s === 'pending') return { label: 'Pending', color: 'slate', priority: 5, runId, filter: 'pending' }
+      if (s === 'applied') return { label: 'Applied', color: 'green', priority: 6, runId, filter: 'applied' }
+      if (s === 'planned' && planOnly) return { label: 'Planned', color: 'green', priority: 7, runId, filter: 'planned' }
+      if (s === 'canceled') return { label: 'Canceled', color: 'slate', priority: 8, runId, filter: 'canceled' }
+      if (s === 'discarded') return { label: 'Discarded', color: 'slate', priority: 8, runId, filter: 'discarded' }
     }
-    return { label: '\u2014', color: 'gray', priority: 9, runId: null }
+    return { label: '\u2014', color: 'gray', priority: 9, runId: null, filter: null }
   }
 
   const badgeColors: Record<string, string> = {
@@ -508,56 +528,101 @@ function WorkspacesPageInner() {
           )
         })()}
 
-        {!loading && workspaces.length > 0 && (
-          <div className="mb-4">
-            <div className="flex items-center gap-2">
-              <input
-                type="text"
-                value={filterInput}
-                onChange={e => setFilterInput(e.target.value)}
-                placeholder='Filter by name or label — e.g. "eu1" or "env:prod" or "repo:tf-aws-core eu1"'
-                aria-label="Filter workspaces"
-                className="flex-1 px-3 py-2 rounded-lg bg-slate-800/50 border border-slate-700/50 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-brand-500"
-              />
-              {parsedFilter.terms.length > 0 && (
+        {!loading && workspaces.length > 0 && (() => {
+          const erroredActive = hasStatusTerm(parsedFilter, STATUS_FILTER_ERRORED)
+          const needsConfirmActive = hasStatusTerm(parsedFilter, STATUS_FILTER_NEEDS_CONFIRM)
+          // Counts shown on the buttons answer "would clicking this find anything?".
+          // Cheap to compute on the unfiltered list — keeps the buttons honest if
+          // the filter input changes but these statuses are no longer present.
+          const erroredCount = workspaces.filter(w => resolveStatus(w).filter === STATUS_FILTER_ERRORED).length
+          const needsConfirmCount = workspaces.filter(w => resolveStatus(w).filter === STATUS_FILTER_NEEDS_CONFIRM).length
+          return (
+            <div className="mb-4">
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={filterInput}
+                  onChange={e => setFilterInput(e.target.value)}
+                  placeholder='Filter by name, label, or status — e.g. "eu1", "env:prod", "status:errored"'
+                  aria-label="Filter workspaces"
+                  className="flex-1 px-3 py-2 rounded-lg bg-slate-800/50 border border-slate-700/50 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-brand-500"
+                />
+                {parsedFilter.terms.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setFilterInput('')}
+                    className="px-3 py-2 rounded-lg text-sm text-slate-400 hover:text-slate-200 transition-colors"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              <div className="flex flex-wrap gap-2 mt-2">
                 <button
                   type="button"
-                  onClick={() => setFilterInput('')}
-                  className="px-3 py-2 rounded-lg text-sm text-slate-400 hover:text-slate-200 transition-colors"
+                  onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, STATUS_FILTER_ERRORED)))}
+                  aria-pressed={erroredActive}
+                  className={
+                    'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-colors ' +
+                    (erroredActive
+                      ? 'bg-red-900/60 text-red-200 ring-1 ring-red-500/40'
+                      : 'bg-slate-800/50 text-slate-300 hover:bg-slate-700/60')
+                  }
+                  title={erroredActive ? 'Remove the errored filter' : 'Show only workspaces with a failed latest run'}
                 >
-                  Clear
+                  <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
+                  <span>Errored</span>
+                  <span className="text-[10px] text-slate-400">{erroredCount}</span>
                 </button>
+                <button
+                  type="button"
+                  onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, STATUS_FILTER_NEEDS_CONFIRM)))}
+                  aria-pressed={needsConfirmActive}
+                  className={
+                    'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-colors ' +
+                    (needsConfirmActive
+                      ? 'bg-amber-900/60 text-amber-200 ring-1 ring-amber-500/40'
+                      : 'bg-slate-800/50 text-slate-300 hover:bg-slate-700/60')
+                  }
+                  title={needsConfirmActive ? 'Remove the needs-confirm filter' : 'Show only workspaces with an apply waiting for confirmation'}
+                >
+                  <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+                  <span>Needs Confirm</span>
+                  <span className="text-[10px] text-slate-400">{needsConfirmCount}</span>
+                </button>
+              </div>
+              {parsedFilter.terms.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {parsedFilter.terms.map((term, i) => {
+                    const label =
+                      term.kind === 'name'
+                        ? `name: ${term.value}`
+                        : term.kind === 'status'
+                          ? `status: ${term.value}`
+                          : term.value === null
+                            ? `${term.key}: (any)`
+                            : `${term.key}: ${term.value}`
+                    return (
+                      <button
+                        type="button"
+                        key={`${i}-${label}`}
+                        onClick={() => setFilterInput(serializeFilter(removeTerm(parsedFilter, i)))}
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-slate-700/50 text-slate-300 hover:bg-slate-700 transition-colors"
+                        title="Remove this term"
+                      >
+                        <span>{label}</span>
+                        <span aria-hidden className="text-slate-500">×</span>
+                      </button>
+                    )
+                  })}
+                  <span className="text-xs text-slate-500 self-center">
+                    Showing {filteredWorkspaces.length} of {workspaces.length}
+                  </span>
+                </div>
               )}
             </div>
-            {parsedFilter.terms.length > 0 && (
-              <div className="flex flex-wrap gap-2 mt-2">
-                {parsedFilter.terms.map((term, i) => {
-                  const label =
-                    term.kind === 'name'
-                      ? `name: ${term.value}`
-                      : term.value === null
-                        ? `${term.key}: (any)`
-                        : `${term.key}: ${term.value}`
-                  return (
-                    <button
-                      type="button"
-                      key={`${i}-${label}`}
-                      onClick={() => setFilterInput(serializeFilter(removeTerm(parsedFilter, i)))}
-                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-slate-700/50 text-slate-300 hover:bg-slate-700 transition-colors"
-                      title="Remove this term"
-                    >
-                      <span>{label}</span>
-                      <span aria-hidden className="text-slate-500">×</span>
-                    </button>
-                  )
-                })}
-                <span className="text-xs text-slate-500 self-center">
-                  Showing {filteredWorkspaces.length} of {workspaces.length}
-                </span>
-              </div>
-            )}
-          </div>
-        )}
+          )
+        })()}
 
         {loading ? (
           <LoadingSpinner />

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -21,26 +21,7 @@ import {
   serializeFilter,
   toggleStatusTerm,
 } from '@/lib/workspace-filter'
-
-// Status options for the filter dropdown — kept in lockstep with `resolveStatus`
-// below so the kebab-case filter value matches what the server-side derived
-// status would be. Order: most operationally interesting first.
-const STATUS_FILTER_OPTIONS: Array<{ value: string; label: string; dot: string }> = [
-  { value: 'errored', label: 'Errored', dot: 'bg-red-400' },
-  { value: 'needs-confirm', label: 'Needs Confirm', dot: 'bg-amber-400' },
-  { value: 'state-diverged', label: 'State Diverged', dot: 'bg-red-400' },
-  { value: 'vcs-error', label: 'VCS Error', dot: 'bg-red-400' },
-  { value: 'drifted', label: 'Drifted', dot: 'bg-amber-400' },
-  { value: 'planning', label: 'Planning', dot: 'bg-blue-400' },
-  { value: 'applying', label: 'Applying', dot: 'bg-blue-400' },
-  { value: 'confirmed', label: 'Confirmed', dot: 'bg-blue-400' },
-  { value: 'queued', label: 'Queued', dot: 'bg-blue-400' },
-  { value: 'applied', label: 'Applied', dot: 'bg-green-400' },
-  { value: 'planned', label: 'Planned', dot: 'bg-green-400' },
-  { value: 'pending', label: 'Pending', dot: 'bg-slate-500' },
-  { value: 'canceled', label: 'Canceled', dot: 'bg-slate-500' },
-  { value: 'discarded', label: 'Discarded', dot: 'bg-slate-500' },
-]
+import { WORKSPACE_STATUSES, resolveStatus } from '@/lib/workspace-status'
 
 interface LatestRun {
   id: string
@@ -134,11 +115,8 @@ function WorkspacesPageInner() {
       // Status terms need the resolved status; pass it conditionally so
       // workspaces without a status (— display) don't accidentally match
       // an empty `status:` predicate.
-      const resolved = resolveStatus(ws)
-      return matchWorkspace(ws, parsedFilter, resolved.filter ?? undefined)
+      return matchWorkspace(ws, parsedFilter, resolveStatus(ws).def?.filter ?? undefined)
     })
-    // resolveStatus is a stateless closure over `ws` — safe to omit from deps.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaces, parsedFilter])
 
   // Create form
@@ -171,47 +149,20 @@ function WorkspacesPageInner() {
 
   type WsSortKey = 'name' | 'mode' | 'pool' | 'resources' | 'status' | 'created'
 
-  // Resolved status. `runId` is the run that *defined* the status — set
-  // when the status comes from `latest-run`. For workspace-level
-  // conditions (state-diverged, vcs-error, drifted, no-runs) there's
-  // no single defining run so runId stays null and the pill doesn't
-  // link anywhere. `filter` is the kebab-case lowercase token used by the
-  // `status:` filter predicate; kept alongside the display label so the
-  // two never drift out of sync.
-  function resolveStatus(ws: Workspace): {
-    label: string
-    color: string
-    priority: number
-    runId: string | null
-    filter: string | null
-  } {
-    const drift = ws.attributes['drift-status']
-    const run = ws.attributes['latest-run']
+  // resolveStatus + WORKSPACE_STATUSES are imported from workspace-status.ts
+  // — single source of truth for both the row pill and the filter dropdown.
 
-    if (ws.attributes['state-diverged'])
-      return { label: 'State Diverged', color: 'red', priority: 0, runId: null, filter: 'state-diverged' }
-    if (ws.attributes['vcs-last-error'])
-      return { label: 'VCS Error', color: 'red', priority: 0, runId: null, filter: 'vcs-error' }
-    if (drift === 'drifted')
-      return { label: 'Drifted', color: 'amber', priority: 1, runId: null, filter: 'drifted' }
-    if (run) {
-      const s = run.status
-      const planOnly = run['plan-only']
-      const runId = run.id
-      if (s === 'errored') return { label: 'Errored', color: 'red', priority: 2, runId, filter: 'errored' }
-      if (s === 'planned' && !planOnly) return { label: 'Needs Confirm', color: 'amber', priority: 3, runId, filter: 'needs-confirm' }
-      if (s === 'planning') return { label: 'Planning', color: 'blue', priority: 4, runId, filter: 'planning' }
-      if (s === 'applying') return { label: 'Applying', color: 'blue', priority: 4, runId, filter: 'applying' }
-      if (s === 'confirmed') return { label: 'Confirmed', color: 'blue', priority: 4, runId, filter: 'confirmed' }
-      if (s === 'queued') return { label: 'Queued', color: 'blue', priority: 4, runId, filter: 'queued' }
-      if (s === 'pending') return { label: 'Pending', color: 'slate', priority: 5, runId, filter: 'pending' }
-      if (s === 'applied') return { label: 'Applied', color: 'green', priority: 6, runId, filter: 'applied' }
-      if (s === 'planned' && planOnly) return { label: 'Planned', color: 'green', priority: 7, runId, filter: 'planned' }
-      if (s === 'canceled') return { label: 'Canceled', color: 'slate', priority: 8, runId, filter: 'canceled' }
-      if (s === 'discarded') return { label: 'Discarded', color: 'slate', priority: 8, runId, filter: 'discarded' }
+  // Per-status counts on the unfiltered workspace list, memoised so the
+  // dropdown render is a constant lookup. Recomputes only when the
+  // workspace data changes.
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const ws of workspaces) {
+      const f = resolveStatus(ws).def?.filter
+      if (f) counts[f] = (counts[f] || 0) + 1
     }
-    return { label: '\u2014', color: 'gray', priority: 9, runId: null, filter: null }
-  }
+    return counts
+  }, [workspaces])
 
   const badgeColors: Record<string, string> = {
     amber: 'bg-amber-900/50 text-amber-300',
@@ -230,7 +181,7 @@ function WorkspacesPageInner() {
         case 'mode': return item.attributes['execution-mode']
         case 'pool': return item.attributes['agent-pool-name'] || ''
         case 'resources': return item.attributes['resource-cpu']
-        case 'status': return resolveStatus(item).label
+        case 'status': return resolveStatus(item).def?.label ?? '\u2014'
         case 'created': return item.attributes['created-at']
       }
     }, []),
@@ -569,19 +520,7 @@ function WorkspacesPageInner() {
         })()}
 
         {!loading && workspaces.length > 0 && (() => {
-          // Per-status counts on the unfiltered workspace list — answers
-          // "what would I find if I picked this option?" before clicking.
-          // Compute once; the dropdown is closed most of the time so this
-          // stays cheap.
-          const statusCounts: Record<string, number> = {}
-          for (const ws of workspaces) {
-            const f = resolveStatus(ws).filter
-            if (f) statusCounts[f] = (statusCounts[f] || 0) + 1
-          }
-          const activeStatusValues = parsedFilter.terms
-            .filter(t => t.kind === 'status')
-            .map(t => (t as { kind: 'status'; value: string }).value)
-          const activeCount = activeStatusValues.length
+          const activeStatusCount = parsedFilter.terms.filter(t => t.kind === 'status').length
           return (
             <div className="mb-4">
               <div className="flex items-center gap-2">
@@ -604,15 +543,15 @@ function WorkspacesPageInner() {
                     onClick={() => setStatusMenuOpen(o => !o)}
                     className={
                       'inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium border transition-colors ' +
-                      (activeCount > 0
+                      (activeStatusCount > 0
                         ? 'bg-slate-700/60 text-slate-100 border-slate-600'
                         : 'bg-slate-800/50 text-slate-300 border-slate-700/50 hover:bg-slate-700/60')
                     }
                   >
                     <span>Status</span>
-                    {activeCount > 0 && (
+                    {activeStatusCount > 0 && (
                       <span className="inline-flex items-center justify-center min-w-5 px-1.5 rounded-full text-[10px] font-semibold bg-brand-600 text-white">
-                        {activeCount}
+                        {activeStatusCount}
                       </span>
                     )}
                     <svg className={'w-3 h-3 transition-transform ' + (statusMenuOpen ? 'rotate-180' : '')} viewBox="0 0 12 12" fill="currentColor" aria-hidden>
@@ -624,16 +563,16 @@ function WorkspacesPageInner() {
                       role="menu"
                       className="absolute right-0 z-10 mt-1 w-64 rounded-lg bg-slate-800 border border-slate-700 shadow-xl py-1 max-h-96 overflow-y-auto"
                     >
-                      {STATUS_FILTER_OPTIONS.map(opt => {
-                        const active = hasStatusTerm(parsedFilter, opt.value)
-                        const count = statusCounts[opt.value] || 0
+                      {WORKSPACE_STATUSES.map(opt => {
+                        const active = hasStatusTerm(parsedFilter, opt.filter)
+                        const count = statusCounts[opt.filter] || 0
                         return (
                           <button
-                            key={opt.value}
+                            key={opt.filter}
                             type="button"
                             role="menuitemcheckbox"
                             aria-checked={active}
-                            onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, opt.value)))}
+                            onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, opt.filter)))}
                             className={
                               'w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors ' +
                               (active ? 'bg-slate-700/60 text-slate-100' : 'text-slate-300 hover:bg-slate-700/40')
@@ -717,7 +656,7 @@ function WorkspacesPageInner() {
               </thead>
               <tbody className="divide-y divide-slate-700/30">
                 {sortedWorkspaces.map((ws) => {
-                  const status = resolveStatus(ws)
+                  const { def, runId } = resolveStatus(ws)
                   return (
                   <tr key={ws.id} className="hover:bg-slate-700/20 transition-colors">
                     <td className="px-4 py-3">
@@ -742,18 +681,18 @@ function WorkspacesPageInner() {
                       </span>
                     </td>
                     <td className="px-4 py-3 hidden lg:table-cell">
-                      {status.color === 'gray' ? (
-                        <span className="text-xs text-slate-500">{status.label}</span>
-                      ) : status.runId ? (
+                      {!def ? (
+                        <span className="text-xs text-slate-500">&mdash;</span>
+                      ) : runId ? (
                         <Link
-                          href={`/workspaces/${ws.id}/runs/${status.runId}`}
-                          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium hover:opacity-80 transition-opacity ${badgeColors[status.color]}`}
+                          href={`/workspaces/${ws.id}/runs/${runId}`}
+                          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium hover:opacity-80 transition-opacity ${badgeColors[def.color]}`}
                         >
-                          {status.label}
+                          {def.label}
                         </Link>
                       ) : (
-                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors[status.color]}`}>
-                          {status.label}
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors[def.color]}`}>
+                          {def.label}
                         </span>
                       )}
                     </td>

--- a/web/src/lib/workspace-filter.ts
+++ b/web/src/lib/workspace-filter.ts
@@ -18,6 +18,12 @@
 // vcs-last-error. The accepted values are kebab-case lowercase versions of
 // the labels in `resolveStatus` on the workspaces page (see STATUS_FILTER
 // constants below).
+//
+// `status` (and the other reserved keys — see `RESERVED_LABEL_KEYS` in
+// `services/terrapod/services/label_validation.py`) cannot be used as
+// literal label keys: the API rejects them at create/update time so the
+// filter language stays unambiguous. The user-facing list lives in
+// `docs/rbac.md` § Reserved label keys.
 
 export interface NameTerm {
   kind: 'name'

--- a/web/src/lib/workspace-filter.ts
+++ b/web/src/lib/workspace-filter.ts
@@ -1,15 +1,23 @@
 // Pure helpers for the workspace-list filter input.
 //
-// The input is a single text box that mixes name substrings and label
-// predicates separated by whitespace. Each token is either:
+// The input is a single text box that mixes name substrings, label predicates,
+// and status predicates separated by whitespace. Each token is either:
 //
 //   - bare word          → name substring match (case-insensitive)
+//   - "status:value"     → status predicate (resolved-status exact match)
 //   - "key:value"        → label predicate (case-sensitive exact match)
 //   - "key=value"        → same as key:value
 //   - "key:" / "key="    → label key-only predicate (any value, including empty)
 //
 // All terms are AND-ed: a workspace matches when every name term appears in
-// its name AND every label predicate matches one of its labels.
+// its name AND every label predicate matches one of its labels AND every
+// status predicate matches the workspace's resolved status.
+//
+// `status` is treated specially because it isn't a label — it's a derived
+// virtual field computed from latest-run / drift-status / state-diverged /
+// vcs-last-error. The accepted values are kebab-case lowercase versions of
+// the labels in `resolveStatus` on the workspaces page (see STATUS_FILTER
+// constants below).
 
 export interface NameTerm {
   kind: 'name'
@@ -22,11 +30,21 @@ export interface LabelTerm {
   value: string | null // null = any-value match
 }
 
-export type FilterTerm = NameTerm | LabelTerm
+export interface StatusTerm {
+  kind: 'status'
+  value: string
+}
+
+export type FilterTerm = NameTerm | LabelTerm | StatusTerm
 
 export interface ParsedFilter {
   terms: FilterTerm[]
 }
+
+// Filter values for the two preset buttons. Kept as exported constants so
+// the buttons + matcher + tests stay in lockstep on the exact string used.
+export const STATUS_FILTER_ERRORED = 'errored'
+export const STATUS_FILTER_NEEDS_CONFIRM = 'needs-confirm'
 
 const SEPARATOR = /[:=]/
 
@@ -43,6 +61,13 @@ export function parseFilterQuery(input: string): ParsedFilter {
     const key = token.slice(0, sep).trim()
     if (!key) continue // ":foo" or "=foo" with no key — skip
     const rest = token.slice(sep + 1)
+    if (key === 'status') {
+      // Status is virtual-only — `status:` with no value would be ambiguous
+      // (no workspace has a "label key" called status), so drop empty.
+      if (rest === '') continue
+      terms.push({ kind: 'status', value: rest })
+      continue
+    }
     terms.push({ kind: 'label', key, value: rest === '' ? null : rest })
   }
   return { terms }
@@ -52,6 +77,7 @@ export function serializeFilter(parsed: ParsedFilter): string {
   return parsed.terms
     .map(t => {
       if (t.kind === 'name') return t.value
+      if (t.kind === 'status') return `status:${t.value}`
       return t.value === null ? `${t.key}:` : `${t.key}:${t.value}`
     })
     .join(' ')
@@ -61,6 +87,23 @@ export function removeTerm(parsed: ParsedFilter, index: number): ParsedFilter {
   return { terms: parsed.terms.filter((_, i) => i !== index) }
 }
 
+/** True if the parsed filter already contains a `status:` term equal to `value`. */
+export function hasStatusTerm(parsed: ParsedFilter, value: string): boolean {
+  return parsed.terms.some(t => t.kind === 'status' && t.value === value)
+}
+
+/** Toggle a `status:value` term: remove it if present, append otherwise.
+ *
+ * Used by the preset filter buttons so a second click clears the filter
+ * the button just applied — standard pill-toggle behaviour.
+ */
+export function toggleStatusTerm(parsed: ParsedFilter, value: string): ParsedFilter {
+  if (hasStatusTerm(parsed, value)) {
+    return { terms: parsed.terms.filter(t => !(t.kind === 'status' && t.value === value)) }
+  }
+  return { terms: [...parsed.terms, { kind: 'status', value }] }
+}
+
 export interface MatchableWorkspace {
   attributes: {
     name: string
@@ -68,12 +111,25 @@ export interface MatchableWorkspace {
   }
 }
 
-export function matchWorkspace(ws: MatchableWorkspace, parsed: ParsedFilter): boolean {
+/**
+ * @param resolvedStatus  Caller-resolved status string for this workspace
+ *   (e.g. "errored", "needs-confirm"). Only consulted when the filter
+ *   contains status terms; safe to omit otherwise. The page resolves it
+ *   from `latest-run` + drift / divergence / VCS-error signals via the
+ *   `resolveStatus` helper, so this module stays UI-agnostic.
+ */
+export function matchWorkspace(
+  ws: MatchableWorkspace,
+  parsed: ParsedFilter,
+  resolvedStatus?: string,
+): boolean {
   const name = ws.attributes.name.toLowerCase()
   const labels = ws.attributes.labels || {}
   for (const term of parsed.terms) {
     if (term.kind === 'name') {
       if (!name.includes(term.value.toLowerCase())) return false
+    } else if (term.kind === 'status') {
+      if (resolvedStatus !== term.value) return false
     } else if (term.value === null) {
       if (!Object.prototype.hasOwnProperty.call(labels, term.key)) return false
     } else if (labels[term.key] !== term.value) {

--- a/web/src/lib/workspace-filter.ts
+++ b/web/src/lib/workspace-filter.ts
@@ -47,11 +47,6 @@ export interface ParsedFilter {
   terms: FilterTerm[]
 }
 
-// Filter values for the two preset buttons. Kept as exported constants so
-// the buttons + matcher + tests stay in lockstep on the exact string used.
-export const STATUS_FILTER_ERRORED = 'errored'
-export const STATUS_FILTER_NEEDS_CONFIRM = 'needs-confirm'
-
 const SEPARATOR = /[:=]/
 
 export function parseFilterQuery(input: string): ParsedFilter {

--- a/web/src/lib/workspace-filter.ts
+++ b/web/src/lib/workspace-filter.ts
@@ -22,8 +22,11 @@
 // `status` (and the other reserved keys — see `RESERVED_LABEL_KEYS` in
 // `services/terrapod/services/label_validation.py`) cannot be used as
 // literal label keys: the API rejects them at create/update time so the
-// filter language stays unambiguous. The user-facing list lives in
-// `docs/rbac.md` § Reserved label keys.
+// filter language stays unambiguous. Today only `status:` is implemented
+// as a virtual term; the other reserved keys parse here as label terms
+// (which always miss because no workspace can have those labels) and
+// will gain virtual-term implementations as they're built out. See
+// `docs/rbac.md` § Reserved label keys for the user-facing list.
 
 export interface NameTerm {
   kind: 'name'

--- a/web/src/lib/workspace-status.ts
+++ b/web/src/lib/workspace-status.ts
@@ -1,0 +1,105 @@
+// Single source of truth for workspace status definitions.
+//
+// Both the workspace-row status pill and the status filter dropdown derive
+// their lists from `WORKSPACE_STATUSES`. Adding a new status only requires
+// editing this file — `resolveStatus` produces the right pill, the dropdown
+// auto-renders the new option, and the kebab-case `filter` value is
+// authoritative for `status:value` predicates in the workspace filter.
+//
+// Order matters: `resolveStatus` walks workspace-level conditions first
+// (`state-diverged`, `vcs-error`, `drifted`) then run statuses; the filter
+// dropdown shows the same order so the most operationally interesting
+// statuses surface at the top.
+
+export type StatusColor = 'red' | 'amber' | 'blue' | 'green' | 'slate' | 'gray'
+
+export interface WorkspaceStatusDef {
+  /** Kebab-case lowercase token used in the `status:value` filter syntax. */
+  filter: string
+  /** Display label for the pill / dropdown row. */
+  label: string
+  /** Logical colour family for the pill background. */
+  color: StatusColor
+  /** Tailwind class for the small coloured dot in dropdown rows. */
+  dot: string
+  /** Sort priority for the workspace list (lower = more urgent). */
+  priority: number
+  /** True when the status is derived from workspace-level signals
+   *  (state-diverged, vcs-error, drifted) rather than from a run. The pill
+   *  for a workspace-level status doesn't link to any specific run. */
+  isWorkspaceLevel?: boolean
+}
+
+export const WORKSPACE_STATUSES: ReadonlyArray<WorkspaceStatusDef> = [
+  // Workspace-level conditions — most urgent.
+  { filter: 'state-diverged', label: 'State Diverged', color: 'red', dot: 'bg-red-400', priority: 0, isWorkspaceLevel: true },
+  { filter: 'vcs-error', label: 'VCS Error', color: 'red', dot: 'bg-red-400', priority: 0, isWorkspaceLevel: true },
+  { filter: 'drifted', label: 'Drifted', color: 'amber', dot: 'bg-amber-400', priority: 1, isWorkspaceLevel: true },
+  // Run-level statuses, in workflow order.
+  { filter: 'errored', label: 'Errored', color: 'red', dot: 'bg-red-400', priority: 2 },
+  { filter: 'needs-confirm', label: 'Needs Confirm', color: 'amber', dot: 'bg-amber-400', priority: 3 },
+  { filter: 'planning', label: 'Planning', color: 'blue', dot: 'bg-blue-400', priority: 4 },
+  { filter: 'applying', label: 'Applying', color: 'blue', dot: 'bg-blue-400', priority: 4 },
+  { filter: 'confirmed', label: 'Confirmed', color: 'blue', dot: 'bg-blue-400', priority: 4 },
+  { filter: 'queued', label: 'Queued', color: 'blue', dot: 'bg-blue-400', priority: 4 },
+  { filter: 'pending', label: 'Pending', color: 'slate', dot: 'bg-slate-500', priority: 5 },
+  { filter: 'applied', label: 'Applied', color: 'green', dot: 'bg-green-400', priority: 6 },
+  { filter: 'planned', label: 'Planned', color: 'green', dot: 'bg-green-400', priority: 7 },
+  { filter: 'canceled', label: 'Canceled', color: 'slate', dot: 'bg-slate-500', priority: 8 },
+  { filter: 'discarded', label: 'Discarded', color: 'slate', dot: 'bg-slate-500', priority: 8 },
+]
+
+const STATUS_BY_FILTER: ReadonlyMap<string, WorkspaceStatusDef> = new Map(
+  WORKSPACE_STATUSES.map(s => [s.filter, s] as const),
+)
+
+interface ResolveInput {
+  attributes: {
+    'state-diverged': boolean
+    'vcs-last-error': string | null
+    'drift-status': string
+    'latest-run': {
+      id: string
+      status: string
+      'plan-only': boolean
+    } | null
+  }
+}
+
+export interface ResolvedStatus {
+  /** Status definition, or null if no run / no signals. */
+  def: WorkspaceStatusDef | null
+  /** Run id for run-level statuses; null for workspace-level conditions. */
+  runId: string | null
+}
+
+/** Resolve a workspace's effective status from its signals.
+ *
+ * Workspace-level conditions (`state-diverged`, `vcs-error`, `drifted`)
+ * take precedence over run statuses — they reflect divergence between the
+ * desired state and reality, which is more urgent than any in-flight run.
+ *
+ * Returns `def: null, runId: null` when there's no run and no condition
+ * (typically a freshly-created workspace with no plan yet).
+ */
+export function resolveStatus(ws: ResolveInput): ResolvedStatus {
+  const a = ws.attributes
+  if (a['state-diverged']) return { def: STATUS_BY_FILTER.get('state-diverged') ?? null, runId: null }
+  if (a['vcs-last-error']) return { def: STATUS_BY_FILTER.get('vcs-error') ?? null, runId: null }
+  if (a['drift-status'] === 'drifted') return { def: STATUS_BY_FILTER.get('drifted') ?? null, runId: null }
+  const run = a['latest-run']
+  if (!run) return { def: null, runId: null }
+  const planOnly = run['plan-only']
+  // Map run.status → status filter token. `planned` is special: a non
+  // plan-only planned run is awaiting confirmation; a plan-only one is
+  // a successful read of the world.
+  let filter: string
+  switch (run.status) {
+    case 'planned':
+      filter = planOnly ? 'planned' : 'needs-confirm'
+      break
+    default:
+      filter = run.status
+  }
+  return { def: STATUS_BY_FILTER.get(filter) ?? null, runId: run.id }
+}


### PR DESCRIPTION
## Summary

Adds two related improvements to the workspace list:

1. **Status filter dropdown** — a single Status picker replaces the original "Errored / Needs Confirm" preset buttons. Lists every derived status with a live count and checkmark; click toggles the corresponding `status:value` term in the filter input.

2. **Reserved label keys** — the `status:` predicate is a virtual filter field, not a literal label. Reserve `status` (plus 9 keys held back for future virtual fields) at the API so a literal label can never collide with the filter language.

## Filter UX

The filter input box remains the single source of truth. The dropdown is purely an input-construction affordance:

```
Click in dropdown → toggleStatusTerm(parsed, value) → serializeFilter(...) → setFilterInput(string)
```

Manual edits and dropdown clicks compose freely. URL `?q=` continues to rehydrate state on refresh; the dropdown's checkmarks reflect the restored filter on next open. The Status trigger button shows a numeric badge when any status terms are active, so it's obvious there are filters in play even when the dropdown is closed.

Status options are listed in operationally-interesting order (errored / needs-confirm / state-diverged / vcs-error / drifted first; queued/applied/canceled later). Coloured dot matches the row's status pill. Counts are computed against the unfiltered workspace list — answers "what would I find?" before clicking.

Closes on outside-click and Esc.

## Reserved label keys

`status:value` resolves against a workspace's derived run status, not against a literal label called `status`. To keep that filter language unambiguous, a small set of label keys are reserved at the API:

| Reserved key | Maps to | Filter status |
|---|---|---|
| `status` | derived run status | implemented (this PR) |
| `pool` | `agent_pool_name` | reserved (future virtual) |
| `mode` | `execution_mode` | reserved |
| `backend` | `execution_backend` | reserved |
| `owner` | `owner_email` | reserved |
| `drift` | `drift_status` | reserved |
| `version` | `terraform_version` | reserved |
| `vcs` | has VCS connection | reserved |
| `locked` | locked boolean | reserved |
| `branch` | `vcs_branch` | reserved |

Common label conventions (`env`, `team`, `repo`, `scope`, `region`, `project`, `managed-by`, `environment`) are explicitly NOT reserved — they're how customers organise workspaces today.

The validator lives in `terrapod.services.label_validation` and is wired into workspace, agent pool, and registry module/provider create/update paths. 422 on any violation, with the full reserved set listed in the error message.

User-facing list documented in `docs/rbac.md` § Reserved Label Keys with migration guidance.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1153 passing (+15 new label-validation tests covering each reserved key, size limits, and a lockfile assertion that the reserved set hasn't drifted unnoticed)
- Filter dropdown: toggle on/off persists to `?q=`, multiple statuses compose with AND, manual edits in the input remain authoritative
- Reserved keys: API rejects on workspace + agent pool + module + provider create/update with 422