### PR TITLE
fix: JSON uvicorn logs + reliable workspace filter URL sync

### DIFF
--- a/services/terrapod/logging_config.py
+++ b/services/terrapod/logging_config.py
@@ -112,6 +112,19 @@ def configure_logging(json_logs: bool = True, log_level: str = "INFO") -> None:
     logging.getLogger("botocore").setLevel(logging.WARNING)
     logging.getLogger("aiobotocore").setLevel(logging.WARNING)
 
+    # Route uvicorn's loggers through our structlog ProcessorFormatter so
+    # access and error lines come out as JSON instead of uvicorn's default
+    # plaintext (`INFO:     10.x.y.z - "GET /path" 200 OK`). Uvicorn
+    # installs its own StreamHandler with a non-JSON formatter on these
+    # loggers at startup; we clear them and force propagation so records
+    # reach the root handler installed above. `foreign_pre_chain` on the
+    # ProcessorFormatter handles structlog enrichment for these stdlib
+    # log records (logger name, level, app context, timestamp).
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.propagate = True
+
 
 def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
     """Get a structured logger instance."""

--- a/services/tests/test_logging_config.py
+++ b/services/tests/test_logging_config.py
@@ -1,0 +1,75 @@
+"""Tests for `terrapod.logging_config`.
+
+Why these tests exist
+---------------------
+Uvicorn ships its own `uvicorn`, `uvicorn.access`, and `uvicorn.error`
+loggers with non-JSON `StreamHandler`s installed by default. Without
+intervention, every request produces a plaintext line like
+`INFO:     10.x.y.z - "GET /path" 200 OK` interleaved with our
+structlog JSON, which breaks log ingestion pipelines that expect
+one-record-per-line JSON. `configure_logging` clears those handlers
+and forces propagation so the records flow through our root JSON
+formatter instead.
+
+Regressing this would mean log shippers silently dropping uvicorn
+events as malformed JSON — exactly the kind of breakage that's
+invisible until someone goes looking.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+from terrapod.logging_config import configure_logging
+
+
+def _install_uvicorn_default_handlers() -> None:
+    """Mimic uvicorn's startup-time logger setup so the test starts
+    from the same state production does — uvicorn loggers with their
+    own handlers and `propagate=False`, which would otherwise emit
+    plaintext lines that bypass our root handler."""
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.addHandler(logging.StreamHandler(io.StringIO()))
+        lg.propagate = False
+        lg.setLevel(logging.INFO)
+
+
+def test_configure_logging_redirects_uvicorn_loggers_through_root():
+    _install_uvicorn_default_handlers()
+    configure_logging(json_logs=True, log_level="INFO")
+
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        assert lg.handlers == [], (
+            f"uvicorn handler not cleared on {name}; logs would emit twice "
+            "(once via uvicorn's own plaintext handler, once via root JSON)"
+        )
+        assert lg.propagate is True, (
+            f"{name} not set to propagate; records would never reach the "
+            "root JSON handler and would be dropped silently"
+        )
+
+
+def test_uvicorn_access_record_emits_as_json(capsys):
+    """Drive the full path: install uvicorn's default handlers, run
+    configure_logging, then log an access-shaped record. The captured
+    stdout must be valid JSON with our app context — proving the
+    handler chain rewires correctly end-to-end, not just at the
+    handler-list level."""
+    _install_uvicorn_default_handlers()
+    configure_logging(json_logs=True, log_level="INFO")
+
+    logging.getLogger("uvicorn.access").info('10.0.0.1 - "GET /health" 200 OK')
+
+    captured = capsys.readouterr().out.strip().splitlines()
+    # The last line is ours; earlier lines may be from the
+    # configure_logging startup (`logging.basicConfig` smokes one too).
+    record = json.loads(captured[-1])
+    assert record["app"] == "terrapod-api"
+    assert record["logger"] == "uvicorn.access"
+    assert record["level"] == "info"
+    assert "GET /health" in record["event"]

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -97,17 +97,32 @@ function WorkspacesPageInner() {
     }
   }, [statusMenuOpen])
 
-  // Sync the input back to the URL whenever the parsed shape changes.
+  // Sync the input to the URL whenever the parsed filter changes.
+  //
+  // Dedup via `lastSyncedQueryRef` — we track the last query string we
+  // wrote and skip redundant `router.replace` calls. We deliberately do
+  // NOT compare against `searchParams.get('q')`: `useSearchParams()` is
+  // updated by Next.js asynchronously after `router.replace`, so its
+  // value in the effect closure can be one render behind the URL we
+  // just wrote. That stale read was the cause of the workspaces filter
+  // sync being "hit and miss" — it would early-return on a comparison
+  // against an out-of-date `current`, leaving the address bar stuck.
+  // The ref is written-once-per-real-update and never reads back from
+  // the URL, so it can't go stale.
+  //
+  // Initialised to the URL's current `q` so that mounting on a page
+  // already loaded with `?q=...` (refresh, shared link) doesn't fire a
+  // redundant `router.replace` over the unchanged URL on first render.
+  const lastSyncedQueryRef = useRef<string | null>(searchParams.get('q') || '')
   useEffect(() => {
     const serialized = serializeFilter(parsedFilter)
-    const current = searchParams.get('q') || ''
-    if (serialized === current) return
-    const params = new URLSearchParams(Array.from(searchParams.entries()))
-    if (serialized) params.set('q', serialized)
-    else params.delete('q')
-    const qs = params.toString()
-    router.replace(qs ? `/workspaces?${qs}` : '/workspaces', { scroll: false })
-  }, [parsedFilter, router, searchParams])
+    if (lastSyncedQueryRef.current === serialized) return
+    lastSyncedQueryRef.current = serialized
+    const url = serialized
+      ? `/workspaces?q=${encodeURIComponent(serialized)}`
+      : '/workspaces'
+    router.replace(url, { scroll: false })
+  }, [parsedFilter, router])
 
   const filteredWorkspaces = useMemo(() => {
     if (parsedFilter.terms.length === 0) return workspaces


### PR DESCRIPTION
## Summary

Two unrelated post-v0.21.0 bug fixes, bundled because both are small and independent.

### 1. Uvicorn logs come out as JSON (`services/terrapod/logging_config.py`)

Uvicorn ships its own `uvicorn`, `uvicorn.access`, `uvicorn.error` loggers with non-JSON `StreamHandler`s installed at startup. Without intervention, every request produces a plaintext line:

\`\`\`
INFO:     10.101.140.65:41640 - "GET /api/v2/workspaces/... HTTP/1.1" 200 OK
\`\`\`

…interleaved with our structlog JSON, which breaks log ingestion pipelines that expect one-record-per-line JSON. Confirmed visible in the mgmt-cluster api logs.

`configure_logging` now clears uvicorn's handlers and forces propagation so records flow through our root JSON formatter — the `ProcessorFormatter`'s `foreign_pre_chain` enriches stdlib log records with our timestamp / app context / level. Adds a regression test that mimics uvicorn's startup-time logger state and asserts the access record emits as JSON with our app context.

### 2. Workspaces filter → URL sync (`web/src/app/workspaces/page.tsx`)

The URL-sync effect compared `serializeFilter(parsedFilter)` against `searchParams.get('q')` to decide whether to call `router.replace`. Next.js App Router updates `useSearchParams()` **asynchronously** after a navigation, so the value in the effect closure could be one render behind the URL we just wrote — causing the early-return to fire incorrectly and leaving the address bar stuck on a stale filter. Symptom was "hit and miss" filter → URL sync, including the Clear button often failing to remove `?q=...`.

Replaced the `searchParams` read with a `useRef` that tracks the last query we wrote. The ref is written every time we call `router.replace`, never read back from the URL, so it can't go stale. Initialised from the URL on mount so a page loaded with `?q=...` (refresh, shared link) doesn't fire a redundant `router.replace` on first render.

**Behaviour after fix:**
- Reload preserves the filter (URL is the persistence layer; `useState` initializer reads `q` once on mount).
- Per-tab isolation — state + ref live in the React component instance, never persisted.
- **Out of scope**: browser back/forward changing the URL while the page is mounted leaves the chips stale until reload. Pre-existing behaviour, not introduced by this PR. Confirmed with the user.

## Test plan

- [x] `make lint` — Python + frontend + helm clean
- [x] `make test` — 1194 passed, 0 failed (added 2 logging tests)
- [x] `tsc --noEmit` + `eslint` clean on the changed file
- [x] Logging fix: regression test exercises end-to-end (uvicorn record → JSON via root)
- [ ] Tilt validation: type into the workspaces filter, click status dropdown options, click Clear, verify `?q=...` updates correctly each time and Clear removes it