### PR TITLE
feat: read-only cross-entity labels browser

### DIFF
--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -18,6 +18,13 @@ RUN pip install --no-cache-dir .
 FROM python:3.14-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
+# Pick up post-publish Debian security patches. Other Dockerfiles
+# (api, runner) already do this in their runtime stage; the migrations
+# image was inconsistent and inherited whatever security state the
+# python:3.14-slim base was published with at the moment Docker Hub
+# last republished. No new packages installed — just upgrades.
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Copy installed Python packages from builder

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -13,3 +13,30 @@
 # connections, so the frame-after-close path isn't reachable. Re-evaluate
 # when alpine 3.23.5+ releases or when we move to a different base.
 CVE-2026-27135
+
+# CVE-2026-4878 — libcap2 privilege escalation via TOCTOU race in
+# `cap_set_file()`. Affects setuid binaries that call libcap to set
+# extended capabilities. No fix in Debian 13 yet. Our migrations
+# image runs `alembic upgrade head` as a non-root user and contains
+# no setuid binaries; the local-priv-esc path requires both shell
+# access and a setuid binary linked against libcap, neither of which
+# exists in this image. Re-evaluate when Debian backports the fix.
+CVE-2026-4878
+
+# CVE-2025-69720 — ncurses buffer overflow when processing malicious
+# terminfo / terminal sequences. No fix in Debian 13 yet. Our images
+# run no terminal applications (no shells served, no curses TUI, no
+# `less`/`more`-style interaction). The exploit path requires
+# attacker-controlled terminfo data being read by an ncurses-using
+# binary; not reachable in any of our containers. Re-evaluate when
+# Debian backports the fix.
+CVE-2025-69720
+
+# CVE-2026-29111 — systemd RCE/DoS via spurious IPC API call data.
+# `libsystemd0` and `libudev1` are pulled in transitively on Debian-
+# based images even though we don't run systemd inside the container
+# (Kubernetes manages process lifecycle). The library code is loaded
+# but the IPC entrypoints aren't reachable without a running systemd
+# instance, which our images never have. Re-evaluate when Debian
+# backports the fix or when the python:3.14-slim base drops systemd.
+CVE-2026-29111

--- a/services/pyproject-migrations.toml
+++ b/services/pyproject-migrations.toml
@@ -6,4 +6,10 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0",
     "asyncpg>=0.31",
     "alembic>=1.14",
+    # Pin Mako forward to dodge CVE-2026-44307 (path traversal via
+    # backslash URI). Mako is pulled in transitively by alembic; the
+    # CVE is Windows-only (backslash URIs aren't a Linux concern) so
+    # this is defence-in-depth — Trivy still flags it because the
+    # advisory doesn't carry an OS qualifier.
+    "Mako>=1.3.12",
 ]

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -504,6 +504,11 @@ def create_application() -> FastAPI:
 
     app.include_router(agent_pools_router)
 
+    # Read-only labels browser (cross-entity: workspaces, pools, modules, providers)
+    from terrapod.api.routers.labels import router as labels_router
+
+    app.include_router(labels_router)
+
     # Run endpoints
     from terrapod.api.routers.runs import router as runs_router
 

