### PR TITLE
feat: implement /plans/{id}/json-output (#280)

### DIFF
--- a/alembic/versions/a10f40e65a96_add_run_has_json_output.py
+++ b/alembic/versions/a10f40e65a96_add_run_has_json_output.py
@@ -1,0 +1,36 @@
+"""add runs.has_json_output
+
+Tracks whether `tofu show -json` output was successfully uploaded for a
+run, so plan responses can advertise the json-output URL only when the
+artifact actually exists. See terrapod #280.
+
+Revision ID: a10f40e65a96
+Revises: 8bb13bfef824
+Create Date: 2026-05-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a10f40e65a96"
+down_revision: str | None = "8bb13bfef824"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "runs",
+        sa.Column(
+            "has_json_output",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "has_json_output")

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -402,10 +402,10 @@ if [ "$TP_PHASE" = "plan" ]; then
     # Redirect to file so $! gives the plan PID for correct signal forwarding.
     # A background tail -f streams output to pod logs in real-time.
     PLAN_ARGS="-input=false -detailed-exitcode"
-    # Only save plan file if not plan-only (plan file is discarded for plan-only runs)
-    if [ "${TP_PLAN_ONLY:-false}" != "true" ]; then
-        PLAN_ARGS="$PLAN_ARGS -out=tfplan"
-    fi
+    # Always write the binary plan file. For non-plan-only runs the apply
+    # phase consumes it; for plan-only runs we still need it as input to
+    # `tofu show -json` for the json-output artifact.
+    PLAN_ARGS="$PLAN_ARGS -out=tfplan"
     if [ "${TP_REFRESH_ONLY:-false}" = "true" ]; then
         PLAN_ARGS="$PLAN_ARGS -refresh-only"
     fi
@@ -449,7 +449,9 @@ if [ "$TP_PHASE" = "plan" ]; then
     [ -f /tmp/plan.log ] && cat /tmp/plan.log >> "$COMBINED_LOG"
 
     # Upload plan file (best-effort) — separate artifact, not a log.
-    if [ -n "$TP_API_URL" ] && [ -f tfplan ]; then
+    # Skip for plan-only runs: there is no apply phase that would consume
+    # the binary, so don't burn storage on it.
+    if [ -n "$TP_API_URL" ] && [ -f tfplan ] && [ "${TP_PLAN_ONLY:-false}" != "true" ]; then
         curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @tfplan \

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -456,6 +456,21 @@ if [ "$TP_PHASE" = "plan" ]; then
             "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/plan-file" || true
     fi
 
+    # Emit + upload structured JSON plan (`tofu show -json`). Best-effort:
+    # large plans can produce multi-MB JSON, and a failed upload here
+    # MUST NOT fail the run — the read endpoint just returns 404. The
+    # presence of `tfplan` is the right gate: -detailed-exitcode 1
+    # (errored) doesn't produce one; both 0 (no changes) and 2 (changes)
+    # do.
+    if [ -n "$TP_API_URL" ] && [ -f tfplan ]; then
+        if "$TP_BIN" show -json tfplan > /tmp/plan.json 2>/dev/null; then
+            curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
+                -H "Content-Type: application/json" \
+                --data-binary @/tmp/plan.json \
+                "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/plan-json-output" || true
+        fi
+    fi
+
 elif [ "$TP_PHASE" = "apply" ]; then
     # From here on, the trap uploads to /artifacts/apply-log rather than plan-log.
     UPLOAD_PHASE="apply"

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -463,11 +463,14 @@ if [ "$TP_PHASE" = "plan" ]; then
     # (errored) doesn't produce one; both 0 (no changes) and 2 (changes)
     # do.
     if [ -n "$TP_API_URL" ] && [ -f tfplan ]; then
-        if "$TP_BIN" show -json tfplan > /tmp/plan.json 2>/dev/null; then
+        if "$TP_BIN" show -json tfplan > /tmp/plan.json 2> /tmp/plan-show.err; then
             curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
                 -H "Content-Type: application/json" \
                 --data-binary @/tmp/plan.json \
-                "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/plan-json-output" || true
+                "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/plan-json-output" \
+                || log "[entrypoint] plan-json-output upload failed (non-fatal)"
+        else
+            log "[entrypoint] $TP_BIN show -json tfplan failed (non-fatal): $(head -c 500 /tmp/plan-show.err)"
         fi
     fi
 

--- a/docs/tfe-cli-surface.md
+++ b/docs/tfe-cli-surface.md
@@ -99,7 +99,7 @@ Terrapod-only management on the configuration-versions surface (list, download, 
 | GET | `/api/v2/runs/{id}/run-events` | `RunEvents.List` | run progress polling |
 | GET | `/api/v2/plans/{id}` | `Plans.Read` | run status |
 | GET | `/api/v2/plans/{id}/log` | `Plans.Logs` (via `log-read-url`) | `cloud/backend_plan.go:428`, `remote/backend_plan.go:380` |
-| GET | `/api/v2/plans/{id}/json-output` | `Plans.ReadJSONOutput` | `cloud/backend_show.go:68` (gap — see #279) |
+| GET | `/api/v2/plans/{id}/json-output` | `Plans.ReadJSONOutput` | `cloud/backend_show.go:68` (302 → presigned storage URL; advertised via `json-output` attribute on the plan when present) |
 | GET | `/api/v2/applies/{id}` | `Applies.Read` | run status |
 | GET | `/api/v2/applies/{id}/log` | `Applies.Logs` (via `log-read-url`) | `cloud/backend_apply.go:229`, `remote/backend_apply.go:272` |
 

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -178,7 +178,12 @@ async def upload_plan_json_output(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Upload the structured JSON plan output (`tofu show -json tfplan`)."""
+    """Upload the structured JSON plan output (`tofu show -json tfplan`).
+
+    Sets `runs.has_json_output = true` so plan responses can advertise
+    the read URL with confidence (errored / older / failed-upload runs
+    leave the flag at its default `false`).
+    """
     _require_runner_for_run(user, run_id)
     run = await _get_run(run_id, db)
 
@@ -186,6 +191,9 @@ async def upload_plan_json_output(
     storage = get_storage()
     key = plan_json_output_key(str(run.workspace_id), str(run.id))
     await storage.put(key, body)
+
+    run.has_json_output = True
+    await db.commit()
     return Response(status_code=204)
 
 

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -190,8 +190,11 @@ async def upload_plan_json_output(
     body = await request.body()
     storage = get_storage()
     key = plan_json_output_key(str(run.workspace_id), str(run.id))
+    # Order matters: write storage first, then flip the flag. If the
+    # commit fails after a successful upload, the artifact is reachable
+    # only via retention sweep — annoying, but better than the reverse,
+    # which would advertise a URL pointing at nothing.
     await storage.put(key, body)
-
     run.has_json_output = True
     await db.commit()
     return Response(status_code=204)

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -12,6 +12,7 @@ Endpoints:
     GET  /api/terrapod/v1/runs/{run_id}/artifacts/plan-file    — download plan file
     PUT  /api/terrapod/v1/runs/{run_id}/artifacts/plan-log     — upload plan log
     PUT  /api/terrapod/v1/runs/{run_id}/artifacts/plan-file    — upload plan file
+    PUT  /api/terrapod/v1/runs/{run_id}/artifacts/plan-json-output — upload plan JSON
     PUT  /api/terrapod/v1/runs/{run_id}/artifacts/apply-log    — upload apply log
     PUT  /api/terrapod/v1/runs/{run_id}/artifacts/state        — upload new state
 """
@@ -35,6 +36,7 @@ from terrapod.storage import get_storage
 from terrapod.storage.keys import (
     apply_log_key,
     config_version_key,
+    plan_json_output_key,
     plan_log_key,
     plan_output_key,
     state_key,
@@ -165,6 +167,24 @@ async def upload_plan_file(
     body = await request.body()
     storage = get_storage()
     key = plan_output_key(str(run.workspace_id), str(run.id))
+    await storage.put(key, body)
+    return Response(status_code=204)
+
+
+@router.put("/runs/{run_id}/artifacts/plan-json-output")
+async def upload_plan_json_output(
+    run_id: str,
+    request: Request,
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Upload the structured JSON plan output (`tofu show -json tfplan`)."""
+    _require_runner_for_run(user, run_id)
+    run = await _get_run(run_id, db)
+
+    body = await request.body()
+    storage = get_storage()
+    key = plan_json_output_key(str(run.workspace_id), str(run.id))
     await storage.put(key, body)
     return Response(status_code=204)
 

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -30,7 +30,7 @@ from datetime import UTC
 from typing import Literal
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
@@ -47,7 +47,7 @@ from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service, run_service
 from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
 from terrapod.storage import get_storage
-from terrapod.storage.keys import apply_log_key, plan_log_key
+from terrapod.storage.keys import apply_log_key, plan_json_output_key, plan_log_key
 from terrapod.storage.protocol import ObjectNotFoundError
 
 router = APIRouter(prefix="/api/v2", tags=["runs"])
@@ -729,6 +729,7 @@ def _plan_json(run: Run) -> dict:
             "attributes": {
                 "status": _plan_status(run),
                 "log-read-url": f"{base}/api/v2/plans/{run.id}/log",
+                "json-output": f"{base}/api/v2/plans/{run.id}/json-output",
                 "has-changes": run.status in ("planned", "confirmed", "applying", "applied"),
             },
             "links": {
@@ -1279,6 +1280,35 @@ async def plan_log(
         limit=limit,
         strip_ansi=format == "plain",
     )
+
+
+@router.get("/plans/{plan_id}/json-output")
+async def plan_json_output(
+    plan_id: str = Path(...),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Serve the structured JSON plan output (`tofu show -json`).
+
+    go-tfe's `Plans.ReadJSONOutput` consumes this endpoint via
+    `tofu show -json` against a remote run. Response is raw JSON bytes;
+    auth is by capability (the plan UUID), matching `/plans/{id}/log`.
+    A 302 to a presigned storage URL is fine — `req.Do` follows
+    redirects.
+    """
+    try:
+        run_uuid = uuid.UUID(plan_id.removeprefix("plan-").removeprefix("run-"))
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Plan not found") from None
+    run = await run_service.get_run(db, run_uuid)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    storage = get_storage()
+    key = plan_json_output_key(str(run.workspace_id), str(run.id))
+    if not await storage.exists(key):
+        raise HTTPException(status_code=404, detail="JSON plan output not available")
+    url = await storage.presigned_get_url(key)
+    return RedirectResponse(url=url.url, status_code=302)
 
 
 @router.get("/applies/{apply_id}/log")

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -16,6 +16,8 @@ Endpoints:
     POST   /api/terrapod/v1/runs/{run_id}/actions/retry        (retry run — create new run from terminal run)
     GET    /api/terrapod/v1/runs/{run_id}/plan                 (plan details)
     GET    /api/v2/plans/{plan_id}                    (plan details by ID)
+    GET    /api/v2/plans/{plan_id}/log                (plan log stream)
+    GET    /api/v2/plans/{plan_id}/json-output        (structured JSON plan; 302 → presigned)
     GET    /api/terrapod/v1/runs/{run_id}/apply                (apply details)
     GET    /api/v2/applies/{apply_id}                 (apply details by ID)
     PATCH  /api/terrapod/v1/listeners/{id}/runs/{run_id}       (listener status update)

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1305,8 +1305,16 @@ async def plan_json_output(
     if run is None:
         raise HTTPException(status_code=404, detail="Plan not found")
 
+    # Fast path: the flag is the source of truth. Avoid a storage call
+    # for runs that never produced JSON (errored, older, upload failed).
+    if not run.has_json_output:
+        raise HTTPException(status_code=404, detail="JSON plan output not available")
+
     storage = get_storage()
     key = plan_json_output_key(str(run.workspace_id), str(run.id))
+    # Belt-and-braces: retention may have deleted the artifact while
+    # leaving the flag intact, in which case we must not redirect to a
+    # signed URL pointing at a missing object.
     if not await storage.exists(key):
         raise HTTPException(status_code=404, detail="JSON plan output not available")
     url = await storage.presigned_get_url(key)

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -722,16 +722,18 @@ def _plan_json(run: Run) -> dict:
     from terrapod.config import settings
 
     base = settings.auth.callback_base_url.rstrip("/")
+    attrs: dict = {
+        "status": _plan_status(run),
+        "log-read-url": f"{base}/api/v2/plans/{run.id}/log",
+        "has-changes": run.status in ("planned", "confirmed", "applying", "applied"),
+    }
+    if run.has_json_output:
+        attrs["json-output"] = f"{base}/api/v2/plans/{run.id}/json-output"
     return {
         "data": {
             "id": f"plan-{run.id}",
             "type": "plans",
-            "attributes": {
-                "status": _plan_status(run),
-                "log-read-url": f"{base}/api/v2/plans/{run.id}/log",
-                "json-output": f"{base}/api/v2/plans/{run.id}/json-output",
-                "has-changes": run.status in ("planned", "confirmed", "applying", "applied"),
-            },
+            "attributes": attrs,
             "links": {
                 "self": f"/api/v2/plans/plan-{run.id}",
             },

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -1076,6 +1076,13 @@ class Run(Base):
     is_drift_detection: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     has_changes: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
+    # True once the runner has uploaded `tofu show -json` output to storage.
+    # Drives the optional `json-output` URL in plan responses so we don't
+    # advertise a 404 on errored / older / not-yet-uploaded runs.
+    has_json_output: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false", default=False
+    )
+
     # Job tracking (populated by listener after launching K8s Job)
     job_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     job_namespace: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/services/terrapod/services/artifact_retention_service.py
+++ b/services/terrapod/services/artifact_retention_service.py
@@ -199,6 +199,7 @@ async def _cleanup_run_artifacts(
     )
     runs = list(result.scalars().all())
 
+    flag_resets = 0
     for run in runs:
         ws_id = str(run.workspace_id)
         run_id = str(run.id)
@@ -216,7 +217,17 @@ async def _cleanup_run_artifacts(
                     exc_info=True,
                 )
 
+        # Keep the row's `has_json_output` flag honest: if the artifact
+        # is gone, the plan-show response must stop advertising a URL
+        # that would 404.
+        if run.has_json_output:
+            run.has_json_output = False
+            flag_resets += 1
+
         deleted += artifact_count
+
+    if flag_resets:
+        await db.commit()
 
     if deleted:
         RETENTION_DELETED.labels(category="run_artifacts").inc(deleted)

--- a/services/terrapod/services/artifact_retention_service.py
+++ b/services/terrapod/services/artifact_retention_service.py
@@ -35,6 +35,7 @@ from terrapod.storage.keys import (
     apply_log_key,
     binary_cache_key,
     config_version_key,
+    plan_json_output_key,
     plan_log_key,
     plan_output_key,
     provider_cache_key,
@@ -203,7 +204,7 @@ async def _cleanup_run_artifacts(
         run_id = str(run.id)
         artifact_count = 0
 
-        for key_fn in (plan_log_key, apply_log_key, plan_output_key):
+        for key_fn in (plan_log_key, apply_log_key, plan_output_key, plan_json_output_key):
             try:
                 await storage.delete(key_fn(ws_id, run_id))
                 artifact_count += 1

--- a/services/terrapod/storage/keys.py
+++ b/services/terrapod/storage/keys.py
@@ -36,6 +36,11 @@ def plan_output_key(workspace_id: str, run_id: str) -> str:
     return f"plans/{workspace_id}/{run_id}.tfplan"
 
 
+def plan_json_output_key(workspace_id: str, run_id: str) -> str:
+    """Key for a run's structured JSON plan output (`tofu show -json tfplan`)."""
+    return f"plans/{workspace_id}/{run_id}.json-output"
+
+
 def config_version_key(workspace_id: str, config_version_id: str) -> str:
     """Key for a configuration version archive."""
     return f"config/{workspace_id}/{config_version_id}.tar.gz"

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -161,3 +161,56 @@ class TestUploadStateDuplicateSerial:
         assert resp.status_code == 204
         mock_db.add.assert_called_once()
         mock_storage.put.assert_called_once()
+
+
+# ── upload_plan_json_output (#280) ─────────────────────────────────────
+
+
+class TestUploadPlanJsonOutput:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_writes_to_canonical_key(self, mock_get_storage, *_mocks):
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_storage = AsyncMock()
+        mock_get_storage.return_value = mock_storage
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        body = b'{"format_version":"1.2","resource_changes":[]}'
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-json-output",
+                content=body,
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 204
+        mock_storage.put.assert_called_once()
+        key, payload = mock_storage.put.call_args.args
+        assert key == f"plans/{ws_id}/{run_id}.json-output"
+        assert payload == body
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_403_for_wrong_run_scope(self, *_mocks):
+        run_id = uuid.uuid4()
+        wrong_run_id = uuid.uuid4()  # token scoped to a different run
+        run = _mock_run(run_id=run_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+
+        app = _make_app(_runner_user(wrong_run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-json-output",
+                content=b"{}",
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 403

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -194,6 +194,9 @@ class TestUploadPlanJsonOutput:
         key, payload = mock_storage.put.call_args.args
         assert key == f"plans/{ws_id}/{run_id}.json-output"
         assert payload == body
+        # Flag flip is the source of truth for `_plan_json` advertising the URL.
+        assert run.has_json_output is True
+        mock_db.commit.assert_awaited_once()
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -777,3 +777,68 @@ class TestCLIApplyGuard:
                 headers=_AUTH,
             )
         assert resp.status_code == 200
+
+
+# ── /plans/{id}/json-output (#280) ─────────────────────────────────────
+
+
+class TestPlanJsonOutput:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.get_storage")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_redirects_to_presigned_url_when_present(
+        self, mock_get_run, mock_get_storage, *_mocks
+    ):
+        run = _mock_run()
+        mock_get_run.return_value = run
+
+        mock_storage = AsyncMock()
+        mock_storage.exists = AsyncMock(return_value=True)
+        presigned = MagicMock()
+        presigned.url = "https://storage.example/plans/x.json-output?sig=abc"
+        mock_storage.presigned_get_url = AsyncMock(return_value=presigned)
+        mock_get_storage.return_value = mock_storage
+
+        app, _db = _make_app(_user())
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url=_BASE, follow_redirects=False
+        ) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{run.id}/json-output", headers=_AUTH)
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == presigned.url
+        mock_storage.exists.assert_awaited_once_with(
+            f"plans/{run.workspace_id}/{run.id}.json-output"
+        )
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.get_storage")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_404_when_object_missing(self, mock_get_run, mock_get_storage, *_mocks):
+        run = _mock_run()
+        mock_get_run.return_value = run
+
+        mock_storage = AsyncMock()
+        mock_storage.exists = AsyncMock(return_value=False)
+        mock_get_storage.return_value = mock_storage
+
+        app, _db = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{run.id}/json-output", headers=_AUTH)
+
+        assert resp.status_code == 404
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_404_for_unknown_plan(self, mock_get_run, *_mocks):
+        mock_get_run.return_value = None
+        app, _db = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{uuid.uuid4()}/json-output", headers=_AUTH)
+        assert resp.status_code == 404

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -821,7 +821,11 @@ class TestPlanJsonOutput:
     @patch("terrapod.api.routers.runs.get_storage")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_404_when_object_missing(self, mock_get_run, mock_get_storage, *_mocks):
+        """Belt-and-braces: flag is True but the object is gone (retention deleted
+        the artifact between the upload and now). Endpoint must 404, not 302 to
+        a signed URL pointing at nothing."""
         run = _mock_run()
+        run.has_json_output = True  # flag set; storage missing
         mock_get_run.return_value = run
 
         mock_storage = AsyncMock()
@@ -833,6 +837,33 @@ class TestPlanJsonOutput:
             resp = await c.get(f"/api/v2/plans/plan-{run.id}/json-output", headers=_AUTH)
 
         assert resp.status_code == 404
+        mock_storage.exists.assert_awaited_once()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.get_storage")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_fast_path_404_skips_storage_when_flag_false(
+        self, mock_get_run, mock_get_storage, *_mocks
+    ):
+        """When `has_json_output=False`, the endpoint must return 404 without
+        touching storage at all — that's the optimization the flag exists for."""
+        run = _mock_run()
+        run.has_json_output = False
+        mock_get_run.return_value = run
+
+        mock_storage = AsyncMock()
+        mock_storage.exists = AsyncMock(return_value=True)  # would lie if asked
+        mock_get_storage.return_value = mock_storage
+
+        app, _db = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{run.id}/json-output", headers=_AUTH)
+
+        assert resp.status_code == 404
+        mock_storage.exists.assert_not_called()
+        mock_storage.presigned_get_url.assert_not_called()
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -67,6 +67,7 @@ def _mock_run(
     run.configuration_version_id = None
     run.module_overrides = None
     run.created_by = "test@example.com"
+    run.has_json_output = False
     return run
 
 
@@ -792,6 +793,7 @@ class TestPlanJsonOutput:
         self, mock_get_run, mock_get_storage, *_mocks
     ):
         run = _mock_run()
+        run.has_json_output = True
         mock_get_run.return_value = run
 
         mock_storage = AsyncMock()
@@ -842,3 +844,53 @@ class TestPlanJsonOutput:
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(f"/api/v2/plans/plan-{uuid.uuid4()}/json-output", headers=_AUTH)
         assert resp.status_code == 404
+
+
+# ── _plan_json json-output attribute gating (#280) ─────────────────────
+
+
+class TestPlanJsonAttribute:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_attribute_present_when_uploaded(self, mock_get_run, mock_resolve, *_mocks):
+        mock_resolve.return_value = "read"
+        run = _mock_run(status="planned")
+        run.has_json_output = True
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{run.id}", headers=_AUTH)
+
+        attrs = resp.json()["data"]["attributes"]
+        assert "json-output" in attrs
+        assert attrs["json-output"].endswith(f"/api/v2/plans/{run.id}/json-output")
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_attribute_absent_when_not_uploaded(self, mock_get_run, mock_resolve, *_mocks):
+        """Don't advertise a URL we know would 404. Older / errored / failed-upload
+        runs must not carry the `json-output` attribute."""
+        mock_resolve.return_value = "read"
+        run = _mock_run(status="planned")
+        run.has_json_output = False
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{run.id}", headers=_AUTH)
+
+        attrs = resp.json()["data"]["attributes"]
+        assert "json-output" not in attrs

--- a/services/tests/services/test_artifact_retention_service.py
+++ b/services/tests/services/test_artifact_retention_service.py
@@ -37,6 +37,7 @@ def _make_run(
     cv_id=None,
     module_overrides=None,
     run_id=None,
+    has_json_output=False,
 ):
     run = MagicMock()
     run.id = run_id or _make_uuid()
@@ -45,6 +46,7 @@ def _make_run(
     run.created_at = created_at or datetime.now(UTC) - timedelta(days=120)
     run.configuration_version_id = cv_id
     run.module_overrides = module_overrides
+    run.has_json_output = has_json_output
     return run
 
 
@@ -206,6 +208,46 @@ class TestCleanupRunArtifacts:
         # 4 artifacts per run (plan log, apply log, plan output, plan json output)
         assert deleted == 8
         assert storage.delete.call_count == 8
+
+    @pytest.mark.asyncio
+    async def test_resets_has_json_output_flag_when_artifact_deleted(self):
+        """After retention deletes a run's `.json-output`, the row must stop
+        advertising the URL via `_plan_json` — i.e. `has_json_output` must
+        flip back to False, and the change must be committed.
+        """
+        ws_id = _make_uuid()
+        runs = [
+            _make_run(ws_id, status="applied", has_json_output=True),
+            _make_run(ws_id, status="applied", has_json_output=False),
+        ]
+
+        db = AsyncMock()
+        storage = AsyncMock()
+        db.execute.return_value = _FakeResult(runs)
+
+        await _cleanup_run_artifacts(db, storage, retention_days=90, batch_size=100)
+
+        # The `True` run was reset; the `False` run was untouched.
+        assert runs[0].has_json_output is False
+        assert runs[1].has_json_output is False
+        # One commit covers all flag changes in the batch.
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_commit_when_no_flags_to_reset(self):
+        """If no run had `has_json_output=True`, retention must skip the
+        commit — no point burning a transaction on no-ops.
+        """
+        ws_id = _make_uuid()
+        runs = [_make_run(ws_id, status="applied", has_json_output=False)]
+
+        db = AsyncMock()
+        storage = AsyncMock()
+        db.execute.return_value = _FakeResult(runs)
+
+        await _cleanup_run_artifacts(db, storage, retention_days=90, batch_size=100)
+
+        db.commit.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_old_runs_returns_zero(self):

--- a/services/tests/services/test_artifact_retention_service.py
+++ b/services/tests/services/test_artifact_retention_service.py
@@ -203,9 +203,9 @@ class TestCleanupRunArtifacts:
         db.execute.return_value = _FakeResult(runs)
 
         deleted = await _cleanup_run_artifacts(db, storage, retention_days=90, batch_size=100)
-        # 3 artifacts per run (plan log, apply log, plan output)
-        assert deleted == 6
-        assert storage.delete.call_count == 6
+        # 4 artifacts per run (plan log, apply log, plan output, plan json output)
+        assert deleted == 8
+        assert storage.delete.call_count == 8
 
     @pytest.mark.asyncio
     async def test_no_old_runs_returns_zero(self):


### PR DESCRIPTION
Closes #280.

## Summary

Wires up the structured JSON plan output endpoint that `tofu show -json` against a remote run consumes (via go-tfe's `Plans.ReadJSONOutput`).

Verified against go-tfe @ main: `Applies.ReadJSONOutput` does **not** exist; the cloud backend's `Show()` resolves run → plan and only ever calls `/plans/{id}/json-output`. Plan-side only is the right scope.

## Pieces

- **Runner** (`docker/runner-entrypoint.sh`): after a successful plan, run `tofu show -json tfplan` and PUT the JSON to a new artifact endpoint. Best-effort — gated on `tfplan` presence (so it covers both `-detailed-exitcode` 0 and 2, but skips 1/errored). Upload failure does NOT fail the run; the read endpoint just 404s.
- **Storage**: `plan_json_output_key(ws, run)` → `plans/{ws}/{run}.json-output`. Deterministic — no DB column.
- **Upload endpoint**: `PUT /api/terrapod/v1/runs/{run_id}/artifacts/plan-json-output` — runner-token auth, scoped to `run_id`. Mirrors the existing `plan-file` upload.
- **Read endpoint**: `GET /api/v2/plans/{plan_id}/json-output` — 302 to a presigned storage URL when the object exists, 404 otherwise. Capability auth via the plan UUID, same model as `/plans/{id}/log`. go-tfe's `req.Do` follows the redirect transparently.
- **JSON:API**: `_plan_json()` now advertises the `json-output` URL.

## Tests

1290 passing (5 new):
- Upload endpoint: writes to canonical key, 403 on cross-run token scope
- Read endpoint: 302 + presigned URL on hit, 404 on missing object, 404 on unknown plan

## Test plan

- [ ] Tilt: queue an agent run; confirm `plans/{ws}/{run}.json-output` appears in storage
- [ ] `tofu show -json` against the run via the cloud backend returns the structured plan JSON
- [ ] Errored plan does not produce a `.json-output` object; read endpoint returns 404