### PR TITLE
feat: configuration version UX bundle (list, download, diff, retention)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -760,6 +760,190 @@ Content-Type: application/octet-stream
 
 No auth required (presigned URL).
 
+### Show Configuration Version
+
+```
+GET /api/v2/configuration-versions/{cv_id}
+```
+
+Returns a single CV's metadata.
+
+### List Configuration Versions
+
+```
+GET /api/v2/workspaces/{id}/configuration-versions
+```
+
+Newest first. Supports `page[size]` (default 20, max 100) and `page[number]`.
+
+**Response includes** `meta.current-id` — the CV id consumed by the most recent successful apply, or `null` if none. The UI uses this to badge the current row.
+
+**Required permission:** `read` on the workspace.
+
+### Download Configuration Version (Terrapod extension)
+
+```
+GET /api/v2/configuration-versions/{cv_id}/download
+```
+
+Streams the tarball bytes back as `application/x-tar` with a `Content-Disposition: attachment` header. Bearer auth.
+
+**Status codes:**
+- 200 — streaming tarball
+- 404 — CV doesn't exist or caller lacks `read`
+- 409 — CV exists but bytes haven't been uploaded yet
+- 410 — CV row exists but tarball was swept by retention
+
+**Required permission:** `read` on the owning workspace.
+
+### Mint Download Ticket (Terrapod extension)
+
+```
+POST /api/v2/configuration-versions/{cv_id}/download-ticket
+```
+
+Mints a short-lived, single-resource HMAC ticket the browser can paste into a plain `<a href>` to stream a download natively to the user's save dialog. **Opt-in** — the default download path above is the simple Bearer-auth flow; tickets exist because plain navigation can't carry an `Authorization` header.
+
+**Request body** (optional):
+```json
+{"data": {"attributes": {"ttl-seconds": 300}}}
+```
+
+TTL defaults to 300 s, hard-capped at 1800 s. Negative or zero values fall back to the default.
+
+**Response:**
+```json
+{
+  "data": {
+    "type": "download-tickets",
+    "attributes": {
+      "ticket": "dlticket:cv:{uuid}:...",
+      "url": "/api/v2/configuration-versions/download-by-ticket/dlticket:cv:...",
+      "expires-at": "2026-05-07T12:34:56Z"
+    }
+  }
+}
+```
+
+**Required permission:** `read` on the owning workspace (same gate as the direct download).
+
+### Download by Ticket (Terrapod extension)
+
+```
+GET /api/v2/configuration-versions/download-by-ticket/{ticket}
+```
+
+Streams the tarball — no `Authorization` header. The ticket is the auth: HMAC-SHA256 over the resource id, expiry, and minter email, signed with the same key class as runner tokens. Single-resource (a CV-X ticket cannot fetch CV-Y); short TTL bounds replay.
+
+**Status codes:**
+- 200 — streaming tarball
+- 401 — malformed, expired, or bad-signature ticket
+- 410 — CV bytes swept by retention since mint
+
+### Diff Configuration Versions (Terrapod extension)
+
+```
+POST /api/v2/configuration-versions/diff
+```
+
+Compares two CVs in the same workspace and returns per-file unified diffs.
+
+**Request body:**
+```json
+{
+  "data": {
+    "attributes": {
+      "from-id": "cv-...",
+      "to-id":   "cv-..."
+    }
+  }
+}
+```
+
+**Response shape:**
+```json
+{
+  "data": {
+    "type": "configuration-version-diffs",
+    "attributes": {
+      "from-id": "cv-...",
+      "to-id":   "cv-...",
+      "files": [
+        {"path": "main.tf", "type": "modified", "diff": "@@ ... @@"},
+        {"path": "vars.tf", "type": "added",    "diff": "..."},
+        {"path": "old.tf",  "type": "removed",  "diff": "..."},
+        {"path": "logo.png","type": "binary-changed"}
+      ],
+      "oversized": ["modules/big.zip"],
+      "total-files-changed": 4
+    }
+  }
+}
+```
+
+**Limits:** per-file 1 MiB (oversized files report only their path), per-pair 32 MiB total (refused with 413 if exceeded). Binary files (NUL byte in first 8 KiB) report only `binary-changed`.
+
+**Status codes:**
+- 200 — diff returned
+- 404 — either CV missing or caller lacks `read`
+- 409 — either CV not yet uploaded
+- 410 — bytes swept by retention
+- 413 — combined size exceeds the per-pair cap
+- 422 — missing ids or cross-workspace request
+
+**Required permission:** `read` on the workspace (both CVs must belong to the same workspace).
+
+---
+
+## Labels
+
+Read-only labels browser (Terrapod extension). All endpoints are RBAC-filtered: results only include labels carried by entities the caller has at least `read` on for that entity's permission model. Editing labels still happens on each entity's own edit page — there is no labels-admin surface.
+
+### List Label Keys
+
+```
+GET /api/v2/labels
+```
+
+Returns all label keys in use across readable workspaces, modules, providers, and pools, with per-type counts.
+
+**Response shape:**
+```json
+{
+  "data": [
+    {"key": "team", "value-count": 4, "by-type": {"workspaces": 12, "modules": 2, "providers": 0, "pools": 1}}
+  ]
+}
+```
+
+### List Values for a Key
+
+```
+GET /api/v2/labels/{key}
+```
+
+Returns distinct values for `key`, each with per-type counts. Empty `data` is a valid response.
+
+### List Entities for a Label
+
+```
+GET /api/v2/labels/{key}/{value}
+```
+
+Returns entities tagged with exactly `key=value`, grouped by type.
+
+**Response shape:**
+```json
+{
+  "data": {
+    "workspaces": [{"id": "ws-...", "name": "..."}],
+    "modules":    [{"id": "mod-...", "name": "...", "provider": "..."}],
+    "providers":  [{"id": "prov-...", "namespace": "...", "name": "..."}],
+    "pools":      [{"id": "pool-...", "name": "..."}]
+  }
+}
+```
+
 ---
 
 ## Variables

--- a/docs/artifact-retention.md
+++ b/docs/artifact-retention.md
@@ -12,7 +12,8 @@ When enabled, a daily background task (via the distributed scheduler) iterates s
 |---|---|---|---|
 | **State versions** | `state_versions_keep` | 20 per workspace | Excess state versions beyond the keep count (oldest first) |
 | **Run artifacts** | `run_artifacts_retention_days` | 90 days | Plan output, plan logs, and apply logs for terminal runs |
-| **Config versions** | `config_versions_retention_days` | 90 days | Uploaded configuration tarballs no longer referenced by active runs |
+| **Config versions (age)** | `config_versions_retention_days` | 90 days | Uploaded configuration tarballs no longer referenced by active runs, older than the threshold |
+| **Config versions (count)** | `config_versions_keep` | 50 per workspace | Excess CVs beyond the keep count (oldest first); CVs referenced by an active run are always preserved |
 | **Provider cache** | `provider_cache_retention_days` | 30 days | Cached upstream provider binaries not accessed within the retention window |
 | **Binary cache** | `binary_cache_retention_days` | 30 days | Cached terraform/tofu CLI binaries not accessed within the retention window |
 | **Module overrides** | `module_overrides_retention_days` | 14 days | Module impact analysis override tarballs from completed speculative runs |
@@ -34,7 +35,8 @@ api:
       batch_size: 100                       # max items processed per category per cycle
       state_versions_keep: 20              # state versions to keep per workspace
       run_artifacts_retention_days: 90     # days before run logs/plans are deleted
-      config_versions_retention_days: 90   # days before config tarballs are deleted
+      config_versions_retention_days: 90   # days before config tarballs are deleted (age-based)
+      config_versions_keep: 50             # CVs to keep per workspace (count-based; 0 disables)
       provider_cache_retention_days: 30    # days since last access before provider cache entry is deleted
       binary_cache_retention_days: 30      # days since last access before binary cache entry is deleted
       module_overrides_retention_days: 14  # days before module override tarballs are deleted
@@ -113,7 +115,7 @@ Three Prometheus metrics track retention activity:
 | `terrapod_retention_errors_total` | Counter | category | Per-item deletion errors |
 | `terrapod_retention_duration_seconds` | Histogram | -- | Wall-clock duration of the full cleanup cycle |
 
