### PR TITLE
feat: API namespace cleanup — Terrapod-native routes move to /api/terrapod/v1 (closes #269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 - **Kubernetes-native** -- deployed exclusively via Helm chart; runner Jobs are ephemeral K8s Jobs
 - **ARC-pattern execution** -- listener creates Jobs on demand (like GitHub Actions Runner Controller)
 - **OpenTofu-first** -- [OpenTofu](https://opentofu.org/) is the recommended execution backend; `terraform` is also supported
-- **Single organization** -- one org per instance; the TFE V2 API accepts `{org}` in paths for CLI compatibility but only `default` is valid
+- **Single organization** -- one org per instance; every Terrapod API path that contains an organization segment uses the literal name `default`
 - **Native object storage** -- speaks each cloud provider's native SDK (S3, Azure Blob, GCS) with filesystem fallback for dev
 
 ---

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -121,7 +121,7 @@ upload_log() {
              -H "$AUTH_HEADER" \
              -H "Content-Type: application/octet-stream" \
              --data-binary @"$COMBINED_LOG" \
-             "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/${_artifact}" \
+             "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/${_artifact}" \
              >/dev/null 2>&1; then
             return 0
         fi
@@ -166,9 +166,10 @@ tp_curl_download() {
                 # *.storage.googleapis.com) are left untouched.
                 if [ "$_redir_host" != "$_api_host" ]; then
                     _path=$(echo "$_location" | sed 's|^https\{0,1\}://[^/]*||')
-                    # Check if path is a filesystem presigned URL (/api/v2/storage/...)
+                    # Check if path is a filesystem presigned URL
+                    # (/api/terrapod/v1/storage/...).
                     case "$_path" in
-                        /api/v2/storage/*)
+                        /api/terrapod/v1/storage/*)
                             _location="${TP_API_URL}${_path}"
                             ;;
                     esac
@@ -198,7 +199,7 @@ case "$TP_ARCH" in
 esac
 
 if [ -n "$TP_API_URL" ] && [ -n "$TP_VERSION" ]; then
-    BINARY_URL="${TP_API_URL}/api/v2/binary-cache/${TP_BACKEND}/${TP_VERSION}/${TP_OS}/${TP_ARCH}"
+    BINARY_URL="${TP_API_URL}/api/terrapod/v1/binary-cache/${TP_BACKEND}/${TP_VERSION}/${TP_OS}/${TP_ARCH}"
     log "[entrypoint] Downloading $TP_BACKEND $TP_VERSION ($TP_OS/$TP_ARCH) from binary cache..."
     if ! tp_curl_download "/tmp/${TP_BACKEND}.zip" -H "$AUTH_HEADER" "$BINARY_URL"; then
         log "[entrypoint] Binary cache unavailable, downloading from upstream..."
@@ -233,7 +234,7 @@ fi
 if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
     log "[entrypoint] Downloading configuration..."
     tp_curl_download /tmp/config.tar.gz -H "$AUTH_HEADER" \
-        "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/config" 2>/dev/null || true
+        "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/config" 2>/dev/null || true
     if [ -f /tmp/config.tar.gz ] && [ -s /tmp/config.tar.gz ]; then
         # --no-same-owner: don't try to restore original UIDs (we run as non-root)
         # BusyBox tar returns non-zero on harmless utime/chmod warnings for "."
@@ -344,7 +345,7 @@ fi
 if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
     log "[entrypoint] Downloading current state..."
     tp_curl_download terraform.tfstate -H "$AUTH_HEADER" \
-        "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/state" 2>/dev/null || true
+        "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/state" 2>/dev/null || true
 fi
 
 # --- Initialize ---
@@ -441,7 +442,7 @@ if [ "$TP_PHASE" = "plan" ]; then
         curl -sSf --max-time 10 -X POST -H "$AUTH_HEADER" \
             -H "Content-Type: application/json" \
             -d "{\"has_changes\": $HAS_CHANGES_JSON}" \
-            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/plan-result" || true
+            "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/plan-result" || true
     fi
 
     # Append plan.log to combined; on_exit trap uploads the combined log.
@@ -452,7 +453,7 @@ if [ "$TP_PHASE" = "plan" ]; then
         curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @tfplan \
-            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/plan-file" || true
+            "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/plan-file" || true
     fi
 
 elif [ "$TP_PHASE" = "apply" ]; then
@@ -463,7 +464,7 @@ elif [ "$TP_PHASE" = "apply" ]; then
     if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
         log "[entrypoint] Downloading plan file from plan phase..."
         tp_curl_download tfplan -H "$AUTH_HEADER" \
-            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/plan-file" 2>/dev/null || true
+            "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/plan-file" 2>/dev/null || true
     fi
 
     echo "[entrypoint] Running $TP_BACKEND apply..."
@@ -489,10 +490,10 @@ elif [ "$TP_PHASE" = "apply" ]; then
         if ! curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @terraform.tfstate \
-            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/artifacts/state"; then
+            "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/state"; then
             echo "[entrypoint] FATAL: state upload failed — flagging workspace"
             curl -sS --max-time 5 -X POST -H "$AUTH_HEADER" \
-                "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/state-diverged" || true
+                "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/state-diverged" || true
             EXIT_CODE=1
         fi
     fi
@@ -503,7 +504,7 @@ elif [ "$TP_PHASE" = "apply" ]; then
     # path is the fallback.
     if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ] && [ "$EXIT_CODE" = "0" ]; then
         curl -sSf --max-time 10 -X POST -H "$AUTH_HEADER" \
-            "${TP_API_URL}/api/v2/runs/${TP_RUN_ID}/apply-result" || true
+            "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/apply-result" || true
     fi
 fi
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,7 +40,7 @@ Responses use `application/json` (accepted by `go-tfe`).
 
 ### Organization
 
-Terrapod uses a single hardcoded organization: `default`. The `{org}` path parameter is accepted for CLI compatibility but only `default` is valid.
+Terrapod is single-organization. The literal organization name `default` is the only valid value; every API path that contains an organization segment uses `organizations/default/` verbatim. Requests to any other organization name return 404.
 
 ---
 
@@ -101,8 +101,8 @@ Returns service discovery document for `terraform login` and registry protocol.
     "token": "/oauth/token",
     "ports": [10000, 10010]
   },
-  "modules.v1": "/api/v2/registry/modules/",
-  "providers.v1": "/api/v2/registry/providers/"
+  "modules.v1": "/api/terrapod/v1/registry/modules/",
+  "providers.v1": "/api/terrapod/v1/registry/providers/"
 }
 ```
 
@@ -157,7 +157,7 @@ Returns the authenticated user's information.
 ### Show Organization
 
 ```
-GET /api/v2/organizations/{org}
+GET /api/terrapod/v1/organizations/default
 ```
 
 Returns organization details. Only `default` is valid.
@@ -165,7 +165,7 @@ Returns organization details. Only `default` is valid.
 ### Entitlement Set
 
 ```
-GET /api/v2/organizations/{org}/entitlement-set
+GET /api/v2/organizations/default/entitlement-set
 ```
 
 Returns feature flags (all enabled for Terrapod).
@@ -177,13 +177,13 @@ Returns feature flags (all enabled for Terrapod).
 ### List Workspaces
 
 ```
-GET /api/v2/organizations/{org}/workspaces
+GET /api/v2/organizations/default/workspaces
 ```
 
 ### Get Workspace by Name
 
 ```
-GET /api/v2/organizations/{org}/workspaces/{name}
+GET /api/v2/organizations/default/workspaces/{name}
 ```
 
 ### Get Workspace by ID
@@ -195,7 +195,7 @@ GET /api/v2/workspaces/{id}
 ### Create Workspace
 
 ```
-POST /api/v2/organizations/{org}/workspaces
+POST /api/v2/organizations/default/workspaces
 ```
 
 **Request body:**
@@ -270,7 +270,7 @@ All workspace responses (show and list) include a `permissions` object reflectin
 ### Delete Workspace
 
 ```
-DELETE /api/v2/workspaces/{id}
+DELETE /api/terrapod/v1/workspaces/{id}
 ```
 
 **Required permission:** `admin` on the workspace.
@@ -310,7 +310,7 @@ The following read-only attributes are included in workspace responses when drif
 ### List VCS Refs (Terrapod Extension)
 
 ```
-GET /api/v2/workspaces/{id}/vcs-refs
+GET /api/terrapod/v1/workspaces/{id}/vcs-refs
 ```
 
 Returns branches, tags, and the default branch for a VCS-connected workspace. Used by the UI to populate the VCS ref picker when queueing runs.
@@ -436,7 +436,7 @@ State version responses include a `created-by` attribute (email of the user who 
 ### Delete State Version (Terrapod Extension)
 
 ```
-DELETE /api/v2/state-versions/{id}/manage
+DELETE /api/terrapod/v1/state-versions/{id}/manage
 ```
 
 Deletes a non-current state version. The current (highest serial) version cannot be deleted.
@@ -448,7 +448,7 @@ Returns 204 on success, 409 if attempting to delete the current version.
 ### Rollback State Version (Terrapod Extension)
 
 ```
-POST /api/v2/state-versions/{id}/actions/rollback
+POST /api/terrapod/v1/state-versions/{id}/actions/rollback
 ```
 
 Creates a new state version with the content of the specified older version. The new version gets serial = max existing + 1. This is a "copy forward" rollback — no versions are deleted, history is preserved.
@@ -460,7 +460,7 @@ Returns 201 with the new state version.
 ### Upload State Manually (Terrapod Extension)
 
 ```
-POST /api/v2/workspaces/{id}/state-versions/actions/upload
+POST /api/terrapod/v1/workspaces/{id}/state-versions/actions/upload
 ```
 
 Upload a raw state JSON file. Serial is auto-assigned (max existing + 1). Useful for state surgery workflows.
@@ -572,7 +572,7 @@ POST /api/v2/runs/{run_id}/actions/cancel
 ### Retry Run
 
 ```
-POST /api/v2/runs/{run_id}/actions/retry
+POST /api/terrapod/v1/runs/{run_id}/actions/retry
 ```
 
 Creates a new run from a terminal run (applied, errored, canceled, discarded) using the same workspace, configuration version, VCS metadata, and settings. Returns a 409 if the run is not in a terminal state.
@@ -582,7 +582,7 @@ Creates a new run from a terminal run (applied, errored, canceled, discarded) us
 ### Workspace Events (SSE)
 
 ```
-GET /api/v2/workspaces/{workspace_id}/runs/events
+GET /api/terrapod/v1/workspaces/{workspace_id}/runs/events
 ```
 
 Server-Sent Events stream for real-time workspace updates. The stream emits events whenever a run changes state, the workspace is locked/unlocked, workspace settings are updated, or a new state version is created. Used by the web UI workspace detail page for live updates without polling.
@@ -603,7 +603,7 @@ The stream sends `: keepalive` comments every ~1 second. Events are JSON-encoded
 ### Workspace List Events (SSE) (Terrapod Extension)
 
 ```
-GET /api/v2/workspace-events
+GET /api/terrapod/v1/workspace-events
 ```
 
 Server-Sent Events stream for the workspace list page. Emits events whenever any workspace changes (run status, lock, settings, state). The web UI uses this to refresh the workspace list without polling.
@@ -613,7 +613,7 @@ Server-Sent Events stream for the workspace list page. Emits events whenever any
 ### Plan Details
 
 ```
-GET /api/v2/runs/{run_id}/plan
+GET /api/terrapod/v1/runs/{run_id}/plan
 ```
 
 Returns plan metadata and log download URL.
@@ -621,7 +621,7 @@ Returns plan metadata and log download URL.
 ### Apply Details
 
 ```
-GET /api/v2/runs/{run_id}/apply
+GET /api/terrapod/v1/runs/{run_id}/apply
 ```
 
 Returns apply metadata and log download URL.
@@ -635,7 +635,7 @@ Run triggers create cross-workspace dependency chains. When a source workspace c
 ### Create Run Trigger
 
 ```
-POST /api/v2/workspaces/{id}/run-triggers
+POST /api/terrapod/v1/workspaces/{id}/run-triggers
 ```
 
 **Request body:**
@@ -667,7 +667,7 @@ curl -s \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -X POST \
-  https://terrapod.example.com/api/v2/workspaces/ws-abc123/run-triggers \
+  https://terrapod.example.com/api/terrapod/v1/workspaces/ws-abc123/run-triggers \
   -d '{
     "data": {
       "relationships": {
@@ -682,7 +682,7 @@ curl -s \
 ### List Run Triggers
 
 ```
-GET /api/v2/workspaces/{id}/run-triggers?filter[run-trigger][type]=inbound|outbound
+GET /api/terrapod/v1/workspaces/{id}/run-triggers?filter[run-trigger][type]=inbound|outbound
 ```
 
 - `inbound`: triggers where this workspace is the destination (what triggers runs here?)
@@ -696,13 +696,13 @@ The `filter[run-trigger][type]` parameter is required (422 if missing).
 ```bash
 curl -s \
   -H "Authorization: Bearer $TOKEN" \
-  "https://terrapod.example.com/api/v2/workspaces/ws-abc123/run-triggers?filter[run-trigger][type]=inbound"
+  "https://terrapod.example.com/api/terrapod/v1/workspaces/ws-abc123/run-triggers?filter[run-trigger][type]=inbound"
 ```
 
 ### Show Run Trigger
 
 ```
-GET /api/v2/run-triggers/{id}
+GET /api/terrapod/v1/run-triggers/{id}
 ```
 
 **Required permission:** `read` on the destination workspace.
@@ -710,7 +710,7 @@ GET /api/v2/run-triggers/{id}
 ### Delete Run Trigger
 
 ```
-DELETE /api/v2/run-triggers/{id}
+DELETE /api/terrapod/v1/run-triggers/{id}
 ```
 
 **Required permission:** `admin` on the destination workspace.
@@ -720,7 +720,7 @@ DELETE /api/v2/run-triggers/{id}
 curl -s \
   -H "Authorization: Bearer $TOKEN" \
   -X DELETE \
-  https://terrapod.example.com/api/v2/run-triggers/rt-abc123
+  https://terrapod.example.com/api/terrapod/v1/run-triggers/rt-abc123
 ```
 
 ---
@@ -783,7 +783,7 @@ Newest first. Supports `page[size]` (default 20, max 100) and `page[number]`.
 ### Download Configuration Version (Terrapod extension)
 
 ```
-GET /api/v2/configuration-versions/{cv_id}/download
+GET /api/terrapod/v1/configuration-versions/{cv_id}/download
 ```
 
 Streams the tarball bytes back as `application/x-tar` with a `Content-Disposition: attachment` header. Bearer auth.
@@ -799,7 +799,7 @@ Streams the tarball bytes back as `application/x-tar` with a `Content-Dispositio
 ### Mint Download Ticket (Terrapod extension)
 
 ```
-POST /api/v2/configuration-versions/{cv_id}/download-ticket
+POST /api/terrapod/v1/configuration-versions/{cv_id}/download-ticket
 ```
 
 Mints a short-lived, single-resource HMAC ticket the browser can paste into a plain `<a href>` to stream a download natively to the user's save dialog. **Opt-in** — the default download path above is the simple Bearer-auth flow; tickets exist because plain navigation can't carry an `Authorization` header.
@@ -818,7 +818,7 @@ TTL defaults to 300 s, hard-capped at 1800 s. Negative or zero values fall back 
     "type": "download-tickets",
     "attributes": {
       "ticket": "dlticket:cv:{uuid}:...",
-      "url": "/api/v2/configuration-versions/download-by-ticket/dlticket:cv:...",
+      "url": "/api/terrapod/v1/configuration-versions/download-by-ticket/dlticket:cv:...",
       "expires-at": "2026-05-07T12:34:56Z"
     }
   }
@@ -830,7 +830,7 @@ TTL defaults to 300 s, hard-capped at 1800 s. Negative or zero values fall back 
 ### Download by Ticket (Terrapod extension)
 
 ```
-GET /api/v2/configuration-versions/download-by-ticket/{ticket}
+GET /api/terrapod/v1/configuration-versions/download-by-ticket/{ticket}
 ```
 
 Streams the tarball — no `Authorization` header. The ticket is the auth: HMAC-SHA256 over the resource id, expiry, and minter email, signed with the same key class as runner tokens. Single-resource (a CV-X ticket cannot fetch CV-Y); short TTL bounds replay.
@@ -843,7 +843,7 @@ Streams the tarball — no `Authorization` header. The ticket is the auth: HMAC-
 ### Diff Configuration Versions (Terrapod extension)
 
 ```
-POST /api/v2/configuration-versions/diff
+POST /api/terrapod/v1/configuration-versions/diff
 ```
 
 Compares two CVs in the same workspace and returns per-file unified diffs.
@@ -902,7 +902,7 @@ Read-only labels browser (Terrapod extension). All endpoints are RBAC-filtered: 
 ### List Label Keys
 
 ```
-GET /api/v2/labels
+GET /api/terrapod/v1/labels
 ```
 
 Returns all label keys in use across readable workspaces, modules, providers, and pools, with per-type counts.
@@ -919,7 +919,7 @@ Returns all label keys in use across readable workspaces, modules, providers, an
 ### List Values for a Key
 
 ```
-GET /api/v2/labels/{key}
+GET /api/terrapod/v1/labels/{key}
 ```
 
 Returns distinct values for `key`, each with per-type counts. Empty `data` is a valid response.
@@ -927,7 +927,7 @@ Returns distinct values for `key`, each with per-type counts. Empty `data` is a 
 ### List Entities for a Label
 
 ```
-GET /api/v2/labels/{key}/{value}
+GET /api/terrapod/v1/labels/{key}/{value}
 ```
 
 Returns entities tagged with exactly `key=value`, grouped by type.
@@ -1003,13 +1003,13 @@ DELETE /api/v2/workspaces/{id}/vars/{var_id}
 ### List Variable Sets
 
 ```
-GET /api/v2/organizations/{org}/varsets
+GET /api/v2/organizations/default/varsets
 ```
 
 ### Create Variable Set
 
 ```
-POST /api/v2/organizations/{org}/varsets
+POST /api/v2/organizations/default/varsets
 ```
 
 **Required permission:** Platform `admin`.
@@ -1044,18 +1044,18 @@ GET /api/v2/registry/modules/{namespace}/{name}/{provider}/{version}/download
 ### TFE V2 Management API
 
 ```
-GET  /api/v2/organizations/{org}/registry-modules
-POST /api/v2/organizations/{org}/registry-modules
-GET  /api/v2/organizations/{org}/registry-modules/private/default/{name}/{provider}
-DELETE /api/v2/organizations/{org}/registry-modules/private/default/{name}/{provider}
-POST /api/v2/organizations/{org}/registry-modules/private/default/{name}/{provider}/versions
-DELETE /api/v2/organizations/{org}/registry-modules/private/default/{name}/{provider}/versions/{version}
+GET  /api/terrapod/v1/registry-modules
+POST /api/terrapod/v1/registry-modules
+GET  /api/terrapod/v1/registry-modules/private/default/{name}/{provider}
+DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{provider}
+POST /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/versions
+DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/versions/{version}
 ```
 
 ### Update Module
 
 ```
-PATCH /api/v2/organizations/{org}/registry-modules/private/default/{name}/{provider}
+PATCH /api/terrapod/v1/registry-modules/private/default/{name}/{provider}
 ```
 
 **Required permission:** `admin` on the module.
@@ -1083,9 +1083,9 @@ Create a version, then upload the tarball to the presigned URL returned in the r
 ### Workspace Links (Module Impact Analysis)
 
 ```
-GET    /api/v2/organizations/{org}/registry-modules/private/default/{name}/{provider}/workspace-links
-POST   /api/v2/organizations/{org}/registry-modules/private/default/{name}/{provider}/workspace-links
-DELETE /api/v2/organizations/{org}/registry-modules/private/default/{name}/{provider}/workspace-links/{link_id}
+GET    /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/workspace-links
+POST   /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/workspace-links
+DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/workspace-links/{link_id}
 ```
 
 **Required permission:** `admin` on the module (create/delete), `read` on the module (list).
@@ -1106,20 +1106,20 @@ GET /api/v2/registry/providers/{namespace}/{type}/{version}/download/{os}/{arch}
 ### TFE V2 Management API
 
 ```
-GET  /api/v2/organizations/{org}/registry-providers
-POST /api/v2/organizations/{org}/registry-providers
-GET  /api/v2/organizations/{org}/registry-providers/private/default/{name}
-DELETE /api/v2/organizations/{org}/registry-providers/private/default/{name}
-POST /api/v2/organizations/{org}/registry-providers/private/default/{name}/versions
-GET  /api/v2/organizations/{org}/registry-providers/private/default/{name}/versions
-DELETE /api/v2/organizations/{org}/registry-providers/private/default/{name}/versions/{version}
-POST /api/v2/organizations/{org}/registry-providers/private/default/{name}/versions/{version}/platforms
+GET  /api/terrapod/v1/registry-providers
+POST /api/terrapod/v1/registry-providers
+GET  /api/terrapod/v1/registry-providers/private/default/{name}
+DELETE /api/terrapod/v1/registry-providers/private/default/{name}
+POST /api/terrapod/v1/registry-providers/private/default/{name}/versions
+GET  /api/terrapod/v1/registry-providers/private/default/{name}/versions
+DELETE /api/terrapod/v1/registry-providers/private/default/{name}/versions/{version}
+POST /api/terrapod/v1/registry-providers/private/default/{name}/versions/{version}/platforms
 ```
 
 ### Update Provider
 
 ```
-PATCH /api/v2/organizations/{org}/registry-providers/private/default/{name}
+PATCH /api/terrapod/v1/registry-providers/private/default/{name}
 ```
 
 **Required permission:** `admin` on the provider.
@@ -1156,13 +1156,13 @@ DELETE /api/registry/private/v2/gpg-keys/{namespace}/{key_id}
 ### List Pools
 
 ```
-GET /api/v2/organizations/{org}/agent-pools
+GET /api/terrapod/v1/agent-pools
 ```
 
 ### Create Pool
 
 ```
-POST /api/v2/organizations/{org}/agent-pools
+POST /api/terrapod/v1/agent-pools
 ```
 
 **Request body:**
@@ -1183,26 +1183,26 @@ POST /api/v2/organizations/{org}/agent-pools
 ### Show Pool
 
 ```
-GET /api/v2/agent-pools/{id}
+GET /api/terrapod/v1/agent-pools/{id}
 ```
 
 ### Delete Pool
 
 ```
-DELETE /api/v2/agent-pools/{id}
+DELETE /api/terrapod/v1/agent-pools/{id}
 ```
 
 ### Pool Tokens
 
 ```
-POST /api/v2/agent-pools/{id}/authentication-tokens
-GET  /api/v2/agent-pools/{id}/authentication-tokens
+POST /api/terrapod/v1/agent-pools/{id}/authentication-tokens
+GET  /api/terrapod/v1/agent-pools/{id}/authentication-tokens
 ```
 
 ### Listener Join
 
 ```
-POST /api/v2/agent-pools/join
+POST /api/terrapod/v1/agent-pools/join
 ```
 
 Registers a listener using a join token. The token identifies the pool — no pool ID needed in the URL. No Bearer auth required; the join token in the body IS the credential.
@@ -1221,25 +1221,25 @@ If a listener with the same name already exists, its certificate is reissued (ha
 
 **Legacy endpoint** (still supported):
 ```
-POST /api/v2/agent-pools/{pool_id}/listeners/join
+POST /api/terrapod/v1/agent-pools/{pool_id}/listeners/join
 ```
 
 ### Listener Heartbeat
 
 ```
-POST /api/v2/listeners/{id}/heartbeat
+POST /api/terrapod/v1/listeners/{id}/heartbeat
 ```
 
 ### Listener Certificate Renewal
 
 ```
-POST /api/v2/listeners/{id}/renew
+POST /api/terrapod/v1/listeners/{id}/renew
 ```
 
 ### Listener Run Polling
 
 ```
-GET /api/v2/listeners/{id}/runs/next
+GET /api/terrapod/v1/listeners/{id}/runs/next
 ```
 
 Returns the next queued run for this listener.
@@ -1247,7 +1247,7 @@ Returns the next queued run for this listener.
 ### Listener Runner Token
 
 ```
-POST /api/v2/listeners/{id}/runs/{run_id}/runner-token
+POST /api/terrapod/v1/listeners/{id}/runs/{run_id}/runner-token
 ```
 
 Generates a short-lived HMAC-signed runner token scoped to the specified run. Called by the listener after claiming a run.
@@ -1276,7 +1276,7 @@ Generates a short-lived HMAC-signed runner token scoped to the specified run. Ca
 ### Listener Status Update
 
 ```
-PATCH /api/v2/listeners/{id}/runs/{run_id}
+PATCH /api/terrapod/v1/listeners/{id}/runs/{run_id}
 ```
 
 Reports run status changes (planning, planned, applying, applied, errored).
@@ -1288,13 +1288,13 @@ Reports run status changes (planning, planned, applying, applied, errored).
 ### List Connections
 
 ```
-GET /api/v2/organizations/{org}/vcs-connections
+GET /api/terrapod/v1/vcs-connections
 ```
 
 ### Create Connection
 
 ```
-POST /api/v2/organizations/{org}/vcs-connections
+POST /api/terrapod/v1/vcs-connections
 ```
 
 **GitHub example:**
@@ -1334,13 +1334,13 @@ POST /api/v2/organizations/{org}/vcs-connections
 ### Show Connection
 
 ```
-GET /api/v2/vcs-connections/{id}
+GET /api/terrapod/v1/vcs-connections/{id}
 ```
 
 ### Delete Connection
 
 ```
-DELETE /api/v2/vcs-connections/{id}
+DELETE /api/terrapod/v1/vcs-connections/{id}
 ```
 
 ---
@@ -1350,7 +1350,7 @@ DELETE /api/v2/vcs-connections/{id}
 ### GitHub Webhook Receiver
 
 ```
-POST /api/v2/vcs-events/github
+POST /api/terrapod/v1/vcs-events/github
 ```
 
 Validates HMAC-SHA256 signature and triggers an immediate poll cycle. The webhook secret must match `TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET`.
@@ -1362,7 +1362,7 @@ Validates HMAC-SHA256 signature and triggers an immediate poll cycle. The webhoo
 ### List Roles
 
 ```
-GET /api/v2/roles
+GET /api/terrapod/v1/roles
 ```
 
 Returns built-in and custom roles.
@@ -1372,7 +1372,7 @@ Returns built-in and custom roles.
 ### Create Role
 
 ```
-POST /api/v2/roles
+POST /api/terrapod/v1/roles
 ```
 
 **Request body:**
@@ -1398,19 +1398,19 @@ POST /api/v2/roles
 ### Show Role
 
 ```
-GET /api/v2/roles/{name}
+GET /api/terrapod/v1/roles/{name}
 ```
 
 ### Update Role
 
 ```
-PATCH /api/v2/roles/{name}
+PATCH /api/terrapod/v1/roles/{name}
 ```
 
 ### Delete Role
 
 ```
-DELETE /api/v2/roles/{name}
+DELETE /api/terrapod/v1/roles/{name}
 ```
 
 Built-in roles cannot be deleted.
@@ -1422,7 +1422,7 @@ Built-in roles cannot be deleted.
 ### List Assignments
 
 ```
-GET /api/v2/role-assignments
+GET /api/terrapod/v1/role-assignments
 ```
 
 **Required permission:** Platform `admin` or `audit`.
@@ -1430,7 +1430,7 @@ GET /api/v2/role-assignments
 ### Set Roles for User
 
 ```
-PUT /api/v2/role-assignments
+PUT /api/terrapod/v1/role-assignments
 ```
 
 **Request body:**
@@ -1452,7 +1452,7 @@ PUT /api/v2/role-assignments
 ### Remove Single Assignment
 
 ```
-DELETE /api/v2/role-assignments/{provider}/{email}/{role}
+DELETE /api/terrapod/v1/role-assignments/{provider}/{email}/{role}
 ```
 
 ---
@@ -1462,25 +1462,25 @@ DELETE /api/v2/role-assignments/{provider}/{email}/{role}
 ### Create Token
 
 ```
-POST /api/v2/users/{user_id}/authentication-tokens
+POST /api/terrapod/v1/users/{user_id}/authentication-tokens
 ```
 
 ### List Tokens
 
 ```
-GET /api/v2/users/{user_id}/authentication-tokens
+GET /api/terrapod/v1/users/{user_id}/authentication-tokens
 ```
 
 ### Show Token
 
 ```
-GET /api/v2/authentication-tokens/{id}
+GET /api/terrapod/v1/authentication-tokens/{id}
 ```
 
 ### Delete Token
 
 ```
-DELETE /api/v2/authentication-tokens/{id}
+DELETE /api/terrapod/v1/authentication-tokens/{id}
 ```
 
 ---
@@ -1492,7 +1492,7 @@ Authenticated endpoints for runner Jobs to download inputs and upload outputs. A
 ### Download Config Archive
 
 ```
-GET /api/v2/runs/{run_id}/artifacts/config
+GET /api/terrapod/v1/runs/{run_id}/artifacts/config
 ```
 
 Returns 302 redirect to presigned storage URL for the configuration tarball.
@@ -1500,7 +1500,7 @@ Returns 302 redirect to presigned storage URL for the configuration tarball.
 ### Download State
 
 ```
-GET /api/v2/runs/{run_id}/artifacts/state
+GET /api/terrapod/v1/runs/{run_id}/artifacts/state
 ```
 
 Returns 302 redirect to presigned storage URL for the current workspace state.
@@ -1508,7 +1508,7 @@ Returns 302 redirect to presigned storage URL for the current workspace state.
 ### Download Plan File
 
 ```
-GET /api/v2/runs/{run_id}/artifacts/plan-file
+GET /api/terrapod/v1/runs/{run_id}/artifacts/plan-file
 ```
 
 Returns 302 redirect to presigned storage URL for the plan binary file.
@@ -1516,7 +1516,7 @@ Returns 302 redirect to presigned storage URL for the plan binary file.
 ### Upload Plan Log
 
 ```
-PUT /api/v2/runs/{run_id}/artifacts/plan-log
+PUT /api/terrapod/v1/runs/{run_id}/artifacts/plan-log
 Content-Type: application/octet-stream
 ```
 
@@ -1525,7 +1525,7 @@ Upload raw plan log bytes. Returns 204 on success.
 ### Upload Plan File
 
 ```
-PUT /api/v2/runs/{run_id}/artifacts/plan-file
+PUT /api/terrapod/v1/runs/{run_id}/artifacts/plan-file
 Content-Type: application/octet-stream
 ```
 
@@ -1534,7 +1534,7 @@ Upload plan binary file. Returns 204 on success.
 ### Upload Apply Log
 
 ```
-PUT /api/v2/runs/{run_id}/artifacts/apply-log
+PUT /api/terrapod/v1/runs/{run_id}/artifacts/apply-log
 Content-Type: application/octet-stream
 ```
 
@@ -1543,7 +1543,7 @@ Upload raw apply log bytes. Returns 204 on success.
 ### Upload State
 
 ```
-PUT /api/v2/runs/{run_id}/artifacts/state
+PUT /api/terrapod/v1/runs/{run_id}/artifacts/state
 Content-Type: application/octet-stream
 ```
 
@@ -1556,7 +1556,7 @@ Upload new state after apply. Returns 204 on success.
 ### Download Binary
 
 ```
-GET /api/v2/binary-cache/{tool}/{version}/{os}/{arch}
+GET /api/terrapod/v1/binary-cache/{tool}/{version}/{os}/{arch}
 ```
 
 Returns a 302 redirect to a presigned URL for the binary. `tool` is `terraform` or `tofu`.
@@ -1566,13 +1566,13 @@ Returns a 302 redirect to a presigned URL for the binary. `tool` is `terraform` 
 ### List Cached Binaries (Admin)
 
 ```
-GET /api/v2/admin/binary-cache
+GET /api/terrapod/v1/admin/binary-cache
 ```
 
 ### Warm Cache (Admin)
 
 ```
-POST /api/v2/admin/binary-cache/warm
+POST /api/terrapod/v1/admin/binary-cache/warm
 ```
 
 Pre-cache a specific tool version.
@@ -1580,7 +1580,7 @@ Pre-cache a specific tool version.
 ### Purge Cache (Admin)
 
 ```
-DELETE /api/v2/admin/binary-cache/{tool}/{version}
+DELETE /api/terrapod/v1/admin/binary-cache/{tool}/{version}
 ```
 
 ---
@@ -1588,7 +1588,7 @@ DELETE /api/v2/admin/binary-cache/{tool}/{version}
 ## Agent Pool Events (SSE)
 
 ```
-GET /api/v2/agent-pools/{pool_id}/events
+GET /api/terrapod/v1/agent-pools/{pool_id}/events
 ```
 
 Server-Sent Events stream for real-time agent pool updates. Emits events when listeners heartbeat or join the pool. Used by the agent pool detail page for live listener status updates.
@@ -1629,32 +1629,32 @@ Returns platform-specific download URLs with `zh:` (zip hash) checksums.
 ### List Auth Providers
 
 ```
-GET /api/v2/auth/providers
+GET /api/terrapod/v1/auth/providers
 ```
 
 ### Authorize (Start Login)
 
 ```
-GET /api/v2/auth/authorize
+GET /api/terrapod/v1/auth/authorize
 ```
 
 ### Callback (IDP Return)
 
 ```
-GET /api/v2/auth/callback
-POST /api/v2/auth/callback
+GET /api/terrapod/v1/auth/callback
+POST /api/terrapod/v1/auth/callback
 ```
 
 ### Active Sessions
 
 ```
-GET /api/v2/auth/sessions
+GET /api/terrapod/v1/auth/sessions
 ```
 
 ### Logout
 
 ```
-POST /api/v2/auth/logout
+POST /api/terrapod/v1/auth/logout
 ```
 
 ---
@@ -1682,7 +1682,7 @@ Immutable record of API requests. Requires `admin` or `audit` role.
 ### List Audit Log Entries
 
 ```
-GET /api/v2/admin/audit-log
+GET /api/terrapod/v1/admin/audit-log
 ```
 
 **Query Parameters:**
@@ -1702,7 +1702,7 @@ GET /api/v2/admin/audit-log
 **Example:**
 
 ```zsh
-curl "https://terrapod.example.com/api/v2/admin/audit-log?filter[actor]=admin@example.com&page[size]=10" \
+curl "https://terrapod.example.com/api/terrapod/v1/admin/audit-log?filter[actor]=admin@example.com&page[size]=10" \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -1715,7 +1715,7 @@ User management endpoints. List and show require `admin` or `audit` role. Update
 ### List Users
 
 ```
-GET /api/v2/organizations/{org}/users
+GET /api/terrapod/v1/users
 ```
 
 **Query Parameters:**
@@ -1729,13 +1729,13 @@ GET /api/v2/organizations/{org}/users
 ### Show User
 
 ```
-GET /api/v2/users/{email}
+GET /api/terrapod/v1/users/{email}
 ```
 
 ### Update User
 
 ```
-PATCH /api/v2/users/{email}
+PATCH /api/terrapod/v1/users/{email}
 ```
 
 **Updatable attributes:** `is-active`, `display-name`.
@@ -1745,7 +1745,7 @@ When `is-active` is set to `false`, all sessions for that user are revoked immed
 ### Delete User
 
 ```
-DELETE /api/v2/users/{email}
+DELETE /api/terrapod/v1/users/{email}
 ```
 
 Cascades: revokes all sessions, deletes all role assignments.
@@ -1759,7 +1759,7 @@ Workspace-scoped notifications that fire on run lifecycle events. Three destinat
 ### Create Notification Configuration
 
 ```
-POST /api/v2/workspaces/{id}/notification-configurations
+POST /api/terrapod/v1/workspaces/{id}/notification-configurations
 ```
 
 **Request body:**
@@ -1794,7 +1794,7 @@ POST /api/v2/workspaces/{id}/notification-configurations
 ### List Notification Configurations
 
 ```
-GET /api/v2/workspaces/{id}/notification-configurations
+GET /api/terrapod/v1/workspaces/{id}/notification-configurations
 ```
 
 **Required permission:** `read` on the workspace.
@@ -1802,7 +1802,7 @@ GET /api/v2/workspaces/{id}/notification-configurations
 ### Show Notification Configuration
 
 ```
-GET /api/v2/notification-configurations/{id}
+GET /api/terrapod/v1/notification-configurations/{id}
 ```
 
 **Required permission:** `read` on the associated workspace.
@@ -1810,7 +1810,7 @@ GET /api/v2/notification-configurations/{id}
 ### Update Notification Configuration
 
 ```
-PATCH /api/v2/notification-configurations/{id}
+PATCH /api/terrapod/v1/notification-configurations/{id}
 ```
 
 Same body format as create. Only include attributes to change. Token is never returned in responses — only `has-token: true/false`.
@@ -1820,7 +1820,7 @@ Same body format as create. Only include attributes to change. Token is never re
 ### Delete Notification Configuration
 
 ```
-DELETE /api/v2/notification-configurations/{id}
+DELETE /api/terrapod/v1/notification-configurations/{id}
 ```
 
 **Required permission:** `admin` on the workspace.
@@ -1828,7 +1828,7 @@ DELETE /api/v2/notification-configurations/{id}
 ### Verify Notification Configuration
 
 ```
-POST /api/v2/notification-configurations/{id}/actions/verify
+POST /api/terrapod/v1/notification-configurations/{id}/actions/verify
 ```
 
 Sends a test payload to the configured destination and returns the delivery response.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ Browser                Next.js (port 3000)         FastAPI API (port 8000)
   |    (page render)        |                              |
   |<--- HTML + JS ----------|                              |
   |                         |                              |
-  |--- GET /api/v2/... ---->|                              |
+  |--- GET /api/terrapod/v1/... ---->|                              |
   |    (data fetch)         |--- proxy /api/* ------------>|
   |                         |<-- JSON response ------------|
   |<--- JSON response ------|                              |
@@ -97,10 +97,10 @@ High-priority pages that users watch actively use SSE for instant updates. The A
 
 | Redis Channel | SSE Endpoint | Frontend Hook | Used By |
 |---|---|---|---|
-| `tp:run_events:{ws_id}` | `GET /api/v2/workspaces/{id}/runs/events` | `useRunEvents` | Workspace detail page |
-| `tp:workspace_list_events` | `GET /api/v2/workspace-events` | `useWorkspaceListEvents` | Workspace list page |
-| `tp:pool_events:{pool_id}` | `GET /api/v2/agent-pools/{id}/events` | `usePoolEvents` | Agent pool detail page |
-| `tp:listener_events:{pool_id}` | `GET /api/v2/listeners/{id}/events` | (listener code) | Runner listeners |
+| `tp:run_events:{ws_id}` | `GET /api/terrapod/v1/workspaces/{id}/runs/events` | `useRunEvents` | Workspace detail page |
+| `tp:workspace_list_events` | `GET /api/terrapod/v1/workspace-events` | `useWorkspaceListEvents` | Workspace list page |
+| `tp:pool_events:{pool_id}` | `GET /api/terrapod/v1/agent-pools/{id}/events` | `usePoolEvents` | Agent pool detail page |
+| `tp:listener_events:{pool_id}` | `GET /api/terrapod/v1/listeners/{id}/events` | (listener code) | Runner listeners |
 
 **Shared SSE engine (`use-sse.ts`):**
 
@@ -201,10 +201,10 @@ Terrapod's execution layer follows the Actions Runner Controller (ARC) pattern: 
         |
 2. API publishes "run_available" event to pool's SSE channel (Redis pub/sub)
         |
-3. Listener receives SSE event → claims run: GET /api/v2/listeners/{id}/runs/next
+3. Listener receives SSE event → claims run: GET /api/terrapod/v1/listeners/{id}/runs/next
         |
 4. Listener requests a runner token:
-   POST /api/v2/listeners/{id}/runs/{run_id}/runner-token
+   POST /api/terrapod/v1/listeners/{id}/runs/{run_id}/runner-token
    - Returns short-lived HMAC-signed token scoped to run_id
         |
 5. Listener creates K8s Job in runner namespace
@@ -274,7 +274,7 @@ T=120s: K8s SIGKILL deadline
 **Key design decisions:**
 - **SIGINT, not SIGTERM**: HashiCorp recommends SIGINT for container graceful shutdown. A second signal (INT or TERM) causes ungraceful abort that may skip state writing entirely
 - **SIGKILL watchdog**: Only one signal is ever sent. If terraform hangs, the watchdog escalates to SIGKILL after `CHILD_GRACE` seconds
-- **State upload is fatal**: If state upload fails after a successful apply, the entrypoint calls `POST /api/v2/runs/{run_id}/state-diverged` to flag the workspace and exits with code 1
+- **State upload is fatal**: If state upload fails after a successful apply, the entrypoint calls `POST /api/terrapod/v1/runs/{run_id}/state-diverged` to flag the workspace and exits with code 1
 - **Time budget**: `TP_TERMINATION_GRACE` env var (from Helm `runners.terminationGracePeriodSeconds`) partitions the K8s grace period between terraform shutdown and artifact uploads (25s reserved for uploads)
 
 The entrypoint script is at `docker/runner-entrypoint.sh`.
@@ -289,10 +289,10 @@ All listeners follow the same flow — there is no distinction between pool type
 2. An admin generates a **join token** for the pool (default: 2 uses, 1h expiry)
 3. The listener Deployment is configured with `TERRAPOD_JOIN_TOKEN` and `TERRAPOD_API_URL`
 4. On startup, each listener pod looks for a Kubernetes Secret named after the Deployment (`{release-fullname}-listener-credentials`, supplied via `TERRAPOD_CREDENTIALS_SECRET_NAME`) in its own namespace. If present and valid, it adopts the existing identity (cert, key, CA, listener-id) and skips the join entirely
-5. If no Secret exists, the pod calls `POST /api/v2/agent-pools/join` with the token. The API validates it (SHA-256 hash, expiry, `max_uses`), issues a short-lived X.509 certificate (Ed25519, 1h validity by default), and returns the listener ID, cert, and pool ID
+5. If no Secret exists, the pod calls `POST /api/terrapod/v1/agent-pools/join` with the token. The API validates it (SHA-256 hash, expiry, `max_uses`), issues a short-lived X.509 certificate (Ed25519, 1h validity by default), and returns the listener ID, cert, and pool ID
 6. The pod writes the credentials to the Secret. If the create returns `409 AlreadyExists` (another pod won the race), the loser re-reads the Secret and adopts the winner's identity
 7. The listener authenticates subsequent API calls via `X-Terrapod-Client-Cert` header (base64-encoded PEM)
-8. The listener connects to the SSE endpoint (`GET /api/v2/listeners/{id}/events`) — a persistent outbound HTTP stream for receiving events from the API
+8. The listener connects to the SSE endpoint (`GET /api/terrapod/v1/listeners/{id}/events`) — a persistent outbound HTTP stream for receiving events from the API
 9. Heartbeats every 60s (300s TTL in Redis), SSE event loop handles run claims, Job status queries, log streaming, and cancellation
 
 The Secret-backed identity model means a listener Deployment has **one shared identity across all pods**, surviving pod replacement and rolling updates without re-joining. See [Runners → Listener identity](runners.md#listener-identity) for the full bootstrap, renewal, and rotation lifecycle.
@@ -336,7 +336,7 @@ Listener Join Flow:
     2. Listener pod reads K8s Secret {fullname}-listener-credentials
        - If valid cert present: adopt and skip join
        - Otherwise: continue to step 3
-    3. Listener calls POST /api/v2/agent-pools/join with the token
+    3. Listener calls POST /api/terrapod/v1/agent-pools/join with the token
     4. API validates join token (SHA-256 hash, expiry, max_uses)
     5. API issues short-lived X.509 certificate (1h default) with SAN URIs:
        - terrapod://listener/{name}
@@ -354,7 +354,7 @@ Certificate Renewal (multi-pod safe):
     - Each pod sleeps until cert reaches its renewal threshold
       (validity/2 + per-pod splay 0..30s, hash of POD_NAME)
     - Re-read the Secret first: if another pod already renewed, adopt and skip /renew
-    - Otherwise: POST /api/v2/listeners/{id}/renew (3 attempts with backoff)
+    - Otherwise: POST /api/terrapod/v1/listeners/{id}/renew (3 attempts with backoff)
     - Write Secret with resourceVersion CAS — on conflict, re-read and adopt
     - On /renew 401/403: clear Secret, fall back to join-token bootstrap
 ```
@@ -377,7 +377,7 @@ Browser                  Next.js              API               IDP (OIDC/SAML)
   |<-- Login page ----------|                   |                     |
   |                         |                   |                     |
   |-- Click SSO button ---->|                   |                     |
-  |                         |-- GET /api/v2/auth/authorize ---------->|
+  |                         |-- GET /api/terrapod/v1/auth/authorize ---------->|
   |                         |<-- redirect URL --|                     |
   |<-- 302 redirect --------|                   |                     |
   |                         |                   |                     |
@@ -471,7 +471,7 @@ Terrapod uses a polling-first design for VCS integration. No inbound connections
 |  For each workspace with VCS:          +------------------+
 |  1. Check branch HEAD SHA              | Optional:        |
 |  2. Check open PRs/MRs                 | GitHub webhook   |
-|  3. If new SHA detected:               | POST /api/v2/    |
+|  3. If new SHA detected:               | POST /api/terrapod/v1/    |
 |     - Download tarball                 | vcs-events/github|
 |     - Create ConfigurationVersion      +--------+---------+
 |     - Queue Run                                 |

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -35,7 +35,7 @@ Logging is asynchronous — it does not block the API response.
 ## Query API
 
 ```
-GET /api/v2/admin/audit-log
+GET /api/terrapod/v1/admin/audit-log
 ```
 
 Requires `admin` or `audit` role.
@@ -63,7 +63,7 @@ All filters are optional and use JSON:API query parameter syntax:
 
 ```bash
 # Last 50 POST requests by a specific user
-curl "https://terrapod.local/api/v2/admin/audit-log?\
+curl "https://terrapod.local/api/terrapod/v1/admin/audit-log?\
 filter[actor]=admin@example.com&\
 filter[action]=POST&\
 page[size]=50" \

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -71,7 +71,7 @@ Passwords are hashed with PBKDF2-SHA256 and validated with [zxcvbn](https://gith
 ### Login Flow
 
 ```
-POST /api/v2/auth/local/authorize
+POST /api/terrapod/v1/auth/local/authorize
   email=admin@example.com
   password=xxx
     |
@@ -127,7 +127,7 @@ The environment variable name follows the pattern `TERRAPOD_{UPPERCASE_NAME}_CLI
 | Setting | Value |
 |---|---|
 | Application Type | Regular Web Application |
-| Allowed Callback URLs | `https://terrapod.example.com/api/v2/auth/callback` |
+| Allowed Callback URLs | `https://terrapod.example.com/api/terrapod/v1/auth/callback` |
 | Allowed Logout URLs | `https://terrapod.example.com` |
 
 ### Okta Example
@@ -163,7 +163,7 @@ TERRAPOD_OKTA_CLIENT_SECRET="your-client-secret"
 |---|---|
 | Sign-in method | OIDC - OpenID Connect |
 | Application type | Web Application |
-| Sign-in redirect URI | `https://terrapod.example.com/api/v2/auth/callback` |
+| Sign-in redirect URI | `https://terrapod.example.com/api/terrapod/v1/auth/callback` |
 | Assignments | Assign to users/groups as needed |
 
 ### Azure AD (Entra ID) Example
@@ -193,7 +193,7 @@ TERRAPOD_AZURE_AD_CLIENT_SECRET="your-client-secret"
 
 | Setting | Value |
 |---|---|
-| Redirect URI | `https://terrapod.example.com/api/v2/auth/callback` (Web platform) |
+| Redirect URI | `https://terrapod.example.com/api/terrapod/v1/auth/callback` (Web platform) |
 | Token configuration | Add optional claim: `groups` |
 | API permissions | `openid`, `profile`, `email` |
 
@@ -244,7 +244,7 @@ api:
             display_name: "Azure AD (SAML)"
             metadata_url: "https://login.microsoftonline.com/{tenant-id}/federationmetadata/2007-06/federationmetadata.xml?appid={app-id}"
             entity_id: "https://terrapod.example.com"
-            acs_url: "https://terrapod.example.com/api/v2/auth/callback"
+            acs_url: "https://terrapod.example.com/api/terrapod/v1/auth/callback"
             role_prefixes: ["terrapod:"]
             claims_to_roles:
               - claim: "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups"
@@ -257,7 +257,7 @@ api:
 | Setting | Value |
 |---|---|
 | Identifier (Entity ID) | `https://terrapod.example.com` |
-| Reply URL (ACS URL) | `https://terrapod.example.com/api/v2/auth/callback` |
+| Reply URL (ACS URL) | `https://terrapod.example.com/api/terrapod/v1/auth/callback` |
 | Sign on URL | `https://terrapod.example.com/login` |
 | Claims | Name ID (email), groups |
 
@@ -339,7 +339,7 @@ Example: `abc123def456.tpod.ghijklmnopqrstuvwxyz0123456789`
 ### Creating Tokens via API
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/users/{user_id}/authentication-tokens \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/users/{user_id}/authentication-tokens \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -366,14 +366,14 @@ The response includes the raw token value in `attributes.token`. Store it secure
 ### Listing Tokens
 
 ```zsh
-curl https://terrapod.example.com/api/v2/authentication-tokens \
+curl https://terrapod.example.com/api/terrapod/v1/authentication-tokens \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
 ### Deleting Tokens
 
 ```zsh
-curl -X DELETE https://terrapod.example.com/api/v2/authentication-tokens/{token-id} \
+curl -X DELETE https://terrapod.example.com/api/terrapod/v1/authentication-tokens/{token-id} \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -418,14 +418,14 @@ Via the web UI: **Settings > Sessions**
 Via the API:
 
 ```zsh
-curl https://terrapod.example.com/api/v2/auth/sessions \
+curl https://terrapod.example.com/api/terrapod/v1/auth/sessions \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
 ### Logging Out
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/auth/logout \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/auth/logout \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -438,8 +438,8 @@ Enable encryption on your managed database and object storage services. For file
 
 The listener joins an agent pool on startup using the join token, then connects to the API via SSE (Server-Sent Events) to receive real-time events: run notifications, Job status queries, log streaming requests, and cancellations. The SSE connection is outbound from the listener — it works through firewalls without requiring inbound access. The pool must already exist (created by an admin via the API). To set up the listener:
 
-1. Create an agent pool via the API: `POST /api/v2/organizations/default/agent-pools`
-2. Create a join token for the pool: `POST /api/v2/agent-pools/{pool_id}/tokens`
+1. Create an agent pool via the API: `POST /api/terrapod/v1/agent-pools`
+2. Create a join token for the pool: `POST /api/terrapod/v1/agent-pools/{pool_id}/tokens`
 3. Store the raw token in a Kubernetes Secret:
 
 ```zsh

--- a/docs/drift-detection.md
+++ b/docs/drift-detection.md
@@ -112,7 +112,7 @@ When a workspace shows `drifted` or `errored` status — for example after you'v
 **API**:
 
 ```http
-POST /api/v2/workspaces/{workspace_id}/actions/dismiss-drift
+POST /api/terrapod/v1/workspaces/{workspace_id}/actions/dismiss-drift
 ```
 
 Effect:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -359,7 +359,7 @@ For managing variables across multiple workspaces, see variable sets (admin-only
 1. Create the module:
 
 ```zsh
-curl -X POST https://terrapod.local/api/v2/organizations/default/registry-modules \
+curl -X POST https://terrapod.local/api/terrapod/v1/registry-modules \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -376,7 +376,7 @@ curl -X POST https://terrapod.local/api/v2/organizations/default/registry-module
 2. Create a version:
 
 ```zsh
-curl -X POST https://terrapod.local/api/v2/organizations/default/registry-modules/private/default/vpc/aws/versions \
+curl -X POST https://terrapod.local/api/terrapod/v1/registry-modules/private/default/vpc/aws/versions \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -107,7 +107,7 @@ All endpoints use JSON:API format. Requires `admin` permission on the workspace 
 ### Create
 
 ```
-POST /api/v2/workspaces/{id}/notification-configurations
+POST /api/terrapod/v1/workspaces/{id}/notification-configurations
 ```
 
 ```json
@@ -127,31 +127,31 @@ POST /api/v2/workspaces/{id}/notification-configurations
 ### List
 
 ```
-GET /api/v2/workspaces/{id}/notification-configurations
+GET /api/terrapod/v1/workspaces/{id}/notification-configurations
 ```
 
 ### Show
 
 ```
-GET /api/v2/notification-configurations/{id}
+GET /api/terrapod/v1/notification-configurations/{id}
 ```
 
 ### Update
 
 ```
-PATCH /api/v2/notification-configurations/{id}
+PATCH /api/terrapod/v1/notification-configurations/{id}
 ```
 
 ### Delete
 
 ```
-DELETE /api/v2/notification-configurations/{id}
+DELETE /api/terrapod/v1/notification-configurations/{id}
 ```
 
 ### Verify (Send Test)
 
 ```
-POST /api/v2/notification-configurations/{id}/actions/verify
+POST /api/terrapod/v1/notification-configurations/{id}/actions/verify
 ```
 
 Sends a test notification with a verification payload. Useful for confirming webhook URLs and Slack integration before enabling.

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -127,7 +127,7 @@ Custom roles define access using allow/deny rules on labels and workspace names.
 ### Creating a Custom Role
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/roles \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/roles \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -171,7 +171,7 @@ curl -X POST https://terrapod.example.com/api/v2/roles \
 ### Listing Roles
 
 ```zsh
-curl https://terrapod.example.com/api/v2/roles \
+curl https://terrapod.example.com/api/terrapod/v1/roles \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -180,7 +180,7 @@ Returns both built-in and custom roles.
 ### Updating a Role
 
 ```zsh
-curl -X PATCH https://terrapod.example.com/api/v2/roles/developer \
+curl -X PATCH https://terrapod.example.com/api/terrapod/v1/roles/developer \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -197,7 +197,7 @@ curl -X PATCH https://terrapod.example.com/api/v2/roles/developer \
 ### Deleting a Role
 
 ```zsh
-curl -X DELETE https://terrapod.example.com/api/v2/roles/developer \
+curl -X DELETE https://terrapod.example.com/api/terrapod/v1/roles/developer \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -212,7 +212,7 @@ Role assignments bind a user (identified by provider + email) to a role.
 ### Setting Roles for a User
 
 ```zsh
-curl -X PUT https://terrapod.example.com/api/v2/role-assignments \
+curl -X PUT https://terrapod.example.com/api/terrapod/v1/role-assignments \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -230,7 +230,7 @@ curl -X PUT https://terrapod.example.com/api/v2/role-assignments \
 For platform roles (admin, audit):
 
 ```zsh
-curl -X PUT https://terrapod.example.com/api/v2/role-assignments \
+curl -X PUT https://terrapod.example.com/api/terrapod/v1/role-assignments \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -248,14 +248,14 @@ curl -X PUT https://terrapod.example.com/api/v2/role-assignments \
 ### Listing All Assignments
 
 ```zsh
-curl https://terrapod.example.com/api/v2/role-assignments \
+curl https://terrapod.example.com/api/terrapod/v1/role-assignments \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
 ### Removing a Single Assignment
 
 ```zsh
-curl -X DELETE https://terrapod.example.com/api/v2/role-assignments/local/alice@example.com/developer \
+curl -X DELETE https://terrapod.example.com/api/terrapod/v1/role-assignments/local/alice@example.com/developer \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -363,7 +363,7 @@ The web UI displays this field as **"Labels (tags)"** to make the dual purpose e
 
 ### Labels Browser
 
-Labels are also queryable as a first-class navigation surface via the **Labels** page in the web UI (and the `GET /api/v2/labels[/{key}[/{value}]]` endpoints — see [API Reference](api-reference.md#labels)). It lists every key in use, drills into the values for a key, and from a value lists every entity carrying it — workspaces, modules, providers, and pools.
+Labels are also queryable as a first-class navigation surface via the **Labels** page in the web UI (and the `GET /api/terrapod/v1/labels[/{key}[/{value}]]` endpoints — see [API Reference](api-reference.md#labels)). It lists every key in use, drills into the values for a key, and from a value lists every entity carrying it — workspaces, modules, providers, and pools.
 
 The browser is **read-only**: editing happens on each entity's own page. It is **RBAC-filtered**: a label only appears if you can `read` at least one entity that carries it, and the per-key/value listings only count entities you can see. There is no admin escape hatch — `admin`/`audit` see everything because their underlying RBAC grants them read on every entity, not because the labels page treats them specially.
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -34,7 +34,7 @@ Publish, version, and share Terraform modules internally.
 ### Creating a Module
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-modules \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/registry-modules \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -51,7 +51,7 @@ curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-
 ### Creating a Version
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws/versions \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/registry-modules/private/default/vpc/aws/versions \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -94,7 +94,7 @@ The Terraform CLI discovers the module registry via `/.well-known/terraform.json
 ### Listing Modules
 
 ```zsh
-curl https://terrapod.example.com/api/v2/organizations/default/registry-modules \
+curl https://terrapod.example.com/api/terrapod/v1/registry-modules \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -106,14 +106,14 @@ curl https://terrapod.example.com/api/v2/registry/modules/default/vpc/aws/versio
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 
 # Show module details (TFE V2 API)
-curl https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws \
+curl https://terrapod.example.com/api/terrapod/v1/registry-modules/private/default/vpc/aws \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
 ### Deleting a Module
 
 ```zsh
-curl -X DELETE https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws \
+curl -X DELETE https://terrapod.example.com/api/terrapod/v1/registry-modules/private/default/vpc/aws \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -158,7 +158,7 @@ Instead of uploading tarballs manually, you can connect a module to a VCS reposi
 
 ```zsh
 # 1. Create the module
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-modules \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/registry-modules \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -169,7 +169,7 @@ curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-
   }'
 
 # 2. Connect VCS
-curl -X PATCH https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws/vcs \
+curl -X PATCH https://terrapod.example.com/api/terrapod/v1/registry-modules/private/default/vpc/aws/vcs \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -315,7 +315,7 @@ terraform import terrapod_module_workspace_link.vpc_prod vpc/aws/<link-uuid>
 
 ```zsh
 # Link a workspace
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws/workspace-links \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/registry-modules/private/default/vpc/aws/workspace-links \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -328,11 +328,11 @@ curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-
   }'
 
 # List linked workspaces
-curl https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws/workspace-links \
+curl https://terrapod.example.com/api/terrapod/v1/registry-modules/private/default/vpc/aws/workspace-links \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 
 # Remove a link
-curl -X DELETE https://terrapod.example.com/api/v2/organizations/default/registry-modules/private/default/vpc/aws/workspace-links/<link-id> \
+curl -X DELETE https://terrapod.example.com/api/terrapod/v1/registry-modules/private/default/vpc/aws/workspace-links/<link-id> \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -430,7 +430,7 @@ curl https://terrapod.example.com/api/registry/private/v2/gpg-keys \
 ### Creating a Provider
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-providers \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/registry-providers \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -446,7 +446,7 @@ curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-
 ### Creating a Version
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-providers/private/default/mycloud/versions \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/registry-providers/private/default/mycloud/versions \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -465,7 +465,7 @@ curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-
 For each OS/architecture combination:
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/registry-providers/private/default/mycloud/versions/1.0.0/platforms \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/registry-providers/private/default/mycloud/versions/1.0.0/platforms \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -591,7 +591,7 @@ The binary cache stores terraform and tofu CLI binaries so runner Jobs can fetch
 ### How It Works
 
 1. Runner Job starts with a generic image (no baked-in terraform/tofu binary)
-2. Runner entrypoint calls `GET /api/v2/binary-cache/{tool}/{version}/{os}/{arch}` with auth header (`Authorization: Bearer <runner-token>`)
+2. Runner entrypoint calls `GET /api/terrapod/v1/binary-cache/{tool}/{version}/{os}/{arch}` with auth header (`Authorization: Bearer <runner-token>`)
 3. API validates authentication, returns 302 redirect to presigned URL in object storage
 4. Cache miss: API fetches from upstream (`releases.hashicorp.com` for terraform, GitHub releases for tofu), stores, redirects
 5. Runner downloads binary and begins execution
@@ -629,7 +629,7 @@ Requesting a version whose tier is not permitted returns HTTP 400 with a clear m
 
 **Download binary (used by runners):**
 ```
-GET /api/v2/binary-cache/{tool}/{version}/{os}/{arch}
+GET /api/terrapod/v1/binary-cache/{tool}/{version}/{os}/{arch}
 Authorization: Bearer <token>
 ```
 
@@ -637,13 +637,13 @@ Returns 302 redirect to presigned URL. Authentication required.
 
 **List cached binaries (admin):**
 ```zsh
-curl https://terrapod.example.com/api/v2/admin/binary-cache \
+curl https://terrapod.example.com/api/terrapod/v1/admin/binary-cache \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
 **Pre-warm cache (admin):**
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/admin/binary-cache/warm \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/admin/binary-cache/warm \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -656,7 +656,7 @@ curl -X POST https://terrapod.example.com/api/v2/admin/binary-cache/warm \
 
 **Purge cached binary (admin):**
 ```zsh
-curl -X DELETE https://terrapod.example.com/api/v2/admin/binary-cache/terraform/1.9.8 \
+curl -X DELETE https://terrapod.example.com/api/terrapod/v1/admin/binary-cache/terraform/1.9.8 \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -670,13 +670,13 @@ cache/binaries/{tool}/{version}/{os}_{arch}
 
 **List cached provider binaries (admin):**
 ```zsh
-curl https://terrapod.example.com/api/v2/admin/provider-cache \
+curl https://terrapod.example.com/api/terrapod/v1/admin/provider-cache \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
 **Purge cached provider version (admin):**
 ```zsh
-curl -X DELETE https://terrapod.example.com/api/v2/admin/provider-cache/registry.terraform.io/hashicorp/aws/6.37.0 \
+curl -X DELETE https://terrapod.example.com/api/terrapod/v1/admin/provider-cache/registry.terraform.io/hashicorp/aws/6.37.0 \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -705,8 +705,8 @@ The `/.well-known/terraform.json` endpoint includes paths for both module and pr
 
 ```json
 {
-  "modules.v1": "/api/v2/registry/modules/",
-  "providers.v1": "/api/v2/registry/providers/"
+  "modules.v1": "/api/terrapod/v1/registry/modules/",
+  "providers.v1": "/api/terrapod/v1/registry/providers/"
 }
 ```
 

--- a/docs/run-tasks.md
+++ b/docs/run-tasks.md
@@ -46,7 +46,7 @@ Requires `admin` permission on the workspace for create, update, and delete. Req
 #### Create Task
 
 ```
-POST /api/v2/workspaces/{id}/run-tasks
+POST /api/terrapod/v1/workspaces/{id}/run-tasks
 ```
 
 ```json
@@ -67,25 +67,25 @@ POST /api/v2/workspaces/{id}/run-tasks
 #### List Tasks
 
 ```
-GET /api/v2/workspaces/{id}/run-tasks
+GET /api/terrapod/v1/workspaces/{id}/run-tasks
 ```
 
 #### Show Task
 
 ```
-GET /api/v2/run-tasks/{id}
+GET /api/terrapod/v1/run-tasks/{id}
 ```
 
 #### Update Task
 
 ```
-PATCH /api/v2/run-tasks/{id}
+PATCH /api/terrapod/v1/run-tasks/{id}
 ```
 
 #### Delete Task
 
 ```
-DELETE /api/v2/run-tasks/{id}
+DELETE /api/terrapod/v1/run-tasks/{id}
 ```
 
 ### Task Stages
@@ -93,7 +93,7 @@ DELETE /api/v2/run-tasks/{id}
 #### List Stages for a Run
 
 ```
-GET /api/v2/runs/{run_id}/task-stages
+GET /api/terrapod/v1/runs/{run_id}/task-stages
 ```
 
 #### Show Stage (with Results)
@@ -115,7 +115,7 @@ Requires `admin` permission. Only works on stages with `failed` status. Sets the
 ### External Callback
 
 ```
-PATCH /api/v2/task-stage-results/{id}/callback
+PATCH /api/terrapod/v1/task-stage-results/{id}/callback
 ```
 
 No authentication header required — verified via `access_token` in the request body.
@@ -141,7 +141,7 @@ When a task fires, Terrapod sends an HTTP POST to the configured URL:
   "payload_version": 1,
   "stage": "pre_apply",
   "access_token": "result-id:timestamp:signature",
-  "task_result_callback_url": "https://terrapod.local/api/v2/task-stage-results/tsr-id/callback",
+  "task_result_callback_url": "https://terrapod.local/api/terrapod/v1/task-stage-results/tsr-id/callback",
   "run_id": "run-uuid",
   "run_status": "planning",
   "run_created_at": "2025-01-01T12:00:00Z",
@@ -279,7 +279,7 @@ def handle_task():
 
     # 2. Fetch plan JSON from Terrapod
     plan_resp = httpx.get(
-        f"https://terrapod.local/api/v2/runs/{run_id}/plan/json-output",
+        f"https://terrapod.local/api/terrapod/v1/runs/{run_id}/plan/json-output",
         headers={"Authorization": f"Bearer {TERRAPOD_TOKEN}"},
     )
     plan_json = plan_resp.json()
@@ -332,7 +332,7 @@ deny[msg] {
 2. Create a run task on the workspace:
 
 ```bash
-curl -X POST https://terrapod.local/api/v2/workspaces/ws-ID/run-tasks \
+curl -X POST https://terrapod.local/api/terrapod/v1/workspaces/ws-ID/run-tasks \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{

--- a/docs/run-triggers.md
+++ b/docs/run-triggers.md
@@ -34,13 +34,13 @@ All endpoints use JSON:API format.
 ### Create Trigger
 
 ```
-POST /api/v2/workspaces/{workspace_id}/run-triggers
+POST /api/terrapod/v1/workspaces/{workspace_id}/run-triggers
 ```
 
 Requires `admin` permission on the destination workspace.
 
 ```bash
-curl -X POST https://terrapod.local/api/v2/workspaces/ws-dest-id/run-triggers \
+curl -X POST https://terrapod.local/api/terrapod/v1/workspaces/ws-dest-id/run-triggers \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -84,7 +84,7 @@ Response (201):
 ### List Triggers
 
 ```
-GET /api/v2/workspaces/{workspace_id}/run-triggers?filter[run-trigger][type]={inbound|outbound}
+GET /api/terrapod/v1/workspaces/{workspace_id}/run-triggers?filter[run-trigger][type]={inbound|outbound}
 ```
 
 Requires `read` permission. The `filter[run-trigger][type]` parameter is required:
@@ -95,7 +95,7 @@ Requires `read` permission. The `filter[run-trigger][type]` parameter is require
 ### Show Trigger
 
 ```
-GET /api/v2/run-triggers/{run_trigger_id}
+GET /api/terrapod/v1/run-triggers/{run_trigger_id}
 ```
 
 Requires `read` permission on the destination workspace.
@@ -103,7 +103,7 @@ Requires `read` permission on the destination workspace.
 ### Delete Trigger
 
 ```
-DELETE /api/v2/run-triggers/{run_trigger_id}
+DELETE /api/terrapod/v1/run-triggers/{run_trigger_id}
 ```
 
 Requires `admin` permission on the destination workspace. Returns 204 No Content.

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -39,7 +39,7 @@ A run is marked "stale" by the reconciler when it has been in `planning` or `app
    ```bash
    # Via API
    curl -H "Authorization: Bearer $TOKEN" \
-     https://<terrapod>/api/v2/agent-pools/<pool-id>/listeners
+     https://<terrapod>/api/terrapod/v1/agent-pools/<pool-id>/listeners
    ```
    If no listeners, see [Listener Offline](#listener-offline).
 
@@ -258,7 +258,7 @@ When no listener is available in a pool, runs cannot be claimed or executed. Que
    Listener logs will show "certificate expired" if the certificate wasn't renewed. The renewal happens at 50% of validity.
 
 5. **Check SSE connectivity:**
-   Listener connects to `GET /api/v2/listeners/{id}/events` via SSE. If the connection is being dropped:
+   Listener connects to `GET /api/terrapod/v1/listeners/{id}/events` via SSE. If the connection is being dropped:
    ```logql
    {namespace="<ns>", pod=~"terrapod-listener.*"} |= "SSE" |= "disconnect"
    ```
@@ -281,7 +281,7 @@ When no listener is available in a pool, runs cannot be claimed or executed. Que
 
 ### Verification
 
-- Listener appears in `GET /api/v2/agent-pools/<pool-id>/listeners`
+- Listener appears in `GET /api/terrapod/v1/agent-pools/<pool-id>/listeners`
 - `terrapod_listener_heartbeats_total{pool_id="..."}` incrementing
 - `terrapod_listener_identity_ready` gauge is 1
 - Queued runs start being claimed
@@ -303,13 +303,13 @@ Runs are accumulating in `pending` or `queued` status faster than they can be pr
 1. **Count queued runs:**
    ```bash
    curl -H "Authorization: Bearer $TOKEN" \
-     "https://<terrapod>/api/v2/admin/runs?filter[status]=queued" | jq '.meta.pagination.total-count'
+     "https://<terrapod>/api/terrapod/v1/admin/runs?filter[status]=queued" | jq '.meta.pagination.total-count'
    ```
 
 2. **Check listener capacity:**
    ```bash
    curl -H "Authorization: Bearer $TOKEN" \
-     https://<terrapod>/api/v2/agent-pools/<pool-id>/listeners | \
+     https://<terrapod>/api/terrapod/v1/agent-pools/<pool-id>/listeners | \
      jq '.data[] | {name: .attributes.name, active: .attributes["active-runs"], capacity: .attributes.capacity}'
    ```
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -230,7 +230,7 @@ This is intentional: scaling the Deployment must not require new join tokens or 
 On startup each pod runs the same flow:
 
 1. Read the credentials Secret (name supplied via `TERRAPOD_CREDENTIALS_SECRET_NAME`, set by Helm to the Deployment fullname + `-credentials`). If it exists and has a valid cert/key/listener-id, adopt that identity and skip everything below.
-2. If no Secret, call `POST /api/v2/agent-pools/join` with `TERRAPOD_JOIN_TOKEN`. The API issues a short-lived cert and returns the full identity.
+2. If no Secret, call `POST /api/terrapod/v1/agent-pools/join` with `TERRAPOD_JOIN_TOKEN`. The API issues a short-lived cert and returns the full identity.
 3. Try to `create` the credentials Secret with that identity. On `409 AlreadyExists` another pod won the race — re-read the Secret and adopt the winner's identity instead. The cert this pod was just issued is silently dropped.
 4. If the join token is exhausted (`401`/`403`) before this pod gets a chance, the pod backs off (1, 2, 4, ... up to 30s, ~3 min total budget) and re-reads the Secret. As soon as a peer pod's bootstrap completes, the loser adopts that identity. This is why the default `max_uses: 2` is enough even for large replica counts — only the first two pods ever consume token uses, the rest discover the Secret.
 
@@ -242,7 +242,7 @@ Each pod independently runs a renewal loop:
 
 - The renewal threshold is `cert_validity_seconds / 2 + pod_splay_seconds`, where `pod_splay_seconds` is a deterministic SHA-256 hash of `POD_NAME` in the range `[0, 30)`. The splay desynchronises pods that started in lockstep so they don't all hit `/renew` simultaneously.
 - When a pod reaches its threshold, it **re-reads the Secret first**. If the cert in the Secret still has more remaining lifetime than this pod's threshold (plus a 30s skew margin), another pod has already renewed it — adopt and reset the timer.
-- Otherwise call `POST /api/v2/listeners/{id}/renew` with up to 3 attempts (exponential backoff on 5xx / network errors; immediate failure on 401/403).
+- Otherwise call `POST /api/terrapod/v1/listeners/{id}/renew` with up to 3 attempts (exponential backoff on 5xx / network errors; immediate failure on 401/403).
 - On success, write the Secret with `resourceVersion` CAS. If another pod beat us to it (`409 Conflict`), re-read and adopt the peer's cert.
 - On `401`/`403` from `/renew`, the cert is rejected (revoked, listener deleted, etc.) — clear the Secret and fall back to the join-token bootstrap flow.
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -194,7 +194,7 @@ Query the audit log API and forward events to your SIEM:
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
-  "https://terrapod.example.com/api/v2/admin/audit-log?page[size]=100"
+  "https://terrapod.example.com/api/terrapod/v1/admin/audit-log?page[size]=100"
 ```
 
 Integrate with your log aggregator (Elasticsearch, Splunk, Datadog) by polling this endpoint periodically.

--- a/docs/tfe-cli-surface.md
+++ b/docs/tfe-cli-surface.md
@@ -1,0 +1,174 @@
+# TFE V2 CLI Surface
+
+This file enumerates the **exact** set of TFE V2 API endpoints that the `terraform` (HashiCorp) and `tofu` (OpenTofu) CLIs consume — directly or via `go-tfe` — when configured with a `cloud` block (or the legacy `remote` backend) pointing at a TFE-compatible server.
+
+**This list is the contract for `/api/v2/` in Terrapod.** A route on this list MUST be served at `/api/v2/...` so the CLI can find it via service discovery. A route NOT on this list — even one defined in the public TFE V2 spec — belongs at `/api/terrapod/v1/...`. The cleanup rule:
+
+> If `terraform`/`tofu` doesn't call it, the route is Terrapod-native, regardless of TFE-V2 lineage.
+
+Verification source: [OpenTofu](https://github.com/opentofu/opentofu) `internal/cloud` and `internal/backend/remote` packages, cross-referenced against [`go-tfe`](https://github.com/hashicorp/go-tfe) `client.NewRequest(...)` paths.
+
+## Discovery / Auth
+
+| Method | Path |
+|---|---|
+| GET | `/.well-known/terraform.json` |
+
+The discovery document points at:
+- `tfe.v2` — the TFE V2 API base, must remain `/api/v2/`
+- `modules.v1` — module registry CLI download protocol
+- `providers.v1` — provider registry CLI download protocol
+- `login.v1` — `terraform login` OAuth2 endpoints (`/oauth/authorize`, `/oauth/token`)
+
+## Organizations
+
+| Method | Path | go-tfe method | Caller |
+|---|---|---|---|
+| GET | `/api/v2/ping` | client init | `go-tfe` configures every connection |
+| GET | `/api/v2/account/details` | `Account.Read` | `go-tfe` startup |
+| GET | `/api/v2/organizations/default` | `Organizations.Read` | cloud backend init |
+| GET | `/api/v2/organizations/default/entitlement-set` | `Organizations.ReadEntitlements` | `cloud/backend.go:349`, `remote/backend.go:362` |
+| GET | `/api/v2/organizations/default/runs/queue` | `Organizations.ReadRunQueue` | `cloud/backend_common.go:170`, `remote/backend_common.go:172` (run-status display) |
+| GET | `/api/v2/organizations/default/capacity` | `Organizations.ReadCapacity` | `cloud/backend_common.go:193`, `remote/backend_common.go:195` |
+
+## Projects
+
+`cloud` block only — the `project` argument routes workspaces into projects.
+
+| Method | Path | go-tfe method | Caller |
+|---|---|---|---|
+| GET | `/api/v2/organizations/default/projects` | `Projects.List` | `cloud/backend.go:588, 676` |
+| POST | `/api/v2/organizations/default/projects` | `Projects.Create` | `cloud/backend.go:715` |
+
+Terrapod is single-organization with no project concept — see #279 for current handling.
+
+## Workspaces
+
+| Method | Path | go-tfe method | Caller |
+|---|---|---|---|
+| GET | `/api/v2/organizations/default/workspaces` | `Workspaces.List` | `cloud/backend.go:601, 1175`, `remote/backend.go:488` |
+| POST | `/api/v2/organizations/default/workspaces` | `Workspaces.Create` | `cloud/backend.go:726`, `remote/backend.go:591` |
+| GET | `/api/v2/organizations/default/workspaces/{name}` | `Workspaces.Read` | `cloud/backend.go:635, 661, 1120, 1151`, `cloud/backend_common.go:95`, `cloud/backend_context.go:178`, `remote/backend.go:575, 643`, `remote/backend_context.go:181` |
+| DELETE | `/api/v2/organizations/default/workspaces/{name}` | `Workspaces.Delete` | `remote/backend_state.go:145` |
+| GET | `/api/v2/workspaces/{id}` | (read by id) | go-tfe pattern |
+| PATCH | `/api/v2/workspaces/{id}` | `Workspaces.UpdateByID` | `cloud/backend.go:739` |
+| POST | `/api/v2/workspaces/{id}/relationships/tags` | `Workspaces.AddTags` | `cloud/backend.go:760` |
+| DELETE | `/api/v2/workspaces/{id}/relationships/tags` | `Workspaces.RemoveTags` | tag-binding maintenance |
+| GET | `/api/v2/workspaces/{id}/tag-bindings` | `Workspaces.ListTagBindings` | tag display |
+| GET | `/api/v2/workspaces/{id}/effective-tag-bindings` | `Workspaces.ListEffectiveTagBindings` | tag display |
+| POST | `/api/v2/workspaces/{id}/actions/lock` | `Workspaces.Lock` | `remote/backend_state.go:164` |
+| POST | `/api/v2/workspaces/{id}/actions/unlock` | `Workspaces.Unlock` | `remote/backend_state.go:201` |
+| POST | `/api/v2/workspaces/{id}/actions/force-unlock` | `Workspaces.ForceUnlock` | `remote/backend_state.go:222` (gap — see #279) |
+| GET | `/api/v2/workspaces/{id}/runs` | `Runs.List` | `cloud/backend_common.go:119`, `remote/backend_common.go:121` |
+| GET | `/api/v2/workspaces/{id}/vars` | `Variables.List` | `cloud/backend_context.go:122`, `remote/backend_context.go:123` (read-only — sensitive-var warnings) |
+
+Note: `DELETE /api/v2/workspaces/{id}` is **not** in the CLI surface. Only the by-name delete is. The by-id delete is admin/UI-only and lives on the management API.
+
+## State Versions
+
+| Method | Path | go-tfe method | Caller |
+|---|---|---|---|
+| GET | `/api/v2/workspaces/{id}/current-state-version` | `StateVersions.ReadCurrent` | `remote/backend_state.go:40` |
+| POST | `/api/v2/workspaces/{id}/state-versions` | `StateVersions.Create` | `remote/backend_state.go:85` |
+| GET | `/api/v2/state-versions/{id}` | `StateVersions.Read` | follow-up reads |
+| PUT | `/api/v2/state-versions/{id}/content` | (raw upload to `upload-url`) | `remote/backend_state.go:129` — **no Authorization header** |
+| PUT | `/api/v2/state-versions/{id}/json-content` | (raw upload) | same flow, JSON state |
+| GET | `/api/v2/state-versions/{id}/download` | `StateVersions.Download` | `remote/backend_state.go:49` (follows `download-url` from resource) |
+
+The `upload-url` and `download-url` returned in JSON:API attributes can be absolute or server-relative — go-tfe's `NewRequest` handles both. Terrapod returns relative `/api/v2/...` paths.
+
+## Configuration Versions
+
+| Method | Path | go-tfe method | Caller |
+|---|---|---|---|
+| POST | `/api/v2/workspaces/{id}/configuration-versions` | `ConfigurationVersions.Create` | `cloud/backend_plan.go:135`, `remote/backend_plan.go:206` |
+| GET | `/api/v2/configuration-versions/{id}` | `ConfigurationVersions.Read` | `cloud/backend_plan.go:199`, `remote/backend_plan.go:270` |
+| PUT | `/api/v2/configuration-versions/{id}/upload` | (raw upload to `upload-url`) | `cloud/backend_plan.go:186`, `remote/backend_plan.go:257` — **no Authorization header** |
+
+Terrapod-only management on the configuration-versions surface (list, download, diff, ticket-based download) lives at `/api/terrapod/v1/configuration-versions/...`.
+
+## Runs / Plans / Applies
+
+| Method | Path | go-tfe method | Caller |
+|---|---|---|---|
+| POST | `/api/v2/runs` | `Runs.Create` | `cloud/backend_plan.go:278`, `remote/backend_plan.go:323` |
+| GET | `/api/v2/runs/{id}` | `Runs.Read` / `ReadWithOptions` | many — every run-status poll |
+| POST | `/api/v2/runs/{id}/actions/apply` | `Runs.Apply` | `cloud/backend_apply.go:197`, `remote/backend_apply.go:253` |
+| POST | `/api/v2/runs/{id}/actions/discard` | `Runs.Discard` | `cloud/backend_common.go:519`, `remote/backend_apply.go:208` |
+| POST | `/api/v2/runs/{id}/actions/cancel` | `Runs.Cancel` | `cloud/backend.go:934`, `remote/backend.go:818` |
+| GET | `/api/v2/runs/{id}/run-events` | `RunEvents.List` | run progress polling |
+| GET | `/api/v2/plans/{id}` | `Plans.Read` | run status |
+| GET | `/api/v2/plans/{id}/log` | `Plans.Logs` (via `log-read-url`) | `cloud/backend_plan.go:428`, `remote/backend_plan.go:380` |
+| GET | `/api/v2/plans/{id}/json-output` | `Plans.ReadJSONOutput` | `cloud/backend_show.go:68` (gap — see #279) |
+| GET | `/api/v2/applies/{id}` | `Applies.Read` | run status |
+| GET | `/api/v2/applies/{id}/log` | `Applies.Logs` (via `log-read-url`) | `cloud/backend_apply.go:229`, `remote/backend_apply.go:272` |
+
+## Cost Estimates / Policy Checks / Task Stages
+
+These are CLI-aware (run progress display branches on relationships) but only exercised when the relationship is present on the run. Terrapod intentionally does not implement cost estimates or Sentinel policy checks (see CLAUDE.md "Out of Scope"). Run tasks ARE supported, with task stages on the CLI surface:
+
+| Method | Path | go-tfe method | Caller |
+|---|---|---|---|
+| GET | `/api/v2/task-stages/{id}` | `TaskStages.Read` | `cloud/backend_taskStages.go:66, 96` |
+| POST | `/api/v2/task-stages/{id}/actions/override` | `TaskStages.Override` | `cloud/backend_taskStages.go:186` |
+
+The run-task management surface (`/run-tasks/*`, `/workspaces/{id}/run-tasks`, callback endpoints) is Terrapod-native and lives at `/api/terrapod/v1/`.
+
+## tfci / tfc-workflows-github
+
+[`tfci`](https://github.com/hashicorp/tfc-workflows-tooling) is HashiCorp's CI binary; [`tfc-workflows-github`](https://github.com/hashicorp/tfc-workflows-github) wraps it for GitHub Actions. It is in widespread use for TFE/HCP-Terraform CI flows. Most of what it calls overlaps with the CLI surface above (workspace lookup, lock/unlock, configuration-version create+upload, run create/apply/discard/cancel/read, plan read+log+JSON output). The one extension beyond the `terraform`/`tofu` CLI surface is **variable management** — `tfci variable …` and `tfci variable-set …` commands.
+
+We extend the "stays at `/api/v2/`" set to cover those calls. The rule is unchanged: anything `terraform`, `tofu`, or `tfci` calls stays at `/api/v2/`; everything else is `/api/terrapod/v1/`.
+
+| Method | Path | go-tfe method | Caller |
+|---|---|---|---|
+| POST | `/api/v2/workspaces/{id}/vars` | `Variables.Create` | `tfci variable create` |
+| PATCH | `/api/v2/workspaces/{id}/vars/{id}` | `Variables.Update` | `tfci variable update` |
+| DELETE | `/api/v2/workspaces/{id}/vars/{id}` | `Variables.Delete` | `tfci variable delete` |
+| GET | `/api/v2/organizations/default/varsets` | `VariableSets.List` | `tfci variable-set list` |
+| POST | `/api/v2/organizations/default/varsets` | `VariableSets.Create` | `tfci variable-set create` |
+| GET | `/api/v2/varsets/{id}` | `VariableSets.Read` | `tfci variable-set show` |
+| PATCH | `/api/v2/varsets/{id}` | `VariableSets.Update` | `tfci variable-set update` |
+| DELETE | `/api/v2/varsets/{id}` | `VariableSets.Delete` | `tfci variable-set delete` |
+| GET | `/api/v2/varsets/{id}/relationships/vars` | `VariableSetVariables.List` | `tfci variable-set ...` |
+| POST | `/api/v2/varsets/{id}/relationships/vars` | `VariableSetVariables.Create` | `tfci variable-set add-variable` |
+| PATCH | `/api/v2/varsets/{id}/relationships/vars/{id}` | `VariableSetVariables.Update` | `tfci variable-set update-variable` |
+| DELETE | `/api/v2/varsets/{id}/relationships/vars/{id}` | `VariableSetVariables.Delete` | `tfci variable-set delete-variable` |
+| POST | `/api/v2/varsets/{id}/relationships/workspaces` | `VariableSets.ApplyToWorkspaces` | `tfci variable-set assign-to-workspace` |
+| DELETE | `/api/v2/varsets/{id}/relationships/workspaces` | `VariableSets.RemoveFromWorkspaces` | `tfci variable-set remove-from-workspace` |
+
+**Verification:** When updating this section, check the `tfci` source at https://github.com/hashicorp/tfc-workflows-tooling — the `internal/cloud/` package exposes the call sites.
+
+**Out of scope for tfci compat:** teams, projects, policy checks, run tasks (TFE-shape), notifications, OAuth client management, the `hashicorp/tfe` Terraform provider's full surface. Those have structural divergence in Terrapod (single-org, label-RBAC instead of teams) that compatibility cannot bridge.
+
+## Module Registry (CLI Download Protocol)
+
+Service-discovered via `modules.v1` URL.
+
+| Method | Path |
+|---|---|
+| GET | `/api/v2/registry/modules/{namespace}/{name}/{provider}/versions` |
+| GET | `/api/v2/registry/modules/{namespace}/{name}/{provider}/{version}/download` |
+
+The download endpoint returns 204 with `X-Terraform-Get` header pointing at the actual tarball URL.
+
+## Provider Registry (CLI Download Protocol)
+
+Service-discovered via `providers.v1` URL.
+
+| Method | Path |
+|---|---|
+| GET | `/api/v2/registry/providers/{namespace}/{type}/versions` |
+| GET | `/api/v2/registry/providers/{namespace}/{type}/{version}/download/{os}/{arch}` |
+
+The platform-download endpoint returns JSON with `download_url`, `shasums_url`, and `shasums_signature_url` — the CLI then follows those URLs (which may be absolute, presigned, or server-relative).
+
+## Maintaining This Document
+
+When OpenTofu adds new go-tfe call sites in `internal/cloud/*` or `internal/backend/remote/*`, this list grows. Re-verify by:
+1. `git clone https://github.com/opentofu/opentofu`
+2. `grep -RP 'tfe\.[A-Z]\w+\(' internal/cloud internal/backend/remote --include='*.go' | grep -v _test.go`
+3. For each match, find the go-tfe method's `client.NewRequest(...)` line in https://github.com/hashicorp/go-tfe to extract the path
+4. Add to the relevant table above
+
+Endpoints **not** verified by this process belong at `/api/terrapod/v1/`, regardless of go-tfe lineage.

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -114,7 +114,7 @@ GitHub integration uses a **GitHub App** for fine-grained permissions and org-le
 ### Step 1: Create a GitHub App
 
 1. Go to **GitHub Settings > Developer settings > GitHub Apps > New GitHub App**
-   - For an organization: `https://github.com/organizations/{org}/settings/apps/new`
+   - For an organization: `https://github.com/organizations/default/settings/apps/new`
    - For a personal account: `https://github.com/settings/apps/new`
 
 ![GitHub Apps List](images/github-app-list.png)
@@ -170,7 +170,7 @@ No platform-level GitHub configuration is needed beyond enabling VCS. The App ID
 ![VCS Connections](images/admin-vcs-connections.png)
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/vcs-connections \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/vcs-connections \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -237,7 +237,7 @@ GitLab integration uses a **Project or Group Access Token** for repository acces
 No platform-level configuration is needed for GitLab -- the access token is stored (encrypted) on the VCS connection itself.
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/vcs-connections \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/vcs-connections \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -261,7 +261,7 @@ Note the returned connection ID (e.g. `vcs-01234...`).
 For a self-hosted GitLab instance, include the `server-url`:
 
 ```zsh
-curl -X POST https://terrapod.example.com/api/v2/organizations/default/vcs-connections \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/vcs-connections \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d '{
@@ -544,7 +544,7 @@ If Terrapod is accessible from GitHub (not behind a firewall), you can add webho
 
 1. Edit your GitHub App settings
 2. Check **Active** under Webhook
-3. Set **Webhook URL** to: `https://terrapod.example.com/api/v2/vcs-events/github`
+3. Set **Webhook URL** to: `https://terrapod.example.com/api/terrapod/v1/vcs-events/github`
 4. Set a **Webhook secret** (a random string)
 5. Subscribe to events: **Push**, **Pull request**
 6. Save
@@ -588,21 +588,21 @@ For full details on setup, tag patterns, and behaviour, see the [VCS-Driven Modu
 ### List Connections
 
 ```zsh
-curl https://terrapod.example.com/api/v2/organizations/default/vcs-connections \
+curl https://terrapod.example.com/api/terrapod/v1/vcs-connections \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
 ### Show a Connection
 
 ```zsh
-curl https://terrapod.example.com/api/v2/vcs-connections/vcs-{id} \
+curl https://terrapod.example.com/api/terrapod/v1/vcs-connections/vcs-{id} \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
 ### Delete a Connection
 
 ```zsh
-curl -X DELETE https://terrapod.example.com/api/v2/vcs-connections/vcs-{id} \
+curl -X DELETE https://terrapod.example.com/api/terrapod/v1/vcs-connections/vcs-{id} \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
@@ -651,7 +651,7 @@ Credentials are never returned in API responses.
 |---|---|---|---|
 | Outbound | HTTPS | GitHub API (`api.github.com` or GHE URL) | Branch SHA, PR list, tarball download |
 | Outbound | HTTPS | GitLab API (`gitlab.com` or self-hosted URL) | Branch SHA, MR list, tarball download |
-| Inbound (optional) | HTTPS | Terrapod API (`/api/v2/vcs-events/github`) | GitHub webhooks (faster feedback) |
+| Inbound (optional) | HTTPS | Terrapod API (`/api/terrapod/v1/vcs-events/github`) | GitHub webhooks (faster feedback) |
 
 No inbound connections are required for basic operation. The poller makes outbound HTTPS calls only.
 

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -24,7 +24,7 @@ export async function getSessionToken(
   const state = randomBytes(16).toString('hex');
 
   // Step 1: authorize
-  const authRes = await fetch(`${API_URL}/api/v2/auth/local/authorize`, {
+  const authRes = await fetch(`${API_URL}/api/terrapod/v1/auth/local/authorize`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -44,7 +44,7 @@ export async function getSessionToken(
   const { code } = await authRes.json();
 
   // Step 2: token exchange
-  const tokenRes = await fetch(`${API_URL}/api/v2/auth/token`, {
+  const tokenRes = await fetch(`${API_URL}/api/terrapod/v1/auth/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
@@ -73,7 +73,7 @@ export async function createUser(
   displayName?: string,
 ): Promise<void> {
   const res = await fetch(
-    `${API_URL}/api/v2/organizations/default/users`,
+    `${API_URL}/api/terrapod/v1/users`,
     {
       method: 'POST',
       headers: {

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -143,7 +143,7 @@ api:
 
       # Public callback URL for SSO redirects. Required when SSO is enabled.
       # Must be the externally-reachable URL of your Terrapod instance.
-      # The IDP callback lands at {callback_base_url}/api/v2/auth/callback.
+      # The IDP callback lands at {callback_base_url}/api/terrapod/v1/auth/callback.
       callback_base_url: ""
 
       session_ttl_hours: 12
@@ -287,7 +287,7 @@ api:
       # artifact uploads — throttling them causes plan failures. Raise if
       # you need a hard cap on a specific cluster.
       runner_requests_per_minute: 0
-      # Auth endpoints (/api/v2/auth/*, /oauth/*) — brute-force defence,
+      # Auth endpoints (/api/terrapod/v1/auth/*, /api/v2/auth/*, /oauth/*) — brute-force defence,
       # applies to all callers regardless of credentials.
       auth_requests_per_minute: 10
 

--- a/pentest/nuclei/terrapod-templates/auth-bypass.yaml
+++ b/pentest/nuclei/terrapod-templates/auth-bypass.yaml
@@ -10,11 +10,11 @@ info:
 http:
   - method: GET
     path:
-      - "{{BaseURL}}/api/v2/admin/users"
-      - "{{BaseURL}}/api/v2/organizations/default/roles"
-      - "{{BaseURL}}/api/v2/admin/audit"
-      - "{{BaseURL}}/api/v2/organizations/default/vcs-connections"
-      - "{{BaseURL}}/api/v2/admin/health"
+      - "{{BaseURL}}/api/terrapod/v1/admin/users"
+      - "{{BaseURL}}/api/terrapod/v1/organizations/default/roles"
+      - "{{BaseURL}}/api/terrapod/v1/admin/audit"
+      - "{{BaseURL}}/api/terrapod/v1/organizations/default/vcs-connections"
+      - "{{BaseURL}}/api/terrapod/v1/admin/health"
 
     matchers-condition: and
     matchers:
@@ -30,8 +30,8 @@ http:
 
   - method: POST
     path:
-      - "{{BaseURL}}/api/v2/organizations/default/roles"
-      - "{{BaseURL}}/api/v2/organizations/default/vcs-connections"
+      - "{{BaseURL}}/api/terrapod/v1/organizations/default/roles"
+      - "{{BaseURL}}/api/terrapod/v1/organizations/default/vcs-connections"
     headers:
       Content-Type: application/json
     body: "{}"
@@ -45,8 +45,8 @@ http:
 
   - method: DELETE
     path:
-      - "{{BaseURL}}/api/v2/roles/test-role"
-      - "{{BaseURL}}/api/v2/vcs-connections/test-id"
+      - "{{BaseURL}}/api/terrapod/v1/roles/test-role"
+      - "{{BaseURL}}/api/terrapod/v1/vcs-connections/test-id"
 
     matchers-condition: and
     matchers:

--- a/pentest/nuclei/terrapod-templates/cors-proxy.yaml
+++ b/pentest/nuclei/terrapod-templates/cors-proxy.yaml
@@ -29,7 +29,7 @@ http:
 
   - method: GET
     path:
-      - "{{BaseURL}}/api/v2/auth/providers"
+      - "{{BaseURL}}/api/terrapod/v1/auth/providers"
 
     headers:
       Origin: https://evil.attacker.com

--- a/pentest/nuclei/terrapod-templates/header-injection.yaml
+++ b/pentest/nuclei/terrapod-templates/header-injection.yaml
@@ -31,7 +31,7 @@ http:
 
   - method: GET
     path:
-      - "{{BaseURL}}/api/v2/admin/users"
+      - "{{BaseURL}}/api/terrapod/v1/admin/users"
 
     headers:
       X-Forwarded-Email: admin@example.com

--- a/provider/internal/datasources/role/data_source.go
+++ b/provider/internal/datasources/role/data_source.go
@@ -1,6 +1,6 @@
 // Package role implements the terrapod_role data source.
 //
-// API Contract: GET /api/v2/roles/{name}
+// API Contract: GET /api/terrapod/v1/roles/{name}
 // Looks up a single role by name.
 package role
 
@@ -80,7 +80,7 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	data, err := d.client.Get(ctx, "/api/v2/roles/"+config.Name.ValueString())
+	data, err := d.client.Get(ctx, "/api/terrapod/v1/roles/"+config.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read role", err.Error())
 		return

--- a/provider/internal/datasources/user/data_source.go
+++ b/provider/internal/datasources/user/data_source.go
@@ -1,6 +1,6 @@
 // Package user implements the terrapod_user data source.
 //
-// API Contract: GET /api/v2/users/{email}
+// API Contract: GET /api/terrapod/v1/users/{email}
 // Looks up a single user by email.
 package user
 
@@ -73,7 +73,7 @@ func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	data, err := d.client.Get(ctx, "/api/v2/users/"+config.Email.ValueString())
+	data, err := d.client.Get(ctx, "/api/terrapod/v1/users/"+config.Email.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read user", err.Error())
 		return

--- a/provider/internal/datasources/vcs_connection/data_source.go
+++ b/provider/internal/datasources/vcs_connection/data_source.go
@@ -1,6 +1,6 @@
 // Package vcs_connection implements the terrapod_vcs_connection data source.
 //
-// API Contract: GET /api/v2/organizations/default/vcs-connections
+// API Contract: GET /api/terrapod/v1/vcs-connections
 // Lists all connections, filters by name client-side.
 package vcs_connection
 
@@ -83,7 +83,7 @@ func (d *vcsConnectionDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	data, err := d.client.Get(ctx, "/api/v2/organizations/default/vcs-connections")
+	data, err := d.client.Get(ctx, "/api/terrapod/v1/vcs-connections")
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to list VCS connections", err.Error())
 		return

--- a/provider/internal/resources/gpg_key/resource.go
+++ b/provider/internal/resources/gpg_key/resource.go
@@ -4,9 +4,9 @@
 //
 //	JSON:API type: "gpg-keys"
 //	ID: UUID (no prefix)
-//	Create:  POST   /api/registry/private/v2/gpg-keys
-//	Read:    GET    /api/registry/private/v2/gpg-keys/{id}
-//	Delete:  DELETE /api/registry/private/v2/gpg-keys/{id}
+//	Create:  POST   /api/terrapod/v1/gpg-keys
+//	Read:    GET    /api/terrapod/v1/gpg-keys/{id}
+//	Delete:  DELETE /api/terrapod/v1/gpg-keys/{id}
 //	No update — immutable resource.
 //
 // Attribute mapping:
@@ -146,7 +146,7 @@ func (r *gpgKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	data, err := r.client.Post(ctx, "/api/registry/private/v2/gpg-keys", body)
+	data, err := r.client.Post(ctx, "/api/terrapod/v1/gpg-keys", body)
 	if err != nil {
 		resp.Diagnostics.AddError("Create failed", err.Error())
 		return
@@ -169,7 +169,7 @@ func (r *gpgKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	data, err := r.client.Get(ctx, "/api/registry/private/v2/gpg-keys/"+state.ID.ValueString())
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/gpg-keys/"+state.ID.ValueString())
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -200,7 +200,7 @@ func (r *gpgKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/registry/private/v2/gpg-keys/"+state.ID.ValueString())
+	err := r.client.Delete(ctx, "/api/terrapod/v1/gpg-keys/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Delete failed", err.Error())
 	}

--- a/provider/internal/resources/module_workspace_link/model.go
+++ b/provider/internal/resources/module_workspace_link/model.go
@@ -3,9 +3,9 @@
 // API Contract (Terrapod API <-> Terraform Provider):
 //
 //	JSON:API type: "workspace-links"
-//	Create: POST   /api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links
-//	List:   GET    /api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links
-//	Delete: DELETE /api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links/{id}
+//	Create: POST   /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/workspace-links
+//	List:   GET    /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/workspace-links
+//	Delete: DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/workspace-links/{id}
 //	No update -- immutable resource (delete + recreate).
 //
 // Attribute mapping:

--- a/provider/internal/resources/module_workspace_link/resource.go
+++ b/provider/internal/resources/module_workspace_link/resource.go
@@ -179,7 +179,7 @@ func (r *moduleWorkspaceLinkResource) ImportState(ctx context.Context, req resou
 }
 
 func linksPath(name, provider string) string {
-	return fmt.Sprintf("/api/v2/organizations/default/registry-modules/private/default/%s/%s/workspace-links", name, provider)
+	return fmt.Sprintf("/api/terrapod/v1/registry-modules/private/default/%s/%s/workspace-links", name, provider)
 }
 
 func readIntoModel(res *client.Resource, m *moduleWorkspaceLinkModel) {

--- a/provider/internal/resources/role/resource.go
+++ b/provider/internal/resources/role/resource.go
@@ -4,11 +4,11 @@
 //
 //	JSON:API type: "roles"
 //	ID: role name (string, not UUID)
-//	Create:  POST   /api/v2/roles
-//	Read:    GET    /api/v2/roles/{name}
-//	Update:  PATCH  /api/v2/roles/{name}
-//	Delete:  DELETE /api/v2/roles/{name}
-//	List:    GET    /api/v2/roles
+//	Create:  POST   /api/terrapod/v1/roles
+//	Read:    GET    /api/terrapod/v1/roles/{name}
+//	Update:  PATCH  /api/terrapod/v1/roles/{name}
+//	Delete:  DELETE /api/terrapod/v1/roles/{name}
+//	List:    GET    /api/terrapod/v1/roles
 //
 // The API uses the role name as the resource identifier — there is no
 // UUID or prefixed ID. The "name" field in the JSON:API response sits
@@ -195,7 +195,7 @@ func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	data, err := r.client.Post(ctx, "/api/v2/roles", body)
+	data, err := r.client.Post(ctx, "/api/terrapod/v1/roles", body)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create role", err.Error())
 		return
@@ -218,7 +218,7 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	data, err := r.client.Get(ctx, "/api/v2/roles/"+state.ID.ValueString())
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/roles/"+state.ID.ValueString())
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -258,7 +258,7 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	data, err := r.client.Patch(ctx, "/api/v2/roles/"+state.ID.ValueString(), body)
+	data, err := r.client.Patch(ctx, "/api/terrapod/v1/roles/"+state.ID.ValueString(), body)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update role", err.Error())
 		return
@@ -281,7 +281,7 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/v2/roles/"+state.ID.ValueString())
+	err := r.client.Delete(ctx, "/api/terrapod/v1/roles/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Failed to delete role", err.Error())
 	}

--- a/provider/internal/resources/role_assignment/resource.go
+++ b/provider/internal/resources/role_assignment/resource.go
@@ -6,12 +6,12 @@
 //	ID: composite — provider_name/email/role_name
 //
 //	Create: Read-modify-write via:
-//	  1. GET  /api/v2/role-assignments                        — list all, filter by provider+email
-//	  2. PUT  /api/v2/role-assignments                        — replace-all semantics for (provider, email)
+//	  1. GET  /api/terrapod/v1/role-assignments                        — list all, filter by provider+email
+//	  2. PUT  /api/terrapod/v1/role-assignments                        — replace-all semantics for (provider, email)
 //	     Body: {"data": {"attributes": {"provider-name": "...", "email": "...", "roles": ["admin", "custom"]}}}
 //
-//	Read:   GET    /api/v2/role-assignments                   — list all, find matching entry
-//	Delete: DELETE /api/v2/role-assignments/{provider}/{email}/{role}
+//	Read:   GET    /api/terrapod/v1/role-assignments                   — list all, find matching entry
+//	Delete: DELETE /api/terrapod/v1/role-assignments/{provider}/{email}/{role}
 //
 // Each Terraform resource instance represents ONE (provider, email, role)
 // triple. Create adds the role to the user's existing set; delete removes
@@ -228,7 +228,7 @@ func (r *roleAssignmentResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	deletePath := fmt.Sprintf("/api/v2/role-assignments/%s/%s/%s",
+	deletePath := fmt.Sprintf("/api/terrapod/v1/role-assignments/%s/%s/%s",
 		state.ProviderName.ValueString(),
 		state.Email.ValueString(),
 		state.RoleName.ValueString(),
@@ -264,7 +264,7 @@ type assignmentData struct {
 // listRolesForIdentity fetches all role assignments and returns the role names
 // for the given (provider, email) pair.
 func (r *roleAssignmentResource) listRolesForIdentity(ctx context.Context, providerName, email string) ([]string, error) {
-	data, err := r.client.Get(ctx, "/api/v2/role-assignments")
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/role-assignments")
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func (r *roleAssignmentResource) listRolesForIdentity(ctx context.Context, provi
 // findAssignment looks up a specific (provider, email, role) triple in the
 // assignment list.
 func (r *roleAssignmentResource) findAssignment(ctx context.Context, providerName, email, roleName string) (*assignmentData, error) {
-	data, err := r.client.Get(ctx, "/api/v2/role-assignments")
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/role-assignments")
 	if err != nil {
 		return nil, err
 	}
@@ -319,11 +319,11 @@ func (r *roleAssignmentResource) putRoles(ctx context.Context, providerName, ema
 		return fmt.Errorf("marshalling PUT body: %w", err)
 	}
 
-	_, err = r.client.Put(ctx, "/api/v2/role-assignments", body)
+	_, err = r.client.Put(ctx, "/api/terrapod/v1/role-assignments", body)
 	return err
 }
 
-// parseAssignmentList parses the GET /api/v2/role-assignments response.
+// parseAssignmentList parses the GET /api/terrapod/v1/role-assignments response.
 // The response has {"data": [{"type": "role-assignments", "attributes": {...}}, ...]}.
 func parseAssignmentList(data []byte) ([]assignmentData, error) {
 	var doc struct {

--- a/provider/internal/resources/user/resource.go
+++ b/provider/internal/resources/user/resource.go
@@ -4,10 +4,10 @@
 //
 //	JSON:API type: "users"
 //	ID: email (string, not a generated ID)
-//	Create:  POST   /api/v2/organizations/default/users
-//	Read:    GET    /api/v2/users/{email}
-//	Update:  PATCH  /api/v2/users/{email}
-//	Delete:  DELETE /api/v2/users/{email}
+//	Create:  POST   /api/terrapod/v1/users
+//	Read:    GET    /api/terrapod/v1/users/{email}
+//	Update:  PATCH  /api/terrapod/v1/users/{email}
+//	Delete:  DELETE /api/terrapod/v1/users/{email}
 //
 // Attribute mapping (JSON:API attribute -> Terraform schema attribute):
 //
@@ -162,7 +162,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	data, err := r.client.Post(ctx, "/api/v2/organizations/default/users", body)
+	data, err := r.client.Post(ctx, "/api/terrapod/v1/users", body)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create user", err.Error())
 		return
@@ -185,7 +185,7 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	data, err := r.client.Get(ctx, "/api/v2/users/"+state.ID.ValueString())
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/users/"+state.ID.ValueString())
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -230,7 +230,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	data, err := r.client.Patch(ctx, "/api/v2/users/"+state.ID.ValueString(), body)
+	data, err := r.client.Patch(ctx, "/api/terrapod/v1/users/"+state.ID.ValueString(), body)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update user", err.Error())
 		return
@@ -257,7 +257,7 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/v2/users/"+state.ID.ValueString())
+	err := r.client.Delete(ctx, "/api/terrapod/v1/users/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Failed to delete user", err.Error())
 	}

--- a/provider/internal/resources/vcs_connection/resource.go
+++ b/provider/internal/resources/vcs_connection/resource.go
@@ -4,9 +4,9 @@
 //
 //	JSON:API type: "vcs-connections"
 //	ID prefix: "vcs-"
-//	Create:  POST   /api/v2/organizations/default/vcs-connections
-//	Read:    GET    /api/v2/vcs-connections/{id}
-//	Delete:  DELETE /api/v2/vcs-connections/{id}
+//	Create:  POST   /api/terrapod/v1/vcs-connections
+//	Read:    GET    /api/terrapod/v1/vcs-connections/{id}
+//	Delete:  DELETE /api/terrapod/v1/vcs-connections/{id}
 //
 // This resource is immutable — there is no update (PATCH) endpoint.
 // Any attribute change forces replacement.
@@ -219,7 +219,7 @@ func (r *vcsConnectionResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	data, err := r.client.Post(ctx, "/api/v2/organizations/default/vcs-connections", body)
+	data, err := r.client.Post(ctx, "/api/terrapod/v1/vcs-connections", body)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create VCS connection", err.Error())
 		return
@@ -242,7 +242,7 @@ func (r *vcsConnectionResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	data, err := r.client.Get(ctx, "/api/v2/vcs-connections/"+state.ID.ValueString())
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/vcs-connections/"+state.ID.ValueString())
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -284,7 +284,7 @@ func (r *vcsConnectionResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/v2/vcs-connections/"+state.ID.ValueString())
+	err := r.client.Delete(ctx, "/api/terrapod/v1/vcs-connections/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Failed to delete VCS connection", err.Error())
 	}

--- a/scripts/pentest.sh
+++ b/scripts/pentest.sh
@@ -180,7 +180,7 @@ authenticate_admin() {
   # Step 1: Initiate authorize flow
   local authorize_response
   authorize_response=$(curl -sk -o /dev/null -w '%{redirect_url}' \
-    "${base_url}/api/v2/auth/authorize?provider=local&redirect_uri=http://127.0.0.1:19876/callback&code_challenge=${code_challenge}&code_challenge_method=S256&state=${state}&response_type=code" \
+    "${base_url}/api/terrapod/v1/auth/authorize?provider=local&redirect_uri=http://127.0.0.1:19876/callback&code_challenge=${code_challenge}&code_challenge_method=S256&state=${state}&response_type=code" \
     2>/dev/null)
 
   # Extract terrapod state from the redirect URL
@@ -200,7 +200,7 @@ authenticate_admin() {
     -X POST \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "email=admin&password=admin&state=${tp_state}" \
-    "${base_url}/api/v2/auth/local/login" \
+    "${base_url}/api/terrapod/v1/auth/local/login" \
     2>/dev/null)
 
   # Extract the auth code from the callback redirect
@@ -220,7 +220,7 @@ authenticate_admin() {
     -X POST \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "grant_type=authorization_code&code=${auth_code}&code_verifier=${code_verifier}" \
-    "${base_url}/api/v2/auth/token" \
+    "${base_url}/api/terrapod/v1/auth/token" \
     2>/dev/null)
 
   local session_token

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -377,6 +377,33 @@ def create_application() -> FastAPI:
 
         return response
 
+    # Deprecation-headers middleware. Stamps RFC 8594 Deprecation + Link
+    # headers on responses for routes flagged `deprecated=True` in the
+    # OpenAPI schema, plus a custom X-Removed-In header naming the version
+    # that drops the alias (RFC 8594's Sunset wants an HTTP-date which
+    # we'd rather not commit to for a release-train product).
+    #
+    # Also emits a structlog warning per legacy-path request so operators
+    # can grep their logs for any client still pointed at the old paths
+    # before the v0.24.0 cutover (see issues #269 + #278).
+    @app.middleware("http")
+    async def deprecation_headers(request: Request, call_next):  # type: ignore[no-untyped-def]
+        response = await call_next(request)
+        route = request.scope.get("route")
+        if route is not None and getattr(route, "deprecated", False):
+            response.headers["Deprecation"] = "true"
+            response.headers["Link"] = (
+                '<https://github.com/mattrobinsonsre/terrapod/issues/278>; rel="deprecation"'
+            )
+            response.headers["X-Removed-In"] = "v0.24.0"
+            logger.warning(
+                "Deprecated API path used",
+                path=request.url.path,
+                method=request.method,
+                user_agent=request.headers.get("user-agent", ""),
+            )
+        return response
+
     # Audit logging middleware
     @app.middleware("http")
     async def audit_logging(request: Request, call_next):  # type: ignore[no-untyped-def]
@@ -433,57 +460,184 @@ def create_application() -> FastAPI:
             content={"detail": "Internal server error"},
         )
 
+    # ── API prefix conventions ──────────────────────────────────────
+    #
+    # Terrapod has two distinct API namespaces:
+    #
+    # * `/api/v2/` — TFE V2 compatibility surface only. Paths must match
+    #   the official HCP Terraform / TFE V2 spec so go-tfe / terraform CLI
+    #   work unchanged. Permanent home; never deprecated wholesale.
+    #
+    # * `/api/terrapod/v1/` — Terrapod-specific extensions (admin,
+    #   labels, roles, audit, listener protocol, runner artifacts, auth
+    #   sessions, etc.). All Terrapod-only endpoints live here from
+    #   v0.23.0 onward.
+    #
+    # During the v0.23.x deprecation window every Terrapod-only route is
+    # ALSO registered at its original `/api/v2/` location with FastAPI's
+    # `deprecated=True` flag — this lets v0.X-1 listeners/runners/the
+    # provider still hit a v0.X API while operators stagger upgrades.
+    # The legacy mounts get dropped in v0.24.0 (see #278). Internal code
+    # always targets the canonical `/api/terrapod/v1/` path.
+    TERRAPOD_PREFIX = "/api/terrapod/v1"
+    TFE_PREFIX = settings.api_prefix  # "/api/v2"
+
+    def include_with_org_legacy(router) -> None:
+        """Register a Terrapod-native router that pre-v0.23 lived under
+        `/api/v2/organizations/default/{resource}`.
+
+        Two mounts:
+        - Canonical: `/api/terrapod/v1/{resource}` (no
+          `organizations/default/` — see CLAUDE.md rule #9 and
+          `docs/tfe-cli-surface.md`).
+        - Legacy alias: `/api/v2/organizations/default/{resource}`
+          (the pre-v0.23 path, kept for v0.22.x callers).
+
+        We deliberately do NOT register a `/api/v2/{resource}` alias —
+        that shape was never published, isn't a TFE-V2 shape, and isn't
+        something we want to preserve. The router's own `prefix=` and
+        each route's path stack on these prefixes as usual.
+
+        Legacy mount is hidden from OpenAPI and emits Deprecation
+        headers via the middleware. Removed in v0.24.0 (#278).
+        """
+        app.include_router(router, prefix=TERRAPOD_PREFIX)
+        app.include_router(
+            router,
+            prefix="/api/v2/organizations/default",
+            deprecated=True,
+            include_in_schema=False,
+        )
+
+    def include_moved(router, legacy_prefix: str = TFE_PREFIX) -> None:
+        """Register a router under both the canonical Terrapod prefix and
+        a legacy alias.
+
+        `legacy_prefix` defaults to `/api/v2/` since that's where every
+        TFE-V2-shaped route used to live; pass a different prefix for
+        routes that historically used a non-`/api/v2/` path (e.g. GPG
+        keys lived at `/api/registry/private/v2/`).
+
+        The legacy mount is `deprecated=True` (so the middleware emits
+        Deprecation/Link/X-Removed-In response headers + a structlog
+        warning per legacy-path request) AND `include_in_schema=False`
+        so the alias paths are hidden from OpenAPI / Swagger UI / ReDoc /
+        generated clients. The canonical `/api/terrapod/v1/...` paths
+        are the only ones documented; the alias is a transitional
+        compatibility-only mount.
+
+        Any prefix on the router itself stacks (e.g. audit's own
+        `prefix="/admin"` becomes `/api/terrapod/v1/admin/...` and
+        `/api/v2/admin/...`).
+        """
+        app.include_router(router, prefix=TERRAPOD_PREFIX)
+        app.include_router(
+            router,
+            prefix=legacy_prefix,
+            deprecated=True,
+            include_in_schema=False,
+        )
+
     # Health endpoints (no prefix)
     app.include_router(health_router)
 
-    # Filesystem storage routes (presigned URL handlers)
+    # Filesystem storage routes (presigned URL handlers) — Terrapod-only
+    # dev backend. Dual-mounted: filesystem.py emits canonical
+    # /api/terrapod/v1 URLs for new presigns; the /api/v2 alias keeps
+    # any URLs already in flight (or generated by older replicas during
+    # rollout) resolvable until v0.24.0 (#278).
     from terrapod.storage.filesystem_routes import router as fs_router
 
-    app.include_router(fs_router, prefix=settings.api_prefix)
+    include_moved(fs_router)
 
-    # Auth routes
+    # Auth routes — Terrapod-specific session/SSO management.
     from terrapod.api.routers.auth import router as auth_router
 
-    app.include_router(auth_router, prefix=settings.api_prefix)
+    include_moved(auth_router)
 
-    # OAuth2 routes (terraform login flow)
-    from terrapod.api.routers.oauth import router as oauth_router
+    # OAuth2 routes (terraform login flow). The OAuth + service-discovery
+    # paths stay at their canonical locations (/.well-known/terraform.json,
+    # /oauth/*) — those are external standards, not Terrapod-versioned.
+    # The Terrapod-only cli-login-status check moves to /api/terrapod/v1.
+    from terrapod.api.routers.oauth import (
+        extensions_router as oauth_extensions_router,
+    )
+    from terrapod.api.routers.oauth import (
+        router as oauth_router,
+    )
 
     app.include_router(oauth_router)
+    include_moved(oauth_extensions_router)
 
-    # Workspace extension routes (SSE, vcs-refs — must come before tfe_v2
-    # so /workspace-events is not matched as a workspace_id parameter)
+    # Workspace extension routes (SSE, vcs-refs) — Terrapod-specific.
+    # MUST come before tfe_v2 so /workspace-events isn't matched as a
+    # workspace_id parameter on either prefix.
     from terrapod.api.routers.workspace_extensions import router as workspace_extensions_router
 
-    app.include_router(workspace_extensions_router)
+    include_moved(workspace_extensions_router)
 
-    # TFE V2 compatibility routes
-    from terrapod.api.routers.tfe_v2 import router as tfe_v2_router
+    # TFE V2 CLI-contract routes — the verified subset of the TFE V2 spec
+    # that terraform/tofu/tfci consume (see docs/tfe-cli-surface.md).
+    # The one workspace-management path the CLI doesn't call (DELETE by
+    # id) lives in extensions_router and dual-mounts under /api/terrapod/v1.
+    from terrapod.api.routers.tfe_v2 import (
+        extensions_router as tfe_v2_extensions_router,
+    )
+    from terrapod.api.routers.tfe_v2 import (
+        router as tfe_v2_router,
+    )
 
     app.include_router(tfe_v2_router)
+    include_moved(tfe_v2_extensions_router)
 
-    # State management routes (Terrapod-specific: delete, rollback, upload)
+    # State management routes — Terrapod-specific (delete, rollback, upload).
     from terrapod.api.routers.state_management import router as state_management_router
 
-    app.include_router(state_management_router)
+    include_moved(state_management_router)
 
-    # Token CRUD routes
+    # Token CRUD routes — Terrapod-native management surface (the CLI
+    # creates tokens via the /oauth flow, never via these endpoints).
     from terrapod.api.routers.tokens import router as tokens_router
 
-    app.include_router(tokens_router)
+    include_moved(tokens_router)
 
-    # Registry routes (modules, providers, GPG keys)
-    from terrapod.api.routers.registry_modules import router as registry_modules_router
+    # Registry routes — module CLI download protocol stays at /api/v2 (the
+    # CLI hits this on `terraform init`). Module management (org-scoped CRUD
+    # on private modules + version + /vcs) and workspace-links are
+    # Terrapod-native and dual-mount under /api/terrapod/v1.
+    from terrapod.api.routers.registry_modules import (
+        management_router as registry_modules_management_router,
+    )
+    from terrapod.api.routers.registry_modules import (
+        router as registry_modules_router,
+    )
+    from terrapod.api.routers.registry_modules import (
+        workspace_links_router as module_workspace_links_router,
+    )
 
     app.include_router(registry_modules_router)
+    include_with_org_legacy(registry_modules_management_router)
+    include_with_org_legacy(module_workspace_links_router)
 
-    from terrapod.api.routers.registry_providers import router as registry_providers_router
+    # Provider registry — CLI download protocol stays at /api/v2; org-scoped
+    # management dual-mounts under /api/terrapod/v1.
+    from terrapod.api.routers.registry_providers import (
+        management_router as registry_providers_management_router,
+    )
+    from terrapod.api.routers.registry_providers import (
+        router as registry_providers_router,
+    )
 
     app.include_router(registry_providers_router)
+    include_with_org_legacy(registry_providers_management_router)
 
+    # GPG keys — Terrapod-native (the CLI reads provider GPG keys from the
+    # provider download response, not via this admin endpoint). Canonical
+    # under /api/terrapod/v1; the historical TFE path /api/registry/private/v2
+    # is dual-mounted as the deprecated alias.
     from terrapod.api.routers.gpg_keys import router as gpg_keys_router
 
-    app.include_router(gpg_keys_router)
+    include_moved(gpg_keys_router, legacy_prefix="/api/registry/private/v2")
 
     # Caching routes (provider mirror, binary cache)
     from terrapod.api.routers.provider_mirror import router as provider_mirror_router
@@ -492,84 +646,156 @@ def create_application() -> FastAPI:
 
     from terrapod.api.routers.binary_cache import router as binary_cache_router
 
-    app.include_router(binary_cache_router)
+    include_moved(binary_cache_router)
 
     # Variable endpoints
     from terrapod.api.routers.variables import router as variables_router
 
     app.include_router(variables_router)
 
-    # Agent pool endpoints
-    from terrapod.api.routers.agent_pools import router as agent_pools_router
+    # Agent pool endpoints — Terrapod-native management (pool CRUD,
+    # token CRUD, listener-protocol). The CLI never manages pools, so
+    # canonical paths drop the /organizations/default/ segment (Terrapod
+    # is single-org — see CLAUDE.md rule #9). Pre-v0.23 path shapes are
+    # preserved as deprecated aliases via legacy_router (mounted only on
+    # /api/v2).
+    from terrapod.api.routers.agent_pools import (
+        legacy_router as agent_pools_legacy_router,
+    )
+    from terrapod.api.routers.agent_pools import (
+        listener_router as listener_protocol_router,
+    )
+    from terrapod.api.routers.agent_pools import (
+        router as agent_pools_router,
+    )
 
-    app.include_router(agent_pools_router)
+    app.include_router(agent_pools_router, prefix=TERRAPOD_PREFIX)
+    app.include_router(
+        agent_pools_legacy_router,
+        prefix=TFE_PREFIX,
+        deprecated=True,
+        include_in_schema=False,
+    )
+    include_moved(listener_protocol_router)
 
-    # Read-only labels browser (cross-entity: workspaces, pools, modules, providers)
+    # Read-only labels browser (cross-entity: workspaces, pools, modules, providers).
     from terrapod.api.routers.labels import router as labels_router
 
-    app.include_router(labels_router)
+    include_moved(labels_router)
 
-    # Run endpoints
-    from terrapod.api.routers.runs import router as runs_router
+    # Run endpoints — TFE-spec stays at /api/v2; Terrapod-only extensions
+    # (listener protocol, runner-driven completion, SSE streams, retry)
+    # move to /api/terrapod/v1 with a deprecated /api/v2 alias.
+    from terrapod.api.routers.runs import (
+        extensions_router as runs_extensions_router,
+    )
+    from terrapod.api.routers.runs import (
+        router as runs_router,
+    )
 
     app.include_router(runs_router)
+    include_moved(runs_extensions_router)
 
-    # Run artifact endpoints (runner token auth)
+    # Run artifact endpoints (runner token auth) — Terrapod runner protocol.
     from terrapod.api.routers.run_artifacts import router as run_artifacts_router
 
-    app.include_router(run_artifacts_router)
+    include_moved(run_artifacts_router)
 
-    # Configuration version endpoints
-    from terrapod.api.routers.config_versions import router as config_versions_router
+    # Configuration version endpoints — TFE-spec stays at /api/v2; the
+    # Terrapod download/diff/ticket extensions move to /api/terrapod/v1.
+    from terrapod.api.routers.config_versions import (
+        extensions_router as config_version_extensions_router,
+    )
+    from terrapod.api.routers.config_versions import (
+        router as config_versions_router,
+    )
 
     app.include_router(config_versions_router)
+    include_moved(config_version_extensions_router)
 
-    # VCS connection endpoints
-    from terrapod.api.routers.vcs_connections import router as vcs_connections_router
+    # VCS connection endpoints — Terrapod-native. Canonical paths at
+    # /api/terrapod/v1/vcs-connections{,/{id}}; legacy_router preserves
+    # the pre-v0.23 list/create at /api/v2/organizations/default/vcs-connections
+    # and by-id at /api/v2/vcs-connections/{id}.
+    from terrapod.api.routers.vcs_connections import (
+        legacy_router as vcs_connections_legacy_router,
+    )
+    from terrapod.api.routers.vcs_connections import (
+        router as vcs_connections_router,
+    )
 
-    app.include_router(vcs_connections_router)
+    app.include_router(vcs_connections_router, prefix=TERRAPOD_PREFIX)
+    app.include_router(
+        vcs_connections_legacy_router,
+        prefix=TFE_PREFIX,
+        deprecated=True,
+        include_in_schema=False,
+    )
 
-    # VCS webhook event receiver
+    # VCS webhook event receiver — Terrapod-specific.
     from terrapod.api.routers.vcs_events import router as vcs_events_router
 
-    app.include_router(vcs_events_router)
+    include_moved(vcs_events_router)
 
-    # Role CRUD
+    # Role CRUD — Terrapod-specific RBAC.
     from terrapod.api.routers.roles import router as roles_router
 
-    app.include_router(roles_router)
+    include_moved(roles_router)
 
-    # Role assignment management
+    # Role assignment management — Terrapod-specific RBAC.
     from terrapod.api.routers.role_assignments import router as role_assignments_router
 
-    app.include_router(role_assignments_router)
+    include_moved(role_assignments_router)
 
-    # Run trigger endpoints
+    # Run trigger endpoints — Terrapod-native management (CLI doesn't use).
     from terrapod.api.routers.run_triggers import router as run_triggers_router
 
-    app.include_router(run_triggers_router)
+    include_moved(run_triggers_router)
 
-    # Audit log query endpoint
+    # Audit log query endpoint — Terrapod-specific.
     from terrapod.api.routers.audit import router as audit_router
 
-    app.include_router(audit_router)
+    include_moved(audit_router)
 
-    # User management endpoints
-    from terrapod.api.routers.users import router as users_router
+    # User management endpoints — Terrapod-native. Canonical paths at
+    # /api/terrapod/v1/users{,/{email}}; legacy_router preserves
+    # pre-v0.23 list/create at /api/v2/organizations/default/users and
+    # by-email at /api/v2/users/{email}.
+    from terrapod.api.routers.users import (
+        legacy_router as users_legacy_router,
+    )
+    from terrapod.api.routers.users import (
+        router as users_router,
+    )
 
-    app.include_router(users_router)
+    app.include_router(users_router, prefix=TERRAPOD_PREFIX)
+    app.include_router(
+        users_legacy_router,
+        prefix=TFE_PREFIX,
+        deprecated=True,
+        include_in_schema=False,
+    )
 
-    # Notification configuration endpoints
+    # Notification configuration endpoints — Terrapod-native management.
     from terrapod.api.routers.notification_configurations import (
         router as notification_configurations_router,
     )
 
-    app.include_router(notification_configurations_router)
+    include_moved(notification_configurations_router)
 
-    # Run task endpoints
-    from terrapod.api.routers.run_tasks import router as run_tasks_router
+    # Run task endpoints — task-stages (read + override) stay at /api/v2
+    # because the CLI's cloud backend reads them on every run; everything
+    # else (workspace-scoped task definition CRUD + callback receiver) is
+    # Terrapod-native and dual-mounts under /api/terrapod/v1.
+    from terrapod.api.routers.run_tasks import (
+        extensions_router as run_tasks_extensions_router,
+    )
+    from terrapod.api.routers.run_tasks import (
+        router as run_tasks_router,
+    )
 
     app.include_router(run_tasks_router)
+    include_moved(run_tasks_extensions_router)
 
     return app
 

--- a/services/terrapod/api/rate_limit.py
+++ b/services/terrapod/api/rate_limit.py
@@ -19,8 +19,10 @@ logger = get_logger(__name__)
 # Paths exempt from rate limiting
 _EXEMPT_PATHS = frozenset({"/health", "/ready", "/metrics"})
 
-# Auth endpoint prefixes (lower rate limit)
-_AUTH_PREFIXES = ("/api/v2/auth/", "/oauth/")
+# Auth endpoint prefixes (lower rate limit). Both the canonical
+# /api/terrapod/v1/auth/* and the deprecated /api/v2/auth/* aliases are
+# covered until the legacy paths are removed in v0.24.0 (see #278).
+_AUTH_PREFIXES = ("/api/terrapod/v1/auth/", "/api/v2/auth/", "/oauth/")
 
 
 def _is_auth_path(path: str) -> bool:
@@ -52,7 +54,7 @@ class RateLimitMiddleware:
       Interactive users and API-token automation rarely approach this, but
       it stops one noisy client taking the pool.
     - Unauthenticated: base limit (`requests_per_minute`).
-    - Auth endpoints (`/api/v2/auth/*`, `/oauth/*`): always `auth_requests_per_minute`
+    - Auth endpoints (`/api/terrapod/v1/auth/*`, `/api/v2/auth/*`, `/oauth/*`): always `auth_requests_per_minute`
       regardless of who's calling — brute-force defence on login.
     """
 

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -7,16 +7,16 @@ UX CONTRACT: Pool/token/listener endpoints are consumed by the web frontend:
   matched by corresponding updates to those frontend pages.
 
 Endpoints:
-    GET/POST   /api/v2/organizations/default/agent-pools
-    GET/PATCH/DELETE /api/v2/agent-pools/{pool_id}
-    POST/GET   /api/v2/agent-pools/{pool_id}/tokens
-    DELETE     /api/v2/agent-pools/{pool_id}/tokens/{token_id}
-    GET        /api/v2/agent-pools/{pool_id}/listeners
-    POST       /api/v2/agent-pools/{pool_id}/listeners/join
-    GET        /api/v2/listeners/{id}/events                   (SSE channel)
-    POST       /api/v2/listeners/{id}/heartbeat
-    POST       /api/v2/listeners/{id}/renew
-    DELETE     /api/v2/listeners/{id}
+    GET/POST   /api/terrapod/v1/agent-pools
+    GET/PATCH/DELETE /api/terrapod/v1/agent-pools/{pool_id}
+    POST/GET   /api/terrapod/v1/agent-pools/{pool_id}/tokens
+    DELETE     /api/terrapod/v1/agent-pools/{pool_id}/tokens/{token_id}
+    GET        /api/terrapod/v1/agent-pools/{pool_id}/listeners
+    POST       /api/terrapod/v1/agent-pools/{pool_id}/listeners/join
+    GET        /api/terrapod/v1/listeners/{id}/events                   (SSE channel)
+    POST       /api/terrapod/v1/listeners/{id}/heartbeat
+    POST       /api/terrapod/v1/listeners/{id}/renew
+    DELETE     /api/terrapod/v1/listeners/{id}
 """
 
 import asyncio
@@ -49,7 +49,12 @@ from terrapod.services.pool_rbac_service import (
     resolve_pool_permission,
 )
 
-router = APIRouter(prefix="/api/v2", tags=["agent-pools"])
+router = APIRouter(tags=["agent-pools"])
+
+# Listener protocol — Terrapod-specific listener join/heartbeat/cert
+# renewal/SSE/admin. Dual-mounted under /api/terrapod/v1 (canonical) and
+# /api/v2 (deprecated, removed in v0.24.0 — see #278).
+listener_router = APIRouter(tags=["listener-protocol"])
 logger = get_logger(__name__)
 
 
@@ -250,7 +255,7 @@ async def _require_pool_permission(
 # ── Agent Pools ──────────────────────────────────────────────────────────
 
 
-@router.get("/organizations/default/agent-pools")
+@router.get("/agent-pools")
 async def list_pools(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -282,7 +287,7 @@ async def list_pools(
     return JSONResponse(content={"data": result})
 
 
-@router.post("/organizations/default/agent-pools", status_code=201)
+@router.post("/agent-pools", status_code=201)
 async def create_pool(
     body: dict = Body(...),
     user: AuthenticatedUser = Depends(require_admin),
@@ -490,7 +495,7 @@ async def delete_pool_token(
 # ── Listener Join ────────────────────────────────────────────────────────
 
 
-@router.post("/agent-pools/{pool_id}/listeners/join", status_code=201)
+@listener_router.post("/agent-pools/{pool_id}/listeners/join", status_code=201)
 async def join_listener(
     pool_id: str = Path(...),
     body: dict = Body(...),
@@ -532,7 +537,7 @@ async def join_listener(
     return JSONResponse(content={"data": result}, status_code=201)
 
 
-@router.post("/agent-pools/join", status_code=201)
+@listener_router.post("/agent-pools/join", status_code=201)
 async def join_listener_by_token(
     body: dict = Body(...),
     db: AsyncSession = Depends(get_db),
@@ -577,7 +582,7 @@ async def join_listener_by_token(
 # ── Listeners ────────────────────────────────────────────────────────────
 
 
-@router.get("/agent-pools/{pool_id}/listeners")
+@listener_router.get("/agent-pools/{pool_id}/listeners")
 async def list_pool_listeners(
     pool_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -619,7 +624,7 @@ async def list_pool_listeners(
     )
 
 
-@router.get("/agent-pools/{pool_id}/events")
+@listener_router.get("/agent-pools/{pool_id}/events")
 async def pool_events(
     request: Request,
     pool_id: str = Path(...),
@@ -668,7 +673,7 @@ async def pool_events(
     return EventSourceResponse(event_generator())
 
 
-@router.delete("/listeners/{listener_id}", status_code=204)
+@listener_router.delete("/listeners/{listener_id}", status_code=204)
 async def delete_listener(
     listener_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -699,7 +704,7 @@ async def delete_listener(
 # ── SSE Event Channel ────────────────────────────────────────────────────
 
 
-@router.get("/listeners/{listener_id}/events")
+@listener_router.get("/listeners/{listener_id}/events")
 async def listener_events(
     request: Request,
     listener_id: str = Path(...),
@@ -747,7 +752,7 @@ async def listener_events(
 # ── Heartbeat & Renewal ─────────────────────────────────────────────────
 
 
-@router.post("/listeners/{listener_id}/heartbeat")
+@listener_router.post("/listeners/{listener_id}/heartbeat")
 async def listener_heartbeat(
     listener_id: str = Path(...),
     body: dict = Body(...),
@@ -810,7 +815,7 @@ async def listener_heartbeat(
     return JSONResponse(content={"status": "ok"})
 
 
-@router.post("/listeners/{listener_id}/renew")
+@listener_router.post("/listeners/{listener_id}/renew")
 async def renew_listener_cert(
     listener_id: str = Path(...),
     identity: ListenerIdentity = Depends(get_listener_identity),
@@ -846,3 +851,31 @@ async def renew_listener_cert(
     )
 
     return JSONResponse(content={"data": result})
+
+
+# ── Legacy alias router (v0.22 → v0.24 deprecation window) ─────────────
+# Mounted only at /api/v2 by app.py with deprecated=True and
+# include_in_schema=False. Pre-v0.23 path shapes:
+#   - list/create: /api/v2/organizations/default/agent-pools
+#   - by-id, tokens: /api/v2/agent-pools/{pool_id}[/tokens[/{token_id}]]
+# Removed in v0.24.0 (#278).
+legacy_router = APIRouter(tags=["agent-pools-legacy"])
+legacy_router.add_api_route("/organizations/default/agent-pools", list_pools, methods=["GET"])
+legacy_router.add_api_route(
+    "/organizations/default/agent-pools", create_pool, methods=["POST"], status_code=201
+)
+legacy_router.add_api_route("/agent-pools/{pool_id}", show_pool, methods=["GET"])
+legacy_router.add_api_route("/agent-pools/{pool_id}", update_pool, methods=["PATCH"])
+legacy_router.add_api_route(
+    "/agent-pools/{pool_id}", delete_pool, methods=["DELETE"], status_code=204
+)
+legacy_router.add_api_route("/agent-pools/{pool_id}/tokens", list_pool_tokens, methods=["GET"])
+legacy_router.add_api_route(
+    "/agent-pools/{pool_id}/tokens", create_pool_token, methods=["POST"], status_code=201
+)
+legacy_router.add_api_route(
+    "/agent-pools/{pool_id}/tokens/{token_id}",
+    delete_pool_token,
+    methods=["DELETE"],
+    status_code=204,
+)

--- a/services/terrapod/api/routers/audit.py
+++ b/services/terrapod/api/routers/audit.py
@@ -15,7 +15,7 @@ from terrapod.api.dependencies import AuthenticatedUser, require_admin_or_audit
 from terrapod.db.session import get_db
 from terrapod.services.audit_service import query_audit_log
 
-router = APIRouter(prefix="/api/v2/admin", tags=["audit"])
+router = APIRouter(prefix="/admin", tags=["audit"])
 
 
 def _format_timestamp(dt: datetime) -> str:

--- a/services/terrapod/api/routers/auth.py
+++ b/services/terrapod/api/routers/auth.py
@@ -12,13 +12,13 @@ UX CONTRACT: Auth endpoints are consumed by the web frontend:
 
 Consumers:
     Web UI:
-        GET  /api/v2/auth/providers         — login page provider list
-        POST /api/v2/auth/local/authorize   — direct JSON login (no redirect)
-        POST /api/v2/auth/token             — exchange code for session
-        POST /api/v2/auth/logout            — revoke current session
-        GET  /api/v2/auth/sessions          — sessions management page
-        GET  /api/v2/auth/sessions/all      — admin sessions view
-        DELETE /api/v2/auth/sessions/user/{email} — admin revoke
+        GET  /api/terrapod/v1/auth/providers         — login page provider list
+        POST /api/terrapod/v1/auth/local/authorize   — direct JSON login (no redirect)
+        POST /api/terrapod/v1/auth/token             — exchange code for session
+        POST /api/terrapod/v1/auth/logout            — revoke current session
+        GET  /api/terrapod/v1/auth/sessions          — sessions management page
+        GET  /api/terrapod/v1/auth/sessions/all      — admin sessions view
+        DELETE /api/terrapod/v1/auth/sessions/user/{email} — admin revoke
 """
 
 import base64

--- a/services/terrapod/api/routers/binary_cache.py
+++ b/services/terrapod/api/routers/binary_cache.py
@@ -12,12 +12,12 @@ UX CONTRACT: Admin cache endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    GET    /api/v2/binary-cache/{tool}/{version}/{os}/{arch}                        — download (redirect)
-    GET    /api/v2/admin/binary-cache                                                — list cached binaries
-    POST   /api/v2/admin/binary-cache/warm                                           — pre-warm binary
-    DELETE /api/v2/admin/binary-cache/{tool}/{version}                               — purge binary
-    GET    /api/v2/admin/provider-cache                                              — list cached providers
-    DELETE /api/v2/admin/provider-cache/{hostname}/{namespace}/{type}/{version}      — purge provider
+    GET    /api/terrapod/v1/binary-cache/{tool}/{version}/{os}/{arch}                        — download (redirect)
+    GET    /api/terrapod/v1/admin/binary-cache                                                — list cached binaries
+    POST   /api/terrapod/v1/admin/binary-cache/warm                                           — pre-warm binary
+    DELETE /api/terrapod/v1/admin/binary-cache/{tool}/{version}                               — purge binary
+    GET    /api/terrapod/v1/admin/provider-cache                                              — list cached providers
+    DELETE /api/terrapod/v1/admin/provider-cache/{hostname}/{namespace}/{type}/{version}      — purge provider
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -58,7 +58,7 @@ class WarmBinaryRequest(BaseModel):
 # --- Version suggestions ---
 
 
-@router.get("/api/v2/binary-cache/versions")
+@router.get("/binary-cache/versions")
 async def available_versions(
     tool: str = "tofu",
     user: AuthenticatedUser = Depends(get_current_user),
@@ -85,7 +85,7 @@ async def available_versions(
 # --- Runner-facing endpoint ---
 
 
-@router.get("/api/v2/binary-cache/{tool}/{version}/{os}/{arch}")
+@router.get("/binary-cache/{tool}/{version}/{os}/{arch}")
 async def download_binary(
     tool: str,
     version: str,
@@ -133,7 +133,7 @@ async def download_binary(
 # --- Admin endpoints ---
 
 
-@router.get("/api/v2/admin/binary-cache")
+@router.get("/admin/binary-cache")
 async def list_cached_binaries_endpoint(
     tool: str | None = None,
     user: AuthenticatedUser = Depends(require_admin),
@@ -163,7 +163,7 @@ async def list_cached_binaries_endpoint(
     )
 
 
-@router.post("/api/v2/admin/binary-cache/warm")
+@router.post("/admin/binary-cache/warm")
 async def warm_binary_endpoint(
     body: WarmBinaryRequest,
     user: AuthenticatedUser = Depends(require_admin),
@@ -194,7 +194,7 @@ async def warm_binary_endpoint(
     )
 
 
-@router.delete("/api/v2/admin/binary-cache/{tool}/{version}")
+@router.delete("/admin/binary-cache/{tool}/{version}")
 async def purge_binary_endpoint(
     tool: str,
     version: str,
@@ -213,7 +213,7 @@ async def purge_binary_endpoint(
 # --- Provider cache admin endpoints ---
 
 
-@router.get("/api/v2/admin/provider-cache")
+@router.get("/admin/provider-cache")
 async def list_cached_providers_endpoint(
     hostname: str | None = None,
     user: AuthenticatedUser = Depends(require_admin),
@@ -244,7 +244,7 @@ async def list_cached_providers_endpoint(
     )
 
 
-@router.delete("/api/v2/admin/provider-cache/{hostname}/{namespace}/{type}/{version}")
+@router.delete("/admin/provider-cache/{hostname}/{namespace}/{type}/{version}")
 async def purge_provider_endpoint(
     hostname: str,
     namespace: str,

--- a/services/terrapod/api/routers/config_versions.py
+++ b/services/terrapod/api/routers/config_versions.py
@@ -12,10 +12,10 @@ Endpoints:
     POST   /api/v2/workspaces/{id}/configuration-versions
     GET    /api/v2/workspaces/{id}/configuration-versions   (list, paginated)
     GET    /api/v2/configuration-versions/{cv_id}
-    GET    /api/v2/configuration-versions/{cv_id}/download  (tarball bytes)
-    POST   /api/v2/configuration-versions/{cv_id}/download-ticket
-    GET    /api/v2/configuration-versions/download-by-ticket/{ticket}
-    POST   /api/v2/configuration-versions/diff              (compare two CVs)
+    GET    /api/terrapod/v1/configuration-versions/{cv_id}/download  (tarball bytes)
+    POST   /api/terrapod/v1/configuration-versions/{cv_id}/download-ticket
+    GET    /api/terrapod/v1/configuration-versions/download-by-ticket/{ticket}
+    POST   /api/terrapod/v1/configuration-versions/diff              (compare two CVs)
     PUT    /api/v2/configuration-versions/{cv_id}/upload    (tarball upload, no auth)
 """
 
@@ -40,6 +40,13 @@ from terrapod.storage.keys import config_version_key
 from terrapod.storage.protocol import ObjectNotFoundError
 
 router = APIRouter(prefix="/api/v2", tags=["configuration-versions"])
+
+# Terrapod-only extensions on the configuration-versions surface
+# (download, download-ticket, download-by-ticket, diff). Dual-mounted
+# under /api/terrapod/v1 (canonical) and /api/v2 (deprecated, removed
+# in v0.24.0 — see #278).
+extensions_router = APIRouter(tags=["configuration-version-extensions"])
+
 logger = get_logger(__name__)
 
 # TFE convention. CV lists can include the run that consumed them; we
@@ -203,7 +210,7 @@ async def list_configuration_versions(
     )
 
 
-@router.get("/configuration-versions/{cv_id}/download")
+@extensions_router.get("/configuration-versions/{cv_id}/download")
 async def download_configuration_version(
     cv_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -259,7 +266,7 @@ async def download_configuration_version(
     )
 
 
-@router.post("/configuration-versions/{cv_id}/download-ticket")
+@extensions_router.post("/configuration-versions/{cv_id}/download-ticket")
 async def mint_download_ticket(
     cv_id: str = Path(...),
     body: dict | None = Body(default=None),
@@ -324,7 +331,7 @@ async def mint_download_ticket(
                 "type": "download-tickets",
                 "attributes": {
                     "ticket": ticket,
-                    "url": f"/api/v2/configuration-versions/download-by-ticket/{ticket}",
+                    "url": f"/api/terrapod/v1/configuration-versions/download-by-ticket/{ticket}",
                     "expires-at": expires_iso,
                 },
             }
@@ -332,7 +339,7 @@ async def mint_download_ticket(
     )
 
 
-@router.get("/configuration-versions/download-by-ticket/{ticket}")
+@extensions_router.get("/configuration-versions/download-by-ticket/{ticket}")
 async def download_by_ticket(
     ticket: str = Path(...),
     db: AsyncSession = Depends(get_db),
@@ -388,7 +395,7 @@ async def download_by_ticket(
     )
 
 
-@router.post("/configuration-versions/diff")
+@extensions_router.post("/configuration-versions/diff")
 async def diff_configuration_versions(
     body: dict = Body(...),
     user: AuthenticatedUser = Depends(get_current_user),

--- a/services/terrapod/api/routers/gpg_keys.py
+++ b/services/terrapod/api/routers/gpg_keys.py
@@ -1,12 +1,18 @@
 """GPG key management endpoints for provider signing.
 
-TFE uses the path prefix /api/registry/private/v2/gpg-keys.
+The CLI doesn't talk to these — `terraform init` reads provider GPG
+public keys from the provider download response, not from a separate
+admin endpoint. They're Terrapod-native management surface and live at
+`/api/terrapod/v1/gpg-keys`.
 
-Endpoints:
-    POST   /api/registry/private/v2/gpg-keys              — create
-    GET    /api/registry/private/v2/gpg-keys               — list
-    GET    /api/registry/private/v2/gpg-keys/{key_id}      — show
-    DELETE /api/registry/private/v2/gpg-keys/{key_id}      — delete
+The historical TFE path was `/api/registry/private/v2/gpg-keys`. That
+form is dual-mounted as a deprecated alias until v0.24.0 (see #278).
+
+Endpoints (canonical):
+    POST   /api/terrapod/v1/gpg-keys              — create
+    GET    /api/terrapod/v1/gpg-keys               — list
+    GET    /api/terrapod/v1/gpg-keys/{key_id}      — show
+    DELETE /api/terrapod/v1/gpg-keys/{key_id}      — delete
 """
 
 import uuid
@@ -69,7 +75,7 @@ def _gpg_key_to_jsonapi(key) -> dict:  # type: ignore[no-untyped-def]
 # --- Endpoints ---
 
 
-@router.post("/api/registry/private/v2/gpg-keys")
+@router.post("/gpg-keys")
 async def create_gpg_key_endpoint(
     body: CreateGPGKeyRequest,
     user: AuthenticatedUser = Depends(get_current_user),
@@ -98,7 +104,7 @@ async def create_gpg_key_endpoint(
     )
 
 
-@router.get("/api/registry/private/v2/gpg-keys")
+@router.get("/gpg-keys")
 async def list_gpg_keys_endpoint(
     filter_namespace: str | None = Query(None, alias="filter[namespace]"),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -111,7 +117,7 @@ async def list_gpg_keys_endpoint(
     )
 
 
-@router.get("/api/registry/private/v2/gpg-keys/{key_id}")
+@router.get("/gpg-keys/{key_id}")
 async def show_gpg_key_endpoint(
     key_id: str,
     user: AuthenticatedUser = Depends(get_current_user),
@@ -130,7 +136,7 @@ async def show_gpg_key_endpoint(
     return JSONResponse(content={"data": _gpg_key_to_jsonapi(key)})
 
 
-@router.delete("/api/registry/private/v2/gpg-keys/{key_id}")
+@router.delete("/gpg-keys/{key_id}")
 async def delete_gpg_key_endpoint(
     key_id: str,
     user: AuthenticatedUser = Depends(get_current_user),

--- a/services/terrapod/api/routers/labels.py
+++ b/services/terrapod/api/routers/labels.py
@@ -4,9 +4,9 @@ UX CONTRACT: consumed by `web/src/app/labels/page.tsx`. Changes to
 response shapes here MUST be matched by frontend updates.
 
 Endpoints:
-    GET /api/v2/labels                       — distinct keys + per-type counts
-    GET /api/v2/labels/{key}                 — distinct values for a key
-    GET /api/v2/labels/{key}/{value}         — entities tagged with key=value
+    GET /api/terrapod/v1/labels                       — distinct keys + per-type counts
+    GET /api/terrapod/v1/labels/{key}                 — distinct values for a key
+    GET /api/terrapod/v1/labels/{key}/{value}         — entities tagged with key=value
 
 All three are RBAC-filtered: results only include labels carried by
 entities the caller has at least `read` on for that entity's
@@ -22,7 +22,7 @@ from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.db.session import get_db
 from terrapod.services import labels_service
 
-router = APIRouter(prefix="/api/v2", tags=["labels"])
+router = APIRouter(tags=["labels"])
 
 
 @router.get("/labels")

--- a/services/terrapod/api/routers/notification_configurations.py
+++ b/services/terrapod/api/routers/notification_configurations.py
@@ -6,12 +6,12 @@ UX CONTRACT: Notification endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    POST   /api/v2/workspaces/{id}/notification-configurations      (create)
-    GET    /api/v2/workspaces/{id}/notification-configurations      (list)
-    GET    /api/v2/notification-configurations/{id}                  (show)
-    PATCH  /api/v2/notification-configurations/{id}                  (update)
-    DELETE /api/v2/notification-configurations/{id}                  (delete)
-    POST   /api/v2/notification-configurations/{id}/actions/verify   (verify)
+    POST   /api/terrapod/v1/workspaces/{id}/notification-configurations      (create)
+    GET    /api/terrapod/v1/workspaces/{id}/notification-configurations      (list)
+    GET    /api/terrapod/v1/notification-configurations/{id}                  (show)
+    PATCH  /api/terrapod/v1/notification-configurations/{id}                  (update)
+    DELETE /api/terrapod/v1/notification-configurations/{id}                  (delete)
+    POST   /api/terrapod/v1/notification-configurations/{id}/actions/verify   (verify)
 """
 
 import uuid
@@ -35,7 +35,7 @@ from terrapod.services.notification_service import (
 )
 from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
 
-router = APIRouter(prefix="/api/v2", tags=["notification-configurations"])
+router = APIRouter(tags=["notification-configurations"])
 logger = get_logger(__name__)
 
 
@@ -70,7 +70,7 @@ def _nc_json(nc: NotificationConfiguration) -> dict:
             },
         },
         "links": {
-            "self": f"/api/v2/notification-configurations/{nc_id}",
+            "self": f"/api/terrapod/v1/notification-configurations/{nc_id}",
         },
     }
 

--- a/services/terrapod/api/routers/oauth.py
+++ b/services/terrapod/api/routers/oauth.py
@@ -28,6 +28,11 @@ from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
 
 router = APIRouter(tags=["oauth"])
+
+# Terrapod-only CLI login completion check. Dual-mounted under
+# /api/terrapod/v1 (canonical) and /api/v2 (deprecated, removed in
+# v0.24.0 — see #278).
+extensions_router = APIRouter(tags=["oauth-extensions"])
 logger = get_logger(__name__)
 
 
@@ -172,7 +177,7 @@ async def oauth_token(
     )
 
 
-@router.get("/api/v2/auth/cli-login-status")
+@extensions_router.get("/auth/cli-login-status")
 async def cli_login_status(code: str = Query(...)) -> JSONResponse:
     """Check if a CLI login flow completed (token was created)."""
     redis = get_redis_client()

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -15,12 +15,12 @@ CLI Protocol:
     GET  /api/v2/registry/modules/{namespace}/{name}/{provider}/{version}/download
 
 TFE V2 Management:
-    POST   /api/v2/organizations/default/registry-modules
-    GET    /api/v2/organizations/default/registry-modules
-    GET    /api/v2/organizations/default/registry-modules/private/default/{name}/{prov}
-    DELETE /api/v2/organizations/default/registry-modules/private/default/{name}/{prov}
-    POST   /api/v2/organizations/default/registry-modules/private/default/{name}/{prov}/versions
-    DELETE /api/v2/organizations/default/registry-modules/private/default/{name}/{prov}/{ver}
+    POST   /api/terrapod/v1/registry-modules
+    GET    /api/terrapod/v1/registry-modules
+    GET    /api/terrapod/v1/registry-modules/private/default/{name}/{prov}
+    DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{prov}
+    POST   /api/terrapod/v1/registry-modules/private/default/{name}/{prov}/versions
+    DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{prov}/{ver}
 """
 
 import uuid as _uuid
@@ -55,7 +55,20 @@ from terrapod.services.registry_rbac_service import (
 from terrapod.storage import get_storage
 from terrapod.storage.protocol import ObjectStore
 
-router = APIRouter(tags=["registry-modules"])
+router = APIRouter(prefix="/api/v2", tags=["registry-modules"])
+
+# Workspace-links — Terrapod extension on top of the TFE registry-modules
+# surface. Dual-mounted under /api/terrapod/v1 (canonical) and /api/v2
+# (deprecated, removed in v0.24.0 — see #278).
+workspace_links_router = APIRouter(tags=["module-workspace-links"])
+
+# Terrapod-native module-registry management — workspace-scoped CRUD on
+# private modules, version create/delete, direct tarball upload, and the
+# /vcs configuration endpoint. The CLI never calls these (it uses the
+# /api/v2/registry/modules/... download protocol on `router`). Dual-mounted
+# at /api/terrapod/v1 (canonical) and /api/v2 (deprecated alias removed in
+# v0.24.0 — see #278).
+management_router = APIRouter(tags=["registry-modules-management"])
 logger = get_logger(__name__)
 
 
@@ -156,7 +169,7 @@ def _module_to_jsonapi(module, effective_permission: str | None = None) -> dict:
 # --- CLI Protocol Endpoints ---
 
 
-@router.get("/api/v2/registry/modules/{namespace}/{name}/{provider}/versions")
+@router.get("/registry/modules/{namespace}/{name}/{provider}/versions")
 async def list_module_versions_cli(
     namespace: str,
     name: str,
@@ -193,7 +206,7 @@ async def list_module_versions_cli(
     )
 
 
-@router.get("/api/v2/registry/modules/{namespace}/{name}/{provider}/{version}/download")
+@router.get("/registry/modules/{namespace}/{name}/{provider}/{version}/download")
 async def download_module_cli(
     namespace: str,
     name: str,
@@ -239,7 +252,7 @@ async def download_module_cli(
 # --- TFE V2 Management Endpoints ---
 
 
-@router.post("/api/v2/organizations/default/registry-modules")
+@management_router.post("/registry-modules")
 async def create_module_endpoint(
     body: CreateModuleRequest,
     user: AuthenticatedUser = Depends(require_non_runner),
@@ -293,7 +306,7 @@ async def create_module_endpoint(
     )
 
 
-@router.get("/api/v2/organizations/default/registry-modules")
+@management_router.get("/registry-modules")
 async def list_modules_endpoint(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -316,7 +329,7 @@ async def list_modules_endpoint(
     return JSONResponse(content={"data": visible})
 
 
-@router.get("/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}")
+@management_router.get("/registry-modules/private/default/{name}/{provider}")
 async def show_module_endpoint(
     name: str,
     provider: str,
@@ -343,7 +356,7 @@ async def show_module_endpoint(
     return JSONResponse(content={"data": _module_to_jsonapi(module, perm)})
 
 
-@router.delete("/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}")
+@management_router.delete("/registry-modules/private/default/{name}/{provider}")
 async def delete_module_endpoint(
     name: str,
     provider: str,
@@ -379,7 +392,7 @@ async def delete_module_endpoint(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.patch("/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}")
+@management_router.patch("/registry-modules/private/default/{name}/{provider}")
 async def update_module_endpoint(
     name: str,
     provider: str,
@@ -493,9 +506,7 @@ async def update_module_endpoint(
     return JSONResponse(content={"data": _module_to_jsonapi(module, perm)})
 
 
-@router.post(
-    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/versions"
-)
+@management_router.post("/registry-modules/private/default/{name}/{provider}/versions")
 async def create_module_version_endpoint(
     name: str,
     provider: str,
@@ -555,9 +566,7 @@ async def create_module_version_endpoint(
     )
 
 
-@router.delete(
-    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/{version}"
-)
+@management_router.delete("/registry-modules/private/default/{name}/{provider}/{version}")
 async def delete_module_version_endpoint(
     name: str,
     provider: str,
@@ -595,8 +604,8 @@ async def delete_module_version_endpoint(
 # --- Direct Upload ---
 
 
-@router.put(
-    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/versions/{version}/upload"
+@management_router.put(
+    "/registry-modules/private/default/{name}/{provider}/versions/{version}/upload"
 )
 async def upload_module_version_endpoint(
     name: str,
@@ -678,9 +687,7 @@ class UpdateModuleVCSRequest(BaseModel):
     data: Data
 
 
-@router.patch(
-    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/vcs"
-)
+@management_router.patch("/registry-modules/private/default/{name}/{provider}/vcs")
 async def update_module_vcs_endpoint(
     name: str,
     provider: str,
@@ -775,9 +782,7 @@ def _link_to_jsonapi(link: ModuleWorkspaceLink) -> dict:
     }
 
 
-@router.get(
-    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links"
-)
+@workspace_links_router.get("/registry-modules/private/default/{name}/{provider}/workspace-links")
 async def list_workspace_links(
     name: str,
     provider: str,
@@ -811,9 +816,7 @@ async def list_workspace_links(
     return JSONResponse(content={"data": [_link_to_jsonapi(link) for link in links]})
 
 
-@router.post(
-    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links"
-)
+@workspace_links_router.post("/registry-modules/private/default/{name}/{provider}/workspace-links")
 async def create_workspace_link(
     name: str,
     provider: str,
@@ -884,8 +887,8 @@ async def create_workspace_link(
     )
 
 
-@router.delete(
-    "/api/v2/organizations/default/registry-modules/private/default/{name}/{provider}/workspace-links/{link_id}"
+@workspace_links_router.delete(
+    "/registry-modules/private/default/{name}/{provider}/workspace-links/{link_id}"
 )
 async def delete_workspace_link(
     name: str,

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -15,10 +15,10 @@ CLI Protocol:
     GET  /api/v2/registry/providers/{namespace}/{name}/{version}/download/{os}/{arch}
 
 TFE V2 Management:
-    POST   /api/v2/organizations/default/registry-providers
-    GET    /api/v2/organizations/default/registry-providers
-    GET    /api/v2/organizations/default/registry-providers/private/default/{name}
-    DELETE /api/v2/organizations/default/registry-providers/private/default/{name}
+    POST   /api/terrapod/v1/registry-providers
+    GET    /api/terrapod/v1/registry-providers
+    GET    /api/terrapod/v1/registry-providers/private/default/{name}
+    DELETE /api/terrapod/v1/registry-providers/private/default/{name}
     POST   .../private/default/{name}/versions
     GET    .../private/default/{name}/versions
     DELETE .../private/default/{name}/versions/{ver}
@@ -67,7 +67,14 @@ from terrapod.services.registry_rbac_service import (
 from terrapod.storage import get_storage
 from terrapod.storage.protocol import ObjectStore
 
-router = APIRouter(tags=["registry-providers"])
+router = APIRouter(prefix="/api/v2", tags=["registry-providers"])
+
+# Terrapod-native provider-registry management — org-scoped CRUD on
+# private providers + their versions + per-platform binaries. The CLI
+# only uses the /api/v2/registry/providers/... download protocol on
+# `router`. Dual-mounted at /api/terrapod/v1 (canonical) and /api/v2
+# (deprecated alias removed in v0.24.0 — see #278).
+management_router = APIRouter(tags=["registry-providers-management"])
 logger = get_logger(__name__)
 
 
@@ -203,7 +210,7 @@ async def _require_provider_permission(
 # --- CLI Protocol Endpoints ---
 
 
-@router.get("/api/v2/registry/providers/{namespace}/{name}/versions")
+@router.get("/registry/providers/{namespace}/{name}/versions")
 async def list_provider_versions_cli(
     namespace: str,
     name: str,
@@ -252,7 +259,7 @@ async def list_provider_versions_cli(
     return JSONResponse(content={"versions": versions})
 
 
-@router.get("/api/v2/registry/providers/{namespace}/{name}/{version}/download/{os}/{arch}")
+@router.get("/registry/providers/{namespace}/{name}/{version}/download/{os}/{arch}")
 async def download_provider_cli(
     namespace: str,
     name: str,
@@ -299,12 +306,12 @@ async def download_provider_cli(
     return JSONResponse(content=info)
 
 
-# --- TFE V2 Management Endpoints ---
+# --- Management Endpoints (Terrapod-native) ---
 
-_ORG_PREFIX = "/api/v2/organizations/default/registry-providers"
+_BASE = "/registry-providers"
 
 
-@router.post(_ORG_PREFIX)
+@management_router.post(_BASE)
 async def create_provider_endpoint(
     body: CreateProviderRequest,
     user: AuthenticatedUser = Depends(require_non_runner),
@@ -326,7 +333,7 @@ async def create_provider_endpoint(
     )
 
 
-@router.get(_ORG_PREFIX)
+@management_router.get(_BASE)
 async def list_providers_endpoint(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -349,7 +356,7 @@ async def list_providers_endpoint(
     return JSONResponse(content={"data": visible})
 
 
-@router.get(_ORG_PREFIX + "/private/default/{name}")
+@management_router.get(_BASE + "/private/default/{name}")
 async def show_provider_endpoint(
     name: str,
     user: AuthenticatedUser = Depends(get_current_user),
@@ -375,7 +382,7 @@ async def show_provider_endpoint(
     return JSONResponse(content={"data": _provider_to_jsonapi(provider, perm)})
 
 
-@router.delete(_ORG_PREFIX + "/private/default/{name}")
+@management_router.delete(_BASE + "/private/default/{name}")
 async def delete_provider_endpoint(
     name: str,
     user: AuthenticatedUser = Depends(get_current_user),
@@ -397,7 +404,7 @@ async def delete_provider_endpoint(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.patch(_ORG_PREFIX + "/private/default/{name}")
+@management_router.patch(_BASE + "/private/default/{name}")
 async def update_provider_endpoint(
     name: str,
     body: dict,
@@ -484,7 +491,7 @@ async def update_provider_endpoint(
 # --- Version Management ---
 
 
-@router.post(_ORG_PREFIX + "/private/default/{name}/versions")
+@management_router.post(_BASE + "/private/default/{name}/versions")
 async def create_provider_version_endpoint(
     name: str,
     body: CreateProviderVersionRequest,
@@ -536,7 +543,7 @@ async def create_provider_version_endpoint(
     )
 
 
-@router.get(_ORG_PREFIX + "/private/default/{name}/versions")
+@management_router.get(_BASE + "/private/default/{name}/versions")
 async def list_provider_versions_endpoint(
     name: str,
     user: AuthenticatedUser = Depends(get_current_user),
@@ -565,7 +572,7 @@ async def list_provider_versions_endpoint(
     )
 
 
-@router.delete(_ORG_PREFIX + "/private/default/{name}/versions/{version}")
+@management_router.delete(_BASE + "/private/default/{name}/versions/{version}")
 async def delete_provider_version_endpoint(
     name: str,
     version: str,
@@ -589,7 +596,7 @@ async def delete_provider_version_endpoint(
 # --- Platform Management ---
 
 
-@router.post(_ORG_PREFIX + "/private/default/{name}/versions/{version}/platforms")
+@management_router.post(_BASE + "/private/default/{name}/versions/{version}/platforms")
 async def create_provider_platform_endpoint(
     name: str,
     version: str,
@@ -621,7 +628,7 @@ async def create_provider_platform_endpoint(
     )
 
 
-@router.get(_ORG_PREFIX + "/private/default/{name}/versions/{version}/platforms")
+@management_router.get(_BASE + "/private/default/{name}/versions/{version}/platforms")
 async def list_provider_platforms_endpoint(
     name: str,
     version: str,
@@ -655,7 +662,9 @@ async def list_provider_platforms_endpoint(
     )
 
 
-@router.put(_ORG_PREFIX + "/private/default/{name}/versions/{version}/platforms/{os}/{arch}/upload")
+@management_router.put(
+    _BASE + "/private/default/{name}/versions/{version}/platforms/{os}/{arch}/upload"
+)
 async def upload_provider_binary_endpoint(
     name: str,
     version: str,
@@ -695,7 +704,9 @@ async def upload_provider_binary_endpoint(
     )
 
 
-@router.delete(_ORG_PREFIX + "/private/default/{name}/versions/{version}/platforms/{os}/{arch}")
+@management_router.delete(
+    _BASE + "/private/default/{name}/versions/{version}/platforms/{os}/{arch}"
+)
 async def delete_provider_platform_endpoint(
     name: str,
     version: str,

--- a/services/terrapod/api/routers/role_assignments.py
+++ b/services/terrapod/api/routers/role_assignments.py
@@ -6,10 +6,10 @@ UX CONTRACT: Role assignment endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    GET    /api/v2/role-assignments                       — list all assignments
-    GET    /api/v2/role-assignments/identities             — list known identities (for autocomplete)
-    PUT    /api/v2/role-assignments                       — set roles for (provider, email)
-    DELETE /api/v2/role-assignments/{provider}/{email}/{role} — remove single assignment
+    GET    /api/terrapod/v1/role-assignments                       — list all assignments
+    GET    /api/terrapod/v1/role-assignments/identities             — list known identities (for autocomplete)
+    PUT    /api/terrapod/v1/role-assignments                       — set roles for (provider, email)
+    DELETE /api/terrapod/v1/role-assignments/{provider}/{email}/{role} — remove single assignment
 """
 
 from datetime import UTC
@@ -26,7 +26,7 @@ from terrapod.db.models import PlatformRoleAssignment, Role, RoleAssignment, Use
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 
-router = APIRouter(prefix="/api/v2", tags=["role-assignments"])
+router = APIRouter(tags=["role-assignments"])
 logger = get_logger(__name__)
 
 

--- a/services/terrapod/api/routers/roles.py
+++ b/services/terrapod/api/routers/roles.py
@@ -6,11 +6,11 @@ UX CONTRACT: Role endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    GET    /api/v2/roles               — list all roles (built-in + custom)
-    POST   /api/v2/roles               — create custom role
-    GET    /api/v2/roles/{name}        — show role
-    PATCH  /api/v2/roles/{name}        — update custom role
-    DELETE /api/v2/roles/{name}        — delete custom role
+    GET    /api/terrapod/v1/roles               — list all roles (built-in + custom)
+    POST   /api/terrapod/v1/roles               — create custom role
+    GET    /api/terrapod/v1/roles/{name}        — show role
+    PATCH  /api/terrapod/v1/roles/{name}        — update custom role
+    DELETE /api/terrapod/v1/roles/{name}        — delete custom role
 """
 
 from datetime import UTC
@@ -26,7 +26,7 @@ from terrapod.db.models import Role
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 
-router = APIRouter(prefix="/api/v2", tags=["roles"])
+router = APIRouter(tags=["roles"])
 logger = get_logger(__name__)
 
 VALID_PERMISSIONS = {"read", "plan", "write", "admin"}

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -7,13 +7,13 @@ Downloads return 302 redirects to presigned storage URLs.
 Uploads accept raw bytes and write to storage directly.
 
 Endpoints:
-    GET  /api/v2/runs/{run_id}/artifacts/config      — download config archive
-    GET  /api/v2/runs/{run_id}/artifacts/state        — download current state
-    GET  /api/v2/runs/{run_id}/artifacts/plan-file    — download plan file
-    PUT  /api/v2/runs/{run_id}/artifacts/plan-log     — upload plan log
-    PUT  /api/v2/runs/{run_id}/artifacts/plan-file    — upload plan file
-    PUT  /api/v2/runs/{run_id}/artifacts/apply-log    — upload apply log
-    PUT  /api/v2/runs/{run_id}/artifacts/state        — upload new state
+    GET  /api/terrapod/v1/runs/{run_id}/artifacts/config      — download config archive
+    GET  /api/terrapod/v1/runs/{run_id}/artifacts/state        — download current state
+    GET  /api/terrapod/v1/runs/{run_id}/artifacts/plan-file    — download plan file
+    PUT  /api/terrapod/v1/runs/{run_id}/artifacts/plan-log     — upload plan log
+    PUT  /api/terrapod/v1/runs/{run_id}/artifacts/plan-file    — upload plan file
+    PUT  /api/terrapod/v1/runs/{run_id}/artifacts/apply-log    — upload apply log
+    PUT  /api/terrapod/v1/runs/{run_id}/artifacts/state        — upload new state
 """
 
 import asyncio
@@ -40,7 +40,7 @@ from terrapod.storage.keys import (
     state_key,
 )
 
-router = APIRouter(prefix="/api/v2", tags=["run-artifacts"])
+router = APIRouter(tags=["run-artifacts"])
 logger = get_logger(__name__)
 
 

--- a/services/terrapod/api/routers/run_tasks.py
+++ b/services/terrapod/api/routers/run_tasks.py
@@ -6,15 +6,15 @@ UX CONTRACT: Run task endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    POST   /api/v2/workspaces/{id}/run-tasks          (create)
-    GET    /api/v2/workspaces/{id}/run-tasks            (list)
-    GET    /api/v2/run-tasks/{id}                       (show)
-    PATCH  /api/v2/run-tasks/{id}                       (update)
-    DELETE /api/v2/run-tasks/{id}                       (delete)
-    GET    /api/v2/runs/{run_id}/task-stages             (list stages for a run)
+    POST   /api/terrapod/v1/workspaces/{id}/run-tasks          (create)
+    GET    /api/terrapod/v1/workspaces/{id}/run-tasks            (list)
+    GET    /api/terrapod/v1/run-tasks/{id}                       (show)
+    PATCH  /api/terrapod/v1/run-tasks/{id}                       (update)
+    DELETE /api/terrapod/v1/run-tasks/{id}                       (delete)
+    GET    /api/terrapod/v1/runs/{run_id}/task-stages             (list stages for a run)
     GET    /api/v2/task-stages/{id}                      (show stage with results)
     POST   /api/v2/task-stages/{id}/actions/override     (override failed stage)
-    PATCH  /api/v2/task-stage-results/{id}/callback      (external callback)
+    PATCH  /api/terrapod/v1/task-stage-results/{id}/callback      (external callback)
 """
 
 import uuid
@@ -41,6 +41,13 @@ from terrapod.services.run_task_service import (
 from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
 
 router = APIRouter(prefix="/api/v2", tags=["run-tasks"])
+
+# Terrapod-native run-task management — workspace-scoped task definitions
+# and the callback receiver. The CLI never touches these (it only reads
+# task-stages on the run via TaskStages.Read + Override at /api/v2/task-stages/...).
+# Dual-mounted at /api/terrapod/v1 (canonical) and /api/v2 (deprecated,
+# removed in v0.24.0 — see #278).
+extensions_router = APIRouter(tags=["run-tasks-management"])
 logger = get_logger(__name__)
 
 
@@ -72,7 +79,7 @@ def _run_task_json(rt: RunTask) -> dict:
             },
         },
         "links": {
-            "self": f"/api/v2/run-tasks/{rt_id}",
+            "self": f"/api/terrapod/v1/run-tasks/{rt_id}",
         },
     }
 
@@ -168,7 +175,7 @@ async def _get_run_task(rt_id: str, db: AsyncSession) -> RunTask:
 # ── Run Task CRUD ─────────────────────────────────────────────────────
 
 
-@router.post("/workspaces/{workspace_id}/run-tasks", status_code=201)
+@extensions_router.post("/workspaces/{workspace_id}/run-tasks", status_code=201)
 async def create_run_task(
     workspace_id: str = Path(...),
     body: dict = Body(...),
@@ -223,7 +230,7 @@ async def create_run_task(
     return JSONResponse(content={"data": _run_task_json(rt)}, status_code=201)
 
 
-@router.get("/workspaces/{workspace_id}/run-tasks")
+@extensions_router.get("/workspaces/{workspace_id}/run-tasks")
 async def list_run_tasks(
     workspace_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -244,7 +251,7 @@ async def list_run_tasks(
     return JSONResponse(content={"data": [_run_task_json(rt) for rt in tasks]})
 
 
-@router.get("/run-tasks/{rt_id}")
+@extensions_router.get("/run-tasks/{rt_id}")
 async def show_run_task(
     rt_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -256,7 +263,7 @@ async def show_run_task(
     return JSONResponse(content={"data": _run_task_json(rt)})
 
 
-@router.patch("/run-tasks/{rt_id}")
+@extensions_router.patch("/run-tasks/{rt_id}")
 async def update_run_task(
     rt_id: str = Path(...),
     body: dict = Body(...),
@@ -313,7 +320,7 @@ async def update_run_task(
     return JSONResponse(content={"data": _run_task_json(rt)})
 
 
-@router.delete("/run-tasks/{rt_id}", status_code=204)
+@extensions_router.delete("/run-tasks/{rt_id}", status_code=204)
 async def delete_run_task(
     rt_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -332,7 +339,7 @@ async def delete_run_task(
 # ── Task Stages ───────────────────────────────────────────────────────
 
 
-@router.get("/runs/{run_id}/task-stages")
+@extensions_router.get("/runs/{run_id}/task-stages")
 async def list_task_stages(
     run_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -428,7 +435,7 @@ async def override_task_stage(
 # ── Callback (Unauthenticated, Token-Verified) ──────────────────────
 
 
-@router.patch("/task-stage-results/{tsr_id}/callback")
+@extensions_router.patch("/task-stage-results/{tsr_id}/callback")
 async def task_stage_result_callback(
     tsr_id: str = Path(...),
     body: dict = Body(...),

--- a/services/terrapod/api/routers/run_triggers.py
+++ b/services/terrapod/api/routers/run_triggers.py
@@ -6,10 +6,10 @@ UX CONTRACT: Run trigger endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    POST   /api/v2/workspaces/{id}/run-triggers      (create trigger)
-    GET    /api/v2/workspaces/{id}/run-triggers       (list inbound/outbound)
-    GET    /api/v2/run-triggers/{id}                   (show trigger)
-    DELETE /api/v2/run-triggers/{id}                   (delete trigger)
+    POST   /api/terrapod/v1/workspaces/{id}/run-triggers      (create trigger)
+    GET    /api/terrapod/v1/workspaces/{id}/run-triggers       (list inbound/outbound)
+    GET    /api/terrapod/v1/run-triggers/{id}                   (show trigger)
+    DELETE /api/terrapod/v1/run-triggers/{id}                   (delete trigger)
 """
 
 import uuid
@@ -27,7 +27,7 @@ from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
 
-router = APIRouter(prefix="/api/v2", tags=["run-triggers"])
+router = APIRouter(tags=["run-triggers"])
 logger = get_logger(__name__)
 
 MAX_SOURCES_PER_WORKSPACE = 20
@@ -62,7 +62,7 @@ def _trigger_json(trigger: RunTrigger) -> dict:
             },
         },
         "links": {
-            "self": f"/api/v2/run-triggers/{trigger_id}",
+            "self": f"/api/terrapod/v1/run-triggers/{trigger_id}",
         },
     }
 

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -13,13 +13,13 @@ Endpoints:
     POST   /api/v2/runs/{run_id}/actions/apply        (confirm plan for apply)
     POST   /api/v2/runs/{run_id}/actions/discard      (discard plan)
     POST   /api/v2/runs/{run_id}/actions/cancel       (cancel run)
-    POST   /api/v2/runs/{run_id}/actions/retry        (retry run — create new run from terminal run)
-    GET    /api/v2/runs/{run_id}/plan                 (plan details)
+    POST   /api/terrapod/v1/runs/{run_id}/actions/retry        (retry run — create new run from terminal run)
+    GET    /api/terrapod/v1/runs/{run_id}/plan                 (plan details)
     GET    /api/v2/plans/{plan_id}                    (plan details by ID)
-    GET    /api/v2/runs/{run_id}/apply                (apply details)
+    GET    /api/terrapod/v1/runs/{run_id}/apply                (apply details)
     GET    /api/v2/applies/{apply_id}                 (apply details by ID)
-    PATCH  /api/v2/listeners/{id}/runs/{run_id}       (listener status update)
-    GET    /api/v2/listeners/{id}/runs/next            (poll for next run)
+    PATCH  /api/terrapod/v1/listeners/{id}/runs/{run_id}       (listener status update)
+    GET    /api/terrapod/v1/listeners/{id}/runs/next            (poll for next run)
 """
 
 import asyncio
@@ -51,6 +51,13 @@ from terrapod.storage.keys import apply_log_key, plan_log_key
 from terrapod.storage.protocol import ObjectNotFoundError
 
 router = APIRouter(prefix="/api/v2", tags=["runs"])
+
+# Terrapod-only run endpoints — listener protocol (claim/launch/status/log
+# streaming), runner-driven completion (plan-result, apply-result), SSE
+# event channels, and the retry action. Dual-mounted under
+# /api/terrapod/v1 (canonical) and /api/v2 (deprecated, removed in v0.24.0
+# — see #278).
+extensions_router = APIRouter(tags=["run-extensions"])
 logger = get_logger(__name__)
 
 # States where cancellation is a sensible action — the run is actively
@@ -178,7 +185,7 @@ def _run_json(
                     "data": {"id": f"apply-{run.id}", "type": "applies"},
                 },
                 "task-stages": {
-                    "links": {"related": f"/api/v2/runs/{run_id}/task-stages"},
+                    "links": {"related": f"/api/terrapod/v1/runs/{run_id}/task-stages"},
                 },
                 "created-state-version": {
                     "data": (
@@ -562,7 +569,7 @@ async def cancel_run(
     return JSONResponse(content=_run_json(run))
 
 
-@router.post("/runs/{run_id}/actions/retry")
+@extensions_router.post("/runs/{run_id}/actions/retry")
 async def retry_run(
     run_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -747,7 +754,7 @@ async def show_plan_by_id(
     return JSONResponse(content=_plan_json(run))
 
 
-@router.get("/runs/{run_id}/plan")
+@extensions_router.get("/runs/{run_id}/plan")
 async def show_plan(
     run_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -795,7 +802,7 @@ async def show_apply_by_id(
     return JSONResponse(content=_apply_json(run))
 
 
-@router.get("/runs/{run_id}/apply")
+@extensions_router.get("/runs/{run_id}/apply")
 async def show_apply(
     run_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
@@ -810,7 +817,7 @@ async def show_apply(
 # ── SSE (Server-Sent Events) ─────────────────────────────────────────────
 
 
-@router.get("/workspaces/{workspace_id}/runs/events")
+@extensions_router.get("/workspaces/{workspace_id}/runs/events")
 async def run_events_stream(
     request: Request,
     workspace_id: str = Path(...),
@@ -869,7 +876,7 @@ async def run_events_stream(
 # ── Listener Run Queue ───────────────────────────────────────────────────
 
 
-@router.get("/listeners/{listener_id}/runs/next")
+@extensions_router.get("/listeners/{listener_id}/runs/next")
 async def next_run(
     listener_id: str = Path(...),
     identity: ListenerIdentity = Depends(get_listener_identity),
@@ -929,7 +936,7 @@ async def next_run(
     return JSONResponse(content=run_data)
 
 
-@router.patch("/listeners/{listener_id}/runs/{run_id}")
+@extensions_router.patch("/listeners/{listener_id}/runs/{run_id}")
 async def update_run_status(
     listener_id: str = Path(...),
     run_id: str = Path(...),
@@ -1012,7 +1019,7 @@ async def update_run_status(
 # ── Runner Token ──────────────────────────────────────────────────────
 
 
-@router.post("/listeners/{listener_id}/runs/{run_id}/runner-token")
+@extensions_router.post("/listeners/{listener_id}/runs/{run_id}/runner-token")
 async def create_runner_token(
     listener_id: str = Path(...),
     run_id: str = Path(...),
@@ -1049,7 +1056,7 @@ async def create_runner_token(
 # ── Job Lifecycle Callbacks ───────────────────────────────────────────────
 
 
-@router.post("/listeners/{listener_id}/runs/{run_id}/job-launched")
+@extensions_router.post("/listeners/{listener_id}/runs/{run_id}/job-launched")
 async def report_job_launched(
     listener_id: str = Path(...),
     run_id: str = Path(...),
@@ -1086,7 +1093,7 @@ async def report_job_launched(
     return JSONResponse(content={"status": "ok"})
 
 
-@router.post("/listeners/{listener_id}/runs/{run_id}/job-status")
+@extensions_router.post("/listeners/{listener_id}/runs/{run_id}/job-status")
 async def report_job_status(
     listener_id: str = Path(...),
     run_id: str = Path(...),
@@ -1121,7 +1128,7 @@ async def report_job_status(
     return JSONResponse(content={"status": "ok"})
 
 
-@router.put("/listeners/{listener_id}/runs/{run_id}/log-stream")
+@extensions_router.put("/listeners/{listener_id}/runs/{run_id}/log-stream")
 async def upload_log_stream(
     listener_id: str = Path(...),
     run_id: str = Path(...),
@@ -1179,7 +1186,7 @@ async def upload_log_stream(
     return Response(status_code=204)
 
 
-@router.post("/runs/{run_id}/plan-result")
+@extensions_router.post("/runs/{run_id}/plan-result")
 async def report_plan_result(
     run_id: str = Path(...),
     body: dict = Body(...),
@@ -1207,7 +1214,7 @@ async def report_plan_result(
     return JSONResponse(content={"status": "ok"})
 
 
-@router.post("/runs/{run_id}/apply-result")
+@extensions_router.post("/runs/{run_id}/apply-result")
 async def report_apply_result(
     run_id: str = Path(...),
     db: AsyncSession = Depends(get_db),

--- a/services/terrapod/api/routers/state_management.py
+++ b/services/terrapod/api/routers/state_management.py
@@ -5,9 +5,9 @@ state lifecycle operations consumed by the web UI: delete, rollback, and
 manual upload.
 
 Endpoints:
-    DELETE /api/v2/state-versions/{id}/manage — delete a non-current state version
-    POST   /api/v2/state-versions/{id}/actions/rollback — rollback to an older version
-    POST   /api/v2/workspaces/{id}/state-versions/actions/upload — manual state upload
+    DELETE /api/terrapod/v1/state-versions/{id}/manage — delete a non-current state version
+    POST   /api/terrapod/v1/state-versions/{id}/actions/rollback — rollback to an older version
+    POST   /api/terrapod/v1/workspaces/{id}/state-versions/actions/upload — manual state upload
 """
 
 import asyncio
@@ -27,7 +27,7 @@ from terrapod.services.workspace_rbac_service import has_permission, resolve_wor
 from terrapod.storage import get_storage
 from terrapod.storage.keys import state_key
 
-router = APIRouter(prefix="/api/v2", tags=["state-management"])
+router = APIRouter(tags=["state-management"])
 logger = get_logger(__name__)
 
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -62,6 +62,13 @@ from terrapod.storage import get_storage
 from terrapod.storage.keys import state_index_key, state_key
 
 router = APIRouter(prefix="/api/v2", tags=["tfe-v2"])
+
+# Workspace by-id DELETE is the one path on the workspaces resource that
+# the terraform/tofu CLI doesn't call (the legacy remote backend deletes
+# by name, the cloud backend never deletes at all). Treated as Terrapod-
+# native management and dual-mounted at /api/terrapod/v1 + a deprecated
+# /api/v2 alias (removed in v0.24.0 — see #278).
+extensions_router = APIRouter(tags=["tfe-v2-management"])
 logger = get_logger(__name__)
 
 TFP_API_VERSION = "2.6"
@@ -1209,7 +1216,7 @@ async def update_workspace(
     return JSONResponse(content=_workspace_json(ws, perm), headers=_tfe_headers())
 
 
-@router.delete("/workspaces/{workspace_id}")
+@extensions_router.delete("/workspaces/{workspace_id}")
 async def delete_workspace(
     workspace_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),

--- a/services/terrapod/api/routers/tokens.py
+++ b/services/terrapod/api/routers/tokens.py
@@ -9,11 +9,11 @@ UX CONTRACT: Token endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    POST   /api/v2/users/:user_id/authentication-tokens — create user token
-    GET    /api/v2/users/:user_id/authentication-tokens — list user tokens
-    GET    /api/v2/admin/authentication-tokens — list all tokens (admin only)
-    GET    /api/v2/authentication-tokens/:id — show token (value is null)
-    DELETE /api/v2/authentication-tokens/:id — revoke token
+    POST   /api/terrapod/v1/users/:user_id/authentication-tokens — create user token
+    GET    /api/terrapod/v1/users/:user_id/authentication-tokens — list user tokens
+    GET    /api/terrapod/v1/admin/authentication-tokens — list all tokens (admin only)
+    GET    /api/terrapod/v1/authentication-tokens/:id — show token (value is null)
+    DELETE /api/terrapod/v1/authentication-tokens/:id — revoke token
 """
 
 from datetime import timedelta
@@ -35,7 +35,7 @@ from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 
-router = APIRouter(prefix="/api/v2", tags=["tokens"])
+router = APIRouter(tags=["tokens"])
 logger = get_logger(__name__)
 
 

--- a/services/terrapod/api/routers/users.py
+++ b/services/terrapod/api/routers/users.py
@@ -23,7 +23,7 @@ from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/api/v2", tags=["users"])
+router = APIRouter(tags=["users"])
 
 
 def _format_timestamp(dt) -> str | None:  # type: ignore[no-untyped-def]
@@ -69,7 +69,7 @@ class UserCreateRequest(BaseModel):
     data: UserCreateData
 
 
-@router.post("/organizations/default/users", status_code=status.HTTP_201_CREATED)
+@router.post("/users", status_code=status.HTTP_201_CREATED)
 async def create_user(
     body: UserCreateRequest,
     user: AuthenticatedUser = Depends(require_admin),
@@ -117,7 +117,7 @@ async def create_user(
     return {"data": _user_to_jsonapi(new_user)}
 
 
-@router.get("/organizations/default/users")
+@router.get("/users")
 async def list_users(
     user: AuthenticatedUser = Depends(require_admin_or_audit),
     db: AsyncSession = Depends(get_db),
@@ -256,3 +256,19 @@ async def delete_user(
     await db.delete(target)
     await db.commit()
     logger.info("Deleted user", target_email=email, by=user.email)
+
+
+# ── Legacy alias router (v0.22 → v0.24 deprecation window) ─────────────
+# Mounted only at /api/v2 by app.py with deprecated=True and
+# include_in_schema=False. Preserves the *exact* path shapes that
+# existed in v0.22 — list/create at /organizations/default/users,
+# by-email at /users/{email} — for clients still using those paths.
+# Removed in v0.24.0 (#278).
+legacy_router = APIRouter(tags=["users-legacy"])
+legacy_router.add_api_route(
+    "/organizations/default/users", create_user, methods=["POST"], status_code=201
+)
+legacy_router.add_api_route("/organizations/default/users", list_users, methods=["GET"])
+legacy_router.add_api_route("/users/{email}", show_user, methods=["GET"])
+legacy_router.add_api_route("/users/{email}", update_user, methods=["PATCH"])
+legacy_router.add_api_route("/users/{email}", delete_user, methods=["DELETE"], status_code=204)

--- a/services/terrapod/api/routers/variables.py
+++ b/services/terrapod/api/routers/variables.py
@@ -12,7 +12,7 @@ Endpoints:
     PATCH/DELETE   /api/v2/workspaces/{id}/vars/{var_id}
     POST/GET       /api/v2/organizations/default/varsets
     GET/PATCH/DELETE /api/v2/varsets/{varset_id}
-    POST/GET/PATCH/DELETE /api/v2/varsets/{varset_id}/relationships/vars[/{var_id}]
+    POST/GET/PATCH/DELETE /api/terrapod/v1/varsets/{varset_id}/relationships/vars[/{var_id}]
     POST/DELETE    /api/v2/varsets/{varset_id}/relationships/workspaces
 """
 

--- a/services/terrapod/api/routers/vcs_connections.py
+++ b/services/terrapod/api/routers/vcs_connections.py
@@ -10,10 +10,10 @@ UX CONTRACT: VCS connection endpoints are consumed by the web frontend:
   matched by corresponding updates to that frontend page.
 
 Endpoints:
-    GET    /api/v2/organizations/default/vcs-connections   (list connections)
-    POST   /api/v2/organizations/default/vcs-connections   (create connection)
-    GET    /api/v2/vcs-connections/{id}                  (show connection)
-    DELETE /api/v2/vcs-connections/{id}                  (delete connection)
+    GET    /api/terrapod/v1/vcs-connections   (list connections)
+    POST   /api/terrapod/v1/vcs-connections   (create connection)
+    GET    /api/terrapod/v1/vcs-connections/{id}                  (show connection)
+    DELETE /api/terrapod/v1/vcs-connections/{id}                  (delete connection)
 """
 
 import uuid
@@ -29,7 +29,7 @@ from terrapod.db.models import VCSConnection, generate_uuid7
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 
-router = APIRouter(prefix="/api/v2", tags=["vcs-connections"])
+router = APIRouter(tags=["vcs-connections"])
 logger = get_logger(__name__)
 
 SUPPORTED_PROVIDERS = {"github", "gitlab"}
@@ -83,7 +83,7 @@ async def _get_connection(db: AsyncSession, connection_id: uuid.UUID) -> VCSConn
     return result.scalar_one_or_none()
 
 
-@router.get("/organizations/default/vcs-connections")
+@router.get("/vcs-connections")
 async def list_connections(
     user: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
@@ -93,7 +93,7 @@ async def list_connections(
     return JSONResponse(content={"data": [_connection_json(c) for c in connections]})
 
 
-@router.post("/organizations/default/vcs-connections", status_code=201)
+@router.post("/vcs-connections", status_code=201)
 async def create_connection(
     body: dict = Body(...),
     user: AuthenticatedUser = Depends(require_admin),
@@ -212,3 +212,21 @@ async def delete_connection(
     await db.delete(conn)
     await db.commit()
     logger.info("VCS connection deleted", connection_id=str(conn.id))
+
+
+# ── Legacy alias router (v0.22 → v0.24 deprecation window) ─────────────
+# Mounted only at /api/v2 by app.py with deprecated=True and
+# include_in_schema=False. Preserves pre-v0.23 path shapes:
+# list/create were at /organizations/default/vcs-connections,
+# by-id at /vcs-connections/{id}. Removed in v0.24.0 (#278).
+legacy_router = APIRouter(tags=["vcs-connections-legacy"])
+legacy_router.add_api_route(
+    "/organizations/default/vcs-connections", list_connections, methods=["GET"]
+)
+legacy_router.add_api_route(
+    "/organizations/default/vcs-connections", create_connection, methods=["POST"], status_code=201
+)
+legacy_router.add_api_route("/vcs-connections/{connection_id}", show_connection, methods=["GET"])
+legacy_router.add_api_route(
+    "/vcs-connections/{connection_id}", delete_connection, methods=["DELETE"], status_code=204
+)

--- a/services/terrapod/api/routers/vcs_events.py
+++ b/services/terrapod/api/routers/vcs_events.py
@@ -5,7 +5,7 @@ and enqueues a triggered immediate poll via the distributed scheduler.
 The poller does all the real work.
 
 Endpoints:
-    POST /api/v2/vcs-events/github   (GitHub webhook receiver)
+    POST /api/terrapod/v1/vcs-events/github   (GitHub webhook receiver)
 """
 
 import json
@@ -18,7 +18,7 @@ from terrapod.logging_config import get_logger
 from terrapod.services.github_service import validate_webhook_signature
 from terrapod.services.scheduler import enqueue_trigger
 
-router = APIRouter(prefix="/api/v2", tags=["vcs-events"])
+router = APIRouter(tags=["vcs-events"])
 logger = get_logger(__name__)
 
 

--- a/services/terrapod/api/routers/workspace_extensions.py
+++ b/services/terrapod/api/routers/workspace_extensions.py
@@ -4,9 +4,9 @@ These endpoints are NOT part of the TFE V2 API specification. They provide
 Terrapod-specific functionality consumed by the web UI.
 
 Endpoints:
-    GET  /api/v2/workspace-events — SSE stream for workspace list updates
-    GET  /api/v2/workspaces/{workspace_id}/vcs-refs — list VCS branches/tags
-    POST /api/v2/workspaces/{workspace_id}/actions/dismiss-drift — clear drift status
+    GET  /api/terrapod/v1/workspace-events — SSE stream for workspace list updates
+    GET  /api/terrapod/v1/workspaces/{workspace_id}/vcs-refs — list VCS branches/tags
+    POST /api/terrapod/v1/workspaces/{workspace_id}/actions/dismiss-drift — clear drift status
 """
 
 import asyncio
@@ -22,7 +22,7 @@ from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
 
-router = APIRouter(prefix="/api/v2", tags=["workspace-extensions"])
+router = APIRouter(tags=["workspace-extensions"])
 logger = get_logger(__name__)
 
 

--- a/services/terrapod/auth/connectors/local.py
+++ b/services/terrapod/auth/connectors/local.py
@@ -45,7 +45,7 @@ class LocalConnector(SSOConnector):
         """Build redirect URL to the Web UI login page.
 
         The Web UI detects the cli_state parameter and renders a form that
-        POSTs to /api/v2/auth/local/login, which validates credentials and
+        POSTs to /api/terrapod/v1/auth/local/login, which validates credentials and
         redirects back to the CLI's localhost callback.
         """
         login_url = f"{settings.auth.callback_base_url}/login?cli_state={state}"

--- a/services/terrapod/auth/download_tickets.py
+++ b/services/terrapod/auth/download_tickets.py
@@ -14,7 +14,7 @@ do) or tokens embedded in the URL itself.
 This module generates the latter: short-lived, stateless cap tokens
 that callers exchange (server-side, with their normal Bearer token)
 for a public URL of the form
-`/api/v2/.../download-by-ticket/{ticket}`. Browser navigates plainly,
+`/api/terrapod/v1/.../download-by-ticket/{ticket}`. Browser navigates plainly,
 the ticket *is* the auth, the response streams to disk via
 `Content-Disposition: attachment` like any download has done forever.
 

--- a/services/terrapod/runner/identity.py
+++ b/services/terrapod/runner/identity.py
@@ -546,7 +546,7 @@ async def _call_join(api_url: str, join_token: str, name: str) -> dict:
 
     async with httpx.AsyncClient(base_url=api_url, timeout=30) as client:
         r = await client.post(
-            "/api/v2/agent-pools/join",
+            "/api/terrapod/v1/agent-pools/join",
             json={"join_token": join_token, "name": name},
         )
     if r.status_code in (401, 403):
@@ -575,7 +575,7 @@ async def _call_renew_with_retries(identity: ListenerIdentity) -> dict | None:
         try:
             async with httpx.AsyncClient(base_url=identity.api_url, timeout=30) as client:
                 r = await client.post(
-                    f"/api/v2/listeners/listener-{identity.listener_id}/renew",
+                    f"/api/terrapod/v1/listeners/listener-{identity.listener_id}/renew",
                     headers=headers,
                 )
             if r.status_code == 200:

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -366,7 +366,7 @@ class RunnerListener:
         running this listener should set POD_NAME explicitly.
         """
         await self._http_client.post(
-            f"/api/v2/listeners/listener-{self.identity.listener_id}/heartbeat",
+            f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}/heartbeat",
             json={
                 "capacity": self._max_concurrent,
                 "active_runs": self._active_launches,
@@ -457,9 +457,7 @@ class RunnerListener:
            HTTP roundtrip + Redis subscribe) and guarantees no stale
            subscription survives indefinitely.
         """
-        url = (
-            f"{self.identity.api_url}/api/v2/listeners/listener-{self.identity.listener_id}/events"
-        )
+        url = f"{self.identity.api_url}/api/terrapod/v1/listeners/listener-{self.identity.listener_id}/events"
         logger.info("SSE connecting", url=url)
 
         async with self._sse_client.stream("GET", url, headers=self._auth_headers()) as response:
@@ -575,7 +573,7 @@ class RunnerListener:
             return
 
         response = await self._http_client.get(
-            f"/api/v2/listeners/listener-{self.identity.listener_id}/runs/next",
+            f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}/runs/next",
             headers=self._auth_headers(),
         )
 
@@ -675,7 +673,7 @@ class RunnerListener:
         # Report Job launched to the API
         try:
             await self._http_client.post(
-                f"/api/v2/listeners/listener-{self.identity.listener_id}"
+                f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}"
                 f"/runs/run-{run_id}/job-launched",
                 json={"job_name": job_name, "job_namespace": namespace},
                 headers=self._auth_headers(),
@@ -705,7 +703,7 @@ class RunnerListener:
         """
         try:
             await self._http_client.patch(
-                f"/api/v2/listeners/listener-{self.identity.listener_id}/runs/run-{run_id}",
+                f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}/runs/run-{run_id}",
                 json={"status": "errored", "error_message": error_message},
                 headers=self._auth_headers(),
             )
@@ -744,7 +742,7 @@ class RunnerListener:
 
         try:
             await self._http_client.post(
-                f"/api/v2/listeners/listener-{self.identity.listener_id}"
+                f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}"
                 f"/runs/run-{run_id}/job-status",
                 json={"status": status, "phase": phase},
                 headers=self._auth_headers(),
@@ -795,7 +793,7 @@ class RunnerListener:
 
         try:
             await self._http_client.put(
-                f"/api/v2/listeners/listener-{self.identity.listener_id}"
+                f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}"
                 f"/runs/run-{run_id}/log-stream",
                 params={"phase": phase},
                 content=log_bytes,
@@ -837,7 +835,7 @@ class RunnerListener:
     async def _get_runner_token(self, run_id: str) -> str:
         """Request a short-lived runner token from the API."""
         response = await self._http_client.post(
-            f"/api/v2/listeners/listener-{self.identity.listener_id}"
+            f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}"
             f"/runs/run-{run_id}/runner-token",
             json={},
             headers=self._auth_headers(),

--- a/services/terrapod/services/audit_service.py
+++ b/services/terrapod/services/audit_service.py
@@ -25,8 +25,11 @@ _EXCLUDED_PREFIXES = (
     "/api/openapi.json",
 )
 
-# Pattern: /api/v2/{resource_type}/{resource_id}/...
-_RESOURCE_PATTERN = re.compile(r"^/api/v2/(?:organizations/[^/]+/)?([a-z_-]+?)(?:/([^/]+))?(?:/|$)")
+# Pattern: /api/{v2,terrapod/v1}/[organizations/default/]{resource_type}/{resource_id}/...
+# Terrapod is single-org; the only valid org segment is the literal "default".
+_RESOURCE_PATTERN = re.compile(
+    r"^/api/(?:v2|terrapod/v1)/(?:organizations/default/)?([a-z_-]+?)(?:/([^/]+))?(?:/|$)"
+)
 
 
 def should_audit(path: str) -> bool:
@@ -40,8 +43,12 @@ def parse_resource(path: str) -> tuple[str, str]:
     Examples:
         /api/v2/workspaces/ws-abc123 → ("workspaces", "ws-abc123")
         /api/v2/organizations/default/workspaces → ("workspaces", "")
-        /api/v2/admin/audit-log → ("audit-log", "")
+        /api/terrapod/v1/admin/audit-log → ("audit-log", "")
+        /api/terrapod/v1/users/admin@example.com → ("users", "admin@example.com")
         /oauth/authorize → ("oauth", "")
+
+    Both /api/v2 (CLI surface + deprecated aliases during the v0.23.x
+    window) and /api/terrapod/v1 (canonical) prefixes are recognised.
     """
     m = _RESOURCE_PATTERN.match(path)
     if m:

--- a/services/terrapod/services/cv_diff_service.py
+++ b/services/terrapod/services/cv_diff_service.py
@@ -1,6 +1,6 @@
 """Diff two configuration version tarballs.
 
-Used by `/api/v2/configuration-versions/diff` (Terrapod-only endpoint
+Used by `/api/terrapod/v1/configuration-versions/diff` (Terrapod-only endpoint
 backing the workspace UI's "compare two versions" view). Pure I/O +
 text diffing; no async networking on the hot path.
 

--- a/services/terrapod/services/run_task_dispatcher.py
+++ b/services/terrapod/services/run_task_dispatcher.py
@@ -117,7 +117,7 @@ async def handle_run_task_call(payload: dict) -> None:
 
         # Build callback URL
         base = settings.auth.callback_base_url.rstrip("/")
-        callback_url = f"{base}/api/v2/task-stage-results/tsr-{tsr.id}/callback"
+        callback_url = f"{base}/api/terrapod/v1/task-stage-results/tsr-{tsr.id}/callback"
 
         # Build payload
         task_payload = build_task_callback_payload(

--- a/services/terrapod/storage/filesystem.py
+++ b/services/terrapod/storage/filesystem.py
@@ -264,7 +264,7 @@ class FilesystemStore:
         sig = self._sign("GET", key, expires)
 
         encoded_key = urllib.parse.quote(key, safe="")
-        url = f"{self._base_url}/api/v2/storage/get/{encoded_key}?expires={expires}&sig={sig}"
+        url = f"{self._base_url}/api/terrapod/v1/storage/get/{encoded_key}?expires={expires}&sig={sig}"
 
         return PresignedURL(
             url=url,
@@ -283,7 +283,7 @@ class FilesystemStore:
 
         encoded_key = urllib.parse.quote(key, safe="")
         url = (
-            f"{self._base_url}/api/v2/storage/put/{encoded_key}"
+            f"{self._base_url}/api/terrapod/v1/storage/put/{encoded_key}"
             f"?expires={expires}&sig={sig}&content_type={urllib.parse.quote(content_type)}"
         )
 

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -89,7 +89,7 @@ class TestListenerHeartbeat:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/listeners/{lid}/heartbeat",
+                f"/api/terrapod/v1/listeners/{lid}/heartbeat",
                 json={"capacity": 5, "active_runs": 2, "pod_name": "listener-abc-123"},
                 headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
@@ -121,7 +121,7 @@ class TestListenerHeartbeat:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/listeners/{lid}/heartbeat",
+                f"/api/terrapod/v1/listeners/{lid}/heartbeat",
                 json={"capacity": 5, "active_runs": 0},
                 headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
@@ -145,7 +145,7 @@ class TestListenerHeartbeat:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/listeners/{lid}/heartbeat",
+                f"/api/terrapod/v1/listeners/{lid}/heartbeat",
                 json={"capacity": 3, "active_runs": 1},
                 headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
@@ -167,7 +167,7 @@ class TestListenerHeartbeat:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/listeners/{lid}/heartbeat",
+                f"/api/terrapod/v1/listeners/{lid}/heartbeat",
                 json={"capacity": 1},
                 headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
@@ -196,7 +196,7 @@ class TestListenerHeartbeat:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/listeners/{path_lid}/heartbeat",
+                f"/api/terrapod/v1/listeners/{path_lid}/heartbeat",
                 json={"capacity": 1},
                 headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
@@ -237,7 +237,7 @@ class TestListPoolsRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+            res = await client.get("/api/terrapod/v1/agent-pools", headers=_AUTH)
 
         assert res.status_code == 200
         data = res.json()["data"]
@@ -271,7 +271,7 @@ class TestListPoolsRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+            res = await client.get("/api/terrapod/v1/agent-pools", headers=_AUTH)
 
         assert res.status_code == 200
         data = res.json()["data"]
@@ -307,7 +307,7 @@ class TestPoolStatus:
 
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+            res = await client.get("/api/terrapod/v1/agent-pools", headers=_AUTH)
 
         assert res.status_code == 200
         attrs = res.json()["data"][0]["attributes"]
@@ -339,7 +339,7 @@ class TestPoolStatus:
 
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+            res = await client.get("/api/terrapod/v1/agent-pools", headers=_AUTH)
 
         assert res.json()["data"][0]["attributes"]["status"] == "offline"
 
@@ -364,7 +364,7 @@ class TestPoolStatus:
 
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+            res = await client.get(f"/api/terrapod/v1/agent-pools/apool-{pool.id}", headers=_AUTH)
 
         assert res.json()["data"]["attributes"]["status"] == "online"
 
@@ -470,7 +470,7 @@ class TestDerivePoolStatus:
 
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get("/api/v2/organizations/default/agent-pools", headers=_AUTH)
+            res = await client.get("/api/terrapod/v1/agent-pools", headers=_AUTH)
 
         assert res.json()["data"][0]["attributes"]["status"] == "degraded"
 
@@ -509,7 +509,9 @@ class TestListListenersReplicaCount:
 
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}/listeners", headers=_AUTH)
+            res = await client.get(
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}/listeners", headers=_AUTH
+            )
 
         assert res.status_code == 200
         data = res.json()["data"]
@@ -547,7 +549,9 @@ class TestListListenersReplicaCount:
 
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}/listeners", headers=_AUTH)
+            res = await client.get(
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}/listeners", headers=_AUTH
+            )
 
         assert res.status_code == 200
         attrs = res.json()["data"][0]["attributes"]
@@ -585,7 +589,9 @@ class TestListListenersReplicaCount:
 
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}/listeners", headers=_AUTH)
+            res = await client.get(
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}/listeners", headers=_AUTH
+            )
 
         data = {item["id"]: item["attributes"] for item in res.json()["data"]}
         assert data[f"listener-{lid_new}"]["replica-count"] == 2
@@ -617,7 +623,7 @@ class TestShowPoolRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+            res = await client.get(f"/api/terrapod/v1/agent-pools/apool-{pool.id}", headers=_AUTH)
 
         assert res.status_code == 200
         attrs = res.json()["data"]["attributes"]
@@ -644,7 +650,7 @@ class TestShowPoolRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+            res = await client.get(f"/api/terrapod/v1/agent-pools/apool-{pool.id}", headers=_AUTH)
 
         assert res.status_code == 404
 
@@ -671,7 +677,7 @@ class TestCreatePoolRBAC:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                "/api/v2/organizations/default/agent-pools",
+                "/api/terrapod/v1/agent-pools",
                 json={
                     "data": {
                         "type": "agent-pools",
@@ -701,7 +707,7 @@ class TestCreatePoolRBAC:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                "/api/v2/organizations/default/agent-pools",
+                "/api/terrapod/v1/agent-pools",
                 json={
                     "data": {
                         "type": "agent-pools",
@@ -744,7 +750,7 @@ class TestUpdatePoolRBAC:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.patch(
-                f"/api/v2/agent-pools/apool-{pool.id}",
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}",
                 json={
                     "data": {
                         "attributes": {
@@ -776,7 +782,7 @@ class TestUpdatePoolRBAC:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.patch(
-                f"/api/v2/agent-pools/apool-{pool.id}",
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}",
                 json={"data": {"attributes": {"description": "updated"}}},
                 headers=_AUTH,
             )
@@ -812,7 +818,9 @@ class TestDeletePoolRBAC:
         mock_db.commit = AsyncMock()
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.delete(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+            res = await client.delete(
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}", headers=_AUTH
+            )
 
         assert res.status_code == 204
 
@@ -833,7 +841,9 @@ class TestDeletePoolRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.delete(f"/api/v2/agent-pools/apool-{pool.id}", headers=_AUTH)
+            res = await client.delete(
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}", headers=_AUTH
+            )
 
         assert res.status_code == 404
 
@@ -859,7 +869,9 @@ class TestTokenEndpointRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.get(f"/api/v2/agent-pools/apool-{pool.id}/tokens", headers=_AUTH)
+            res = await client.get(
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}/tokens", headers=_AUTH
+            )
 
         assert res.status_code == 403
 
@@ -882,7 +894,7 @@ class TestTokenEndpointRBAC:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/agent-pools/apool-{pool.id}/tokens",
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}/tokens",
                 json={"data": {"attributes": {"description": "test"}}},
                 headers=_AUTH,
             )
@@ -916,7 +928,7 @@ class TestUpdatePoolSelfLockout:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.patch(
-                f"/api/v2/agent-pools/apool-{pool.id}",
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}",
                 json={"data": {"attributes": {"labels": {"team": "other"}}}},
                 headers=_AUTH,
             )
@@ -950,7 +962,7 @@ class TestUpdatePoolSelfLockout:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.patch(
-                f"/api/v2/agent-pools/apool-{pool.id}",
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}",
                 json={"data": {"attributes": {"labels": {"team": "other"}, "force": True}}},
                 headers=_AUTH,
             )
@@ -983,7 +995,7 @@ class TestUpdatePoolSelfLockout:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.patch(
-                f"/api/v2/agent-pools/apool-{pool.id}",
+                f"/api/terrapod/v1/agent-pools/apool-{pool.id}",
                 json={"data": {"attributes": {"labels": {}}}},
                 headers=_AUTH,
             )
@@ -1021,7 +1033,7 @@ class TestDeleteListenerRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.delete(f"/api/v2/listeners/{lid}", headers=_AUTH)
+            res = await client.delete(f"/api/terrapod/v1/listeners/{lid}", headers=_AUTH)
 
         assert res.status_code == 204
 
@@ -1049,7 +1061,7 @@ class TestDeleteListenerRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.delete(f"/api/v2/listeners/{lid}", headers=_AUTH)
+            res = await client.delete(f"/api/terrapod/v1/listeners/{lid}", headers=_AUTH)
 
         assert res.status_code == 403
 
@@ -1068,7 +1080,7 @@ class TestDeleteListenerRBAC:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.delete(f"/api/v2/listeners/{lid}", headers=_AUTH)
+            res = await client.delete(f"/api/terrapod/v1/listeners/{lid}", headers=_AUTH)
 
         assert res.status_code == 403
 
@@ -1123,7 +1135,7 @@ class TestRenewListenerCert:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/listeners/{lid}/renew",
+                f"/api/terrapod/v1/listeners/{lid}/renew",
                 headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
 
@@ -1146,7 +1158,7 @@ class TestRenewListenerCert:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/listeners/{path_lid}/renew",
+                f"/api/terrapod/v1/listeners/{path_lid}/renew",
                 headers={"X-Terrapod-Client-Cert": "irrelevant-mocked"},
             )
 

--- a/services/tests/api/test_api_namespace.py
+++ b/services/tests/api/test_api_namespace.py
@@ -1,0 +1,214 @@
+"""Tests for the /api/v2 → /api/terrapod/v1 dual-mount and deprecation contract.
+
+These tests assert the runtime behaviour of `include_moved` (in app.py):
+canonical and legacy paths both serve traffic; only the legacy path
+emits the deprecation headers; only the canonical path appears in
+OpenAPI; the CLI surface stays put on /api/v2.
+
+When the legacy aliases are removed in v0.24.0 (#278) most of these
+will fail — the dual-serve assertions are exactly what a future
+maintainer should drop.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from terrapod.api.app import app
+
+
+@pytest.fixture
+def client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+class TestOpenAPIVisibility:
+    """Deprecated aliases must not pollute the OpenAPI schema."""
+
+    def test_canonical_paths_in_schema(self) -> None:
+        schema = app.openapi()
+        # Pick a few canonical Terrapod-native paths that should be in the
+        # schema (one per major moved router).
+        for path in (
+            "/api/terrapod/v1/labels",
+            "/api/terrapod/v1/auth/providers",
+            "/api/terrapod/v1/listeners/{listener_id}/heartbeat",
+            "/api/terrapod/v1/gpg-keys",
+            "/api/terrapod/v1/admin/audit-log",
+        ):
+            assert path in schema["paths"], f"canonical path {path} missing from OpenAPI"
+
+    def test_deprecated_aliases_not_in_schema(self) -> None:
+        """The /api/v2 aliases of moved routes must NOT show in OpenAPI."""
+        schema = app.openapi()
+        for path in (
+            "/api/v2/labels",
+            "/api/v2/auth/providers",
+            "/api/v2/listeners/{listener_id}/heartbeat",
+        ):
+            assert path not in schema["paths"], (
+                f"deprecated alias {path} leaked into OpenAPI — include_in_schema=False missing?"
+            )
+
+    def test_cli_surface_stays_at_v2_in_schema(self) -> None:
+        """CLI/tfci-consumed paths are at /api/v2/ in the schema, not under /api/terrapod/v1/."""
+        schema = app.openapi()
+        for path in (
+            "/api/v2/ping",
+            "/api/v2/runs",
+            "/api/v2/runs/{run_id}",
+            "/api/v2/state-versions/{state_version_id}/download",
+            "/api/v2/registry/modules/{namespace}/{name}/{provider}/versions",
+            "/api/v2/varsets/{varset_id}",
+        ):
+            assert path in schema["paths"], f"CLI surface path {path} missing from OpenAPI"
+        # And these CLI paths must not also show under the Terrapod prefix.
+        for path in (
+            "/api/terrapod/v1/runs",
+            "/api/terrapod/v1/varsets/{varset_id}",
+            "/api/terrapod/v1/registry/modules/{namespace}/{name}/{provider}/versions",
+        ):
+            assert path not in schema["paths"], f"{path} should not exist"
+
+
+class TestRouteTopology:
+    """The actual app.routes table must include both canonical and legacy mounts.
+
+    OpenAPI schema visibility is decoupled (asserted above); these checks
+    are about whether requests can route at all.
+    """
+
+    def test_canonical_and_legacy_both_routable(self) -> None:
+        """Every dual-mounted path resolves on both prefixes."""
+        paths = {getattr(r, "path", "") for r in app.routes}
+        for canonical, legacy in (
+            ("/api/terrapod/v1/labels", "/api/v2/labels"),
+            ("/api/terrapod/v1/auth/providers", "/api/v2/auth/providers"),
+            (
+                "/api/terrapod/v1/listeners/{listener_id}/heartbeat",
+                "/api/v2/listeners/{listener_id}/heartbeat",
+            ),
+        ):
+            assert canonical in paths, f"canonical {canonical} not routable"
+            assert legacy in paths, f"legacy alias {legacy} not routable"
+
+    def test_gpg_keys_legacy_alias_uses_historical_prefix(self) -> None:
+        """gpg_keys lived at /api/registry/private/v2/, not /api/v2/."""
+        paths = {getattr(r, "path", "") for r in app.routes}
+        assert "/api/terrapod/v1/gpg-keys" in paths
+        assert "/api/registry/private/v2/gpg-keys" in paths
+        # NOT at /api/v2 — it never lived there.
+        assert "/api/v2/gpg-keys" not in paths
+
+    def test_terrapod_native_paths_have_no_org_segment(self) -> None:
+        """Per CLAUDE.md rule #9, the canonical /api/terrapod/v1 surface
+        must never carry an `organizations/default/` segment — Terrapod
+        is single-org and the segment is dead weight outside the
+        TFE-compat layer.
+        """
+        paths = {getattr(r, "path", "") for r in app.routes}
+        for path in (
+            "/api/terrapod/v1/organizations/default/users",
+            "/api/terrapod/v1/organizations/default/vcs-connections",
+            "/api/terrapod/v1/organizations/default/agent-pools",
+            "/api/terrapod/v1/organizations/default/registry-modules",
+            "/api/terrapod/v1/organizations/default/registry-providers",
+        ):
+            assert path not in paths, (
+                f"canonical path {path} leaks /organizations/default/ — Terrapod-native "
+                f"paths must use the short form (e.g. /api/terrapod/v1/users)"
+            )
+
+    def test_legacy_aliases_preserve_pre_v0_23_shapes(self) -> None:
+        """For routers that pre-v0.23 lived under
+        /api/v2/organizations/default/{resource}, the legacy alias at
+        that exact path must keep working through v0.23.x for v0.22
+        clients. We do NOT introduce /api/v2/{resource} (without the
+        org segment) — that path never existed pre-v0.23 and has no
+        callers.
+        """
+        paths = {getattr(r, "path", "") for r in app.routes}
+        # Pre-v0.23 paths still routable.
+        for path in (
+            "/api/v2/organizations/default/users",
+            "/api/v2/organizations/default/vcs-connections",
+            "/api/v2/organizations/default/agent-pools",
+            "/api/v2/organizations/default/registry-modules",
+            "/api/v2/organizations/default/registry-providers",
+        ):
+            assert path in paths, f"legacy alias {path} missing — v0.22 callers will break"
+        # /api/v2/{resource} (without org) was never published — must not
+        # exist as a deprecated alias.
+        for path in (
+            "/api/v2/users",
+            "/api/v2/vcs-connections",
+            "/api/v2/registry-modules",
+            "/api/v2/registry-providers",
+        ):
+            assert path not in paths, (
+                f"{path} should not exist — pre-v0.23 callers used the "
+                f"/organizations/default/ form, and {path} was never published"
+            )
+
+    def test_workspace_delete_only_at_canonical(self) -> None:
+        """Same path under both prefixes for different methods is fine —
+        but we assert specifically that the DELETE on /workspaces/{id}
+        isn't accidentally back on the TFE-spec router."""
+        # The route exists under both /api/v2 (deprecated alias) and
+        # /api/terrapod/v1 (canonical) for the DELETE method.
+        delete_routes = [
+            r
+            for r in app.routes
+            if getattr(r, "path", "")
+            in (
+                "/api/v2/workspaces/{workspace_id}",
+                "/api/terrapod/v1/workspaces/{workspace_id}",
+            )
+            and "DELETE" in getattr(r, "methods", set())
+        ]
+        # Two routes total: canonical + deprecated alias.
+        assert len(delete_routes) == 2, (
+            f"expected DELETE on both prefixes, got {len(delete_routes)}: {delete_routes}"
+        )
+
+
+class TestDeprecationHeaders:
+    """The middleware must emit Deprecation/Link/X-Removed-In on legacy
+    paths only — not on canonical paths or on CLI-surface /api/v2 routes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_legacy_alias_emits_deprecation_headers(self, client: httpx.AsyncClient) -> None:
+        async with client:
+            # /auth/providers doesn't require DB or Redis — pure connector
+            # registry lookup — so it works in unit-test context. We're
+            # only asserting on response headers, not body.
+            resp = await client.get("/api/v2/auth/providers")
+        assert resp.headers.get("Deprecation") == "true", (
+            f"missing Deprecation header on legacy alias; headers: {dict(resp.headers)}"
+        )
+        assert 'rel="deprecation"' in resp.headers.get("Link", "")
+        assert resp.headers.get("X-Removed-In") == "v0.24.0"
+
+    @pytest.mark.asyncio
+    async def test_canonical_path_does_not_emit_deprecation_headers(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        async with client:
+            resp = await client.get("/api/terrapod/v1/auth/providers")
+        assert "Deprecation" not in resp.headers, (
+            f"canonical path leaking deprecation header: {dict(resp.headers)}"
+        )
+        assert "X-Removed-In" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_cli_surface_v2_path_does_not_emit_deprecation_headers(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """/api/v2/ping is permanent CLI surface — not deprecated even
+        though it's under /api/v2."""
+        async with client:
+            resp = await client.get("/api/v2/ping")
+        assert "Deprecation" not in resp.headers
+        assert "X-Removed-In" not in resp.headers

--- a/services/tests/api/test_audit.py
+++ b/services/tests/api/test_audit.py
@@ -63,12 +63,12 @@ class TestAuditLogRequiresAuth:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     async def test_no_auth_returns_401(self, *mocks):
-        """GET /api/v2/admin/audit-log without auth → 401."""
+        """GET /api/terrapod/v1/admin/audit-log without auth → 401."""
         app = create_app()
         app.dependency_overrides[get_db] = lambda: AsyncMock()
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/admin/audit-log")
+            resp = await c.get("/api/terrapod/v1/admin/audit-log")
         assert resp.status_code == 401
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
@@ -80,7 +80,7 @@ class TestAuditLogRequiresAuth:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/admin/audit-log", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/admin/audit-log", headers=_AUTH)
         assert resp.status_code == 403
 
 
@@ -96,7 +96,7 @@ class TestAuditLogReturnsEntries:
 
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/admin/audit-log", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/admin/audit-log", headers=_AUTH)
 
         assert resp.status_code == 200
         body = resp.json()
@@ -117,7 +117,7 @@ class TestAuditLogReturnsEntries:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/admin/audit-log", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/admin/audit-log", headers=_AUTH)
         assert resp.status_code == 200
 
 
@@ -133,7 +133,7 @@ class TestAuditLogPassesFilters:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                "/api/v2/admin/audit-log",
+                "/api/terrapod/v1/admin/audit-log",
                 params={
                     "filter[actor]": "admin@test.com",
                     "filter[resource-type]": "runs",
@@ -166,7 +166,7 @@ class TestAuditLogPagination:
         app, _ = _make_app(_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                "/api/v2/admin/audit-log",
+                "/api/terrapod/v1/admin/audit-log",
                 params={"page[number]": "2", "page[size]": "5"},
                 headers=_AUTH,
             )
@@ -187,7 +187,7 @@ class TestAuditLogPagination:
         app, _ = _make_app(_user())
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/admin/audit-log", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/admin/audit-log", headers=_AUTH)
         assert resp.status_code == 200
         body = resp.json()
         assert body["data"] == []

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -253,7 +253,7 @@ class TestDismissDriftAction:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/actions/dismiss-drift",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/actions/dismiss-drift",
                 headers=_AUTH,
             )
 
@@ -283,7 +283,7 @@ class TestDismissDriftAction:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/actions/dismiss-drift",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/actions/dismiss-drift",
                 headers=_AUTH,
             )
 
@@ -311,7 +311,7 @@ class TestDismissDriftAction:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/actions/dismiss-drift",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/actions/dismiss-drift",
                 headers=_AUTH,
             )
 

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -278,7 +278,7 @@ class TestRetryRunCopiesOverrides:
         app, _ = _make_app(_admin_user(), mock_db=mock_db)
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.post(
-                f"/api/v2/runs/run-{original.id}/actions/retry",
+                f"/api/terrapod/v1/runs/run-{original.id}/actions/retry",
                 headers=_AUTH,
             )
 
@@ -311,7 +311,7 @@ class TestWorkspaceLinkCRUD:
         app, _ = _make_app(_admin_user(), mock_db=mock_db)
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.get(
-                "/api/v2/organizations/default/registry-modules/private/default/eks/aws/workspace-links",
+                "/api/terrapod/v1/registry-modules/private/default/eks/aws/workspace-links",
                 headers=_AUTH,
             )
 
@@ -335,7 +335,7 @@ class TestWorkspaceLinkCRUD:
         app, _ = _make_app(_admin_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.post(
-                "/api/v2/organizations/default/registry-modules/private/default/eks/aws/workspace-links",
+                "/api/terrapod/v1/registry-modules/private/default/eks/aws/workspace-links",
                 headers={**_AUTH, "Content-Type": "application/vnd.api+json"},
                 json={
                     "data": {

--- a/services/tests/api/test_notification_configurations.py
+++ b/services/tests/api/test_notification_configurations.py
@@ -88,7 +88,7 @@ class TestCreateNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/notification-configurations",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/notification-configurations",
                 json={
                     "data": {
                         "type": "notification-configurations",
@@ -121,7 +121,7 @@ class TestCreateNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/notification-configurations",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/notification-configurations",
                 json={
                     "data": {
                         "type": "notification-configurations",
@@ -152,7 +152,7 @@ class TestCreateNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/notification-configurations",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/notification-configurations",
                 json={
                     "data": {
                         "type": "notification-configurations",
@@ -185,7 +185,7 @@ class TestCreateNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/notification-configurations",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/notification-configurations",
                 json={
                     "data": {
                         "type": "notification-configurations",
@@ -217,7 +217,7 @@ class TestCreateNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/notification-configurations",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/notification-configurations",
                 json={
                     "data": {
                         "type": "notification-configurations",
@@ -249,7 +249,7 @@ class TestCreateNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/notification-configurations",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/notification-configurations",
                 json={
                     "data": {
                         "type": "notification-configurations",
@@ -289,7 +289,7 @@ class TestListNotificationConfigurations:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/workspaces/ws-{ws.id}/notification-configurations",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/notification-configurations",
                 headers=_AUTH,
             )
         assert resp.status_code == 200
@@ -316,7 +316,7 @@ class TestShowNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/notification-configurations/nc-{nc.id}",
+                f"/api/terrapod/v1/notification-configurations/nc-{nc.id}",
                 headers=_AUTH,
             )
         assert resp.status_code == 200
@@ -364,7 +364,7 @@ class TestUpdateNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                f"/api/v2/notification-configurations/nc-{nc.id}",
+                f"/api/terrapod/v1/notification-configurations/nc-{nc.id}",
                 json={
                     "data": {
                         "type": "notification-configurations",
@@ -391,7 +391,7 @@ class TestUpdateNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                f"/api/v2/notification-configurations/nc-{nc.id}",
+                f"/api/terrapod/v1/notification-configurations/nc-{nc.id}",
                 json={"data": {"type": "notification-configurations", "attributes": {"name": "X"}}},
                 headers=_AUTH,
             )
@@ -419,7 +419,7 @@ class TestDeleteNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(
-                f"/api/v2/notification-configurations/nc-{nc.id}",
+                f"/api/terrapod/v1/notification-configurations/nc-{nc.id}",
                 headers=_AUTH,
             )
         assert resp.status_code == 204
@@ -449,7 +449,7 @@ class TestVerifyNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/notification-configurations/nc-{nc.id}/actions/verify",
+                f"/api/terrapod/v1/notification-configurations/nc-{nc.id}/actions/verify",
                 headers=_AUTH,
             )
         assert resp.status_code == 200

--- a/services/tests/api/test_rate_limit.py
+++ b/services/tests/api/test_rate_limit.py
@@ -13,10 +13,10 @@ from terrapod.auth.runner_tokens import generate_runner_token
 
 class TestHelpers:
     def test_is_auth_path(self):
-        assert _is_auth_path("/api/v2/auth/login") is True
-        assert _is_auth_path("/api/v2/auth/callback") is True
+        assert _is_auth_path("/api/terrapod/v1/auth/login") is True
+        assert _is_auth_path("/api/terrapod/v1/auth/callback") is True
         assert _is_auth_path("/oauth/authorize") is True
-        assert _is_auth_path("/api/v2/workspaces") is False
+        assert _is_auth_path("/api/terrapod/v1/workspaces") is False
         assert _is_auth_path("/health") is False
 
     def test_get_client_ip_forwarded(self):
@@ -78,11 +78,11 @@ def _make_app(
     async def health():
         return {"status": "ok"}
 
-    @app.get("/api/v2/workspaces")
+    @app.get("/api/terrapod/v1/workspaces")
     async def workspaces():
         return {"data": []}
 
-    @app.post("/api/v2/auth/login")
+    @app.post("/api/terrapod/v1/auth/login")
     async def login():
         return {"token": "test"}
 
@@ -112,7 +112,7 @@ class TestRateLimitMiddleware:
         mock_redis = _make_redis_mock(count=1)
         app = _make_app(get_redis=lambda: mock_redis, rpm=5)
         client = TestClient(app)
-        response = client.get("/api/v2/workspaces")
+        response = client.get("/api/terrapod/v1/workspaces")
         assert "X-Ratelimit-Limit" in response.headers
         assert "X-Ratelimit-Remaining" in response.headers
         assert response.headers["X-Ratelimit-Limit"] == "5"
@@ -123,7 +123,7 @@ class TestRateLimitMiddleware:
         mock_redis = _make_redis_mock(count=6)
         app = _make_app(get_redis=lambda: mock_redis, rpm=5)
         client = TestClient(app)
-        response = client.get("/api/v2/workspaces")
+        response = client.get("/api/terrapod/v1/workspaces")
         assert response.status_code == 429
         assert "Retry-After" in response.headers
         body = response.json()
@@ -134,7 +134,7 @@ class TestRateLimitMiddleware:
         mock_redis = _make_redis_mock(count=3)
         app = _make_app(get_redis=lambda: mock_redis, rpm=100, auth_rpm=2)
         client = TestClient(app)
-        response = client.post("/api/v2/auth/login")
+        response = client.post("/api/terrapod/v1/auth/login")
         assert response.status_code == 429
 
     def test_redis_failure_fails_open(self):
@@ -142,7 +142,7 @@ class TestRateLimitMiddleware:
         mock_redis = _make_redis_mock(error=Exception("Redis down"))
         app = _make_app(get_redis=lambda: mock_redis)
         client = TestClient(app)
-        response = client.get("/api/v2/workspaces")
+        response = client.get("/api/terrapod/v1/workspaces")
         assert response.status_code == 200
 
     def test_redis_not_initialized_fails_open(self):
@@ -153,7 +153,7 @@ class TestRateLimitMiddleware:
 
         app = _make_app(get_redis=raise_runtime_error)
         client = TestClient(app)
-        response = client.get("/api/v2/workspaces")
+        response = client.get("/api/terrapod/v1/workspaces")
         assert response.status_code == 200
 
     def test_runner_token_default_unlimited_bypasses_redis(self):
@@ -164,7 +164,7 @@ class TestRateLimitMiddleware:
         token = generate_runner_token(uuid.uuid4())
         for _ in range(10):
             response = client.get(
-                "/api/v2/workspaces", headers={"Authorization": f"Bearer {token}"}
+                "/api/terrapod/v1/workspaces", headers={"Authorization": f"Bearer {token}"}
             )
             assert response.status_code == 200
         # Bypass path must not touch Redis
@@ -176,7 +176,9 @@ class TestRateLimitMiddleware:
         app = _make_app(get_redis=lambda: mock_redis, runner_rpm=5, rpm=100)
         client = TestClient(app)
         token = generate_runner_token(uuid.uuid4())
-        response = client.get("/api/v2/workspaces", headers={"Authorization": f"Bearer {token}"})
+        response = client.get(
+            "/api/terrapod/v1/workspaces", headers={"Authorization": f"Bearer {token}"}
+        )
         assert response.status_code == 429
         # Verify the runner-specific key prefix was used
         incr_call = mock_redis.pipeline.return_value.incr.call_args
@@ -189,7 +191,7 @@ class TestRateLimitMiddleware:
         app = _make_app(get_redis=lambda: mock_redis, runner_rpm=0, authenticated_rpm=10)
         client = TestClient(app)
         response = client.get(
-            "/api/v2/workspaces",
+            "/api/terrapod/v1/workspaces",
             headers={"Authorization": "Bearer runtok:bogus:3600:0:deadbeef"},
         )
         assert response.status_code == 200
@@ -205,7 +207,7 @@ class TestRateLimitMiddleware:
         app = _make_app(get_redis=lambda: mock_redis, rpm=5, authenticated_rpm=500)
         client = TestClient(app)
         response = client.get(
-            "/api/v2/workspaces", headers={"Authorization": "Bearer some-api-token"}
+            "/api/terrapod/v1/workspaces", headers={"Authorization": "Bearer some-api-token"}
         )
         assert response.status_code == 200
         incr_call = mock_redis.pipeline.return_value.incr.call_args
@@ -217,7 +219,7 @@ class TestRateLimitMiddleware:
         mock_redis = _make_redis_mock(count=1)
         app = _make_app(get_redis=lambda: mock_redis, rpm=5, authenticated_rpm=500)
         client = TestClient(app)
-        response = client.get("/api/v2/workspaces")
+        response = client.get("/api/terrapod/v1/workspaces")
         assert response.status_code == 200
         incr_call = mock_redis.pipeline.return_value.incr.call_args
         key = incr_call[0][0]
@@ -230,7 +232,7 @@ class TestRateLimitMiddleware:
         mock_redis = _make_redis_mock(count=9999)
         app = _make_app(get_redis=lambda: mock_redis, rpm=0)
         client = TestClient(app)
-        response = client.get("/api/v2/workspaces")
+        response = client.get("/api/terrapod/v1/workspaces")
         assert response.status_code == 200
         mock_redis.pipeline.assert_not_called()
 
@@ -240,5 +242,7 @@ class TestRateLimitMiddleware:
         app = _make_app(get_redis=lambda: mock_redis, auth_rpm=2, runner_rpm=0)
         client = TestClient(app)
         token = generate_runner_token(uuid.uuid4())
-        response = client.post("/api/v2/auth/login", headers={"Authorization": f"Bearer {token}"})
+        response = client.post(
+            "/api/terrapod/v1/auth/login", headers={"Authorization": f"Bearer {token}"}
+        )
         assert response.status_code == 429

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -76,7 +76,7 @@ class TestListRoles:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles", headers=_AUTH)
         assert resp.status_code == 200
         data = resp.json()["data"]
         names = [r["name"] for r in data]
@@ -105,7 +105,7 @@ class TestListRoles:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles", headers=_AUTH)
         assert resp.status_code == 200
         data = resp.json()["data"]
         custom_entry = next(r for r in data if r["name"] == "pool-role")
@@ -125,7 +125,7 @@ class TestListRoles:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles", headers=_AUTH)
         assert resp.status_code == 200
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
@@ -136,7 +136,7 @@ class TestListRoles:
         app, _ = _make_app(user)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles", headers=_AUTH)
         assert resp.status_code == 403
 
 
@@ -158,7 +158,7 @@ class TestCreateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                "/api/v2/roles",
+                "/api/terrapod/v1/roles",
                 json={
                     "data": {
                         "name": "new-role",
@@ -182,7 +182,7 @@ class TestCreateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                "/api/v2/roles",
+                "/api/terrapod/v1/roles",
                 json={
                     "data": {
                         "name": "admin",
@@ -206,7 +206,7 @@ class TestCreateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                "/api/v2/roles",
+                "/api/terrapod/v1/roles",
                 json={
                     "data": {
                         "name": "existing",
@@ -230,7 +230,7 @@ class TestCreateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                "/api/v2/roles",
+                "/api/terrapod/v1/roles",
                 json={
                     "data": {
                         "name": "bad-role",
@@ -254,7 +254,7 @@ class TestCreateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                "/api/v2/roles",
+                "/api/terrapod/v1/roles",
                 json={
                     "data": {
                         "name": "pool-admin-role",
@@ -280,7 +280,7 @@ class TestCreateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                "/api/v2/roles",
+                "/api/terrapod/v1/roles",
                 json={
                     "data": {
                         "name": "bad-pool",
@@ -303,7 +303,7 @@ class TestCreateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                "/api/v2/roles",
+                "/api/terrapod/v1/roles",
                 json={
                     "data": {
                         "name": "x",
@@ -326,7 +326,7 @@ class TestShowRole:
         app, _ = _make_app(_user(roles=["admin"]))
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles/admin", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles/admin", headers=_AUTH)
         assert resp.status_code == 200
         assert resp.json()["data"]["attributes"]["built-in"] is True
 
@@ -341,7 +341,7 @@ class TestShowRole:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles/my-role", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles/my-role", headers=_AUTH)
         assert resp.status_code == 200
         assert resp.json()["data"]["attributes"]["workspace-permission"] == "write"
 
@@ -357,7 +357,7 @@ class TestShowRole:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles/pool-role", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles/pool-role", headers=_AUTH)
         assert resp.status_code == 200
         assert resp.json()["data"]["attributes"]["pool-permission"] == "write"
 
@@ -368,7 +368,7 @@ class TestShowRole:
         app, _ = _make_app(_user(roles=["admin"]))
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles/admin", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles/admin", headers=_AUTH)
         assert resp.status_code == 200
         assert resp.json()["data"]["attributes"]["pool-permission"] == "admin"
 
@@ -379,7 +379,7 @@ class TestShowRole:
         app, _ = _make_app(_user(roles=["admin"]))
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles/everyone", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles/everyone", headers=_AUTH)
         assert resp.status_code == 200
         assert resp.json()["data"]["attributes"]["pool-permission"] == "read"
 
@@ -393,7 +393,7 @@ class TestShowRole:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/roles/nope", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/roles/nope", headers=_AUTH)
         assert resp.status_code == 404
 
 
@@ -409,7 +409,7 @@ class TestUpdateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                "/api/v2/roles/admin",
+                "/api/terrapod/v1/roles/admin",
                 json={"data": {"attributes": {"description": "hacked"}}},
                 headers=_AUTH,
             )
@@ -429,7 +429,7 @@ class TestUpdateRole:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                "/api/v2/roles/my-role",
+                "/api/terrapod/v1/roles/my-role",
                 json={"data": {"attributes": {"workspace-permission": "write"}}},
                 headers=_AUTH,
             )
@@ -447,7 +447,7 @@ class TestDeleteRole:
         app, _ = _make_app(_user(roles=["admin"]))
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.delete("/api/v2/roles/everyone", headers=_AUTH)
+            resp = await c.delete("/api/terrapod/v1/roles/everyone", headers=_AUTH)
         assert resp.status_code == 422
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
@@ -461,7 +461,7 @@ class TestDeleteRole:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.delete("/api/v2/roles/temp-role", headers=_AUTH)
+            resp = await c.delete("/api/terrapod/v1/roles/temp-role", headers=_AUTH)
         assert resp.status_code == 204
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
@@ -474,7 +474,7 @@ class TestDeleteRole:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.delete("/api/v2/roles/nope", headers=_AUTH)
+            resp = await c.delete("/api/terrapod/v1/roles/nope", headers=_AUTH)
         assert resp.status_code == 404
 
 
@@ -493,7 +493,7 @@ class TestRoleAssignments:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/v2/role-assignments", headers=_AUTH)
+            resp = await c.get("/api/terrapod/v1/role-assignments", headers=_AUTH)
         assert resp.status_code == 200
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
@@ -513,7 +513,7 @@ class TestRoleAssignments:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.put(
-                "/api/v2/role-assignments",
+                "/api/terrapod/v1/role-assignments",
                 json={
                     "data": {
                         "attributes": {
@@ -536,7 +536,7 @@ class TestRoleAssignments:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.put(
-                "/api/v2/role-assignments",
+                "/api/terrapod/v1/role-assignments",
                 json={
                     "data": {
                         "attributes": {

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -76,7 +76,7 @@ class TestUploadStateDuplicateSerial:
         state_json = json.dumps({"version": 4, "serial": 8, "lineage": "abc"})
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.put(
-                f"/api/v2/runs/{run.id}/artifacts/state",
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/state",
                 content=state_json,
                 headers={**_AUTH, "Content-Type": "application/json"},
             )
@@ -115,7 +115,7 @@ class TestUploadStateDuplicateSerial:
         state_json = json.dumps({"version": 4, "serial": 8, "lineage": "abc"})
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.put(
-                f"/api/v2/runs/{run.id}/artifacts/state",
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/state",
                 content=state_json,
                 headers={**_AUTH, "Content-Type": "application/json"},
             )
@@ -153,7 +153,7 @@ class TestUploadStateDuplicateSerial:
         state_json = json.dumps({"version": 4, "serial": 9, "lineage": "abc"})
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.put(
-                f"/api/v2/runs/{run.id}/artifacts/state",
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/state",
                 content=state_json,
                 headers={**_AUTH, "Content-Type": "application/json"},
             )

--- a/services/tests/api/test_run_tasks.py
+++ b/services/tests/api/test_run_tasks.py
@@ -113,7 +113,7 @@ class TestCreateRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/run-tasks",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-tasks",
                 json={
                     "data": {
                         "type": "run-tasks",
@@ -147,7 +147,7 @@ class TestCreateRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/run-tasks",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-tasks",
                 json={
                     "data": {
                         "type": "run-tasks",
@@ -179,7 +179,7 @@ class TestCreateRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/run-tasks",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-tasks",
                 json={
                     "data": {
                         "type": "run-tasks",
@@ -210,7 +210,7 @@ class TestCreateRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/run-tasks",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-tasks",
                 json={
                     "data": {
                         "type": "run-tasks",
@@ -250,7 +250,7 @@ class TestListRunTasks:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/workspaces/ws-{ws.id}/run-tasks",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-tasks",
                 headers=_AUTH,
             )
         assert resp.status_code == 200
@@ -277,7 +277,7 @@ class TestShowRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/run-tasks/task-{rt.id}",
+                f"/api/terrapod/v1/run-tasks/task-{rt.id}",
                 headers=_AUTH,
             )
         assert resp.status_code == 200
@@ -324,7 +324,7 @@ class TestUpdateRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                f"/api/v2/run-tasks/task-{rt.id}",
+                f"/api/terrapod/v1/run-tasks/task-{rt.id}",
                 json={
                     "data": {
                         "type": "run-tasks",
@@ -351,7 +351,7 @@ class TestUpdateRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                f"/api/v2/run-tasks/task-{rt.id}",
+                f"/api/terrapod/v1/run-tasks/task-{rt.id}",
                 json={"data": {"type": "run-tasks", "attributes": {"name": "X"}}},
                 headers=_AUTH,
             )
@@ -379,7 +379,7 @@ class TestDeleteRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(
-                f"/api/v2/run-tasks/task-{rt.id}",
+                f"/api/terrapod/v1/run-tasks/task-{rt.id}",
                 headers=_AUTH,
             )
         assert resp.status_code == 204
@@ -408,7 +408,7 @@ class TestCallback:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                f"/api/v2/task-stage-results/tsr-{tsr.id}/callback",
+                f"/api/terrapod/v1/task-stage-results/tsr-{tsr.id}/callback",
                 json={
                     "access_token": "valid-token",
                     "status": "passed",
@@ -456,7 +456,7 @@ class TestCallback:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                f"/api/v2/task-stage-results/tsr-{tsr.id}/callback",
+                f"/api/terrapod/v1/task-stage-results/tsr-{tsr.id}/callback",
                 json={
                     "access_token": "valid-token",
                     "status": "maybe",

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -97,7 +97,7 @@ class TestCreateRunTrigger:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{dest_ws.id}/run-triggers",
+                f"/api/terrapod/v1/workspaces/ws-{dest_ws.id}/run-triggers",
                 json={
                     "data": {
                         "relationships": {
@@ -128,7 +128,7 @@ class TestCreateRunTrigger:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/run-triggers",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-triggers",
                 json={
                     "data": {
                         "relationships": {
@@ -167,7 +167,7 @@ class TestCreateRunTrigger:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{dest_ws.id}/run-triggers",
+                f"/api/terrapod/v1/workspaces/ws-{dest_ws.id}/run-triggers",
                 json={
                     "data": {
                         "relationships": {
@@ -210,7 +210,7 @@ class TestCreateRunTrigger:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{dest_ws.id}/run-triggers",
+                f"/api/terrapod/v1/workspaces/ws-{dest_ws.id}/run-triggers",
                 json={
                     "data": {
                         "relationships": {
@@ -241,7 +241,7 @@ class TestCreateRunTrigger:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
-                f"/api/v2/workspaces/ws-{ws.id}/run-triggers",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-triggers",
                 json={
                     "data": {
                         "relationships": {
@@ -279,7 +279,7 @@ class TestListRunTriggers:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/workspaces/ws-{ws.id}/run-triggers",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-triggers",
                 params={"filter[run-trigger][type]": "inbound"},
                 headers=_AUTH,
             )
@@ -305,7 +305,7 @@ class TestListRunTriggers:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/workspaces/ws-{ws.id}/run-triggers",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-triggers",
                 params={"filter[run-trigger][type]": "outbound"},
                 headers=_AUTH,
             )
@@ -328,7 +328,7 @@ class TestListRunTriggers:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/workspaces/ws-{ws.id}/run-triggers",
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/run-triggers",
                 headers=_AUTH,
             )
         assert resp.status_code == 422
@@ -352,7 +352,7 @@ class TestShowRunTrigger:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get(f"/api/v2/run-triggers/rt-{trigger.id}", headers=_AUTH)
+            resp = await c.get(f"/api/terrapod/v1/run-triggers/rt-{trigger.id}", headers=_AUTH)
         assert resp.status_code == 200
         data = resp.json()["data"]
         assert data["type"] == "run-triggers"
@@ -391,7 +391,7 @@ class TestDeleteRunTrigger:
         mock_db.delete = AsyncMock()
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.delete(f"/api/v2/run-triggers/rt-{trigger.id}", headers=_AUTH)
+            resp = await c.delete(f"/api/terrapod/v1/run-triggers/rt-{trigger.id}", headers=_AUTH)
         assert resp.status_code == 204
 
 

--- a/services/tests/api/test_state_management.py
+++ b/services/tests/api/test_state_management.py
@@ -115,7 +115,9 @@ class TestDeleteStateVersion:
 
         sv_id = f"sv-{sv.id}"
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            resp = await client.delete(f"/api/v2/state-versions/{sv_id}/manage", headers=_AUTH)
+            resp = await client.delete(
+                f"/api/terrapod/v1/state-versions/{sv_id}/manage", headers=_AUTH
+            )
 
         assert resp.status_code == 204
         mock_db.delete.assert_called_once_with(sv)
@@ -150,7 +152,9 @@ class TestDeleteStateVersion:
 
         sv_id = f"sv-{sv.id}"
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            resp = await client.delete(f"/api/v2/state-versions/{sv_id}/manage", headers=_AUTH)
+            resp = await client.delete(
+                f"/api/terrapod/v1/state-versions/{sv_id}/manage", headers=_AUTH
+            )
 
         assert resp.status_code == 409
         assert "current" in resp.json()["detail"].lower()
@@ -181,7 +185,9 @@ class TestDeleteStateVersion:
 
         sv_id = f"sv-{sv.id}"
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            resp = await client.delete(f"/api/v2/state-versions/{sv_id}/manage", headers=_AUTH)
+            resp = await client.delete(
+                f"/api/terrapod/v1/state-versions/{sv_id}/manage", headers=_AUTH
+            )
 
         assert resp.status_code == 403
 
@@ -237,7 +243,7 @@ class TestRollbackStateVersion:
         sv_id = f"sv-{sv.id}"
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.post(
-                f"/api/v2/state-versions/{sv_id}/actions/rollback", headers=_AUTH
+                f"/api/terrapod/v1/state-versions/{sv_id}/actions/rollback", headers=_AUTH
             )
 
         assert resp.status_code == 201
@@ -278,7 +284,7 @@ class TestRollbackStateVersion:
         sv_id = f"sv-{sv.id}"
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.post(
-                f"/api/v2/state-versions/{sv_id}/actions/rollback", headers=_AUTH
+                f"/api/terrapod/v1/state-versions/{sv_id}/actions/rollback", headers=_AUTH
             )
 
         assert resp.status_code == 404
@@ -331,7 +337,7 @@ class TestUploadState:
         ws_id_str = f"ws-{ws_id}"
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.post(
-                f"/api/v2/workspaces/{ws_id_str}/state-versions/actions/upload",
+                f"/api/terrapod/v1/workspaces/{ws_id_str}/state-versions/actions/upload",
                 content=state_json,
                 headers={**_AUTH, "Content-Type": "application/json"},
             )
@@ -365,7 +371,7 @@ class TestUploadState:
         ws_id_str = f"ws-{ws.id}"
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.post(
-                f"/api/v2/workspaces/{ws_id_str}/state-versions/actions/upload",
+                f"/api/terrapod/v1/workspaces/{ws_id_str}/state-versions/actions/upload",
                 content='{"version": 4}',
                 headers={**_AUTH, "Content-Type": "application/json"},
             )
@@ -396,7 +402,7 @@ class TestUploadState:
         ws_id_str = f"ws-{ws.id}"
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             resp = await client.post(
-                f"/api/v2/workspaces/{ws_id_str}/state-versions/actions/upload",
+                f"/api/terrapod/v1/workspaces/{ws_id_str}/state-versions/actions/upload",
                 content="not json {{{",
                 headers={**_AUTH, "Content-Type": "application/json"},
             )

--- a/services/tests/api/test_tfe_v2.py
+++ b/services/tests/api/test_tfe_v2.py
@@ -174,7 +174,7 @@ class TestTokenCRUD:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.post(
-                "/api/v2/users/test/authentication-tokens",
+                "/api/terrapod/v1/users/test/authentication-tokens",
                 json={
                     "data": {
                         "type": "authentication-tokens",
@@ -225,7 +225,7 @@ class TestTokenCRUD:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
-                "/api/v2/users/test/authentication-tokens",
+                "/api/terrapod/v1/users/test/authentication-tokens",
                 headers={"Authorization": "Bearer dummy"},
             )
 
@@ -266,7 +266,7 @@ class TestTokenCRUD:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.delete(
-                "/api/v2/authentication-tokens/at-abc123",
+                "/api/terrapod/v1/authentication-tokens/at-abc123",
                 headers={"Authorization": "Bearer dummy"},
             )
 
@@ -299,7 +299,7 @@ class TestTokenCRUD:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.delete(
-                "/api/v2/authentication-tokens/at-abc123",
+                "/api/terrapod/v1/authentication-tokens/at-abc123",
                 headers={"Authorization": "Bearer dummy"},
             )
 
@@ -322,7 +322,7 @@ class TestTokenCRUD:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.post(
-                "/api/v2/users/other-user/authentication-tokens",
+                "/api/terrapod/v1/users/other-user/authentication-tokens",
                 json={"data": {"type": "authentication-tokens", "attributes": {}}},
                 headers={"Authorization": "Bearer dummy"},
             )

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -143,19 +143,6 @@ class TestCreateWorkspace:
             )
         assert resp.status_code == 422
 
-    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
-    @patch("terrapod.api.app.init_redis")
-    @patch("terrapod.api.app.init_db")
-    async def test_create_wrong_org_returns_404(self, *mocks):
-        app, _ = _make_app(_user())
-        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.post(
-                "/api/v2/organizations/other-org/workspaces",
-                json={"data": {"attributes": {"name": "ws"}}},
-                headers=_AUTH,
-            )
-        assert resp.status_code == 404
-
 
 # ── Show Workspace ─────────────────────────────────────────────────────
 
@@ -328,7 +315,7 @@ class TestDeleteWorkspace:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.delete(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+            resp = await c.delete(f"/api/terrapod/v1/workspaces/ws-{ws.id}", headers=_AUTH)
         assert resp.status_code == 204
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
@@ -344,7 +331,7 @@ class TestDeleteWorkspace:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.delete(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+            resp = await c.delete(f"/api/terrapod/v1/workspaces/ws-{ws.id}", headers=_AUTH)
         assert resp.status_code == 403
 
 

--- a/services/tests/integration/test_rbac_enforcement.py
+++ b/services/tests/integration/test_rbac_enforcement.py
@@ -68,7 +68,7 @@ class TestAdminBypass:
         ws_id = create.json()["data"]["id"]
 
         set_auth(app, admin_user("admin-del@test.com"))
-        resp = await client.delete(f"/api/v2/workspaces/{ws_id}", headers=AUTH)
+        resp = await client.delete(f"/api/terrapod/v1/workspaces/{ws_id}", headers=AUTH)
         assert resp.status_code == 204
 
 
@@ -102,7 +102,7 @@ class TestOwnerPermissions:
         create = await client.post(WS_ENDPOINT, json=_ws_body("owner-del"), headers=AUTH)
         ws_id = create.json()["data"]["id"]
 
-        resp = await client.delete(f"/api/v2/workspaces/{ws_id}", headers=AUTH)
+        resp = await client.delete(f"/api/terrapod/v1/workspaces/{ws_id}", headers=AUTH)
         assert resp.status_code == 204
 
 
@@ -129,7 +129,7 @@ class TestRegularUserAccess:
         ws_id = create.json()["data"]["id"]
 
         set_auth(app, regular_user("dave@test.com"))
-        resp = await client.delete(f"/api/v2/workspaces/{ws_id}", headers=AUTH)
+        resp = await client.delete(f"/api/terrapod/v1/workspaces/{ws_id}", headers=AUTH)
         assert resp.status_code == 403
 
 

--- a/services/tests/integration/test_run_execution.py
+++ b/services/tests/integration/test_run_execution.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.integration
 # ---------------------------------------------------------------------------
 
 WS_ENDPOINT = "/api/v2/organizations/default/workspaces"
-POOLS_ENDPOINT = "/api/v2/organizations/default/agent-pools"
+POOLS_ENDPOINT = "/api/terrapod/v1/agent-pools"
 RUNS_ENDPOINT = "/api/v2/runs"
 
 FAKE_PLAN_LOG = b"Terraform will perform the following actions:\n  + aws_instance.web\nPlan: 1 to add, 0 to change, 0 to destroy."
@@ -59,7 +59,7 @@ async def _create_pool(client, name="test-pool") -> str:
 async def _create_pool_token(client, pool_id: str) -> str:
     """Create a join token for a pool, return the raw token string."""
     resp = await client.post(
-        f"/api/v2/agent-pools/{pool_id}/tokens",
+        f"/api/terrapod/v1/agent-pools/{pool_id}/tokens",
         json={"data": {"attributes": {"description": "test token"}}},
         headers=AUTH,
     )
@@ -70,7 +70,7 @@ async def _create_pool_token(client, pool_id: str) -> str:
 async def _join_listener(client, pool_id: str, join_token: str, name="test-listener") -> dict:
     """Join a listener to a pool via token exchange, return result dict."""
     resp = await client.post(
-        f"/api/v2/agent-pools/{pool_id}/listeners/join",
+        f"/api/terrapod/v1/agent-pools/{pool_id}/listeners/join",
         json={"join_token": join_token, "name": name},
     )
     assert resp.status_code == 201, resp.text
@@ -121,7 +121,7 @@ async def _create_run(client, ws_id: str, **attrs) -> dict:
 
 async def _claim_run(client, listener_id: str):
     """Claim the next available run. Returns (data, phase) or None."""
-    resp = await client.get(f"/api/v2/listeners/{listener_id}/runs/next")
+    resp = await client.get(f"/api/terrapod/v1/listeners/{listener_id}/runs/next")
     if resp.status_code == 204:
         return None
     assert resp.status_code == 200, resp.text
@@ -133,7 +133,7 @@ async def _claim_run(client, listener_id: str):
 async def _report_job_launched(client, listener_id: str, run_id: str) -> None:
     """Report that a K8s Job was launched for a run."""
     resp = await client.post(
-        f"/api/v2/listeners/{listener_id}/runs/{run_id}/job-launched",
+        f"/api/terrapod/v1/listeners/{listener_id}/runs/{run_id}/job-launched",
         json={"job_name": f"tprun-{run_id[:8]}", "job_namespace": "terrapod-runners"},
     )
     assert resp.status_code == 200, resp.text
@@ -142,7 +142,7 @@ async def _report_job_launched(client, listener_id: str, run_id: str) -> None:
 async def _get_runner_token(client, listener_id: str, run_id: str) -> str:
     """Get a runner token for artifact uploads. Run must be claimed first."""
     resp = await client.post(
-        f"/api/v2/listeners/{listener_id}/runs/{run_id}/runner-token",
+        f"/api/terrapod/v1/listeners/{listener_id}/runs/{run_id}/runner-token",
         json={},
     )
     assert resp.status_code == 200, resp.text
@@ -160,7 +160,7 @@ async def _upload_artifact(
     """Upload an artifact with runner token auth. Returns status code."""
     bare_id = _bare_run_id(run_id)
     resp = await client.put(
-        f"/api/v2/runs/{bare_id}/artifacts/{artifact_type}",
+        f"/api/terrapod/v1/runs/{bare_id}/artifacts/{artifact_type}",
         content=data,
         headers={"Authorization": f"Bearer {runner_token}"},
     )
@@ -172,7 +172,7 @@ async def _report_job_status(
 ) -> None:
     """Report Job status (writes to Redis for reconciler)."""
     resp = await client.post(
-        f"/api/v2/listeners/{listener_id}/runs/{run_id}/job-status",
+        f"/api/terrapod/v1/listeners/{listener_id}/runs/{run_id}/job-status",
         json={"status": job_status, "phase": phase},
     )
     assert resp.status_code == 200, resp.text

--- a/services/tests/integration/test_workspace_state_lifecycle.py
+++ b/services/tests/integration/test_workspace_state_lifecycle.py
@@ -118,7 +118,7 @@ class TestWorkspaceLifecycle:
         create = await client.post(WS_ENDPOINT, json=_ws_body("del-ws"), headers=AUTH)
         ws_id = create.json()["data"]["id"]
 
-        resp = await client.delete(f"/api/v2/workspaces/{ws_id}", headers=AUTH)
+        resp = await client.delete(f"/api/terrapod/v1/workspaces/{ws_id}", headers=AUTH)
         assert resp.status_code == 204
 
         resp = await client.get(f"/api/v2/workspaces/{ws_id}", headers=AUTH)

--- a/services/tests/services/test_audit_service.py
+++ b/services/tests/services/test_audit_service.py
@@ -28,7 +28,7 @@ class TestShouldAudit:
         assert should_audit("/api/openapi.json") is False
 
     def test_api_endpoint_included(self):
-        assert should_audit("/api/v2/workspaces") is True
+        assert should_audit("/api/terrapod/v1/workspaces") is True
 
     def test_oauth_endpoint_included(self):
         assert should_audit("/oauth/authorize") is True
@@ -54,7 +54,7 @@ class TestParseResource:
         assert rid == "run-xyz"
 
     def test_admin_audit_log(self):
-        rtype, rid = parse_resource("/api/v2/admin/audit-log")
+        rtype, rid = parse_resource("/api/terrapod/v1/admin/audit-log")
         assert rtype == "admin"
         assert rid == "audit-log"
 

--- a/services/tests/services/test_cv_diff_service.py
+++ b/services/tests/services/test_cv_diff_service.py
@@ -1,6 +1,6 @@
 """Tests for `cv_diff_service` — diffs between two CV tarballs.
 
-The service is the backing for `POST /api/v2/configuration-versions/diff`.
+The service is the backing for `POST /api/terrapod/v1/configuration-versions/diff`.
 These tests cover the pure tarball-walking + diffing layer; the
 storage round-trip is exercised via a real local filesystem store
 fixture so we touch the same `_stream_to_tempfile` path the API uses.

--- a/services/tests/storage/test_filesystem.py
+++ b/services/tests/storage/test_filesystem.py
@@ -151,9 +151,15 @@ class TestFilesystemRoutes:
 
     @pytest.fixture
     def app(self, fs_store: FilesystemStore) -> FastAPI:
-        """Create a test FastAPI app with filesystem routes."""
+        """Create a test FastAPI app with filesystem routes.
+
+        Mounts under both the canonical /api/terrapod/v1 prefix (which is
+        what `filesystem.py` emits in presigned URLs) and the deprecated
+        /api/v2 alias, mirroring `app.py`'s `include_moved` behaviour.
+        """
         test_app = FastAPI()
         set_filesystem_store(fs_store)
+        test_app.include_router(router, prefix="/api/terrapod/v1")
         test_app.include_router(router, prefix="/api/v2")
         return test_app
 

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -6,8 +6,30 @@ const nextConfig = {
   // small messages (keepalives, events) indefinitely, breaking real-time
   // streaming. Setting Content-Encoding: none tells the compression
   // middleware to pass these responses through unmodified.
+  //
+  // SSE endpoints all moved from /api/v2 to /api/terrapod/v1 in #269. The
+  // /api/v2 entries are kept until the deprecated alias is dropped in
+  // v0.24.0 (#278).
   async headers() {
     return [
+      // Canonical /api/terrapod/v1 SSE paths
+      {
+        source: '/api/terrapod/v1/listeners/:path*',
+        headers: [{ key: 'Content-Encoding', value: 'none' }],
+      },
+      {
+        source: '/api/terrapod/v1/workspaces/:path*/runs/events',
+        headers: [{ key: 'Content-Encoding', value: 'none' }],
+      },
+      {
+        source: '/api/terrapod/v1/workspace-events',
+        headers: [{ key: 'Content-Encoding', value: 'none' }],
+      },
+      {
+        source: '/api/terrapod/v1/agent-pools/:path*/events',
+        headers: [{ key: 'Content-Encoding', value: 'none' }],
+      },
+      // Deprecated /api/v2 aliases — kept until v0.24.0 (#278)
       {
         source: '/api/v2/listeners/:path*',
         headers: [{ key: 'Content-Encoding', value: 'none' }],
@@ -22,10 +44,6 @@ const nextConfig = {
       },
       {
         source: '/api/v2/agent-pools/:path*/events',
-        headers: [{ key: 'Content-Encoding', value: 'none' }],
-      },
-      {
-        source: '/api/v2/runs/:path*/run-events',
         headers: [{ key: 'Content-Encoding', value: 'none' }],
       },
     ]

--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -125,7 +125,7 @@ export default function AgentPoolDetailPage() {
 
   const loadPool = useCallback(async () => {
     try {
-      const res = await apiFetch(`/api/v2/agent-pools/${poolId}`)
+      const res = await apiFetch(`/api/terrapod/v1/agent-pools/${poolId}`)
       if (!res.ok) throw new Error('Failed to load pool')
       const data = await res.json()
       setPool(data.data)
@@ -150,7 +150,7 @@ export default function AgentPoolDetailPage() {
   async function loadTokens() {
     setTokensLoading(true)
     try {
-      const res = await apiFetch(`/api/v2/agent-pools/${poolId}/tokens`)
+      const res = await apiFetch(`/api/terrapod/v1/agent-pools/${poolId}/tokens`)
       if (!res.ok) throw new Error('Failed to load tokens')
       const data = await res.json()
       setTokens(data.data || [])
@@ -164,7 +164,7 @@ export default function AgentPoolDetailPage() {
   const loadListeners = useCallback(async () => {
     setListenersLoading(true)
     try {
-      const res = await apiFetch(`/api/v2/agent-pools/${poolId}/listeners`)
+      const res = await apiFetch(`/api/terrapod/v1/agent-pools/${poolId}/listeners`)
       if (!res.ok) throw new Error('Failed to load listeners')
       const data = await res.json()
       setListeners(data.data || [])
@@ -197,7 +197,7 @@ export default function AgentPoolDetailPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/agent-pools/${poolId}`, {
+      const res = await apiFetch(`/api/terrapod/v1/agent-pools/${poolId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -227,7 +227,7 @@ export default function AgentPoolDetailPage() {
   async function handleDelete() {
     setDeleting(true)
     try {
-      const res = await apiFetch(`/api/v2/agent-pools/${poolId}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/agent-pools/${poolId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete pool')
       router.push('/admin/agent-pools')
     } catch (err) {
@@ -247,7 +247,7 @@ export default function AgentPoolDetailPage() {
       if (tokenMaxUses) attrs['max-uses'] = parseInt(tokenMaxUses)
       if (tokenExpiry) attrs['expires-at'] = tokenExpiry
 
-      const res = await apiFetch(`/api/v2/agent-pools/${poolId}/tokens`, {
+      const res = await apiFetch(`/api/terrapod/v1/agent-pools/${poolId}/tokens`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'agent-pool-tokens', attributes: attrs } }),
@@ -274,7 +274,7 @@ export default function AgentPoolDetailPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/agent-pools/${poolId}/tokens/${tokenId}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/agent-pools/${poolId}/tokens/${tokenId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to revoke token')
       setSuccess('Token revoked')
       await loadTokens()
@@ -287,7 +287,7 @@ export default function AgentPoolDetailPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/listeners/${listenerId}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/listeners/${listenerId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete listener')
       setSuccess('Listener deleted')
       await loadListeners()

--- a/web/src/app/admin/agent-pools/page.tsx
+++ b/web/src/app/admin/agent-pools/page.tsx
@@ -72,7 +72,7 @@ export default function AgentPoolsPage() {
   async function loadPools() {
     setLoading(true)
     try {
-      const res = await apiFetch('/api/v2/organizations/default/agent-pools')
+      const res = await apiFetch('/api/terrapod/v1/agent-pools')
       if (!res.ok) throw new Error('Failed to load agent pools')
       const data = await res.json()
       setPools(data.data || [])
@@ -92,7 +92,7 @@ export default function AgentPoolsPage() {
       if (description) attrs.description = description
       if (Object.keys(createLabels).length > 0) attrs.labels = createLabels
 
-      const res = await apiFetch('/api/v2/organizations/default/agent-pools', {
+      const res = await apiFetch('/api/terrapod/v1/agent-pools', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'agent-pools', attributes: attrs } }),

--- a/web/src/app/admin/audit-log/page.tsx
+++ b/web/src/app/admin/audit-log/page.tsx
@@ -99,7 +99,7 @@ export default function AuditLogPage() {
       if (filterSince) params.set('filter[since]', new Date(filterSince).toISOString())
       if (filterUntil) params.set('filter[until]', new Date(filterUntil).toISOString())
 
-      const res = await apiFetch(`/api/v2/admin/audit-log?${params.toString()}`)
+      const res = await apiFetch(`/api/terrapod/v1/admin/audit-log?${params.toString()}`)
       if (!res.ok) throw new Error('Failed to load audit log')
       const data = await res.json()
       setEntries(data.data || [])

--- a/web/src/app/admin/binary-cache/page.tsx
+++ b/web/src/app/admin/binary-cache/page.tsx
@@ -94,8 +94,8 @@ export default function CachePage() {
     setLoading(true)
     try {
       const [binaryRes, providerRes] = await Promise.all([
-        apiFetch('/api/v2/admin/binary-cache'),
-        apiFetch('/api/v2/admin/provider-cache'),
+        apiFetch('/api/terrapod/v1/admin/binary-cache'),
+        apiFetch('/api/terrapod/v1/admin/provider-cache'),
       ])
       if (!binaryRes.ok) throw new Error('Failed to load binary cache')
       const binaryData = await binaryRes.json()
@@ -116,7 +116,7 @@ export default function CachePage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/admin/binary-cache/${tool}/${version}`, {
+      const res = await apiFetch(`/api/terrapod/v1/admin/binary-cache/${tool}/${version}`, {
         method: 'DELETE',
       })
       if (!res.ok) throw new Error(`Purge failed (${res.status})`)
@@ -132,7 +132,7 @@ export default function CachePage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/admin/provider-cache/${hostname}/${namespace}/${type}/${version}`, {
+      const res = await apiFetch(`/api/terrapod/v1/admin/provider-cache/${hostname}/${namespace}/${type}/${version}`, {
         method: 'DELETE',
       })
       if (!res.ok) throw new Error(`Purge failed (${res.status})`)
@@ -191,7 +191,7 @@ export default function CachePage() {
       }
       let totalPurged = 0
       for (const { tool, version } of keys.values()) {
-        const res = await apiFetch(`/api/v2/admin/binary-cache/${tool}/${version}`, { method: 'DELETE' })
+        const res = await apiFetch(`/api/terrapod/v1/admin/binary-cache/${tool}/${version}`, { method: 'DELETE' })
         if (!res.ok) throw new Error(`Purge failed for ${tool} ${version}`)
         const data = await res.json()
         totalPurged += data.count || 0
@@ -226,7 +226,7 @@ export default function CachePage() {
       }
       let totalPurged = 0
       for (const { hostname, namespace, type, version } of keys.values()) {
-        const res = await apiFetch(`/api/v2/admin/provider-cache/${hostname}/${namespace}/${type}/${version}`, { method: 'DELETE' })
+        const res = await apiFetch(`/api/terrapod/v1/admin/provider-cache/${hostname}/${namespace}/${type}/${version}`, { method: 'DELETE' })
         if (!res.ok) throw new Error(`Purge failed for ${namespace}/${type} ${version}`)
         const data = await res.json()
         totalPurged += data.count || 0

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -123,7 +123,7 @@ export default function RolesPage() {
   async function loadRoles() {
     setRolesLoading(true)
     try {
-      const res = await apiFetch('/api/v2/roles')
+      const res = await apiFetch('/api/terrapod/v1/roles')
       if (!res.ok) throw new Error('Failed to load roles')
       const data = await res.json()
       setRoles(data.data || [])
@@ -138,8 +138,8 @@ export default function RolesPage() {
     setAssignmentsLoading(true)
     try {
       const [assignRes, identRes] = await Promise.all([
-        apiFetch('/api/v2/role-assignments'),
-        apiFetch('/api/v2/role-assignments/identities'),
+        apiFetch('/api/terrapod/v1/role-assignments'),
+        apiFetch('/api/terrapod/v1/role-assignments/identities'),
       ])
       if (!assignRes.ok) throw new Error('Failed to load assignments')
       const assignData = await assignRes.json()
@@ -186,7 +186,7 @@ export default function RolesPage() {
       if (roleDenyLabels.trim()) attrs['deny-labels'] = parseLabels(roleDenyLabels)
       if (roleDenyNames.trim()) attrs['deny-names'] = roleDenyNames.split(',').map((s) => s.trim()).filter(Boolean)
 
-      const res = await apiFetch('/api/v2/roles', {
+      const res = await apiFetch('/api/terrapod/v1/roles', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'roles', attributes: attrs } }),
@@ -239,7 +239,7 @@ export default function RolesPage() {
         'deny-labels': parseLabels(editRoleDenyLabels),
         'deny-names': editRoleDenyNames.split(',').map((s) => s.trim()).filter(Boolean),
       }
-      const res = await apiFetch(`/api/v2/roles/${editingRole}`, {
+      const res = await apiFetch(`/api/terrapod/v1/roles/${editingRole}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'roles', attributes: attrs } }),
@@ -262,7 +262,7 @@ export default function RolesPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/roles/${name}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/roles/${name}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete role')
       setDeleteRoleName(null)
       setSuccess(`Role "${name}" deleted`)
@@ -278,7 +278,7 @@ export default function RolesPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch('/api/v2/role-assignments', {
+      const res = await apiFetch('/api/terrapod/v1/role-assignments', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -312,7 +312,7 @@ export default function RolesPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/role-assignments/${encodeURIComponent(provider)}/${encodeURIComponent(email)}/${encodeURIComponent(roleName)}`, {
+      const res = await apiFetch(`/api/terrapod/v1/role-assignments/${encodeURIComponent(provider)}/${encodeURIComponent(email)}/${encodeURIComponent(roleName)}`, {
         method: 'DELETE',
       })
       if (!res.ok) throw new Error('Failed to delete assignment')

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -289,7 +289,7 @@ export default function UsersPage() {
   async function loadUsers() {
     setLoading(true)
     try {
-      const res = await apiFetch('/api/v2/organizations/default/users?page[size]=100')
+      const res = await apiFetch('/api/terrapod/v1/users?page[size]=100')
       if (!res.ok) throw new Error('Failed to load users')
       const data = await res.json()
       setUsers(data.data || [])
@@ -309,7 +309,7 @@ export default function UsersPage() {
       if (data.password) attrs.password = data.password
       if (data.displayName) attrs['display-name'] = data.displayName
 
-      const res = await apiFetch('/api/v2/organizations/default/users', {
+      const res = await apiFetch('/api/terrapod/v1/users', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'users', attributes: attrs } }),
@@ -340,7 +340,7 @@ export default function UsersPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/users/${encodeURIComponent(editingEmail)}`, {
+      const res = await apiFetch(`/api/terrapod/v1/users/${encodeURIComponent(editingEmail)}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -365,7 +365,7 @@ export default function UsersPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/users/${encodeURIComponent(email)}`, {
+      const res = await apiFetch(`/api/terrapod/v1/users/${encodeURIComponent(email)}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -385,7 +385,7 @@ export default function UsersPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/users/${encodeURIComponent(email)}`, {
+      const res = await apiFetch(`/api/terrapod/v1/users/${encodeURIComponent(email)}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -410,7 +410,7 @@ export default function UsersPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/users/${encodeURIComponent(email)}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/users/${encodeURIComponent(email)}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete user')
       setDeleteEmail(null)
       if (resetEmail === email) setResetEmail(null)

--- a/web/src/app/admin/vcs-connections/page.tsx
+++ b/web/src/app/admin/vcs-connections/page.tsx
@@ -80,7 +80,7 @@ export default function VCSConnectionsPage() {
   async function loadConnections() {
     setLoading(true)
     try {
-      const res = await apiFetch('/api/v2/organizations/default/vcs-connections')
+      const res = await apiFetch('/api/terrapod/v1/vcs-connections')
       if (!res.ok) throw new Error('Failed to load VCS connections')
       const data = await res.json()
       setConnections(data.data || [])
@@ -106,7 +106,7 @@ export default function VCSConnectionsPage() {
       } else {
         attrs.token = token
       }
-      const res = await apiFetch('/api/v2/organizations/default/vcs-connections', {
+      const res = await apiFetch('/api/terrapod/v1/vcs-connections', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'vcs-connections', attributes: attrs } }),
@@ -135,7 +135,7 @@ export default function VCSConnectionsPage() {
     setError('')
     setSuccess('')
     try {
-      const res = await apiFetch(`/api/v2/vcs-connections/${id}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/vcs-connections/${id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete connection')
       setDeleteId(null)
       setSuccess('VCS connection deleted')

--- a/web/src/app/app/[...path]/page.tsx
+++ b/web/src/app/app/[...path]/page.tsx
@@ -10,12 +10,15 @@ import NavBar from '@/components/nav-bar'
  * TFE-compatible URL redirect.
  *
  * The terraform/tofu CLI prints URLs like:
- *   /app/{org}/{workspace-name}/runs/{runId}
+ *   /app/default/{workspace-name}/runs/{runId}
  *
  * Terrapod uses workspace IDs in its routes:
  *   /workspaces/{wsId}/runs/{runId}
  *
- * This page resolves the workspace name to an ID and redirects.
+ * This page resolves the workspace name to an ID and redirects. The
+ * organization segment from the CLI URL is always "default" in Terrapod
+ * (single-organization); we ignore whatever value lands in segments[0]
+ * and look the workspace up under the literal "default" org.
  */
 export default function TFERedirectPage() {
   const router = useRouter()
@@ -24,14 +27,15 @@ export default function TFERedirectPage() {
 
   useEffect(() => {
     async function resolve() {
-      // Expected: [org, workspace-name, "runs", runId]
+      // Expected: [_org, workspace-name, "runs", runId]. The org
+      // segment is ignored — Terrapod is single-org and the only
+      // valid value is "default".
       if (segments.length >= 4 && segments[2] === 'runs') {
-        const org = segments[0]
         const wsName = segments[1]
         const runId = segments[3]
 
         try {
-          const res = await apiFetch(`/api/v2/organizations/${org}/workspaces/${wsName}`)
+          const res = await apiFetch(`/api/v2/organizations/default/workspaces/${wsName}`)
           if (res.ok) {
             const data = await res.json()
             const wsId = data.data.id

--- a/web/src/app/auth/callback/callback-handler.tsx
+++ b/web/src/app/auth/callback/callback-handler.tsx
@@ -51,7 +51,7 @@ export default function CallbackHandler() {
       code_verifier: verifier,
     })
 
-    fetch('/api/v2/auth/token', {
+    fetch('/api/terrapod/v1/auth/token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: body.toString(),

--- a/web/src/app/auth/cli-complete/page.tsx
+++ b/web/src/app/auth/cli-complete/page.tsx
@@ -42,7 +42,7 @@ function CliCompleteInner() {
 
     const check = async () => {
       try {
-        const res = await fetch(`/api/v2/auth/cli-login-status?code=${encodeURIComponent(code)}`)
+        const res = await fetch(`/api/terrapod/v1/auth/cli-login-status?code=${encodeURIComponent(code)}`)
         if (res.ok) {
           const data = await res.json()
           if (data.complete) {

--- a/web/src/app/labels/page.tsx
+++ b/web/src/app/labels/page.tsx
@@ -1,5 +1,5 @@
 // Labels browser — read-only cross-entity view over the
-// /api/v2/labels endpoints. Three view states, all on `/labels`,
+// /api/terrapod/v1/labels endpoints. Three view states, all on `/labels`,
 // driven by query string:
 //
 //   /labels                    → list distinct label keys
@@ -110,7 +110,7 @@ function KeysView() {
 
   useEffect(() => {
     let alive = true
-    apiFetch('/api/v2/labels')
+    apiFetch('/api/terrapod/v1/labels')
       .then(async r => {
         if (!r.ok) throw new Error(`Failed to load labels (${r.status})`)
         return r.json()
@@ -177,7 +177,7 @@ function ValuesView({ labelKey }: { labelKey: string }) {
 
   useEffect(() => {
     let alive = true
-    apiFetch(`/api/v2/labels/${encodeURIComponent(labelKey)}`)
+    apiFetch(`/api/terrapod/v1/labels/${encodeURIComponent(labelKey)}`)
       .then(async r => {
         if (!r.ok) throw new Error(`Failed to load values for ${labelKey} (${r.status})`)
         return r.json()
@@ -248,7 +248,7 @@ function EntitiesView({ labelKey, labelValue }: { labelKey: string; labelValue: 
   useEffect(() => {
     let alive = true
     apiFetch(
-      `/api/v2/labels/${encodeURIComponent(labelKey)}/${encodeURIComponent(labelValue)}`,
+      `/api/terrapod/v1/labels/${encodeURIComponent(labelKey)}/${encodeURIComponent(labelValue)}`,
     )
       .then(async r => {
         if (!r.ok) throw new Error(`Failed to load entities (${r.status})`)

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -41,7 +41,7 @@ function LoginContent() {
   const externalProviders = providers.filter((p) => p.type !== 'local')
 
   useEffect(() => {
-    fetch('/api/v2/auth/providers')
+    fetch('/api/terrapod/v1/auth/providers')
       .then(async (res) => {
         if (!res.ok) throw new Error('Failed to load providers')
         const data = await res.json()
@@ -61,7 +61,7 @@ function LoginContent() {
     if (cliState) {
       const form = document.createElement('form')
       form.method = 'POST'
-      form.action = '/api/v2/auth/local/login'
+      form.action = '/api/terrapod/v1/auth/local/login'
       for (const [k, v] of Object.entries({ state: cliState, email, password })) {
         const input = document.createElement('input')
         input.type = 'hidden'
@@ -78,7 +78,7 @@ function LoginContent() {
       const { verifier, challenge } = await generatePKCE()
       const state = generateState()
 
-      const authRes = await fetch('/api/v2/auth/local/authorize', {
+      const authRes = await fetch('/api/terrapod/v1/auth/local/authorize', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -97,7 +97,7 @@ function LoginContent() {
 
       const { code } = await authRes.json()
 
-      const tokenRes = await fetch('/api/v2/auth/token', {
+      const tokenRes = await fetch('/api/terrapod/v1/auth/token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         credentials: 'include',
@@ -132,7 +132,7 @@ function LoginContent() {
     // CLI login flow: redirect to the CLI SSO endpoint which carries
     // over the pending auth state from /oauth/authorize
     if (cliState) {
-      window.location.href = `/api/v2/auth/cli-sso-redirect?provider=${encodeURIComponent(providerName)}&cli_state=${encodeURIComponent(cliState)}`
+      window.location.href = `/api/terrapod/v1/auth/cli-sso-redirect?provider=${encodeURIComponent(providerName)}&cli_state=${encodeURIComponent(cliState)}`
       return
     }
 
@@ -155,7 +155,7 @@ function LoginContent() {
         response_type: 'code',
       })
 
-      window.location.href = `/api/v2/auth/authorize?${params.toString()}`
+      window.location.href = `/api/terrapod/v1/auth/authorize?${params.toString()}`
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to start login')
     }

--- a/web/src/app/registry/modules/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[name]/[provider]/page.tsx
@@ -205,7 +205,7 @@ export default function ModuleDetailPage() {
     setLoading(true)
     try {
       const res = await apiFetch(
-        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}`
+        `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}`
       )
       if (!res.ok) throw new Error('Module not found')
       const data = await res.json()
@@ -228,7 +228,7 @@ export default function ModuleDetailPage() {
 
   async function loadVcsConnections() {
     try {
-      const res = await apiFetch('/api/v2/organizations/default/vcs-connections')
+      const res = await apiFetch('/api/terrapod/v1/vcs-connections')
       if (res.ok) {
         const data = await res.json()
         setVcsConnections(data.data || [])
@@ -241,7 +241,7 @@ export default function ModuleDetailPage() {
   async function loadWorkspaceLinks() {
     try {
       const res = await apiFetch(
-        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/workspace-links`
+        `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}/workspace-links`
       )
       if (res.ok) {
         const data = await res.json()
@@ -279,7 +279,7 @@ export default function ModuleDetailPage() {
     setError('')
     try {
       const res = await apiFetch(
-        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/workspace-links`,
+        `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}/workspace-links`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/vnd.api+json' },
@@ -306,7 +306,7 @@ export default function ModuleDetailPage() {
     setError('')
     try {
       const res = await apiFetch(
-        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/workspace-links/${linkId}`,
+        `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}/workspace-links/${linkId}`,
         { method: 'DELETE' }
       )
       if (!res.ok && res.status !== 204) {
@@ -338,7 +338,7 @@ export default function ModuleDetailPage() {
     try {
       const tarGz = await buildTarGz(selectedFiles)
       const res = await apiFetch(
-        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/versions/${uploadVersion}/upload`,
+        `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}/versions/${uploadVersion}/upload`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/gzip' },
@@ -366,7 +366,7 @@ export default function ModuleDetailPage() {
     setError('')
     try {
       const res = await apiFetch(
-        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/vcs`,
+        `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}/vcs`,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/vnd.api+json' },
@@ -401,7 +401,7 @@ export default function ModuleDetailPage() {
     setError('')
     try {
       const res = await apiFetch(
-        `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/vcs`,
+        `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}/vcs`,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/vnd.api+json' },
@@ -436,8 +436,8 @@ export default function ModuleDetailPage() {
     setError('')
     try {
       const path = deleteTarget === 'module'
-        ? `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}`
-        : `/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}/${deleteTarget}`
+        ? `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}`
+        : `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}/${deleteTarget}`
 
       const res = await apiFetch(path, { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
@@ -469,7 +469,7 @@ export default function ModuleDetailPage() {
     setError('')
     setLockoutWarning('')
     try {
-      const res = await apiFetch(`/api/v2/organizations/default/registry-modules/private/default/${name}/${provider}`, {
+      const res = await apiFetch(`/api/terrapod/v1/registry-modules/private/default/${name}/${provider}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({

--- a/web/src/app/registry/modules/page.tsx
+++ b/web/src/app/registry/modules/page.tsx
@@ -49,7 +49,7 @@ export default function ModulesPage() {
   async function loadModules() {
     setLoading(true)
     try {
-      const res = await apiFetch('/api/v2/organizations/default/registry-modules')
+      const res = await apiFetch('/api/terrapod/v1/registry-modules')
       if (!res.ok) throw new Error('Failed to load modules')
       const data = await res.json()
       setModules(data.data || [])
@@ -65,7 +65,7 @@ export default function ModulesPage() {
     setCreating(true)
     setError('')
     try {
-      const res = await apiFetch('/api/v2/organizations/default/registry-modules', {
+      const res = await apiFetch('/api/terrapod/v1/registry-modules', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({

--- a/web/src/app/registry/providers/[name]/page.tsx
+++ b/web/src/app/registry/providers/[name]/page.tsx
@@ -118,7 +118,7 @@ export default function ProviderDetailPage() {
 
   usePollingInterval(!loading, 60_000, loadVersions)
 
-  const basePath = `/api/v2/organizations/default/registry-providers/private/default/${name}`
+  const basePath = `/api/terrapod/v1/registry-providers/private/default/${name}`
 
   async function loadVersions() {
     setLoading(true)

--- a/web/src/app/registry/providers/page.tsx
+++ b/web/src/app/registry/providers/page.tsx
@@ -42,7 +42,7 @@ export default function ProvidersPage() {
   async function loadProviders() {
     setLoading(true)
     try {
-      const res = await apiFetch('/api/v2/organizations/default/registry-providers')
+      const res = await apiFetch('/api/terrapod/v1/registry-providers')
       if (!res.ok) throw new Error('Failed to load providers')
       const data = await res.json()
       setProviders(data.data || [])
@@ -58,7 +58,7 @@ export default function ProvidersPage() {
     setCreating(true)
     setError('')
     try {
-      const res = await apiFetch('/api/v2/organizations/default/registry-providers', {
+      const res = await apiFetch('/api/terrapod/v1/registry-providers', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({

--- a/web/src/app/settings/sessions/page.tsx
+++ b/web/src/app/settings/sessions/page.tsx
@@ -53,7 +53,7 @@ export default function SessionsPage() {
   async function loadSessions(adminView: boolean) {
     setLoading(true)
     try {
-      const endpoint = adminView ? '/api/v2/auth/sessions/all' : '/api/v2/auth/sessions'
+      const endpoint = adminView ? '/api/terrapod/v1/auth/sessions/all' : '/api/terrapod/v1/auth/sessions'
       const res = await apiFetch(endpoint)
       if (!res.ok) throw new Error('Failed to load sessions')
       const data = await res.json()
@@ -68,7 +68,7 @@ export default function SessionsPage() {
   async function handleRevokeUser(email: string) {
     setError('')
     try {
-      const res = await apiFetch(`/api/v2/auth/sessions/user/${encodeURIComponent(email)}`, {
+      const res = await apiFetch(`/api/terrapod/v1/auth/sessions/user/${encodeURIComponent(email)}`, {
         method: 'DELETE',
       })
       if (!res.ok && res.status !== 204) throw new Error(`Failed to revoke sessions (${res.status})`)

--- a/web/src/app/settings/tokens/page.tsx
+++ b/web/src/app/settings/tokens/page.tsx
@@ -79,8 +79,8 @@ export default function TokensPage() {
     setLoading(true)
     try {
       const url = showAll
-        ? '/api/v2/admin/authentication-tokens'
-        : `/api/v2/users/${userId}/authentication-tokens`
+        ? '/api/terrapod/v1/admin/authentication-tokens'
+        : `/api/terrapod/v1/users/${userId}/authentication-tokens`
       const res = await apiFetch(url)
       if (!res.ok) throw new Error('Failed to load tokens')
       const data = await res.json()
@@ -98,7 +98,7 @@ export default function TokensPage() {
     setError('')
     setCreatedToken(null)
     try {
-      const res = await apiFetch(`/api/v2/users/${userId}/authentication-tokens`, {
+      const res = await apiFetch(`/api/terrapod/v1/users/${userId}/authentication-tokens`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -131,7 +131,7 @@ export default function TokensPage() {
   async function handleRevoke(tokenId: string) {
     setError('')
     try {
-      const res = await apiFetch(`/api/v2/authentication-tokens/${tokenId}`, {
+      const res = await apiFetch(`/api/terrapod/v1/authentication-tokens/${tokenId}`, {
         method: 'DELETE',
       })
       if (!res.ok && res.status !== 204) throw new Error(`Failed to revoke token (${res.status})`)
@@ -150,7 +150,7 @@ export default function TokensPage() {
     try {
       const ids = [...selected]
       await Promise.all(ids.map((id) =>
-        apiFetch(`/api/v2/authentication-tokens/${id}`, { method: 'DELETE' })
+        apiFetch(`/api/terrapod/v1/authentication-tokens/${id}`, { method: 'DELETE' })
       ))
       setSelected(new Set())
       await loadTokens()

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -432,7 +432,7 @@ function WorkspaceDetailContent() {
     if (vcsRefsLoaded || vcsRefsLoading) return
     setVcsRefsLoading(true)
     try {
-      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/vcs-refs`)
+      const res = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}/vcs-refs`)
       if (!res.ok) return
       const data = await res.json()
       setVcsBranches(data.branches || [])
@@ -549,7 +549,7 @@ function WorkspaceDetailContent() {
   async function downloadCv(cvId: string) {
     try {
       const res = await apiFetch(
-        `/api/v2/configuration-versions/${cvId}/download-ticket`,
+        `/api/terrapod/v1/configuration-versions/${cvId}/download-ticket`,
         { method: 'POST' },
       )
       if (!res.ok) {
@@ -585,7 +585,7 @@ function WorkspaceDetailContent() {
         .filter(id => cvSelected.has(id))
       // ids[] preserves cv list order (newest first); reverse to get older first
       const [toId, fromId] = ids
-      const res = await apiFetch('/api/v2/configuration-versions/diff', {
+      const res = await apiFetch('/api/terrapod/v1/configuration-versions/diff', {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({
@@ -608,7 +608,7 @@ function WorkspaceDetailContent() {
   async function loadNotifications() {
     setNotifLoading(true)
     try {
-      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/notification-configurations`)
+      const res = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}/notification-configurations`)
       if (!res.ok) throw new Error('Failed to load notifications')
       const data = await res.json()
       setNotifications(data.data || [])
@@ -622,7 +622,7 @@ function WorkspaceDetailContent() {
   async function loadRunTasks() {
     setRunTasksLoading(true)
     try {
-      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/run-tasks`)
+      const res = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}/run-tasks`)
       if (!res.ok) throw new Error('Failed to load run tasks')
       const data = await res.json()
       setRunTasks(data.data || [])
@@ -647,7 +647,7 @@ function WorkspaceDetailContent() {
       }
       if (rtHmacKey) attrs['hmac-key'] = rtHmacKey
 
-      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/run-tasks`, {
+      const res = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}/run-tasks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'run-tasks', attributes: attrs } }),
@@ -672,7 +672,7 @@ function WorkspaceDetailContent() {
 
   async function handleToggleRunTask(rt: RunTaskItem) {
     try {
-      const res = await apiFetch(`/api/v2/run-tasks/${rt.id}`, {
+      const res = await apiFetch(`/api/terrapod/v1/run-tasks/${rt.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'run-tasks', attributes: { enabled: !rt.attributes.enabled } } }),
@@ -686,7 +686,7 @@ function WorkspaceDetailContent() {
 
   async function handleDeleteRunTask(rtId: string) {
     try {
-      const res = await apiFetch(`/api/v2/run-tasks/${rtId}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/run-tasks/${rtId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete')
       setDeleteRtId(null)
       await loadRunTasks()
@@ -718,21 +718,21 @@ function WorkspaceDetailContent() {
     setEditVcsBranch(workspace.attributes['vcs-branch'] || '')
     setEditing(true)
     if (!poolsLoaded) {
-      apiFetch('/api/v2/organizations/default/agent-pools').then(res => res.ok ? res.json() : { data: [] }).then(data => {
+      apiFetch('/api/terrapod/v1/agent-pools').then(res => res.ok ? res.json() : { data: [] }).then(data => {
         const allPools: AgentPool[] = data.data || []
         setAgentPools(allPools.filter(p => p.attributes.permission === 'write' || p.attributes.permission === 'admin'))
         setPoolsLoaded(true)
       }).catch(() => {})
     }
     if (!vcsConnectionsLoaded) {
-      apiFetch('/api/v2/organizations/default/vcs-connections').then(res => res.ok ? res.json() : { data: [] }).then(data => {
+      apiFetch('/api/terrapod/v1/vcs-connections').then(res => res.ok ? res.json() : { data: [] }).then(data => {
         setVcsConnections(data.data || [])
         setVcsConnectionsLoaded(true)
       }).catch(() => {})
     }
     const backend = workspace.attributes['execution-backend'] || 'tofu'
     if (versionsBackend !== backend) {
-      apiFetch(`/api/v2/binary-cache/versions?tool=${backend}`)
+      apiFetch(`/api/terrapod/v1/binary-cache/versions?tool=${backend}`)
         .then(res => res.ok ? res.json() : { data: [] })
         .then(data => {
           setVersionSuggestions(data.data || [])
@@ -802,7 +802,7 @@ function WorkspaceDetailContent() {
     if (!workspace) return
     const action = workspace.attributes.locked ? 'unlock' : 'lock'
     try {
-      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/actions/${action}`, {
+      const res = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}/actions/${action}`, {
         method: 'POST',
       })
       if (!res.ok) throw new Error(`Failed to ${action} workspace`)
@@ -897,7 +897,7 @@ function WorkspaceDetailContent() {
     setError('')
     try {
       const res = await apiFetch(
-        `/api/v2/workspaces/${workspaceId}/actions/dismiss-drift`,
+        `/api/terrapod/v1/workspaces/${workspaceId}/actions/dismiss-drift`,
         { method: 'POST' }
       )
       if (!res.ok) {
@@ -915,7 +915,7 @@ function WorkspaceDetailContent() {
   async function handleDelete() {
     setDeleting(true)
     try {
-      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete workspace')
       router.push('/workspaces')
     } catch (err) {
@@ -1125,7 +1125,7 @@ function WorkspaceDetailContent() {
       if (notifType === 'generic' && notifToken) attrs.token = notifToken
       if (notifType === 'email') attrs['email-addresses'] = notifEmails.split(',').map(s => s.trim()).filter(Boolean)
 
-      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/notification-configurations`, {
+      const res = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}/notification-configurations`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'notification-configurations', attributes: attrs } }),
@@ -1150,7 +1150,7 @@ function WorkspaceDetailContent() {
 
   async function handleToggleNotif(nc: NotificationConfig) {
     try {
-      const res = await apiFetch(`/api/v2/notification-configurations/${nc.id}`, {
+      const res = await apiFetch(`/api/terrapod/v1/notification-configurations/${nc.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'notification-configurations', attributes: { enabled: !nc.attributes.enabled } } }),
@@ -1164,7 +1164,7 @@ function WorkspaceDetailContent() {
 
   async function handleDeleteNotif(ncId: string) {
     try {
-      const res = await apiFetch(`/api/v2/notification-configurations/${ncId}`, { method: 'DELETE' })
+      const res = await apiFetch(`/api/terrapod/v1/notification-configurations/${ncId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete')
       setDeleteNotifId(null)
       await loadNotifications()
@@ -1177,7 +1177,7 @@ function WorkspaceDetailContent() {
     setVerifyingId(ncId)
     setError('')
     try {
-      const res = await apiFetch(`/api/v2/notification-configurations/${ncId}/actions/verify`, { method: 'POST' })
+      const res = await apiFetch(`/api/terrapod/v1/notification-configurations/${ncId}/actions/verify`, { method: 'POST' })
       if (!res.ok) throw new Error('Verification failed')
       const data = await res.json()
       const success = data?.data?.attributes?.success
@@ -2204,13 +2204,13 @@ function WorkspaceDetailContent() {
                       setStateActionLoading(sv.id)
                       try {
                         if (action === 'delete') {
-                          const resp = await apiFetch(`/api/v2/state-versions/${sv.id}/manage`, { method: 'DELETE' })
+                          const resp = await apiFetch(`/api/terrapod/v1/state-versions/${sv.id}/manage`, { method: 'DELETE' })
                           if (!resp.ok) {
                             const err = await resp.json().catch(() => ({ detail: 'Failed' }))
                             throw new Error(err.detail || 'Failed to delete state version')
                           }
                         } else {
-                          const resp = await apiFetch(`/api/v2/state-versions/${sv.id}/actions/rollback`, { method: 'POST' })
+                          const resp = await apiFetch(`/api/terrapod/v1/state-versions/${sv.id}/actions/rollback`, { method: 'POST' })
                           if (!resp.ok) {
                             const err = await resp.json().catch(() => ({ detail: 'Failed' }))
                             throw new Error(err.detail || 'Failed to rollback state version')
@@ -2258,7 +2258,7 @@ function WorkspaceDetailContent() {
                       try {
                         const body = await file.text()
                         JSON.parse(body) // validate JSON
-                        const resp = await apiFetch(`/api/v2/workspaces/${workspaceId}/state-versions/actions/upload`, {
+                        const resp = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}/state-versions/actions/upload`, {
                           method: 'POST',
                           headers: { 'Content-Type': 'application/json' },
                           body,

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -365,7 +365,7 @@ export default function RunDetailPage() {
     const urlRef = phase === 'plan' ? planLogUrl : applyLogUrl
     if (urlRef.current) return urlRef.current
     const endpoint = phase === 'plan' ? 'plan' : 'apply'
-    const res = await apiFetch(`/api/v2/runs/${runId}/${endpoint}`)
+    const res = await apiFetch(`/api/terrapod/v1/runs/${runId}/${endpoint}`)
     if (!res.ok) return null
     const data = await res.json()
     const obj = data.data as PlanApply
@@ -458,7 +458,7 @@ export default function RunDetailPage() {
     try {
       // TFE V2 API uses "apply" to confirm a planned run
       const apiAction = action === 'confirm' ? 'apply' : action
-      const res = await apiFetch(`/api/v2/runs/${runId}/actions/${apiAction}`, { method: 'POST' })
+      const res = await apiFetch(`/api/terrapod/v1/runs/${runId}/actions/${apiAction}`, { method: 'POST' })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
         throw new Error(data.detail || `Failed to ${action} run`)

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -216,13 +216,13 @@ function WorkspacesPageInner() {
   useEffect(() => {
     if (!showCreate) return
     if (!vcsConnectionsLoaded) {
-      apiFetch('/api/v2/organizations/default/vcs-connections')
+      apiFetch('/api/terrapod/v1/vcs-connections')
         .then(res => res.ok ? res.json() : { data: [] })
         .then(data => { setVcsConnections(data.data || []); setVcsConnectionsLoaded(true) })
         .catch(() => {})
     }
     if (!agentPoolsLoaded) {
-      apiFetch('/api/v2/organizations/default/agent-pools')
+      apiFetch('/api/terrapod/v1/agent-pools')
         .then(res => res.ok ? res.json() : { data: [] })
         .then(data => { setAgentPools(data.data || []); setAgentPoolsLoaded(true) })
         .catch(() => {})
@@ -232,7 +232,7 @@ function WorkspacesPageInner() {
   // Fetch version suggestions when backend changes and form is open
   useEffect(() => {
     if (!showCreate || newBackend === versionsBackend) return
-    apiFetch(`/api/v2/binary-cache/versions?tool=${newBackend}`)
+    apiFetch(`/api/terrapod/v1/binary-cache/versions?tool=${newBackend}`)
       .then(res => res.ok ? res.json() : { data: [] })
       .then(data => {
         setVersionSuggestions(data.data || [])

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,18 @@
  *
  * Automatically sets Bearer token from auth state. On 401, clears auth
  * and redirects to login.
+ *
+ * API path conventions: callers will see two prefixes mixed throughout
+ * the frontend.
+ *   - `/api/v2/...`         — the TFE V2 API surface that terraform/tofu
+ *                             and tfci consume directly. Permanent.
+ *   - `/api/terrapod/v1/...` — Terrapod-native management surface
+ *                             (auth, labels, listeners, audit, drift,
+ *                             etc.). Canonical home from v0.23.0.
+ *
+ * The split is documented in `docs/tfe-cli-surface.md`. If you're
+ * adding a new API call from the frontend: if it's CLI-consumed, hit
+ * `/api/v2/`; otherwise hit `/api/terrapod/v1/`.
  */
 
 import { clearAuth, getAuthState, loginRedirectUrl, updateExpiresAt } from '@/lib/auth'

--- a/web/src/lib/use-pool-events.ts
+++ b/web/src/lib/use-pool-events.ts
@@ -15,7 +15,7 @@ export function usePoolEvents(
   onEvent: (event: PoolEvent) => void,
 ) {
   return useSSE({
-    url: `/api/v2/agent-pools/${poolId}/events`,
+    url: `/api/terrapod/v1/agent-pools/${poolId}/events`,
     enabled: !!poolId,
     onEvent: onEvent as (data: Record<string, unknown>) => void,
     onReconnect: () => onEvent({ event: 'reconnect' }),

--- a/web/src/lib/use-run-events.ts
+++ b/web/src/lib/use-run-events.ts
@@ -18,7 +18,7 @@ export function useRunEvents(
   onEvent: (event: RunEvent) => void,
 ) {
   return useSSE({
-    url: `/api/v2/workspaces/${workspaceId}/runs/events`,
+    url: `/api/terrapod/v1/workspaces/${workspaceId}/runs/events`,
     enabled: !!workspaceId,
     onEvent: onEvent as (data: Record<string, unknown>) => void,
     onReconnect: () => onEvent({ event: 'reconnect', workspace_id: workspaceId! }),

--- a/web/src/lib/use-workspace-list-events.ts
+++ b/web/src/lib/use-workspace-list-events.ts
@@ -13,7 +13,7 @@ export function useWorkspaceListEvents(
   onEvent: (event: WorkspaceListEvent) => void,
 ) {
   return useSSE({
-    url: '/api/v2/workspace-events',
+    url: '/api/terrapod/v1/workspace-events',
     enabled,
     onEvent: onEvent as (data: Record<string, unknown>) => void,
     onReconnect: () => onEvent({ event: 'reconnect' }),


### PR DESCRIPTION
## Summary

Establishes the principle: **TFE V2 compatibility is for what `terraform`, `tofu`, and `tfci` consume. Everything else is Terrapod-native at `/api/terrapod/v1/`.**

The verified CLI-consumed surface is catalogued in [`docs/tfe-cli-surface.md`](../blob/feat/api-namespace-cleanup/docs/tfe-cli-surface.md) — that file is now the contract for what stays at `/api/v2/`.

Routes are dual-mounted: canonical `/api/terrapod/v1/...` plus a deprecated `/api/v2/...` alias that emits `Deprecation: true`, `Link: <#278>; rel="deprecation"`, and `X-Removed-In: v0.24.0` headers. The alias is removed in v0.24.0 (#278).

## What moved

**Whole-router moves**: auth, oauth-extensions, labels, workspace-extensions, state-management, run-artifacts, vcs-connections, vcs-events, roles, role-assignments, audit, users, binary-cache, tokens, run-triggers, notification-configurations, agent-pools (CRUD + listener-protocol), filesystem-storage presigned routes.

**Surgical splits** (CLI-consumed paths stay; rest moves):
- `runs.py` — listener-protocol, plan-result/apply-result, retry, SSE streams move
- `config_versions.py` — download/diff/ticket extensions move
- `registry_modules.py` — org-scoped management + workspace-links + /vcs move; CLI download protocol stays
- `registry_providers.py` — same split as modules
- `run_tasks.py` — workspace-scoped run-task management + callback move; `task-stages` (CLI-consumed) stays
- `tfe_v2.py` — `DELETE /workspaces/{id}` moves (CLI deletes by name only); everything else stays

**Variable + variable-set CRUD remain at `/api/v2`** — `tfci` uses them, so they're added to the keep-set.

**Internal callers updated** to canonical paths: runner listener, runner identity, runner-entrypoint.sh, terraform provider (Go), audit-service path regex, rate-limit auth-prefix tuple.

**Frontend** rewritten via a classifier driven by `docs/tfe-cli-surface.md`.

**Docs** updated mechanically with the same classifier.

## Out of scope / filed separately

- #279 — gaps in CLI-consumed coverage (force-unlock by separate path, by-name delete, organization queue/capacity, projects)
- #280 — spike for `GET /plans/{id}/json-output` (used by `tofu show -json` and `tfci plan output`)
- `hashicorp/tfe` Terraform provider, Backstage TFC plugin — not compat targets (structural divergence: single org, label-based RBAC instead of teams)

## Test plan

- [x] `make test` — all 1242 tests pass
- [x] `helm template` — chart still valid
- [x] Frontend `tsc --noEmit` clean
- [x] Smoke-test app construction: 349 routes registered, dual-mount topology verified for canonical-vs-deprecated paths
- [ ] Tilt local stack — verify CLI-driven `tofu plan/apply` still works against `/api/v2/`
- [ ] Tilt local stack — verify web UI works against `/api/terrapod/v1/`
- [ ] Tilt local stack — verify deprecated alias emits the right headers + structlog warning