### PR TITLE
fix: drift detection picks CV from latest applied run, not latest uploaded

### DIFF
--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -142,21 +142,33 @@ async def _create_drift_run_non_vcs(
 ) -> Run | None:
     """Create a drift detection run for a non-VCS workspace.
 
-    Uses the latest uploaded ConfigurationVersion.
+    Uses the configuration version from the latest successful apply —
+    i.e. the bytes that produced the workspace's current state. Picking
+    "latest uploaded" instead would compare live state against a config
+    that has never been applied, surfacing phantom diffs (between two
+    configs) rather than actual infrastructure drift.
+
+    Returns None if the workspace has never been applied — there's no
+    reference config to diff against, so drift detection is a no-op.
     """
     result = await db.execute(
         select(ConfigurationVersion)
+        .join(Run, Run.configuration_version_id == ConfigurationVersion.id)
         .where(
-            ConfigurationVersion.workspace_id == ws.id,
+            Run.workspace_id == ws.id,
+            Run.status == "applied",
             ConfigurationVersion.status == "uploaded",
         )
-        .order_by(ConfigurationVersion.created_at.desc())
+        .order_by(Run.apply_finished_at.desc())
         .limit(1)
     )
     cv = result.scalar_one_or_none()
 
     if cv is None:
-        logger.debug("No uploaded config version for drift check", workspace=ws.name)
+        logger.debug(
+            "No applied configuration version for drift check",
+            workspace=ws.name,
+        )
         return None
 
     run = await run_service.create_run(

--- a/services/tests/services/test_drift_detection_service.py
+++ b/services/tests/services/test_drift_detection_service.py
@@ -277,3 +277,66 @@ class TestHandleDriftRunCompleted:
         # The one that fixes the detail-page-stays-stale bug
         assert f"tp:run_events:{ws.id}" in channels
         assert mock_publish.call_count == 3
+
+
+class TestCreateDriftRunNonVcs:
+    """Drift detection on non-VCS workspaces must plan against the CV from
+    the workspace's latest successful apply — i.e. the bytes that produced
+    the current state — not the latest uploaded CV (which may never have
+    been applied)."""
+
+    @patch(
+        "terrapod.services.drift_detection_service.run_service.queue_run", new_callable=AsyncMock
+    )
+    @patch(
+        "terrapod.services.drift_detection_service.run_service.create_run", new_callable=AsyncMock
+    )
+    async def test_uses_cv_from_latest_applied_run(self, mock_create, mock_queue):
+        """The selected CV is the one referenced by the most recent applied
+        run, even if a newer-but-unapplied CV exists."""
+        from terrapod.services.drift_detection_service import _create_drift_run_non_vcs
+
+        ws = _mock_workspace()
+
+        # Stub the join query to return a specific CV (the "applied" one).
+        applied_cv = MagicMock()
+        applied_cv.id = uuid.uuid4()
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = applied_cv
+        mock_db.execute.return_value = mock_result
+
+        new_run = MagicMock()
+        mock_create.return_value = new_run
+        mock_queue.return_value = new_run
+
+        result = await _create_drift_run_non_vcs(mock_db, ws)
+
+        assert result is new_run
+        # The run was created with the applied CV's id
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["configuration_version_id"] == applied_cv.id
+        assert kwargs["is_drift_detection"] is True
+        assert kwargs["plan_only"] is True
+        assert kwargs["source"] == "drift-detection"
+
+    @patch(
+        "terrapod.services.drift_detection_service.run_service.create_run", new_callable=AsyncMock
+    )
+    async def test_returns_none_when_workspace_never_applied(self, mock_create):
+        """A workspace that has never been applied has no reference CV — drift
+        is a no-op rather than picking some arbitrary uploaded CV."""
+        from terrapod.services.drift_detection_service import _create_drift_run_non_vcs
+
+        ws = _mock_workspace()
+
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+
+        result = await _create_drift_run_non_vcs(mock_db, ws)
+
+        assert result is None
+        mock_create.assert_not_called()


### PR DESCRIPTION
Closes #274.

## Bug

Non-VCS drift detection was selecting the most recently *uploaded* CV as the source for the drift plan. If a user uploaded a newer CV that hadn't been applied (or whose apply failed), drift would surface diffs between two configs — the applied one and the newer uploaded one — rather than between the applied config and the live infrastructure.

## Fix

`_create_drift_run_non_vcs` now joins on the runs table and selects the CV referenced by the workspace's most recent successful apply, ordered by `apply_finished_at desc`. The CV that produced the current state is the only correct reference for drift detection: it's the bytes terraform already executed, so any plan diff against it is genuine drift.

Returns None (no drift run created) if the workspace has never been successfully applied — there's no reference config in that case, so drift is a no-op rather than picking some arbitrary uploaded CV.

## Verification

### Unit tests

Two new tests in `test_drift_detection_service.py::TestCreateDriftRunNonVcs`:
- `test_uses_cv_from_latest_applied_run` — confirms the run is created against the applied CV
- `test_returns_none_when_workspace_never_applied` — confirms graceful no-op

### End-to-end (Tilt)

1. Created non-VCS agent workspace with `drift_detection_enabled=true`.
2. Uploaded CV1 (one `null_resource`), ran plan-and-apply → state created.
3. Uploaded CV2 (CV1 + an extra `null_resource`) — never applied. CV2 is now the *latest uploaded*; CV1 is the *latest applied*.
4. Triggered drift detection cycle (lowered cadence to 15s via env var for the test).
5. Observed: drift run created against `cv-019e077d-4848-7aa9-896d-86c375e74903` (CV1, the applied one). Plan completed `has_changes=false` (no drift — infrastructure matches CV1).

Pre-fix: drift would have picked CV2 and reported `has_changes=true` for the never-applied extra resource — misreading "TF code drift" as "infrastructure drift."