### PR TITLE
feat: apply-then-merge VCS workflow + PR/MR comment interactivity (#282)

### DIFF
--- a/alembic/versions/a0b6c95a281d_audit_dual_actor.py
+++ b/alembic/versions/a0b6c95a281d_audit_dual_actor.py
@@ -1,0 +1,62 @@
+"""audit dual-actor model (#282 phase 7)
+
+Adds `actor_type` / `origin` / `actor_login` / `actor_id` to the audit
+log so we can distinguish HTTP/UI/API actions (`actor_type=terrapod_user`,
+`origin=api|terrapod_ui`) from PR-comment-driven actions
+(`actor_type=vcs_user`, `origin=pr_comment`) from background-task work
+(`actor_type=system`). Lets a security review isolate VCS-driven changes
+from Terrapod-user changes.
+
+Also widens `action` from 20 → 40 chars to accommodate verb-based VCS
+audit entries (e.g. "plan", "apply", "merge") in addition to the HTTP
+method captured for API events.
+
+Revision ID: a0b6c95a281d
+Revises: c17aecf92ac8
+Create Date: 2026-05-11
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a0b6c95a281d"
+down_revision: str | None = "c17aecf92ac8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "audit_logs",
+        sa.Column(
+            "actor_type",
+            sa.String(20),
+            nullable=False,
+            server_default="terrapod_user",
+        ),
+    )
+    op.add_column(
+        "audit_logs",
+        sa.Column("origin", sa.String(20), nullable=False, server_default="api"),
+    )
+    op.add_column(
+        "audit_logs",
+        sa.Column("actor_login", sa.String(255), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "audit_logs",
+        sa.Column("actor_id", sa.String(64), nullable=False, server_default=""),
+    )
+    op.create_index("ix_audit_logs_actor_type", "audit_logs", ["actor_type"])
+    op.alter_column("audit_logs", "action", type_=sa.String(40))
+
+
+def downgrade() -> None:
+    op.alter_column("audit_logs", "action", type_=sa.String(20))
+    op.drop_index("ix_audit_logs_actor_type", table_name="audit_logs")
+    op.drop_column("audit_logs", "actor_id")
+    op.drop_column("audit_logs", "actor_login")
+    op.drop_column("audit_logs", "origin")
+    op.drop_column("audit_logs", "actor_type")

--- a/alembic/versions/c17aecf92ac8_add_apply_then_merge_schema.py
+++ b/alembic/versions/c17aecf92ac8_add_apply_then_merge_schema.py
@@ -1,0 +1,103 @@
+"""add apply-then-merge schema (#282)
+
+Phase 1 of apply-then-merge: adds the new workspace columns
+(`vcs_workflow`, `auto_merge`, `auto_merge_strategy`), the new nullable
+run columns (`vcs_apply_blocked_reason`, `vcs_actor_login`,
+`vcs_actor_user_id`), and the `pr_sessions` table that tracks the
+edit-in-place status comment + poll cursors for each open PR.
+
+No behavioural change — purely the data model for subsequent phases.
+
+Revision ID: c17aecf92ac8
+Revises: a10f40e65a96
+Create Date: 2026-05-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "c17aecf92ac8"
+down_revision: str | None = "a10f40e65a96"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Workspace: VCS workflow mode + auto-merge config.
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "vcs_workflow",
+            sa.String(20),
+            nullable=False,
+            server_default="merge_then_apply",
+        ),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("auto_merge", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "auto_merge_strategy",
+            sa.String(20),
+            nullable=False,
+            server_default="merge",
+        ),
+    )
+
+    # Run: apply-blocked reason + VCS actor for comment-driven actions.
+    op.add_column(
+        "runs",
+        sa.Column("vcs_apply_blocked_reason", sa.String(500), nullable=True),
+    )
+    op.add_column("runs", sa.Column("vcs_actor_login", sa.String(255), nullable=True))
+    op.add_column("runs", sa.Column("vcs_actor_user_id", sa.String(64), nullable=True))
+
+    # PR conversation state (status comment + poll cursors + lifecycle).
+    op.create_table(
+        "pr_sessions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "vcs_connection_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("vcs_connections.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("repo", sa.String(500), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=False),
+        sa.Column("head_sha", sa.String(40), nullable=False, server_default=""),
+        sa.Column("status_comment_id", sa.String(64), nullable=True),
+        sa.Column("last_processed_comment_id", sa.String(64), nullable=True),
+        sa.Column("last_processed_review_id", sa.String(64), nullable=True),
+        sa.Column("state", sa.String(20), nullable=False, server_default="open"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("vcs_connection_id", "repo", "pr_number", name="uq_pr_session"),
+    )
+    op.create_index("ix_pr_sessions_open", "pr_sessions", ["vcs_connection_id", "state"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pr_sessions_open", table_name="pr_sessions")
+    op.drop_table("pr_sessions")
+    op.drop_column("runs", "vcs_actor_user_id")
+    op.drop_column("runs", "vcs_actor_login")
+    op.drop_column("runs", "vcs_apply_blocked_reason")
+    op.drop_column("workspaces", "auto_merge_strategy")
+    op.drop_column("workspaces", "auto_merge")
+    op.drop_column("workspaces", "vcs_workflow")

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | **Remote State Management** | Versioned state storage with locking, rollback, encryption at rest via CSP services |
 | **Agent Execution** | Plan/apply runs on the server via K8s Job-based runner infrastructure |
 | **VCS Integration** | GitHub (App) and GitLab (access token); polling-first with optional webhooks |
+| **VCS Workflows** | Default merge-then-apply (TFE standard) plus opt-in apply-then-merge mode (Atlantis-style: PR comments drive applies, `terrapod apply` from a PR comment, auto-merge after apply) |
 | **Variables & Secrets** | Per-workspace env and Terraform variables; sensitive values protected by database encryption-at-rest; variable sets |
 | **RBAC** | Label-based role system with hierarchical workspace permissions (read/plan/write/admin) |
 | **Private Registry** | Publish, version, and share modules and providers internally with pull-through caching |
@@ -80,6 +81,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Authentication](authentication.md) | Local auth, OIDC, SAML, terraform login, API tokens |
 | [RBAC](rbac.md) | Permission model, label-based access control, custom roles |
 | [VCS Integration](vcs-integration.md) | GitHub and GitLab setup, polling, webhooks |
+| [VCS Workflows](vcs-workflows.md) | merge_then_apply (default) vs apply_then_merge (Atlantis-style, opt-in) |
 | [Autodiscovery](autodiscovery.md) | Atlantis-style monorepo workspace autodiscovery |
 | [Drift Detection](drift-detection.md) | Scheduled plan-only runs to detect infrastructure drift |
 | [Run Triggers](run-triggers.md) | Cross-workspace dependency chains |

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -131,11 +131,12 @@ GitHub integration uses a **GitHub App** for fine-grained permissions and org-le
 
    | Permission | Access | Purpose |
    |---|---|---|
-   | **Contents** | Read-only | Download repository archives |
+   | **Contents** | Read-only (read & write if using apply-then-merge auto-merge — see [VCS Workflows](vcs-workflows.md)) | Download repository archives; merging PRs creates a commit on the target branch |
    | **Metadata** | Read-only (auto-selected) | Repository metadata |
    | **Checks** | Read & write | Post check runs on commits |
    | **Commit statuses** | Read & write | Post plan/apply status to commits |
-   | **Pull requests** | Read & write | Post and update PR comments |
+   | **Pull requests** | Read & write | Post and update PR comments, read mergeability state |
+   | **Issues** | Read & write (only if using apply-then-merge) | Receive and post PR comments — GitHub serves PR comments through the Issues API |
 
    ![GitHub App Permissions](images/github-app-permissions.png)
 

--- a/docs/vcs-workflows.md
+++ b/docs/vcs-workflows.md
@@ -125,11 +125,14 @@ If you configure webhooks, the same events arrive in seconds instead of up to on
 
 ## GitHub App permissions
 
-If you're moving an existing Terrapod installation onto apply-then-merge, the GitHub App needs one additional permission:
+If you're moving an existing Terrapod installation onto apply-then-merge, the GitHub App needs two permission upgrades:
 
 | Permission | Required for |
 |---|---|
 | **Issues: Read & Write** | Posting and reading PR comments (PR comments use GitHub's Issues API) |
+| **Contents: Read & Write** | Performing the auto-merge / `terrapod merge`. GitHub's `PUT /repos/{o}/{r}/pulls/{n}/merge` endpoint creates a commit on the target branch, which requires `contents: write` — verified via the `X-Accepted-GitHub-Permissions` response header. Note that this is *Contents*, not *Pull requests* (which `Read` is sufficient for, since the App reads PR state but doesn't modify it). |
+
+If you only need apply-then-merge without auto-merge or `terrapod merge`, `Contents: Read` is sufficient — the apply phase doesn't touch the merge API.
 
 Webhook event subscriptions:
 - `issue_comment` — receive `terrapod ...` commands sub-second

--- a/docs/vcs-workflows.md
+++ b/docs/vcs-workflows.md
@@ -1,0 +1,161 @@
+# VCS Workflows
+
+Terrapod offers two workflow modes per workspace for how PR/MR changes drive runs and merges.
+
+## Credit and positioning
+
+[Atlantis](https://www.runatlantis.io/) pioneered the apply-then-merge workflow described below. Almost every concept on this page — comment-driven applies, per-project locks, mergeability gating, automerge — comes from Atlantis, and we are following their model deliberately because it is the right model and the community already understands it.
+
+Terrapod offers apply-then-merge as one workflow inside a broader platform. **Atlantis remains the right tool for many users** — teams who want a focused GitOps-only workflow with no separate platform UI, teams who don't need state management / RBAC / a registry / audit logs, and teams whose mental model is *"my Terraform automation lives in my PR comments, full stop"*. If apply-then-merge from PR comments is *all* you need, Atlantis is likely the better fit and we recommend evaluating it first.
+
+If you also want a UI, state management, label-based RBAC, a private registry, audit logs, and the option to mix this with a more traditional merge-then-apply workflow, that's where Terrapod earns its keep.
+
+## The two modes
+
+| Mode | Run on PR/MR push | Apply runs against | Merge happens | Authorization | Where it shines |
+|---|---|---|---|---|---|
+| **merge_then_apply** (default — TFE/HCP standard) | speculative plan-only | merged commit on the default branch | before apply | Terrapod RBAC | central control plane; protected default branch is the source of truth |
+| **apply_then_merge** (opt-in — Atlantis standard) | full plan-and-apply with saved tfplan | the PR/MR head commit | after a successful apply | **VCS repo permissions + branch protection** | per-PR review of real diff and apply outcome before code lands |
+
+The toggle lives on each workspace (`vcs_workflow`); flipping it is a deliberate operational decision and is rejected while PR runs are in flight on that workspace.
+
+## Authorization model for apply-then-merge — read this carefully
+
+> If you can merge the PR, you can apply it.
+
+In `apply_then_merge` mode, **Terrapod's role-based and label-based RBAC do not apply to comment-driven actions.** Authorization is delegated to your VCS provider:
+
+- Anyone who can comment on the PR can issue `terrapod apply`.
+- The apply only proceeds when the PR's mergeability state is clean — branch protection (required reviews, status checks, code owner approval) becomes the gate.
+- Audit log entries for comment-driven actions reference the **VCS user id and login** directly; there is no Terrapod identity in the chain.
+
+This is deliberate and matches Atlantis exactly. It sidesteps a brittle mapping between VCS identities and Terrapod identities, and means there's a single source of truth for who can change infra: the repo's branch-protection settings.
+
+**Recommended**: configure branch protection to **require a linear history** (rebase or squash before merge). Apply-then-merge applies against the PR head commit; if the PR is behind the default branch, the apply outcome may diverge from what eventually merges. With required-linear-history, the PR head is what gets merged, so the commit you applied is the commit that lands.
+
+The workspace settings page surfaces this contract as a banner when you switch a workspace into `apply_then_merge`.
+
+## How apply-then-merge runs work
+
+A PR push in `apply_then_merge` mode does **not** trigger a speculative plan-only run. It triggers a **full run that saves the plan file**, then sits in `planned` waiting on a user action. When the user comments `terrapod apply`, the apply phase consumes the exact saved tfplan — so the user reviews and approves the same plan that gets applied, with no re-plan in between.
+
+```
+PR opened / pushed
+    ↓
+full run created (NOT speculative), workspace lock acquired
+    ↓
+plan phase runs → tfplan saved to storage
+    ↓
+status comment posted on PR: summary + "Run `terrapod apply` to apply these changes"
+    ↓
+[run sits in `planned`, workspace remains locked]
+    ↓
+user comments `terrapod apply`
+    ↓
+mergeability check (branch protection, required reviews, …)
+    ↓
+apply phase runs against the saved tfplan
+    ↓
+if auto_merge: merge PR; if not: comment prompts `terrapod merge`
+    ↓
+workspace lock released
+```
+
+If a user pushes a new commit before apply, the existing run is canceled and a new full run is created — same workspace lock, new plan, new tfplan.
+
+### Lock semantics — this is the tradeoff
+
+While a PR's run sits in `planned`, the **workspace is locked**. A second PR touching the same workspace can't plan until the first PR is merged, discarded, or its run is canceled. The PR comment thread explains the wait.
+
+This matches Atlantis's per-project lock and is the price of "the user reviews the exact plan that gets applied". For workspaces with many concurrent PRs, consider whether `merge_then_apply` (with its speculative plans not holding the lock) is a better fit.
+
+### Stale-plan handling
+
+`tofu apply tfplan` refuses to apply if state drifted between plan and apply (e.g. a sibling PR applied and changed state). Terrapod surfaces that on the PR comment with a prompt to comment `terrapod plan` to refresh. No bespoke staleness logic — we lean on the tool.
+
+## PR comment vocabulary
+
+Commands must start with `terrapod` (or the configured mention prefix — e.g. `@terrapod-bot`) at the beginning of a line. Mid-sentence mentions are ignored.
+
+| Command | Effect |
+|---|---|
+| `terrapod plan` | Cancel the current run + plan a fresh one against the PR head |
+| `terrapod plan -W <workspace>` | Same, scoped to one workspace (monorepo) |
+| `terrapod apply` | Apply the current `planned` run for all PR-affected workspaces |
+| `terrapod apply -W <workspace>` | Apply a single workspace |
+| `terrapod unlock` | Release the workspace lock if stuck |
+| `terrapod merge` | Force-merge despite incomplete applies (audit-logged) |
+| `terrapod help` | List commands |
+
+Code-fenced blocks don't match — discussing the bot in a code sample never accidentally triggers a command.
+
+## Status comment
+
+One Terrapod-authored comment per PR, edited in place:
+
+```
+| Workspace             | Mode             | Plan      | Apply       | Mergeable |
+|---|---|---|---|---|
+| accounts-alpha-net    | apply_then_merge | + 3 ~ 1   | applied     | yes       |
+| accounts-beta-compute | apply_then_merge | + 0 ~ 2   | not applied | yes       |
+| shared-network        | merge_then_apply | + 0 ~ 0   | will apply on merge | yes |
+
+Comment `terrapod apply -W accounts-beta-compute` to apply remaining changes.
+Auto-merge will fire when all workspaces are applied.
+```
+
+The table covers every workspace whose runs reference this PR, regardless of mode. `merge_then_apply` workspaces show "will apply on merge" in the Apply column to make the mode distinction explicit.
+
+## Monorepo behaviour
+
+A PR can touch multiple workspaces. `terrapod apply` (no `-W`) operates on all apply-then-merge workspaces ready to apply, in the order their plans finish. `-W <name>` scopes to one.
+
+**Auto-merge** fires only when every PR-affected workspace meets its per-mode required state:
+
+- `apply_then_merge` → successful applied run for the head SHA (or `has_changes=false`, which auto-counts)
+- `merge_then_apply` → speculative plan succeeded
+
+If the user wants to merge despite incomplete applies, `terrapod merge` is the force escape hatch. The per-workspace state at merge time is recorded in the audit log; unapplied workspaces get a banner on their detail page indicating known drift between code and infrastructure.
+
+## Webhook + polling
+
+Hook-and-poll: webhooks accelerate, polling is the source of truth. Every behaviour described here works without webhooks configured — Terrapod's poll cycle (default 60s) handles new commits, new comments, new reviews, and PR-closed events.
+
+If you configure webhooks, the same events arrive in seconds instead of up to one poll interval. Either path produces the same outcome; a Redis dedup key ensures each command is processed exactly once even when webhook and poll race.
+
+## GitHub App permissions
+
+If you're moving an existing Terrapod installation onto apply-then-merge, the GitHub App needs one additional permission:
+
+| Permission | Required for |
+|---|---|
+| **Issues: Read & Write** | Posting and reading PR comments (PR comments use GitHub's Issues API) |
+
+Webhook event subscriptions:
+- `issue_comment` — receive `terrapod ...` commands sub-second
+- `pull_request_review` — refresh mergeability after approvals
+
+Existing installations have to accept the permission upgrade once via the GitHub org-admin UI. Until accepted, default-mode workflows are completely unaffected; apply-then-merge is simply unavailable.
+
+## GitLab token scope
+
+Project / Group access tokens need `api` scope (the existing requirement covers the new endpoints). Webhook events: enable `Comments` and `Merge request events`.
+
+## Troubleshooting
+
+**"Apply blocked by mergeability"** — your branch protection rejected the apply. Read the reason on the PR status comment (or the run detail page). Fix on the VCS side (resolve conflicts / get approval / rerun status checks), then comment `terrapod apply` again.
+
+**"PR #X currently holds the lock"** — another PR is mid-flight on the same workspace. Wait for it to merge/discard, or merge/discard it yourself, then push your PR to retrigger the plan.
+
+**Stale plan after a sibling apply** — `terrapod plan` to replan against the new state, then `terrapod apply`.
+
+**Comment didn't trigger anything** — check (a) the comment starts with `terrapod` at the beginning of a line, (b) the verb is one of the supported commands, (c) the workspace is in `apply_then_merge` mode, (d) the GitHub App has Issues permission accepted, (e) `tilt logs` (local) or `kubectl logs` (cluster) on the API pod for `vcs_comment_dispatch` events.
+
+**Workflow flip rejected** — you can't change `vcs_workflow` while PR runs are in flight on the workspace. Cancel or merge those PR runs first.
+
+## See also
+
+- [Atlantis docs](https://www.runatlantis.io/docs/using-atlantis.html) — the prior art
+- [`docs/vcs-integration.md`](vcs-integration.md) — VCS connection setup
+- [`docs/rbac.md`](rbac.md) — Terrapod's RBAC (which does *not* gate comment-driven applies)
+- [`docs/audit-logging.md`](audit-logging.md) — dual-actor audit model

--- a/provider/internal/resources/workspace/model.go
+++ b/provider/internal/resources/workspace/model.go
@@ -66,6 +66,9 @@ type workspaceModel struct {
 	VCSRepoURL                    types.String `tfsdk:"vcs_repo_url"`
 	VCSBranch                     types.String `tfsdk:"vcs_branch"`
 	VCSConnectionID               types.String `tfsdk:"vcs_connection_id"`
+	VCSWorkflow                   types.String `tfsdk:"vcs_workflow"`
+	AutoMerge                     types.Bool   `tfsdk:"auto_merge"`
+	AutoMergeStrategy             types.String `tfsdk:"auto_merge_strategy"`
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
 	VarFiles                      types.List   `tfsdk:"var_files"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -115,6 +115,30 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "VCS connection ID (e.g. vcs-abc123).",
 				Optional:    true,
 			},
+			"vcs_workflow": schema.StringAttribute{
+				Description: "VCS workflow mode: `merge_then_apply` (default, TFE/HCP standard) or `apply_then_merge` (Atlantis-style; PR runs are full plan-and-apply that wait on a `terrapod apply` comment). Apply-then-merge requires a VCS connection and is incompatible with `auto_apply=true`.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"auto_merge": schema.BoolAttribute{
+				Description: "If true, Terrapod merges the PR/MR after a successful apply (subject to branch protection). Default: false.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"auto_merge_strategy": schema.StringAttribute{
+				Description: "Merge strategy for auto-merge: `merge` (default), `squash`, or `rebase`.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"agent_pool_id": schema.StringAttribute{
 				Description: "Agent pool ID for agent execution mode.",
 				Optional:    true,
@@ -356,6 +380,15 @@ func buildWorkspaceAttrs(m *workspaceModel) map[string]any {
 	if !m.VCSBranch.IsNull() {
 		attrs["vcs-branch"] = m.VCSBranch.ValueString()
 	}
+	if !m.VCSWorkflow.IsNull() && !m.VCSWorkflow.IsUnknown() {
+		attrs["vcs-workflow"] = m.VCSWorkflow.ValueString()
+	}
+	if !m.AutoMerge.IsNull() && !m.AutoMerge.IsUnknown() {
+		attrs["auto-merge"] = m.AutoMerge.ValueBool()
+	}
+	if !m.AutoMergeStrategy.IsNull() && !m.AutoMergeStrategy.IsUnknown() {
+		attrs["auto-merge-strategy"] = m.AutoMergeStrategy.ValueString()
+	}
 	if !m.AgentPoolID.IsNull() {
 		attrs["agent-pool-id"] = m.AgentPoolID.ValueString()
 	}
@@ -403,6 +436,9 @@ func readResourceIntoModel(ctx context.Context, res *client.Resource, m *workspa
 	m.WorkingDirectory = types.StringValue(client.GetStringAttr(res, "working-directory"))
 	m.ResourceCPU = types.StringValue(client.GetStringAttr(res, "resource-cpu"))
 	m.ResourceMemory = types.StringValue(client.GetStringAttr(res, "resource-memory"))
+	m.VCSWorkflow = types.StringValue(client.GetStringAttr(res, "vcs-workflow"))
+	m.AutoMerge = types.BoolValue(client.GetBoolAttr(res, "auto-merge"))
+	m.AutoMergeStrategy = types.StringValue(client.GetStringAttr(res, "auto-merge-strategy"))
 	m.OwnerEmail = types.StringValue(client.GetStringAttr(res, "owner-email"))
 	m.Locked = types.BoolValue(client.GetBoolAttr(res, "locked"))
 	m.CreatedAt = types.StringValue(client.GetStringAttr(res, "created-at"))

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -123,6 +123,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             description="Post VCS status when module-test run completes",
         )
 
+    # VCS comment dispatcher (#282 apply-then-merge). Always registered —
+    # it's a no-op for comments on PRs without an apply-then-merge workspace.
+    from terrapod.services.vcs_command_dispatcher import handle_vcs_comment_dispatch
+
+    register_trigger_handler(
+        "vcs_comment_dispatch",
+        handler=handle_vcs_comment_dispatch,
+        description="Parse and dispatch `terrapod ...` PR/MR comments",
+    )
+
     # Notification delivery handler (always registered)
     from terrapod.services.notification_dispatcher import handle_notification_delivery
 

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -139,6 +139,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         description="Edit-in-place PR status comment for apply-then-merge PRs",
     )
 
+    from terrapod.services.vcs_auto_merge import handle_vcs_apply_completed
+
+    register_trigger_handler(
+        "vcs_apply_completed",
+        handler=handle_vcs_apply_completed,
+        description="Cross-workspace merge gate evaluation + auto-merge",
+    )
+
     # Notification delivery handler (always registered)
     from terrapod.services.notification_dispatcher import handle_notification_delivery
 

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -126,11 +126,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # VCS comment dispatcher (#282 apply-then-merge). Always registered —
     # it's a no-op for comments on PRs without an apply-then-merge workspace.
     from terrapod.services.vcs_command_dispatcher import handle_vcs_comment_dispatch
+    from terrapod.services.vcs_status_comment import handle_vcs_status_comment_update
 
     register_trigger_handler(
         "vcs_comment_dispatch",
         handler=handle_vcs_comment_dispatch,
         description="Parse and dispatch `terrapod ...` PR/MR comments",
+    )
+    register_trigger_handler(
+        "vcs_status_comment_update",
+        handler=handle_vcs_status_comment_update,
+        description="Edit-in-place PR status comment for apply-then-merge PRs",
     )
 
     # Notification delivery handler (always registered)

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -532,6 +532,12 @@ async def confirm_run(
     try:
         run = await run_service.confirm_run(db, run)
         await db.commit()
+    except run_service.ApplyBlocked as e:
+        # Mergeability gate rejected (apply-then-merge mode). `vcs_apply_blocked_reason`
+        # is already persisted on the run by the gate; the 422 surfaces the
+        # provider's own language to the API caller (web UI, terraform CLI).
+        await db.commit()
+        raise HTTPException(status_code=422, detail=str(e.reason)) from e
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
     return JSONResponse(content=_run_json(run))

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -605,6 +605,9 @@ def _workspace_json(
                 "vcs-last-polled-at": _rfc3339(ws.vcs_last_polled_at),
                 "vcs-last-error": ws.vcs_last_error,
                 "vcs-last-error-at": _rfc3339(ws.vcs_last_error_at),
+                "vcs-workflow": ws.vcs_workflow,
+                "auto-merge": ws.auto_merge,
+                "auto-merge-strategy": ws.auto_merge_strategy,
                 "latest-run": latest_run_attr,
                 "agent-pool-id": f"apool-{ws.agent_pool_id}" if ws.agent_pool_id else None,
                 "agent-pool-name": ws.agent_pool.name if ws.agent_pool else None,
@@ -1119,6 +1122,76 @@ async def update_workspace(
         ws.execution_mode = attrs["execution-mode"]
     if "auto-apply" in attrs:
         ws.auto_apply = attrs["auto-apply"]
+
+    # VCS workflow + auto-merge (#282). We only validate when the relevant
+    # fields are actually being touched in this PATCH — unrelated updates
+    # (drift, pool assignment, labels) must not pay the cross-validation
+    # tax or fail it.
+    if "vcs-workflow" in attrs:
+        new_workflow = attrs["vcs-workflow"]
+        if new_workflow not in ("merge_then_apply", "apply_then_merge"):
+            raise HTTPException(
+                status_code=422,
+                detail="vcs-workflow must be 'merge_then_apply' or 'apply_then_merge'",
+            )
+        # Flipping vcs_workflow while PR runs are in-flight is rejected
+        # (Q4 in #282): the operator must explicitly cancel/discard them
+        # first.
+        if new_workflow != ws.vcs_workflow:
+            active = await db.execute(
+                select(Run.id).where(
+                    Run.workspace_id == ws.id,
+                    Run.vcs_pull_request_number.isnot(None),
+                    Run.status.in_(("pending", "queued", "planning", "planned", "applying")),
+                )
+            )
+            active_ids = [str(r[0]) for r in active.all()]
+            if active_ids:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Cannot change vcs-workflow while {len(active_ids)} PR run(s) "
+                        "are in flight. Cancel or discard them first."
+                    ),
+                )
+        ws.vcs_workflow = new_workflow
+
+    # Cross-field invariants for apply_then_merge mode — checked against
+    # the post-update state so the user can flip vcs_workflow and
+    # auto_apply in one PATCH.
+    pending_workflow = ws.vcs_workflow
+    pending_auto_apply = attrs.get("auto-apply", ws.auto_apply)
+    if pending_workflow == "apply_then_merge" and (
+        "vcs-workflow" in attrs or "auto-apply" in attrs
+    ):
+        if ws.vcs_connection_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "vcs-workflow 'apply_then_merge' requires a VCS connection — "
+                    "configure the workspace's VCS settings first"
+                ),
+            )
+        if pending_auto_apply:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "vcs-workflow 'apply_then_merge' is incompatible with auto-apply — "
+                    "set auto-apply to false in the same request"
+                ),
+            )
+
+    if "auto-merge" in attrs:
+        ws.auto_merge = bool(attrs["auto-merge"])
+    if "auto-merge-strategy" in attrs:
+        strat = attrs["auto-merge-strategy"]
+        if strat not in ("merge", "squash", "rebase"):
+            raise HTTPException(
+                status_code=422,
+                detail="auto-merge-strategy must be 'merge', 'squash', or 'rebase'",
+            )
+        ws.auto_merge_strategy = strat
+
     if "execution-backend" in attrs:
         backend = attrs["execution-backend"]
         if backend not in ("terraform", "tofu"):

--- a/services/terrapod/api/routers/vcs_events.py
+++ b/services/terrapod/api/routers/vcs_events.py
@@ -2,7 +2,8 @@
 
 Only active when a webhook secret is configured. Validates HMAC signature
 and enqueues a triggered immediate poll via the distributed scheduler.
-The poller does all the real work.
+The poller does all the real work — webhooks are an accelerator, not the
+source of truth (hook-and-poll model per #282).
 
 Endpoints:
     POST /api/terrapod/v1/vcs-events/github   (GitHub webhook receiver)
@@ -12,8 +13,11 @@ import json
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
+from sqlalchemy import select
 
 from terrapod.config import settings
+from terrapod.db.models import VCSConnection
+from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services.github_service import validate_webhook_signature
 from terrapod.services.scheduler import enqueue_trigger
@@ -22,13 +26,43 @@ router = APIRouter(tags=["vcs-events"])
 logger = get_logger(__name__)
 
 
+async def _resolve_connection(installation_id: int) -> VCSConnection | None:
+    """Look up the VCSConnection corresponding to an incoming installation id.
+
+    Returns None if no connection matches. The receiver rejects unknown
+    installations with 404 so a webhook from an installation Terrapod
+    doesn't have a connection for can't enqueue spurious work (Q10 fix
+    in #282).
+    """
+    if not installation_id:
+        return None
+    async with get_db_session() as db:
+        result = await db.execute(
+            select(VCSConnection).where(
+                VCSConnection.provider == "github",
+                VCSConnection.github_installation_id == installation_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+
 @router.post("/vcs-events/github")
 async def github_webhook(request: Request) -> Response:
     """Receive GitHub webhook events.
 
     Validates HMAC-SHA256 signature when webhook_secret is configured.
-    Enqueues an immediate poll via the distributed scheduler so any
-    replica can pick it up.
+    Resolves the incoming `installation.id` to a known VCSConnection and
+    rejects unknown installations. Enqueues a triggered task via the
+    distributed scheduler so any replica can pick it up.
+
+    Events handled:
+      - ping: handshake (acks with pong)
+      - push, pull_request: immediate-poll trigger (existing behaviour)
+      - issue_comment: parse for `terrapod ...` command (#282)
+      - pull_request_review: re-evaluate mergeability gate (#282)
+      - pull_request:closed (action): release any locks held by planned
+        runs on this PR (#282, hook fast path for the poller's
+        _reconcile_closed_pr_sessions)
     """
     # Check if webhooks are configured
     if not settings.vcs.github.webhook_secret:
@@ -51,7 +85,6 @@ async def github_webhook(request: Request) -> Response:
         logger.info("GitHub webhook ping received")
         return JSONResponse(content={"message": "pong"})
 
-    # For push and pull_request events, extract the repo and trigger a poll
     try:
         body = json.loads(payload)
     except json.JSONDecodeError:
@@ -60,38 +93,97 @@ async def github_webhook(request: Request) -> Response:
     repo = body.get("repository", {})
     full_name = repo.get("full_name", "")
 
+    # Resolve installation.id → VCSConnection. Reject unknown
+    # installations so a webhook from an unrelated installation can't
+    # enqueue work even if it knows the global webhook secret (Q10 in
+    # #282). The poll still serves as the source of truth — this just
+    # closes the noise / abuse vector at the webhook surface.
+    installation_id = (body.get("installation") or {}).get("id", 0)
+    conn = await _resolve_connection(installation_id)
+    if conn is None:
+        logger.info(
+            "Webhook event for unknown installation",
+            event_type=event_type,
+            installation_id=installation_id,
+            repo=full_name,
+        )
+        # 200 (not 404) so GitHub doesn't keep retrying — we'll re-
+        # process organically via polling if a connection is added.
+        return JSONResponse(content={"message": "unknown installation"})
+
     if not full_name:
         logger.debug("Webhook event without repository", event_type=event_type)
         return JSONResponse(content={"message": "ignored"})
 
-    if event_type in ("push", "pull_request"):
-        from terrapod.api.metrics import VCS_WEBHOOK_RECEIVED
+    from terrapod.api.metrics import VCS_WEBHOOK_RECEIVED
 
+    if event_type in ("push", "pull_request"):
         VCS_WEBHOOK_RECEIVED.labels(provider="github").inc()
-        logger.info(
-            "Webhook event received",
-            event_type=event_type,
-            repo=full_name,
-        )
-        # Enqueue via scheduler — any replica can pick this up.
-        # Dedup key prevents duplicate polls for rapid-fire webhook events.
-        # `provider` scopes the poll to GitHub workspaces so a GitHub
-        # push on owner/repo doesn't match a GitLab workspace tracking
-        # a same-named gitlab.com/owner/repo.
+        logger.info("Webhook event received", event_type=event_type, repo=full_name)
+        # Enqueue an immediate poll. The poller picks up everything
+        # downstream including (in apply-then-merge mode) creating
+        # full-run-with-tfplan for new PR head SHAs and reconciling
+        # closed PRs.
         await enqueue_trigger(
             "vcs_immediate_poll",
             {"repo": full_name, "provider": "github"},
             dedup_key=f"vcs_poll:github:{full_name}",
         )
-        # Also trigger module impact analysis for VCS-connected modules.
-        # The module-impact consumer runs a full cycle over all linked
-        # modules regardless of source, so leave the payload/dedup key
-        # unscoped — adding a `github:` prefix here would just churn
-        # Redis key space without any filtering benefit.
         await enqueue_trigger(
             "module_impact_immediate_poll",
             {"repo": full_name},
             dedup_key=f"module_impact_poll:{full_name}",
         )
+
+    elif event_type == "issue_comment":
+        # GitHub fires `issue_comment` for both PR comments and plain
+        # issue comments. We only want the PR variety. Filter via
+        # `payload.issue.pull_request` (present only on PR comments).
+        issue = body.get("issue") or {}
+        if "pull_request" not in issue:
+            return JSONResponse(content={"message": "ignored (not a PR comment)"})
+        action = body.get("action")
+        if action not in ("created", "edited"):
+            return JSONResponse(content={"message": f"ignored ({action})"})
+        comment = body.get("comment") or {}
+        pr_number = issue.get("number")
+        if not pr_number:
+            return JSONResponse(content={"message": "ignored (missing PR number)"})
+        VCS_WEBHOOK_RECEIVED.labels(provider="github").inc()
+        # Dispatch via scheduler with dedup keyed on the comment id so a
+        # webhook/poll race only runs the dispatch once.
+        await enqueue_trigger(
+            "vcs_comment_dispatch",
+            {
+                "connection_id": str(conn.id),
+                "repo": full_name,
+                "pr_number": pr_number,
+                "comment_id": str(comment.get("id", "")),
+                "actor_login": (comment.get("user") or {}).get("login", ""),
+                "actor_user_id": str((comment.get("user") or {}).get("id", "")),
+                "body": comment.get("body") or "",
+            },
+            dedup_key=f"vcs_cmd:{conn.id}:{full_name}:{pr_number}:{comment.get('id')}",
+        )
+
+    elif event_type == "pull_request_review":
+        # Reviews can flip mergeability state (approved → no longer
+        # blocked by "review required"). We don't auto-resume the
+        # previously-blocked apply (Q3 design decision); just trigger
+        # an immediate poll so the status comment can refresh.
+        VCS_WEBHOOK_RECEIVED.labels(provider="github").inc()
+        await enqueue_trigger(
+            "vcs_immediate_poll",
+            {"repo": full_name, "provider": "github"},
+            dedup_key=f"vcs_poll:github:{full_name}",
+        )
+
+    elif event_type == "pull_request" and body.get("action") == "closed":
+        # Already handled in the (push, pull_request) branch above —
+        # this elif is unreachable because the above branch matches
+        # event_type == 'pull_request' first. Left as documentation:
+        # the poller's _reconcile_closed_pr_sessions handles the close
+        # cleanup; the immediate poll triggered above runs it sub-second.
+        pass
 
     return JSONResponse(content={"message": "accepted"})

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -309,6 +309,26 @@ class Workspace(Base):
         ARRAY(String(255)), nullable=False, server_default="{}"
     )
 
+    # VCS workflow mode — see #282 + docs/vcs-workflows.md
+    # - merge_then_apply (default, TFE/HCP standard): PR runs are speculative;
+    #   apply happens against the merged commit on the default branch.
+    # - apply_then_merge (Atlantis standard, opt-in): PR runs are full
+    #   plan-and-apply with saved tfplan; apply runs against the PR head and
+    #   the user drives apply via PR comments.
+    vcs_workflow: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="merge_then_apply", default="merge_then_apply"
+    )
+
+    # Auto-merge after apply succeeds. Available in both modes; primary use is
+    # apply_then_merge. When all PR-affected workspaces meet their per-mode
+    # required state, the merge fires via the VCS provider's merge API.
+    auto_merge: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false", default=False
+    )
+    auto_merge_strategy: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="merge", default="merge"
+    )  # merge, squash, rebase
+
     # Drift detection
     drift_detection_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     drift_detection_interval_seconds: Mapped[int] = mapped_column(
@@ -852,6 +872,61 @@ class AutodiscoveryRule(Base):
     )
 
 
+class PRSession(Base):
+    """Conversation state for one PR/MR in apply-then-merge mode (#282).
+
+    Tracks the edit-in-place status comment, the current head SHA, the
+    poll cursors for comments/reviews, and the lifecycle state of the PR.
+    One row per (connection, repo, pr_number). Created lazily when the
+    first apply-then-merge workspace plans against the PR.
+    """
+
+    __tablename__ = "pr_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=generate_uuid7
+    )
+
+    vcs_connection_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("vcs_connections.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    vcs_connection: Mapped["VCSConnection"] = relationship(
+        "VCSConnection", foreign_keys=[vcs_connection_id], lazy="joined"
+    )
+    repo: Mapped[str] = mapped_column(String(500), nullable=False)  # owner/name
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    head_sha: Mapped[str] = mapped_column(String(40), nullable=False, default="")
+
+    # Edit-in-place status comment id from the VCS provider (string because
+    # GitHub uses int64s but GitLab and other providers may differ).
+    status_comment_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    # Poll cursors — last item we've processed via webhook or poll, so the
+    # poll fallback doesn't re-dispatch already-handled events. Strings to
+    # accommodate provider-specific id shapes.
+    last_processed_comment_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_processed_review_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    # PR lifecycle state. Mirrors the VCS provider's notion: open, closed
+    # (without merge), or merged. Closed/merged sessions are kept for
+    # historical audit but don't dispatch commands.
+    state: Mapped[str] = mapped_column(String(20), nullable=False, default="open")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+    )
+
+    __table_args__ = (
+        sa.UniqueConstraint("vcs_connection_id", "repo", "pr_number", name="uq_pr_session"),
+        sa.Index("ix_pr_sessions_open", "vcs_connection_id", "state"),
+    )
+
+
 # --- Variables ---
 
 
@@ -1091,6 +1166,15 @@ class Run(Base):
     vcs_commit_sha: Mapped[str] = mapped_column(String(40), nullable=False, default="")
     vcs_branch: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     vcs_pull_request_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Apply-then-merge bookkeeping (#282)
+    # Populated when the apply gate rejects (e.g. branch protection blocks merge);
+    # surfaced on the run UI and on the PR status comment.
+    vcs_apply_blocked_reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # VCS-side actor for comment-driven actions. Recorded directly (no Terrapod
+    # identity mapping) — see "Authorization model" in #282.
+    vcs_actor_login: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    vcs_actor_user_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     plan_started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     plan_finished_at: Mapped[datetime | None] = mapped_column(

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -1225,14 +1225,30 @@ class AuditLog(Base):
     actor_email: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     actor_ip: Mapped[str] = mapped_column(String(45), nullable=False, default="")
     action: Mapped[str] = mapped_column(
-        String(20), nullable=False
-    )  # HTTP method: GET, POST, PATCH, DELETE
+        String(40), nullable=False
+    )  # HTTP method for API events; verb (apply/plan/merge/...) for VCS events
     resource_type: Mapped[str] = mapped_column(String(63), nullable=False, default="")
     resource_id: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     status_code: Mapped[int] = mapped_column(Integer, nullable=False)
     request_id: Mapped[str] = mapped_column(String(63), nullable=False, default="")
     duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     detail: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    # Dual-actor model (#282).
+    # - actor_type: "terrapod_user" (HTTP/UI/API), "vcs_user" (PR comment),
+    #   "system" (background tasks).
+    # - origin: "api", "terrapod_ui", "pr_comment", "system".
+    # - actor_login: VCS-side display login (e.g. GitHub username) when
+    #   actor_type is vcs_user; empty otherwise.
+    # - actor_id: provider-side immutable user id (e.g. GitHub user id) when
+    #   actor_type is vcs_user; empty otherwise.
+    actor_type: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="terrapod_user"
+    )
+    origin: Mapped[str] = mapped_column(String(20), nullable=False, server_default="api")
+    actor_login: Mapped[str] = mapped_column(String(255), nullable=False, server_default="")
+    actor_id: Mapped[str] = mapped_column(String(64), nullable=False, server_default="")
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, nullable=False
     )
@@ -1241,6 +1257,7 @@ class AuditLog(Base):
         Index("ix_audit_logs_timestamp", "timestamp"),
         Index("ix_audit_logs_actor_email", "actor_email"),
         Index("ix_audit_logs_resource", "resource_type", "resource_id"),
+        Index("ix_audit_logs_actor_type", "actor_type"),
     )
 
 

--- a/services/terrapod/services/audit_service.py
+++ b/services/terrapod/services/audit_service.py
@@ -70,8 +70,18 @@ async def log_audit_event(
     request_id: str = "",
     duration_ms: int = 0,
     detail: str = "",
+    actor_type: str = "terrapod_user",
+    origin: str = "api",
+    actor_login: str = "",
+    actor_id: str = "",
 ) -> None:
-    """Insert an audit log entry."""
+    """Insert an audit log entry.
+
+    Dual-actor model (#282): set `actor_type='vcs_user'` and pass the VCS
+    login + provider user id for PR-comment-driven actions. `origin`
+    distinguishes the surface that initiated the action (api /
+    terrapod_ui / pr_comment / system).
+    """
     entry = AuditLog(
         id=generate_uuid7(),
         actor_email=actor_email,
@@ -83,9 +93,45 @@ async def log_audit_event(
         request_id=request_id,
         duration_ms=duration_ms,
         detail=detail,
+        actor_type=actor_type,
+        origin=origin,
+        actor_login=actor_login,
+        actor_id=actor_id,
     )
     db.add(entry)
     await db.commit()
+
+
+async def log_vcs_action(
+    db: AsyncSession,
+    *,
+    verb: str,
+    workspace_id: str,
+    actor_login: str,
+    actor_user_id: str,
+    pr_number: int,
+    repo: str,
+    detail: str = "",
+    status_code: int = 200,
+) -> None:
+    """Audit a PR-comment-driven action (#282 phase 7).
+
+    Records the VCS user (login + provider id) as the actor, without any
+    Terrapod identity mapping — authorization in apply-then-merge mode is
+    delegated to VCS repo permissions, so the audit trail mirrors that.
+    """
+    await log_audit_event(
+        db,
+        actor_type="vcs_user",
+        origin="pr_comment",
+        actor_login=actor_login,
+        actor_id=actor_user_id,
+        action=verb,
+        resource_type="workspace",
+        resource_id=workspace_id,
+        status_code=status_code,
+        detail=f"PR {repo}#{pr_number}: {detail}" if detail else f"PR {repo}#{pr_number}",
+    )
 
 
 async def purge_old_entries(db: AsyncSession, retention_days: int) -> int:

--- a/services/terrapod/services/github_service.py
+++ b/services/terrapod/services/github_service.py
@@ -16,6 +16,13 @@ import jwt
 from terrapod.config import settings
 from terrapod.db.models import VCSConnection
 from terrapod.logging_config import get_logger
+from terrapod.services.vcs_provider import (
+    MergeabilityStatus,
+    PRComment,
+    PRMergeResult,
+    PRReview,
+    PullRequest,
+)
 
 logger = get_logger(__name__)
 
@@ -582,6 +589,215 @@ async def list_pr_comments(
     )
     resp.raise_for_status()
     return resp.json()
+
+
+# ── Apply-then-merge surface (#282) ─────────────────────────────────────
+
+
+# GitHub `mergeable_state` values that we treat as "blocked". `clean` and
+# `has_hooks` are the green-light states. `unstable` means non-blocking
+# status checks are failing (e.g. CodeQL not required by protection) —
+# we allow apply since branch protection doesn't reject.
+# Documentation: https://docs.github.com/en/graphql/reference/enums#mergestatestatus
+_GITHUB_BLOCKING_STATES = frozenset({"dirty", "blocked", "behind"})
+_GITHUB_MERGEABLE_STATES = frozenset({"clean", "has_hooks", "unstable"})
+
+
+async def get_pull_request(
+    conn: VCSConnection, owner: str, repo: str, pr_number: int
+) -> PullRequest | None:
+    """Fetch a single PR's current state."""
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+    resp = await _github_request("GET", f"{api_url}/repos/{owner}/{repo}/pulls/{pr_number}", token)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    pr = resp.json()
+    return PullRequest(
+        number=pr["number"],
+        head_sha=pr["head"]["sha"],
+        head_ref=pr["head"]["ref"],
+        title=pr["title"],
+        draft=bool(pr.get("draft", False)),
+        author_login=(pr.get("user") or {}).get("login", ""),
+    )
+
+
+async def get_pull_request_mergeability(
+    conn: VCSConnection, owner: str, repo: str, pr_number: int
+) -> MergeabilityStatus:
+    """Apply-gate query.
+
+    GitHub computes `mergeable` asynchronously after a push — it returns
+    `null` until the check completes (typically <2s). We surface that as
+    `unknown=True` so the caller can retry rather than treating it as a
+    permanent block.
+    """
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+    resp = await _github_request("GET", f"{api_url}/repos/{owner}/{repo}/pulls/{pr_number}", token)
+    resp.raise_for_status()
+    pr = resp.json()
+    if pr.get("draft", False):
+        return MergeabilityStatus(
+            mergeable=False,
+            state="draft",
+            reason="Pull request is in draft state; convert to ready for review first.",
+        )
+    if pr.get("state") != "open":
+        return MergeabilityStatus(
+            mergeable=False,
+            state=pr.get("state", "unknown"),
+            reason=f"Pull request is {pr.get('state')}.",
+        )
+    mergeable = pr.get("mergeable")
+    state = pr.get("mergeable_state", "unknown")
+    if mergeable is None:
+        return MergeabilityStatus(
+            mergeable=False,
+            state=state,
+            reason="GitHub is still computing mergeability; retry shortly.",
+            unknown=True,
+        )
+    if not mergeable or state in _GITHUB_BLOCKING_STATES:
+        reasons = {
+            "dirty": "Merge conflicts; resolve and push.",
+            "blocked": "Branch protection requirements not met (review, status checks, or code owner approval).",
+            "behind": "Branch is behind the base; rebase or merge the base in.",
+        }
+        return MergeabilityStatus(
+            mergeable=False,
+            state=state,
+            reason=reasons.get(state, f"GitHub reports mergeable_state={state}."),
+        )
+    if state not in _GITHUB_MERGEABLE_STATES:
+        # New / unknown state — be conservative and block, surface the raw state.
+        return MergeabilityStatus(
+            mergeable=False,
+            state=state,
+            reason=f"Unrecognised mergeable_state '{state}'.",
+        )
+    return MergeabilityStatus(mergeable=True, state=state, reason="")
+
+
+async def merge_pull_request(
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    strategy: str,
+    commit_title: str = "",
+    commit_message: str = "",
+) -> PRMergeResult:
+    """Merge a PR via GitHub's merge API.
+
+    Strategy maps:
+      - merge → `merge_method=merge`
+      - squash → `merge_method=squash`
+      - rebase → `merge_method=rebase`
+
+    422 = "PR is not mergeable" per GitHub's own gate. 405 = "merge method
+    not allowed by repo settings" (e.g. repo disables squash). Both come
+    back as `merged=False` with the provider's error message in
+    `error_reason`.
+    """
+    if strategy not in ("merge", "squash", "rebase"):
+        return PRMergeResult(merged=False, error_reason=f"invalid strategy {strategy!r}")
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+    payload: dict = {"merge_method": strategy}
+    if commit_title:
+        payload["commit_title"] = commit_title
+    if commit_message:
+        payload["commit_message"] = commit_message
+    resp = await _github_request(
+        "PUT",
+        f"{api_url}/repos/{owner}/{repo}/pulls/{pr_number}/merge",
+        token,
+        json=payload,
+    )
+    if resp.status_code == 200:
+        body = resp.json()
+        return PRMergeResult(
+            merged=bool(body.get("merged")),
+            sha=body.get("sha", ""),
+            message=body.get("message", ""),
+        )
+    # GitHub returns the rejection reason in the body's `message`.
+    try:
+        msg = resp.json().get("message", resp.text)
+    except Exception:
+        msg = resp.text
+    return PRMergeResult(merged=False, error_reason=f"{resp.status_code}: {msg}")
+
+
+async def list_pr_comments_typed(
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    since: str | None = None,
+) -> list[PRComment]:
+    """List PR comments, typed for the comment-dispatch path.
+
+    Distinct from the legacy `list_pr_comments` (returns raw dicts) which
+    other callers — notification dispatcher, status-comment lookup —
+    still use.
+    """
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+    params: dict = {"per_page": 100, "sort": "updated", "direction": "asc"}
+    if since:
+        params["since"] = since
+    resp = await _github_request(
+        "GET",
+        f"{api_url}/repos/{owner}/{repo}/issues/{pr_number}/comments",
+        token,
+        params=params,
+    )
+    resp.raise_for_status()
+    out: list[PRComment] = []
+    for c in resp.json():
+        user = c.get("user") or {}
+        out.append(
+            PRComment(
+                id=str(c["id"]),
+                body=c.get("body") or "",
+                author_login=user.get("login", ""),
+                author_user_id=str(user.get("id", "")),
+                created_at=c.get("created_at", ""),
+                updated_at=c.get("updated_at", ""),
+            )
+        )
+    return out
+
+
+async def list_pr_reviews(
+    conn: VCSConnection, owner: str, repo: str, pr_number: int
+) -> list[PRReview]:
+    """List reviews submitted on a PR (used for approval-state detection)."""
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+    resp = await _github_request(
+        "GET",
+        f"{api_url}/repos/{owner}/{repo}/pulls/{pr_number}/reviews",
+        token,
+        params={"per_page": 100},
+    )
+    resp.raise_for_status()
+    out: list[PRReview] = []
+    for r in resp.json():
+        user = r.get("user") or {}
+        out.append(
+            PRReview(
+                id=str(r["id"]),
+                state=(r.get("state") or "").lower(),
+                author_login=user.get("login", ""),
+                submitted_at=r.get("submitted_at") or "",
+            )
+        )
+    return out
 
 
 def parse_repo_url(repo_url: str) -> tuple[str, str] | None:

--- a/services/terrapod/services/gitlab_service.py
+++ b/services/terrapod/services/gitlab_service.py
@@ -11,7 +11,13 @@ import httpx
 
 from terrapod.db.models import VCSConnection
 from terrapod.logging_config import get_logger
-from terrapod.services.vcs_provider import PullRequest
+from terrapod.services.vcs_provider import (
+    MergeabilityStatus,
+    PRComment,
+    PRMergeResult,
+    PRReview,
+    PullRequest,
+)
 
 logger = get_logger(__name__)
 
@@ -333,6 +339,223 @@ async def list_mr_comments(
         )
         resp.raise_for_status()
         return resp.json()
+
+
+# ── Apply-then-merge surface (#282) ─────────────────────────────────────
+
+
+# GitLab's `detailed_merge_status` values that mean "can merge". See
+# https://docs.gitlab.com/api/merge_requests/#merge-status — values
+# evolve across GitLab versions; we whitelist the safe ones and treat
+# anything else as a block to surface verbatim.
+_GITLAB_MERGEABLE_DETAILED = frozenset({"mergeable", "ci_must_pass", "ci_still_running"})
+
+
+async def get_pull_request(
+    conn: VCSConnection, owner: str, repo: str, mr_number: int
+) -> PullRequest | None:
+    """Fetch a single MR's current state."""
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{api}/projects/{project}/merge_requests/{mr_number}",
+            headers=_headers(conn),
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+    mr = resp.json()
+    return PullRequest(
+        number=mr["iid"],
+        head_sha=mr.get("sha") or "",
+        head_ref=mr.get("source_branch") or "",
+        title=mr.get("title") or "",
+        draft=bool(mr.get("draft", False)),
+        author_login=(mr.get("author") or {}).get("username", ""),
+    )
+
+
+async def get_pull_request_mergeability(
+    conn: VCSConnection, owner: str, repo: str, mr_number: int
+) -> MergeabilityStatus:
+    """Apply-gate query.
+
+    GitLab returns `merge_status` ("can_be_merged" / "cannot_be_merged" /
+    "checking" / "unchecked") plus a `detailed_merge_status` (newer,
+    finer-grained). We prefer the detailed status when present.
+    `checking` / `unchecked` map to `unknown=True` so the caller retries.
+    """
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{api}/projects/{project}/merge_requests/{mr_number}",
+            headers=_headers(conn),
+        )
+        resp.raise_for_status()
+    mr = resp.json()
+    if mr.get("draft", False):
+        return MergeabilityStatus(
+            mergeable=False,
+            state="draft",
+            reason="Merge request is in draft state; mark as ready first.",
+        )
+    if mr.get("state") != "opened":
+        return MergeabilityStatus(
+            mergeable=False,
+            state=mr.get("state", "unknown"),
+            reason=f"Merge request is {mr.get('state')}.",
+        )
+    detailed = mr.get("detailed_merge_status") or ""
+    legacy = mr.get("merge_status") or ""
+    state = detailed or legacy
+    if legacy in ("checking", "unchecked"):
+        return MergeabilityStatus(
+            mergeable=False,
+            state=state,
+            reason="GitLab is still computing mergeability; retry shortly.",
+            unknown=True,
+        )
+    if detailed and detailed in _GITLAB_MERGEABLE_DETAILED:
+        return MergeabilityStatus(mergeable=True, state=state, reason="")
+    if legacy == "can_be_merged" and not detailed:
+        return MergeabilityStatus(mergeable=True, state=state, reason="")
+    # Anything else is a block — surface verbatim so the user sees
+    # GitLab's own language (e.g. `discussions_not_resolved`,
+    # `not_approved`, `conflict`).
+    return MergeabilityStatus(
+        mergeable=False,
+        state=state,
+        reason=f"GitLab reports merge status '{state}'.",
+    )
+
+
+async def merge_pull_request(
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    mr_number: int,
+    strategy: str,
+    commit_title: str = "",
+    commit_message: str = "",
+) -> PRMergeResult:
+    """Merge an MR via GitLab's merge API.
+
+    Strategy mapping:
+      - merge → default GitLab behaviour (merge commit, unless project
+        is configured for fast-forward)
+      - squash → `squash=true` (still produces a merge commit on top of
+        the squashed commit unless project requires fast-forward)
+      - rebase → fast-forward merge attempt. If project doesn't allow
+        fast-forward, this falls back to the default and the caller
+        sees the GitLab error verbatim.
+    """
+    if strategy not in ("merge", "squash", "rebase"):
+        return PRMergeResult(merged=False, error_reason=f"invalid strategy {strategy!r}")
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+    payload: dict = {}
+    if strategy == "squash":
+        payload["squash"] = True
+        if commit_message:
+            payload["squash_commit_message"] = commit_message
+    if commit_title:
+        payload["merge_commit_message"] = commit_title
+    async with httpx.AsyncClient() as client:
+        resp = await client.put(
+            f"{api}/projects/{project}/merge_requests/{mr_number}/merge",
+            json=payload,
+            headers=_headers(conn),
+        )
+    if resp.status_code == 200:
+        body = resp.json()
+        return PRMergeResult(
+            merged=body.get("state") == "merged",
+            sha=body.get("merge_commit_sha") or body.get("squash_commit_sha") or "",
+            message=body.get("merge_commit_message", ""),
+        )
+    try:
+        msg = resp.json().get("message", resp.text)
+    except Exception:
+        msg = resp.text
+    return PRMergeResult(merged=False, error_reason=f"{resp.status_code}: {msg}")
+
+
+async def list_pr_comments_typed(
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    mr_number: int,
+    since: str | None = None,
+) -> list[PRComment]:
+    """List MR notes, typed and filtered for the comment-dispatch path.
+
+    GitLab's notes API has no `since` parameter — we fetch with
+    `sort=asc&order_by=updated_at` and filter client-side. System notes
+    (state changes, assignment events) are filtered out — we only want
+    human comments.
+    """
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{api}/projects/{project}/merge_requests/{mr_number}/notes",
+            params={"per_page": 100, "sort": "asc", "order_by": "updated_at"},
+            headers=_headers(conn),
+        )
+        resp.raise_for_status()
+    out: list[PRComment] = []
+    for n in resp.json():
+        if n.get("system"):
+            continue
+        if since and (n.get("updated_at") or "") <= since:
+            continue
+        author = n.get("author") or {}
+        out.append(
+            PRComment(
+                id=str(n["id"]),
+                body=n.get("body") or "",
+                author_login=author.get("username", ""),
+                author_user_id=str(author.get("id", "")),
+                created_at=n.get("created_at", ""),
+                updated_at=n.get("updated_at", ""),
+            )
+        )
+    return out
+
+
+async def list_pr_reviews(
+    conn: VCSConnection, owner: str, repo: str, mr_number: int
+) -> list[PRReview]:
+    """Approvals on a GitLab MR, expressed as PRReview entries.
+
+    GitLab approvals aren't event-like (no list of individual review
+    submissions) — they're a snapshot. We synthesise one PRReview per
+    current approver so the consumer can count them; `submitted_at` is
+    left blank because the snapshot doesn't tell us when each approval
+    landed.
+    """
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{api}/projects/{project}/merge_requests/{mr_number}/approvals",
+            headers=_headers(conn),
+        )
+        resp.raise_for_status()
+    out: list[PRReview] = []
+    for a in resp.json().get("approved_by", []):
+        u = a.get("user") or {}
+        out.append(
+            PRReview(
+                id=str(u.get("id", "")),
+                state="approved",
+                author_login=u.get("username", ""),
+                submitted_at="",
+            )
+        )
+    return out
 
 
 def parse_repo_url(repo_url: str) -> tuple[str, str] | None:

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -17,10 +17,12 @@ from terrapod.db.models import (
     ConfigurationVersion,
     Run,
     RunTrigger,
+    VCSConnection,
     Workspace,
     utc_now,
 )
 from terrapod.logging_config import get_logger
+from terrapod.services import github_service, gitlab_service
 from terrapod.services.notification_service import STATUS_TO_TRIGGER
 
 logger = get_logger(__name__)
@@ -549,10 +551,94 @@ async def fire_run_triggers(
         )
 
 
+class ApplyBlocked(Exception):
+    """Raised when confirm_run rejects an apply because the underlying
+    PR/MR isn't mergeable per the VCS provider's gate (#282).
+
+    The reason string is what gets surfaced on the PR status comment.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+async def _check_mergeability_or_block(db: AsyncSession, run: Run) -> None:
+    """For apply-then-merge runs, query the VCS provider's mergeability
+    gate before allowing confirm. If blocked, persist the reason on the
+    run and raise ApplyBlocked.
+
+    No-op for runs that aren't PR-associated apply-then-merge runs
+    (default-mode runs, drift-detection runs, CLI runs). The branch is
+    gated to keep the default-mode `confirm_run` path zero-cost.
+    """
+    if run.vcs_pull_request_number is None:
+        return
+    workspace = await db.get(Workspace, run.workspace_id)
+    if workspace is None or workspace.vcs_workflow != "apply_then_merge":
+        return
+    if workspace.vcs_connection_id is None or not workspace.vcs_repo_url:
+        return
+    conn = await db.get(VCSConnection, workspace.vcs_connection_id)
+    if conn is None:
+        return
+
+    # Provider dispatch — github_service / gitlab_service expose
+    # get_pull_request_mergeability with the same signature.
+    if conn.provider == "github":
+        parsed = github_service.parse_repo_url(workspace.vcs_repo_url)
+        check = github_service.get_pull_request_mergeability
+    elif conn.provider == "gitlab":
+        parsed = gitlab_service.parse_repo_url(workspace.vcs_repo_url)
+        check = gitlab_service.get_pull_request_mergeability
+    else:
+        logger.warning(
+            "confirm_run: unknown VCS provider, skipping mergeability check",
+            provider=conn.provider,
+        )
+        return
+    if parsed is None:
+        logger.warning(
+            "confirm_run: could not parse repo URL, skipping mergeability check",
+            repo_url=workspace.vcs_repo_url,
+        )
+        return
+    owner, repo = parsed
+
+    try:
+        status = await check(conn, owner, repo, run.vcs_pull_request_number)
+    except Exception as e:
+        # If the provider call fails we don't want to silently apply —
+        # surface the error as a transient block so the user retries.
+        reason = f"Could not verify mergeability ({e}); retry shortly."
+        run.vcs_apply_blocked_reason = reason
+        raise ApplyBlocked(reason) from e
+
+    if status.unknown:
+        # GitHub returns mergeable=null for a few seconds after a push
+        # while it computes the merge check. Surface this as a transient
+        # block — caller / user retries within seconds.
+        reason = status.reason or "Mergeability is still being computed; retry shortly."
+        run.vcs_apply_blocked_reason = reason
+        raise ApplyBlocked(reason)
+    if not status.mergeable:
+        run.vcs_apply_blocked_reason = status.reason or f"PR is not mergeable ({status.state})."
+        raise ApplyBlocked(run.vcs_apply_blocked_reason)
+    # Mergeable now — clear any stale block reason from a previous attempt.
+    run.vcs_apply_blocked_reason = None
+
+
 async def confirm_run(db: AsyncSession, run: Run) -> Run:
-    """Confirm a planned run for apply."""
+    """Confirm a planned run for apply.
+
+    For apply-then-merge runs, the VCS provider's mergeability gate
+    fires first — if the PR isn't mergeable, this raises `ApplyBlocked`
+    with the provider's own language (`dirty` / `blocked` / `behind` /
+    `draft` / etc.) attached to the run for the status comment.
+    """
     if run.status != "planned":
         raise ValueError(f"Can only confirm runs in 'planned' status, got '{run.status}'")
+    await _check_mergeability_or_block(db, run)
     return await transition_run(db, run, "confirmed")
 
 

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -457,6 +457,11 @@ async def complete_apply(db: AsyncSession, run: Run) -> Run:
     Idempotent counterpart to :func:`complete_plan`. Same dual-path rationale
     — either the runner's `/apply-result` POST or the reconciler's listener
     round-trip can win; whichever lands first does the transition.
+
+    On successful apply for a PR-associated run, schedules cross-workspace
+    gate evaluation (#282 phase 8): invalidate stale sibling-PR plans on
+    the same workspace, refresh the status comment, and fire auto-merge
+    if every PR-affected workspace has met its required state.
     """
     if run.status != "applying":
         return run
@@ -469,7 +474,68 @@ async def complete_apply(db: AsyncSession, run: Run) -> Run:
         ws.lock_id = None
 
     logger.info("Apply succeeded", run_id=str(run.id))
+
+    # Apply-then-merge follow-ups: invalidate stale sibling-PR plans on
+    # the same workspace, then trigger cross-workspace gate evaluation
+    # for the PR this run was associated with. Enqueueing here keeps
+    # the transition synchronous and the gate evaluation async.
+    if run.vcs_pull_request_number is not None and ws is not None:
+        await _invalidate_sibling_pr_plans(db, ws.id, run.id, run.vcs_pull_request_number)
+        from terrapod.services.scheduler import enqueue_trigger
+
+        await enqueue_trigger(
+            "vcs_apply_completed",
+            {
+                "run_id": str(run.id),
+                "workspace_id": str(ws.id),
+                "pr_number": run.vcs_pull_request_number,
+            },
+            dedup_key=f"vcs_apply_completed:{run.id}",
+        )
     return run
+
+
+async def _invalidate_sibling_pr_plans(
+    db: AsyncSession,
+    workspace_id: uuid.UUID,
+    just_applied_run_id: uuid.UUID,
+    just_applied_pr_number: int,
+) -> None:
+    """Cancel any other-PR `planned` runs on this workspace.
+
+    After a successful state-mutating apply, sibling PR plans against
+    pre-apply state are no longer valid — `tofu apply tfplan` would
+    refuse with a state-lineage error. We cancel them proactively
+    (#282 cross-PR lock race section); the poller's next cycle will
+    re-plan against the new state once the workspace lock allows.
+    """
+    sibling_q = await db.execute(
+        select(Run).where(
+            Run.workspace_id == workspace_id,
+            Run.status == "planned",
+            Run.vcs_pull_request_number.isnot(None),
+            Run.vcs_pull_request_number != just_applied_pr_number,
+            Run.id != just_applied_run_id,
+        )
+    )
+    for sibling in sibling_q.scalars().all():
+        sibling.vcs_apply_blocked_reason = (
+            f"Plan superseded by apply of PR #{just_applied_pr_number}."
+        )
+        try:
+            await cancel_run(db, sibling, force=True)
+            logger.info(
+                "invalidated sibling-PR plan",
+                run_id=str(sibling.id),
+                workspace_id=str(workspace_id),
+                superseded_by_pr=just_applied_pr_number,
+            )
+        except Exception as e:
+            logger.warning(
+                "failed to cancel sibling-PR plan",
+                run_id=str(sibling.id),
+                error=str(e),
+            )
 
 
 async def complete_planned_as_noop(db: AsyncSession, run: Run) -> Run:

--- a/services/terrapod/services/vcs_auto_merge.py
+++ b/services/terrapod/services/vcs_auto_merge.py
@@ -1,0 +1,231 @@
+"""Cross-workspace auto-merge gate + executor (#282 phase 8).
+
+When a PR-associated apply completes, this handler evaluates whether the
+PR is ready to merge — every PR-affected workspace must have met its
+per-mode required state for the current head SHA:
+
+- `apply_then_merge` workspaces: have an `applied` run for the head SHA
+  (or `has_changes=False`, which auto-counts as applied).
+- `merge_then_apply` workspaces: have a `planned` speculative run for
+  the head SHA (i.e. the speculative plan succeeded, regardless of
+  has_changes).
+
+If all PR-affected workspaces meet their bar AND at least one has
+`auto_merge=true`, fire the VCS merge API. Force-merge (the `terrapod
+merge` command) bypasses the gate but records the partial state.
+
+Triggered task: `vcs_apply_completed`. Payload:
+  { "run_id": "<uuid>", "workspace_id": "<uuid>", "pr_number": <int> }
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+
+from terrapod.db.models import PRSession, Run, VCSConnection, Workspace
+from terrapod.db.session import get_db_session
+from terrapod.logging_config import get_logger
+from terrapod.services import github_service, gitlab_service
+from terrapod.services.scheduler import enqueue_trigger
+
+logger = get_logger(__name__)
+
+
+def _meets_required_state(ws: Workspace, run: Run | None) -> bool:
+    """Per-mode gate: is this workspace's latest run for the head SHA OK?"""
+    if run is None:
+        return False
+    if ws.vcs_workflow == "apply_then_merge":
+        # Apply succeeded, OR plan reported no changes (state-equivalent).
+        return run.status == "applied" or (run.status == "planned" and run.has_changes is False)
+    # merge_then_apply: speculative plan must have succeeded. Plan-only
+    # speculative runs terminate at `planned`.
+    return run.status == "planned"
+
+
+async def _latest_run_for_pr(
+    db, workspace_id: uuid.UUID, pr_number: int, head_sha: str
+) -> Run | None:
+    """Return the latest run on this workspace for (pr, head_sha)."""
+    result = await db.execute(
+        select(Run)
+        .where(
+            Run.workspace_id == workspace_id,
+            Run.vcs_pull_request_number == pr_number,
+            Run.vcs_commit_sha == head_sha,
+        )
+        .order_by(Run.created_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _affected_workspaces(db, sess: PRSession) -> list[Workspace]:
+    """Workspaces with runs for this PR on this connection+repo."""
+    result = await db.execute(
+        select(Workspace)
+        .join(Run, Run.workspace_id == Workspace.id)
+        .where(
+            Run.vcs_pull_request_number == sess.pr_number,
+            Workspace.vcs_connection_id == sess.vcs_connection_id,
+            Workspace.vcs_repo_url.endswith(sess.repo),
+        )
+        .distinct()
+    )
+    return list(result.scalars().all())
+
+
+async def handle_vcs_apply_completed(payload: dict[str, Any]) -> None:
+    """Triggered handler: re-evaluate the merge gate after a PR-run apply.
+
+    Doesn't unconditionally merge — only fires if at least one
+    PR-affected workspace has `auto_merge=true` AND every PR-affected
+    workspace meets its per-mode required state for the current head
+    SHA. The status comment is refreshed regardless so the user can see
+    progress.
+    """
+    pr_number = payload.get("pr_number")
+    workspace_id_str = payload.get("workspace_id")
+    if pr_number is None or workspace_id_str is None:
+        return
+    async with get_db_session() as db:
+        ws = await db.get(Workspace, uuid.UUID(workspace_id_str))
+        if ws is None or ws.vcs_connection_id is None:
+            return
+        sess_result = await db.execute(
+            select(PRSession).where(
+                PRSession.vcs_connection_id == ws.vcs_connection_id,
+                PRSession.pr_number == pr_number,
+                PRSession.state == "open",
+            )
+        )
+        sess = sess_result.scalar_one_or_none()
+        if sess is None:
+            return
+
+        # Refresh the status comment unconditionally so the apply
+        # outcome shows up even if auto-merge doesn't fire.
+        await enqueue_trigger(
+            "vcs_status_comment_update",
+            {"session_id": str(sess.id)},
+            dedup_key=f"vcs_status:{sess.id}",
+        )
+
+        affected = await _affected_workspaces(db, sess)
+        if not affected:
+            return
+        any_auto_merge = any(w.auto_merge for w in affected)
+        if not any_auto_merge:
+            # No workspace opted into auto-merge — even if the gate is
+            # green, the user has to comment `terrapod merge` (phase 8b).
+            return
+
+        # Evaluate the gate.
+        for w in affected:
+            run = await _latest_run_for_pr(db, w.id, pr_number, sess.head_sha)
+            if not _meets_required_state(w, run):
+                logger.info(
+                    "auto_merge gate not met",
+                    workspace=w.name,
+                    pr_number=pr_number,
+                    run_status=(run.status if run else None),
+                )
+                return  # gate not met; let the next state change re-evaluate
+
+        # Gate green — execute the merge.
+        conn = await db.get(VCSConnection, ws.vcs_connection_id)
+        if conn is None:
+            return
+        # Strategy: prefer the policy of any auto_merge=true workspace.
+        # When multiple workspaces disagree, use the first one's setting
+        # — the user opted in, they chose the strategy. Document.
+        strategy = next((w.auto_merge_strategy for w in affected if w.auto_merge), "merge")
+        await _execute_merge(conn, sess, strategy)
+        await db.commit()
+
+
+async def _execute_merge(conn: VCSConnection, sess: PRSession, strategy: str) -> None:
+    """Provider-dispatched merge."""
+    owner, repo = sess.repo.split("/", 1)
+    if conn.provider == "github":
+        merge_fn = github_service.merge_pull_request
+    elif conn.provider == "gitlab":
+        merge_fn = gitlab_service.merge_pull_request
+    else:
+        logger.warning("auto_merge: unknown provider", provider=conn.provider)
+        return
+    try:
+        result = await merge_fn(conn, owner, repo, sess.pr_number, strategy)
+    except Exception as e:
+        logger.warning(
+            "auto_merge: provider call raised",
+            pr_number=sess.pr_number,
+            error=str(e),
+        )
+        return
+    if result.merged:
+        sess.state = "merged"
+        logger.info(
+            "auto_merge: PR merged",
+            pr_number=sess.pr_number,
+            sha=result.sha,
+            strategy=strategy,
+        )
+    else:
+        logger.info(
+            "auto_merge: provider rejected",
+            pr_number=sess.pr_number,
+            reason=result.error_reason,
+        )
+
+
+async def force_merge(
+    db,
+    sess: PRSession,
+    conn: VCSConnection,
+    strategy: str,
+    actor_login: str,
+    actor_user_id: str,
+) -> tuple[bool, str]:
+    """Force-merge handler for the `terrapod merge` command (#282).
+
+    Records the per-workspace apply state at merge time in the audit
+    log so the partial state is reconstructible. Used by the dispatcher.
+    Returns (merged, error_reason) — error_reason populated on rejection.
+    """
+    from terrapod.services.audit_service import log_vcs_action
+
+    affected = await _affected_workspaces(db, sess)
+    # Snapshot per-workspace state at merge time so the audit entry
+    # captures what was / wasn't applied — the operational forensic
+    # surface the force-merge escape hatch exists for.
+    state_parts: list[str] = []
+    for w in affected:
+        run = await _latest_run_for_pr(db, w.id, sess.pr_number, sess.head_sha)
+        state_parts.append(f"{w.name}={(run.status if run else 'no-run')}")
+    state_summary = ", ".join(state_parts)
+    await log_vcs_action(
+        db,
+        verb="merge",
+        workspace_id="*",
+        actor_login=actor_login,
+        actor_user_id=actor_user_id,
+        pr_number=sess.pr_number,
+        repo=sess.repo,
+        detail=f"force-merge strategy={strategy}; per-workspace state: {state_summary}",
+    )
+    owner, repo = sess.repo.split("/", 1)
+    if conn.provider == "github":
+        merge_fn = github_service.merge_pull_request
+    elif conn.provider == "gitlab":
+        merge_fn = gitlab_service.merge_pull_request
+    else:
+        return False, f"unsupported provider {conn.provider}"
+    result = await merge_fn(conn, owner, repo, sess.pr_number, strategy)
+    if result.merged:
+        sess.state = "merged"
+        return True, ""
+    return False, result.error_reason

--- a/services/terrapod/services/vcs_command_dispatcher.py
+++ b/services/terrapod/services/vcs_command_dispatcher.py
@@ -31,6 +31,7 @@ from terrapod.db.models import PRSession, Run, VCSConnection, Workspace
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import run_service
+from terrapod.services.scheduler import enqueue_trigger
 from terrapod.services.vcs_command_parser import Command, parse
 
 logger = get_logger(__name__)
@@ -159,6 +160,14 @@ async def _route(
         await _route_plan(db, sess, candidates, actor_login, actor_user_id)
     elif cmd.verb == "unlock":
         await _route_unlock(db, candidates, actor_login, actor_user_id)
+
+    # Every command-driven mutation refreshes the status comment so the
+    # PR thread reflects the latest state in seconds.
+    await enqueue_trigger(
+        "vcs_status_comment_update",
+        {"session_id": str(sess.id)},
+        dedup_key=f"vcs_status:{sess.id}",
+    )
 
 
 async def _route_apply(

--- a/services/terrapod/services/vcs_command_dispatcher.py
+++ b/services/terrapod/services/vcs_command_dispatcher.py
@@ -31,6 +31,7 @@ from terrapod.db.models import PRSession, Run, VCSConnection, Workspace
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import run_service
+from terrapod.services.audit_service import log_vcs_action
 from terrapod.services.scheduler import enqueue_trigger
 from terrapod.services.vcs_command_parser import Command, parse
 
@@ -160,6 +161,24 @@ async def _route(
         await _route_plan(db, sess, candidates, actor_login, actor_user_id)
     elif cmd.verb == "unlock":
         await _route_unlock(db, candidates, actor_login, actor_user_id)
+
+    # Audit: one entry per affected workspace. Dual-actor model — see
+    # log_vcs_action / #282. Errors swallowed so audit failure never
+    # breaks the dispatch path.
+    for ws in candidates:
+        try:
+            await log_vcs_action(
+                db,
+                verb=cmd.verb,
+                workspace_id=str(ws.id),
+                actor_login=actor_login,
+                actor_user_id=actor_user_id,
+                pr_number=sess.pr_number,
+                repo=sess.repo,
+                detail=cmd.raw,
+            )
+        except Exception as e:
+            logger.warning("audit log failed", verb=cmd.verb, error=str(e))
 
     # Every command-driven mutation refreshes the status comment so the
     # PR thread reflects the latest state in seconds.

--- a/services/terrapod/services/vcs_command_dispatcher.py
+++ b/services/terrapod/services/vcs_command_dispatcher.py
@@ -140,8 +140,33 @@ async def _route(
         return
 
     if cmd.verb == "merge":
-        # Force-merge lands with auto-merge in phase 8.
-        logger.info("vcs_comment_dispatch: merge requested (phase 8)", **audit_ctx)
+        # Force-merge: skip the cross-workspace gate, record the partial
+        # apply state at merge time in the audit log, then call the
+        # provider's merge API.
+        from terrapod.services.vcs_auto_merge import force_merge
+
+        merged, error_reason = await force_merge(
+            db, sess, conn, "merge", actor_login, actor_user_id
+        )
+        if merged:
+            logger.info(
+                "vcs_comment_dispatch: force-merged",
+                **audit_ctx,
+                strategy="merge",
+            )
+        else:
+            logger.info(
+                "vcs_comment_dispatch: force-merge rejected by provider",
+                **audit_ctx,
+                error_reason=error_reason,
+            )
+        # Refresh the status comment so the merge result is visible.
+        await db.commit()
+        await enqueue_trigger(
+            "vcs_status_comment_update",
+            {"session_id": str(sess.id)},
+            dedup_key=f"vcs_status:{sess.id}",
+        )
         return
 
     if not candidates:

--- a/services/terrapod/services/vcs_command_dispatcher.py
+++ b/services/terrapod/services/vcs_command_dispatcher.py
@@ -207,6 +207,17 @@ async def _route_apply(
                 pr_number=sess.pr_number,
                 actor_login=actor_login,
             )
+        except run_service.ApplyBlocked as e:
+            # Mergeability gate rejected. `vcs_apply_blocked_reason` is
+            # already persisted on the run by the gate — that's what the
+            # status comment (phase 6) reads to render the block message.
+            logger.info(
+                "apply: blocked by mergeability gate",
+                workspace=ws.name,
+                run_id=str(run.id),
+                pr_number=sess.pr_number,
+                reason=e.reason,
+            )
         except Exception as e:
             logger.warning(
                 "apply: confirm_run failed",

--- a/services/terrapod/services/vcs_command_dispatcher.py
+++ b/services/terrapod/services/vcs_command_dispatcher.py
@@ -1,0 +1,287 @@
+"""Dispatcher for `terrapod ...` comments on PRs/MRs (#282 phase 4).
+
+Receives parsed commands from the webhook receiver (or the poll-fallback
+comment scanner) and routes them to the right action. Authorization is
+delegated to VCS repo permissions (the apply-then-merge contract) — this
+module records the VCS actor on whatever run/action it kicks off, but
+does not consult Terrapod RBAC.
+
+Triggered task name: `vcs_comment_dispatch`.
+
+Payload shape:
+  {
+    "connection_id": "<uuid>",        # VCSConnection.id
+    "repo": "owner/name",
+    "pr_number": 123,
+    "comment_id": "987654321",        # provider-side, for dedup / audit
+    "actor_login": "octocat",
+    "actor_user_id": "12345",
+    "body": "terrapod apply -W foo",
+  }
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+
+from terrapod.db.models import PRSession, Run, VCSConnection, Workspace
+from terrapod.db.session import get_db_session
+from terrapod.logging_config import get_logger
+from terrapod.services import run_service
+from terrapod.services.vcs_command_parser import Command, parse
+
+logger = get_logger(__name__)
+
+
+# Verbs we route in phase 4. Surfaces that depend on later phases
+# (status comment posting, auto-merge) are stubbed with audit-only
+# acknowledgements that say "this will work after phase N".
+_ROUTABLE_VERBS = frozenset({"plan", "apply", "unlock", "merge", "help"})
+
+
+async def handle_vcs_comment_dispatch(payload: dict[str, Any]) -> None:
+    """Scheduler trigger handler.
+
+    Parses the comment, validates against the PRSession + workspace
+    state, and enqueues the appropriate action. Idempotent — the
+    dedup key (set by the webhook receiver) prevents duplicate
+    dispatches from a webhook/poll race.
+    """
+    body = payload.get("body") or ""
+    cmd = parse(body)
+    if cmd is None:
+        return  # not a command
+
+    connection_id = payload.get("connection_id")
+    repo = payload.get("repo")
+    pr_number = payload.get("pr_number")
+    if not (connection_id and repo and pr_number):
+        logger.warning("vcs_comment_dispatch missing required fields", payload_keys=list(payload))
+        return
+
+    actor_login = payload.get("actor_login") or ""
+    actor_user_id = str(payload.get("actor_user_id") or "")
+
+    async with get_db_session() as db:
+        conn = await db.get(VCSConnection, uuid.UUID(connection_id))
+        if conn is None:
+            logger.warning("vcs_comment_dispatch: unknown connection", connection_id=connection_id)
+            return
+
+        sess_result = await db.execute(
+            select(PRSession).where(
+                PRSession.vcs_connection_id == conn.id,
+                PRSession.repo == repo,
+                PRSession.pr_number == pr_number,
+            )
+        )
+        sess = sess_result.scalar_one_or_none()
+        # No active session means either (a) no apply-then-merge
+        # workspace plans against this PR, or (b) the PR closed before
+        # the dispatcher ran. Silently drop — there's nothing to act on.
+        if sess is None or sess.state != "open":
+            logger.info(
+                "vcs_comment_dispatch: no open session for PR",
+                connection_id=connection_id,
+                repo=repo,
+                pr_number=pr_number,
+                verb=cmd.verb,
+            )
+            return
+
+        # Find PR-affected apply-then-merge workspaces (the ones the
+        # commands actually operate on). Other workspaces (different
+        # mode, different repo) are ignored.
+        ws_result = await db.execute(
+            select(Workspace).where(
+                Workspace.vcs_connection_id == conn.id,
+                Workspace.vcs_workflow == "apply_then_merge",
+            )
+        )
+        candidates = [
+            ws
+            for ws in ws_result.scalars().all()
+            if (ws.vcs_repo_url or "").rstrip("/").endswith(repo)
+        ]
+        if cmd.workspace:
+            candidates = [ws for ws in candidates if ws.name == cmd.workspace]
+
+        await _route(db, cmd, conn, sess, candidates, actor_login, actor_user_id)
+
+
+async def _route(
+    db,
+    cmd: Command,
+    conn: VCSConnection,
+    sess: PRSession,
+    candidates: list[Workspace],
+    actor_login: str,
+    actor_user_id: str,
+) -> None:
+    """Dispatch a parsed command to the right action."""
+    audit_ctx = {
+        "verb": cmd.verb,
+        "repo": sess.repo,
+        "pr_number": sess.pr_number,
+        "actor_login": actor_login,
+        "actor_user_id": actor_user_id,
+        "candidate_count": len(candidates),
+    }
+
+    if cmd.verb == "help":
+        # Help-back is delivered via the status-comment surface
+        # (phase 6). For now we audit-log so the dispatch is visible.
+        logger.info("vcs_comment_dispatch: help requested", **audit_ctx)
+        return
+
+    if cmd.verb == "merge":
+        # Force-merge lands with auto-merge in phase 8.
+        logger.info("vcs_comment_dispatch: merge requested (phase 8)", **audit_ctx)
+        return
+
+    if not candidates:
+        if cmd.workspace:
+            logger.info(
+                "vcs_comment_dispatch: workspace not affected by PR",
+                workspace_filter=cmd.workspace,
+                **audit_ctx,
+            )
+        else:
+            logger.info("vcs_comment_dispatch: no apply-then-merge workspaces on PR", **audit_ctx)
+        return
+
+    if cmd.verb == "apply":
+        await _route_apply(db, sess, candidates, actor_login, actor_user_id)
+    elif cmd.verb == "plan":
+        await _route_plan(db, sess, candidates, actor_login, actor_user_id)
+    elif cmd.verb == "unlock":
+        await _route_unlock(db, candidates, actor_login, actor_user_id)
+
+
+async def _route_apply(
+    db,
+    sess: PRSession,
+    candidates: list[Workspace],
+    actor_login: str,
+    actor_user_id: str,
+) -> None:
+    """For each candidate workspace, confirm the current planned run.
+
+    The mergeability gate is enforced inside `run_service.confirm_run`
+    (phase 5) — if the PR isn't mergeable, confirm raises and we log /
+    later surface the reason on the status comment.
+    """
+    for ws in candidates:
+        # Find the most recent planned run for this PR on this workspace.
+        result = await db.execute(
+            select(Run)
+            .where(
+                Run.workspace_id == ws.id,
+                Run.vcs_pull_request_number == sess.pr_number,
+                Run.status == "planned",
+            )
+            .order_by(Run.created_at.desc())
+            .limit(1)
+        )
+        run = result.scalar_one_or_none()
+        if run is None:
+            logger.info(
+                "apply: no planned run for workspace",
+                workspace=ws.name,
+                pr_number=sess.pr_number,
+            )
+            continue
+        # Stamp the actor before triggering confirm so the audit trail
+        # captures who applied the run from the comment side.
+        run.vcs_actor_login = actor_login
+        run.vcs_actor_user_id = actor_user_id
+        try:
+            await run_service.confirm_run(db, run)
+            logger.info(
+                "apply: confirmed",
+                workspace=ws.name,
+                run_id=str(run.id),
+                pr_number=sess.pr_number,
+                actor_login=actor_login,
+            )
+        except Exception as e:
+            logger.warning(
+                "apply: confirm_run failed",
+                workspace=ws.name,
+                run_id=str(run.id),
+                error=str(e),
+            )
+    await db.commit()
+
+
+async def _route_plan(
+    db,
+    sess: PRSession,
+    candidates: list[Workspace],
+    actor_login: str,
+    actor_user_id: str,
+) -> None:
+    """Discard the current run on each candidate and let the poller
+    create a fresh one against the same head SHA.
+
+    Cancelling here releases the workspace lock; the next poll cycle's
+    "new PR head SHA" detection notices that this PR has no current
+    run for its head SHA and creates one. We don't create the run
+    inline because doing so duplicates the poller's archive-fetch +
+    config-version-upload path; let the existing machinery do its job.
+    """
+    for ws in candidates:
+        active = await db.execute(
+            select(Run).where(
+                Run.workspace_id == ws.id,
+                Run.vcs_pull_request_number == sess.pr_number,
+                Run.status.notin_(run_service.TERMINAL_STATES),
+            )
+        )
+        for run in active.scalars().all():
+            run.vcs_actor_login = actor_login
+            run.vcs_actor_user_id = actor_user_id
+            try:
+                await run_service.cancel_run(db, run, force=True)
+                logger.info(
+                    "plan: cancelled existing run",
+                    workspace=ws.name,
+                    run_id=str(run.id),
+                    pr_number=sess.pr_number,
+                )
+            except Exception as e:
+                logger.warning(
+                    "plan: cancel_run failed",
+                    workspace=ws.name,
+                    run_id=str(run.id),
+                    error=str(e),
+                )
+    await db.commit()
+
+
+async def _route_unlock(
+    db,
+    candidates: list[Workspace],
+    actor_login: str,
+    actor_user_id: str,
+) -> None:
+    """Release the workspace lock if stuck.
+
+    Unlock is a manual escape hatch (Atlantis ships the same). Per the
+    authorization model, anyone who can comment on the PR can unlock —
+    branch protection isn't a meaningful gate here because no apply is
+    happening.
+    """
+    for ws in candidates:
+        if ws.locked:
+            ws.locked = False
+            ws.lock_id = None
+            logger.info(
+                "unlock: released workspace lock",
+                workspace=ws.name,
+                actor_login=actor_login,
+            )
+    await db.commit()

--- a/services/terrapod/services/vcs_command_parser.py
+++ b/services/terrapod/services/vcs_command_parser.py
@@ -1,0 +1,99 @@
+"""Parse `terrapod ...` commands from PR/MR comments (#282).
+
+Strict prefix match: a comment line starting with `terrapod` (or the
+configured mention prefix) is the only signal of intent. Mid-sentence
+mentions never match. Unknown verbs match the parser but resolve to
+`Command(verb="help", ...)` so the dispatcher can post help-back instead
+of silently ignoring a deliberate-looking message.
+
+Per the design in #282:
+- Authorization is delegated to VCS repo permissions — the parser does
+  not consult Terrapod RBAC.
+- Code-fenced blocks (``` ... ```) MUST NOT match. Users discussing the
+  bot in a code sample shouldn't get a reply.
+- The command must start at the beginning of a non-blank line (after
+  whitespace). Continuation text after the command on the same line is
+  ignored.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Verbs we recognise. Anything else becomes "help" so the dispatcher can
+# respond with usage rather than silently ignoring a `terrapod ...`
+# comment that looks deliberate.
+_KNOWN_VERBS = frozenset({"plan", "apply", "unlock", "merge", "help"})
+
+
+@dataclass(frozen=True)
+class Command:
+    """Parsed `terrapod ...` command from a PR/MR comment.
+
+    `verb` is one of the known verbs (or "help" if the verb was missing
+    or unrecognised). `workspace` is the value of the `-W` / `--workspace`
+    flag, if any. `raw` is the matched line for diagnostics + audit.
+    """
+
+    verb: str
+    workspace: str | None
+    raw: str
+
+
+# Match `terrapod <verb>` optionally with `-W <name>` / `--workspace=<name>`.
+# Anchored to start-of-string (the caller passes one logical line at a
+# time). Trailing content after the recognised tokens is allowed but
+# ignored — we'd rather match a stray suffix than reject a valid command.
+_PREFIX_VERB_RE = re.compile(r"^[ \t]*(?P<prefix>\S+)[ \t]+(?P<verb>\S+)(?P<rest>.*)$")
+_WORKSPACE_RE = re.compile(
+    r"(?:^|\s)(?:-W|--workspace)(?:[ \t]+|=)(?P<ws>[A-Za-z0-9][A-Za-z0-9_.-]*)"
+)
+
+
+def parse(body: str, *, mention_prefix: str = "terrapod") -> Command | None:
+    """Parse a comment body looking for a `terrapod ...` command.
+
+    Returns the first matching command (one per comment), or None if no
+    line in the body starts with the prefix.
+
+    `mention_prefix` is configurable per deployment (e.g. `@terrapod-bot`
+    if the App has a distinct name in the repo).
+    """
+    target_prefix = mention_prefix.lower()
+    in_code_block = False
+    for raw_line in body.splitlines():
+        # Track fenced code blocks (```) and skip everything inside them
+        # so a discussion of the bot in a code sample never matches.
+        stripped = raw_line.lstrip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        m = _PREFIX_VERB_RE.match(raw_line)
+        if m is None:
+            continue
+        # Strip optional `@` so `@terrapod-bot` and `terrapod-bot` both match
+        # when the deployment sets mention_prefix accordingly.
+        observed = m.group("prefix").lstrip("@").lower()
+        if observed != target_prefix:
+            continue
+        verb = m.group("verb").strip(".,!?:;").lower()
+        rest = m.group("rest") or ""
+        if verb not in _KNOWN_VERBS:
+            return Command(verb="help", workspace=None, raw=raw_line.strip())
+        ws_match = _WORKSPACE_RE.search(rest)
+        workspace = ws_match.group("ws") if ws_match else None
+        return Command(verb=verb, workspace=workspace, raw=raw_line.strip())
+    return None
+
+
+def is_command_comment(body: str, *, mention_prefix: str = "terrapod") -> bool:
+    """Cheap pre-filter for the dispatcher: does this comment look like
+    a command at all? Returns True iff parse() would return a Command.
+
+    Used by the dispatcher to avoid loading PRSession / VCSConnection for
+    comments that obviously aren't directed at the bot.
+    """
+    return parse(body, mention_prefix=mention_prefix) is not None

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -460,6 +460,98 @@ async def _upsert_pr_session(
     return sess
 
 
+async def _poll_pr_comments(
+    db: AsyncSession,
+    conn: VCSConnection,
+    repo: str,
+) -> None:
+    """Poll-fallback for `issue_comment` / `note` webhooks (#282).
+
+    For each open PRSession on this (connection, repo), fetch comments
+    since the last processed comment id and dispatch any `terrapod ...`
+    commands via the scheduler. The scheduler's per-comment-id dedup
+    key ensures webhook+poll racing doesn't double-dispatch.
+
+    Required for deployments where the GitHub App doesn't have
+    `issue_comment` webhook delivery (firewalled installs, local dev
+    stacks, App permission upgrade not yet accepted) — webhooks
+    accelerate, polling is the source of truth.
+    """
+    sessions = await db.execute(
+        select(PRSession).where(
+            PRSession.vcs_connection_id == conn.id,
+            PRSession.repo == repo,
+            PRSession.state == "open",
+        )
+    )
+    open_sessions = list(sessions.scalars().all())
+    if not open_sessions:
+        return
+
+    owner, repo_name = repo.split("/", 1)
+    for sess in open_sessions:
+        try:
+            if conn.provider == "github":
+                comments = await github_service.list_pr_comments_typed(
+                    conn, owner, repo_name, sess.pr_number, since=None
+                )
+            elif conn.provider == "gitlab":
+                comments = await gitlab_service.list_pr_comments_typed(
+                    conn, owner, repo_name, sess.pr_number, since=None
+                )
+            else:
+                continue
+        except Exception as e:
+            logger.warning(
+                "comment poll: provider call failed",
+                repo=repo,
+                pr_number=sess.pr_number,
+                error=str(e),
+            )
+            continue
+
+        # Filter to comments newer than the last processed id (string
+        # compare is fine — GitHub + GitLab comment ids are
+        # monotonically increasing integers as strings).
+        new_comments = [
+            c
+            for c in comments
+            if sess.last_processed_comment_id is None
+            or int(c.id) > int(sess.last_processed_comment_id)
+        ]
+        for c in new_comments:
+            # Local import to avoid pulling the parser into the global
+            # import graph for this single use.
+            from terrapod.services.vcs_command_parser import is_command_comment
+
+            if not is_command_comment(c.body):
+                continue
+            await enqueue_trigger(
+                "vcs_comment_dispatch",
+                {
+                    "connection_id": str(conn.id),
+                    "repo": repo,
+                    "pr_number": sess.pr_number,
+                    "comment_id": c.id,
+                    "actor_login": c.author_login,
+                    "actor_user_id": c.author_user_id,
+                    "body": c.body,
+                },
+                dedup_key=f"vcs_cmd:{conn.id}:{repo}:{sess.pr_number}:{c.id}",
+            )
+            logger.info(
+                "comment poll: dispatched terrapod command",
+                repo=repo,
+                pr_number=sess.pr_number,
+                comment_id=c.id,
+                author=c.author_login,
+            )
+        if new_comments:
+            # Advance the cursor regardless of whether any comments
+            # matched the parser — saves us re-scanning prose comments.
+            sess.last_processed_comment_id = max((c.id for c in new_comments), key=lambda x: int(x))
+
+
 async def _reconcile_closed_pr_sessions(
     db: AsyncSession,
     conn: VCSConnection,
@@ -524,15 +616,16 @@ async def _poll_workspace_prs(
     """Check open PRs/MRs targeting the tracked branch for speculative plans."""
     prs = await _list_open_prs(conn, owner, repo, branch)
 
-    # Hook-and-poll fallback for `pull_request:closed` (#282): if any
-    # PRSession on this (connection, repo) is no longer in the open list,
-    # cancel its runs and mark closed. Releases workspace locks held by
-    # planned apply-then-merge runs on PRs the user just closed without
-    # merging. Skip when the workspace isn't apply-then-merge — default-
-    # mode PR runs are plan-only and don't hold locks worth reconciling.
+    # Hook-and-poll fallbacks (#282). Only run for apply-then-merge —
+    # default-mode PR runs are plan-only and don't drive any of this.
     if ws.vcs_workflow == "apply_then_merge":
         open_pr_numbers = {pr.number for pr in prs}
+        # PR-closed: cancel runs, release workspace locks.
         await _reconcile_closed_pr_sessions(db, conn, f"{owner}/{repo}", open_pr_numbers)
+        # Comment polling: dispatch any new `terrapod ...` commands the
+        # webhook either didn't deliver (no subscription, firewall) or
+        # raced with this poll cycle (dedup key in dispatcher handles the race).
+        await _poll_pr_comments(db, conn, f"{owner}/{repo}")
 
     for pr in prs:
         # Check if we already have any run for this PR + SHA (avoid duplicates)

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -41,6 +41,7 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service, run_service
+from terrapod.services.scheduler import enqueue_trigger
 from terrapod.services.vcs_archive_cache import VCSArchiveCache, materialize_archive
 from terrapod.services.vcs_provider import PullRequest
 from terrapod.services.workspace_autodiscovery_service import autodiscover_for_paths
@@ -647,7 +648,14 @@ async def _poll_workspace_prs(
             # later phases (status comment, dispatcher) can hang state
             # off a stable PRSession id without re-querying the VCS.
             if is_apply_then_merge:
-                await _upsert_pr_session(db, conn, f"{owner}/{repo}", pr.number, pr.head_sha)
+                sess = await _upsert_pr_session(db, conn, f"{owner}/{repo}", pr.number, pr.head_sha)
+                # Fire the status-comment refresh asynchronously so the
+                # poll cycle isn't blocked on the VCS API write.
+                await enqueue_trigger(
+                    "vcs_status_comment_update",
+                    {"session_id": str(sess.id)},
+                    dedup_key=f"vcs_status:{sess.id}",
+                )
             await db.commit()
             logger.info(
                 "Speculative run created for PR",

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -30,7 +30,14 @@ from terrapod.api.metrics import (
     VCS_PRS_DETECTED,
     VCS_RUNS_CREATED,
 )
-from terrapod.db.models import AutodiscoveryRule, Run, VCSConnection, Workspace, utc_now
+from terrapod.db.models import (
+    AutodiscoveryRule,
+    PRSession,
+    Run,
+    VCSConnection,
+    Workspace,
+    utc_now,
+)
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service, run_service
@@ -413,6 +420,96 @@ async def _poll_workspace_branch(
         )
 
 
+async def _upsert_pr_session(
+    db: AsyncSession,
+    conn: VCSConnection,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+) -> PRSession:
+    """Find or create the PRSession row for this (connection, repo, PR).
+
+    Updates `head_sha` if the PR has new commits. Idempotent — designed
+    to be called every poll cycle that sees an open PR. Returns the
+    persisted row (flushed but not committed; caller drives the commit).
+    """
+    existing = await db.execute(
+        select(PRSession).where(
+            PRSession.vcs_connection_id == conn.id,
+            PRSession.repo == repo,
+            PRSession.pr_number == pr_number,
+        )
+    )
+    sess = existing.scalar_one_or_none()
+    if sess is None:
+        sess = PRSession(
+            vcs_connection_id=conn.id,
+            repo=repo,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            state="open",
+        )
+        db.add(sess)
+        await db.flush()
+        return sess
+    if sess.head_sha != head_sha:
+        sess.head_sha = head_sha
+    if sess.state != "open":
+        sess.state = "open"
+    return sess
+
+
+async def _reconcile_closed_pr_sessions(
+    db: AsyncSession,
+    conn: VCSConnection,
+    repo: str,
+    open_pr_numbers: set[int],
+) -> None:
+    """Detect PRs that have been closed since the last poll and clean up.
+
+    For each open PRSession on this (connection, repo) that's no longer
+    in the VCS provider's open-PR list, cancel any active runs to release
+    the workspace lock and mark the session as `closed`. This is the
+    poll-cycle fallback for the `pull_request:closed` webhook (which
+    phase 4 wires up). Hook-and-poll per #282: webhooks accelerate, polling
+    is the source of truth.
+    """
+    sessions = await db.execute(
+        select(PRSession).where(
+            PRSession.vcs_connection_id == conn.id,
+            PRSession.repo == repo,
+            PRSession.state == "open",
+        )
+    )
+    for sess in sessions.scalars().all():
+        if sess.pr_number in open_pr_numbers:
+            continue
+        # PR no longer in the open list — cancel active runs, close session.
+        active = await db.execute(
+            select(Run).where(
+                Run.vcs_pull_request_number == sess.pr_number,
+                Run.status.notin_(run_service.TERMINAL_STATES),
+            )
+        )
+        for run in active.scalars().all():
+            try:
+                await run_service.cancel_run(db, run, force=True)
+                logger.info(
+                    "Canceled run for closed PR",
+                    run_id=str(run.id),
+                    pr_number=sess.pr_number,
+                    repo=repo,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to cancel run for closed PR",
+                    run_id=str(run.id),
+                    pr_number=sess.pr_number,
+                    error=str(e),
+                )
+        sess.state = "closed"
+
+
 async def _poll_workspace_prs(
     db: AsyncSession,
     ws: Workspace,
@@ -425,6 +522,16 @@ async def _poll_workspace_prs(
 ) -> None:
     """Check open PRs/MRs targeting the tracked branch for speculative plans."""
     prs = await _list_open_prs(conn, owner, repo, branch)
+
+    # Hook-and-poll fallback for `pull_request:closed` (#282): if any
+    # PRSession on this (connection, repo) is no longer in the open list,
+    # cancel its runs and mark closed. Releases workspace locks held by
+    # planned apply-then-merge runs on PRs the user just closed without
+    # merging. Skip when the workspace isn't apply-then-merge — default-
+    # mode PR runs are plan-only and don't hold locks worth reconciling.
+    if ws.vcs_workflow == "apply_then_merge":
+        open_pr_numbers = {pr.number for pr in prs}
+        await _reconcile_closed_pr_sessions(db, conn, f"{owner}/{repo}", open_pr_numbers)
 
     for pr in prs:
         # Check if we already have any run for this PR + SHA (avoid duplicates)
@@ -505,6 +612,20 @@ async def _poll_workspace_prs(
                     error=repr(e),
                 )
 
+        # Branch on workspace mode (#282).
+        # - merge_then_apply (default): PR run is speculative plan-only.
+        # - apply_then_merge: PR run is a full plan-and-apply that saves
+        #   the tfplan and sits in `planned` waiting on a user comment.
+        #   The non-speculative run holds the workspace lock through
+        #   `planned` (confirmed via Q8 in #282 — non-plan-only runs
+        #   only release the lock at terminal/applied/cancelled).
+        is_apply_then_merge = ws.vcs_workflow == "apply_then_merge"
+        speculative = not is_apply_then_merge
+        if is_apply_then_merge:
+            message = f"Plan for PR #{pr.number}: {pr.title}"
+        else:
+            message = f"Speculative plan for PR #{pr.number}: {pr.title}"
+
         run = await _create_vcs_run(
             db,
             ws,
@@ -513,15 +634,20 @@ async def _poll_workspace_prs(
             repo,
             pr.head_sha,
             pr.head_ref,
-            speculative=True,
+            speculative=speculative,
             pr_number=pr.number,
-            message=f"Speculative plan for PR #{pr.number}: {pr.title}",
+            message=message,
             cache=cache,
             fetch_paths=fetch_paths,
         )
 
         if run:
             VCS_RUNS_CREATED.labels(provider=conn.provider, type="pr").inc()
+            # For apply-then-merge, upsert the conversation-state row so
+            # later phases (status comment, dispatcher) can hang state
+            # off a stable PRSession id without re-querying the VCS.
+            if is_apply_then_merge:
+                await _upsert_pr_session(db, conn, f"{owner}/{repo}", pr.number, pr.head_sha)
             await db.commit()
             logger.info(
                 "Speculative run created for PR",

--- a/services/terrapod/services/vcs_provider.py
+++ b/services/terrapod/services/vcs_provider.py
@@ -4,6 +4,7 @@ Defines the VCSProvider protocol that GitHub and GitLab implementations
 conform to. The poller works against this interface, not specific providers.
 """
 
+from dataclasses import dataclass
 from typing import Protocol
 
 from terrapod.db.models import VCSConnection
@@ -12,13 +13,83 @@ from terrapod.db.models import VCSConnection
 class PullRequest:
     """Minimal PR/MR representation shared across providers."""
 
-    __slots__ = ("number", "head_sha", "head_ref", "title")
+    __slots__ = ("number", "head_sha", "head_ref", "title", "draft", "author_login")
 
-    def __init__(self, number: int, head_sha: str, head_ref: str, title: str) -> None:
+    def __init__(
+        self,
+        number: int,
+        head_sha: str,
+        head_ref: str,
+        title: str,
+        draft: bool = False,
+        author_login: str = "",
+    ) -> None:
         self.number = number
         self.head_sha = head_sha
         self.head_ref = head_ref
         self.title = title
+        self.draft = draft
+        self.author_login = author_login
+
+
+@dataclass(frozen=True)
+class MergeabilityStatus:
+    """Result of a "can this PR be merged right now?" check.
+
+    `mergeable` is the boolean we gate the apply on. `state` is the
+    provider-native string surfaced verbatim on the PR comment so users
+    see the same language their VCS uses (`dirty`, `blocked`, `behind`,
+    `mergeable`, `unknown`, etc.). `reason` is a human-readable summary
+    we synthesise from the provider response — used when the PR comment
+    needs more than the bare state string (e.g. "blocked: review
+    required by branch protection").
+
+    `unknown=True` means the provider has not yet computed mergeability
+    (GitHub returns `mergeable: null` briefly after a push). Callers
+    should retry rather than treating this as "blocked".
+    """
+
+    mergeable: bool
+    state: str
+    reason: str
+    unknown: bool = False
+
+
+@dataclass(frozen=True)
+class PRComment:
+    """A comment on a PR/MR (the conversational kind, not a code review)."""
+
+    id: str  # provider-side comment id, as a string for cross-provider portability
+    body: str
+    author_login: str
+    author_user_id: str
+    created_at: str  # ISO 8601
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class PRReview:
+    """A PR/MR review. Used to detect approvals for apply gating."""
+
+    id: str
+    state: str  # "approved" / "changes_requested" / "commented" / etc.
+    author_login: str
+    submitted_at: str
+
+
+@dataclass(frozen=True)
+class PRMergeResult:
+    """Outcome of a merge attempt. `merged=True` means the API confirmed merge.
+
+    `message` is the provider-side response message (typically the
+    commit message GitHub used). `error_reason` is set when `merged=False`
+    and contains the provider's rejection reason, surfaced verbatim.
+    """
+
+    merged: bool
+    sha: str = ""
+    message: str = ""
+    error_reason: str = ""
 
 
 class VCSProvider(Protocol):
@@ -70,4 +141,109 @@ class VCSProvider(Protocol):
 
     def parse_repo_url(self, repo_url: str) -> tuple[str, str] | None:
         """Parse a repo URL into (owner/namespace, repo). Returns None if unparseable."""
+        ...
+
+    # ── Apply-then-merge surface (#282) ─────────────────────────────────
+
+    async def get_pull_request(
+        self, conn: VCSConnection, owner: str, repo: str, pr_number: int
+    ) -> PullRequest | None:
+        """Fetch a single PR/MR's current state (including draft flag).
+
+        Used when we have a PR number from a webhook event and need its
+        current state. Returns None if not found.
+        """
+        ...
+
+    async def is_mergeable(
+        self, conn: VCSConnection, owner: str, repo: str, pr_number: int
+    ) -> MergeabilityStatus:
+        """Check whether a PR/MR is currently mergeable per the VCS provider.
+
+        This is the apply gate for apply-then-merge mode — branch
+        protection, required reviews, status checks, draft state, etc.
+        are all the VCS provider's domain. We surface its decision
+        verbatim.
+        """
+        ...
+
+    async def merge_pull_request(
+        self,
+        conn: VCSConnection,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        strategy: str,
+        commit_title: str = "",
+        commit_message: str = "",
+    ) -> PRMergeResult:
+        """Merge a PR/MR via the provider's merge API.
+
+        `strategy` is one of `merge` / `squash` / `rebase`. Failure
+        modes (conflicts, protection rules) come back as
+        `merged=False` with `error_reason` populated.
+        """
+        ...
+
+    async def list_pr_comments(
+        self,
+        conn: VCSConnection,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        since: str | None = None,
+    ) -> list[PRComment]:
+        """List conversational comments on a PR/MR.
+
+        `since` is an ISO 8601 timestamp; the provider filters server-
+        side where supported (`?sort=asc&order_by=updated_at` for
+        GitLab; `?since=` for GitHub). Caller is responsible for
+        client-side de-duplication via `PRSession.last_processed_comment_id`.
+        """
+        ...
+
+    async def post_pr_comment(
+        self,
+        conn: VCSConnection,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        body: str,
+    ) -> str:
+        """Post a new conversational comment on a PR/MR.
+
+        Returns the provider-side comment id (stringified for
+        portability). Used for the announcement comment when a Terrapod
+        UI user clicks "Confirm and Apply".
+        """
+        ...
+
+    async def update_pr_comment(
+        self,
+        conn: VCSConnection,
+        owner: str,
+        repo: str,
+        comment_id: str,
+        body: str,
+    ) -> None:
+        """Update (edit-in-place) the body of an existing PR comment.
+
+        Used by the status-comment surface so the same comment is
+        re-rendered on every state transition rather than appending a
+        new comment per update.
+        """
+        ...
+
+    async def list_pr_reviews(
+        self,
+        conn: VCSConnection,
+        owner: str,
+        repo: str,
+        pr_number: int,
+    ) -> list[PRReview]:
+        """List reviews on a PR (GitHub) or approvals on an MR (GitLab).
+
+        Used to detect approval-state transitions for the mergeability
+        gate, alongside the provider's `is_mergeable` summary.
+        """
         ...

--- a/services/terrapod/services/vcs_status_comment.py
+++ b/services/terrapod/services/vcs_status_comment.py
@@ -1,0 +1,240 @@
+"""Renders + posts the per-PR status comment (#282 phase 6).
+
+One Terrapod-authored comment per PR/MR, edited in place. The renderer
+collects every PR-affected workspace across modes (apply_then_merge and
+merge_then_apply) and emits a single Markdown table per the worked
+examples in #282.
+
+Posted-from triggers:
+  - vcs_poller after a plan finishes for a PR run
+  - run_service apply-completion path
+  - vcs_command_dispatcher on every command
+  - run_reconciler when a planned run is invalidated by a sibling apply
+
+The triggered task handler is `vcs_status_comment_update`. It's
+idempotent — the same payload run multiple times converges on the same
+comment body.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+
+from terrapod.db.models import PRSession, Run, VCSConnection, Workspace
+from terrapod.db.session import get_db_session
+from terrapod.logging_config import get_logger
+from terrapod.services import github_service, gitlab_service
+
+logger = get_logger(__name__)
+
+
+# Marker hidden in the comment body so we can find our own comment on a
+# PR even if the status_comment_id isn't recorded (e.g. comment created
+# manually, or PRSession was rebuilt). The HTML-comment form is invisible
+# to GitHub / GitLab rendering.
+_COMMENT_MARKER = "<!-- terrapod:status-comment -->"
+
+
+@dataclass(frozen=True)
+class _Row:
+    """One row in the rendered status table."""
+
+    workspace_name: str
+    mode: str
+    plan_summary: str
+    apply_summary: str
+    mergeable_summary: str
+
+
+def _plan_summary(run: Run | None) -> str:
+    """Compact plan summary: `+ N ~ N` style, or status word for non-planned."""
+    if run is None:
+        return "—"
+    if run.status in ("pending", "queued"):
+        return "queued"
+    if run.status == "planning":
+        return "running"
+    if run.status == "errored":
+        return "errored"
+    if run.status == "discarded":
+        return "discarded"
+    if run.status == "canceled":
+        return "canceled"
+    # Planned / applying / applied — we don't currently parse the plan
+    # log to extract add/change/destroy counts. has_changes carries the
+    # bool. Refine later by surfacing the counts from `plan-result` or
+    # `tofu show -json`.
+    if run.has_changes is False:
+        return "no changes"
+    return "changes"
+
+
+def _apply_summary(run: Run | None) -> str:
+    if run is None:
+        return "—"
+    if run.status == "applied":
+        return "applied"
+    if run.status == "applying":
+        return "applying"
+    if run.status == "errored":
+        return "errored"
+    if run.status == "discarded":
+        return "discarded"
+    if run.status == "canceled":
+        return "canceled"
+    return "not applied"
+
+
+def _mergeable_summary(run: Run | None) -> str:
+    if run is None:
+        return "—"
+    if run.vcs_apply_blocked_reason:
+        return f"blocked: {run.vcs_apply_blocked_reason[:60]}"
+    return "yes"
+
+
+def render_comment(rows: list[_Row], *, force_merge_hint: bool = False) -> str:
+    """Render the Markdown status-comment body.
+
+    Mode-aware rows: apply_then_merge workspaces show 'not applied' /
+    'applied'; merge_then_apply workspaces show 'will apply on merge'
+    in the apply column because they don't apply pre-merge by design.
+    """
+    if not rows:
+        return f"{_COMMENT_MARKER}\n\n_No Terrapod workspaces affected by this PR._"
+
+    header = "| Workspace | Mode | Plan | Apply | Mergeable |\n|---|---|---|---|---|"
+    body_lines: list[str] = []
+    pending_apply: list[str] = []
+    for r in rows:
+        # merge_then_apply rows annotate the apply column to make the
+        # mode-distinction explicit; apply_then_merge rows pass through.
+        apply_cell = "will apply on merge" if r.mode == "merge_then_apply" else r.apply_summary
+        body_lines.append(
+            f"| `{_escape(r.workspace_name)}` | {r.mode} | {r.plan_summary} | {apply_cell} | {r.mergeable_summary} |"
+        )
+        if r.mode == "apply_then_merge" and r.apply_summary == "not applied":
+            pending_apply.append(r.workspace_name)
+
+    parts: list[str] = [_COMMENT_MARKER, "", header, *body_lines]
+    if pending_apply:
+        if len(pending_apply) == 1:
+            parts.append("")
+            parts.append(f"Comment `terrapod apply` to apply `{_escape(pending_apply[0])}`.")
+        else:
+            parts.append("")
+            parts.append(
+                "Comment `terrapod apply` to apply all pending workspaces, "
+                "or `terrapod apply -W <workspace>` for one at a time."
+            )
+    if force_merge_hint:
+        parts.append("")
+        parts.append(
+            "Auto-merge is blocked. Use `terrapod merge` to merge despite incomplete applies."
+        )
+    return "\n".join(parts)
+
+
+def _escape(text: str) -> str:
+    """Minimal Markdown / table-cell escaping for user-controlled cells."""
+    return (text or "").replace("|", "\\|").replace("\n", " ").strip()
+
+
+async def _collect_rows(db, sess: PRSession) -> list[_Row]:
+    """Find every workspace whose runs reference this PR, latest run per."""
+    # Workspaces in either mode that have a run for this PR. We don't
+    # have a direct (connection, repo, pr) → workspace index, so we
+    # pivot through the Run rows themselves.
+    result = await db.execute(
+        select(Run, Workspace)
+        .join(Workspace, Workspace.id == Run.workspace_id)
+        .where(
+            Run.vcs_pull_request_number == sess.pr_number,
+            Workspace.vcs_connection_id == sess.vcs_connection_id,
+            (Workspace.vcs_repo_url.endswith(sess.repo)),
+        )
+        .order_by(Workspace.name, Run.created_at.desc())
+    )
+    # Reduce to latest run per workspace.
+    latest_per_ws: dict[uuid.UUID, tuple[Workspace, Run]] = {}
+    for run, ws in result.all():
+        latest_per_ws.setdefault(ws.id, (ws, run))
+
+    rows: list[_Row] = []
+    for ws, run in sorted(latest_per_ws.values(), key=lambda pair: pair[0].name):
+        rows.append(
+            _Row(
+                workspace_name=ws.name,
+                mode=ws.vcs_workflow,
+                plan_summary=_plan_summary(run),
+                apply_summary=_apply_summary(run),
+                mergeable_summary=_mergeable_summary(run),
+            )
+        )
+    return rows
+
+
+async def _post_or_update(
+    conn: VCSConnection,
+    repo: str,
+    pr_number: int,
+    sess: PRSession,
+    body: str,
+) -> None:
+    """Provider-dispatched post-or-update via the existing comment helpers."""
+    owner, repo_name = repo.split("/", 1)
+    if conn.provider == "github":
+        post = github_service.create_pr_comment
+        update = github_service.update_pr_comment
+    elif conn.provider == "gitlab":
+        post = gitlab_service.create_mr_comment
+        update = gitlab_service.update_mr_comment
+    else:
+        logger.warning("status comment: unknown provider", provider=conn.provider)
+        return
+
+    try:
+        if sess.status_comment_id:
+            if conn.provider == "gitlab":
+                # GitLab update takes (conn, owner, repo, mr_number, note_id, body)
+                await update(conn, owner, repo_name, pr_number, int(sess.status_comment_id), body)
+            else:
+                await update(conn, owner, repo_name, int(sess.status_comment_id), body)
+            return
+        new_id = await post(conn, owner, repo_name, pr_number, body)
+        sess.status_comment_id = str(new_id)
+    except Exception as e:
+        # Status comment failure must never break the run lifecycle. Log
+        # and move on; the next state-change trigger will retry.
+        logger.warning(
+            "status comment post/update failed",
+            provider=conn.provider,
+            pr_number=pr_number,
+            error=str(e),
+        )
+
+
+async def handle_vcs_status_comment_update(payload: dict[str, Any]) -> None:
+    """Scheduler trigger handler.
+
+    Payload:
+      { "session_id": "<uuid>" }
+    """
+    session_id = payload.get("session_id")
+    if not session_id:
+        return
+    async with get_db_session() as db:
+        sess = await db.get(PRSession, uuid.UUID(session_id))
+        if sess is None or sess.state != "open":
+            return
+        conn = await db.get(VCSConnection, sess.vcs_connection_id)
+        if conn is None:
+            return
+        rows = await _collect_rows(db, sess)
+        body = render_comment(rows)
+        await _post_or_update(conn, sess.repo, sess.pr_number, sess, body)
+        await db.commit()

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -47,6 +47,9 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.drift_last_checked_at = overrides.get("drift_last_checked_at", None)
     ws.drift_status = overrides.get("drift_status", "")
     ws.state_diverged = overrides.get("state_diverged", False)
+    ws.vcs_workflow = overrides.get("vcs_workflow", "merge_then_apply")
+    ws.auto_merge = overrides.get("auto_merge", False)
+    ws.auto_merge_strategy = overrides.get("auto_merge_strategy", "merge")
     ws.execution_backend = overrides.get("execution_backend", "tofu")
     ws.agent_pool = None
     ws.agent_pool_id = overrides.get("agent_pool_id", None)

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -56,6 +56,9 @@ def _mock_workspace(ws_id=None, pool_id=None):
     ws.drift_last_checked_at = None
     ws.drift_status = ""
     ws.state_diverged = False
+    ws.vcs_workflow = "merge_then_apply"
+    ws.auto_merge = False
+    ws.auto_merge_strategy = "merge"
     ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return ws

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -67,6 +67,9 @@ def _mock_workspace(
     ws.drift_last_checked_at = None
     ws.drift_status = ""
     ws.state_diverged = False
+    ws.vcs_workflow = "merge_then_apply"
+    ws.auto_merge = False
+    ws.auto_merge_strategy = "merge"
     ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return ws
@@ -746,3 +749,216 @@ class TestParseTagFilters:
         )
         out = _parse_tag_filters(self._req(q))
         assert out == [("core", None), ("env", "prod")]
+
+
+# ── VCS workflow + auto-merge (#282 phase 1) ───────────────────────────
+
+
+class TestVcsWorkflowAttributes:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_default_workspace_serializes_default_workflow(self, mock_resolve, *_mocks):
+        """Default-mode regression: an existing workspace serializes with the
+        new attributes at default values. Frontend / providers must see the
+        new fields, but their values are inert."""
+        mock_resolve.return_value = "read"
+        ws = _mock_workspace()
+        app, mock_db = _make_app(_user())
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run = MagicMock()
+        no_run.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+
+        assert resp.status_code == 200
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["vcs-workflow"] == "merge_then_apply"
+        assert attrs["auto-merge"] is False
+        assert attrs["auto-merge-strategy"] == "merge"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_invalid_workflow_value_rejected(self, mock_resolve, *_mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()
+        ws.vcs_connection_id = uuid.uuid4()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"vcs-workflow": "nonsense"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "vcs-workflow" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_apply_then_merge_requires_vcs_connection(self, mock_resolve, *_mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()  # no VCS connection
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"vcs-workflow": "apply_then_merge"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "VCS connection" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_apply_then_merge_incompatible_with_auto_apply(self, mock_resolve, *_mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace(auto_apply=True)
+        ws.vcs_connection_id = uuid.uuid4()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"vcs-workflow": "apply_then_merge"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "auto-apply" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_combined_flip_off_auto_apply_and_into_apply_then_merge_succeeds(
+        self, mock_resolve, *_mocks
+    ):
+        """User may set vcs-workflow=apply_then_merge AND auto-apply=false in
+        one request — the validation evaluates the post-update state."""
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace(auto_apply=True)
+        ws.vcs_connection_id = uuid.uuid4()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        # No active PR runs.
+        active_result = MagicMock()
+        active_result.all.return_value = []
+        mock_db.execute.side_effect = [mock_result, active_result]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "vcs-workflow": "apply_then_merge",
+                            "auto-apply": False,
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert ws.vcs_workflow == "apply_then_merge"
+        assert ws.auto_apply is False
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_workflow_flip_blocked_by_active_pr_runs(self, mock_resolve, *_mocks):
+        """Q4 of the design: cannot flip vcs-workflow with PR runs in flight.
+        Operator must cancel/discard them first."""
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()
+        ws.vcs_workflow = "apply_then_merge"
+        ws.vcs_connection_id = uuid.uuid4()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        # Two PR runs in flight.
+        active_result = MagicMock()
+        active_result.all.return_value = [(uuid.uuid4(),), (uuid.uuid4(),)]
+        mock_db.execute.side_effect = [mock_result, active_result]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"vcs-workflow": "merge_then_apply"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        body = resp.json()["detail"]
+        assert "2 PR run(s)" in body
+        assert "Cancel" in body
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_invalid_auto_merge_strategy_rejected(self, mock_resolve, *_mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"auto-merge-strategy": "ff"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "merge" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_auto_merge_toggle_persists(self, mock_resolve, *_mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "auto-merge": True,
+                            "auto-merge-strategy": "squash",
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert ws.auto_merge is True
+        assert ws.auto_merge_strategy == "squash"

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -28,6 +28,7 @@ def _mock_run(**kwargs):
     run.auto_apply = kwargs.get("auto_apply", False)
     run.plan_only = kwargs.get("plan_only", False)
     run.error_message = kwargs.get("error_message", "")
+    run.vcs_pull_request_number = kwargs.get("vcs_pull_request_number", None)
     run.vcs_commit_sha = kwargs.get("vcs_commit_sha", None)
     run.is_drift_detection = kwargs.get("is_drift_detection", False)
     # Default `has_changes=True` so existing tests keep matching the

--- a/services/tests/services/test_vcs_command_parser.py
+++ b/services/tests/services/test_vcs_command_parser.py
@@ -1,0 +1,142 @@
+"""Tests for the VCS comment command parser (#282 phase 4)."""
+
+from terrapod.services.vcs_command_parser import Command, is_command_comment, parse
+
+
+class TestBasicVocabulary:
+    def test_plan_matches(self):
+        c = parse("terrapod plan")
+        assert c == Command(verb="plan", workspace=None, raw="terrapod plan")
+
+    def test_apply_matches(self):
+        c = parse("terrapod apply")
+        assert c is not None and c.verb == "apply"
+
+    def test_unlock_matches(self):
+        c = parse("terrapod unlock")
+        assert c is not None and c.verb == "unlock"
+
+    def test_merge_matches(self):
+        c = parse("terrapod merge")
+        assert c is not None and c.verb == "merge"
+
+    def test_help_matches(self):
+        c = parse("terrapod help")
+        assert c is not None and c.verb == "help"
+
+
+class TestWorkspaceFlag:
+    def test_short_flag(self):
+        c = parse("terrapod apply -W accounts-alpha-net")
+        assert c is not None
+        assert c.verb == "apply"
+        assert c.workspace == "accounts-alpha-net"
+
+    def test_long_flag_with_equals(self):
+        c = parse("terrapod plan --workspace=billing-prod")
+        assert c is not None
+        assert c.workspace == "billing-prod"
+
+    def test_long_flag_with_space(self):
+        c = parse("terrapod plan --workspace billing-prod")
+        assert c is not None
+        assert c.workspace == "billing-prod"
+
+    def test_no_flag_returns_none(self):
+        c = parse("terrapod plan")
+        assert c is not None and c.workspace is None
+
+
+class TestPrefixMatching:
+    def test_mid_sentence_does_not_match(self):
+        """Mentions of `terrapod` mid-text are not commands."""
+        assert parse("Earlier I was using terrapod apply but...") is None
+        assert parse("see terrapod docs") is None
+
+    def test_must_start_line(self):
+        """Indented start is OK; suffix after `terrapod foo` on the same line is ignored."""
+        c = parse("  terrapod apply  # please")
+        assert c is not None and c.verb == "apply"
+
+    def test_at_prefix_matches(self):
+        """`@terrapod-bot apply` matches when the prefix is configured."""
+        c = parse("@terrapod-bot apply", mention_prefix="terrapod-bot")
+        assert c is not None and c.verb == "apply"
+
+    def test_at_prefix_does_not_match_default(self):
+        """With the default `terrapod` prefix, `@terrapod-bot ...` is silently ignored."""
+        # The observed prefix stripped of `@` is `terrapod-bot`, which
+        # doesn't equal the default `terrapod`. The comment is ignored.
+        assert parse("@terrapod-bot apply") is None
+
+    def test_wrong_prefix_ignored(self):
+        assert parse("atlantis apply") is None
+
+
+class TestCodeFences:
+    def test_inside_code_block_ignored(self):
+        body = """Here's how it would work:
+
+```
+terrapod apply
+```
+
+Thoughts?"""
+        assert parse(body) is None
+
+    def test_after_code_block_matches(self):
+        body = """Example:
+
+```
+some code
+```
+
+terrapod apply
+"""
+        c = parse(body)
+        assert c is not None and c.verb == "apply"
+
+    def test_inline_backticks_not_a_fence(self):
+        """Single backticks should not flip the fence state."""
+        c = parse("note that `terrapod` is the name\nterrapod apply")
+        assert c is not None and c.verb == "apply"
+
+
+class TestMultilineBodies:
+    def test_first_command_wins(self):
+        body = "terrapod plan\nterrapod apply"
+        c = parse(body)
+        assert c is not None and c.verb == "plan"
+
+    def test_finds_command_after_prose(self):
+        body = "Looks good!\n\nterrapod apply"
+        c = parse(body)
+        assert c is not None and c.verb == "apply"
+
+
+class TestUnknownVerb:
+    def test_typo_becomes_help(self):
+        """A deliberate-looking `terrapod ploon` resolves to help so the
+        dispatcher can reply with usage instead of silent-ignoring."""
+        c = parse("terrapod ploon")
+        assert c is not None and c.verb == "help"
+
+    def test_bare_terrapod_is_not_a_command(self):
+        """`terrapod` with no verb has no second token to match."""
+        assert parse("terrapod") is None
+
+    def test_trailing_punctuation_stripped(self):
+        c = parse("terrapod apply!")
+        assert c is not None and c.verb == "apply"
+
+
+class TestIsCommandComment:
+    def test_true_for_command(self):
+        assert is_command_comment("terrapod plan") is True
+
+    def test_false_for_prose(self):
+        assert is_command_comment("looks good to me!") is False
+
+    def test_false_for_code_block(self):
+        body = "```\nterrapod apply\n```"
+        assert is_command_comment(body) is False

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -49,6 +49,9 @@ interface WorkspaceAttrs {
   'vcs-branch': string
   'vcs-connection-id': string | null
   'vcs-connection-name': string | null
+  'vcs-workflow': 'merge_then_apply' | 'apply_then_merge'
+  'auto-merge': boolean
+  'auto-merge-strategy': 'merge' | 'squash' | 'rebase'
   'drift-detection-enabled': boolean
   'drift-detection-interval-seconds': number
   'drift-last-checked-at': string
@@ -241,6 +244,13 @@ function WorkspaceDetailContent() {
   const [editVcsConnectionId, setEditVcsConnectionId] = useState<string | null>(null)
   const [editVcsRepoUrl, setEditVcsRepoUrl] = useState('')
   const [editVcsBranch, setEditVcsBranch] = useState('')
+  const [editVcsWorkflow, setEditVcsWorkflow] = useState<'merge_then_apply' | 'apply_then_merge'>(
+    'merge_then_apply'
+  )
+  const [editAutoMerge, setEditAutoMerge] = useState(false)
+  const [editAutoMergeStrategy, setEditAutoMergeStrategy] = useState<
+    'merge' | 'squash' | 'rebase'
+  >('merge')
   const [saving, setSaving] = useState(false)
 
   // Agent pools
@@ -716,6 +726,9 @@ function WorkspaceDetailContent() {
     setEditVcsConnectionId(workspace.attributes['vcs-connection-id'] || null)
     setEditVcsRepoUrl(workspace.attributes['vcs-repo-url'] || '')
     setEditVcsBranch(workspace.attributes['vcs-branch'] || '')
+    setEditVcsWorkflow(workspace.attributes['vcs-workflow'] || 'merge_then_apply')
+    setEditAutoMerge(workspace.attributes['auto-merge'] || false)
+    setEditAutoMergeStrategy(workspace.attributes['auto-merge-strategy'] || 'merge')
     setEditing(true)
     if (!poolsLoaded) {
       apiFetch('/api/terrapod/v1/agent-pools').then(res => res.ok ? res.json() : { data: [] }).then(data => {
@@ -767,6 +780,9 @@ function WorkspaceDetailContent() {
               'trigger-prefixes': editTriggerPrefixes,
               'vcs-repo-url': editVcsRepoUrl,
               'vcs-branch': editVcsBranch,
+              'vcs-workflow': editVcsWorkflow,
+              'auto-merge': editAutoMerge,
+              'auto-merge-strategy': editAutoMergeStrategy,
               labels: editLabels,
               ...(isAdmin() ? { 'owner-email': editOwner } : {}),
               ...(force ? { force: true } : {}),
@@ -1502,6 +1518,72 @@ function WorkspaceDetailContent() {
                     <input type="text" value={editVcsBranch} onChange={(e) => setEditVcsBranch(e.target.value)} placeholder="main (default)" className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                   ) : (
                     <dd className="mt-1 text-sm text-slate-200">{attrs['vcs-branch'] || 'Default'}</dd>
+                  )}
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">VCS Workflow</dt>
+                  {editing ? (
+                    <select
+                      value={editVcsWorkflow}
+                      onChange={(e) => setEditVcsWorkflow(e.target.value as 'merge_then_apply' | 'apply_then_merge')}
+                      className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    >
+                      <option value="merge_then_apply">merge_then_apply (default — TFE / HCP standard)</option>
+                      <option value="apply_then_merge">apply_then_merge (Atlantis standard — opt-in)</option>
+                    </select>
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">{attrs['vcs-workflow']}</dd>
+                  )}
+                </div>
+                {editing && editVcsWorkflow === 'apply_then_merge' && (
+                  <div className="sm:col-span-2 rounded border border-amber-700 bg-amber-900/30 p-3 text-xs text-amber-100">
+                    <p className="font-medium">Authorization delegated to your VCS repository.</p>
+                    <p className="mt-1">
+                      Anyone who can merge the PR can apply. Branch protection rules (required reviews,
+                      status checks, code owner approval) become the gate. Terrapod role/label RBAC does
+                      <em> not</em> apply to comment-driven actions in this mode.
+                    </p>
+                    <p className="mt-1">
+                      <strong>Recommended:</strong> require linear history (rebase/squash before merge) so the
+                      commit you apply is the commit that lands.
+                    </p>
+                    <p className="mt-1">
+                      Credit: this workflow is modelled on{' '}
+                      <a href="https://www.runatlantis.io/" target="_blank" rel="noopener noreferrer" className="underline">Atlantis</a>.
+                      Atlantis remains the right tool for teams who only want PR-comment-driven applies and no platform UI.
+                    </p>
+                  </div>
+                )}
+                <div>
+                  <dt className="text-xs text-slate-500">Auto-merge after apply</dt>
+                  {editing ? (
+                    <label className="mt-1 flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={editAutoMerge}
+                        onChange={(e) => setEditAutoMerge(e.target.checked)}
+                        className="rounded border-slate-600 bg-slate-700 text-brand-600"
+                      />
+                      <span className="text-sm text-slate-200">{editAutoMerge ? 'Enabled' : 'Disabled'}</span>
+                    </label>
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">{attrs['auto-merge'] ? 'Enabled' : 'Disabled'}</dd>
+                  )}
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Auto-merge Strategy</dt>
+                  {editing ? (
+                    <select
+                      value={editAutoMergeStrategy}
+                      onChange={(e) => setEditAutoMergeStrategy(e.target.value as 'merge' | 'squash' | 'rebase')}
+                      className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    >
+                      <option value="merge">merge</option>
+                      <option value="squash">squash</option>
+                      <option value="rebase">rebase</option>
+                    </select>
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">{attrs['auto-merge-strategy']}</dd>
                   )}
                 </div>
                 {attrs['vcs-connection-name'] && !editing && (


### PR DESCRIPTION
First reviewable slice of #282 (apply-then-merge VCS workflow). **No behavioural change.** Pure data-model + API plumbing that subsequent phases build on.

This is intentionally tiny so the rest of the work — VCS provider extensions, comment dispatcher, mergeability gate, status comment, auto-merge, frontend, provider — can land as focused follow-ups rather than one mega-PR.

## What's in this PR

**Schema** (one new migration, `c17aecf92ac8`):

- `workspaces.vcs_workflow` (enum: `merge_then_apply` (default) / `apply_then_merge`)
- `workspaces.auto_merge` (bool, default false) + `auto_merge_strategy` (enum: merge/squash/rebase)
- `runs.vcs_apply_blocked_reason`, `runs.vcs_actor_login`, `runs.vcs_actor_user_id` — all nullable
- New `pr_sessions` table — per-PR conversation state (status comment id, poll cursors, lifecycle)

**API** (`tfe_v2.py`):

- Workspace JSON gains `vcs-workflow`, `auto-merge`, `auto-merge-strategy`
- Workspace PATCH validates:
  - Enum membership for workflow + strategy
  - `apply_then_merge` requires `vcs_connection_id`
  - `apply_then_merge` is incompatible with `auto_apply=true` (checked post-update so the user can flip both fields in one request)
  - Q4 design: flipping `vcs_workflow` while PR runs are in flight is rejected with the in-flight count
- Validation gated on the relevant attribute being touched — unrelated patches (drift, pool assignment, labels) don't pay the cross-validation tax

## Behavioural-change checklist

- [x] Default-mode workspaces serialize the new attributes at default values (verified in Tilt)
- [x] PATCH without any of the new fields runs unchanged code paths (regression test added)
- [x] Migration runs against a populated DB (Tilt smoke)
- [x] No new VCS API calls, no new polling cost — that's phase 2+

## Tests

8 new tests in `test_workspaces.py`:
- Default-mode serialization of new attrs
- Invalid workflow enum value → 422
- `apply_then_merge` without VCS connection → 422
- `apply_then_merge` + `auto_apply=true` → 422
- Combined flip-off-`auto_apply` + into-`apply_then_merge` in one PATCH → 200
- Flipping `vcs_workflow` with active PR runs → 422 with count
- Invalid `auto_merge_strategy` → 422
- `auto_merge` + strategy persistence

Existing mock workspace helpers in `test_drift_detection.py` and `test_workspace_pool_assignment.py` updated for the new default-mode attributes.

**1305 passing.**

## Tilt smoke

- Migration applied cleanly (`alembic_version → c17aecf92ac8`)
- New columns visible on `workspaces` + `runs`
- `pr_sessions` table created with FK + index + unique constraint
- API exposes the three new workspace attributes at defaults on existing rows

## Next phases (not in this PR)

Per #282's phasing:
2. VCS provider extensions (`is_mergeable`, `merge_pull_request`, comment APIs)
3. VCS poller branches on `vcs_workflow`; non-speculative full-run path for `apply_then_merge`
4. Comment parser + dispatcher
5. Mergeability gate in `run_service.confirm_run`
6. Status-comment builder
7. Audit-log dual-actor model
8. Auto-merge dispatcher + monorepo aggregation
9. Frontend wiring + provider attributes
10. Docs
11. Tilt smoke

Each is independent and reviewable on its own.

## Test plan

- [ ] Verify existing default-mode workspaces continue to work unchanged (workspace list, create, run lifecycle)
- [ ] Set `vcs_workflow: apply_then_merge` on a workspace with a VCS connection — verify it sticks
- [ ] Try to set `apply_then_merge` without a VCS connection — verify 422
- [ ] Try to set `apply_then_merge` while `auto_apply=true` — verify 422 (and the combined-flip path works)