### PR TITLE
feat: workspace autodiscovery for monorepos (#283)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | Notifications | Implemented | Webhook (HMAC-SHA512), Slack (Block Kit), and email alerts on run events |
 | Run Tasks | Implemented | Pre/post-plan webhook hooks for external validation |
 | Workspace Health | Implemented | Per-workspace health conditions, VCS polling status, drift detection indicators |
+| Workspace Autodiscovery | Implemented | Atlantis-style monorepo autodiscovery — pattern-matched rules auto-create workspaces on PRs to new directories |
 | Cloud Credentials | Implemented | Dynamic provider credentials via K8s workload identity (AWS IRSA, GCP WIF, Azure WI) |
 
 ### Screenshots
@@ -249,6 +250,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Deployment](docs/deployment.md) | Production Helm deployment, storage backends, scaling |
 | [Registry](docs/registry.md) | Private module/provider registry, caching layers |
 | [VCS Integration](docs/vcs-integration.md) | GitHub and GitLab setup, polling, webhooks |
+| [Autodiscovery](docs/autodiscovery.md) | Atlantis-style monorepo workspace autodiscovery |
 | [Drift Detection](docs/drift-detection.md) | Scheduled plan-only runs to detect infrastructure drift |
 | [Run Triggers](docs/run-triggers.md) | Cross-workspace dependency chains |
 | [Notifications](docs/notifications.md) | Webhook, Slack, and email alerts on run events |

