### PR TITLE
fix: runner-driven run transitions + listener SSE recovery

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -496,6 +496,15 @@ elif [ "$TP_PHASE" = "apply" ]; then
             EXIT_CODE=1
         fi
     fi
+
+    # Report apply completion to API on success — drives the
+    # `applying → applied` transition without waiting for the listener-
+    # driven Job-status round-trip. Best-effort; the reconciler's listener
+    # path is the fallback.
+    if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ] && [ "$EXIT_CODE" = "0" ]; then
+        curl -sSf --max-time 10 -X POST -H "$AUTH_HEADER" \
+            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/apply-result" || true
+    fi
 fi
 
 echo "[entrypoint] Phase $TP_PHASE completed with exit code $EXIT_CODE"

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1185,17 +1185,42 @@ async def report_plan_result(
     body: dict = Body(...),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Runner Job reports plan has_changes result.
+    """Runner Job reports plan completion.
 
-    Called by the runner entrypoint after plan completes. The has_changes
-    value is used by the reconciler to set the run's has_changes field.
+    Authoritative state-transition trigger: the runner has the exit code
+    and the diff in hand, so its successful POST here is sufficient
+    evidence that the plan finished. We update `has_changes` and drive the
+    `planning → planned` (or `applied` for zero-change non-speculative)
+    transition directly via `run_service.complete_plan`.
+
+    The reconciler's listener-driven path remains as a fallback for cases
+    where the runner can't post (OOM-killed before the entrypoint runs,
+    network partition, etc.). Both paths land in the same idempotent helper
+    so whichever wins, the second is a no-op.
     """
     run = await _get_run(run_id, db)
 
     has_changes = body.get("has_changes")
-    if has_changes is not None:
-        run.has_changes = has_changes
-        await db.commit()
+    await run_service.complete_plan(db, run, has_changes=has_changes)
+    await db.commit()
+
+    return JSONResponse(content={"status": "ok"})
+
+
+@router.post("/runs/{run_id}/apply-result")
+async def report_apply_result(
+    run_id: str = Path(...),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Runner Job reports apply completion.
+
+    Mirror of `plan-result`: authoritative transition trigger driven by the
+    runner's exit. Drives `applying → applied` via `run_service.complete_apply`,
+    which is idempotent against the listener-driven fallback.
+    """
+    run = await _get_run(run_id, db)
+    await run_service.complete_apply(db, run)
+    await db.commit()
 
     return JSONResponse(content={"status": "ok"})
 

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -39,6 +39,19 @@ logger = get_logger(__name__)
 # Shutdown flag
 _shutdown = asyncio.Event()
 
+# SSE read watchdog: API sends a keepalive comment every 1s, so any stretch
+# of silence longer than this means the stream has gone silent even though
+# the TCP socket is still open (e.g. API-side Redis pubsub detached, proxy
+# buffering). 30s is generous enough to absorb network jitter without
+# accidentally killing healthy streams.
+_SSE_READ_TIMEOUT = int(os.environ.get("TERRAPOD_SSE_READ_TIMEOUT", "30"))
+
+# Mandatory periodic reconnect — even a healthy connection is torn down
+# and rebuilt at this interval to guarantee no stale subscription state
+# survives forever. 10 minutes balances "cheap to reconnect" against
+# "don't churn unnecessarily."
+_SSE_MAX_AGE = int(os.environ.get("TERRAPOD_SSE_MAX_AGE", "600"))
+
 
 class RunnerListener:
     """Stateless Job launcher — ARC-pattern controller."""
@@ -427,7 +440,23 @@ class RunnerListener:
                 pass
 
     async def _sse_connect(self) -> None:
-        """Maintain a single SSE connection and dispatch events."""
+        """Maintain a single SSE connection and dispatch events.
+
+        Two recovery mechanisms guard against the silent-stall failure mode
+        observed in production where the TCP connection stays alive but
+        events stop reaching us (Redis pubsub on the API side detaches, the
+        proxy chain buffers, etc.):
+
+        1. **Read watchdog.** Every read of `aiter_lines()` is wrapped in a
+           timeout. The API yields a keepalive comment every second, so any
+           silence longer than `_SSE_READ_TIMEOUT` means the stream has
+           stalled even though the socket is still nominally open. Closing
+           the response triggers the outer reconnect loop in `_sse_loop`.
+        2. **Mandatory periodic reconnect.** Even a healthy-looking stream
+           is torn down and rebuilt every `_SSE_MAX_AGE` seconds. Cheap (one
+           HTTP roundtrip + Redis subscribe) and guarantees no stale
+           subscription survives indefinitely.
+        """
         url = (
             f"{self.identity.api_url}/api/v2/listeners/listener-{self.identity.listener_id}/events"
         )
@@ -436,12 +465,30 @@ class RunnerListener:
         async with self._sse_client.stream("GET", url, headers=self._auth_headers()) as response:
             response.raise_for_status()
             logger.info("SSE connected")
+            connected_at = time.monotonic()
 
             event_type = ""
             event_data = ""
 
-            async for line in response.aiter_lines():
+            line_iter = response.aiter_lines()
+            while True:
                 if _shutdown.is_set():
+                    return
+
+                # Mandatory periodic reconnect — return cleanly so the outer
+                # loop reopens a fresh connection (and a fresh Redis pubsub
+                # subscription on the API side).
+                if time.monotonic() - connected_at > _SSE_MAX_AGE:
+                    logger.info("SSE max-age reached, reconnecting", age=_SSE_MAX_AGE)
+                    return
+
+                try:
+                    line = await asyncio.wait_for(line_iter.__anext__(), timeout=_SSE_READ_TIMEOUT)
+                except StopAsyncIteration:
+                    return  # Stream closed by server — outer loop reconnects
+                except TimeoutError:
+                    # Silent stall — kill the connection, outer loop reconnects.
+                    logger.warning("SSE read timeout — stream stalled", timeout=_SSE_READ_TIMEOUT)
                     return
 
                 if line.startswith("event:"):
@@ -451,12 +498,14 @@ class RunnerListener:
                 elif line == "":
                     # Empty line = end of event
                     if event_type and event_data:
+                        logger.info("SSE event received", event_type=event_type)
                         task = asyncio.create_task(self._dispatch_event(event_type, event_data))
                         self._background_tasks.add(task)
                         task.add_done_callback(self._background_tasks.discard)
                     event_type = ""
                     event_data = ""
-                # Ignore comment lines (keepalives start with ":")
+                # Comment lines (keepalives start with ":") are ignored but
+                # still reset the read-watchdog by virtue of having yielded.
 
     # ── Poll Fallback Loop ─────────────────────────────────────────
 

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -158,61 +158,22 @@ async def _reconcile_one(db: AsyncSession, run: Run) -> None:
 
 
 async def _handle_succeeded(db: AsyncSession, run: Run) -> None:
-    """Handle a succeeded Job."""
-    from terrapod.services import run_service, run_task_service
+    """Handle a succeeded Job.
+
+    Thin wrapper around the shared `run_service.complete_plan` /
+    `complete_apply` helpers. Both helpers are idempotent — if the runner's
+    direct POST (`/plan-result` / `/apply-result`) already drove the
+    transition, this is a no-op.
+    """
+    from terrapod.services import run_service
 
     phase = "plan" if run.status == "planning" else "apply"
     await _persist_live_log_if_missing(run, phase)
 
     if run.status == "planning":
-        # Check post_plan task stage
-        ts = await run_task_service.create_task_stage(db, run.id, run.workspace_id, "post_plan")
-        if ts is not None:
-            # Task stage created — resolve it
-            stage_status = await run_task_service.resolve_stage(db, ts.id)
-            if stage_status not in ("passed", "overridden"):
-                if stage_status == "failed":
-                    await run_service.transition_run(
-                        db, run, "errored", error_message="Post-plan task stage failed"
-                    )
-                # Stage still pending/running — will be re-checked next cycle
-                return
-
-        run = await run_service.transition_run(db, run, "planned")
-
-        # Unlock workspace for plan-only runs
-        if run.plan_only:
-            ws = await db.get(Workspace, run.workspace_id)
-            if ws and ws.locked:
-                ws.locked = False
-                ws.lock_id = None
-
-        # No-op short-circuit: a plan that reports no changes has nothing
-        # for an apply Job to do. Skip straight to applied via the shared
-        # helper (sets apply_*_at, releases lock). Applies regardless of
-        # auto_apply since the manual confirm path also has nothing
-        # meaningful to do.
-        if not run.plan_only and run.has_changes is False:
-            run = await run_service.complete_planned_as_noop(db, run)
-            logger.info("Plan succeeded — no changes, skipping apply", run_id=str(run.id))
-            return
-
-        # Auto-apply if configured
-        if run.auto_apply and not run.plan_only:
-            run = await run_service.transition_run(db, run, "confirmed")
-
-        logger.info("Plan succeeded", run_id=str(run.id))
-
+        await run_service.complete_plan(db, run)
     elif run.status == "applying":
-        run = await run_service.transition_run(db, run, "applied")
-
-        # Unlock workspace
-        ws = await db.get(Workspace, run.workspace_id)
-        if ws and ws.locked:
-            ws.locked = False
-            ws.lock_id = None
-
-        logger.info("Apply succeeded", run_id=str(run.id))
+        await run_service.complete_apply(db, run)
 
 
 async def _handle_failed(db: AsyncSession, run: Run, error_message: str) -> None:

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -381,6 +381,95 @@ async def transition_run(
     return run
 
 
+async def complete_plan(
+    db: AsyncSession,
+    run: Run,
+    has_changes: bool | None = None,
+) -> Run:
+    """Drive a `planning` run to its post-plan terminal state.
+
+    Idempotent landing point shared by the two paths that can authoritatively
+    declare a plan finished:
+
+    1. The runner Job posting `/plan-result` (runner is source of truth — it
+       has the exit code and the diff in hand).
+    2. The reconciler observing the K8s Job as Completed via the listener
+       (indirect; covers the case where the runner died before posting).
+
+    Either path can race the other. The first one to win does the work; the
+    second sees `run.status != "planning"` and returns the run unchanged.
+
+    Mirrors the previous behaviour of `_handle_succeeded` in the reconciler:
+    optionally runs post-plan task stages, transitions to `planned`, releases
+    the lock for plan-only runs, short-circuits zero-change non-speculative
+    plans straight to `applied`, and auto-applies when configured.
+    """
+    from terrapod.services import run_task_service
+
+    # Idempotency guard — both callers can race; later one is a no-op.
+    if run.status != "planning":
+        return run
+
+    if has_changes is not None:
+        run.has_changes = has_changes
+
+    # Post-plan task stage gate. If the stage isn't passed/overridden yet,
+    # leave the run in `planning` for the next reconciler tick to re-check.
+    ts = await run_task_service.create_task_stage(db, run.id, run.workspace_id, "post_plan")
+    if ts is not None:
+        stage_status = await run_task_service.resolve_stage(db, ts.id)
+        if stage_status not in ("passed", "overridden"):
+            if stage_status == "failed":
+                await transition_run(
+                    db, run, "errored", error_message="Post-plan task stage failed"
+                )
+            return run
+
+    run = await transition_run(db, run, "planned")
+
+    # Unlock workspace for plan-only runs — they make no further state moves.
+    if run.plan_only:
+        ws = await db.get(Workspace, run.workspace_id)
+        if ws and ws.locked:
+            ws.locked = False
+            ws.lock_id = None
+
+    # Zero-change non-speculative plans short-circuit straight to `applied`.
+    # No apply Job is launched — the runner couldn't change anything anyway,
+    # and an empty apply triggers the duplicate-serial 500 on state upload.
+    if not run.plan_only and run.has_changes is False:
+        run = await complete_planned_as_noop(db, run)
+        logger.info("Plan succeeded — no changes, skipping apply", run_id=str(run.id))
+        return run
+
+    if run.auto_apply and not run.plan_only:
+        run = await transition_run(db, run, "confirmed")
+
+    logger.info("Plan succeeded", run_id=str(run.id))
+    return run
+
+
+async def complete_apply(db: AsyncSession, run: Run) -> Run:
+    """Drive an `applying` run to `applied`.
+
+    Idempotent counterpart to :func:`complete_plan`. Same dual-path rationale
+    — either the runner's `/apply-result` POST or the reconciler's listener
+    round-trip can win; whichever lands first does the transition.
+    """
+    if run.status != "applying":
+        return run
+
+    run = await transition_run(db, run, "applied")
+
+    ws = await db.get(Workspace, run.workspace_id)
+    if ws and ws.locked:
+        ws.locked = False
+        ws.lock_id = None
+
+    logger.info("Apply succeeded", run_id=str(run.id))
+    return run
+
+
 async def complete_planned_as_noop(db: AsyncSession, run: Run) -> Run:
     """Transition a planned run directly to `applied` without an apply Job.
 

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -15,6 +15,8 @@ from terrapod.services.run_service import (
     can_transition,
     cancel_run,
     claim_next_run,
+    complete_apply,
+    complete_plan,
     confirm_run,
     create_run,
     discard_run,
@@ -443,3 +445,146 @@ class TestPublishRunAvailable:
 
         # Should not raise
         await _publish_run_available(run)
+
+
+# ── complete_plan / complete_apply ────────────────────────────────────
+
+
+@pytest.fixture
+def _mock_db():
+    db = AsyncMock(spec=AsyncSession)
+    db.flush = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+    return db
+
+
+class TestCompletePlan:
+    """`complete_plan` is the shared landing point for both the runner-driven
+    `/plan-result` POST and the reconciler-driven listener Job-status path.
+    Critical property: it is idempotent against re-entry from either path.
+    """
+
+    @patch("terrapod.services.run_service._publish_run_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.run_task_service.create_task_stage",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+    async def test_no_op_when_already_past_planning(self, _stage, _avail, _evt, _mock_db):
+        """If the run is already `planned`, the call is a no-op — the racing
+        path won. No transition_run, no flush, run returned unchanged."""
+        run = _mock_run(status="planned")
+        result = await complete_plan(_mock_db, run)
+        assert result.status == "planned"
+        # transition_run was never called → no flush
+        _mock_db.flush.assert_not_called()
+
+    @patch("terrapod.services.run_service._publish_run_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.run_task_service.create_task_stage",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+    async def test_clean_plan_transitions_to_planned(self, _stage, _avail, _evt, _mock_db):
+        run = _mock_run(status="planning", plan_started_at=datetime.now(UTC), plan_only=True)
+        run.has_changes = True
+        result = await complete_plan(_mock_db, run, has_changes=True)
+        assert result.status == "planned"
+        assert result.has_changes is True
+
+    @patch("terrapod.services.run_service.fire_run_triggers", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.run_task_service.create_task_stage",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+    async def test_zero_change_non_speculative_short_circuits_to_applied(
+        self, _stage, _avail, _evt, _fire, _mock_db
+    ):
+        """A non-plan-only run that produced no changes goes straight to
+        `applied` (no apply Job needed; otherwise we d burn an empty apply
+        and trip the duplicate-serial 500 on state upload)."""
+        run = _mock_run(
+            status="planning", plan_started_at=datetime.now(UTC), plan_only=False, auto_apply=False
+        )
+        result = await complete_plan(_mock_db, run, has_changes=False)
+        assert result.status == "applied"
+
+    @patch("terrapod.services.run_service._publish_run_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.run_task_service.create_task_stage",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+    async def test_auto_apply_advances_to_confirmed(self, _stage, _avail, _evt, _mock_db):
+        run = _mock_run(
+            status="planning", plan_started_at=datetime.now(UTC), plan_only=False, auto_apply=True
+        )
+        result = await complete_plan(_mock_db, run, has_changes=True)
+        assert result.status == "confirmed"
+
+    @patch("terrapod.services.run_service._publish_run_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    @patch("terrapod.services.run_task_service.resolve_stage", new_callable=AsyncMock)
+    @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)
+    async def test_failed_post_plan_stage_errors_run(
+        self, mock_create, mock_resolve, _avail, _evt, _mock_db
+    ):
+        """A failed post-plan task stage transitions the run to `errored`
+        instead of `planned`."""
+        ts = MagicMock()
+        ts.id = uuid.uuid4()
+        mock_create.return_value = ts
+        mock_resolve.return_value = "failed"
+
+        run = _mock_run(status="planning", plan_started_at=datetime.now(UTC), plan_only=True)
+        result = await complete_plan(_mock_db, run, has_changes=True)
+        assert result.status == "errored"
+
+    @patch("terrapod.services.run_service._publish_run_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    @patch("terrapod.services.run_task_service.resolve_stage", new_callable=AsyncMock)
+    @patch("terrapod.services.run_task_service.create_task_stage", new_callable=AsyncMock)
+    async def test_pending_post_plan_stage_keeps_run_in_planning(
+        self, mock_create, mock_resolve, _avail, _evt, _mock_db
+    ):
+        """A still-pending post-plan stage leaves the run in `planning` so
+        the next reconciler tick re-checks. No transition fires."""
+        ts = MagicMock()
+        ts.id = uuid.uuid4()
+        mock_create.return_value = ts
+        mock_resolve.return_value = "running"
+
+        run = _mock_run(status="planning", plan_started_at=datetime.now(UTC), plan_only=True)
+        result = await complete_plan(_mock_db, run, has_changes=True)
+        assert result.status == "planning"
+
+
+class TestCompleteApply:
+    @patch("terrapod.services.run_service._publish_run_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.run_service.fire_run_triggers",
+        new_callable=AsyncMock,
+    )
+    async def test_no_op_when_not_applying(self, _fire, _avail, _evt, _mock_db):
+        run = _mock_run(status="applied")
+        result = await complete_apply(_mock_db, run)
+        assert result.status == "applied"
+        _mock_db.flush.assert_not_called()
+
+    @patch("terrapod.services.run_service._publish_run_event", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.run_service.fire_run_triggers",
+        new_callable=AsyncMock,
+    )
+    async def test_applying_transitions_to_applied(self, _fire, _avail, _evt, _mock_db):
+        run = _mock_run(status="applying", apply_started_at=datetime.now(UTC))
+        result = await complete_apply(_mock_db, run)
+        assert result.status == "applied"


### PR DESCRIPTION
Closes #273.

## Why

A run can finish its plan/apply Job cleanly in K8s but sit in `planning` (or `applying`) for an hour until the stale-check timeout errors it out. Investigated in the issue: the runner POSTs `/plan-result` successfully, the Job completes, but the reconciler's listener-driven `check_job_status` round-trip silently fails to reach the listener. State machine never transitions; user sees a perpetually pending PR check.

## What

Two interlocking fixes.

### 1. Architectural: runner is now authoritative for transitions

New helpers in `run_service`:

- `complete_plan(db, run, has_changes=None)` — idempotent. Drives `planning → planned` (or `→ applied` for zero-change non-speculative, or `→ confirmed` for auto-apply). Runs the post-plan task-stage gate.
- `complete_apply(db, run)` — idempotent counterpart for `applying → applied`.

Two callers, both routed through these helpers:

- `POST /api/v2/runs/{rid}/plan-result` (existing, was thin) — now calls `complete_plan` directly. Runner has the exit code and diff in hand → its successful POST is sufficient evidence.
- `POST /api/v2/runs/{rid}/apply-result` (**new**) — mirror for the apply phase. `runner-entrypoint.sh` now POSTs this on success.

The reconciler's `_handle_succeeded` is simplified to delegate to the same helpers — same code path, idempotent so the runner-side and listener-side paths are safe to race.

The listener-driven Job-status flow becomes a **fallback** for cases where the runner can't post (OOM-killed before entrypoint runs, network partition, etc.). Stale-check stays as the last-resort safety net.

### 2. Listener SSE recovery

Two robustness changes to `_sse_connect`:

- **Read watchdog** (`TERRAPOD_SSE_READ_TIMEOUT`, default 30s). Every `aiter_lines` read is wrapped in `asyncio.wait_for`. API yields a keepalive every 1s; longer silence = the stream has gone dead even though TCP is nominally open. Timeout → fresh reconnect via the outer loop.
- **Mandatory periodic reconnect** (`TERRAPOD_SSE_MAX_AGE`, default 600s). Even a healthy stream is rebuilt at this cadence so no stale subscription state can survive forever.

Plus visibility: `INFO` log on every dispatched SSE event. Today the only way to tell whether a listener is consuming events is from the absence of output, which is exactly the failure mode we just hit.

## Files

- `services/terrapod/services/run_service.py` — adds `complete_plan` / `complete_apply`.
- `services/terrapod/api/routers/runs.py` — `POST /plan-result` now drives the transition; new `POST /apply-result`.
- `services/terrapod/services/run_reconciler.py` — `_handle_succeeded` simplified to delegate.
- `services/terrapod/runner/listener.py` — SSE watchdog + max-age reconnect + visibility logging.
- `docker/runner-entrypoint.sh` — POSTs `/apply-result` on apply success.
- `services/tests/services/test_run_service.py` — 8 new tests for `complete_plan` / `complete_apply`.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1237 passing (1229 prior + 8 new)
- [ ] Smoke: deploy to a non-prod cluster, observe a clean run transitions to `planned` in <1s without listener round-trip
- [ ] Behaviour test for the SSE watchdog — block keepalives → observe listener reconnect within `read_timeout`s

## Compatibility

Old runners (no `/apply-result` POST) still work — the reconciler's listener path remains. The `complete_*` helpers' idempotency means upgrading the API ahead of the runner is safe; upgrading the runner ahead of the API is also safe (the new endpoint already exists once API is upgraded).

The new SSE env vars have safe defaults; no Helm chart changes required.