### PR TITLE
fix(runs): skip apply when plan has no changes

### DIFF
--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -215,6 +215,30 @@ async def upload_state(
     # Hash off the event loop — runner state uploads can be multi-MB
     md5 = await asyncio.to_thread(lambda: hashlib.md5(body).hexdigest())  # noqa: S324  # nosemgrep: insecure-hash-algorithm-md5
 
+    # Reject duplicate-serial uploads with 409 Conflict instead of letting
+    # the unique constraint surface as a 500. tofu doesn't bump the state
+    # serial on a no-op apply, so a runner re-uploading the same state would
+    # otherwise blow up with `IntegrityError on uq_state_versions`. The
+    # reconciler short-circuits planned→applied for has_changes=False so
+    # this path shouldn't be reached in steady state, but explicit 409 is
+    # correct semantics regardless: a stale serial is a client-visible
+    # conflict, not a server error.
+    existing = await db.execute(
+        select(StateVersion).where(
+            StateVersion.workspace_id == run.workspace_id,
+            StateVersion.serial == serial,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"State serial {serial} already exists for this workspace. "
+                "tofu apply did not bump the serial — likely a no-op apply that "
+                "should not have produced a state upload."
+            ),
+        )
+
     # Create StateVersion record
     sv = StateVersion(
         workspace_id=run.workspace_id,

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -24,6 +24,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
@@ -223,6 +224,16 @@ async def upload_state(
     # this path shouldn't be reached in steady state, but explicit 409 is
     # correct semantics regardless: a stale serial is a client-visible
     # conflict, not a server error.
+    #
+    # Two-layer check: (1) pre-INSERT lookup gives the common case a clean
+    # 409 with a helpful message; (2) IntegrityError catch on the INSERT
+    # closes the race window where a concurrent upload inserts between our
+    # SELECT and INSERT — the unique constraint is the source of truth.
+    _existing_serial_msg = (
+        f"State serial {serial} already exists for this workspace. "
+        "tofu apply did not bump the serial — likely a no-op apply that "
+        "should not have produced a state upload."
+    )
     existing = await db.execute(
         select(StateVersion).where(
             StateVersion.workspace_id == run.workspace_id,
@@ -230,14 +241,7 @@ async def upload_state(
         )
     )
     if existing.scalar_one_or_none() is not None:
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                f"State serial {serial} already exists for this workspace. "
-                "tofu apply did not bump the serial — likely a no-op apply that "
-                "should not have produced a state upload."
-            ),
-        )
+        raise HTTPException(status_code=409, detail=_existing_serial_msg)
 
     # Create StateVersion record
     sv = StateVersion(
@@ -250,7 +254,14 @@ async def upload_state(
         created_by=run.created_by or None,
     )
     db.add(sv)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError:
+        # Race: another upload inserted the same (workspace_id, serial)
+        # between our SELECT and INSERT. Roll back so the session is
+        # usable for any caller-side cleanup, then return 409.
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=_existing_serial_msg) from None
 
     # Store at canonical key (same format used by download_state)
     storage = get_storage()

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -120,11 +120,21 @@ def _run_json(
                 "created-at": _rfc3339(run.created_at),
                 "updated-at": _rfc3339(run.updated_at),
                 "created-by": run.created_by or "",
+                # Confirm/Discard are only meaningful for planned runs that
+                # actually have work to apply. A plan with has_changes=False
+                # is a no-op — the reconciler short-circuits it straight to
+                # `applied`, so seeing `planned` + has_changes=False here is
+                # only possible for legacy runs created before that fix.
+                # Hide the buttons so the UI doesn't push users into the
+                # state-upload 500 path.
                 "actions": {
                     "is-confirmable": run.status == "planned"
                     and not run.auto_apply
-                    and not run.plan_only,
-                    "is-discardable": run.status == "planned" and not run.plan_only,
+                    and not run.plan_only
+                    and run.has_changes is not False,
+                    "is-discardable": run.status == "planned"
+                    and not run.plan_only
+                    and run.has_changes is not False,
                     # Cancel only applies to in-progress states. In particular
                     # `planned` (awaiting confirmation) is NOT cancelable —
                     # the user should confirm or discard. Terminal states
@@ -134,9 +144,13 @@ def _run_json(
                     or (run.plan_only and run.status == "planned"),
                 },
                 "permissions": {
-                    "can-apply": run.status == "planned" and not run.plan_only,
+                    "can-apply": run.status == "planned"
+                    and not run.plan_only
+                    and run.has_changes is not False,
                     "can-cancel": run.status in _CANCELABLE_STATES,
-                    "can-discard": run.status == "planned" and not run.plan_only,
+                    "can-discard": run.status == "planned"
+                    and not run.plan_only
+                    and run.has_changes is not False,
                     "can-retry": run.status in run_service.TERMINAL_STATES
                     or (run.plan_only and run.status == "planned"),
                     "can-force-execute": False,
@@ -464,6 +478,17 @@ async def confirm_run(
     """Confirm a planned run for apply. Requires write."""
     run = await _get_run(run_id, db)
     await _require_run_ws_permission(run, "write", user, db)
+
+    # No-op apply guard: a plan with has_changes=False has nothing to apply.
+    # The reconciler short-circuits these directly to `applied`, so this
+    # endpoint should only see them in narrow races (or for legacy data
+    # predating that fix). Reject explicitly so the API and the UI surface
+    # the same answer.
+    if run.has_changes is False:
+        raise HTTPException(
+            status_code=422,
+            detail="Plan reported no changes — there is nothing to apply.",
+        )
 
     # Block apply for CLI-uploaded code on VCS-connected agent workspaces.
     # Destroy runs are exempt — they don't depend on uploaded code.
@@ -940,8 +965,18 @@ async def update_run_status(
     try:
         run = await run_service.transition_run(db, run, target_status, error_message=error_message)
 
+        # No-op short-circuit: a plan with has_changes=False has nothing for an
+        # apply Job to do. Skip straight to applied without an apply Job — see
+        # `run_reconciler._handle_succeeded` for the full rationale; the same
+        # logic applies here for listeners that PATCH planned directly.
+        if target_status == "planned" and not run.plan_only and run.has_changes is False:
+            run = await run_service.transition_run(db, run, "applied")
+            ws = await db.get(Workspace, run.workspace_id)
+            if ws and ws.locked:
+                ws.locked = False
+                ws.lock_id = None
         # Auto-apply if configured
-        if target_status == "planned" and run.auto_apply and not run.plan_only:
+        elif target_status == "planned" and run.auto_apply and not run.plan_only:
             run = await run_service.transition_run(db, run, "confirmed")
 
         # Unlock workspace when plan-only run reaches planned

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -966,15 +966,10 @@ async def update_run_status(
         run = await run_service.transition_run(db, run, target_status, error_message=error_message)
 
         # No-op short-circuit: a plan with has_changes=False has nothing for an
-        # apply Job to do. Skip straight to applied without an apply Job — see
-        # `run_reconciler._handle_succeeded` for the full rationale; the same
-        # logic applies here for listeners that PATCH planned directly.
+        # apply Job to do. Use the shared helper so this path stays in lockstep
+        # with the reconciler's `_handle_succeeded` no-op skip.
         if target_status == "planned" and not run.plan_only and run.has_changes is False:
-            run = await run_service.transition_run(db, run, "applied")
-            ws = await db.get(Workspace, run.workspace_id)
-            if ws and ws.locked:
-                ws.locked = False
-                ws.lock_id = None
+            run = await run_service.complete_planned_as_noop(db, run)
         # Auto-apply if configured
         elif target_status == "planned" and run.auto_apply and not run.plan_only:
             run = await run_service.transition_run(db, run, "confirmed")

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -188,17 +188,12 @@ async def _handle_succeeded(db: AsyncSession, run: Run) -> None:
                 ws.lock_id = None
 
         # No-op short-circuit: a plan that reports no changes has nothing
-        # for an apply Job to do. tofu wouldn't bump the state serial, so
-        # an apply Job would either no-op or — given a same-serial state
-        # upload — 500 on the unique constraint. Skip straight to applied
-        # without launching a Job. Applies regardless of auto_apply since
-        # the manual confirm path also has nothing meaningful to do.
+        # for an apply Job to do. Skip straight to applied via the shared
+        # helper (sets apply_*_at, releases lock). Applies regardless of
+        # auto_apply since the manual confirm path also has nothing
+        # meaningful to do.
         if not run.plan_only and run.has_changes is False:
-            run = await run_service.transition_run(db, run, "applied")
-            ws = await db.get(Workspace, run.workspace_id)
-            if ws and ws.locked:
-                ws.locked = False
-                ws.lock_id = None
+            run = await run_service.complete_planned_as_noop(db, run)
             logger.info("Plan succeeded — no changes, skipping apply", run_id=str(run.id))
             return
 

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -187,6 +187,21 @@ async def _handle_succeeded(db: AsyncSession, run: Run) -> None:
                 ws.locked = False
                 ws.lock_id = None
 
+        # No-op short-circuit: a plan that reports no changes has nothing
+        # for an apply Job to do. tofu wouldn't bump the state serial, so
+        # an apply Job would either no-op or — given a same-serial state
+        # upload — 500 on the unique constraint. Skip straight to applied
+        # without launching a Job. Applies regardless of auto_apply since
+        # the manual confirm path also has nothing meaningful to do.
+        if not run.plan_only and run.has_changes is False:
+            run = await run_service.transition_run(db, run, "applied")
+            ws = await db.get(Workspace, run.workspace_id)
+            if ws and ws.locked:
+                ws.locked = False
+                ws.lock_id = None
+            logger.info("Plan succeeded — no changes, skipping apply", run_id=str(run.id))
+            return
+
         # Auto-apply if configured
         if run.auto_apply and not run.plan_only:
             run = await run_service.transition_run(db, run, "confirmed")

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -381,6 +381,32 @@ async def transition_run(
     return run
 
 
+async def complete_planned_as_noop(db: AsyncSession, run: Run) -> Run:
+    """Transition a planned run directly to `applied` without an apply Job.
+
+    Used when the plan reports `has_changes=False`: tofu apply on a
+    zero-change plan does no work and doesn't bump the state serial, so
+    launching an apply Job is wasted compute and triggers the duplicate-
+    serial 500 on state upload. Skip straight to `applied`.
+
+    Sets `apply_started_at` before transitioning so `transition_run` sets
+    `apply_finished_at` in turn — the resulting run reports an
+    `applied-at` status timestamp, keeping the API response coherent for
+    UI timelines and TFE clients that expect both timestamps on a
+    terminal `applied` run. Apply duration recorded as 0s, which is
+    accurate (the apply phase was a no-op).
+
+    Releases the workspace lock since no Job will run.
+    """
+    run.apply_started_at = utc_now()
+    run = await transition_run(db, run, "applied")
+    ws = await db.get(Workspace, run.workspace_id)
+    if ws and ws.locked:
+        ws.locked = False
+        ws.lock_id = None
+    return run
+
+
 async def queue_run(db: AsyncSession, run: Run) -> Run:
     """Queue a run for execution."""
     return await transition_run(db, run, "queued")

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -30,7 +30,13 @@ VALID_TRANSITIONS: dict[str, set[str]] = {
     "pending": {"queued", "canceled", "errored"},
     "queued": {"planning", "canceled", "errored"},
     "planning": {"planned", "errored", "canceled"},
-    "planned": {"confirmed", "discarded", "errored", "canceled"},
+    # `planned → applied` is the no-op apply: when the plan reports
+    # has_changes=False there is nothing for an apply Job to do and
+    # no new state version to upload (tofu doesn't bump serial on a
+    # zero-change apply, so the upload would 500 on the unique
+    # constraint anyway). The reconciler short-circuits to applied
+    # without launching a Job.
+    "planned": {"confirmed", "applied", "discarded", "errored", "canceled"},
     "confirmed": {"applying", "errored", "canceled"},
     "applying": {"applied", "errored", "canceled"},
 }

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -1,0 +1,125 @@
+"""Tests for runner artifact upload/download endpoints."""
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.models import StateVersion
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer runtok:dummy"}
+
+
+def _runner_user(run_id: uuid.UUID) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        email="runner",
+        display_name="Runner Job",
+        roles=["everyone"],
+        provider_name="runner_token",
+        auth_method="runner_token",
+        run_id=str(run_id),
+    )
+
+
+def _mock_run(run_id=None, ws_id=None):
+    run = MagicMock()
+    run.id = run_id or uuid.uuid4()
+    run.workspace_id = ws_id or uuid.uuid4()
+    run.created_by = "matt@example.com"
+    return run
+
+
+def _make_app(user, mock_db):
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app
+
+
+# ── upload_state — duplicate-serial 409 regression ────────────────────
+
+
+class TestUploadStateDuplicateSerial:
+    """Re-uploading state with an already-used serial returns 409, not 500.
+
+    A no-op `tofu apply` doesn't bump the state serial — without this
+    check, the re-upload triggers `IntegrityError` on `uq_state_versions`
+    and FastAPI surfaces a 500. The reconciler short-circuit (no-op
+    planned → applied) prevents this path from being hit in steady state,
+    but the explicit 409 keeps the API correct against legacy clients,
+    races, and any future caller that re-uploads stale state.
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_existing_serial_returns_409(self, *_mocks):
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id)
+
+        mock_db = AsyncMock()
+        # `_get_run` does db.get(Run, uuid); the dup-serial check does
+        # db.execute(select(StateVersion)) — different call sites, separate mocks.
+        mock_db.get.return_value = run
+        existing = MagicMock()
+        existing.scalar_one_or_none.return_value = MagicMock(spec=StateVersion)
+        mock_db.execute.return_value = existing
+
+        app = _make_app(_runner_user(run_id), mock_db)
+
+        state_json = json.dumps({"version": 4, "serial": 8, "lineage": "abc"})
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/v2/runs/{run.id}/artifacts/state",
+                content=state_json,
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 409
+        body = resp.json()
+        assert "serial 8 already exists" in body["detail"].lower()
+        # Critically, the StateVersion row was NOT inserted.
+        mock_db.add.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_new_serial_succeeds(self, mock_get_storage, *_mocks):
+        """Sanity: a genuinely new serial still goes through (no false-positive 409)."""
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id)
+
+        mock_db = AsyncMock()
+        # First db.get is for Run (in _get_run). Second is for Workspace
+        # (in the post-insert state_diverged clear branch).
+        ws = MagicMock()
+        ws.state_diverged = False
+        mock_db.get.side_effect = [run, ws]
+        existing = MagicMock()
+        existing.scalar_one_or_none.return_value = None  # no conflict
+        mock_db.execute.return_value = existing
+
+        mock_storage = AsyncMock()
+        mock_get_storage.return_value = mock_storage
+
+        app = _make_app(_runner_user(run_id), mock_db)
+
+        state_json = json.dumps({"version": 4, "serial": 9, "lineage": "abc"})
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/v2/runs/{run.id}/artifacts/state",
+                content=state_json,
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 204
+        mock_db.add.assert_called_once()
+        mock_storage.put.assert_called_once()

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -90,6 +90,44 @@ class TestUploadStateDuplicateSerial:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
+    async def test_race_window_falls_back_to_409(self, *_mocks):
+        """SELECT-then-INSERT race: another upload inserts between our
+        check and our flush. The unique constraint catches it; the
+        IntegrityError handler translates to 409 instead of letting it
+        surface as 500.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        run_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id)
+
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        # First db.execute is the proactive lookup — returns None (no row).
+        empty = MagicMock()
+        empty.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = empty
+        # The race: db.flush() raises IntegrityError as the constraint kicks in.
+        mock_db.flush.side_effect = IntegrityError("INSERT", {}, Exception("uq_state_versions"))
+
+        app = _make_app(_runner_user(run_id), mock_db)
+
+        state_json = json.dumps({"version": 4, "serial": 8, "lineage": "abc"})
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/v2/runs/{run.id}/artifacts/state",
+                content=state_json,
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 409
+        assert "serial 8 already exists" in resp.json()["detail"].lower()
+        # Rollback was issued so the session is usable for the caller.
+        mock_db.rollback.assert_awaited_once()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.run_artifacts.get_storage")
     async def test_new_serial_succeeds(self, mock_get_storage, *_mocks):
         """Sanity: a genuinely new serial still goes through (no false-positive 409)."""

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -265,6 +265,41 @@ class TestConfirmRun:
             )
         assert resp.status_code == 409
 
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.confirm_run")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_confirm_no_changes_returns_422(
+        self, mock_get_run, mock_resolve, mock_confirm, *mocks
+    ):
+        """Confirm on a no-op plan must 422 — there is nothing to apply.
+
+        Reconciler short-circuits this case directly to `applied`, so under
+        normal conditions the endpoint never sees `planned` + has_changes=False.
+        Defensive check guards against legacy data and races, and pairs with
+        `is-confirmable=false` in the response so UI and API agree.
+        """
+        mock_resolve.return_value = "write"
+        run = _mock_run(status="planned")
+        run.has_changes = False
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/v2/runs/run-{run.id}/actions/apply",
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "no changes" in resp.json()["detail"].lower()
+        # confirm_run service was NOT invoked — endpoint rejected before transition.
+        mock_confirm.assert_not_called()
+
 
 # ── Discard Run ────────────────────────────────────────────────────────
 
@@ -376,6 +411,37 @@ class TestRunJsonSerialization:
         # cancelable — the right actions are confirm or discard. Cancel
         # only applies to in-progress states.
         assert actions["is-cancelable"] is False
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_no_changes_hides_confirm_and_discard(self, mock_get_run, mock_resolve, *mocks):
+        """Planned run with has_changes=False must not advertise confirm/discard.
+
+        Frontend gates the buttons on these flags. If the backend says
+        is-confirmable=true on a no-op plan, the user can click and trigger
+        the state-upload 500 cycle. Keep both flags false (and the matching
+        permission booleans) so the API and the UI present the same answer.
+        """
+        mock_resolve.return_value = "read"
+        run = _mock_run(status="planned", auto_apply=False)
+        run.has_changes = False
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["actions"]["is-confirmable"] is False
+        assert attrs["actions"]["is-discardable"] is False
+        assert attrs["permissions"]["can-apply"] is False
+        assert attrs["permissions"]["can-discard"] is False
 
     @pytest.mark.parametrize(
         "status,expected",

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -30,6 +30,9 @@ def _mock_run(**kwargs):
     run.error_message = kwargs.get("error_message", "")
     run.vcs_commit_sha = kwargs.get("vcs_commit_sha", None)
     run.is_drift_detection = kwargs.get("is_drift_detection", False)
+    # Default `has_changes=True` so existing tests keep matching the
+    # "real plan with changes" path — only the no-op short-circuit cares.
+    run.has_changes = kwargs.get("has_changes", True)
     return run
 
 
@@ -163,6 +166,72 @@ class TestHandleSucceeded:
         assert mock_transition.call_count == 2
         assert mock_transition.call_args_list[0].args[2] == "planned"
         assert mock_transition.call_args_list[1].args[2] == "confirmed"
+
+    @patch(_PERSIST_PATCH, new_callable=AsyncMock)
+    @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service.transition_run", new_callable=AsyncMock)
+    async def test_plan_with_no_changes_skips_apply(
+        self, mock_transition, mock_stage, mock_persist
+    ):
+        """has_changes=False short-circuits planned → applied without an apply Job.
+
+        Regression for the state-upload 500 cycle: tofu apply of a no-changes
+        plan doesn't bump the state serial, so the runner's PUT
+        /artifacts/state hits the unique constraint on (workspace_id, serial)
+        and 500s. Skipping the apply Job entirely avoids the round-trip.
+        """
+        db = AsyncMock()
+        run = _mock_run(status="planning", auto_apply=False, plan_only=False, has_changes=False)
+        mock_stage.return_value = None
+        planned_run = _mock_run(
+            status="planned", auto_apply=False, plan_only=False, has_changes=False
+        )
+        applied_run = _mock_run(
+            status="applied", auto_apply=False, plan_only=False, has_changes=False
+        )
+        mock_transition.side_effect = [planned_run, applied_run]
+        ws = MagicMock()
+        ws.locked = True
+        db.get.return_value = ws
+
+        await _handle_succeeded(db, run)
+
+        # Two transitions: planning→planned, then planned→applied.
+        # Critically, NO transition to "confirmed" — the apply Job is never queued.
+        assert mock_transition.call_count == 2
+        assert mock_transition.call_args_list[0].args[2] == "planned"
+        assert mock_transition.call_args_list[1].args[2] == "applied"
+        assert ws.locked is False
+
+    @patch(_PERSIST_PATCH, new_callable=AsyncMock)
+    @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service.transition_run", new_callable=AsyncMock)
+    async def test_plan_with_no_changes_overrides_auto_apply(
+        self, mock_transition, mock_stage, mock_persist
+    ):
+        """auto_apply doesn't matter when has_changes=False — still skip to applied.
+
+        Without this, an auto-apply workspace with a no-op plan would queue a
+        confirm → applying transition and re-trigger the same 500 loop.
+        """
+        db = AsyncMock()
+        run = _mock_run(status="planning", auto_apply=True, plan_only=False, has_changes=False)
+        mock_stage.return_value = None
+        planned_run = _mock_run(
+            status="planned", auto_apply=True, plan_only=False, has_changes=False
+        )
+        applied_run = _mock_run(
+            status="applied", auto_apply=True, plan_only=False, has_changes=False
+        )
+        mock_transition.side_effect = [planned_run, applied_run]
+        db.get.return_value = MagicMock(locked=False)
+
+        await _handle_succeeded(db, run)
+
+        # Must be planned → applied, not planned → confirmed.
+        assert mock_transition.call_args_list[1].args[2] == "applied"
+        # No third transition — auto_apply path is bypassed.
+        assert mock_transition.call_count == 2
 
     @patch(_PERSIST_PATCH, new_callable=AsyncMock)
     @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -38,6 +38,7 @@ interface RunAttrs {
   'vcs-commit-sha': string | null
   'vcs-branch': string | null
   'vcs-pull-request-number': number | null
+  'has-changes': boolean
   'workspace-name': string
   'workspace-has-vcs': boolean
   'module-overrides': Record<string, string> | null
@@ -582,6 +583,18 @@ export default function RunDetailPage() {
           <div className="mb-6 p-4 bg-red-900/20 rounded-lg border border-red-800/50">
             <h3 className="text-sm font-medium text-red-400 mb-1">Error</h3>
             <pre className="text-sm text-red-300 whitespace-pre-wrap font-mono">{attrs['error-message']}</pre>
+          </div>
+        )}
+
+        {/* No-changes notice — explains why Confirm & Apply isn't shown.
+            Only relevant for plan-and-apply runs (plan-only runs simply
+            report the plan and have no concept of an apply phase). */}
+        {attrs['has-changes'] === false && !attrs['plan-only'] && ['planned', 'applied'].includes(attrs.status) && (
+          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6 text-sm text-slate-300">
+            <span className="font-medium text-slate-100">No changes.</span>{' '}
+            {attrs.status === 'applied'
+              ? 'Plan reported nothing to do; the apply was skipped automatically.'
+              : 'Plan reported nothing to do — there is nothing to apply.'}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

A plan that reports `has_changes=false` has nothing for an apply Job to do. Running it anyway was a load-bearing bug: tofu apply on a zero-change plan does not bump the state serial, so the runner's `PUT /artifacts/state` hit the unique constraint on `(workspace_id, serial)` and 500'd. The runner then flagged the workspace `state-diverged` and exited 1 — surfacing as "Job failed" with a misleading state-divergence banner even though the actual infrastructure was untouched.

## Reproduced in production

Workspace `sls-grafana`, agent execution mode, auto-apply off:
- Yesterday's run applied successfully (state at serial=8, md5 `92b446...`)
- Today's VCS push triggered a fresh plan against the already-applied commit → plan reports 0 changes
- User clicks Confirm & Apply → apply Job 500s uploading the same-serial state → run errored
- Workspace flagged `state_diverged: true` + UI banner "State may be diverged"

Confirmed via Loki:
- Runner log: `curl: (22) The requested URL returned error: 500` then `[entrypoint] FATAL: state upload failed — flagging workspace`
- API exception: `IntegrityError UniqueViolationError on uq_state_versions, key (workspace_id, serial)=(019db570-..., 8) already exists`

A second run with real changes (`019de292`) on the same workspace plan→apply'd cleanly under v0.20.4 — so this is specifically the no-op path.

## Fix

| Layer | Change |
|---|---|
| `run_service.VALID_TRANSITIONS` | Allow `planned → applied` (the no-op short-circuit) |
| `run_service.complete_planned_as_noop` | New helper. Pre-sets `apply_started_at` so `transition_run` sets `apply_finished_at` — keeps `status-timestamps` coherent with both `planning-at`, `planned-at`, and `applied-at`. Releases the workspace lock |
| `run_reconciler._handle_succeeded` | When `has_changes=False` after a successful plan, call the helper. Skip the auto-apply branch — it would just re-trigger the loop |
| `runs.update_run_status` (listener PATCH path) | Same helper for listeners that PATCH planned directly |
| `_run_json` action flags | `is-confirmable` / `is-discardable` / `can-apply` / `can-discard` require `has_changes is not False`. The frontend already gates the buttons on these, so they hide automatically |
| `confirm_run` endpoint | Defensive 422 on confirm with `has_changes=False`. Should be unreachable in steady state but guards legacy data and races |
| `upload_state` endpoint | Pre-INSERT SELECT for a clean 409 message in the common case, plus IntegrityError → 409 fallback to close the SELECT-then-INSERT race window. Both layers ensure the unique constraint is the source of truth |
| Run detail page | New "No changes" notice explains why Confirm & Apply isn't shown |

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1138 passing (+7 new)
- New tests: reconciler short-circuit (auto_apply on/off), API 422 on no-op confirm, action flags false in payload, upload duplicate-serial 409, upload race-window IntegrityError → 409, upload happy path 204