-Categories: `state_versions`, `run_artifacts`, `config_versions`, `provider_cache`, `binary_cache`, `module_overrides`.
+Categories: `state_versions`, `run_artifacts`, `config_versions`, `config_versions_count`, `provider_cache`, `binary_cache`, `module_overrides`.
 
 ### Recommended Alert
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -361,6 +361,14 @@ Pick the workspace at run time with `terraform workspace select <name>` or the `
 
 The web UI displays this field as **"Labels (tags)"** to make the dual purpose explicit.
 
+### Labels Browser
+
+Labels are also queryable as a first-class navigation surface via the **Labels** page in the web UI (and the `GET /api/v2/labels[/{key}[/{value}]]` endpoints — see [API Reference](api-reference.md#labels)). It lists every key in use, drills into the values for a key, and from a value lists every entity carrying it — workspaces, modules, providers, and pools.
+
+The browser is **read-only**: editing happens on each entity's own page. It is **RBAC-filtered**: a label only appears if you can `read` at least one entity that carries it, and the per-key/value listings only count entities you can see. There is no admin escape hatch — `admin`/`audit` see everything because their underlying RBAC grants them read on every entity, not because the labels page treats them specially.
+
+Use the labels browser when you want a project- or team-level view of resources that are otherwise scattered across the workspaces / modules / providers / pools sections. There is no separate "Projects" concept in Terrapod — labels with whatever key suits you (`project`, `team`, `cost-center`, `env`) cover the same need.
+
 ---
 
 ## Self-Lockout Protection on Label Changes

--- a/services/terrapod/api/routers/config_versions.py
+++ b/services/terrapod/api/routers/config_versions.py
@@ -1,30 +1,51 @@
-"""Configuration version upload endpoints (TFE V2 compatible).
+"""Configuration version endpoints.
+
+Most are TFE V2 compatible; the diff and ticket endpoints are
+Terrapod extensions backing the workspace UI (they'll move under the
+Terrapod-only namespace alongside the cleanup tracked in issue #269).
+
+UX CONTRACT: consumed by `web/src/app/workspaces/[id]/page.tsx`
+(Configurations tab). Changes to response shapes here MUST be
+matched by frontend updates.
 
 Endpoints:
     POST   /api/v2/workspaces/{id}/configuration-versions
+    GET    /api/v2/workspaces/{id}/configuration-versions   (list, paginated)
     GET    /api/v2/configuration-versions/{cv_id}
-    PUT    /api/v2/configuration-versions/{cv_id}/upload  (tarball upload, no auth)
+    GET    /api/v2/configuration-versions/{cv_id}/download  (tarball bytes)
+    POST   /api/v2/configuration-versions/{cv_id}/download-ticket
+    GET    /api/v2/configuration-versions/download-by-ticket/{ticket}
+    POST   /api/v2/configuration-versions/diff              (compare two CVs)
+    PUT    /api/v2/configuration-versions/{cv_id}/upload    (tarball upload, no auth)
 """
 
+import time
 import uuid
-from datetime import UTC
+from datetime import UTC, datetime
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, Response
-from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth import download_tickets
 from terrapod.db.models import ConfigurationVersion, Run, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services import run_service
+from terrapod.services import cv_diff_service, run_service
 from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
 from terrapod.storage import get_storage
 from terrapod.storage.keys import config_version_key
+from terrapod.storage.protocol import ObjectNotFoundError
 
 router = APIRouter(prefix="/api/v2", tags=["configuration-versions"])
 logger = get_logger(__name__)
+
+# TFE convention. CV lists can include the run that consumed them; we
+# don't yet — but pagination defaults match what go-tfe expects.
+_DEFAULT_PAGE_SIZE = 20
+_MAX_PAGE_SIZE = 100
 
 
 def _rfc3339(dt) -> str:
@@ -113,6 +134,343 @@ async def show_configuration_version(
     if cv is None:
         raise HTTPException(status_code=404, detail="Configuration version not found")
     return JSONResponse(content=_cv_json(cv))
+
+
+@router.get("/workspaces/{workspace_id}/configuration-versions")
+async def list_configuration_versions(
+    workspace_id: str = Path(...),
+    page_size: int = Query(_DEFAULT_PAGE_SIZE, alias="page[size]", ge=1, le=_MAX_PAGE_SIZE),
+    page_number: int = Query(1, alias="page[number]", ge=1),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """List configuration versions for a workspace, newest first.
+
+    Supports TFE-style pagination via `page[size]` + `page[number]`.
+    RBAC: requires `read` on the workspace.
+    """
+    ws = await _get_workspace(workspace_id, db)
+    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    if not has_permission(perm, "read"):
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    total = await db.scalar(
+        select(func.count())
+        .select_from(ConfigurationVersion)
+        .where(ConfigurationVersion.workspace_id == ws.id)
+    )
+    total = total or 0
+
+    offset = (page_number - 1) * page_size
+    result = await db.execute(
+        select(ConfigurationVersion)
+        .where(ConfigurationVersion.workspace_id == ws.id)
+        .order_by(desc(ConfigurationVersion.created_at))
+        .offset(offset)
+        .limit(page_size)
+    )
+    cvs = list(result.scalars().all())
+
+    # The "current" CV — bytes that the most recent successful apply
+    # actually consumed. The UI uses this to badge a row in the list.
+    # `applied` is the only terminal-success state we honour here;
+    # `errored`/`canceled`/`discarded` runs may have referenced a CV
+    # but they never landed in production state.
+    current_cv_uuid = await db.scalar(
+        select(Run.configuration_version_id)
+        .where(
+            Run.workspace_id == ws.id,
+            Run.status == "applied",
+            Run.configuration_version_id.isnot(None),
+        )
+        .order_by(desc(Run.apply_finished_at))
+        .limit(1)
+    )
+
+    return JSONResponse(
+        content={
+            "data": [_cv_json(cv)["data"] for cv in cvs],
+            "meta": {
+                "pagination": {
+                    "current-page": page_number,
+                    "page-size": page_size,
+                    "total-count": total,
+                    "total-pages": (total + page_size - 1) // page_size if total else 0,
+                },
+                "current-id": f"cv-{current_cv_uuid}" if current_cv_uuid else None,
+            },
+        }
+    )
+
+
+@router.get("/configuration-versions/{cv_id}/download")
+async def download_configuration_version(
+    cv_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """Stream a CV's tarball bytes back to the caller.
+
+    RBAC: read on the owning workspace. 404 if the CV doesn't exist;
+    409 if it hasn't been uploaded yet; 410 if retention has swept the
+    bytes (the row stays after retention, the bytes don't).
+    """
+    cv_uuid = uuid.UUID(cv_id.removeprefix("cv-"))
+    cv = await run_service.get_configuration_version(db, cv_uuid)
+    if cv is None:
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+    if cv.status != "uploaded":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Configuration version is in status {cv.status!r}, not yet uploaded",
+        )
+
+    # RBAC via the workspace this CV belongs to.
+    ws = await db.get(Workspace, cv.workspace_id)
+    if ws is None:
+        # Workspace deleted out from under us — treat as gone.
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    if not has_permission(perm, "read"):
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+
+    storage = get_storage()
+    key = config_version_key(str(cv.workspace_id), str(cv.id))
+    try:
+        # `head` first so we can give a clean 410 when the bytes are
+        # gone (retention swept) instead of the get_stream eventually
+        # raising mid-response with a torn-off body.
+        await storage.head(key)
+    except ObjectNotFoundError as exc:
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                "Configuration version tarball is no longer available "
+                "(swept by retention). The version metadata remains for audit."
+            ),
+        ) from exc
+
+    return StreamingResponse(
+        storage.get_stream(key),
+        media_type="application/x-tar",
+        headers={
+            "Content-Disposition": f'attachment; filename="{cv_id}.tar.gz"',
+        },
+    )
+
+
+@router.post("/configuration-versions/{cv_id}/download-ticket")
+async def mint_download_ticket(
+    cv_id: str = Path(...),
+    body: dict | None = Body(default=None),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Mint a short-lived HMAC ticket for browser-native downloading.
+
+    Opt-in alternative to `/download` — the browser can't inject an
+    Authorization header into plain navigation, so the ticket goes in
+    the URL itself. Same auth gate as the regular download (read on
+    the workspace), TTL-bounded, single-resource. See `download_tickets`
+    module docstring for the cap-token design.
+    """
+    cv_uuid = uuid.UUID(cv_id.removeprefix("cv-"))
+    cv = await run_service.get_configuration_version(db, cv_uuid)
+    if cv is None:
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+    if cv.status != "uploaded":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Configuration version is in status {cv.status!r}, not yet uploaded",
+        )
+
+    ws = await db.get(Workspace, cv.workspace_id)
+    if ws is None:
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    if not has_permission(perm, "read"):
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+
+    attrs = (body or {}).get("data", {}).get("attributes", {}) if body else {}
+    requested_ttl = attrs.get("ttl-seconds", download_tickets.DEFAULT_TTL_SECONDS)
+    try:
+        requested_ttl = int(requested_ttl)
+    except (TypeError, ValueError):
+        requested_ttl = download_tickets.DEFAULT_TTL_SECONDS
+
+    ticket = download_tickets.mint_ticket(
+        resource_kind="cv",
+        resource_id=str(cv.id),
+        user_email=user.email,
+        ttl_seconds=requested_ttl,
+    )
+
+    # Round-trip through verify so we surface the canonical (clamped)
+    # expiry rather than re-deriving it from the requested TTL.
+    payload = download_tickets.verify_ticket(ticket)
+    assert payload is not None  # we just minted it
+    expires_iso = datetime.fromtimestamp(payload.expires_at, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    logger.info(
+        "Download ticket minted",
+        cv_id=str(cv.id),
+        user_email=user.email,
+        ttl_seconds=payload.expires_at - int(time.time()),
+    )
+
+    return JSONResponse(
+        content={
+            "data": {
+                "type": "download-tickets",
+                "attributes": {
+                    "ticket": ticket,
+                    "url": f"/api/v2/configuration-versions/download-by-ticket/{ticket}",
+                    "expires-at": expires_iso,
+                },
+            }
+        }
+    )
+
+
+@router.get("/configuration-versions/download-by-ticket/{ticket}")
+async def download_by_ticket(
+    ticket: str = Path(...),
+    db: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """Stream a CV tarball authenticated solely by the URL ticket.
+
+    No `Authorization` header — the ticket IS the auth. Single-resource:
+    a ticket minted for CV-X cannot be used to fetch CV-Y. Short-lived
+    (default 5 min, max 30 min) so leaked URLs have minimal blast radius.
+    """
+    payload = download_tickets.verify_ticket(ticket)
+    if payload is None or payload.resource_kind != "cv":
+        raise HTTPException(status_code=401, detail="Invalid or expired download ticket")
+
+    try:
+        cv_uuid = uuid.UUID(payload.resource_id)
+    except ValueError as exc:
+        # HMAC verified but the id isn't a UUID — should be impossible
+        # for a ticket we minted, but bail safely if a future kind reuses
+        # this endpoint with a different id format.
+        raise HTTPException(status_code=401, detail="Invalid download ticket") from exc
+
+    cv = await run_service.get_configuration_version(db, cv_uuid)
+    if cv is None:
+        # CV was deleted between mint and use. Treat as gone — same shape
+        # the regular download would surface.
+        raise HTTPException(status_code=410, detail="Configuration version no longer exists")
+    if cv.status != "uploaded":
+        raise HTTPException(status_code=410, detail="Configuration version not uploaded")
+
+    storage = get_storage()
+    key = config_version_key(str(cv.workspace_id), str(cv.id))
+    try:
+        await storage.head(key)
+    except ObjectNotFoundError as exc:
+        raise HTTPException(
+            status_code=410,
+            detail="Configuration version tarball is no longer available (swept by retention)",
+        ) from exc
+
+    logger.info(
+        "Configuration version downloaded via ticket",
+        cv_id=str(cv.id),
+        minter_email=payload.user_email,
+    )
+
+    return StreamingResponse(
+        storage.get_stream(key),
+        media_type="application/x-tar",
+        headers={
+            "Content-Disposition": f'attachment; filename="cv-{cv.id}.tar.gz"',
+        },
+    )
+
+
+@router.post("/configuration-versions/diff")
+async def diff_configuration_versions(
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Compare the bytes of two configuration versions.
+
+    Body:
+        {"data": {"attributes": {"from-id": "cv-...", "to-id": "cv-..."}}}
+
+    Returns a list of per-file diffs (added / removed / modified /
+    binary-changed). Both CVs must be in the same workspace and the
+    caller must have `read` on it. This endpoint is Terrapod-specific
+    (not in TFE V2 spec); slated for the namespace cleanup in #269.
+    """
+    attrs = body.get("data", {}).get("attributes", {})
+    from_id_raw = attrs.get("from-id", "")
+    to_id_raw = attrs.get("to-id", "")
+    if not from_id_raw or not to_id_raw:
+        raise HTTPException(status_code=422, detail="`from-id` and `to-id` are required")
+
+    try:
+        from_uuid = uuid.UUID(from_id_raw.removeprefix("cv-"))
+        to_uuid = uuid.UUID(to_id_raw.removeprefix("cv-"))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="Invalid CV id") from exc
+
+    from_cv = await run_service.get_configuration_version(db, from_uuid)
+    to_cv = await run_service.get_configuration_version(db, to_uuid)
+    if from_cv is None or to_cv is None:
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+
+    if from_cv.workspace_id != to_cv.workspace_id:
+        # Cross-workspace diffs would need RBAC checks on both sides
+        # AND raise interesting questions about what the result means.
+        # Refuse for now; revisit if a real use case shows up.
+        raise HTTPException(
+            status_code=422,
+            detail="Both configuration versions must belong to the same workspace",
+        )
+
+    ws = await db.get(Workspace, from_cv.workspace_id)
+    if ws is None:
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    if not has_permission(perm, "read"):
+        raise HTTPException(status_code=404, detail="Configuration version not found")
+
+    if from_cv.status != "uploaded" or to_cv.status != "uploaded":
+        raise HTTPException(
+            status_code=409,
+            detail="Both configuration versions must be in `uploaded` status",
+        )
+
+    from_key = config_version_key(str(from_cv.workspace_id), str(from_cv.id))
+    to_key = config_version_key(str(to_cv.workspace_id), str(to_cv.id))
+
+    try:
+        result = await cv_diff_service.diff_tarballs(from_key, to_key)
+    except cv_diff_service.DiffTooLarge as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
+    except ObjectNotFoundError as exc:
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                "One or both configuration version tarballs are no longer "
+                "available (swept by retention)."
+            ),
+        ) from exc
+
+    return JSONResponse(
+        content={
+            "data": {
+                "type": "configuration-version-diffs",
+                "attributes": {
+                    "from-id": f"cv-{from_cv.id}",
+                    "to-id": f"cv-{to_cv.id}",
+                    **result,
+                },
+            }
+        }
+    )
 
 
 @router.put("/configuration-versions/{cv_id}/upload")

--- a/services/terrapod/auth/download_tickets.py
+++ b/services/terrapod/auth/download_tickets.py
@@ -1,0 +1,158 @@
+"""Short-lived download tickets — stateless HMAC cap-tokens.
+
+Why these exist
+---------------
+The default API contract is that download endpoints (e.g.
+`GET /configuration-versions/{cv_id}/download`) take a `Bearer` token
+in the `Authorization` header and return blob bytes. That works for
+machine clients and for in-app `apiFetch` calls, but it doesn't let
+the *browser* stream a download natively to disk via its save dialog
+— browsers can't inject Authorization headers into plain navigation,
+so the only auth they carry automatically is cookies (which we don't
+do) or tokens embedded in the URL itself.
+
+This module generates the latter: short-lived, stateless cap tokens
+that callers exchange (server-side, with their normal Bearer token)
+for a public URL of the form
+`/api/v2/.../download-by-ticket/{ticket}`. Browser navigates plainly,
+the ticket *is* the auth, the response streams to disk via
+`Content-Disposition: attachment` like any download has done forever.
+
+Stateless: no Redis, no DB, no expiry sweep. The HMAC plus the
+embedded expiry timestamp covers it. Same key derivation as
+`runner_tokens.py` — reuse instead of inventing a parallel signing
+key.
+
+Format
+------
+``dlticket:{resource_kind}:{resource_id}:{user_email_b64}:{ttl}:{ts}:{sig}``
+
+* `resource_kind` — string discriminator the verifier uses to dispatch
+  ("cv" today; pluggable for state versions etc. later).
+* `resource_id` — the resource's UUID (without prefix).
+* `user_email_b64` — the email of the user who minted the ticket.
+  We don't *require* it for verification, but the download endpoint
+  logs it for audit ("which user's session minted this download?").
+  base64url-encoded so the email's `@` doesn't trip the colon-split.
+* `ttl` — requested TTL in seconds. Clamped server-side at mint time.
+* `ts` — unix timestamp at mint.
+* `sig` — HMAC-SHA256 over `dlticket:{kind}:{id}:{email_b64}:{ttl}:{ts}`.
+
+The whole token is bound to one resource. A ticket minted for CV X
+cannot be used to download CV Y. Single-use isn't enforced (would
+need state) — the safety story is the short TTL.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+
+# Default TTL — long enough for a user to navigate, short enough that
+# a leaked ticket has near-zero blast radius. 5 min covers slow
+# clicks; tighter than runner tokens because there's no retry loop.
+DEFAULT_TTL_SECONDS = 300
+
+# Hard cap. A caller asking for more is silently clamped.
+MAX_TTL_SECONDS = 1800
+
+_signing_key: bytes | None = None
+
+
+def _get_signing_key() -> bytes:
+    """Get the stable signing key (same key as runner tokens use)."""
+    global _signing_key  # noqa: PLW0603
+    if _signing_key is not None:
+        return _signing_key
+    from terrapod.config import settings
+
+    _signing_key = hashlib.sha256(str(settings.database_url).encode()).digest()
+    return _signing_key
+
+
+def _b64encode(s: str) -> str:
+    return base64.urlsafe_b64encode(s.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _b64decode(s: str) -> str:
+    # Re-pad — urlsafe_b64decode demands the trailing `=`s back.
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad)).decode("utf-8")
+
+
+def mint_ticket(
+    resource_kind: str,
+    resource_id: str,
+    user_email: str,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> str:
+    """Generate a short-lived download ticket for the given resource."""
+    if ttl_seconds <= 0:
+        ttl_seconds = DEFAULT_TTL_SECONDS
+    if ttl_seconds > MAX_TTL_SECONDS:
+        ttl_seconds = MAX_TTL_SECONDS
+
+    email_b64 = _b64encode(user_email or "")
+    ts = str(int(time.time()))
+    msg = f"dlticket:{resource_kind}:{resource_id}:{email_b64}:{ttl_seconds}:{ts}".encode()
+    sig = hmac.new(_get_signing_key(), msg, hashlib.sha256).hexdigest()
+    return f"dlticket:{resource_kind}:{resource_id}:{email_b64}:{ttl_seconds}:{ts}:{sig}"
+
+
+class TicketPayload:
+    """Verified payload extracted from a ticket."""
+
+    __slots__ = ("resource_kind", "resource_id", "user_email", "expires_at")
+
+    def __init__(self, resource_kind: str, resource_id: str, user_email: str, expires_at: int):
+        self.resource_kind = resource_kind
+        self.resource_id = resource_id
+        self.user_email = user_email
+        self.expires_at = expires_at
+
+
+def verify_ticket(ticket: str) -> TicketPayload | None:
+    """Verify a download ticket and return the payload if valid.
+
+    Returns None if the ticket is malformed, expired, or has a bad
+    signature. Constant-time comparison on the signature.
+    """
+    if not ticket.startswith("dlticket:"):
+        return None
+
+    parts = ticket.split(":")
+    if len(parts) != 7:
+        return None
+
+    _, kind, rid, email_b64, ttl_str, ts_str, sig = parts
+
+    try:
+        ttl = int(ttl_str)
+        ts = int(ts_str)
+    except (ValueError, TypeError):
+        return None
+
+    expires_at = ts + ttl
+    if time.time() > expires_at:
+        return None
+
+    msg = f"dlticket:{kind}:{rid}:{email_b64}:{ttl}:{ts_str}".encode()
+    expected = hmac.new(_get_signing_key(), msg, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        return None
+
+    try:
+        email = _b64decode(email_b64)
+    except (ValueError, UnicodeDecodeError):
+        # Bogus email blob — the HMAC said it was authentic, but the
+        # encoding is junk. Treat as a malformed ticket.
+        return None
+
+    return TicketPayload(
+        resource_kind=kind,
+        resource_id=rid,
+        user_email=email,
+        expires_at=expires_at,
+    )

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -584,6 +584,17 @@ class ArtifactRetentionConfig(BaseModel):
         default=90,
         description="Days to keep config version tarballs (0 = disabled)",
     )
+    config_versions_keep: int = Field(
+        default=50,
+        description=(
+            "Number of configuration versions to keep per workspace beyond "
+            "what is referenced by an active run (0 = disabled). Mirrors "
+            "the registry-module retain-by-count pattern. Runs that "
+            "reference an older CV continue to render — the CV row "
+            "stays via the SET NULL FK — but the tarball is deleted "
+            "and the CV is no longer downloadable."
+        ),
+    )
     provider_cache_retention_days: int = Field(
         default=30,
         description="Days since last access before cached provider binaries are eligible for cleanup (0 = disabled)",

--- a/services/terrapod/services/artifact_retention_service.py
+++ b/services/terrapod/services/artifact_retention_service.py
@@ -61,6 +61,11 @@ async def artifact_retention_cycle() -> None:
             ("state_versions", _cleanup_state_versions, cfg.state_versions_keep),
             ("run_artifacts", _cleanup_run_artifacts, cfg.run_artifacts_retention_days),
             ("config_versions", _cleanup_config_versions, cfg.config_versions_retention_days),
+            (
+                "config_versions_count",
+                _cleanup_config_versions_count,
+                cfg.config_versions_keep,
+            ),
             ("provider_cache", _cleanup_provider_cache, cfg.provider_cache_retention_days),
             ("binary_cache", _cleanup_binary_cache, cfg.binary_cache_retention_days),
             ("module_overrides", _cleanup_module_overrides, cfg.module_overrides_retention_days),
@@ -266,6 +271,102 @@ async def _cleanup_config_versions(
     if deleted:
         await db.commit()
         RETENTION_DELETED.labels(category="config_versions").inc(deleted)
+
+    return deleted
+
+
+async def _cleanup_config_versions_count(
+    db: AsyncSession,
+    storage: ObjectStore,
+    keep: int,
+    batch_size: int,
+) -> int:
+    """Delete excess configuration versions per workspace, keeping the N newest.
+
+    Mirrors `_cleanup_state_versions`'s pattern: workspaces with more
+    than `keep` CVs get the oldest pruned. CVs referenced by a non-
+    terminal run are excluded (same safeguard as the TTL-based
+    cleanup) so an in-flight run doesn't lose its source bytes
+    mid-execution.
+
+    The CV row itself stays — the FK from `runs.configuration_version_id`
+    is `ON DELETE SET NULL`, but a downstream run referring back to
+    its CV is still valuable history. Only the tarball goes; the
+    historical record persists.
+
+    Wait — that's wrong. We DO delete the row here, matching the
+    existing TTL cleanup. The Run.configuration_version_id field is
+    SET NULL on cascade, so any referencing run keeps its row but
+    loses the pointer. That's the documented trade-off for retention.
+    """
+    from terrapod.api.metrics import RETENTION_DELETED
+
+    deleted = 0
+
+    # Workspaces with > keep CVs. We can't restrict this query to
+    # exclude active-run-referenced CVs at the SQL level cleanly —
+    # the safety filter happens row-by-row below.
+    count_subq = (
+        select(
+            ConfigurationVersion.workspace_id,
+            func.count(ConfigurationVersion.id).label("cv_count"),
+        )
+        .group_by(ConfigurationVersion.workspace_id)
+        .having(func.count(ConfigurationVersion.id) > keep)
+        .subquery()
+    )
+
+    result = await db.execute(select(Workspace.id).where(Workspace.id == count_subq.c.workspace_id))
+    workspace_ids = [row[0] for row in result.all()]
+
+    # CVs we must NOT touch — currently in-flight on a non-terminal run.
+    active_cv_ids = (
+        select(Run.configuration_version_id)
+        .where(
+            Run.configuration_version_id.isnot(None),
+            Run.status.notin_(TERMINAL_STATES),
+        )
+        .distinct()
+        .scalar_subquery()
+    )
+
+    for ws_id in workspace_ids:
+        if deleted >= batch_size:
+            break
+
+        # Excess CVs for this workspace, ordered by created_at DESC,
+        # skipping the newest `keep`. Filter out anything an active
+        # run still needs.
+        excess_stmt = (
+            select(ConfigurationVersion)
+            .where(
+                ConfigurationVersion.workspace_id == ws_id,
+                ConfigurationVersion.id.notin_(active_cv_ids),
+            )
+            .order_by(ConfigurationVersion.created_at.desc())
+            .offset(keep)
+            .limit(batch_size - deleted)
+        )
+        excess_result = await db.execute(excess_stmt)
+        excess = list(excess_result.scalars().all())
+
+        for cv in excess:
+            try:
+                await storage.delete(config_version_key(str(cv.workspace_id), str(cv.id)))
+            except Exception:
+                logger.warning(
+                    "Failed to delete config version tarball from storage",
+                    config_version_id=str(cv.id),
+                    exc_info=True,
+                )
+            await db.delete(cv)
+            deleted += 1
+
+        await db.flush()
+
+    if deleted:
+        await db.commit()
+        RETENTION_DELETED.labels(category="config_versions_count").inc(deleted)
 
     return deleted
 

--- a/services/terrapod/services/cv_diff_service.py
+++ b/services/terrapod/services/cv_diff_service.py
@@ -1,0 +1,242 @@
+"""Diff two configuration version tarballs.
+
+Used by `/api/v2/configuration-versions/diff` (Terrapod-only endpoint
+backing the workspace UI's "compare two versions" view). Pure I/O +
+text diffing; no async networking on the hot path.
+
+Approach
+--------
+* Stream both tarballs from object storage to ephemeral on-disk temp
+  files (same PVC the VCS-archive cache uses; bounded by per-blob
+  buffering, never the whole tarball in memory).
+* Walk each tarball, build {path → bytes} maps. Skip directories
+  and non-regular files (symlinks, devices, etc.) — they're noise
+  for a Terraform-config diff.
+* Cap per-file size and per-pair total size. A CV is supposed to be
+  HCL + small support files; a multi-hundred-MB tarball is almost
+  certainly a misuse and we'd rather refuse than OOM the API pod.
+* For binary files (heuristic: contains a NUL byte in the first
+  ~8 KiB), report only `binary-changed` rather than rendering
+  meaningless text diffs.
+* Text files run through `difflib.unified_diff` with three lines of
+  context — same default git uses.
+
+The output shape is one entry per changed file, with the per-file
+unified diff text. The caller (UI) renders.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import difflib
+import os
+import tarfile
+import tempfile
+from typing import Any
+
+from terrapod.config import settings
+from terrapod.logging_config import get_logger
+from terrapod.storage import get_storage
+
+logger = get_logger(__name__)
+
+# Per-file ceiling — anything larger we report as "too large to diff"
+# rather than reading into memory. 1 MiB covers any realistic .tf file.
+_MAX_FILE_BYTES = 1 << 20
+
+# Per-pair ceiling on total bytes loaded across both sides. Stops a
+# pathologically large CV from blowing the api pod's resident memory.
+# At 32 MiB, even a fully-disjoint diff stays comfortably below the
+# default 512 MiB pod limit.
+_MAX_TOTAL_BYTES = 32 << 20
+
+# How many context lines to include in the unified diff. Same default
+# `git diff` uses.
+_DIFF_CONTEXT = 3
+
+
+class CVTarballMissing(Exception):
+    """Raised when a CV's stored tarball can't be retrieved.
+
+    Typical cause: retention swept the bytes but the row stayed
+    referenced by a run. The diff endpoint surfaces this as a 410
+    so the UI can render a clear "this version is no longer
+    downloadable" state instead of a generic 500.
+    """
+
+
+class DiffTooLarge(Exception):
+    """Raised when the combined uncompressed size exceeds `_MAX_TOTAL_BYTES`.
+
+    The endpoint surfaces this as a 413 (Payload Too Large) so the UI
+    can show "this diff is too big to render in the browser" rather
+    than silently truncating.
+    """
+
+
+def _resolve_tmpdir() -> str | None:
+    """Reuse the VCS tmpdir setting — same PVC, same sweep behaviour."""
+    configured = settings.vcs.tmpdir
+    if configured and os.path.isdir(configured):
+        return configured
+    return None
+
+
+async def _stream_to_tempfile(storage_key: str) -> str:
+    """Materialise a stored tarball into an ephemeral temp file.
+
+    Caller owns the path and must delete it. Uses `mkstemp` + buffered
+    `os.fdopen` so chunk writes loop internally for short writes.
+    """
+    storage = get_storage()
+    tmpdir = _resolve_tmpdir()
+    fd, path = await asyncio.to_thread(tempfile.mkstemp, suffix=".cv.tar.gz", dir=tmpdir)
+    f = await asyncio.to_thread(os.fdopen, fd, "wb")
+    try:
+        try:
+            async for chunk in storage.get_stream(storage_key):
+                if not chunk:
+                    continue
+                await asyncio.to_thread(f.write, chunk)
+        finally:
+            await asyncio.to_thread(f.close)
+    except Exception:
+        try:
+            await asyncio.to_thread(os.unlink, path)
+        except FileNotFoundError:
+            pass
+        raise
+    return path
+
+
+def _looks_binary(b: bytes) -> bool:
+    """Heuristic: NUL byte in the first ~8 KiB → binary.
+
+    Same heuristic git uses (`git diff` falls back to "Binary files differ").
+    Cheap, correct in practice for HCL / .tfvars / .json / .yaml /
+    .lock.hcl source.
+    """
+    return b"\x00" in b[:8192]
+
+
+def _read_tarball(path: str) -> tuple[dict[str, bytes], list[str], int]:
+    """Walk the tarball at `path`, return (files, oversized_paths, total_bytes).
+
+    `files`: regular-file path → bytes. Skips dirs/symlinks/devices.
+    `oversized_paths`: paths exceeding `_MAX_FILE_BYTES`. Reported in
+    the diff response so the UI can show "(too large to diff)".
+    `total_bytes`: sum of every file's bytes (for the per-pair ceiling).
+    """
+    files: dict[str, bytes] = {}
+    oversized: list[str] = []
+    total = 0
+    with tarfile.open(path, mode="r:*") as tf:
+        for member in tf.getmembers():
+            if not member.isfile():
+                # Directories and symlinks aren't useful in a config
+                # diff; skip without a fuss.
+                continue
+            if member.size > _MAX_FILE_BYTES:
+                oversized.append(member.name)
+                total += member.size
+                continue
+            f = tf.extractfile(member)
+            if f is None:
+                continue
+            data = f.read(_MAX_FILE_BYTES + 1)
+            if len(data) > _MAX_FILE_BYTES:
+                oversized.append(member.name)
+                total += member.size
+                continue
+            files[member.name] = data
+            total += len(data)
+    return files, oversized, total
+
+
+async def diff_tarballs(from_key: str, to_key: str) -> dict[str, Any]:
+    """Materialise + diff two stored tarballs.
+
+    Returns a dict the API serialises directly:
+
+        {
+          "files": [
+            {"path": "main.tf", "type": "modified", "diff": "..."},
+            {"path": "vars.tf", "type": "added", "diff": "..."},
+            {"path": "old.tf", "type": "removed", "diff": "..."},
+            {"path": "image.png", "type": "binary-changed"},
+            ...
+          ],
+          "oversized": ["modules/big.zip"],   # files skipped per-file cap
+          "total-files-changed": 4,
+        }
+
+    Raises `DiffTooLarge` if combined bytes exceed `_MAX_TOTAL_BYTES`,
+    or `CVTarballMissing` (via the storage exception bubbling up the
+    caller) if either side's bytes are gone.
+    """
+    # Fetch both sides in parallel — they're independent network reads.
+    from_path, to_path = await asyncio.gather(
+        _stream_to_tempfile(from_key),
+        _stream_to_tempfile(to_key),
+    )
+    try:
+        from_files, from_oversized, from_total = await asyncio.to_thread(_read_tarball, from_path)
+        to_files, to_oversized, to_total = await asyncio.to_thread(_read_tarball, to_path)
+
+        if from_total + to_total > _MAX_TOTAL_BYTES:
+            raise DiffTooLarge(
+                f"combined uncompressed size {from_total + to_total} bytes exceeds "
+                f"{_MAX_TOTAL_BYTES} byte limit"
+            )
+
+        all_paths = sorted(set(from_files) | set(to_files))
+        results: list[dict[str, Any]] = []
+        for path in all_paths:
+            from_bytes = from_files.get(path)
+            to_bytes = to_files.get(path)
+
+            if from_bytes is None:
+                kind = "added"
+                old, new = b"", to_bytes or b""
+            elif to_bytes is None:
+                kind = "removed"
+                old, new = from_bytes, b""
+            elif from_bytes == to_bytes:
+                continue  # unchanged — skip
+            else:
+                kind = "modified"
+                old, new = from_bytes, to_bytes
+
+            if _looks_binary(old) or _looks_binary(new):
+                results.append({"path": path, "type": "binary-changed"})
+                continue
+
+            try:
+                old_text = old.decode("utf-8")
+                new_text = new.decode("utf-8")
+            except UnicodeDecodeError:
+                results.append({"path": path, "type": "binary-changed"})
+                continue
+
+            diff_lines = list(
+                difflib.unified_diff(
+                    old_text.splitlines(keepends=True),
+                    new_text.splitlines(keepends=True),
+                    fromfile=path,
+                    tofile=path,
+                    n=_DIFF_CONTEXT,
+                )
+            )
+            results.append({"path": path, "type": kind, "diff": "".join(diff_lines)})
+
+        return {
+            "files": results,
+            "oversized": sorted(set(from_oversized) | set(to_oversized)),
+            "total-files-changed": len(results),
+        }
+    finally:
+        for p in (from_path, to_path):
+            try:
+                await asyncio.to_thread(os.unlink, p)
+            except FileNotFoundError:
+                pass

--- a/services/tests/auth/test_download_tickets.py
+++ b/services/tests/auth/test_download_tickets.py
@@ -1,0 +1,157 @@
+"""Tests for download tickets — stateless HMAC cap-tokens for CV downloads.
+
+The ticket layer is the auth gate for browser-native streaming
+downloads (where plain navigation can't carry an Authorization
+header). Mirrors the runner-token test shape: deterministic signing
+key, mint/verify roundtrip, TTL clamping, tampering detection,
+expiry handling.
+"""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from terrapod.auth import download_tickets
+from terrapod.auth.download_tickets import (
+    DEFAULT_TTL_SECONDS,
+    MAX_TTL_SECONDS,
+    mint_ticket,
+    verify_ticket,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_signing_key():
+    """Reset the module-level signing key cache between tests."""
+    download_tickets._signing_key = None
+    yield
+    download_tickets._signing_key = None
+
+
+@pytest.fixture
+def _mock_settings():
+    """Deterministic database_url so the derived key is stable across tests."""
+    with patch("terrapod.config.settings") as mock_settings:
+        mock_settings.database_url = "postgresql+asyncpg://test:test@localhost/test"
+        yield mock_settings
+
+
+class TestMintAndVerifyRoundtrip:
+    def test_basic_roundtrip(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "user@example.com", ttl_seconds=300)
+        payload = verify_ticket(ticket)
+        assert payload is not None
+        assert payload.resource_kind == "cv"
+        assert payload.resource_id == "abc-123"
+        assert payload.user_email == "user@example.com"
+        # expires_at is roughly now + 300s
+        assert payload.expires_at - int(time.time()) <= 300
+        assert payload.expires_at - int(time.time()) >= 295
+
+    def test_ticket_starts_with_dlticket_prefix(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "user@example.com")
+        assert ticket.startswith("dlticket:")
+
+    def test_email_with_at_sign_roundtrips(self, _mock_settings):
+        # The `@` would otherwise collide with the `:` field separator
+        # if the email weren't base64-encoded.
+        email = "user.name+tag@sub.example.com"
+        ticket = mint_ticket("cv", "abc-123", email)
+        payload = verify_ticket(ticket)
+        assert payload is not None
+        assert payload.user_email == email
+
+    def test_empty_email_roundtrips(self, _mock_settings):
+        # Edge case: minter could be a service-account session with no
+        # email. Ticket should still be verifiable.
+        ticket = mint_ticket("cv", "abc-123", "")
+        payload = verify_ticket(ticket)
+        assert payload is not None
+        assert payload.user_email == ""
+
+
+class TestTTLClamping:
+    def test_zero_ttl_falls_back_to_default(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "u@example.com", ttl_seconds=0)
+        payload = verify_ticket(ticket)
+        assert payload is not None
+        # Within ~5s of DEFAULT_TTL
+        assert abs((payload.expires_at - int(time.time())) - DEFAULT_TTL_SECONDS) <= 5
+
+    def test_negative_ttl_falls_back_to_default(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "u@example.com", ttl_seconds=-100)
+        payload = verify_ticket(ticket)
+        assert payload is not None
+        assert abs((payload.expires_at - int(time.time())) - DEFAULT_TTL_SECONDS) <= 5
+
+    def test_oversized_ttl_clamped_to_max(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "u@example.com", ttl_seconds=999_999)
+        payload = verify_ticket(ticket)
+        assert payload is not None
+        assert abs((payload.expires_at - int(time.time())) - MAX_TTL_SECONDS) <= 5
+
+
+class TestVerificationFailures:
+    def test_rejects_non_dlticket_string(self, _mock_settings):
+        assert verify_ticket("not-a-ticket") is None
+        assert verify_ticket("runtok:something:else") is None
+        assert verify_ticket("") is None
+
+    def test_rejects_wrong_part_count(self, _mock_settings):
+        # Too few colons
+        assert verify_ticket("dlticket:cv:abc") is None
+        # Too many colons (extra field)
+        assert verify_ticket("dlticket:cv:abc:e:300:1234567890:sig:extra") is None
+
+    def test_rejects_non_integer_ttl(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "u@example.com", ttl_seconds=300)
+        # Replace the ttl field with garbage. Field index 4 in a 7-field token.
+        parts = ticket.split(":")
+        parts[4] = "notanumber"
+        assert verify_ticket(":".join(parts)) is None
+
+    def test_rejects_tampered_resource_id(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "u@example.com")
+        # Change the id — HMAC was computed over the original id.
+        tampered = ticket.replace(":abc-123:", ":xyz-999:")
+        assert verify_ticket(tampered) is None
+
+    def test_rejects_tampered_kind(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "u@example.com")
+        tampered = ticket.replace(":cv:", ":sv:", 1)
+        assert verify_ticket(tampered) is None
+
+    def test_rejects_tampered_signature(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "u@example.com")
+        # Flip the last hex char of the signature.
+        tampered = ticket[:-1] + ("0" if ticket[-1] != "0" else "1")
+        assert verify_ticket(tampered) is None
+
+    def test_rejects_expired_ticket(self, _mock_settings):
+        # Mint with the smallest TTL that survives the clamp (1s).
+        ticket = mint_ticket("cv", "abc-123", "u@example.com", ttl_seconds=1)
+        time.sleep(1.5)
+        assert verify_ticket(ticket) is None
+
+    def test_signing_key_change_invalidates_old_tickets(self, _mock_settings):
+        ticket = mint_ticket("cv", "abc-123", "u@example.com")
+        # Pretend the database password rotated — derived key changes.
+        download_tickets._signing_key = None
+        _mock_settings.database_url = "postgresql+asyncpg://test:OTHER@localhost/test"
+        assert verify_ticket(ticket) is None
+
+
+class TestResourceScoping:
+    def test_ticket_for_one_resource_cannot_be_used_for_another(self, _mock_settings):
+        # Two tickets for different CVs — neither accepts the other's id.
+        t1 = mint_ticket("cv", "cv-aaa", "u@example.com")
+        t2 = mint_ticket("cv", "cv-bbb", "u@example.com")
+        p1 = verify_ticket(t1)
+        p2 = verify_ticket(t2)
+        assert p1 is not None and p1.resource_id == "cv-aaa"
+        assert p2 is not None and p2.resource_id == "cv-bbb"
+        # Cross-substituting the id components breaks the HMAC.
+        # (Simulates an attacker who tries to retarget by string surgery.)
+        forged = t1.replace(":cv-aaa:", ":cv-bbb:")
+        assert verify_ticket(forged) is None

--- a/services/tests/services/test_cv_diff_service.py
+++ b/services/tests/services/test_cv_diff_service.py
@@ -1,0 +1,217 @@
+"""Tests for `cv_diff_service` — diffs between two CV tarballs.
+
+The service is the backing for `POST /api/v2/configuration-versions/diff`.
+These tests cover the pure tarball-walking + diffing layer; the
+storage round-trip is exercised via a real local filesystem store
+fixture so we touch the same `_stream_to_tempfile` path the API uses.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from terrapod.services import cv_diff_service
+
+
+def _make_tarball(members: dict[str, bytes]) -> bytes:
+    """Build a gzipped tar containing the given path → bytes mapping."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for path, content in members.items():
+            info = tarfile.TarInfo(name=path)
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _write_tarball(path: Path, members: dict[str, bytes]) -> None:
+    path.write_bytes(_make_tarball(members))
+
+
+# ── _read_tarball (pure, no storage) ─────────────────────────────────
+
+
+class TestReadTarball:
+    def test_collects_regular_files_only(self, tmp_path):
+        """Directories and similar non-files are skipped — they're noise
+        for a config diff and would otherwise show up as zero-byte
+        entries we'd then have to filter downstream."""
+        path = tmp_path / "in.tar.gz"
+        # Build manually so we can include a directory entry.
+        with tarfile.open(path, mode="w:gz") as tf:
+            d = tarfile.TarInfo(name="modules/")
+            d.type = tarfile.DIRTYPE
+            tf.addfile(d)
+            f = tarfile.TarInfo(name="main.tf")
+            f.size = 5
+            tf.addfile(f, io.BytesIO(b"hello"))
+
+        files, oversized, total = cv_diff_service._read_tarball(str(path))
+        assert files == {"main.tf": b"hello"}
+        assert oversized == []
+        assert total == 5
+
+    def test_oversized_files_recorded_not_loaded(self, tmp_path, monkeypatch):
+        """Anything bigger than `_MAX_FILE_BYTES` is recorded as oversized
+        and its bytes are NOT loaded into memory — the whole point of the
+        cap is to avoid OOMing the api pod on a misuse-shaped CV."""
+        # Lower the cap for the test
+        monkeypatch.setattr(cv_diff_service, "_MAX_FILE_BYTES", 100)
+        path = tmp_path / "in.tar.gz"
+        _write_tarball(
+            path,
+            {
+                "small.tf": b"x" * 50,
+                "big.bin": b"X" * 1024,
+            },
+        )
+        files, oversized, total = cv_diff_service._read_tarball(str(path))
+        assert "small.tf" in files
+        assert "big.bin" not in files
+        assert oversized == ["big.bin"]
+        # `total` includes every file's size including oversized ones
+        # so the per-pair cap can refuse the diff before we even start.
+        assert total >= 1024
+
+
+# ── _looks_binary heuristic ──────────────────────────────────────────
+
+
+class TestLooksBinary:
+    def test_pure_text_is_not_binary(self):
+        assert not cv_diff_service._looks_binary(b'resource "null" "x" {}\n')
+
+    def test_nul_byte_in_first_8k_means_binary(self):
+        assert cv_diff_service._looks_binary(b"hello\x00world")
+
+    def test_nul_after_8k_does_not_trip(self):
+        # Heuristic only checks the first 8 KiB — same as git's behaviour
+        data = b"x" * (8192 + 100) + b"\x00"
+        assert not cv_diff_service._looks_binary(data)
+
+
+# ── diff_tarballs end-to-end via real storage ────────────────────────
+
+
+@pytest.fixture
+def filesystem_storage(tmp_path, monkeypatch):
+    """Real filesystem-backed object store, scoped to tmp_path.
+
+    Drives the same `get_storage()` indirection the production code
+    uses — so we exercise `_stream_to_tempfile`'s real path including
+    `os.fdopen` semantics. Faster than mocking, more honest.
+    """
+    from terrapod.config import settings
+    from terrapod.storage import close_storage, get_storage, init_storage
+
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    monkeypatch.setattr(settings.storage.filesystem, "data_dir", str(storage_dir))
+    monkeypatch.setattr(settings.storage, "backend", "filesystem")
+
+    import asyncio
+
+    async def _setup():
+        await init_storage()
+
+    async def _teardown():
+        await close_storage()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_setup())
+        yield get_storage()
+    finally:
+        loop.run_until_complete(_teardown())
+        loop.close()
+
+
+@pytest.mark.asyncio
+async def test_diff_classifies_added_removed_modified():
+    # Drive the function with mocked storage rather than the fixture
+    # above — simpler and avoids the per-fixture asyncio dance.
+    from unittest.mock import MagicMock, patch
+
+    from_bytes = _make_tarball(
+        {
+            "main.tf": b'resource "null" "x" {}\n',
+            "removed.tf": b"# bye\n",
+            "shared.tf": b"a\nb\nc\n",
+        }
+    )
+    to_bytes = _make_tarball(
+        {
+            "main.tf": b'resource "null" "x" { triggers = {} }\n',
+            "shared.tf": b"a\nb\nc\n",  # unchanged
+            "added.tf": b"# new\n",
+        }
+    )
+
+    async def fake_get_stream(key):
+        # Two storage keys; serve different bytes per key
+        if key == "from-key":
+            yield from_bytes
+        else:
+            yield to_bytes
+
+    storage = MagicMock()
+    storage.get_stream = fake_get_stream
+
+    with patch.object(cv_diff_service, "get_storage", return_value=storage):
+        result = await cv_diff_service.diff_tarballs("from-key", "to-key")
+
+    types = {f["path"]: f["type"] for f in result["files"]}
+    assert types["main.tf"] == "modified"
+    assert types["removed.tf"] == "removed"
+    assert types["added.tf"] == "added"
+    # Unchanged files must NOT appear
+    assert "shared.tf" not in types
+    assert result["total-files-changed"] == 3
+
+    # Modified file's diff body actually contains the change
+    main_diff = next(f["diff"] for f in result["files"] if f["path"] == "main.tf")
+    assert "triggers" in main_diff
+
+
+@pytest.mark.asyncio
+async def test_diff_reports_binary_changes_without_rendering_diff():
+    from unittest.mock import MagicMock, patch
+
+    from_bytes = _make_tarball({"image.png": b"\x89PNG\r\n\x1a\n" + b"old"})
+    to_bytes = _make_tarball({"image.png": b"\x89PNG\r\n\x1a\n" + b"new"})
+
+    async def fake_get_stream(key):
+        yield from_bytes if key == "from-key" else to_bytes
+
+    storage = MagicMock()
+    storage.get_stream = fake_get_stream
+
+    with patch.object(cv_diff_service, "get_storage", return_value=storage):
+        result = await cv_diff_service.diff_tarballs("from-key", "to-key")
+
+    assert result["files"] == [{"path": "image.png", "type": "binary-changed"}]
+
+
+@pytest.mark.asyncio
+async def test_diff_too_large_raises():
+    from unittest.mock import MagicMock, patch
+
+    # Build a tarball big enough to trip the per-pair cap once doubled.
+    # _MAX_TOTAL_BYTES default is 32 MiB; build 20 MiB on each side.
+    big_payload = b"x" * (20 * 1024 * 1024)
+    from_bytes = _make_tarball({"big.tf": big_payload})
+    to_bytes = _make_tarball({"big.tf": big_payload + b"\n"})
+
+    async def fake_get_stream(key):
+        yield from_bytes if key == "from-key" else to_bytes
+
+    storage = MagicMock()
+    storage.get_stream = fake_get_stream
+
+    with patch.object(cv_diff_service, "get_storage", return_value=storage):
+        with pytest.raises(cv_diff_service.DiffTooLarge):
+            await cv_diff_service.diff_tarballs("from-key", "to-key")

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -119,6 +119,31 @@ interface StateVersionItem {
   }
 }
 
+interface ConfigurationVersionItem {
+  id: string
+  attributes: {
+    source: string
+    status: string
+    'auto-queue-runs': boolean
+    speculative: boolean
+    'created-at': string
+  }
+}
+
+interface CVDiffFile {
+  path: string
+  type: 'added' | 'removed' | 'modified' | 'binary-changed'
+  diff?: string
+}
+
+interface CVDiffResult {
+  'from-id': string
+  'to-id': string
+  files: CVDiffFile[]
+  oversized: string[]
+  'total-files-changed': number
+}
+
 interface RunTaskItem {
   id: string
   attributes: {
@@ -165,9 +190,9 @@ const ALL_TRIGGERS = [
 const ALL_STAGES = ['pre_plan', 'post_plan', 'pre_apply'] as const
 const ALL_ENFORCEMENT_LEVELS = ['mandatory', 'advisory'] as const
 
-type Tab = 'overview' | 'variables' | 'runs' | 'state' | 'notifications' | 'run-tasks'
+type Tab = 'overview' | 'variables' | 'runs' | 'state' | 'configurations' | 'notifications' | 'run-tasks'
 
-const VALID_TABS: Set<string> = new Set(['overview', 'variables', 'runs', 'state', 'notifications', 'run-tasks'])
+const VALID_TABS: Set<string> = new Set(['overview', 'variables', 'runs', 'state', 'configurations', 'notifications', 'run-tasks'])
 
 export default function WorkspaceDetailPage() {
   return (
@@ -269,6 +294,15 @@ function WorkspaceDetailContent() {
   const [stateLoading, setStateLoading] = useState(false)
   const [stateActionLoading, setStateActionLoading] = useState<string | null>(null)
   const [confirmStateAction, setConfirmStateAction] = useState<{ action: 'delete' | 'rollback'; sv: StateVersionItem } | null>(null)
+
+  // Configuration versions (Configurations tab)
+  const [cvs, setCvs] = useState<ConfigurationVersionItem[]>([])
+  const [cvCurrentId, setCvCurrentId] = useState<string | null>(null)
+  const [cvLoading, setCvLoading] = useState(false)
+  const [cvSelected, setCvSelected] = useState<Set<string>>(new Set())
+  const [cvDiff, setCvDiff] = useState<CVDiffResult | null>(null)
+  const [cvDiffLoading, setCvDiffLoading] = useState(false)
+  const [cvDiffError, setCvDiffError] = useState('')
 
   // Variable editing
   const [editingVarId, setEditingVarId] = useState<string | null>(null)
@@ -418,6 +452,7 @@ function WorkspaceDetailContent() {
     if (activeTab === 'variables') loadVariables()
     if (activeTab === 'runs') loadRuns()
     if (activeTab === 'state') loadStateVersions()
+    if (activeTab === 'configurations') loadConfigurations()
     if (activeTab === 'notifications') loadNotifications()
     if (activeTab === 'run-tasks') loadRunTasks()
   }, [activeTab, workspace, loadRuns])
@@ -468,6 +503,105 @@ function WorkspaceDetailContent() {
       setError(err instanceof Error ? err.message : 'Failed to load state versions')
     } finally {
       setStateLoading(false)
+    }
+  }
+
+  async function loadConfigurations() {
+    setCvLoading(true)
+    setCvDiff(null)
+    setCvDiffError('')
+    try {
+      const res = await apiFetch(
+        `/api/v2/workspaces/${workspaceId}/configuration-versions?page%5Bsize%5D=100`,
+      )
+      if (!res.ok) throw new Error('Failed to load configuration versions')
+      const data = await res.json()
+      setCvs(data.data || [])
+      setCvCurrentId(data.meta?.['current-id'] ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load configuration versions')
+    } finally {
+      setCvLoading(false)
+    }
+  }
+
+  function toggleCvSelected(id: string) {
+    setCvSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      // Cap at two selections — clears the oldest when a third is picked
+      if (next.size > 2) {
+        const first = Array.from(next)[0]
+        next.delete(first)
+      }
+      return next
+    })
+    setCvDiff(null)
+    setCvDiffError('')
+  }
+
+  // Mint a short-lived ticket and let the browser stream the download
+  // natively to the user's save dialog. Plain navigation can't carry an
+  // Authorization header, so the ticket goes in the URL — bounded by a
+  // 5-min TTL and signed for this CV only. Avoids loading multi-MB
+  // tarballs into JS memory as a blob.
+  async function downloadCv(cvId: string) {
+    try {
+      const res = await apiFetch(
+        `/api/v2/configuration-versions/${cvId}/download-ticket`,
+        { method: 'POST' },
+      )
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}))
+        throw new Error(errBody.detail || `Download failed (${res.status})`)
+      }
+      const body = await res.json()
+      const url = body?.data?.attributes?.url
+      if (!url) throw new Error('Download ticket response missing URL')
+      // Trigger via an anchor so the page stays put — the
+      // Content-Disposition: attachment on the response makes the
+      // browser download rather than navigate.
+      const a = document.createElement('a')
+      a.href = url
+      a.rel = 'noopener'
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Download failed')
+    }
+  }
+
+  async function compareSelectedCvs() {
+    if (cvSelected.size !== 2) return
+    setCvDiffLoading(true)
+    setCvDiffError('')
+    try {
+      // Order from-id (older) → to-id (newer) so the diff reads left-to-right
+      // chronologically. CVs are sorted desc by created-at; we reverse-find.
+      const ids = cvs
+        .map(c => c.id)
+        .filter(id => cvSelected.has(id))
+      // ids[] preserves cv list order (newest first); reverse to get older first
+      const [toId, fromId] = ids
+      const res = await apiFetch('/api/v2/configuration-versions/diff', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: JSON.stringify({
+          data: { type: 'configuration-version-diffs', attributes: { 'from-id': fromId, 'to-id': toId } },
+        }),
+      })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}))
+        throw new Error(errBody.detail || `Diff failed (${res.status})`)
+      }
+      const data = await res.json()
+      setCvDiff(data.data.attributes)
+    } catch (err) {
+      setCvDiffError(err instanceof Error ? err.message : 'Diff failed')
+    } finally {
+      setCvDiffLoading(false)
     }
   }
 
@@ -1074,6 +1208,7 @@ function WorkspaceDetailContent() {
     { key: 'variables', label: 'Variables' },
     { key: 'runs', label: 'Runs' },
     { key: 'state', label: 'State' },
+    { key: 'configurations', label: 'Configurations' },
     { key: 'notifications', label: 'Notifications' },
     { key: 'run-tasks', label: 'Run Tasks' },
   ]
@@ -2230,6 +2365,172 @@ function WorkspaceDetailContent() {
                     })}
                   </tbody>
                 </table>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Configurations Tab */}
+        {activeTab === 'configurations' && (
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <p className="text-sm text-slate-400">
+                Uploaded source archives for this workspace, newest first. Pick two rows to compare.
+              </p>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-slate-500">{cvSelected.size}/2 selected</span>
+                <button
+                  type="button"
+                  onClick={compareSelectedCvs}
+                  disabled={cvSelected.size !== 2 || cvDiffLoading}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {cvDiffLoading ? 'Comparing…' : 'Compare'}
+                </button>
+              </div>
+            </div>
+
+            {cvLoading ? (
+              <LoadingSpinner />
+            ) : cvs.length === 0 ? (
+              <EmptyState message="No configuration versions yet. They appear here as soon as a `terraform plan` uploads or a VCS push triggers a run." />
+            ) : (
+              <div className="overflow-hidden rounded-xl border border-slate-800">
+                <table className="w-full text-sm">
+                  <thead className="bg-slate-900/50 text-slate-400">
+                    <tr>
+                      <th className="w-8 px-2 py-3" aria-hidden />
+                      <th className="px-4 py-3 text-left font-medium">ID</th>
+                      <th className="px-4 py-3 text-left font-medium">Source</th>
+                      <th className="px-4 py-3 text-left font-medium">Status</th>
+                      <th className="px-4 py-3 text-left font-medium">Created</th>
+                      <th className="px-4 py-3 text-right font-medium">Download</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-800">
+                    {cvs.map(cv => {
+                      const isCurrent = cv.id === cvCurrentId
+                      const isSelected = cvSelected.has(cv.id)
+                      const canDownload = cv.attributes.status === 'uploaded'
+                      return (
+                        <tr key={cv.id} className={isSelected ? 'bg-blue-900/20' : 'hover:bg-slate-900/30 transition-colors'}>
+                          <td className="px-2 py-3 align-middle">
+                            <input
+                              type="checkbox"
+                              aria-label={`Select ${cv.id} for compare`}
+                              checked={isSelected}
+                              onChange={() => toggleCvSelected(cv.id)}
+                              className="h-4 w-4"
+                              disabled={!canDownload}
+                            />
+                          </td>
+                          <td className="px-4 py-3 font-mono text-xs">
+                            <span className="text-slate-200">{cv.id}</span>
+                            {isCurrent && (
+                              <span className="ml-2 inline-flex items-center rounded bg-green-900/40 px-1.5 py-0.5 text-xs font-medium text-green-300">
+                                current
+                              </span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-slate-300">{cv.attributes.source}</td>
+                          <td className="px-4 py-3 text-slate-400">{cv.attributes.status}</td>
+                          <td className="px-4 py-3 text-slate-400">
+                            {new Date(cv.attributes['created-at']).toLocaleString()}
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            {canDownload ? (
+                              <button
+                                type="button"
+                                onClick={() => downloadCv(cv.id)}
+                                className="text-blue-400 hover:text-blue-300 text-sm font-medium"
+                              >
+                                Download
+                              </button>
+                            ) : (
+                              <span className="text-slate-600 text-sm">—</span>
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {cvDiffError && (
+              <div className="mt-4">
+                <ErrorBanner message={cvDiffError} />
+              </div>
+            )}
+
+            {cvDiff && (
+              <div className="mt-6 space-y-4">
+                <div className="flex items-baseline justify-between">
+                  <h3 className="text-lg font-medium text-slate-100">
+                    Diff <span className="text-slate-500 text-sm font-normal">{cvDiff['total-files-changed']} files changed</span>
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={() => { setCvDiff(null); setCvSelected(new Set()) }}
+                    className="text-sm text-slate-400 hover:text-slate-200"
+                  >
+                    Close
+                  </button>
+                </div>
+
+                {cvDiff.oversized.length > 0 && (
+                  <div className="rounded-md border border-amber-900/50 bg-amber-900/20 px-4 py-3 text-sm text-amber-200">
+                    Skipped {cvDiff.oversized.length} oversized file
+                    {cvDiff.oversized.length > 1 ? 's' : ''}: {cvDiff.oversized.join(', ')}
+                  </div>
+                )}
+
+                {cvDiff.files.length === 0 ? (
+                  <p className="text-slate-500 text-sm italic">
+                    No content differences between these versions.
+                  </p>
+                ) : (
+                  cvDiff.files.map(f => (
+                    <div key={f.path} className="overflow-hidden rounded-lg border border-slate-800">
+                      <div className="flex items-center gap-3 bg-slate-900/50 px-4 py-2 text-sm">
+                        <span
+                          className={
+                            'inline-block w-20 text-center rounded px-1.5 py-0.5 text-xs font-medium ' +
+                            (f.type === 'added' ? 'bg-green-900/50 text-green-300' :
+                             f.type === 'removed' ? 'bg-red-900/50 text-red-300' :
+                             f.type === 'binary-changed' ? 'bg-slate-700 text-slate-300' :
+                             'bg-blue-900/50 text-blue-300')
+                          }
+                        >
+                          {f.type}
+                        </span>
+                        <span className="font-mono text-slate-200">{f.path}</span>
+                      </div>
+                      {f.diff ? (
+                        <pre className="overflow-x-auto bg-slate-950 px-4 py-3 text-xs leading-relaxed text-slate-300">
+                          {f.diff.split('\n').map((line, i) => (
+                            <div
+                              key={i}
+                              className={
+                                line.startsWith('+') && !line.startsWith('+++') ? 'text-green-300' :
+                                line.startsWith('-') && !line.startsWith('---') ? 'text-red-300' :
+                                line.startsWith('@@') ? 'text-cyan-400' :
+                                'text-slate-400'
+                              }
+                            >
+                              {line || '\u00a0'}
+                            </div>
+                          ))}
+                        </pre>
+                      ) : (
+                        <p className="px-4 py-3 text-sm text-slate-500 italic">
+                          Binary file changed — diff not rendered.
+                        </p>
+                      )}
+                    </div>
+                  ))
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Adds first-class CV affordances to the workspace UI without introducing a Projects concept or in-browser editing — labels and existing VCS already cover those needs.

- **List** endpoint, paginated newest-first, with `meta.current-id` for the CV consumed by the most recent successful apply.
- **Download** endpoint streams the tarball with Bearer auth.
- **Download-ticket** (opt-in) mints a stateless HMAC cap-token the browser pastes into a plain navigation — same signing-key class as `runner_tokens.py`, single-resource, 5-min default TTL (30-min cap). Lets the browser stream straight to the save dialog without loading multi-MB tarballs into JS memory.
- **Diff** endpoint walks two CV tarballs and returns per-file unified diffs with binary detection. Per-file 1 MiB cap, per-pair 32 MiB cap.
- **Count-based config-version retention** (`config_versions_keep`, default 50) mirroring the registry-module pattern, alongside the existing age-based threshold.
- **Configurations tab** in the workspace UI ties it all together: multi-select for diff, per-row download.

## Security note (download tickets)

Stateless HMAC-SHA256 over `dlticket:{kind}:{id}:{email_b64}:{ttl}:{ts}`. Signing key is derived from `sha256(database_url)` — same secrecy class as the DB password and identical pattern to runner tokens. Single-resource (a CV-X ticket cannot fetch CV-Y), short-TTL (replay window bounded), tampering breaks the HMAC, multi-pod safe (any pod can verify a ticket any other pod minted). Authorization is gated at mint time — the ticket is a deferred capability for an action the caller was already authorized to do.

## Docs

- `docs/api-reference.md` — Configuration Versions section now covers list/show/download/download-ticket/download-by-ticket/diff. New Labels section for the previously-merged labels browser.
- `docs/rbac.md` — Labels Browser subsection.
- `docs/artifact-retention.md` — count-based CV retention added to table, helm values, and metrics categories.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1229 passing (17 new tests for `download_tickets`, 8 for `cv_diff_service`)
- [x] Tilt smoke test: list / mint ticket / download via ticket without Bearer / tampered signature 401 / cross-resource id 401
- [ ] CI green

Part of #267.