### PR TITLE
fix: cloud-block init against Terrapod workspaces (closes #271)

### DIFF
--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -186,6 +186,28 @@ def _validate_workspace_name(name: str) -> str:
     return cleaned
 
 
+def _labels_to_tag_names(labels: dict | None) -> list[str]:
+    """Render a workspace's labels as the legacy `tag-names` array.
+
+    OpenTofu/Terraform's cloud backend reads `tag-names` to decide whether
+    a workspace already carries the tags declared in its cloud block. We
+    expose each label in both bare-key and `key=value` form so a cloud
+    block written either way matches without an extra round-trip.
+
+    Empty values are skipped on the `key=value` rendering only — a label
+    with key `foo` and value `""` still appears as `"foo"` (matches
+    `tags = ["foo"]`) but not `"foo="` (which no one would write).
+    """
+    if not labels:
+        return []
+    names: list[str] = []
+    for k, v in labels.items():
+        names.append(str(k))
+        if v not in (None, ""):
+            names.append(f"{k}={v}")
+    return names
+
+
 def _clamp_drift_interval(value: int) -> int:
     """Clamp drift detection interval to the configured minimum."""
     from terrapod.config import settings
@@ -535,6 +557,15 @@ def _workspace_json(
                 "agent-pool-name": ws.agent_pool.name if ws.agent_pool else None,
                 "vcs-connection-name": ws.vcs_connection.name if ws.vcs_connection else None,
                 "labels": ws.labels or {},
+                # `tag-names` is what OpenTofu/Terraform's cloud backend
+                # reads to decide whether the workspace already has the
+                # cloud-block tags. Without it, `workspaceTagsRequireUpdate`
+                # always returns true → fires `AddTags` (POST
+                # /relationships/tags) → 404 → init fails. We mirror each
+                # label as both bare-key and key=value form so cloud blocks
+                # written either way (`tags = ["foo"]` vs
+                # `tags = ["foo=bar"]`) match.
+                "tag-names": _labels_to_tag_names(ws.labels),
                 "owner-email": ws.owner_email,
                 "created-at": _rfc3339(ws.created_at),
                 "updated-at": _rfc3339(ws.updated_at),
@@ -893,8 +924,15 @@ async def list_workspace_tag_bindings(
     """
     ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
 
+    # `id` is required by JSON:API and go-tfe's jsonapi parser silently
+    # drops entries that are missing it. Without an id, ListTagBindings
+    # returns an empty list, terraform-cli concludes the workspace has no
+    # tags, and tries to PATCH them in — which we don't support and
+    # don't want to. Synthesised from {workspace-id}:{key} so the id is
+    # stable per binding without requiring a separate row to track it.
     bindings = [
         {
+            "id": f"{ws.id}:{k}",
             "type": "tag-bindings",
             "attributes": {
                 "key": str(k),
@@ -923,8 +961,11 @@ async def list_workspace_effective_tag_bindings(
     """
     ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
 
+    # See note on `id` in `list_workspace_tag_bindings` above — required by
+    # JSON:API or go-tfe drops the entry on parse.
     bindings = [
         {
+            "id": f"{ws.id}:{k}",
             "type": "effective-tag-bindings",
             "attributes": {
                 "key": str(k),
@@ -937,6 +978,47 @@ async def list_workspace_effective_tag_bindings(
         content={"data": bindings},
         headers=_tfe_headers(),
     )
+
+
+# ── Tag-binding writes — accept-and-ignore ──────────────────────────────
+#
+# In the common case `workspace.tag-names` (above) covers OpenTofu's
+# `workspaceTagsRequireUpdate`: if the workspace's labels already include
+# the cloud-block tags, the CLI skips writing entirely. These endpoints
+# only fire when the cloud-block declares a tag that the workspace
+# doesn't have — and in that case Terrapod's design is operator-controlled
+# labels (set via the terrapod-config provider). Clients can't mutate
+# them.
+#
+# So accept the request, ignore the body, return TFE-shaped success. The
+# init proceeds, no mutation happens, the operator stays in charge of
+# what tags exist. Subsequent runs from a misconfigured cloud block fail
+# at workspace-by-tag discovery (which IS tag-filtered) when the tags
+# genuinely don't exist anywhere.
+
+
+@router.post("/workspaces/{workspace_id}/relationships/tags", status_code=204)
+async def add_workspace_tag_names(
+    workspace_id: str = Path(...),
+    body: dict = Body(default={}),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Legacy POST tag-add — no-op."""
+    await _require_ws_permission(workspace_id, "read", user, db)
+    return Response(status_code=204, headers=_tfe_headers())
+
+
+@router.delete("/workspaces/{workspace_id}/relationships/tags", status_code=204)
+async def remove_workspace_tag_names(
+    workspace_id: str = Path(...),
+    body: dict = Body(default={}),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Legacy DELETE tag-remove — no-op."""
+    await _require_ws_permission(workspace_id, "read", user, db)
+    return Response(status_code=204, headers=_tfe_headers())
 
 
 @router.patch("/workspaces/{workspace_id}")

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -533,6 +533,37 @@ class TestPermissionsBlock:
 # ── Tag bindings (terraform key-value tag support probe) ───────────────
 
 
+class TestLabelsToTagNames:
+    """`tag-names` is the legacy attribute that OpenTofu/Terraform's cloud
+    backend reads on workspace lookup. Without it, the CLI thinks the
+    workspace has no tags, fires AddTags (POST /relationships/tags), 404s,
+    init fails. We render labels in both bare-key and key=value form so
+    cloud blocks written either way match."""
+
+    def test_empty_labels(self):
+        from terrapod.api.routers.tfe_v2 import _labels_to_tag_names
+
+        assert _labels_to_tag_names({}) == []
+        assert _labels_to_tag_names(None) == []
+
+    def test_renders_both_bare_and_kv_form(self):
+        from terrapod.api.routers.tfe_v2 import _labels_to_tag_names
+
+        names = _labels_to_tag_names({"env": "dev", "team": "platform"})
+        assert "env" in names
+        assert "env=dev" in names
+        assert "team" in names
+        assert "team=platform" in names
+
+    def test_empty_value_skips_kv_form(self):
+        """An empty-value label only appears in bare-key form."""
+        from terrapod.api.routers.tfe_v2 import _labels_to_tag_names
+
+        names = _labels_to_tag_names({"flag": ""})
+        assert "flag" in names
+        assert "flag=" not in names
+
+
 class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -556,6 +587,12 @@ class TestWorkspaceTagBindings:
             ("env", "dev"),
         }
         assert all(i["type"] == "tag-bindings" for i in items)
+        # JSON:API requires `id` on every resource. go-tfe's jsonapi parser
+        # silently drops entries that are missing it — leaving the CLI to
+        # think the workspace has no tags and try to PATCH them in.
+        assert all(i["id"] for i in items)
+        # IDs must be unique within the response (JSON:API requirement).
+        assert len({i["id"] for i in items}) == len(items)
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -615,6 +652,7 @@ class TestWorkspaceTagBindings:
         items = resp.json()["data"]
         assert items == [
             {
+                "id": f"{ws.id}:repo",
                 "type": "effective-tag-bindings",
                 "attributes": {"key": "repo", "value": "tf-aws-core"},
             }


### PR DESCRIPTION
Closes #271. Replaces the original "implement workspace tag-binding write endpoints" approach with a smaller, design-aligned fix that keeps labels operator-controlled.

## What was actually broken

OpenTofu's cloud backend (and Terraform 1.10+) calls `workspaceTagsRequireUpdate` on init, which checks the workspace's existing tags against the cloud-block-declared tags. We returned only \`labels\` (Terrapod-specific) and not \`tag-names\` (the TFE-spec attribute go-tfe parses into \`Workspace.TagNames\`). The CLI saw an empty set, decided an update was needed, and called \`AddTags\` → 404 → \`Error updating workspace ... resource not found\`.

Bonus secondary issue: GET tag-bindings response was missing \`id\`. JSON:API requires it; go-tfe's parser silently drops entries that don't have one. Was breaking the KV-tag discovery on Terraform 1.10+ HCP-Terraform-branch clients.

## Fix

1. **Add \`tag-names\` to the workspace JSON.** Rendered from labels in both bare-key and key=value form so cloud blocks written either way (\`tags = ["foo"]\` vs \`tags = ["foo=bar"]\`) match without provoking a write.

2. **Add no-op \`POST\`/\`DELETE /workspaces/{id}/relationships/tags\`.** Belt-and-braces — the CLI's pre-check usually skips them now, but if any code path (older clients, terraform-cli vs OpenTofu) does fire AddTags/RemoveTags we accept the body and return 204. **Labels stay operator-set.** This is the design we agreed on: clients can't mutate labels.

3. **Add \`id\` to the GET tag-bindings response.** JSON:API conformance.

## End-to-end verification (Tilt)

| Scenario | Result |
|---|---|
| Cloud block with matching tags (\`tags = ["project=smoke", "env=dev"]\`) | ✓ \`tofu init\` succeeds |
| Cloud block with mismatched tags (\`tags = ["does-not-exist"]\`) | ✓ \`tofu init\` fails with \"OpenTofu failed to find workspace ... with the tags specified\". Labels on the workspace untouched |

Verified that the workspace's labels remain exactly what \`terrapod-config\`'s \`terrapod_workspace\` resource set them to in both cases. No client-side mutation possible.

## Tests

- \`TestLabelsToTagNames\` — helper unit tests (empty, both forms, empty-value skipping)
- Existing \`TestWorkspaceTagBindings\` updated to assert \`id\` field is present on every binding

## Files

- \`services/terrapod/api/routers/tfe_v2.py\` — \`_labels_to_tag_names\` helper, \`tag-names\` in workspace JSON, no-op POST/DELETE \`/relationships/tags\`, \`id\` on GET tag-bindings response
- \`services/tests/api/test_workspaces.py\` — new \`TestLabelsToTagNames\` + \`id\` assertions