### PR TITLE
fix(listener): per-phase auth Secret name to avoid plan/apply 409

### DIFF
--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -573,7 +573,13 @@ class RunnerListener:
         ]
 
         run_short = run_id[:16]
-        auth_secret_name = f"tprun-{run_short}-auth"
+        # Phase is part of the Secret name to avoid a 409 AlreadyExists when
+        # apply runs immediately after plan: the plan Job's auth Secret has
+        # an ownerReference back to the plan Job, but K8s GC doesn't always
+        # finalise the cascade before the apply phase tries to create its
+        # own. Per-phase names mean plan and apply have independent Secrets
+        # that GC at their own pace and never collide.
+        auth_secret_name = f"tprun-{run_short}-{phase}-auth"
 
         spec = build_job_spec(
             run_id=run_id,
@@ -609,7 +615,9 @@ class RunnerListener:
         # Create auth Secret with ownerReference to the Job
         try:
             job_uid = await get_job_uid(job_name)
-            await self._create_auth_secret(run_id, runner_token, job_name, job_uid)
+            await self._create_auth_secret(
+                auth_secret_name, run_id, runner_token, job_name, job_uid
+            )
         except Exception as e:
             logger.error("Failed to create auth secret", run_id=run_id, error=str(e))
             await self._report_launch_failed(run_id, f"Failed to create runner auth Secret: {e}")
@@ -789,16 +797,19 @@ class RunnerListener:
         return response.json()["token"]
 
     async def _create_auth_secret(
-        self, run_id: str, token: str, job_name: str, job_uid: str
+        self, secret_name: str, run_id: str, token: str, job_name: str, job_uid: str
     ) -> str:
-        """Create a K8s Secret containing the runner token with ownerReference."""
+        """Create a K8s Secret containing the runner token with ownerReference.
+
+        `secret_name` is computed by the caller (which knows the phase) so
+        plan and apply Secrets have distinct names and don't 409 each other
+        when both Jobs of the same run live briefly in the cluster.
+        """
         from kubernetes import client as k8s_client
 
         from terrapod.runner.job_manager import _get_core_api
 
         namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
-        run_short = run_id[:16]
-        secret_name = f"tprun-{run_short}-auth"
 
         secret = k8s_client.V1Secret(
             metadata=k8s_client.V1ObjectMeta(

--- a/services/tests/services/test_listener.py
+++ b/services/tests/services/test_listener.py
@@ -279,3 +279,53 @@ class TestLaunchFailureReporting:
 
         # Must not raise
         await listener._report_launch_failed("abc-123", "boom")
+
+
+# ── Auth Secret naming (phase collision regression) ───────────────────
+
+
+class TestAuthSecretNaming:
+    """Plan and apply phases of the same run must use distinct Secret names.
+
+    Confirm-and-Apply transitions a run from `planned` to `applying` within
+    seconds. The plan Job's auth Secret has an ownerReference back to the
+    plan Job, but K8s GC doesn't always finalise the cascade before the
+    apply phase tries to create its own Secret. Pre-fix, both phases used
+    `tprun-{run_short}-auth` → second create → 409 AlreadyExists → entire
+    apply Job fails to launch.
+
+    Per-phase names (`tprun-{run_short}-{phase}-auth`) eliminate the race
+    by giving each Job its own Secret keyed on the same phase suffix the
+    Job name already uses.
+    """
+
+    async def test_plan_and_apply_use_distinct_secret_names(self, fresh_shutdown_event):
+        """build_job_spec sees a phase-aware secret name; plan != apply."""
+        listener = _make_listener(fresh_shutdown_event)
+        listener._get_runner_token = AsyncMock(return_value="runtok:xyz")
+        listener._http_client = AsyncMock()
+        listener._create_auth_secret = AsyncMock(return_value="ok")
+        listener.runner_config = MagicMock()
+
+        captured = {}
+
+        def fake_build(**kwargs):
+            captured.setdefault("calls", []).append(kwargs)
+            return {"kind": "Job"}
+
+        with (
+            patch("terrapod.runner.job_template.build_job_spec", side_effect=fake_build),
+            patch("terrapod.runner.job_manager.create_job", AsyncMock(return_value="job-x")),
+            patch("terrapod.runner.job_manager.get_job_uid", AsyncMock(return_value="uid-x")),
+        ):
+            run_id = "0123456789abcdef-zzzz"
+            await listener._launch_run(run_id, {"phase": "plan"})
+            await listener._launch_run(run_id, {"phase": "apply"})
+
+        names = [c["auth_secret_name"] for c in captured["calls"]]
+        assert names[0] != names[1], f"plan/apply must differ, got {names}"
+        assert "plan" in names[0] and "apply" in names[1]
+        # Same run prefix on both — only the phase suffix differs.
+        prefix_plan = names[0].rsplit("-plan-", 1)[0]
+        prefix_apply = names[1].rsplit("-apply-", 1)[0]
+        assert prefix_plan == prefix_apply


### PR DESCRIPTION
## Summary

Confirm-and-Apply triggered a 409 AlreadyExists when creating the apply phase's auth Secret because plan and apply shared the same Secret name (`tprun-{run_short}-auth`). The plan Job's Secret had an ownerReference back to the plan Job; K8s GC didn't finalise the cascade before the apply phase tried to create its own.

Pre-v0.20.3 this manifested as the apply Job running without a properly-attached auth Secret → Job failure → reconciler saw "Job deleted". v0.20.3 made the failure visible (good) but didn't fix it (bad).

Fix: make the Secret name phase-aware — `tprun-{run_short}-{phase}-auth` — mirroring the Job name which already includes phase. Plan and apply now have independent Secrets and never collide.

## Repro (production)

- Workspace `sls-grafana` on prod, agent execution mode, auto-apply off
- VCS push triggers plan → "planned" → user clicks Confirm & Apply → apply Job tries to create `tprun-019dddee-da84-7a-auth`, plan Secret hadn't GC'd yet → 409 → run errored

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1131 passing (+1 new regression test in `TestAuthSecretNaming`)