--- a/alembic/versions/8bb13bfef824_add_workspace_autodiscovery_rules.py
+++ b/alembic/versions/8bb13bfef824_add_workspace_autodiscovery_rules.py
@@ -1,0 +1,97 @@
+"""Add autodiscovery_rules table.
+
+Adds connection-scoped rules that drive workspace autodiscovery in
+monorepos. When the VCS poller scans a PR (or a default-branch push)
+and the changed paths don't match any existing workspace's
+trigger_prefixes, autodiscovery rules are consulted: a path that
+matches a rule's `pattern` and isn't excluded by `ignore_patterns`
+auto-creates a workspace using the rule's template fields and
+queues the corresponding run.
+
+Rules belong to a VCS connection, not an organization (Terrapod is
+single-org). Every rule names exactly one repo so rule-fanout is
+simple and predictable. The `repo_url` mirrors the existing
+`workspaces.vcs_repo_url` so the same parser/dispatch logic works
+unchanged.
+
+See terrapod #283.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "8bb13bfef824"
+down_revision = "ad9e14fa1469"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "autodiscovery_rules",
+        sa.Column("id", sa.UUID(), nullable=False, server_default=sa.text("gen_random_uuid()")),
+        # Scoping
+        sa.Column("vcs_connection_id", sa.UUID(), nullable=False),
+        sa.Column("repo_url", sa.String(2048), nullable=False),
+        sa.Column("branch", sa.String(255), nullable=False, server_default=""),
+        # Match
+        sa.Column("pattern", sa.String(1024), nullable=False),
+        sa.Column("ignore_patterns", JSONB, nullable=False, server_default="[]"),
+        # Identity
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("name_template", sa.String(255), nullable=False, server_default=""),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        # Workspace template
+        sa.Column("execution_mode", sa.String(20), nullable=False, server_default="agent"),
+        sa.Column("agent_pool_id", sa.UUID(), nullable=True),
+        sa.Column("execution_backend", sa.String(20), nullable=False, server_default="tofu"),
+        sa.Column("terraform_version", sa.String(50), nullable=False, server_default="1.11"),
+        sa.Column("resource_cpu", sa.String(20), nullable=False, server_default="1"),
+        sa.Column("resource_memory", sa.String(20), nullable=False, server_default="2Gi"),
+        sa.Column("auto_apply", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("labels", JSONB, nullable=False, server_default="{}"),
+        sa.Column("owner_email", sa.String(255), nullable=True),
+        # Audit
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["vcs_connection_id"], ["vcs_connections.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["agent_pool_id"], ["agent_pools.id"], ondelete="SET NULL"),
+        sa.UniqueConstraint("vcs_connection_id", "name", name="uq_autodiscovery_rule_name"),
+    )
+    op.create_index(
+        "ix_autodiscovery_rules_repo",
+        "autodiscovery_rules",
+        ["vcs_connection_id", "repo_url"],
+    )
+    # Track which rule (if any) auto-created a workspace, so we can
+    # audit autodiscovered workspaces and avoid re-creating them on
+    # subsequent poll cycles.
+    op.add_column(
+        "workspaces",
+        sa.Column("autodiscovery_rule_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_workspaces_autodiscovery_rule_id",
+        "workspaces",
+        "autodiscovery_rules",
+        ["autodiscovery_rule_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_workspaces_autodiscovery_rule_id", "workspaces", type_="foreignkey")
+    op.drop_column("workspaces", "autodiscovery_rule_id")
+    op.drop_index("ix_autodiscovery_rules_repo", table_name="autodiscovery_rules")
+    op.drop_table("autodiscovery_rules")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1345,6 +1345,79 @@ DELETE /api/terrapod/v1/vcs-connections/{id}
 
 ---
 
+## Autodiscovery Rules
+
+Connection-scoped rules that auto-create workspaces when a PR or default-branch push touches a path matching `pattern`. See [Autodiscovery](autodiscovery.md) for the full feature doc.
+
+All endpoints require `admin` role.
+
+### List Rules
+
+```
+GET /api/terrapod/v1/autodiscovery-rules
+```
+
+### Create Rule
+
+```
+POST /api/terrapod/v1/autodiscovery-rules
+```
+
+**Request body** (every attribute except `name`, `vcs-connection-id`, `repo-url`, `pattern` is optional):
+
+```json
+{
+  "data": {
+    "type": "autodiscovery-rules",
+    "attributes": {
+      "name": "monorepo",
+      "vcs-connection-id": "vcs-019e0e7b-...",
+      "repo-url": "https://github.com/myorg/monorepo",
+      "branch": "main",
+      "pattern": "accounts/*/**/*.tf",
+      "ignore-patterns": ["modules/**"],
+      "name-template": "ws-{path}",
+      "enabled": true,
+      "execution-mode": "agent",
+      "execution-backend": "tofu",
+      "agent-pool-id": "apool-019e01db-...",
+      "terraform-version": "1.11",
+      "resource-cpu": "1",
+      "resource-memory": "2Gi",
+      "auto-apply": false,
+      "labels": {"managed-by": "monorepo-autodiscover"},
+      "owner-email": "platform@example.com"
+    }
+  }
+}
+```
+
+Returns `201` with the created rule, or `409` if a rule with that name already exists for the connection.
+
+### Show Rule
+
+```
+GET /api/terrapod/v1/autodiscovery-rules/{id}
+```
+
+### Update Rule
+
+```
+PATCH /api/terrapod/v1/autodiscovery-rules/{id}
+```
+
+Same body shape as create; only the attributes you include are updated.
+
+### Delete Rule
+
+```
+DELETE /api/terrapod/v1/autodiscovery-rules/{id}
+```
+
+Workspaces auto-created by this rule keep working — their `autodiscovery-rule-id` foreign key is set to NULL.
+
+---
+
 ## VCS Events (Webhooks)
 
 ### GitHub Webhook Receiver

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -476,6 +476,14 @@ Terrapod uses a polling-first design for VCS integration. No inbound connections
 |     - Create ConfigurationVersion      +--------+---------+
 |     - Queue Run                                 |
 |                                    triggers immediate poll
+|
+|  Then: autodiscovery pass — for every connection with enabled
+|  AutodiscoveryRule rows, scan open PRs and auto-create
+|  workspaces for changed paths matching `pattern` (and not
+|  matching `ignore_patterns`). Created workspaces are picked up
+|  by the next workspace-poll iteration via the normal flow.
+|  Webhooks call the same autodiscovery pass scoped to the
+|  webhook's repo.
 ```
 
 ### Provider Dispatch

--- a/docs/autodiscovery.md
+++ b/docs/autodiscovery.md
@@ -1,0 +1,186 @@
+# Workspace Autodiscovery
+
+Modelled on [Atlantis's `autodiscover`](https://www.runatlantis.io/docs/server-side-repo-config.html#autodiscover) feature, autodiscovery auto-creates a Terrapod workspace the first time a PR (or default-branch push) touches a path matching one of your rules. Designed for monorepos where pre-provisioning a workspace per directory is impractical.
+
+## When you'd want this
+
+- A monorepo with hundreds of nested terraform root modules (one per AWS account, one per environment, etc.).
+- New roots are added regularly via PRs, and you don't want every PR-author to also have to create a Terrapod workspace.
+- You're happy giving every discovered directory the *same* execution defaults — agent pool, terraform version, resource requests, default labels, owner.
+
+## When you wouldn't
+
+- You only have a handful of long-lived workspaces. Just create them.
+- Different directories need different workspace configuration that can't be expressed by a single rule.
+
+## How it works
+
+```
+┌─────────────────┐       ┌──────────────────────┐       ┌─────────────────────┐
+│ PR opened       │  PR's │ Poller scans changed │ Match │ Workspace created   │
+│ on branch X     ├──────►│ files vs rules       ├──────►│ with rule's         │
+│                 │ files │ (pattern + ignore)   │       │ template defaults   │
+└─────────────────┘       └──────────────────────┘       └─────────────────────┘
+                                                                    │
+                                                                    ▼
+                                                         ┌─────────────────────┐
+                                                         │ Next poll cycle     │
+                                                         │ runs the speculative│
+                                                         │ plan as normal      │
+                                                         └─────────────────────┘
+```
+
+Autodiscovery runs on every poll cycle (default 60s) and on every webhook-triggered immediate poll for the matching repo. It only creates workspaces — the existing PR/branch poll logic queues the speculative plan on the next pass.
+
+## GitHub App permissions
+
+**No new permissions required.** The same `Contents: read`, `Pull requests: read & write`, and `Metadata: read` you've already granted for VCS integration cover autodiscovery (file listing on PRs uses `Pull requests: read`). Existing GitLab access tokens with `read_api` + `read_repository` (or `api`) work without changes.
+
+## Rule schema
+
+Rules are scoped to a single VCS connection + repo. A rule has:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Display name for the rule. Unique per VCS connection. |
+| `vcs-connection-id` | UUID | yes | Reference to an existing VCS connection. |
+| `repo-url` | string | yes | Full repo URL, e.g. `https://github.com/myorg/monorepo`. |
+| `branch` | string | no | Branch the rule scopes to. Empty = default branch. |
+| `pattern` | string | yes | Glob matched against changed file paths (gitignore-style with `**` support). |
+| `ignore-patterns` | string[] | no | Globs filtered out before pattern matching. |
+| `name-template` | string | no | Template for derived workspace names. Default: directory path with `/` replaced by `-`. |
+| `enabled` | bool | no | Default `true`. |
+| `execution-mode` | enum | no | Must be `agent` (default). Autodiscovery is VCS-driven; `local` mode would create workspaces with queued runs and no executor. |
+| `agent-pool-id` | UUID | no | Inherited by created workspaces in `agent` mode. |
+| `execution-backend` | enum | no | `tofu` or `terraform`. Default `tofu`. |
+| `terraform-version` | string | no | Default `1.11`. |
+| `resource-cpu` / `resource-memory` | string | no | Defaults `1` / `2Gi`. |
+| `auto-apply` | bool | no | Default `false`. |
+| `labels` | map | no | Inherited by created workspaces — feeds Terrapod's label-based RBAC and filtering. |
+| `owner-email` | string | no | Inherited by created workspaces; if unset, created workspaces have no owner and label-RBAC alone determines access. |
+
+## Pattern syntax
+
+Rules use gitignore-style globs. Patterns are matched against the **full file path** (e.g. `accounts/alpha/network/main.tf`).
+
+| Token | Meaning |
+|---|---|
+| `*` | match anything within a single path segment (no `/`) |
+| `**` | match zero or more path segments |
+| `?` | match a single non-`/` character |
+| `[abc]` | match one of `a`, `b`, `c`; `[!abc]` = NOT one of those |
+
+Only terraform configuration files (`*.tf`, `*.tfvars`, `*.tf.json`, `*.tfvars.json`, `*.hcl`) trigger autodiscovery. README/CI/script changes are filtered out before pattern matching.
+
+## How the workspace is named
+
+The created workspace's `working-directory` is the directory containing the matched terraform file. The default name is that directory with `/` replaced by `-`:
+
+```
+accounts/alpha/network/main.tf  →  workspace `accounts-alpha-network` (working_directory = `accounts/alpha/network`)
+```
+
+If the default would collide with an existing unrelated workspace, Terrapod logs a warning and skips creation. Tighten `name-template` to disambiguate:
+
+```
+name-template: "monorepo-{path}"   →  monorepo-accounts-alpha-network
+name-template: "ws-{root}"         →  ws-accounts-alpha-network  ({root} preserves /, sanitiser maps to -)
+```
+
+`{path}` is the dashed directory; `{root}` is the directory with `/` preserved. Names are sanitised to `[A-Za-z0-9_-]` and capped at 90 chars (the workspaces.name column limit).
+
+## Created workspace properties
+
+A workspace created by a rule:
+- Inherits all template fields above.
+- Has `vcs-connection-id`, `vcs-repo-url`, `vcs-branch` set from the rule.
+- Has `working-directory` set to the matched file's parent.
+- Has `trigger-prefixes` set to `[working_directory]` so subsequent PRs that touch the same dir route to the same workspace via the regular PR-scan path (not via re-running autodiscovery).
+- Tracks `autodiscovery-rule-id` so you can audit which rule created it.
+
+If you delete the rule later, existing workspaces keep working — the foreign key sets to NULL on cascade.
+
+## Example
+
+A monorepo for ~2000 AWS accounts in this shape:
+
+```
+accounts/
+  alpha/network/main.tf
+  alpha/compute/main.tf
+  beta/network/main.tf
+  ...
+modules/
+  vpc/main.tf      # reusable module — NOT a discoverable root
+```
+
+Rule:
+
+```yaml
+name: monorepo
+vcs-connection-id: vcs-019e0e7b-a6de-7ea6-8b27-3a983c0a098e
+repo-url: https://github.com/myorg/monorepo
+branch: main
+pattern: accounts/*/**/*.tf
+ignore-patterns:
+  - modules/**
+execution-mode: agent
+agent-pool-id: apool-019e01db-a2a3-7494-afe0-1a8ecf70b3eb
+labels:
+  managed-by: monorepo-autodiscover
+owner-email: platform@example.com
+```
+
+Outcome:
+
+| PR change | Result |
+|---|---|
+| `accounts/alpha/network/main.tf` | Workspace `accounts-alpha-network` auto-created (if it didn't exist) |
+| `accounts/gamma/dns/main.tf` | New workspace `accounts-gamma-dns` auto-created |
+| `modules/vpc/main.tf` | No workspace created (matches ignore pattern) |
+| `README.md` | No workspace created (not a terraform file) |
+
+## API
+
+Admin-only CRUD at `/api/terrapod/v1/autodiscovery-rules`:
+
+```
+GET    /api/terrapod/v1/autodiscovery-rules
+POST   /api/terrapod/v1/autodiscovery-rules
+GET    /api/terrapod/v1/autodiscovery-rules/{id}
+PATCH  /api/terrapod/v1/autodiscovery-rules/{id}
+DELETE /api/terrapod/v1/autodiscovery-rules/{id}
+```
+
+JSON:API request body example:
+
+```json
+{
+  "data": {
+    "type": "autodiscovery-rules",
+    "attributes": {
+      "name": "monorepo",
+      "vcs-connection-id": "vcs-019e0e7b-...",
+      "repo-url": "https://github.com/myorg/monorepo",
+      "pattern": "accounts/*/**/*.tf",
+      "ignore-patterns": ["modules/**"],
+      "execution-mode": "agent",
+      "agent-pool-id": "apool-019e01db-...",
+      "labels": {"managed-by": "monorepo-autodiscover"},
+      "owner-email": "platform@example.com"
+    }
+  }
+}
+```
+
+## Operational notes
+
+- **Lifecycle of discovered workspaces**: workspaces persist after the source directory is deleted. Operators can archive/delete via the normal workspace API.
+- **Race-safety**: idempotent. Concurrent poll cycles trying to create the same workspace fall through to a "found existing" branch.
+- **Failure isolation**: a misconfigured rule (bad repo URL, GitHub auth failure, rate limit) is logged and skipped; other rules in the same cycle continue.
+- **Observability**: every autodiscovery action emits a structlog entry — grep API logs for `Autodiscovery created workspace` and `Autodiscovery name collision`.
+
+## Related
+
+- Atlantis autodiscover docs: <https://www.runatlantis.io/docs/server-side-repo-config.html#autodiscover>
+- Original feature request: <https://github.com/mattrobinsonsre/terrapod/issues/283>

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Authentication](authentication.md) | Local auth, OIDC, SAML, terraform login, API tokens |
 | [RBAC](rbac.md) | Permission model, label-based access control, custom roles |
 | [VCS Integration](vcs-integration.md) | GitHub and GitLab setup, polling, webhooks |
+| [Autodiscovery](autodiscovery.md) | Atlantis-style monorepo workspace autodiscovery |
 | [Drift Detection](drift-detection.md) | Scheduled plan-only runs to detect infrastructure drift |
 | [Run Triggers](run-triggers.md) | Cross-workspace dependency chains |
 | [Notifications](notifications.md) | Webhook, Slack, and email alerts on run events |

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -550,3 +550,51 @@ Object storage (S3, Azure Blob, GCS, or filesystem) failures prevent state uploa
 - `terrapod_storage_errors_total` rate drops to zero
 - State uploads succeed (create a test state version)
 - Runner Jobs can download configs and upload artifacts
+
+---
+
+## Autodiscovery rule didn't fire
+
+**Symptom**: a PR added a directory matching what you thought your autodiscovery rule covers, but no workspace was auto-created.
+
+### Diagnosis
+
+Walk the rule evaluation logic from the outside in:
+
+1. **Is the rule enabled?**
+   ```sh
+   curl -sk -H "Authorization: Bearer $TOKEN" \
+     https://<terrapod>/api/terrapod/v1/autodiscovery-rules \
+     | jq '.data[] | {name: .attributes.name, enabled: .attributes.enabled, repo: .attributes."repo-url"}'
+   ```
+
+2. **Did the poller see the PR?** Search the API logs for the rule's repo:
+   ```sh
+   kubectl logs deploy/terrapod-api --tail=2000 | grep -E "Autodiscovery|<your-repo>"
+   ```
+   You should see `Autodiscovery created workspace` (success) or `Autodiscovery name collision`/`Autodiscovery: cannot parse repo URL`/`Autodiscovery: failed to list PRs` (each is a clear cause).
+
+3. **Does the rule's pattern actually match the file?** The pattern is matched against the *full path* (e.g. `accounts/alpha/network/main.tf`, not `main.tf`). Test the pattern in a Python REPL with the same engine:
+   ```python
+   from terrapod.services.workspace_autodiscovery_service import _match_glob
+   _match_glob("accounts/alpha/network/main.tf", "accounts/*/**/*.tf")  # True/False
+   ```
+
+4. **Is the file actually a terraform file?** Only `*.tf`, `*.tfvars`, `*.tf.json`, `*.tfvars.json`, `*.hcl` trigger autodiscovery. README/CI changes don't.
+
+5. **Is it caught by ignore_patterns?** Same `_match_glob` test against each ignore pattern.
+
+6. **Did the workspace name collide with an existing unrelated workspace?** Search logs for `Autodiscovery name collision`. The collision skip is logged but never errored to the user. Tighten `name-template` to disambiguate (e.g. `name-template: "monorepo-{path}"`).
+
+### Common gotchas
+
+- **GitHub App permissions**: requires `Pull requests: read` (not just `Contents`). If the install was created before commit-status reporting was enabled, the App may lack pull-request scope. Re-grant in GitHub App settings.
+- **Default-branch override**: a rule with `branch: ""` resolves to the repo's default branch. If you've renamed the default branch on GitHub but the rule was created before, the rule still tracks the default branch — no action needed. If you set `branch: "main"` literally and renamed to `master`, you need to update the rule.
+- **Webhook payloads**: webhook-driven autodiscovery only fires for the repo named in the webhook payload. If you've configured the webhook on a different repo (or org-level webhook with selective filters), autodiscovery may only run on the next 60s poll cycle.
+
+### Verification
+
+After fixing the rule:
+- Push a new commit to the test PR (small change to the `.tf` file is enough)
+- Within 60s (or sooner via webhook), see the workspace appear in the list
+- Workspace's `autodiscovery-rule-id` attribute references the rule

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -139,6 +139,8 @@ GitHub integration uses a **GitHub App** for fine-grained permissions and org-le
 
    ![GitHub App Permissions](images/github-app-permissions.png)
 
+   These permissions also cover [workspace autodiscovery](autodiscovery.md). No App reinstall is needed if you enable autodiscovery later — `Contents: read` and `Pull requests: read & write` are what the autodiscovery scanner uses.
+
 4. Under **Where can this GitHub App be installed?**, choose based on your needs:
    - **Only on this account** -- if all repos are in one org/account
    - **Any account** -- if repos span multiple orgs

--- a/provider/internal/provider/provider.go
+++ b/provider/internal/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	workspacesDS "github.com/mattrobinsonsre/terrapod/provider/internal/datasources/workspaces"
 	agentPoolRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/agent_pool"
 	agentPoolTokenRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/agent_pool_token"
+	autodiscoveryRuleRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/autodiscovery_rule"
 	gpgKeyRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/gpg_key"
 	moduleWorkspaceLinkRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/module_workspace_link"
 	notificationConfigRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/notification_configuration"
@@ -134,6 +135,7 @@ func (p *terrapodProvider) Resources(_ context.Context) []func() resource.Resour
 		vcsConnectionRes.NewResource,
 		agentPoolRes.NewResource,
 		agentPoolTokenRes.NewResource,
+		autodiscoveryRuleRes.NewResource,
 		registryModuleRes.NewResource,
 		registryProviderRes.NewResource,
 		moduleWorkspaceLinkRes.NewResource,

--- a/provider/internal/resources/autodiscovery_rule/resource.go
+++ b/provider/internal/resources/autodiscovery_rule/resource.go
@@ -1,0 +1,485 @@
+// Package autodiscovery_rule implements the terrapod_autodiscovery_rule
+// resource. See terrapod #283 and docs/autodiscovery.md.
+//
+// API Contract (Terrapod API <-> Terraform Provider):
+//
+//	JSON:API type: "autodiscovery-rules"
+//	ID format: bare UUID (no prefix)
+//	Create:  POST   /api/terrapod/v1/autodiscovery-rules
+//	Read:    GET    /api/terrapod/v1/autodiscovery-rules/{id}
+//	Update:  PATCH  /api/terrapod/v1/autodiscovery-rules/{id}
+//	Delete:  DELETE /api/terrapod/v1/autodiscovery-rules/{id}
+//
+// Attribute mapping (JSON:API attribute -> Terraform schema attribute):
+//
+//	"name"               -> name                (string, required)
+//	"name-template"      -> name_template       (string, optional)
+//	"vcs-connection-id"  -> vcs_connection_id   (string, required)
+//	"repo-url"           -> repo_url            (string, required)
+//	"branch"             -> branch              (string, optional, "" = default branch)
+//	"pattern"            -> pattern             (string, required)
+//	"ignore-patterns"    -> ignore_patterns     (list of strings, optional)
+//	"enabled"            -> enabled             (bool, optional, default true)
+//	"execution-mode"     -> execution_mode      (string, optional, default "agent")
+//	"execution-backend"  -> execution_backend   (string, optional, default "tofu")
+//	"agent-pool-id"      -> agent_pool_id       (string, optional)
+//	"terraform-version"  -> terraform_version   (string, optional, default "1.11")
+//	"resource-cpu"       -> resource_cpu        (string, optional, default "1")
+//	"resource-memory"    -> resource_memory     (string, optional, default "2Gi")
+//	"auto-apply"         -> auto_apply          (bool, optional, default false)
+//	"labels"             -> labels              (map[string]string, optional)
+//	"owner-email"        -> owner_email         (string, optional)
+//
+// Read-only:
+//
+//	"created-at"         -> created_at          (string, computed)
+//	"updated-at"         -> updated_at          (string, computed)
+//
+// Import: by rule ID (bare UUID).
+package autodiscovery_rule
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/mattrobinsonsre/terrapod/provider/internal/client"
+)
+
+var (
+	_ resource.Resource                = &autodiscoveryRuleResource{}
+	_ resource.ResourceWithImportState = &autodiscoveryRuleResource{}
+)
+
+type autodiscoveryRuleModel struct {
+	ID types.String `tfsdk:"id"`
+
+	Name             types.String `tfsdk:"name"`
+	NameTemplate     types.String `tfsdk:"name_template"`
+	VCSConnectionID  types.String `tfsdk:"vcs_connection_id"`
+	RepoURL          types.String `tfsdk:"repo_url"`
+	Branch           types.String `tfsdk:"branch"`
+	Pattern          types.String `tfsdk:"pattern"`
+	IgnorePatterns   types.List   `tfsdk:"ignore_patterns"`
+	Enabled          types.Bool   `tfsdk:"enabled"`
+	ExecutionMode    types.String `tfsdk:"execution_mode"`
+	ExecutionBackend types.String `tfsdk:"execution_backend"`
+	AgentPoolID      types.String `tfsdk:"agent_pool_id"`
+	TerraformVersion types.String `tfsdk:"terraform_version"`
+	ResourceCPU      types.String `tfsdk:"resource_cpu"`
+	ResourceMemory   types.String `tfsdk:"resource_memory"`
+	AutoApply        types.Bool   `tfsdk:"auto_apply"`
+	Labels           types.Map    `tfsdk:"labels"`
+	OwnerEmail       types.String `tfsdk:"owner_email"`
+
+	CreatedAt types.String `tfsdk:"created_at"`
+	UpdatedAt types.String `tfsdk:"updated_at"`
+}
+
+type autodiscoveryRuleResource struct {
+	client *client.Client
+}
+
+func NewResource() resource.Resource {
+	return &autodiscoveryRuleResource{}
+}
+
+func (r *autodiscoveryRuleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_autodiscovery_rule"
+}
+
+func (r *autodiscoveryRuleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a Terrapod workspace autodiscovery rule. " +
+			"When the VCS poller detects a PR or default-branch push that touches " +
+			"a path matching this rule's pattern (and not matching ignore_patterns), " +
+			"it auto-creates a workspace using the rule's template fields. " +
+			"See https://github.com/mattrobinsonsre/terrapod/blob/main/docs/autodiscovery.md.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The autodiscovery rule ID (UUID).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Display name for the rule. Unique per VCS connection.",
+				Required:    true,
+			},
+			"name_template": schema.StringAttribute{
+				Description: "Optional template for derived workspace names. Use {path} for the dashed working_directory or {root} to keep slashes. Defaults to {path}.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
+			},
+			"vcs_connection_id": schema.StringAttribute{
+				Description: "The VCS connection ID this rule scopes to (e.g. \"vcs-abc123\").",
+				Required:    true,
+			},
+			"repo_url": schema.StringAttribute{
+				Description: "Full repository URL (e.g. https://github.com/myorg/monorepo).",
+				Required:    true,
+			},
+			"branch": schema.StringAttribute{
+				Description: "Branch the rule scopes to. Empty (default) tracks the repo's default branch.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
+			},
+			"pattern": schema.StringAttribute{
+				Description: "Glob matched against changed file paths (gitignore-style with ** support).",
+				Required:    true,
+			},
+			"ignore_patterns": schema.ListAttribute{
+				Description: "Globs filtered out before pattern matching.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether the rule is active. Defaults to true.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"execution_mode": schema.StringAttribute{
+				Description: "Default execution mode for created workspaces (\"agent\" or \"local\"). Defaults to \"agent\".",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("agent"),
+			},
+			"execution_backend": schema.StringAttribute{
+				Description: "Default execution backend for created workspaces (\"tofu\" or \"terraform\"). Defaults to \"tofu\".",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("tofu"),
+			},
+			"agent_pool_id": schema.StringAttribute{
+				Description: "Default agent pool ID for created workspaces (e.g. \"apool-abc123\"). Optional.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"terraform_version": schema.StringAttribute{
+				Description: "Default terraform/tofu version for created workspaces. Defaults to \"1.11\".",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("1.11"),
+			},
+			"resource_cpu": schema.StringAttribute{
+				Description: "Default CPU request for runner Jobs in created workspaces. Defaults to \"1\".",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("1"),
+			},
+			"resource_memory": schema.StringAttribute{
+				Description: "Default memory request for runner Jobs in created workspaces. Defaults to \"2Gi\".",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("2Gi"),
+			},
+			"auto_apply": schema.BoolAttribute{
+				Description: "Default auto-apply setting for created workspaces. Defaults to false.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"labels": schema.MapAttribute{
+				Description: "Labels inherited by created workspaces — feeds Terrapod's label-based RBAC and filtering.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"owner_email": schema.StringAttribute{
+				Description: "Email used as owner_email on created workspaces. Empty = no owner; label-RBAC alone determines access.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
+			},
+
+			// Read-only
+			"created_at": schema.StringAttribute{
+				Description: "Creation timestamp.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Last update timestamp.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (r *autodiscoveryRuleResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client, got %T", req.ProviderData))
+		return
+	}
+	r.client = c
+}
+
+func (r *autodiscoveryRuleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan autodiscoveryRuleModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	attrs := buildAutodiscoveryRuleAttrs(&plan)
+
+	body, err := client.MarshalResource("autodiscovery-rules", attrs, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to marshal request", err.Error())
+		return
+	}
+
+	data, err := r.client.Post(ctx, "/api/terrapod/v1/autodiscovery-rules", body)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create autodiscovery rule", err.Error())
+		return
+	}
+
+	res, err := client.ParseResource(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse response", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(readAutodiscoveryRuleIntoModel(ctx, res, &plan)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *autodiscoveryRuleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state autodiscoveryRuleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/autodiscovery-rules/"+state.ID.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read autodiscovery rule", err.Error())
+		return
+	}
+
+	res, err := client.ParseResource(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse response", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(readAutodiscoveryRuleIntoModel(ctx, res, &state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *autodiscoveryRuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan autodiscoveryRuleModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state autodiscoveryRuleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	attrs := buildAutodiscoveryRuleAttrs(&plan)
+
+	body, err := client.MarshalResourceWithID(state.ID.ValueString(), "autodiscovery-rules", attrs)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to marshal request", err.Error())
+		return
+	}
+
+	data, err := r.client.Patch(ctx, "/api/terrapod/v1/autodiscovery-rules/"+state.ID.ValueString(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to update autodiscovery rule", err.Error())
+		return
+	}
+
+	res, err := client.ParseResource(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse response", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(readAutodiscoveryRuleIntoModel(ctx, res, &plan)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *autodiscoveryRuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state autodiscoveryRuleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Delete(ctx, "/api/terrapod/v1/autodiscovery-rules/"+state.ID.ValueString())
+	if err != nil && !client.IsNotFound(err) {
+		resp.Diagnostics.AddError("Failed to delete autodiscovery rule", err.Error())
+	}
+}
+
+func (r *autodiscoveryRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// buildAutodiscoveryRuleAttrs converts the Terraform model into JSON:API
+// attributes for create/update. Computed-only attributes are omitted.
+func buildAutodiscoveryRuleAttrs(m *autodiscoveryRuleModel) map[string]any {
+	attrs := map[string]any{
+		"name":              m.Name.ValueString(),
+		"vcs-connection-id": m.VCSConnectionID.ValueString(),
+		"repo-url":          m.RepoURL.ValueString(),
+		"pattern":           m.Pattern.ValueString(),
+	}
+
+	if !m.NameTemplate.IsNull() && !m.NameTemplate.IsUnknown() {
+		attrs["name-template"] = m.NameTemplate.ValueString()
+	}
+	if !m.Branch.IsNull() && !m.Branch.IsUnknown() {
+		attrs["branch"] = m.Branch.ValueString()
+	}
+
+	if !m.IgnorePatterns.IsNull() && !m.IgnorePatterns.IsUnknown() {
+		patterns := make([]string, 0, len(m.IgnorePatterns.Elements()))
+		for _, v := range m.IgnorePatterns.Elements() {
+			patterns = append(patterns, v.(types.String).ValueString())
+		}
+		attrs["ignore-patterns"] = patterns
+	} else {
+		attrs["ignore-patterns"] = []string{}
+	}
+
+	if !m.Enabled.IsNull() && !m.Enabled.IsUnknown() {
+		attrs["enabled"] = m.Enabled.ValueBool()
+	}
+	if !m.ExecutionMode.IsNull() && !m.ExecutionMode.IsUnknown() {
+		attrs["execution-mode"] = m.ExecutionMode.ValueString()
+	}
+	if !m.ExecutionBackend.IsNull() && !m.ExecutionBackend.IsUnknown() {
+		attrs["execution-backend"] = m.ExecutionBackend.ValueString()
+	}
+	if !m.AgentPoolID.IsNull() && !m.AgentPoolID.IsUnknown() {
+		v := m.AgentPoolID.ValueString()
+		if v == "" {
+			attrs["agent-pool-id"] = nil
+		} else {
+			attrs["agent-pool-id"] = v
+		}
+	}
+	if !m.TerraformVersion.IsNull() && !m.TerraformVersion.IsUnknown() {
+		attrs["terraform-version"] = m.TerraformVersion.ValueString()
+	}
+	if !m.ResourceCPU.IsNull() && !m.ResourceCPU.IsUnknown() {
+		attrs["resource-cpu"] = m.ResourceCPU.ValueString()
+	}
+	if !m.ResourceMemory.IsNull() && !m.ResourceMemory.IsUnknown() {
+		attrs["resource-memory"] = m.ResourceMemory.ValueString()
+	}
+	if !m.AutoApply.IsNull() && !m.AutoApply.IsUnknown() {
+		attrs["auto-apply"] = m.AutoApply.ValueBool()
+	}
+
+	if !m.Labels.IsNull() && !m.Labels.IsUnknown() {
+		labels := map[string]string{}
+		for k, v := range m.Labels.Elements() {
+			labels[k] = v.(types.String).ValueString()
+		}
+		attrs["labels"] = labels
+	} else {
+		attrs["labels"] = map[string]string{}
+	}
+
+	if !m.OwnerEmail.IsNull() && !m.OwnerEmail.IsUnknown() {
+		attrs["owner-email"] = m.OwnerEmail.ValueString()
+	}
+
+	return attrs
+}
+
+// readAutodiscoveryRuleIntoModel maps a JSON:API resource into the
+// Terraform model.
+func readAutodiscoveryRuleIntoModel(ctx context.Context, res *client.Resource, m *autodiscoveryRuleModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	m.ID = types.StringValue(res.ID)
+
+	m.Name = types.StringValue(client.GetStringAttr(res, "name"))
+	m.NameTemplate = types.StringValue(client.GetStringAttr(res, "name-template"))
+	m.VCSConnectionID = types.StringValue(client.GetStringAttr(res, "vcs-connection-id"))
+	m.RepoURL = types.StringValue(client.GetStringAttr(res, "repo-url"))
+	m.Branch = types.StringValue(client.GetStringAttr(res, "branch"))
+	m.Pattern = types.StringValue(client.GetStringAttr(res, "pattern"))
+
+	patterns := client.GetListAttr(res, "ignore-patterns")
+	if patterns == nil {
+		patterns = []string{}
+	}
+	v, d := types.ListValueFrom(ctx, types.StringType, patterns)
+	diags.Append(d...)
+	m.IgnorePatterns = v
+
+	m.Enabled = types.BoolValue(client.GetBoolAttr(res, "enabled"))
+	m.ExecutionMode = types.StringValue(client.GetStringAttr(res, "execution-mode"))
+	m.ExecutionBackend = types.StringValue(client.GetStringAttr(res, "execution-backend"))
+	m.AgentPoolID = types.StringValue(client.GetStringAttr(res, "agent-pool-id"))
+	m.TerraformVersion = types.StringValue(client.GetStringAttr(res, "terraform-version"))
+	m.ResourceCPU = types.StringValue(client.GetStringAttr(res, "resource-cpu"))
+	m.ResourceMemory = types.StringValue(client.GetStringAttr(res, "resource-memory"))
+	m.AutoApply = types.BoolValue(client.GetBoolAttr(res, "auto-apply"))
+
+	labels := client.GetMapAttr(res, "labels")
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	mv, dl := types.MapValueFrom(ctx, types.StringType, labels)
+	diags.Append(dl...)
+	m.Labels = mv
+
+	m.OwnerEmail = types.StringValue(client.GetStringAttr(res, "owner-email"))
+	m.CreatedAt = types.StringValue(client.GetStringAttr(res, "created-at"))
+	m.UpdatedAt = types.StringValue(client.GetStringAttr(res, "updated-at"))
+
+	return diags
+}

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -732,6 +732,15 @@ def create_application() -> FastAPI:
         include_in_schema=False,
     )
 
+    # Autodiscovery rules — Terrapod-native, introduced in v0.24 (#283).
+    # No legacy alias: this surface didn't exist in v0.22, so /api/v2 has
+    # nothing to preserve.
+    from terrapod.api.routers.autodiscovery_rules import (
+        router as autodiscovery_rules_router,
+    )
+
+    app.include_router(autodiscovery_rules_router, prefix=TERRAPOD_PREFIX)
+
     # VCS webhook event receiver — Terrapod-specific.
     from terrapod.api.routers.vcs_events import router as vcs_events_router
 

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -1,0 +1,340 @@
+"""Autodiscovery rule CRUD (terrapod #283).
+
+Connection-scoped rules that auto-create workspaces in monorepos when
+a PR or default-branch push touches a path matching `pattern`. See
+`docs/autodiscovery.md` for the rule schema and pattern semantics.
+
+UX CONTRACT: consumed by the web frontend at
+`web/src/app/admin/autodiscovery/page.tsx`. Changes to response shapes,
+attribute names, or status codes MUST be matched there.
+
+Endpoints:
+    GET    /api/terrapod/v1/autodiscovery-rules                (list)
+    POST   /api/terrapod/v1/autodiscovery-rules                (create)
+    GET    /api/terrapod/v1/autodiscovery-rules/{id}           (show)
+    PATCH  /api/terrapod/v1/autodiscovery-rules/{id}           (update)
+    DELETE /api/terrapod/v1/autodiscovery-rules/{id}           (delete)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path
+from fastapi.responses import JSONResponse, Response
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.api.dependencies import AuthenticatedUser, require_admin
+from terrapod.db.models import AgentPool, AutodiscoveryRule, VCSConnection
+from terrapod.db.session import get_db
+from terrapod.logging_config import get_logger
+
+router = APIRouter(tags=["autodiscovery-rules"])
+logger = get_logger(__name__)
+
+_VALID_EXEC_MODES = frozenset({"agent"})
+_VALID_BACKENDS = frozenset({"tofu", "terraform"})
+
+
+def _rfc3339(dt) -> str:  # noqa: ANN001
+    if dt is None:
+        return ""
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _rule_json(rule: AutodiscoveryRule) -> dict:
+    """Serialize an AutodiscoveryRule to JSON:API."""
+    return {
+        "id": str(rule.id),
+        "type": "autodiscovery-rules",
+        "attributes": {
+            "name": rule.name,
+            "name-template": rule.name_template,
+            "vcs-connection-id": str(rule.vcs_connection_id),
+            "repo-url": rule.repo_url,
+            "branch": rule.branch,
+            "pattern": rule.pattern,
+            "ignore-patterns": list(rule.ignore_patterns or []),
+            "enabled": rule.enabled,
+            "execution-mode": rule.execution_mode,
+            "execution-backend": rule.execution_backend,
+            "agent-pool-id": str(rule.agent_pool_id) if rule.agent_pool_id else None,
+            "terraform-version": rule.terraform_version,
+            "resource-cpu": rule.resource_cpu,
+            "resource-memory": rule.resource_memory,
+            "auto-apply": rule.auto_apply,
+            "labels": dict(rule.labels or {}),
+            "owner-email": rule.owner_email or "",
+            "created-at": _rfc3339(rule.created_at),
+            "updated-at": _rfc3339(rule.updated_at),
+        },
+        "links": {"self": f"/api/terrapod/v1/autodiscovery-rules/{rule.id}"},
+    }
+
+
+def _strip_uuid_prefix(s: str, prefix: str) -> uuid.UUID:
+    """Parse `<prefix>{uuid}` or a bare uuid; raises on invalid."""
+    raw = s.removeprefix(prefix)
+    return uuid.UUID(raw)
+
+
+async def _validate_connection(db: AsyncSession, connection_id: uuid.UUID) -> VCSConnection:
+    conn = await db.get(VCSConnection, connection_id)
+    if conn is None:
+        raise HTTPException(status_code=422, detail="vcs-connection-id not found")
+    return conn
+
+
+async def _validate_pool(db: AsyncSession, pool_id: uuid.UUID | None) -> None:
+    if pool_id is None:
+        return
+    pool = await db.get(AgentPool, pool_id)
+    if pool is None:
+        raise HTTPException(status_code=422, detail="agent-pool-id not found")
+
+
+def _coerce_attrs(attrs: dict, *, on_create: bool) -> dict[str, Any]:
+    """Normalise + validate request attributes. Returns a dict suitable
+    for `setattr` onto a model.
+    """
+    out: dict[str, Any] = {}
+
+    # Required on create
+    required = ("name", "vcs-connection-id", "repo-url", "pattern") if on_create else ()
+    for k in required:
+        if (
+            not (attrs.get(k) or "").strip()
+            if isinstance(attrs.get(k), str)
+            else attrs.get(k) is None
+        ):
+            raise HTTPException(status_code=422, detail=f"{k} is required")
+
+    if "name" in attrs:
+        out["name"] = str(attrs["name"]).strip()
+        if not out["name"]:
+            raise HTTPException(status_code=422, detail="name must be non-empty")
+    if "name-template" in attrs:
+        out["name_template"] = str(attrs["name-template"] or "")
+    if "vcs-connection-id" in attrs:
+        try:
+            out["vcs_connection_id"] = _strip_uuid_prefix(str(attrs["vcs-connection-id"]), "vcs-")
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail="vcs-connection-id is not a UUID") from e
+    if "repo-url" in attrs:
+        out["repo_url"] = str(attrs["repo-url"]).strip()
+        if not out["repo_url"]:
+            raise HTTPException(status_code=422, detail="repo-url must be non-empty")
+    if "branch" in attrs:
+        out["branch"] = str(attrs["branch"] or "")
+    if "pattern" in attrs:
+        out["pattern"] = str(attrs["pattern"]).strip()
+        if not out["pattern"]:
+            raise HTTPException(status_code=422, detail="pattern must be non-empty")
+    if "ignore-patterns" in attrs:
+        ip = attrs["ignore-patterns"]
+        if not isinstance(ip, list) or not all(isinstance(p, str) for p in ip):
+            raise HTTPException(status_code=422, detail="ignore-patterns must be a list of strings")
+        out["ignore_patterns"] = ip
+    if "enabled" in attrs:
+        out["enabled"] = bool(attrs["enabled"])
+    if "execution-mode" in attrs:
+        em = str(attrs["execution-mode"])
+        if em not in _VALID_EXEC_MODES:
+            # Autodiscovery is inherently VCS-driven; "local" execution
+            # mode would create zombie workspaces with queued runs and
+            # no executor.
+            raise HTTPException(
+                status_code=422,
+                detail="execution-mode must be 'agent' (autodiscovery is VCS-driven; local-mode workspaces have no executor for queued runs)",
+            )
+        out["execution_mode"] = em
+    if "execution-backend" in attrs:
+        eb = str(attrs["execution-backend"])
+        if eb not in _VALID_BACKENDS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"execution-backend must be one of {sorted(_VALID_BACKENDS)}",
+            )
+        out["execution_backend"] = eb
+    if "agent-pool-id" in attrs:
+        v = attrs["agent-pool-id"]
+        if v in (None, ""):
+            out["agent_pool_id"] = None
+        else:
+            try:
+                out["agent_pool_id"] = _strip_uuid_prefix(str(v), "apool-")
+            except ValueError as e:
+                raise HTTPException(status_code=422, detail="agent-pool-id is not a UUID") from e
+    if "terraform-version" in attrs:
+        out["terraform_version"] = str(attrs["terraform-version"])
+    if "resource-cpu" in attrs:
+        out["resource_cpu"] = str(attrs["resource-cpu"])
+    if "resource-memory" in attrs:
+        out["resource_memory"] = str(attrs["resource-memory"])
+    if "auto-apply" in attrs:
+        out["auto_apply"] = bool(attrs["auto-apply"])
+    if "labels" in attrs:
+        labels = attrs["labels"]
+        if not isinstance(labels, dict):
+            raise HTTPException(status_code=422, detail="labels must be an object")
+        out["labels"] = labels
+    if "owner-email" in attrs:
+        out["owner_email"] = (str(attrs["owner-email"]) or "").strip() or None
+
+    return out
+
+
+# ── List ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/autodiscovery-rules")
+async def list_rules(
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """List all autodiscovery rules. Admin only."""
+    result = await db.execute(
+        select(AutodiscoveryRule).order_by(AutodiscoveryRule.created_at.desc())
+    )
+    rules = result.scalars().all()
+    return JSONResponse(content={"data": [_rule_json(r) for r in rules]})
+
+
+# ── Create ───────────────────────────────────────────────────────────────
+
+
+@router.post("/autodiscovery-rules", status_code=201)
+async def create_rule(
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Create an autodiscovery rule. Admin only."""
+    attrs = body.get("data", {}).get("attributes", {})
+    fields = _coerce_attrs(attrs, on_create=True)
+
+    await _validate_connection(db, fields["vcs_connection_id"])
+    await _validate_pool(db, fields.get("agent_pool_id"))
+
+    rule = AutodiscoveryRule(**fields)
+    db.add(rule)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="An autodiscovery rule with that name already exists for this connection",
+        ) from exc
+    await db.refresh(rule)
+    logger.info(
+        "Autodiscovery rule created",
+        rule_id=str(rule.id),
+        rule_name=rule.name,
+        connection_id=str(rule.vcs_connection_id),
+        repo_url=rule.repo_url,
+        actor=user.email,
+    )
+    return JSONResponse(status_code=201, content={"data": _rule_json(rule)})
+
+
+# ── Show ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/autodiscovery-rules/{rule_id}")
+async def show_rule(
+    rule_id: str = Path(...),
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Show one autodiscovery rule. Admin only."""
+    try:
+        rid = uuid.UUID(rule_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="autodiscovery rule not found") from None
+    rule = await db.get(AutodiscoveryRule, rid)
+    if rule is None:
+        raise HTTPException(status_code=404, detail="autodiscovery rule not found")
+    return JSONResponse(content={"data": _rule_json(rule)})
+
+
+# ── Update ───────────────────────────────────────────────────────────────
+
+
+@router.patch("/autodiscovery-rules/{rule_id}")
+async def update_rule(
+    rule_id: str = Path(...),
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Update an autodiscovery rule. Admin only."""
+    try:
+        rid = uuid.UUID(rule_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="autodiscovery rule not found") from None
+    rule = await db.get(AutodiscoveryRule, rid)
+    if rule is None:
+        raise HTTPException(status_code=404, detail="autodiscovery rule not found")
+
+    attrs = body.get("data", {}).get("attributes", {})
+    fields = _coerce_attrs(attrs, on_create=False)
+    if "vcs_connection_id" in fields:
+        await _validate_connection(db, fields["vcs_connection_id"])
+    if "agent_pool_id" in fields:
+        await _validate_pool(db, fields["agent_pool_id"])
+    for k, v in fields.items():
+        setattr(rule, k, v)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="An autodiscovery rule with that name already exists for this connection",
+        ) from exc
+    await db.refresh(rule)
+    logger.info(
+        "Autodiscovery rule updated",
+        rule_id=str(rule.id),
+        actor=user.email,
+        changed=sorted(fields.keys()),
+    )
+    return JSONResponse(content={"data": _rule_json(rule)})
+
+
+# ── Delete ───────────────────────────────────────────────────────────────
+
+
+@router.delete("/autodiscovery-rules/{rule_id}", status_code=204)
+async def delete_rule(
+    rule_id: str = Path(...),
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Delete an autodiscovery rule. Admin only.
+
+    Workspaces auto-created by this rule keep working — their
+    `autodiscovery_rule_id` foreign key is set to NULL on cascade. Future
+    poll cycles won't create more workspaces under this rule.
+    """
+    try:
+        rid = uuid.UUID(rule_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="autodiscovery rule not found") from None
+    rule = await db.get(AutodiscoveryRule, rid)
+    if rule is None:
+        raise HTTPException(status_code=404, detail="autodiscovery rule not found")
+    await db.delete(rule)
+    await db.commit()
+    logger.info(
+        "Autodiscovery rule deleted",
+        rule_id=rule_id,
+        rule_name=rule.name,
+        actor=user.email,
+    )
+    return Response(status_code=204)

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -324,6 +324,16 @@ class Workspace(Base):
     # State divergence — set when an apply Job succeeds but state upload fails
     state_diverged: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
+    # Autodiscovery — set when this workspace was auto-created by an
+    # AutodiscoveryRule rather than manually. Used to attribute
+    # workspaces in the audit log and to skip re-creation on subsequent
+    # poll cycles.
+    autodiscovery_rule_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("autodiscovery_rules.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, nullable=False
     )
@@ -772,6 +782,73 @@ class VCSConnection(Base):
         sa.UniqueConstraint(
             "provider", "github_installation_id", name="uq_vcs_connections_install"
         ),
+    )
+
+
+# --- Autodiscovery (Atlantis-style) ---
+
+
+class AutodiscoveryRule(Base):
+    """Connection-scoped rule that auto-creates a workspace when a PR
+    or default-branch push touches a path matching `pattern`.
+
+    Modelled on Atlantis's `repos.yaml` autodiscover block. Workspaces
+    are created with the rule's template fields (execution mode, agent
+    pool, terraform version, resources, labels, owner) inherited.
+    """
+
+    __tablename__ = "autodiscovery_rules"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=generate_uuid7
+    )
+
+    # Scoping
+    vcs_connection_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("vcs_connections.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    vcs_connection: Mapped["VCSConnection"] = relationship(
+        "VCSConnection", foreign_keys=[vcs_connection_id], lazy="joined"
+    )
+    repo_url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    branch: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+
+    # Match
+    pattern: Mapped[str] = mapped_column(String(1024), nullable=False)
+    ignore_patterns: Mapped[list[str]] = mapped_column(JSONB, default=list, nullable=False)
+
+    # Identity
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    name_template: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    # Workspace template — defaults inherited by auto-created workspaces.
+    execution_mode: Mapped[str] = mapped_column(String(20), nullable=False, default="agent")
+    agent_pool_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_pools.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    execution_backend: Mapped[str] = mapped_column(String(20), nullable=False, default="tofu")
+    terraform_version: Mapped[str] = mapped_column(String(50), nullable=False, default="1.11")
+    resource_cpu: Mapped[str] = mapped_column(String(20), nullable=False, default="1")
+    resource_memory: Mapped[str] = mapped_column(String(20), nullable=False, default="2Gi")
+    auto_apply: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    labels: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
+    owner_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Audit
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+    )
+
+    __table_args__ = (
+        sa.UniqueConstraint("vcs_connection_id", "name", name="uq_autodiscovery_rule_name"),
     )
 
 

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -30,12 +30,13 @@ from terrapod.api.metrics import (
     VCS_PRS_DETECTED,
     VCS_RUNS_CREATED,
 )