--- a/services/terrapod/api/routers/labels.py
+++ b/services/terrapod/api/routers/labels.py
@@ -1,0 +1,66 @@
+"""Read-only labels browser API.
+
+UX CONTRACT: consumed by `web/src/app/labels/page.tsx`. Changes to
+response shapes here MUST be matched by frontend updates.
+
+Endpoints:
+    GET /api/v2/labels                       — distinct keys + per-type counts
+    GET /api/v2/labels/{key}                 — distinct values for a key
+    GET /api/v2/labels/{key}/{value}         — entities tagged with key=value
+
+All three are RBAC-filtered: results only include labels carried by
+entities the caller has at least `read` on for that entity's
+permission model. Read-only by design — labels continue to be edited
+on each entity's own edit page (no labels-admin surface here).
+"""
+
+from fastapi import APIRouter, Depends, Path
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.session import get_db
+from terrapod.services import labels_service
+
+router = APIRouter(prefix="/api/v2", tags=["labels"])
+
+
+@router.get("/labels")
+async def list_keys(
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Return all label keys in use across readable entities.
+
+    Each key entry includes the count of distinct values and a
+    breakdown of how many entities of each type carry that key.
+    """
+    keys = await labels_service.aggregate_keys(db, user)
+    return JSONResponse(content={"data": keys})
+
+
+@router.get("/labels/{key}")
+async def list_values(
+    key: str = Path(..., min_length=1, max_length=200),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Return distinct values for `key`, with per-entity-type counts.
+
+    Empty `data` is a valid response — means no readable entity
+    carries this key (or no entity at all).
+    """
+    values = await labels_service.aggregate_values_for_key(db, user, key)
+    return JSONResponse(content={"data": values})
+
+
+@router.get("/labels/{key}/{value}")
+async def list_entities(
+    key: str = Path(..., min_length=1, max_length=200),
+    value: str = Path(..., max_length=500),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Return entities tagged with exactly `key=value`, grouped by type."""
+    grouped = await labels_service.list_entities_for_label(db, user, key, value)
+    return JSONResponse(content={"data": grouped})

--- a/services/terrapod/services/labels_service.py
+++ b/services/terrapod/services/labels_service.py
@@ -1,0 +1,284 @@
+"""Read-only cross-entity label aggregation.
+
+Why this exists
+---------------
+Terrapod's organizational primitive is the label, not the team or
+project. Workspaces, agent pools, registry modules and registry
+providers all carry a `labels: dict[str, str]` JSONB column, all
+feeding the same RBAC machinery.
+
+This service answers three questions for the labels-browser UI:
+
+* "What label keys exist across the things I can see?"  →
+  `aggregate_keys(db, user)`
+* "What values does this key have, and what's tagged with each?"  →
+  `aggregate_values_for_key(db, user, key)`
+* "What's tagged with this exact key=value?"  →
+  `list_entities_for_label(db, user, key, value)`
+
+Read-only by design. Editing labels stays on each entity's own edit
+page; we don't want a labels-admin surface that becomes a back-door
+for mass-mutating workspaces / pools / modules / providers.
+
+RBAC
+----
+Each entity type has its own permission resolver
+(`resolve_workspace_permission`, `resolve_pool_permission`,
+`resolve_registry_permission`). We only surface labels on entities
+the caller has at least `read` on. The four resolvers each support
+`preloaded_roles=` to avoid an N+1 DB hit when iterating over many
+entities; we pre-load roles once per entity type.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.api.dependencies import AuthenticatedUser
+from terrapod.db.models import (
+    AgentPool,
+    RegistryModule,
+    RegistryProvider,
+    Workspace,
+)
+from terrapod.services import (
+    pool_rbac_service,
+    registry_rbac_service,
+    workspace_rbac_service,
+)
+
+# Stable type identifiers used in the API and UI. Match the JSON:API
+# `type` strings each entity uses elsewhere where possible, so frontend
+# code can route consistently.
+ENTITY_TYPES = ("workspaces", "agent-pools", "registry-modules", "registry-providers")
+
+
+async def _readable_workspaces(db: AsyncSession, user: AuthenticatedUser) -> list[Workspace]:
+    """Return workspaces the user has at least read access to."""
+    result = await db.execute(select(Workspace).order_by(Workspace.name))
+    workspaces = list(result.scalars().all())
+    preloaded = await workspace_rbac_service.fetch_custom_roles(db, user.roles)
+    out: list[Workspace] = []
+    for ws in workspaces:
+        perm = await workspace_rbac_service.resolve_workspace_permission(
+            db,
+            user_email=user.email,
+            user_roles=user.roles,
+            workspace=ws,
+            preloaded_roles=preloaded,
+        )
+        if perm is not None:
+            out.append(ws)
+    return out
+
+
+async def _readable_pools(db: AsyncSession, user: AuthenticatedUser) -> list[AgentPool]:
+    result = await db.execute(select(AgentPool).order_by(AgentPool.name))
+    pools = list(result.scalars().all())
+    preloaded = await pool_rbac_service.fetch_custom_roles(db, user.roles)
+    out: list[AgentPool] = []
+    for p in pools:
+        perm = await pool_rbac_service.resolve_pool_permission(
+            db,
+            user_email=user.email,
+            user_roles=user.roles,
+            pool_name=p.name,
+            pool_labels=p.labels or {},
+            owner_email=p.owner_email or "",
+            preloaded_roles=preloaded,
+        )
+        if perm is not None:
+            out.append(p)
+    return out
+
+
+async def _readable_modules(db: AsyncSession, user: AuthenticatedUser) -> list[RegistryModule]:
+    result = await db.execute(select(RegistryModule).order_by(RegistryModule.name))
+    modules = list(result.scalars().all())
+    preloaded = await registry_rbac_service.fetch_custom_roles(db, user.roles)
+    out: list[RegistryModule] = []
+    for m in modules:
+        perm = await registry_rbac_service.resolve_registry_permission(
+            db,
+            user_email=user.email,
+            user_roles=user.roles,
+            resource_name=m.name,
+            resource_labels=m.labels or {},
+            owner_email=m.owner_email or "",
+            preloaded_roles=preloaded,
+        )
+        if perm is not None:
+            out.append(m)
+    return out
+
+
+async def _readable_providers(db: AsyncSession, user: AuthenticatedUser) -> list[RegistryProvider]:
+    result = await db.execute(select(RegistryProvider).order_by(RegistryProvider.name))
+    providers = list(result.scalars().all())
+    preloaded = await registry_rbac_service.fetch_custom_roles(db, user.roles)
+    out: list[RegistryProvider] = []
+    for p in providers:
+        perm = await registry_rbac_service.resolve_registry_permission(
+            db,
+            user_email=user.email,
+            user_roles=user.roles,
+            resource_name=p.name,
+            resource_labels=p.labels or {},
+            owner_email=p.owner_email or "",
+            preloaded_roles=preloaded,
+        )
+        if perm is not None:
+            out.append(p)
+    return out
+
+
+async def _readable_by_type(db: AsyncSession, user: AuthenticatedUser) -> dict[str, list]:
+    """Return the readable entities of every type, keyed by ENTITY_TYPES."""
+    return {
+        "workspaces": await _readable_workspaces(db, user),
+        "agent-pools": await _readable_pools(db, user),
+        "registry-modules": await _readable_modules(db, user),
+        "registry-providers": await _readable_providers(db, user),
+    }
+
+
+def _empty_counts() -> dict[str, int]:
+    return dict.fromkeys(ENTITY_TYPES, 0)
+
+
+async def aggregate_keys(db: AsyncSession, user: AuthenticatedUser) -> list[dict[str, Any]]:
+    """Return distinct label keys across all readable entities, with counts.
+
+    Shape:
+        [
+          {
+            "key": "account",
+            "value-count": 3,
+            "entity-counts": {"workspaces": 12, "agent-pools": 1, ...},
+          },
+          ...
+        ]
+
+    Sorted alphabetically by key. An entity contributes to the count
+    for a key once if it has that key in its labels dict, regardless
+    of value.
+    """
+    by_type = await _readable_by_type(db, user)
+    # Per-key: set of distinct values seen + per-type entity counts.
+    key_values: dict[str, set[str]] = defaultdict(set)
+    key_counts: dict[str, dict[str, int]] = defaultdict(_empty_counts)
+
+    for entity_type, entities in by_type.items():
+        for entity in entities:
+            for key, value in (entity.labels or {}).items():
+                key_values[key].add(value)
+                key_counts[key][entity_type] += 1
+
+    return [
+        {
+            "key": key,
+            "value-count": len(key_values[key]),
+            "entity-counts": dict(key_counts[key]),
+        }
+        for key in sorted(key_values)
+    ]
+
+
+async def aggregate_values_for_key(
+    db: AsyncSession, user: AuthenticatedUser, key: str
+) -> list[dict[str, Any]]:
+    """Return distinct values for `key`, each with per-type entity counts.
+
+    Shape:
+        [
+          {
+            "value": "prod",
+            "entity-counts": {"workspaces": 4, ...},
+          },
+          ...
+        ]
+
+    Sorted alphabetically by value. Returns [] if no entity carries
+    the key.
+    """
+    by_type = await _readable_by_type(db, user)
+    value_counts: dict[str, dict[str, int]] = defaultdict(_empty_counts)
+
+    for entity_type, entities in by_type.items():
+        for entity in entities:
+            v = (entity.labels or {}).get(key)
+            if v is None:
+                continue
+            value_counts[v][entity_type] += 1
+
+    return [{"value": v, "entity-counts": dict(value_counts[v])} for v in sorted(value_counts)]
+
+
+def _entity_to_json(entity_type: str, entity: Any) -> dict[str, Any]:
+    """Minimal JSON shape for the entity-list view.
+
+    Just enough for the UI to render a row + link to the entity's own
+    page: id-prefix, name, and the entity's full labels dict so the
+    UI can render the label badges.
+    """
+    if entity_type == "workspaces":
+        return {
+            "type": "workspaces",
+            "id": f"ws-{entity.id}",
+            "name": entity.name,
+            "labels": entity.labels or {},
+        }
+    if entity_type == "agent-pools":
+        return {
+            "type": "agent-pools",
+            "id": f"apool-{entity.id}",
+            "name": entity.name,
+            "labels": entity.labels or {},
+        }
+    if entity_type == "registry-modules":
+        return {
+            "type": "registry-modules",
+            "id": f"mod-{entity.id}",
+            "name": entity.name,
+            "namespace": entity.namespace,
+            "provider": entity.provider,
+            "labels": entity.labels or {},
+        }
+    if entity_type == "registry-providers":
+        return {
+            "type": "registry-providers",
+            "id": f"prov-{entity.id}",
+            "name": entity.name,
+            "namespace": entity.namespace,
+            "labels": entity.labels or {},
+        }
+    raise ValueError(f"unknown entity type {entity_type!r}")
+
+
+async def list_entities_for_label(
+    db: AsyncSession, user: AuthenticatedUser, key: str, value: str
+) -> dict[str, list[dict[str, Any]]]:
+    """List the entities (across all four types) tagged exactly `key=value`.
+
+    Shape:
+        {
+          "workspaces": [{...}, ...],
+          "agent-pools": [...],
+          "registry-modules": [...],
+          "registry-providers": [...],
+        }
+
+    Each entity-type list is sorted by name. Empty lists are kept so
+    the UI can render an empty section cleanly.
+    """
+    by_type = await _readable_by_type(db, user)
+    out: dict[str, list[dict[str, Any]]] = {t: [] for t in ENTITY_TYPES}
+    for entity_type, entities in by_type.items():
+        for entity in entities:
+            if (entity.labels or {}).get(key) == value:
+                out[entity_type].append(_entity_to_json(entity_type, entity))
+    return out

--- a/services/terrapod/services/registry_rbac_service.py
+++ b/services/terrapod/services/registry_rbac_service.py
@@ -39,6 +39,22 @@ def has_registry_permission(effective: str | None, required: str) -> bool:
     )
 
 
+async def fetch_custom_roles(
+    db: AsyncSession,
+    user_roles: list[str],
+) -> list[Role]:
+    """Fetch custom (non-builtin) Role objects for the given role names.
+
+    Use this to pre-load roles once before calling resolve_registry_permission
+    in a loop, passing the result as ``preloaded_roles`` to avoid N+1 queries.
+    """
+    custom_names = set(user_roles) - BUILTIN_ROLE_NAMES
+    if not custom_names:
+        return []
+    result = await db.execute(select(Role).where(Role.name.in_(custom_names)))
+    return list(result.scalars().all())
+
+
 async def resolve_registry_permission(
     db: AsyncSession,
     user_email: str,
@@ -47,6 +63,8 @@ async def resolve_registry_permission(
     resource_labels: dict,
     owner_email: str,
     auth_method: str = "",
+    *,
+    preloaded_roles: list[Role] | None = None,
 ) -> str | None:
     """Returns highest permission level (read/write/admin), or None.
 
@@ -58,6 +76,9 @@ async def resolve_registry_permission(
     5. Label-based RBAC (custom roles) → mapped workspace_permission
     6. 'everyone' role with access: everyone label → read
     7. Default → None (no access)
+
+    Pass ``preloaded_roles`` (from :func:`fetch_custom_roles`) to skip the
+    per-call DB query — useful when resolving permissions for many resources.
     """
     role_set = set(user_roles)
 
@@ -83,8 +104,11 @@ async def resolve_registry_permission(
     # 5. Label-based RBAC from custom roles
     custom_role_names = role_set - BUILTIN_ROLE_NAMES
     if custom_role_names:
-        result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
-        roles = list(result.scalars().all())
+        if preloaded_roles is not None:
+            roles = [r for r in preloaded_roles if r.name in custom_role_names]
+        else:
+            result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
+            roles = list(result.scalars().all())
 
         for role in roles:
             # Check deny first

--- a/services/terrapod/services/workspace_rbac_service.py
+++ b/services/terrapod/services/workspace_rbac_service.py
@@ -27,11 +27,29 @@ def has_permission(effective: str | None, required: str) -> bool:
     return PERMISSION_HIERARCHY.get(effective, -1) >= PERMISSION_HIERARCHY.get(required, 99)
 
 
+async def fetch_custom_roles(
+    db: AsyncSession,
+    user_roles: list[str],
+) -> list[Role]:
+    """Fetch custom (non-builtin) Role objects for the given role names.
+
+    Use this to pre-load roles once before calling resolve_workspace_permission
+    in a loop, passing the result as ``preloaded_roles`` to avoid N+1 queries.
+    """
+    custom_names = set(user_roles) - BUILTIN_ROLE_NAMES
+    if not custom_names:
+        return []
+    result = await db.execute(select(Role).where(Role.name.in_(custom_names)))
+    return list(result.scalars().all())
+
+
 async def resolve_workspace_permission(
     db: AsyncSession,
     user_email: str,
     user_roles: list[str],
     workspace: Workspace,
+    *,
+    preloaded_roles: list[Role] | None = None,
 ) -> str | None:
     """Returns the highest permission level for a user on a workspace, or None.
 
@@ -42,6 +60,9 @@ async def resolve_workspace_permission(
     4. Label-based RBAC (custom roles) → role's workspace_permission (highest wins)
     5. 'everyone' role with access: everyone label → read
     6. Default → None (no access)
+
+    Pass ``preloaded_roles`` (from :func:`fetch_custom_roles`) to skip the
+    per-call DB query — useful when resolving permissions for many workspaces.
     """
     role_set = set(user_roles)
 
@@ -62,8 +83,11 @@ async def resolve_workspace_permission(
     # 4. Label-based RBAC from custom roles
     custom_role_names = role_set - BUILTIN_ROLE_NAMES
     if custom_role_names:
-        result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
-        roles = list(result.scalars().all())
+        if preloaded_roles is not None:
+            roles = [r for r in preloaded_roles if r.name in custom_role_names]
+        else:
+            result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
+            roles = list(result.scalars().all())
 
         resource_labels = workspace.labels or {}
         resource_name = workspace.name

--- a/services/tests/services/test_labels_service.py
+++ b/services/tests/services/test_labels_service.py
@@ -1,0 +1,252 @@
+"""Tests for the cross-entity labels aggregation service.
+
+Why these tests exist
+---------------------
+The labels browser surfaces label keys and values across four entity
+types (workspaces, agent pools, registry modules, registry providers).
+RBAC filtering happens per-entity per-type — and the response shapes
+back the UI's three drill-down levels. Regressions here would
+silently leak labels the caller shouldn't see, or hide ones they
+should.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.services import labels_service
+
+
+def _ws(name, labels=None, *, owner=None, id_=None):
+    m = MagicMock()
+    m.id = id_ or uuid.uuid4()
+    m.name = name
+    m.labels = labels or {}
+    m.owner_email = owner
+    return m
+
+
+def _pool(name, labels=None, *, owner=None, id_=None):
+    return _ws(name, labels, owner=owner, id_=id_)
+
+
+def _module(name, labels=None, *, owner=None, namespace="default", provider="aws", id_=None):
+    m = MagicMock()
+    m.id = id_ or uuid.uuid4()
+    m.name = name
+    m.namespace = namespace
+    m.provider = provider
+    m.labels = labels or {}
+    m.owner_email = owner
+    return m
+
+
+def _provider(name, labels=None, *, owner=None, namespace="default", id_=None):
+    m = MagicMock()
+    m.id = id_ or uuid.uuid4()
+    m.name = name
+    m.namespace = namespace
+    m.labels = labels or {}
+    m.owner_email = owner
+    return m
+
+
+def _user(roles=("admin",), email="admin@example.com"):
+    u = MagicMock()
+    u.email = email
+    u.roles = list(roles)
+    return u
+
+
+def _readables(workspaces=(), pools=(), modules=(), providers=()):
+    """Context manager that patches all four `_readable_*` helpers.
+
+    Tests the aggregation logic in isolation — RBAC filtering inside
+    the readable helpers has its own dedicated tests. Yielding a
+    populated set here is equivalent to "the user has read access to
+    exactly these entities."
+    """
+    stack = ExitStack()
+    stack.enter_context(
+        patch.object(
+            labels_service, "_readable_workspaces", AsyncMock(return_value=list(workspaces))
+        )
+    )
+    stack.enter_context(
+        patch.object(labels_service, "_readable_pools", AsyncMock(return_value=list(pools)))
+    )
+    stack.enter_context(
+        patch.object(labels_service, "_readable_modules", AsyncMock(return_value=list(modules)))
+    )
+    stack.enter_context(
+        patch.object(labels_service, "_readable_providers", AsyncMock(return_value=list(providers)))
+    )
+    return stack
+
+
+class TestAggregateKeys:
+    @pytest.mark.asyncio
+    async def test_collects_keys_across_all_entity_types(self):
+        ws = _ws("alpha", {"account": "prod", "team": "platform"})
+        pool = _pool("runner-prod", {"account": "prod"})
+        mod = _module("vpc", {"team": "platform"})
+        prov = _provider("aws", {"managed-by": "terrapod"})
+
+        with _readables(workspaces=[ws], pools=[pool], modules=[mod], providers=[prov]):
+            result = await labels_service.aggregate_keys(MagicMock(), _user())
+
+        keys = {entry["key"] for entry in result}
+        assert keys == {"account", "team", "managed-by"}
+        # Sorted alphabetically — frontend depends on this for stable display order
+        assert [e["key"] for e in result] == sorted(keys)
+
+    @pytest.mark.asyncio
+    async def test_value_count_dedupes_per_key(self):
+        ws1 = _ws("a", {"env": "prod"})
+        ws2 = _ws("b", {"env": "prod"})
+        ws3 = _ws("c", {"env": "staging"})
+
+        with _readables(workspaces=[ws1, ws2, ws3]):
+            result = await labels_service.aggregate_keys(MagicMock(), _user())
+
+        env_entry = next(e for e in result if e["key"] == "env")
+        # Two workspaces share "prod" — value-count is 2 (prod, staging), not 3
+        assert env_entry["value-count"] == 2
+        assert env_entry["entity-counts"]["workspaces"] == 3
+
+    @pytest.mark.asyncio
+    async def test_entity_counts_break_down_by_type(self):
+        ws = _ws("a", {"account": "prod"})
+        pool1 = _pool("p1", {"account": "prod"})
+        pool2 = _pool("p2", {"account": "prod"})
+        mod = _module("m", {"account": "prod"})
+
+        with _readables(workspaces=[ws], pools=[pool1, pool2], modules=[mod]):
+            result = await labels_service.aggregate_keys(MagicMock(), _user())
+
+        entry = next(e for e in result if e["key"] == "account")
+        assert entry["entity-counts"] == {
+            "workspaces": 1,
+            "agent-pools": 2,
+            "registry-modules": 1,
+            "registry-providers": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_empty_list(self):
+        with _readables():
+            result = await labels_service.aggregate_keys(MagicMock(), _user())
+        assert result == []
+
+
+class TestAggregateValuesForKey:
+    @pytest.mark.asyncio
+    async def test_returns_distinct_values_with_counts(self):
+        ws1 = _ws("a", {"env": "prod"})
+        ws2 = _ws("b", {"env": "prod"})
+        ws3 = _ws("c", {"env": "staging"})
+        pool = _pool("p", {"env": "prod"})
+
+        with _readables(workspaces=[ws1, ws2, ws3], pools=[pool]):
+            result = await labels_service.aggregate_values_for_key(MagicMock(), _user(), "env")
+
+        # Two values: prod (3 entities), staging (1 entity)
+        assert {e["value"] for e in result} == {"prod", "staging"}
+        prod = next(e for e in result if e["value"] == "prod")
+        assert prod["entity-counts"]["workspaces"] == 2
+        assert prod["entity-counts"]["agent-pools"] == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_key_returns_empty(self):
+        ws = _ws("a", {"env": "prod"})
+        with _readables(workspaces=[ws]):
+            result = await labels_service.aggregate_values_for_key(
+                MagicMock(), _user(), "does-not-exist"
+            )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_other_keys_ignored(self):
+        """A workspace with `env: prod` AND `team: platform` shouldn't
+        contribute to the `team` key's count when querying `env`."""
+        ws = _ws("a", {"env": "prod", "team": "platform"})
+        with _readables(workspaces=[ws]):
+            result = await labels_service.aggregate_values_for_key(MagicMock(), _user(), "env")
+        assert len(result) == 1
+        assert result[0]["value"] == "prod"
+
+
+class TestListEntitiesForLabel:
+    @pytest.mark.asyncio
+    async def test_groups_results_by_entity_type(self):
+        ws = _ws("alpha", {"account": "prod"})
+        pool = _pool("runner-prod", {"account": "prod"})
+        mod = _module("vpc", {"account": "prod"})
+
+        with _readables(workspaces=[ws], pools=[pool], modules=[mod]):
+            result = await labels_service.list_entities_for_label(
+                MagicMock(), _user(), "account", "prod"
+            )
+
+        assert len(result["workspaces"]) == 1
+        assert result["workspaces"][0]["id"].startswith("ws-")
+        assert result["workspaces"][0]["name"] == "alpha"
+
+        assert len(result["agent-pools"]) == 1
+        assert result["agent-pools"][0]["id"].startswith("apool-")
+
+        assert len(result["registry-modules"]) == 1
+        assert result["registry-modules"][0]["id"].startswith("mod-")
+
+        # Empty list still present so frontend can render the section
+        assert result["registry-providers"] == []
+
+    @pytest.mark.asyncio
+    async def test_value_must_match_exactly(self):
+        """`account: prod` must NOT match a query for `account: production`."""
+        ws = _ws("a", {"account": "prod"})
+        with _readables(workspaces=[ws]):
+            result = await labels_service.list_entities_for_label(
+                MagicMock(), _user(), "account", "production"
+            )
+        assert all(v == [] for v in result.values())
+
+    @pytest.mark.asyncio
+    async def test_includes_full_labels_so_ui_can_render_badges(self):
+        """The entity payload includes the full labels dict, not just
+        the queried key — UI renders all of an entity's labels as
+        context when a row is shown."""
+        ws = _ws("a", {"account": "prod", "team": "platform", "env": "us-east-1"})
+        with _readables(workspaces=[ws]):
+            result = await labels_service.list_entities_for_label(
+                MagicMock(), _user(), "account", "prod"
+            )
+        assert result["workspaces"][0]["labels"] == {
+            "account": "prod",
+            "team": "platform",
+            "env": "us-east-1",
+        }
+
+
+class TestRBACFiltering:
+    """The labels service must only surface labels on entities the
+    user has at least `read` on. We check this by stubbing the
+    `_readable_*` helpers — they're the RBAC barrier — and asserting
+    the aggregation only sees what they return."""
+
+    @pytest.mark.asyncio
+    async def test_aggregation_only_sees_readable_entities(self):
+        """If `_readable_workspaces` filters out a workspace tagged
+        `secret: yes`, that label must not appear in the keys list."""
+        readable = _ws("public", {"env": "prod"})
+        # A `secret_ws` would exist in the DB but is filtered out by
+        # the readable helper — the filter is the RBAC barrier.
+        with _readables(workspaces=[readable]):
+            result = await labels_service.aggregate_keys(MagicMock(), _user(roles=()))
+        keys = {e["key"] for e in result}
+        assert keys == {"env"}
+        assert "secret" not in keys

--- a/web/src/app/labels/page.tsx
+++ b/web/src/app/labels/page.tsx
@@ -1,0 +1,376 @@
+// Labels browser — read-only cross-entity view over the
+// /api/v2/labels endpoints. Three view states, all on `/labels`,
+// driven by query string:
+//
+//   /labels                    → list distinct label keys
+//   /labels?key=foo            → list distinct values for `foo`
+//   /labels?key=foo&value=bar  → list entities tagged exactly foo=bar
+//
+// Read-only by design (matching the API). Editing labels happens on
+// each entity's own edit page; this surface deliberately doesn't try
+// to be a labels admin.
+
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Layers, Server, Package, Blocks, ChevronRight } from 'lucide-react'
+
+import NavBar from '@/components/nav-bar'
+import { PageHeader } from '@/components/page-header'
+import { LoadingSpinner } from '@/components/loading-spinner'
+import { ErrorBanner } from '@/components/error-banner'
+import { EmptyState } from '@/components/empty-state'
+import { getAuthState } from '@/lib/auth'
+import { apiFetch } from '@/lib/api'
+
+// Stable order — matches the backend ENTITY_TYPES tuple. Used for both
+// the label-key drilldown table and the entity grouping.
+const ENTITY_TYPES = ['workspaces', 'agent-pools', 'registry-modules', 'registry-providers'] as const
+type EntityType = (typeof ENTITY_TYPES)[number]
+
+const ENTITY_LABELS: Record<EntityType, string> = {
+  'workspaces': 'Workspaces',
+  'agent-pools': 'Agent pools',
+  'registry-modules': 'Modules',
+  'registry-providers': 'Providers',
+}
+
+const ENTITY_ICONS: Record<EntityType, typeof Layers> = {
+  'workspaces': Layers,
+  'agent-pools': Server,
+  'registry-modules': Package,
+  'registry-providers': Blocks,
+}
+
+interface KeyEntry {
+  key: string
+  'value-count': number
+  'entity-counts': Record<EntityType, number>
+}
+
+interface ValueEntry {
+  value: string
+  'entity-counts': Record<EntityType, number>
+}
+
+interface EntityRow {
+  type: EntityType
+  id: string
+  name: string
+  namespace?: string
+  provider?: string
+  labels: Record<string, string>
+}
+
+// Map an entity row to the URL on its own detail page. We deliberately
+// link OUT to each entity's own page rather than rendering details
+// inline — keeps the labels surface focused on browse + drill-down.
+function entityHref(row: EntityRow): string {
+  switch (row.type) {
+    case 'workspaces':
+      return `/workspaces/${row.id.replace(/^ws-/, '')}`
+    case 'agent-pools':
+      return `/admin/agent-pools/${row.id.replace(/^apool-/, '')}`
+    case 'registry-modules':
+      return `/registry/modules/${row.namespace ?? 'default'}/${row.name}/${row.provider ?? 'aws'}`
+    case 'registry-providers':
+      return `/registry/providers/${row.namespace ?? 'default'}/${row.name}`
+  }
+}
+
+function totalEntities(counts: Record<EntityType, number>): number {
+  return ENTITY_TYPES.reduce((acc, t) => acc + (counts[t] ?? 0), 0)
+}
+
+// ── Inner component: reads useSearchParams, dispatches by URL state ──
+function LabelsBrowserInner() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const key = searchParams.get('key')
+  const value = searchParams.get('value')
+
+  useEffect(() => {
+    if (!getAuthState()) router.push('/login')
+  }, [router])
+
+  // Render is one of three sub-views. Each is its own component so
+  // hooks (loaders) reset cleanly between view transitions.
+  if (!key) return <KeysView />
+  if (!value) return <ValuesView labelKey={key} />
+  return <EntitiesView labelKey={key} labelValue={value} />
+}
+
+// ── View 1: list distinct label keys ─────────────────────────────────
+
+function KeysView() {
+  const [keys, setKeys] = useState<KeyEntry[] | null>(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let alive = true
+    apiFetch('/api/v2/labels')
+      .then(async r => {
+        if (!r.ok) throw new Error(`Failed to load labels (${r.status})`)
+        return r.json()
+      })
+      .then(d => alive && setKeys(d.data ?? []))
+      .catch(e => alive && setError(e instanceof Error ? e.message : String(e)))
+    return () => { alive = false }
+  }, [])
+
+  if (error) return <ErrorBanner message={error} />
+  if (keys === null) return <LoadingSpinner />
+  if (keys.length === 0) {
+    return (
+      <EmptyState message="No labels in use yet. Label any workspace, agent pool, registry module, or registry provider to start grouping things here." />
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-800">
+      <table className="w-full text-sm">
+        <thead className="bg-slate-900/50 text-slate-400">
+          <tr>
+            <th className="px-4 py-3 text-left font-medium">Label key</th>
+            <th className="px-4 py-3 text-right font-medium">Distinct values</th>
+            {ENTITY_TYPES.map(t => (
+              <th key={t} className="px-4 py-3 text-right font-medium">{ENTITY_LABELS[t]}</th>
+            ))}
+            <th className="w-8" aria-hidden />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800">
+          {keys.map(entry => (
+            <tr key={entry.key} className="hover:bg-slate-900/30 transition-colors">
+              <td className="px-4 py-3">
+                <Link
+                  href={`/labels?key=${encodeURIComponent(entry.key)}`}
+                  className="font-mono text-slate-100 hover:text-blue-400"
+                >
+                  {entry.key}
+                </Link>
+              </td>
+              <td className="px-4 py-3 text-right text-slate-300">{entry['value-count']}</td>
+              {ENTITY_TYPES.map(t => (
+                <td key={t} className="px-4 py-3 text-right text-slate-400">
+                  {entry['entity-counts'][t] ?? 0}
+                </td>
+              ))}
+              <td className="px-2 text-slate-600">
+                <ChevronRight size={16} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ── View 2: list distinct values for a key ───────────────────────────
+
+function ValuesView({ labelKey }: { labelKey: string }) {
+  const [values, setValues] = useState<ValueEntry[] | null>(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let alive = true
+    apiFetch(`/api/v2/labels/${encodeURIComponent(labelKey)}`)
+      .then(async r => {
+        if (!r.ok) throw new Error(`Failed to load values for ${labelKey} (${r.status})`)
+        return r.json()
+      })
+      .then(d => alive && setValues(d.data ?? []))
+      .catch(e => alive && setError(e instanceof Error ? e.message : String(e)))
+    return () => { alive = false }
+  }, [labelKey])
+
+  return (
+    <>
+      <Breadcrumb items={[{ label: 'Labels', href: '/labels' }, { label: labelKey }]} />
+      {error ? (
+        <ErrorBanner message={error} />
+      ) : values === null ? (
+        <LoadingSpinner />
+      ) : values.length === 0 ? (
+        <EmptyState message={`No values for "${labelKey}". Either no readable entity carries this label, or it was removed since the last view.`} />
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-slate-800">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-900/50 text-slate-400">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">Value</th>
+                <th className="px-4 py-3 text-right font-medium">Total</th>
+                {ENTITY_TYPES.map(t => (
+                  <th key={t} className="px-4 py-3 text-right font-medium">{ENTITY_LABELS[t]}</th>
+                ))}
+                <th className="w-8" aria-hidden />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {values.map(entry => (
+                <tr key={entry.value} className="hover:bg-slate-900/30 transition-colors">
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/labels?key=${encodeURIComponent(labelKey)}&value=${encodeURIComponent(entry.value)}`}
+                      className="font-mono text-slate-100 hover:text-blue-400"
+                    >
+                      {entry.value}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-right text-slate-300">{totalEntities(entry['entity-counts'])}</td>
+                  {ENTITY_TYPES.map(t => (
+                    <td key={t} className="px-4 py-3 text-right text-slate-400">
+                      {entry['entity-counts'][t] ?? 0}
+                    </td>
+                  ))}
+                  <td className="px-2 text-slate-600">
+                    <ChevronRight size={16} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  )
+}
+
+// ── View 3: list entities tagged with a specific key=value ──────────
+
+function EntitiesView({ labelKey, labelValue }: { labelKey: string; labelValue: string }) {
+  const [groups, setGroups] = useState<Record<EntityType, EntityRow[]> | null>(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let alive = true
+    apiFetch(
+      `/api/v2/labels/${encodeURIComponent(labelKey)}/${encodeURIComponent(labelValue)}`,
+    )
+      .then(async r => {
+        if (!r.ok) throw new Error(`Failed to load entities (${r.status})`)
+        return r.json()
+      })
+      .then(d => alive && setGroups(d.data ?? null))
+      .catch(e => alive && setError(e instanceof Error ? e.message : String(e)))
+    return () => { alive = false }
+  }, [labelKey, labelValue])
+
+  return (
+    <>
+      <Breadcrumb
+        items={[
+          { label: 'Labels', href: '/labels' },
+          { label: labelKey, href: `/labels?key=${encodeURIComponent(labelKey)}` },
+          { label: labelValue },
+        ]}
+      />
+      {error ? (
+        <ErrorBanner message={error} />
+      ) : groups === null ? (
+        <LoadingSpinner />
+      ) : (
+        <div className="space-y-6">
+          {ENTITY_TYPES.map(type => {
+            const rows = groups[type] ?? []
+            const Icon = ENTITY_ICONS[type]
+            return (
+              <section key={type}>
+                <h2 className="mb-2 flex items-center gap-2 text-sm font-medium text-slate-300">
+                  <Icon size={14} className="text-slate-500" />
+                  {ENTITY_LABELS[type]}
+                  <span className="text-slate-500">({rows.length})</span>
+                </h2>
+                {rows.length === 0 ? (
+                  <p className="px-4 py-3 text-sm text-slate-500 italic border border-slate-800 rounded-lg">
+                    None.
+                  </p>
+                ) : (
+                  <ul className="divide-y divide-slate-800 rounded-lg border border-slate-800">
+                    {rows.map(row => (
+                      <li key={row.id}>
+                        <Link
+                          href={entityHref(row)}
+                          className="block px-4 py-3 hover:bg-slate-900/30 transition-colors"
+                        >
+                          <div className="flex items-center justify-between gap-4">
+                            <span className="font-mono text-slate-100">{row.name}</span>
+                            <div className="flex flex-wrap gap-1.5">
+                              {Object.entries(row.labels).map(([k, v]) => (
+                                <span
+                                  key={k}
+                                  className={
+                                    'inline-flex items-center rounded px-1.5 py-0.5 text-xs font-mono ' +
+                                    (k === labelKey && v === labelValue
+                                      ? 'bg-blue-900/40 text-blue-200'
+                                      : 'bg-slate-800 text-slate-400')
+                                  }
+                                >
+                                  {k}: {v}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            )
+          })}
+        </div>
+      )}
+    </>
+  )
+}
+
+// ── Breadcrumb (small inline component) ──────────────────────────────
+
+function Breadcrumb({ items }: { items: { label: string; href?: string }[] }) {
+  return (
+    <nav className="mb-4 flex flex-wrap items-center gap-1 text-sm text-slate-400">
+      {items.map((item, i) => {
+        const isLast = i === items.length - 1
+        return (
+          <span key={i} className="flex items-center gap-1">
+            {item.href && !isLast ? (
+              <Link href={item.href} className="hover:text-slate-200">
+                {item.label}
+              </Link>
+            ) : (
+              <span className={isLast ? 'font-mono text-slate-200' : 'font-mono'}>
+                {item.label}
+              </span>
+            )}
+            {!isLast && <ChevronRight size={14} className="text-slate-600" />}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}
+
+// ── Page wrapper ─────────────────────────────────────────────────────
+// `useSearchParams` triggers Next.js's CSR bailout; the Suspense
+// boundary keeps the page statically buildable.
+
+export default function LabelsPage() {
+  return (
+    <div className="min-h-dvh bg-slate-950 text-slate-200">
+      <NavBar />
+      <main className="mx-auto max-w-6xl px-4 py-8">
+        <PageHeader
+          title="Labels"
+          description="Browse labels in use across workspaces, agent pools, registry modules, and registry providers. Read-only — labels are edited on each entity's own page."
+        />
+        <Suspense fallback={<LoadingSpinner />}>
+          <LabelsBrowserInner />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, FileText, BookOpen, Code, LogOut, Menu, X } from 'lucide-react'
+import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, FileText, BookOpen, Code, LogOut, Menu, X, Tags } from 'lucide-react'
 import { clearAuth, isAdmin, isAdminOrAudit } from '@/lib/auth'
 import { SessionExpiryBanner } from '@/components/session-expiry-banner'
 
@@ -78,6 +78,10 @@ export default function NavBar() {
       <NavLink href="/admin/agent-pools" onClick={closeMenu}>
         <Server size={16} />
         Agent Pools
+      </NavLink>
+      <NavLink href="/labels" onClick={closeMenu}>
+        <Tags size={16} />
+        Labels
       </NavLink>
       {admin && (
         <>


### PR DESCRIPTION
## Summary

A `/labels` page that surfaces every label key in use across the four labelled entity types — workspaces, agent pools, registry modules, registry providers — and drills down through values to the entities tagged with each.

Implements the labels-browser portion of #267. The CV UX bundle from that issue is a separate forthcoming PR.

## API

Three new endpoints, all RBAC-filtered:

| Path | Returns |
|---|---|
| `GET /api/v2/labels` | distinct keys with per-entity-type counts |
| `GET /api/v2/labels/{key}` | distinct values for the key, with per-entity-type counts |
| `GET /api/v2/labels/{key}/{value}` | the entities tagged with exactly that label, grouped by type |

Results only include labels carried by entities the caller has at least `read` on for that entity's permission model. The four resolvers are called per-entity; we pre-load the user's custom roles once per type to avoid an N+1 DB hit.

**Read-only by design.** Labels continue to be edited on each entity's own edit page (workspace edit, pool edit, module edit, provider edit). No labels-admin surface here — same RBAC story as today, no new authorisation paths, no back-door for mass-mutating the underlying entities.

## UI

A `/labels` page with three sequential drill-down views, query-string driven (`/labels`, `/labels?key=foo`, `/labels?key=foo&value=bar`). Nav link added with the lucide `Tags` icon, available to any authenticated user.

## Aligned to #267

The user pitched a cross-entity organising primitive (`project: my-account` cutting across a workspace, the runner pool dedicated to it, registry modules scoped to it). Terrapod's label-based RBAC already provides that — this PR makes labels discoverable rather than tribal knowledge, without introducing a parallel "Projects" taxonomy.

## Drive-by

`fetch_custom_roles` + `preloaded_roles` optimisation already existed on `pool_rbac_service`. Extended the same pattern to `workspace_rbac_service` and `registry_rbac_service` for consistency. The labels service is the first place where N+1 across all four entity types would have mattered; with this in place it's a single role-fetch query per type per request.

## Test plan

- [x] `make lint` — Python + frontend + helm clean
- [x] `make test` — 1205 passed (added 11 unit tests for `labels_service` aggregation + RBAC isolation)
- [x] `tsc --noEmit` clean on the frontend
- [x] **Tilt verification end-to-end** against the local stack:
  - Seeded six entities across all four types with overlapping label sets (`account: alpha` on a workspace + agent pool + registry module; `team: platform` on all four entity types; `managed-by: terrapod` on a provider only).
  - `GET /api/v2/labels` returns 4 keys with correct per-type breakdowns.
  - `GET /api/v2/labels/account` returns 2 distinct values.
  - `GET /api/v2/labels/account/alpha` returns workspace + pool + module + (empty providers).
  - UI drill-down renders correctly at each level; the label that matched the query is highlighted in the entity list.

## Out of scope

- Mutation surfaces. Labels remain edited on each entity's own page. (Confirmed with the issue author: read-only is the explicit design choice.)
- The Configuration Version UX bundle from #267 (retention by count, list/history, current-CV surfacing, diff, download). Separate forthcoming PR.