### PR TITLE
feat: clear 422 on projects endpoints + cloud-block guidance (#279)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -157,6 +157,10 @@ resource "null_resource" "hello" {
 
 > Note: The `terraform {}` block syntax is used by both OpenTofu and Terraform. No changes are needed when switching between them.
 
+> **Do not set `project = "..."` in the cloud block.** Terrapod is single-organization and has no project concept — workspaces live directly under the organization. Setting `project` causes `tofu init` to fail with a `422 Projects are not supported` error from the API. Omit the argument.
+>
+> If you used TFC projects to scope RBAC (e.g. "team X has write on project Y"), Terrapod's [label-based RBAC](rbac.md) covers the same use case and more flexibly: roles match workspaces by label allow/deny rules (e.g. `team: payments` + `env: prod` → `write`), so a workspace can belong to any combination of dimensions instead of a single project. The same labels also drive **filtering in the web UI** — workspace lists, registry modules, and other resources can be filtered by any label key/value, so labels double as the navigation hierarchy projects provided in TFC. See `docs/rbac.md` for examples.
+
 If you'd rather select a workspace at run time (typical when a single repo backs several environments) replace `name` with `tags`. Tags are matched against the workspace's labels — see the [RBAC docs](rbac.md#labels-are-also-tags) for details.
 
 ```hcl

--- a/docs/tfe-cli-surface.md
+++ b/docs/tfe-cli-surface.md
@@ -37,10 +37,10 @@ The discovery document points at:
 
 | Method | Path | go-tfe method | Caller |
 |---|---|---|---|
-| GET | `/api/v2/organizations/default/projects` | `Projects.List` | `cloud/backend.go:588, 676` |
-| POST | `/api/v2/organizations/default/projects` | `Projects.Create` | `cloud/backend.go:715` |
+| GET | `/api/v2/organizations/default/projects` | `Projects.List` | `cloud/backend.go:588, 676` (returns 422 — see below) |
+| POST | `/api/v2/organizations/default/projects` | `Projects.Create` | `cloud/backend.go:715` (returns 422 — see below) |
 
-Terrapod is single-organization with no project concept — see #279 for current handling.
+Terrapod is single-organization with no project concept. Both endpoints return `422 Projects are not supported` with a JSON:API error directing the caller to omit the `project` argument from the cloud block. See `docs/getting-started.md`. Label-based RBAC (`docs/rbac.md`) covers the same scoping use case projects served in TFC, and is more flexible — a workspace can match on any combination of label dimensions instead of a single project, and the same labels drive UI filtering of workspaces and other resources.
 
 ## Workspaces
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -14,6 +14,8 @@ Endpoints:
     GET  /api/v2/account/details — current user info
     GET  /api/v2/organizations/default — organization details
     GET  /api/v2/organizations/default/entitlement-set — feature entitlements
+    GET  /api/v2/organizations/default/projects — 422 (Terrapod has no projects; see #279)
+    POST /api/v2/organizations/default/projects — 422 (Terrapod has no projects; see #279)
     GET  /api/v2/organizations/default/workspaces — list workspaces
     GET  /api/v2/organizations/default/workspaces/{name} — workspace by name
     POST /api/v2/organizations/default/workspaces — create workspace
@@ -440,6 +442,50 @@ async def organization_entitlements(
             }
         },
         headers=_tfe_headers(),
+    )
+
+
+# ── Projects (unsupported — see #279) ────────────────────────────────────────
+
+# Terrapod is single-organization and has no project concept. The cloud
+# backend calls these endpoints when the user sets `project = "..."` in
+# their cloud block (see `cloud/backend.go:588, 676, 715` in OpenTofu).
+# Returning 404 from a missing route would surface as "endpoint not
+# found" with no actionable hint. Instead, return a 422 JSON:API error
+# that points at the actual fix: omit the `project` argument.
+
+_PROJECTS_NOT_SUPPORTED_BODY = {
+    "errors": [
+        {
+            "status": "422",
+            "title": "Projects are not supported",
+            "detail": (
+                "Terrapod is single-organization and has no project concept. "
+                "Remove the `project` argument from your cloud block — the "
+                "workspace lives directly under the organization."
+            ),
+        }
+    ]
+}
+
+
+@router.get("/organizations/default/projects")
+async def list_projects_unsupported(
+    user: AuthenticatedUser = Depends(get_current_user),
+) -> JSONResponse:
+    """Reject project listings with a clear, actionable error."""
+    return JSONResponse(
+        status_code=422, content=_PROJECTS_NOT_SUPPORTED_BODY, headers=_tfe_headers()
+    )
+
+
+@router.post("/organizations/default/projects")
+async def create_project_unsupported(
+    user: AuthenticatedUser = Depends(get_current_user),
+) -> JSONResponse:
+    """Reject project creation with a clear, actionable error."""
+    return JSONResponse(
+        status_code=422, content=_PROJECTS_NOT_SUPPORTED_BODY, headers=_tfe_headers()
     )
 
 

--- a/services/tests/api/test_tfe_v2.py
+++ b/services/tests/api/test_tfe_v2.py
@@ -328,3 +328,66 @@ class TestTokenCRUD:
             )
 
         assert response.status_code == 403
+
+
+# ── Projects endpoints — clear 422 (#279) ────────────────────────────
+
+
+class TestProjectsUnsupported:
+    """Terrapod doesn't support TFC's project concept. The cloud backend
+    only calls these when `project = "..."` is set in the cloud block.
+    We surface a clear, actionable error instead of a generic 404.
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_get_projects_returns_422_with_jsonapi_error(self, *_mocks):
+        user = AuthenticatedUser(
+            email="t@example.com",
+            display_name="T",
+            roles=["everyone"],
+            provider_name="local",
+            auth_method="session",
+        )
+        app = _make_app_with_auth(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(
+                "/api/v2/organizations/default/projects",
+                headers={"Authorization": "Bearer dummy"},
+            )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert "errors" in body
+        err = body["errors"][0]
+        assert err["status"] == "422"
+        assert err["title"] == "Projects are not supported"
+        # The detail must point at the actual fix.
+        assert "project" in err["detail"]
+        assert "cloud block" in err["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_post_projects_returns_422_with_jsonapi_error(self, *_mocks):
+        user = AuthenticatedUser(
+            email="t@example.com",
+            display_name="T",
+            roles=["everyone"],
+            provider_name="local",
+            auth_method="session",
+        )
+        app = _make_app_with_auth(user)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/v2/organizations/default/projects",
+                json={"data": {"type": "projects", "attributes": {"name": "anything"}}},
+                headers={"Authorization": "Bearer dummy"},
+            )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["errors"][0]["title"] == "Projects are not supported"


### PR DESCRIPTION
Closes #279.

## Summary

The `cloud` block in `terraform`/`tofu` supports a `project = "..."` argument for scoping a workspace to a TFC project. Terrapod is single-organization and has no project concept, so this argument has no meaning — but without these endpoints, the cloud backend fails with a generic 404 and no actionable hint.

This PR:

1. Adds `GET` and `POST` to `/api/v2/organizations/default/projects` returning a `422 Projects are not supported` JSON:API error that directs the caller to omit the `project` argument.
2. Documents the constraint in `docs/getting-started.md` next to the cloud-block example, with a pointer to label-based RBAC and UI filtering as the equivalent (and more flexible) alternative for the use cases TFC projects served.
3. Updates `docs/tfe-cli-surface.md` so the projects rows reflect the new 422 behaviour.

## Out of scope

- Legacy `remote` backend gaps (force-unlock by name, workspace-delete by name) — the remote backend is deprecated and Terrapod targets the cloud backend.
- The other gaps from the original #279 audit (`/runs/queue`, `/capacity`) are silently-degrading UI hints; they remain unimplemented and are not part of this issue's scope.

## Tests

3 new tests in `test_tfe_v2.py`. 1297 passing total.

## Test plan

- [ ] Set `project = "anything"` in a cloud block pointing at a Terrapod instance
- [ ] `tofu init` should fail with a 422 mentioning `project` and `cloud block`
- [ ] Remove the `project` argument
- [ ] `tofu init` succeeds against the same workspace