-from terrapod.db.models import Run, VCSConnection, Workspace, utc_now
+from terrapod.db.models import AutodiscoveryRule, Run, VCSConnection, Workspace, utc_now
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service, run_service
 from terrapod.services.vcs_archive_cache import VCSArchiveCache, materialize_archive
 from terrapod.services.vcs_provider import PullRequest
+from terrapod.services.workspace_autodiscovery_service import autodiscover_for_paths
 from terrapod.storage import get_storage
 from terrapod.storage.keys import config_version_key
 
@@ -819,6 +820,160 @@ async def _compute_paths_unions(db: AsyncSession, workspace_ids: list[uuid.UUID]
     return out
 
 
+async def _poll_autodiscovery_for_connection(
+    db: AsyncSession,
+    conn: VCSConnection,
+    rules: list[AutodiscoveryRule],
+) -> int:
+    """Scan open PRs for one connection's rules and auto-create workspaces.
+
+    Returns the number of workspaces created. Per-connection scoping
+    means a single bad connection (auth issue, GitHub rate limit) does
+    not block other connections in the same cycle.
+    """
+    # Group rules by (repo_url, branch) so we don't re-fetch the same
+    # PR list once per rule.
+    by_repo_branch: dict[tuple[str, str], list[AutodiscoveryRule]] = {}
+    for rule in rules:
+        by_repo_branch.setdefault((rule.repo_url, rule.branch or ""), []).append(rule)
+
+    created_count = 0
+    for (repo_url, branch), group in by_repo_branch.items():
+        owner_repo = _parse_repo_url(conn, repo_url)
+        if owner_repo is None:
+            logger.warning(
+                "Autodiscovery: cannot parse repo URL",
+                connection_id=str(conn.id),
+                repo_url=repo_url,
+            )
+            continue
+        owner, repo = owner_repo
+
+        # Resolve the default branch if the rule didn't pin one.
+        target_branch = branch
+        if not target_branch:
+            try:
+                target_branch = await _get_default_branch(conn, owner, repo) or "main"
+            except Exception:
+                logger.warning(
+                    "Autodiscovery: failed to resolve default branch — skipping",
+                    connection_id=str(conn.id),
+                    repo_url=repo_url,
+                    exc_info=True,
+                )
+                continue
+
+        # Pull open PRs and the default-branch tip — both are sources of
+        # discoverable changed files.
+        try:
+            prs = await _list_open_prs(conn, owner, repo, target_branch)
+        except Exception:
+            logger.warning(
+                "Autodiscovery: failed to list PRs — skipping",
+                connection_id=str(conn.id),
+                repo_url=repo_url,
+                branch=target_branch,
+                exc_info=True,
+            )
+            continue
+
+        for pr in prs:
+            try:
+                changed = await _get_changed_files(conn, owner, repo, target_branch, pr.head_sha)
+            except Exception:
+                logger.warning(
+                    "Autodiscovery: failed to get changed files for PR — skipping",
+                    connection_id=str(conn.id),
+                    repo_url=repo_url,
+                    pr_number=pr.number,
+                    exc_info=True,
+                )
+                continue
+            new_workspaces = await autodiscover_for_paths(db, group, changed)
+            created_count += len(new_workspaces)
+
+    return created_count
+
+
+async def _poll_autodiscovery(
+    *, owner_repo: tuple[str, str] | None = None, provider: str | None = None
+) -> int:
+    """Run autodiscovery across every VCS connection that has at least
+    one enabled rule.
+
+    Auto-created workspaces are picked up by the *next* poll cycle's
+    workspace scan, which queues their first speculative run via the
+    existing PR/branch logic. We don't queue runs from here directly —
+    keeps the autodiscovery pass narrow (just creates workspaces) and
+    leaves run-creation to the existing well-tested code path.
+
+    `owner_repo` + `provider` filter rules to a single repo — used by
+    the webhook-triggered immediate poll so we don't fan out to every
+    connection on every webhook.
+    """
+    async with get_db_session() as db:
+        # Eager-load the connection so the per-rule code path doesn't
+        # need a second round-trip per connection.
+        result = await db.execute(
+            select(AutodiscoveryRule)
+            .where(AutodiscoveryRule.enabled.is_(True))
+            .order_by(AutodiscoveryRule.vcs_connection_id, AutodiscoveryRule.id)
+        )
+        rules = list(result.scalars().all())
+
+        # Webhook fast-path: keep only rules whose repo matches the
+        # webhook source. We do the filter Python-side because the
+        # repo URL form (https vs git@) and trailing-slash semantics
+        # differ across providers.
+        if owner_repo is not None:
+            owner, repo = owner_repo
+            match_pairs: set[tuple[str, str]] = {(owner, repo), (owner.lower(), repo.lower())}
+            filtered: list[AutodiscoveryRule] = []
+            for rule in rules:
+                conn = rule.vcs_connection
+                if provider is not None and conn is not None and conn.provider != provider:
+                    continue
+                if conn is None:
+                    continue
+                parsed = _parse_repo_url(conn, rule.repo_url)
+                if parsed is None:
+                    continue
+                if parsed in match_pairs or (parsed[0].lower(), parsed[1].lower()) in match_pairs:
+                    filtered.append(rule)
+            rules = filtered
+        if not rules:
+            return 0
+
+        # Group rules by connection so we open one VCSConnection load per
+        # connection rather than per rule.
+        by_conn: dict[uuid.UUID, list[AutodiscoveryRule]] = {}
+        for rule in rules:
+            by_conn.setdefault(rule.vcs_connection_id, []).append(rule)
+
+        total_created = 0
+        for conn_id, conn_rules in by_conn.items():
+            conn = await db.get(VCSConnection, conn_id)
+            if conn is None or conn.status != "active":
+                continue
+            try:
+                created = await _poll_autodiscovery_for_connection(db, conn, conn_rules)
+                total_created += created
+            except Exception:
+                # Per-connection isolation: log and continue.
+                logger.warning(
+                    "Autodiscovery: connection scan failed",
+                    connection_id=str(conn_id),
+                    exc_info=True,
+                )
+
+        if total_created:
+            logger.info(
+                "Autodiscovery created workspaces this cycle",
+                count=total_created,
+            )
+        return total_created
+
+
 async def poll_cycle() -> None:
     """Execute one poll cycle: check all VCS-enabled workspaces in parallel.
 
@@ -826,6 +981,15 @@ async def poll_cycle() -> None:
     replica runs this per interval across the entire deployment.
     """
     start = time_mod.monotonic()
+
+    # Autodiscovery first — any newly-created workspaces will be
+    # picked up by the workspace scan below (or, if their query
+    # snapshot already ran, by the next cycle).
+    try:
+        await _poll_autodiscovery()
+    except Exception:
+        logger.warning("Autodiscovery pass failed", exc_info=True)
+
     async with get_db_session() as db:
         workspace_ids = await _select_workspace_ids(db)
         paths_unions = await _compute_paths_unions(db, workspace_ids)
@@ -869,6 +1033,21 @@ async def handle_immediate_poll(payload: dict) -> None:
     # historical behaviour for any in-flight triggers.
     provider = payload.get("provider", "github")
     logger.info("Immediate poll triggered by webhook", repo=repo, provider=provider)
+
+    # Run autodiscovery scoped to this repo first so any newly-created
+    # workspaces get picked up by the workspace scan that follows. The
+    # repo string in the webhook payload is "owner/repo" — split for
+    # the autodiscovery filter.
+    if repo and "/" in repo:
+        owner, repo_name = repo.split("/", 1)
+        try:
+            await _poll_autodiscovery(owner_repo=(owner, repo_name), provider=provider)
+        except Exception:
+            logger.warning(
+                "Autodiscovery: webhook-triggered scan failed",
+                repo=repo,
+                exc_info=True,
+            )
 
     async with get_db_session() as db:
         workspace_ids = await _select_workspace_ids(

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -1,0 +1,337 @@
+"""Workspace autodiscovery — Atlantis-style.
+
+When a VCS poll detects changes to terraform files in a monorepo and
+none of the existing workspaces' `trigger_prefixes` claim the path,
+this service consults `AutodiscoveryRule` rows for the connection. A
+rule whose `pattern` matches the file (and whose `ignore_patterns`
+don't) auto-creates a workspace pointed at the file's directory.
+
+The auto-created workspace inherits the rule's template fields:
+execution mode, agent pool, terraform version, resources, labels,
+owner. It carries `autodiscovery_rule_id` so subsequent poll cycles
+recognise it and don't recreate.
+
+Pattern syntax (gitignore-style):
+- `*`  matches any sequence within a single path segment
+- `**` matches any number of path segments (including zero)
+- `?`  matches one character
+- Patterns are matched against the *full file path* (e.g.
+  `accounts/alpha/network/main.tf`).
+
+Only terraform files (`*.tf`, `*.tfvars`) trigger autodiscovery —
+README and other non-terraform changes are filtered out before rule
+evaluation.
+
+See terrapod #283.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import PurePosixPath
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.db.models import AutodiscoveryRule, Workspace
+from terrapod.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+# ── Pattern matching ─────────────────────────────────────────────────────
+
+# File extensions that count as terraform configuration. Matches
+# Atlantis's default `when_modified: ["*.tf*"]` semantics.
+_TF_EXTENSIONS = (".tf", ".tfvars", ".tf.json", ".tfvars.json", ".hcl")
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a gitignore-style glob to a compiled regex.
+
+    Semantics:
+    - `**`  → match any number of path segments (including zero), with
+              optional trailing slash
+    - `*`   → match anything within a single path segment (no `/`)
+    - `?`   → match a single non-`/` character
+    - everything else is treated literally (re.escape)
+    """
+    # Walk the pattern and emit regex pieces. Two-pass to handle the
+    # double-star token before single-star.
+    out: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        ch = pattern[i]
+        if ch == "*" and i + 1 < n and pattern[i + 1] == "*":
+            # `**` — match zero or more path segments.
+            # Consume an optional `/` immediately after.
+            i += 2
+            if i < n and pattern[i] == "/":
+                # `**/` — match zero or more segments with trailing slash
+                out.append(r"(?:.*/)?")
+                i += 1
+            else:
+                # bare `**` — match anything, including across segments
+                out.append(r".*")
+        elif ch == "*":
+            # Single segment wildcard.
+            out.append(r"[^/]*")
+            i += 1
+        elif ch == "?":
+            out.append(r"[^/]")
+            i += 1
+        elif ch == "[":
+            # Character class — find the closing bracket and copy the
+            # contents through. gitignore also allows negation via `!`.
+            j = pattern.find("]", i + 1)
+            if j == -1:
+                # Unclosed — escape literally.
+                out.append(re.escape(ch))
+                i += 1
+            else:
+                cls = pattern[i + 1 : j]
+                if cls.startswith("!"):
+                    cls = "^" + cls[1:]
+                out.append(f"[{cls}]")
+                i = j + 1
+        else:
+            out.append(re.escape(ch))
+            i += 1
+    return re.compile(r"\A" + "".join(out) + r"\Z")
+
+
+def _match_glob(path: str, pattern: str) -> bool:
+    """Return True if `path` matches the glob `pattern`."""
+    return bool(_glob_to_regex(pattern).match(path))
+
+
+def _is_terraform_file(path: str) -> bool:
+    """True if the path looks like a terraform configuration file."""
+    return any(path.endswith(ext) for ext in _TF_EXTENSIONS)
+
+
+def _is_ignored(path: str, ignore_patterns: list[str]) -> bool:
+    """True if any ignore pattern matches the path."""
+    return any(_match_glob(path, p) for p in ignore_patterns)
+
+
+def rule_claims_path(rule: AutodiscoveryRule, path: str) -> bool:
+    """Decide whether `rule` would auto-create a workspace for `path`.
+
+    Pure-logic; no I/O. Three checks: terraform file, matches the
+    rule's pattern, not ignored.
+    """
+    if not _is_terraform_file(path):
+        return False
+    if _is_ignored(path, rule.ignore_patterns or []):
+        return False
+    return _match_glob(path, rule.pattern)
+
+
+# ── Workspace derivation ─────────────────────────────────────────────────
+
+
+def derive_root_directory(file_path: str) -> str:
+    """Compute the workspace's `working_directory` from a matched file.
+
+    By Atlantis's convention the root is the directory containing the
+    terraform file. We just return the dirname.
+
+    >>> derive_root_directory("accounts/alpha/network/main.tf")
+    'accounts/alpha/network'
+    >>> derive_root_directory("main.tf")
+    ''
+    """
+    parent = PurePosixPath(file_path).parent
+    return "" if str(parent) == "." else str(parent)
+
+
+# Workspaces are 1..90 chars; legal set is letters/digits/`-`/`_`.
+# We map disallowed chars to `-` and trim to fit.
+_NAME_SANITISE_RE = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+def derive_workspace_name(rule: AutodiscoveryRule, root_directory: str) -> str:
+    """Derive a workspace name from the rule + root directory.
+
+    Default behaviour (no `name_template` set): replace each `/` in the
+    root_directory with `-` and sanitise. e.g.
+        accounts/alpha/network → accounts-alpha-network
+
+    If `name_template` is set, it can contain `{path}` (dashed root_dir)
+    or `{root}` (the root_dir as-is). Useful when a single rule wants
+    a prefix:
+        name_template = "ws-{path}"
+        accounts/alpha/network → ws-accounts-alpha-network
+    """
+    dashed = root_directory.replace("/", "-") or rule.name
+    if rule.name_template:
+        candidate = rule.name_template.format(path=dashed, root=root_directory)
+    else:
+        candidate = dashed
+
+    # Sanitise + truncate to the workspaces.name 90-char column limit.
+    candidate = _NAME_SANITISE_RE.sub("-", candidate).strip("-")
+    return candidate[:90] or rule.name[:90]
+
+
+# ── Find-or-autocreate ───────────────────────────────────────────────────
+
+
+async def find_or_autocreate_workspace(
+    db: AsyncSession,
+    rule: AutodiscoveryRule,
+    root_directory: str,
+) -> tuple[Workspace, bool]:
+    """Look up the workspace this rule + directory should map to, or
+    create it if it doesn't exist.
+
+    Returns `(workspace, created)`.
+
+    Idempotent — concurrent autodiscovery on the same rule + path
+    will not create duplicates. We commit the new workspace
+    immediately so subsequent poller passes within the same poll
+    cycle see it.
+    """
+    # Lookup #1: any workspace already claiming the (connection, repo,
+    # working_directory) tuple? If so we reuse it regardless of how it
+    # was created (rule, manual, etc.) — autodiscovery never replaces
+    # an explicit workspace.
+    existing = await db.execute(
+        select(Workspace).where(
+            Workspace.vcs_connection_id == rule.vcs_connection_id,
+            Workspace.vcs_repo_url == rule.repo_url,
+            Workspace.working_directory == root_directory,
+        )
+    )
+    ws = existing.scalar_one_or_none()
+    if ws is not None:
+        return ws, False
+
+    name = derive_workspace_name(rule, root_directory)
+
+    # Lookup #2: the derived name might collide with an unrelated
+    # workspace (different repo or working_directory) — refuse and let
+    # the operator pick a more specific `name_template`. We log and
+    # skip rather than mangle the name silently.
+    name_clash = await db.execute(select(Workspace).where(Workspace.name == name))
+    if name_clash.scalar_one_or_none() is not None:
+        logger.warning(
+            "Autodiscovery name collision — skipping",
+            rule_id=str(rule.id),
+            rule_name=rule.name,
+            derived_name=name,
+            working_directory=root_directory,
+        )
+        raise AutodiscoveryNameCollision(name)
+
+    ws = Workspace(
+        id=uuid.uuid4(),  # generate_uuid7 default also fine; explicit for log clarity
+        name=name,
+        execution_mode=rule.execution_mode,
+        execution_backend=rule.execution_backend,
+        terraform_version=rule.terraform_version,
+        resource_cpu=rule.resource_cpu,
+        resource_memory=rule.resource_memory,
+        auto_apply=rule.auto_apply,
+        working_directory=root_directory,
+        agent_pool_id=rule.agent_pool_id,
+        labels=dict(rule.labels or {}),
+        owner_email=rule.owner_email or "",
+        vcs_connection_id=rule.vcs_connection_id,
+        vcs_repo_url=rule.repo_url,
+        vcs_branch=rule.branch,
+        autodiscovery_rule_id=rule.id,
+        # trigger_prefixes scoped tightly to the discovered directory so
+        # the regular VCS poller treats this workspace as a normal
+        # working_directory-targeted one from now on.
+        trigger_prefixes=[root_directory] if root_directory else [],
+    )
+    db.add(ws)
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        # Race: another poll cycle / replica autocreated the same
+        # workspace between our lookup and flush. Roll back and
+        # return the now-existing row.
+        await db.rollback()
+        existing = await db.execute(
+            select(Workspace).where(
+                Workspace.vcs_connection_id == rule.vcs_connection_id,
+                Workspace.vcs_repo_url == rule.repo_url,
+                Workspace.working_directory == root_directory,
+            )
+        )
+        ws = existing.scalar_one_or_none()
+        if ws is not None:
+            return ws, False
+        # Different integrity violation we don't expect — surface it.
+        raise exc
+    await db.commit()
+
+    logger.info(
+        "Autodiscovery created workspace",
+        rule_id=str(rule.id),
+        rule_name=rule.name,
+        workspace_id=str(ws.id),
+        workspace_name=ws.name,
+        working_directory=root_directory,
+        repo_url=rule.repo_url,
+    )
+    return ws, True
+
+
+class AutodiscoveryNameCollision(RuntimeError):
+    """Raised when the derived workspace name collides with an
+    existing unrelated workspace. Operator action required: tighten
+    the rule's `name_template` to disambiguate.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(
+            f"Autodiscovery would create a workspace named {name!r}, but an unrelated workspace with that name already exists"
+        )
+        self.name = name
+
+
+# ── Top-level entry point ────────────────────────────────────────────────
+
+
+async def autodiscover_for_paths(
+    db: AsyncSession,
+    rules: list[AutodiscoveryRule],
+    changed_files: list[str],
+) -> list[Workspace]:
+    """For a set of changed files, return the list of workspaces that
+    should be created/used. New workspaces are persisted; existing
+    workspaces are returned untouched.
+
+    Idempotent across repeated calls with the same inputs.
+    """
+    # Group `(rule, root_directory)` so multiple files in the same
+    # directory only fire once.
+    matches: dict[tuple[uuid.UUID, str], AutodiscoveryRule] = {}
+    for path in changed_files:
+        for rule in rules:
+            if not rule.enabled:
+                continue
+            if not rule_claims_path(rule, path):
+                continue
+            root = derive_root_directory(path)
+            matches[(rule.id, root)] = rule
+            # First matching rule wins — don't fan out to multiple
+            # rules for the same file.
+            break
+
+    created: list[Workspace] = []
+    for (_rule_id, root), rule in matches.items():
+        try:
+            ws, _ = await find_or_autocreate_workspace(db, rule, root)
+            created.append(ws)
+        except AutodiscoveryNameCollision:
+            # Logged inside; skip to next match.
+            continue
+    return created

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -1,0 +1,281 @@
+"""Tests for autodiscovery rule CRUD endpoints (terrapod #283, admin-only)."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, require_admin
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+def _admin():
+    return AuthenticatedUser(
+        email="admin@example.com",
+        display_name="Admin",
+        roles=["admin"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _mock_rule(
+    rule_id=None,
+    name="monorepo",
+    repo_url="https://github.com/example/repo",
+    pattern="accounts/*/**/*.tf",
+    ignore_patterns=None,
+):
+    r = MagicMock()
+    r.id = rule_id or uuid.uuid4()
+    r.name = name
+    r.name_template = ""
+    r.vcs_connection_id = uuid.uuid4()
+    r.repo_url = repo_url
+    r.branch = ""
+    r.pattern = pattern
+    r.ignore_patterns = ignore_patterns or ["modules/**"]
+    r.enabled = True
+    r.execution_mode = "agent"
+    r.execution_backend = "tofu"
+    r.agent_pool_id = None
+    r.terraform_version = "1.11"
+    r.resource_cpu = "1"
+    r.resource_memory = "2Gi"
+    r.auto_apply = False
+    r.labels = {"env": "monorepo"}
+    r.owner_email = "admin@example.com"
+    r.created_at = datetime(2026, 5, 9, tzinfo=UTC)
+    r.updated_at = datetime(2026, 5, 9, tzinfo=UTC)
+    return r
+
+
+def _make_app(user, mock_db=None):
+    app = create_app()
+    app.dependency_overrides[require_admin] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app, mock_db
+
+
+def _query_result(value):
+    """Wrap a value as a SQLAlchemy result-like object."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    result.scalars.return_value.all.return_value = value if isinstance(value, list) else []
+    return result
+
+
+# ── List ─────────────────────────────────────────────────────────────────
+
+
+class TestListRules:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_returns_all_rules(self, *_mocks):
+        rules = [_mock_rule(name="alpha"), _mock_rule(name="beta")]
+        app, db = _make_app(_admin())
+        db.execute.return_value = _query_result(rules)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/autodiscovery-rules", headers=_AUTH)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert {r["attributes"]["name"] for r in body["data"]} == {"alpha", "beta"}
+
+
+# ── Create ───────────────────────────────────────────────────────────────
+
+
+class TestCreateRule:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_201_with_valid_attrs(self, *_mocks):
+        conn_id = uuid.uuid4()
+        # validate_connection: connection exists
+        # refresh after commit
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(side_effect=[MagicMock(id=conn_id)])  # _validate_connection
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        body = {
+            "data": {
+                "type": "autodiscovery-rules",
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{conn_id}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "ignore-patterns": ["modules/**"],
+                    "execution-mode": "agent",
+                    "labels": {"env": "monorepo"},
+                },
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 201, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["name"] == "monorepo"
+        assert attrs["pattern"] == "accounts/*/**/*.tf"
+        assert attrs["ignore-patterns"] == ["modules/**"]
+        assert attrs["execution-mode"] == "agent"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_when_pattern_missing(self, *_mocks):
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_when_connection_does_not_exist(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=None)  # connection missing
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_invalid_execution_mode(self, *_mocks):
+        app, db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "**/*.tf",
+                    "execution-mode": "local",  # autodiscovery is VCS-driven; only "agent" is allowed
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+
+
+# ── Show ─────────────────────────────────────────────────────────────────
+
+
+class TestShowRule:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_200_when_exists(self, *_mocks):
+        rule = _mock_rule()
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/terrapod/v1/autodiscovery-rules/{rule.id}", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attributes"]["name"] == "monorepo"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_404_when_missing(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/autodiscovery-rules/{uuid.uuid4()}", headers=_AUTH
+            )
+        assert resp.status_code == 404
+
+
+# ── Update ───────────────────────────────────────────────────────────────
+
+
+class TestUpdateRule:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_patches_pattern_and_enabled(self, *_mocks):
+        rule = _mock_rule()
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {
+            "data": {
+                "attributes": {
+                    "pattern": "envs/*/**/*.tf",
+                    "enabled": False,
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert rule.pattern == "envs/*/**/*.tf"
+        assert rule.enabled is False
+
+
+# ── Delete ───────────────────────────────────────────────────────────────
+
+
+class TestDeleteRule:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_204_on_success(self, *_mocks):
+        rule = _mock_rule()
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        db.delete = AsyncMock()
+        db.commit = AsyncMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(f"/api/terrapod/v1/autodiscovery-rules/{rule.id}", headers=_AUTH)
+        assert resp.status_code == 204
+        db.delete.assert_awaited_once_with(rule)
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_404_when_missing(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(
+                f"/api/terrapod/v1/autodiscovery-rules/{uuid.uuid4()}", headers=_AUTH
+            )
+        assert resp.status_code == 404

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -790,12 +790,20 @@ class TestPollCycleParallel:
         ):
             await handle_immediate_poll({"repo": "ns/repo", "provider": "github"})
 
-        # Inspect the emitted SQL on the FIRST execute call (workspace-id select)
-        # to confirm the provider filter is there — the actual scoping happens
-        # in SQL, not in Python. (The compute-paths-unions call is patched out.)
-        stmt = mock_db.execute.await_args_list[0][0][0]
-        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
-        assert "vcs_connections.provider = 'github'" in compiled
+        # Find the workspace-id select among the emitted statements (the
+        # first `execute` is now the autodiscovery-rule fetch added by
+        # #283; the workspace-id select comes after).
+        provider_filtered = [
+            str(call[0][0].compile(compile_kwargs={"literal_binds": True}))
+            for call in mock_db.execute.await_args_list
+            if "workspaces" in str(call[0][0])
+            and "vcs_connections.provider"
+            in str(call[0][0].compile(compile_kwargs={"literal_binds": True}))
+        ]
+        assert provider_filtered, (
+            "expected at least one workspace SELECT with vcs_connections.provider filter"
+        )
+        assert "vcs_connections.provider = 'github'" in provider_filtered[0]
         assert polled == [github_match]
 
     @pytest.mark.asyncio

--- a/services/tests/services/test_workspace_autodiscovery_service.py
+++ b/services/tests/services/test_workspace_autodiscovery_service.py
@@ -1,0 +1,177 @@
+"""Tests for workspace autodiscovery service (terrapod #283).
+
+The pure-logic functions (`rule_claims_path`, `derive_root_directory`,
+`derive_workspace_name`, `_glob_to_regex`) are exercised here without
+hitting the DB. The find-or-autocreate path is covered by the API +
+integration tests that run against a real session.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+from terrapod.services.workspace_autodiscovery_service import (
+    _is_terraform_file,
+    _match_glob,
+    derive_root_directory,
+    derive_workspace_name,
+    rule_claims_path,
+)
+
+
+def _rule(
+    pattern: str = "accounts/*/**/*.tf",
+    ignore_patterns: list[str] | None = None,
+    name: str = "monorepo",
+    name_template: str = "",
+    enabled: bool = True,
+):
+    r = MagicMock()
+    r.id = uuid.uuid4()
+    r.pattern = pattern
+    r.ignore_patterns = ignore_patterns or []
+    r.name = name
+    r.name_template = name_template
+    r.enabled = enabled
+    return r
+
+
+# ── Glob translation ─────────────────────────────────────────────────────
+
+
+class TestGlobMatching:
+    def test_single_star_within_segment(self):
+        assert _match_glob("foo/bar.tf", "foo/*.tf")
+        assert not _match_glob("foo/sub/bar.tf", "foo/*.tf")  # `*` not crossing /
+
+    def test_double_star_crosses_segments(self):
+        assert _match_glob("a/b/c/main.tf", "a/**/*.tf")
+        assert _match_glob("a/main.tf", "a/**/*.tf")  # ** matches zero segments
+        assert _match_glob("modules/vpc/inner/foo.tf", "modules/**")
+
+    def test_question_mark_single_char(self):
+        assert _match_glob("a/b.tf", "a/?.tf")
+        assert not _match_glob("a/bb.tf", "a/?.tf")
+
+    def test_character_class(self):
+        assert _match_glob("v1/main.tf", "v[123]/main.tf")
+        assert not _match_glob("v9/main.tf", "v[123]/main.tf")
+
+    def test_full_path_anchored(self):
+        # Patterns are anchored to the whole path.
+        assert _match_glob("accounts/alpha/main.tf", "accounts/*/main.tf")
+        assert not _match_glob("subdir/accounts/alpha/main.tf", "accounts/*/main.tf")
+
+    def test_double_star_at_end(self):
+        assert _match_glob("modules/vpc/main.tf", "modules/**")
+        assert _match_glob("modules/vpc/sub/foo.tf", "modules/**")
+
+    def test_literal_segments_escaped(self):
+        # Dots inside path segments are literal — not regex metacharacters.
+        assert _match_glob("a.b/c.tf", "a.b/*.tf")
+        assert not _match_glob("aXb/c.tf", "a.b/*.tf")
+
+
+# ── Terraform file detection ─────────────────────────────────────────────
+
+
+class TestIsTerraformFile:
+    def test_tf_files_recognised(self):
+        assert _is_terraform_file("main.tf")
+        assert _is_terraform_file("a/b/main.tf")
+        assert _is_terraform_file("variables.tf")
+        assert _is_terraform_file("a/b/c.tfvars")
+        assert _is_terraform_file("override.tf.json")
+
+    def test_non_tf_files_rejected(self):
+        assert not _is_terraform_file("README.md")
+        assert not _is_terraform_file("Makefile")
+        assert not _is_terraform_file(".github/workflows/ci.yml")
+        assert not _is_terraform_file("scripts/main.py")
+
+
+# ── rule_claims_path ─────────────────────────────────────────────────────
+
+
+class TestRuleClaimsPath:
+    def test_matches_pattern(self):
+        rule = _rule(pattern="accounts/*/**/*.tf")
+        assert rule_claims_path(rule, "accounts/alpha/network/main.tf")
+
+    def test_pattern_miss(self):
+        rule = _rule(pattern="accounts/*/**/*.tf")
+        assert not rule_claims_path(rule, "infrastructure/network/main.tf")
+
+    def test_ignore_pattern_excludes(self):
+        rule = _rule(
+            pattern="**/*.tf",
+            ignore_patterns=["modules/**"],
+        )
+        assert rule_claims_path(rule, "accounts/alpha/main.tf")
+        assert not rule_claims_path(rule, "modules/vpc/main.tf")
+
+    def test_non_terraform_file_rejected(self):
+        rule = _rule(pattern="**/*")  # very permissive
+        assert not rule_claims_path(rule, "accounts/alpha/README.md")
+
+    def test_multiple_ignore_patterns(self):
+        rule = _rule(
+            pattern="**/*.tf",
+            ignore_patterns=["modules/**", "deprecated/**", "**/_archive/**"],
+        )
+        assert rule_claims_path(rule, "accounts/alpha/main.tf")
+        assert not rule_claims_path(rule, "modules/vpc/main.tf")
+        assert not rule_claims_path(rule, "deprecated/old/main.tf")
+        assert not rule_claims_path(rule, "accounts/alpha/_archive/main.tf")
+
+
+# ── derive_root_directory ────────────────────────────────────────────────
+
+
+class TestDeriveRootDirectory:
+    def test_nested_file(self):
+        assert derive_root_directory("accounts/alpha/network/main.tf") == "accounts/alpha/network"
+
+    def test_top_level_file(self):
+        # main.tf at repo root → empty working_directory (matches the
+        # workspace model's default — repo root is "").
+        assert derive_root_directory("main.tf") == ""
+
+    def test_two_levels(self):
+        assert derive_root_directory("a/b/c.tf") == "a/b"
+
+
+# ── derive_workspace_name ────────────────────────────────────────────────
+
+
+class TestDeriveWorkspaceName:
+    def test_default_template_dashes_path(self):
+        rule = _rule(name="monorepo")
+        assert derive_workspace_name(rule, "accounts/alpha/network") == "accounts-alpha-network"
+
+    def test_root_directory_empty_falls_back_to_rule_name(self):
+        rule = _rule(name="monorepo-root")
+        assert derive_workspace_name(rule, "") == "monorepo-root"
+
+    def test_explicit_template_with_path_placeholder(self):
+        rule = _rule(name="monorepo", name_template="ws-{path}")
+        assert derive_workspace_name(rule, "accounts/alpha/network") == "ws-accounts-alpha-network"
+
+    def test_explicit_template_with_root_placeholder(self):
+        # {root} preserves the slashes; sanitiser maps them to dashes.
+        rule = _rule(name="monorepo", name_template="prefix.{root}")
+        assert derive_workspace_name(rule, "accounts/alpha") == "prefix-accounts-alpha"
+
+    def test_sanitisation_drops_invalid_chars(self):
+        rule = _rule(name="monorepo", name_template="ws/{path}@latest")
+        # `/` and `@` are not allowed in workspace names; collapse to dashes.
+        result = derive_workspace_name(rule, "a/b")
+        assert result == "ws-a-b-latest"
+
+    def test_truncation_to_90_chars(self):
+        # Workspace names are capped at 90 chars (matches the schema).
+        long_path = "a/" + "verylongsegment/" * 10  # well over 90 chars when dashed
+        rule = _rule(name="monorepo")
+        result = derive_workspace_name(rule, long_path.rstrip("/"))
+        assert len(result) <= 90

--- a/web/src/app/admin/agent-pools/page.tsx
+++ b/web/src/app/admin/agent-pools/page.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
 import { LabelsEditor } from '@/components/labels-editor'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useIsAdmin } from '@/lib/use-auth-roles'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
 import { usePollingInterval } from '@/lib/use-polling-interval'
@@ -39,6 +40,11 @@ function statusDotClass(status: string | undefined): string {
 
 export default function AgentPoolsPage() {
   const router = useRouter()
+  // Auth-derived UI is gated on `isAdminClient` rather than `isAdmin()`
+  // so the first render matches SSR (no roles available) and the admin
+  // affordances appear on the post-mount re-render. Avoids hydration
+  // mismatches that Next.js dev mode reports as a blocking modal.
+  const isAdminClient = useIsAdmin()
   const [pools, setPools] = useState<AgentPool[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -120,7 +126,7 @@ export default function AgentPoolsPage() {
         <PageHeader
           title="Agent Pools"
           description="Manage runner agent pools and their listeners"
-          actions={isAdmin() ? (
+          actions={isAdminClient ? (
             <button
               onClick={() => setShowCreate(!showCreate)}
               className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors btn-smoke"

--- a/web/src/app/admin/autodiscovery/page.tsx
+++ b/web/src/app/admin/autodiscovery/page.tsx
@@ -1,0 +1,561 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import NavBar from '@/components/nav-bar'
+import { PageHeader } from '@/components/page-header'
+import { LoadingSpinner } from '@/components/loading-spinner'
+import { ErrorBanner } from '@/components/error-banner'
+import { EmptyState } from '@/components/empty-state'
+import { SortableHeader } from '@/components/sortable-header'
+import { LabelsEditor } from '@/components/labels-editor'
+import { getAuthState, isAdmin } from '@/lib/auth'
+import { apiFetch } from '@/lib/api'
+import { useSortable } from '@/lib/use-sortable'
+
+interface AutodiscoveryRule {
+  id: string
+  attributes: {
+    name: string
+    'name-template': string
+    'vcs-connection-id': string
+    'repo-url': string
+    branch: string
+    pattern: string
+    'ignore-patterns': string[]
+    enabled: boolean
+    'execution-mode': string
+    'execution-backend': string
+    'agent-pool-id': string | null
+    'terraform-version': string
+    'resource-cpu': string
+    'resource-memory': string
+    'auto-apply': boolean
+    labels: Record<string, string>
+    'owner-email': string
+    'created-at': string
+    'updated-at': string
+  }
+}
+
+interface VCSConnection {
+  id: string
+  attributes: { name: string; provider: string }
+}
+
+interface AgentPool {
+  id: string
+  attributes: { name: string }
+}
+
+type SortKey = 'name' | 'repo' | 'pattern' | 'enabled' | 'created'
+
+export default function AutodiscoveryPage() {
+  const router = useRouter()
+  const [rules, setRules] = useState<AutodiscoveryRule[]>([])
+  const [connections, setConnections] = useState<VCSConnection[]>([])
+  const [pools, setPools] = useState<AgentPool[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  // Create / edit form
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [vcsConnectionId, setVcsConnectionId] = useState('')
+  const [repoUrl, setRepoUrl] = useState('')
+  const [branch, setBranch] = useState('')
+  const [pattern, setPattern] = useState('accounts/*/**/*.tf')
+  const [ignorePatternsText, setIgnorePatternsText] = useState('modules/**')
+  const [nameTemplate, setNameTemplate] = useState('')
+  const [enabled, setEnabled] = useState(true)
+  const [executionMode, setExecutionMode] = useState<'agent'>('agent')
+  const [agentPoolId, setAgentPoolId] = useState('')
+  const [executionBackend, setExecutionBackend] = useState<'tofu' | 'terraform'>('tofu')
+  const [terraformVersion, setTerraformVersion] = useState('1.11')
+  const [resourceCpu, setResourceCpu] = useState('1')
+  const [resourceMemory, setResourceMemory] = useState('2Gi')
+  const [autoApply, setAutoApply] = useState(false)
+  const [labels, setLabels] = useState<Record<string, string>>({})
+  const [ownerEmail, setOwnerEmail] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const [deleteId, setDeleteId] = useState<string | null>(null)
+
+  const accessor = useCallback((r: AutodiscoveryRule, key: SortKey) => {
+    switch (key) {
+      case 'name': return r.attributes.name
+      case 'repo': return r.attributes['repo-url']
+      case 'pattern': return r.attributes.pattern
+      case 'enabled': return r.attributes.enabled ? '1' : '0'
+      case 'created': return r.attributes['created-at']
+    }
+  }, [])
+
+  const { sortedItems, sortState, toggleSort } = useSortable<AutodiscoveryRule, SortKey>(
+    rules, 'name', 'asc', accessor,
+  )
+
+  useEffect(() => {
+    if (!getAuthState()) { router.push('/login'); return }
+    if (!isAdmin()) { router.push('/'); return }
+    loadAll()
+  }, [router])
+
+  async function loadAll() {
+    setLoading(true)
+    try {
+      const [rulesRes, connsRes, poolsRes] = await Promise.all([
+        apiFetch('/api/terrapod/v1/autodiscovery-rules'),
+        apiFetch('/api/terrapod/v1/vcs-connections'),
+        apiFetch('/api/terrapod/v1/agent-pools'),
+      ])
+      if (!rulesRes.ok) throw new Error('Failed to load autodiscovery rules')
+      const rulesData = await rulesRes.json()
+      setRules(rulesData.data || [])
+      if (connsRes.ok) {
+        const cd = await connsRes.json()
+        setConnections(cd.data || [])
+      }
+      if (poolsRes.ok) {
+        const pd = await poolsRes.json()
+        setPools(pd.data || [])
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function resetForm() {
+    setEditingId(null)
+    setName('')
+    setVcsConnectionId('')
+    setRepoUrl('')
+    setBranch('')
+    setPattern('accounts/*/**/*.tf')
+    setIgnorePatternsText('modules/**')
+    setNameTemplate('')
+    setEnabled(true)
+    setExecutionMode('agent')
+    setAgentPoolId('')
+    setExecutionBackend('tofu')
+    setTerraformVersion('1.11')
+    setResourceCpu('1')
+    setResourceMemory('2Gi')
+    setAutoApply(false)
+    setLabels({})
+    setOwnerEmail('')
+  }
+
+  function openCreateForm() {
+    resetForm()
+    setShowForm(true)
+  }
+
+  function openEditForm(r: AutodiscoveryRule) {
+    setEditingId(r.id)
+    const a = r.attributes
+    setName(a.name)
+    setVcsConnectionId(a['vcs-connection-id'] ? `vcs-${a['vcs-connection-id']}` : '')
+    setRepoUrl(a['repo-url'])
+    setBranch(a.branch)
+    setPattern(a.pattern)
+    setIgnorePatternsText((a['ignore-patterns'] || []).join('\n'))
+    setNameTemplate(a['name-template'])
+    setEnabled(a.enabled)
+    setExecutionMode('agent')
+    setAgentPoolId(a['agent-pool-id'] ? `apool-${a['agent-pool-id']}` : '')
+    setExecutionBackend((a['execution-backend'] as 'tofu' | 'terraform') || 'tofu')
+    setTerraformVersion(a['terraform-version'])
+    setResourceCpu(a['resource-cpu'])
+    setResourceMemory(a['resource-memory'])
+    setAutoApply(a['auto-apply'])
+    setLabels(a.labels || {})
+    setOwnerEmail(a['owner-email'] || '')
+    setShowForm(true)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError('')
+    setSuccess('')
+
+    const ignorePatterns = ignorePatternsText
+      .split('\n')
+      .map(s => s.trim())
+      .filter(Boolean)
+
+    const attrs: Record<string, unknown> = {
+      name,
+      'vcs-connection-id': vcsConnectionId,
+      'repo-url': repoUrl,
+      branch,
+      pattern,
+      'ignore-patterns': ignorePatterns,
+      'name-template': nameTemplate,
+      enabled,
+      'execution-mode': executionMode,
+      'execution-backend': executionBackend,
+      'agent-pool-id': agentPoolId || null,
+      'terraform-version': terraformVersion,
+      'resource-cpu': resourceCpu,
+      'resource-memory': resourceMemory,
+      'auto-apply': autoApply,
+      labels,
+      'owner-email': ownerEmail,
+    }
+
+    try {
+      const path = editingId
+        ? `/api/terrapod/v1/autodiscovery-rules/${editingId}`
+        : '/api/terrapod/v1/autodiscovery-rules'
+      const method = editingId ? 'PATCH' : 'POST'
+      const res = await apiFetch(path, {
+        method,
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: JSON.stringify({ data: { type: 'autodiscovery-rules', attributes: attrs } }),
+      })
+      if (!res.ok) {
+        const txt = await res.text()
+        throw new Error(`${editingId ? 'Update' : 'Create'} failed: ${res.status} ${txt}`)
+      }
+      setSuccess(editingId ? `Updated ${name}` : `Created ${name}`)
+      setShowForm(false)
+      resetForm()
+      loadAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setError('')
+    try {
+      const res = await apiFetch(`/api/terrapod/v1/autodiscovery-rules/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Failed to delete rule')
+      setSuccess('Deleted rule')
+      setDeleteId(null)
+      loadAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete')
+    }
+  }
+
+  if (loading) return <><NavBar /><main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto"><LoadingSpinner /></main></>
+
+  return (
+    <>
+      <NavBar />
+      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto">
+        <PageHeader
+          title="Autodiscovery"
+          description="Auto-create workspaces in monorepos when PRs touch matching paths"
+          actions={
+            <button
+              onClick={() => (showForm ? setShowForm(false) : openCreateForm())}
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors btn-smoke"
+            >
+              {showForm ? 'Cancel' : 'New Rule'}
+            </button>
+          }
+        />
+
+        {error && <ErrorBanner message={error} />}
+        {success && (
+          <div className="mb-4 px-4 py-3 rounded-lg bg-green-900/30 border border-green-800 text-green-300 text-sm">
+            {success}
+          </div>
+        )}
+
+        {showForm && (
+          <form onSubmit={handleSubmit} className="mb-6 p-6 rounded-lg bg-slate-900/60 border border-slate-800 space-y-4">
+            <h2 className="text-lg font-semibold text-slate-100">
+              {editingId ? 'Edit rule' : 'Create rule'}
+            </h2>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">Name</label>
+                <input
+                  required
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  placeholder="monorepo"
+                  className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">VCS connection</label>
+                <select
+                  required
+                  value={vcsConnectionId}
+                  onChange={e => setVcsConnectionId(e.target.value)}
+                  className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                >
+                  <option value="">Select connection</option>
+                  {connections.map(c => (
+                    <option key={c.id} value={c.id}>
+                      {c.attributes.name} ({c.attributes.provider})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">Repo URL</label>
+                <input
+                  required
+                  value={repoUrl}
+                  onChange={e => setRepoUrl(e.target.value)}
+                  placeholder="https://github.com/org/monorepo"
+                  className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-slate-300 mb-1">Branch (empty = default)</label>
+                <input
+                  value={branch}
+                  onChange={e => setBranch(e.target.value)}
+                  placeholder="main"
+                  className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm text-slate-300 mb-1">Match pattern</label>
+              <input
+                required
+                value={pattern}
+                onChange={e => setPattern(e.target.value)}
+                placeholder="accounts/*/**/*.tf"
+                className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm font-mono"
+              />
+              <p className="text-xs text-slate-500 mt-1">Gitignore-style globs. <code>**</code> matches across path segments. Only <code>*.tf*</code> files trigger autodiscovery.</p>
+            </div>
+
+            <div>
+              <label className="block text-sm text-slate-300 mb-1">Ignore patterns (one per line)</label>
+              <textarea
+                rows={3}
+                value={ignorePatternsText}
+                onChange={e => setIgnorePatternsText(e.target.value)}
+                placeholder="modules/**&#10;deprecated/**"
+                className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm font-mono"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm text-slate-300 mb-1">Workspace name template (optional)</label>
+              <input
+                value={nameTemplate}
+                onChange={e => setNameTemplate(e.target.value)}
+                placeholder="ws-{path}"
+                className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm font-mono"
+              />
+              <p className="text-xs text-slate-500 mt-1">Use <code>{'{path}'}</code> for the directory with <code>/</code> replaced by <code>-</code>, or <code>{'{root}'}</code> for the directory as-is. Empty = default (just the dashed path).</p>
+            </div>
+
+            <details className="group">
+              <summary className="text-sm text-slate-300 cursor-pointer">Workspace template defaults</summary>
+              <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4 pt-3 border-t border-slate-800">
+                <div>
+                  <label className="block text-sm text-slate-300 mb-1">Execution mode</label>
+                  <input
+                    value="agent"
+                    disabled
+                    className="w-full bg-slate-950/60 border border-slate-800 rounded px-3 py-2 text-sm text-slate-500"
+                  />
+                  <p className="text-xs text-slate-500 mt-1">Autodiscovery is VCS-driven; only agent execution is supported.</p>
+                </div>
+                <div>
+                  <label className="block text-sm text-slate-300 mb-1">Agent pool</label>
+                  <select
+                    value={agentPoolId}
+                    onChange={e => setAgentPoolId(e.target.value)}
+                    className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                  >
+                    <option value="">(none)</option>
+                    {pools.map(p => (
+                      <option key={p.id} value={p.id}>{p.attributes.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm text-slate-300 mb-1">Execution backend</label>
+                  <select
+                    value={executionBackend}
+                    onChange={e => setExecutionBackend(e.target.value as 'tofu' | 'terraform')}
+                    className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                  >
+                    <option value="tofu">tofu</option>
+                    <option value="terraform">terraform</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm text-slate-300 mb-1">Terraform version</label>
+                  <input
+                    value={terraformVersion}
+                    onChange={e => setTerraformVersion(e.target.value)}
+                    className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-slate-300 mb-1">CPU request</label>
+                  <input
+                    value={resourceCpu}
+                    onChange={e => setResourceCpu(e.target.value)}
+                    className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-slate-300 mb-1">Memory request</label>
+                  <input
+                    value={resourceMemory}
+                    onChange={e => setResourceMemory(e.target.value)}
+                    className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-slate-300 mb-1">Owner email</label>
+                  <input
+                    value={ownerEmail}
+                    onChange={e => setOwnerEmail(e.target.value)}
+                    placeholder="platform@example.com"
+                    className="w-full bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                  />
+                </div>
+                <div className="flex items-center gap-4 pt-6">
+                  <label className="flex items-center gap-2 text-sm text-slate-300">
+                    <input
+                      type="checkbox"
+                      checked={autoApply}
+                      onChange={e => setAutoApply(e.target.checked)}
+                    />
+                    Auto-apply
+                  </label>
+                  <label className="flex items-center gap-2 text-sm text-slate-300">
+                    <input
+                      type="checkbox"
+                      checked={enabled}
+                      onChange={e => setEnabled(e.target.checked)}
+                    />
+                    Enabled
+                  </label>
+                </div>
+              </div>
+              <div className="mt-4">
+                <label className="block text-sm text-slate-300 mb-1">Labels (inherited by created workspaces)</label>
+                <LabelsEditor labels={labels} onChange={setLabels} />
+              </div>
+            </details>
+
+            <div className="flex gap-2 pt-2">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="px-4 py-2 rounded-lg bg-brand-600 hover:bg-brand-500 text-white text-sm font-medium disabled:opacity-50"
+              >
+                {submitting ? 'Saving...' : (editingId ? 'Update' : 'Create')}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowForm(false); resetForm() }}
+                className="px-4 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 text-sm"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        )}
+
+        {sortedItems.length === 0 ? (
+          <EmptyState message="No autodiscovery rules yet. Create one to start auto-provisioning workspaces from PRs in your monorepo." />
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-left text-slate-400 border-b border-slate-800">
+              <tr>
+                <SortableHeader label="Name" sortKey="name" sortState={sortState} onSort={toggleSort} />
+                <SortableHeader label="Repo" sortKey="repo" sortState={sortState} onSort={toggleSort} />
+                <SortableHeader label="Pattern" sortKey="pattern" sortState={sortState} onSort={toggleSort} />
+                <SortableHeader label="Enabled" sortKey="enabled" sortState={sortState} onSort={toggleSort} />
+                <SortableHeader label="Created" sortKey="created" sortState={sortState} onSort={toggleSort} />
+                <th className="py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedItems.map(r => (
+                <tr key={r.id} className="border-b border-slate-900 hover:bg-slate-900/40">
+                  <td className="py-3 text-slate-200">{r.attributes.name}</td>
+                  <td className="py-3 text-slate-400 font-mono text-xs">
+                    {r.attributes['repo-url'].replace(/^https?:\/\//, '')}
+                  </td>
+                  <td className="py-3 text-slate-400 font-mono text-xs">{r.attributes.pattern}</td>
+                  <td className="py-3">
+                    {r.attributes.enabled ? (
+                      <span className="text-green-400">enabled</span>
+                    ) : (
+                      <span className="text-slate-500">disabled</span>
+                    )}
+                  </td>
+                  <td className="py-3 text-slate-400">
+                    {r.attributes['created-at']
+                      ? new Date(r.attributes['created-at']).toLocaleDateString()
+                      : ''}
+                  </td>
+                  <td className="py-3 text-right">
+                    <button
+                      onClick={() => openEditForm(r)}
+                      className="text-slate-400 hover:text-slate-200 text-xs px-2 py-1"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => setDeleteId(r.id)}
+                      className="text-red-400 hover:text-red-300 text-xs px-2 py-1"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {deleteId && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+            <div className="bg-slate-900 border border-slate-700 rounded-lg p-6 max-w-md w-full">
+              <h3 className="text-lg font-semibold text-slate-100 mb-2">Delete rule?</h3>
+              <p className="text-sm text-slate-400 mb-4">
+                Workspaces auto-created by this rule keep working. Future PRs touching new paths under this rule won&apos;t auto-create more workspaces.
+              </p>
+              <div className="flex gap-2 justify-end">
+                <button
+                  onClick={() => setDeleteId(null)}
+                  className="px-4 py-2 rounded bg-slate-800 hover:bg-slate-700 text-slate-200 text-sm"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => handleDelete(deleteId)}
+                  className="px-4 py-2 rounded bg-red-700 hover:bg-red-600 text-white text-sm"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+    </>
+  )
+}

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, FileText, BookOpen, Code, LogOut, Menu, X, Tags } from 'lucide-react'
+import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, FileText, BookOpen, Code, LogOut, Menu, X, Tags, Compass } from 'lucide-react'
 import { clearAuth, isAdmin, isAdminOrAudit } from '@/lib/auth'
 import { SessionExpiryBanner } from '@/components/session-expiry-banner'
 
@@ -104,6 +104,10 @@ export default function NavBar() {
           <NavLink href="/admin/variable-sets" onClick={closeMenu}>
             <Variable size={16} />
             Variable Sets
+          </NavLink>
+          <NavLink href="/admin/autodiscovery" onClick={closeMenu}>
+            <Compass size={16} />
+            Autodiscovery
           </NavLink>
         </>
       )}

--- a/web/src/lib/use-auth-roles.ts
+++ b/web/src/lib/use-auth-roles.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { getAuthState } from '@/lib/auth'
+
+/**
+ * Hook returning the authenticated user's roles, with a stable first
+ * render.
+ *
+ * Auth state lives in localStorage, which is unavailable during SSR.
+ * Calling `getAuthState()`/`isAdmin()` directly in render produces
+ * different output on the server (no roles) than on the first client
+ * render (real roles), which Next.js dev mode reports as a hydration
+ * error and then layers a blocking modal on top of the page.
+ *
+ * This hook returns `[]` on the server and on the very first client
+ * render, then updates to the real roles in a `useEffect`. The
+ * second render — strictly after hydration — is the one that shows
+ * admin/audit-gated UI. Callers should derive `isAdmin` /
+ * `isAdminOrAudit` from the returned array.
+ */
+export function useAuthRoles(): string[] {
+  const [roles, setRoles] = useState<string[]>([])
+  useEffect(() => {
+    // The deferred-update is the entire point of this hook — pre-hydration
+    // render returns []; post-hydration render returns the real roles.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRoles(getAuthState()?.roles ?? [])
+  }, [])
+  return roles
+}
+
+export function useIsAdmin(): boolean {
+  const roles = useAuthRoles()
+  return roles.includes('admin')
+}
+
+export function useIsAdminOrAudit(): boolean {
+  const roles = useAuthRoles()
+  return roles.includes('admin') || roles.includes('audit')
+}


### PR DESCRIPTION
Closes #283.

## Summary

Atlantis-style workspace autodiscovery for monorepos. Connection-scoped rules with glob patterns + ignore_paths auto-create workspaces when a PR or default-branch push touches a new directory matching the pattern.

- **DB**: new `autodiscovery_rules` table + `workspaces.autodiscovery_rule_id` FK (SET NULL on delete)
- **Service**: `workspace_autodiscovery_service` — gitignore-style glob matcher (`**`, `*`, `?`, `[abc]`), idempotent find-or-create with race-safe `IntegrityError` rollback
- **VCS poller**: runs an autodiscovery pass on every poll cycle and on webhook immediate-poll, scoped to the connection's rules — created workspaces are picked up by the regular poll on the next iteration
- **API**: `/api/terrapod/v1/autodiscovery-rules` CRUD (admin only)
- **UI**: admin page at `/admin/autodiscovery` with rule editor + nav entry; SSR-safe `useAuthRoles` hook fixes a hydration mismatch on admin-gated pages
- **Provider**: `terrapod_autodiscovery_rule` resource
- **Docs**: feature doc, runbook entry, API reference, architecture diagram

## Design notes

- **Connection-scoped, not workspace-scoped.** A workspace doesn't exist yet at autodiscovery time, so attaching rules to a workspace is a chicken-and-egg. Connection-scope mirrors how Atlantis stores autodiscovery in `repos.yaml`.
- **`execution-mode` must be `agent`.** Autodiscovery is inherently VCS-driven; a `local` rule would create workspaces with no executor, leaving runs queued forever.
- **No new VCS provider permissions.** Existing GitHub App / GitLab token scopes already cover the read paths autodiscovery uses.
- **First matching rule wins** per file — rules don't fan out.

## Verification

- `make test` — 1285 passing (33 new tests)
- `make lint` — passing
- `npm run build` (in Docker) — passing
- Tilt smoke: created rule via API → opened PR with `accounts/gamma/network/main.tf` → autodiscovery created `accounts-gamma-network` workspace

## Test plan

- [ ] Create an autodiscovery rule via UI; confirm it appears in the list
- [ ] Edit the rule; confirm VCS connection populates correctly (the bug fixed mid-PR)
- [ ] Open a PR touching a new directory matching the rule's pattern; confirm a workspace is auto-created and a speculative plan runs
- [ ] Push to default branch in a new directory; confirm a workspace is auto-created and a full run is queued
- [ ] Disable the rule; confirm new directories no longer trigger autodiscovery
- [ ] Try to create a rule with `execution-mode: local`; confirm 422 with a clear message