### PR TITLE
feat: plan summary badges on run detail (closes #301)

### DIFF
--- a/alembic/versions/00b4c01e70e7_add_plan_summary_counts.py
+++ b/alembic/versions/00b4c01e70e7_add_plan_summary_counts.py
@@ -1,0 +1,41 @@
+"""add plan summary counts to runs (#301)
+
+Adds five nullable integer columns to `runs` that hold the
+resource-change counts parsed from the JSON plan output:
+`resource_additions`, `resource_changes`, `resource_destructions`,
+`resource_replacements`, `resource_imports`.
+
+Null = not yet computed (older runs, or parse failed). Zero = computed,
+no resources of that kind. This lets the UI distinguish "we don't know"
+from "no changes".
+
+Revision ID: 00b4c01e70e7
+Revises: a0b6c95a281d
+Create Date: 2026-05-11
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "00b4c01e70e7"
+down_revision: str | None = "a0b6c95a281d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("runs", sa.Column("resource_additions", sa.Integer(), nullable=True))
+    op.add_column("runs", sa.Column("resource_changes", sa.Integer(), nullable=True))
+    op.add_column("runs", sa.Column("resource_destructions", sa.Integer(), nullable=True))
+    op.add_column("runs", sa.Column("resource_replacements", sa.Integer(), nullable=True))
+    op.add_column("runs", sa.Column("resource_imports", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "resource_imports")
+    op.drop_column("runs", "resource_replacements")
+    op.drop_column("runs", "resource_destructions")
+    op.drop_column("runs", "resource_changes")
+    op.drop_column("runs", "resource_additions")

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -32,6 +32,7 @@ from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.db.models import Run, StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
+from terrapod.services.plan_summary import summarize_plan_json
 from terrapod.storage import get_storage
 from terrapod.storage.keys import (
     apply_log_key,
@@ -196,6 +197,23 @@ async def upload_plan_json_output(
     # which would advertise a URL pointing at nothing.
     await storage.put(key, body)
     run.has_json_output = True
+    # Parse the plan in a thread so a multi-MB JSON doesn't block the
+    # event loop. A parse failure leaves the count columns null — the
+    # download URL is still served, just no UI summary.
+    summary = await asyncio.to_thread(summarize_plan_json, body)
+    if summary is not None:
+        run.resource_additions = summary["additions"]
+        run.resource_changes = summary["changes"]
+        run.resource_destructions = summary["destructions"]
+        run.resource_replacements = summary["replacements"]
+        run.resource_imports = summary["imports"]
+    else:
+        logger.warning(
+            "plan_json_output.summary_unparseable",
+            run_id=str(run.id),
+            workspace_id=str(run.workspace_id),
+            body_bytes=len(body),
+        )
     await db.commit()
     return Response(status_code=204)
 

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -76,6 +76,24 @@ def _rfc3339(dt) -> str:
     return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _plan_summary_attr(run: Run) -> dict[str, int] | None:
+    """Compact plan summary used by the UI to render the badge row.
+
+    Returns None when the runner hasn't uploaded a JSON plan yet, or the
+    upload was unparseable — the UI uses None to mean "we don't know"
+    and renders nothing, vs an all-zero dict which means "no changes".
+    """
+    if run.resource_additions is None:
+        return None
+    return {
+        "add": run.resource_additions or 0,
+        "change": run.resource_changes or 0,
+        "destroy": run.resource_destructions or 0,
+        "replace": run.resource_replacements or 0,
+        "import": run.resource_imports or 0,
+    }
+
+
 def _run_json(
     run: Run,
     *,
@@ -109,6 +127,7 @@ def _run_json(
                 "allow-empty-apply": run.allow_empty_apply,
                 "is-drift-detection": run.is_drift_detection,
                 "has-changes": run.has_changes,
+                "plan-summary": _plan_summary_attr(run),
                 "workspace-name": workspace_name,
                 "workspace-has-vcs": workspace_has_vcs,
                 "module-overrides": run.module_overrides,
@@ -737,6 +756,15 @@ def _plan_json(run: Run) -> dict:
     }
     if run.has_json_output:
         attrs["json-output"] = f"{base}/api/v2/plans/{run.id}/json-output"
+    # TFE-named counts on the Plan resource (additions / changes /
+    # destructions / imports). Replacements have no TFE-equivalent so
+    # the UI gets that from the Run resource instead. Surfaced only
+    # when the runner has uploaded and we parsed successfully.
+    if run.resource_additions is not None:
+        attrs["resource-additions"] = run.resource_additions
+        attrs["resource-changes"] = run.resource_changes
+        attrs["resource-destructions"] = run.resource_destructions
+        attrs["resource-imports"] = run.resource_imports
     return {
         "data": {
             "id": f"plan-{run.id}",

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -1158,6 +1158,15 @@ class Run(Base):
         Boolean, nullable=False, server_default="false", default=False
     )
 
+    # Plan resource-change counts parsed from the JSON plan output on
+    # upload. Null until parsed (older runs, or parse failed); zero means
+    # parsed-and-no-resources-of-that-kind. The UI distinguishes the two.
+    resource_additions: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    resource_changes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    resource_destructions: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    resource_replacements: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    resource_imports: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Job tracking (populated by listener after launching K8s Job)
     job_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     job_namespace: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/services/terrapod/services/plan_summary.py
+++ b/services/terrapod/services/plan_summary.py
@@ -1,0 +1,88 @@
+"""Parse Terraform plan JSON (`tofu show -json tfplan`) into resource-change counts.
+
+Pure function — called from the runner artifact upload handler. Keep it
+small and side-effect-free so a future backfill script can reuse it.
+
+The interesting field is `resource_changes[]`, where each entry has:
+- `change.actions: list[str]` — one of `no-op`, `read`, `create`,
+  `update`, `delete`, or a `[create, delete]` / `[delete, create]` pair
+  for replacements.
+- `change.importing.id` (optional) — set when this resource is being
+  imported as part of this plan.
+
+Counting rules:
+- `[create]` → additions
+- `[update]` → changes
+- `[delete]` → destructions
+- Any 2-element actions list containing both `create` and `delete` → replacements
+  (NOT counted as additions or destructions — TFE/HCP shows replaces
+  as a separate column for the same reason)
+- `[no-op]`, `[read]`, unknown shapes → ignored
+- `change.importing.id` non-null → imports (counted independently from the
+  action-based bucket; an imported resource also has e.g. `[update]`)
+"""
+
+import json
+from typing import Any
+
+
+def summarize_plan_json(body: bytes) -> dict[str, int] | None:
+    """Return additions/changes/destructions/replacements/imports counts.
+
+    Returns None if the body isn't parseable JSON or the structure
+    doesn't look like a Terraform plan (so the caller can leave the
+    DB columns null rather than write zeros that would imply
+    "definitely no changes").
+    """
+    try:
+        data = json.loads(body)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    resource_changes = data.get("resource_changes")
+    if not isinstance(resource_changes, list):
+        return None
+    return _count_changes(resource_changes)
+
+
+def _count_changes(resource_changes: list[Any]) -> dict[str, int]:
+    additions = 0
+    changes = 0
+    destructions = 0
+    replacements = 0
+    imports = 0
+
+    for entry in resource_changes:
+        if not isinstance(entry, dict):
+            continue
+        change = entry.get("change")
+        if not isinstance(change, dict):
+            continue
+        actions = change.get("actions")
+        if not isinstance(actions, list):
+            continue
+
+        action_set = {a for a in actions if isinstance(a, str)}
+
+        if len(action_set) == 2 and {"create", "delete"} <= action_set:
+            replacements += 1
+        elif action_set == {"create"}:
+            additions += 1
+        elif action_set == {"update"}:
+            changes += 1
+        elif action_set == {"delete"}:
+            destructions += 1
+        # else: no-op, read, unknown — ignore
+
+        importing = change.get("importing")
+        if isinstance(importing, dict) and importing.get("id"):
+            imports += 1
+
+    return {
+        "additions": additions,
+        "changes": changes,
+        "destructions": destructions,
+        "replacements": replacements,
+        "imports": imports,
+    }

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -211,6 +211,11 @@ class TestRunDriftAttributes:
         run.resource_memory = "2Gi"
         run.module_overrides = None
         run.created_by = "test@example.com"
+        run.resource_additions = None
+        run.resource_changes = None
+        run.resource_destructions = None
+        run.resource_replacements = None
+        run.resource_imports = None
 
         ws = _mock_workspace(ws_id=ws_id)
 

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -124,6 +124,11 @@ def _mock_run(
     run.resource_memory = "2Gi"
     run.configuration_version_id = None
     run.created_by = "test@example.com"
+    run.resource_additions = None
+    run.resource_changes = None
+    run.resource_destructions = None
+    run.resource_replacements = None
+    run.resource_imports = None
     return run
 
 

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -217,3 +217,78 @@ class TestUploadPlanJsonOutput:
             )
 
         assert resp.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_populates_resource_counts_from_parsed_plan(self, mock_get_storage, *_mocks):
+        """Issue #301: the upload handler parses the JSON plan and writes
+        resource_additions / _changes / _destructions / _replacements /
+        _imports onto the run row so the UI can render a summary badge.
+        """
+        run_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+
+        plan = {
+            "resource_changes": [
+                {"change": {"actions": ["create"]}},
+                {"change": {"actions": ["create"]}},
+                {"change": {"actions": ["update"]}},
+                {"change": {"actions": ["delete"]}},
+                {"change": {"actions": ["create", "delete"]}},
+                {"change": {"actions": ["update"], "importing": {"id": "i-abc"}}},
+            ]
+        }
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-json-output",
+                content=json.dumps(plan).encode(),
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 204
+        assert run.resource_additions == 2
+        assert run.resource_changes == 2  # one plain update + one update-with-import
+        assert run.resource_destructions == 1
+        assert run.resource_replacements == 1
+        assert run.resource_imports == 1
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_malformed_plan_leaves_counts_null_but_still_204(self, mock_get_storage, *_mocks):
+        """A parse failure must not fail the upload — the download URL
+        is still served, the UI just won't show a summary.
+        """
+        run_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id)
+        # Sentinel: count columns start unset and must STAY unset after a
+        # malformed body.
+        run.resource_additions = None
+        run.resource_changes = None
+        run.resource_destructions = None
+        run.resource_replacements = None
+        run.resource_imports = None
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-json-output",
+                content=b"not json at all",
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 204
+        assert run.has_json_output is True
+        assert run.resource_additions is None
+        assert run.resource_changes is None

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -68,6 +68,11 @@ def _mock_run(
     run.module_overrides = None
     run.created_by = "test@example.com"
     run.has_json_output = False
+    run.resource_additions = None
+    run.resource_changes = None
+    run.resource_destructions = None
+    run.resource_replacements = None
+    run.resource_imports = None
     return run
 
 

--- a/services/tests/services/test_plan_summary.py
+++ b/services/tests/services/test_plan_summary.py
@@ -1,0 +1,133 @@
+"""Tests for plan_summary.summarize_plan_json (#301)."""
+
+import json
+
+from terrapod.services.plan_summary import summarize_plan_json
+
+
+def _plan(resource_changes: list[dict]) -> bytes:
+    return json.dumps({"resource_changes": resource_changes}).encode()
+
+
+def _change(actions: list[str], importing_id: str | None = None) -> dict:
+    change: dict = {"actions": actions}
+    if importing_id is not None:
+        change["importing"] = {"id": importing_id}
+    return {"change": change}
+
+
+def test_empty_plan_zeros_everything():
+    summary = summarize_plan_json(_plan([]))
+    assert summary == {
+        "additions": 0,
+        "changes": 0,
+        "destructions": 0,
+        "replacements": 0,
+        "imports": 0,
+    }
+
+
+def test_create_update_delete_counted_independently():
+    body = _plan(
+        [
+            _change(["create"]),
+            _change(["create"]),
+            _change(["update"]),
+            _change(["delete"]),
+        ]
+    )
+    summary = summarize_plan_json(body)
+    assert summary is not None
+    assert summary["additions"] == 2
+    assert summary["changes"] == 1
+    assert summary["destructions"] == 1
+    assert summary["replacements"] == 0
+
+
+def test_replace_counts_as_replacement_not_add_plus_delete():
+    """A `[create, delete]` pair is one replacement, not one add + one destroy."""
+    body = _plan(
+        [
+            _change(["create", "delete"]),
+            _change(["delete", "create"]),
+        ]
+    )
+    summary = summarize_plan_json(body)
+    assert summary is not None
+    assert summary["replacements"] == 2
+    assert summary["additions"] == 0
+    assert summary["destructions"] == 0
+
+
+def test_no_op_and_read_ignored():
+    body = _plan(
+        [
+            _change(["no-op"]),
+            _change(["read"]),
+            _change(["create"]),
+        ]
+    )
+    summary = summarize_plan_json(body)
+    assert summary is not None
+    assert summary["additions"] == 1
+    assert summary["changes"] == 0
+    assert summary["destructions"] == 0
+
+
+def test_importing_counted_separately_from_action():
+    """An imported resource also has a regular action — count both."""
+    body = _plan(
+        [
+            _change(["update"], importing_id="i-abc123"),
+            _change(["no-op"], importing_id="i-def456"),
+            _change(["update"]),
+        ]
+    )
+    summary = summarize_plan_json(body)
+    assert summary is not None
+    assert summary["imports"] == 2
+    assert summary["changes"] == 2  # both update entries, the import flag is independent
+
+
+def test_malformed_json_returns_none():
+    assert summarize_plan_json(b"not valid json") is None
+
+
+def test_missing_resource_changes_returns_none():
+    """A JSON document that doesn't look like a Terraform plan."""
+    assert summarize_plan_json(b'{"version": 1}') is None
+
+
+def test_resource_changes_not_a_list_returns_none():
+    assert summarize_plan_json(b'{"resource_changes": "oops"}') is None
+
+
+def test_entries_with_unexpected_shape_skipped():
+    body = json.dumps(
+        {
+            "resource_changes": [
+                "not a dict",
+                {"no_change_field": True},
+                {"change": "not a dict"},
+                {"change": {"actions": "not a list"}},
+                {"change": {"actions": ["create"]}},
+            ]
+        }
+    ).encode()
+    summary = summarize_plan_json(body)
+    assert summary is not None
+    assert summary["additions"] == 1
+    assert summary["changes"] == 0
+
+
+def test_unknown_action_shape_ignored():
+    body = _plan([_change(["mystery"]), _change(["create", "update"])])
+    summary = summarize_plan_json(body)
+    # mystery is unknown; create+update is also unknown (not the replace pair)
+    assert summary == {
+        "additions": 0,
+        "changes": 0,
+        "destructions": 0,
+        "replacements": 0,
+        "imports": 0,
+    }

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
 import { LabelsEditor } from '@/components/labels-editor'
 import { HealthConditions } from '@/components/health-conditions'
+import { PlanSummaryBadges } from '@/components/plan-summary-badges'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
@@ -100,6 +101,13 @@ interface RunItem {
     'created-by': string
     'plan-started-at': string | null
     'apply-finished-at': string | null
+    'plan-summary': {
+      add: number
+      change: number
+      destroy: number
+      replace: number
+      import: number
+    } | null
     actions?: {
       'is-confirmable': boolean
       'is-discardable': boolean
@@ -2208,6 +2216,7 @@ function WorkspaceDetailContent() {
                       <SortableHeader label="Run ID" sortKey="id" sortState={runSortState} onSort={toggleRunSort} />
                       <SortableHeader label="Status" sortKey="status" sortState={runSortState} onSort={toggleRunSort} />
                       <SortableHeader label="Type" sortKey="type" sortState={runSortState} onSort={toggleRunSort} className="hidden sm:table-cell" />
+                      <th className="text-left px-4 py-2 text-xs font-medium text-slate-400 uppercase tracking-wider hidden md:table-cell">Changes</th>
                       <SortableHeader label="Source" sortKey="source" sortState={runSortState} onSort={toggleRunSort} className="hidden sm:table-cell" />
                       <SortableHeader label="Triggered By" sortKey="created-by" sortState={runSortState} onSort={toggleRunSort} className="hidden lg:table-cell" />
                       <SortableHeader label="Created" sortKey="created-at" sortState={runSortState} onSort={toggleRunSort} className="hidden md:table-cell" />
@@ -2243,6 +2252,13 @@ function WorkspaceDetailContent() {
                             </span>
                           ) : (
                             <span className="text-xs text-slate-500">plan + apply</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 hidden md:table-cell">
+                          {run.attributes['plan-summary'] ? (
+                            <PlanSummaryBadges summary={run.attributes['plan-summary']} size="sm" />
+                          ) : (
+                            <span className="text-slate-600">&mdash;</span>
                           )}
                         </td>
                         <td className="px-4 py-3 text-xs text-slate-400 hidden sm:table-cell">

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -8,6 +8,7 @@ import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
+import { PlanSummaryBadges } from '@/components/plan-summary-badges'
 import { getAuthState } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useRunEvents } from '@/lib/use-run-events'
@@ -39,6 +40,13 @@ interface RunAttrs {
   'vcs-branch': string | null
   'vcs-pull-request-number': number | null
   'has-changes': boolean
+  'plan-summary': {
+    add: number
+    change: number
+    destroy: number
+    replace: number
+    import: number
+  } | null
   'workspace-name': string
   'workspace-has-vcs': boolean
   'module-overrides': Record<string, string> | null
@@ -596,6 +604,14 @@ export default function RunDetailPage() {
               ? 'Plan reported nothing to do; the apply was skipped automatically.'
               : 'Plan reported nothing to do — there is nothing to apply.'}
           </div>
+        )}
+
+        {/* Plan summary badges — render whenever the runner has uploaded
+            and parsed the JSON plan, regardless of run status. Sits
+            immediately above the action row so the operator sees the
+            shape of the change next to Confirm & Apply. */}
+        {attrs['plan-summary'] && (
+          <PlanSummaryBadges summary={attrs['plan-summary']} />
         )}
 
         {/* Action buttons */}

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -609,10 +609,17 @@ export default function RunDetailPage() {
         {/* Plan summary badges — render whenever the runner has uploaded
             and parsed the JSON plan, regardless of run status. Sits
             immediately above the action row so the operator sees the
-            shape of the change next to Confirm & Apply. */}
-        {attrs['plan-summary'] && (
-          <PlanSummaryBadges summary={attrs['plan-summary']} />
-        )}
+            shape of the change next to Confirm & Apply.
+            Suppress when the bigger No-changes callout above will already
+            render (non-plan-only runs in planned/applied with has-changes
+            false) — the callout is the more explanatory surface and the
+            pill would just duplicate it. */}
+        {attrs['plan-summary'] &&
+          !(
+            attrs['has-changes'] === false &&
+            !attrs['plan-only'] &&
+            ['planned', 'applied'].includes(attrs.status)
+          ) && <PlanSummaryBadges summary={attrs['plan-summary']} />}
 
         {/* Action buttons */}
         {(actions['is-confirmable'] || actions['is-discardable'] || actions['is-cancelable'] || actions['is-retryable']) && (

--- a/web/src/components/plan-summary-badges.tsx
+++ b/web/src/components/plan-summary-badges.tsx
@@ -1,0 +1,86 @@
+/**
+ * Compact resource-change summary for a planned run.
+ *
+ * Renders one chip per non-zero count (additions, changes, destructions,
+ * replacements, imports), TFE/HCP-style: `+5  ~2  -1  ⟳3  ↓1`. When every
+ * count is zero we render a single "No changes" pill so the user knows the
+ * plan ran and reported nothing to do (distinct from "we don't know yet",
+ * which is signalled by `summary == null` — the caller renders nothing in
+ * that case).
+ */
+
+interface PlanSummary {
+  add: number
+  change: number
+  destroy: number
+  replace: number
+  import: number
+}
+
+interface Props {
+  summary: PlanSummary
+  size?: 'sm' | 'md'
+}
+
+export function PlanSummaryBadges({ summary, size = 'md' }: Props) {
+  const { add, change, destroy, replace, import: imports } = summary
+  const total = add + change + destroy + replace + imports
+
+  const containerCls = `flex flex-wrap items-center gap-1.5 ${size === 'sm' ? '' : 'mb-4'}`
+
+  // Zero-count case: render nothing. Callers that want a "No changes"
+  // pill (e.g. inline on the runs list) wrap a small inline render
+  // around this; the run detail page already has its own No-changes
+  // callout block, so a duplicate pill would just be noise.
+  if (total === 0) {
+    if (size === 'sm') {
+      return (
+        <span
+          className="inline-flex items-center rounded-full bg-slate-700/40 text-slate-300 px-2 py-0.5 text-xs"
+          title="Plan reported no resource changes"
+        >
+          no changes
+        </span>
+      )
+    }
+    return null
+  }
+
+  const cls =
+    size === 'sm'
+      ? 'inline-flex items-center rounded px-1.5 py-0.5 text-xs font-mono font-medium'
+      : 'inline-flex items-center rounded px-2 py-0.5 text-sm font-mono font-medium'
+
+  return (
+    <div className={containerCls}>
+      {add > 0 && (
+        <span className={`${cls} bg-green-900/40 text-green-300`} title={`${add} to add`}>
+          +{add}
+        </span>
+      )}
+      {change > 0 && (
+        <span className={`${cls} bg-amber-900/40 text-amber-300`} title={`${change} to change`}>
+          ~{change}
+        </span>
+      )}
+      {destroy > 0 && (
+        <span className={`${cls} bg-red-900/40 text-red-300`} title={`${destroy} to destroy`}>
+          -{destroy}
+        </span>
+      )}
+      {replace > 0 && (
+        <span
+          className={`${cls} bg-purple-900/40 text-purple-300`}
+          title={`${replace} to replace`}
+        >
+          ⟳{replace}
+        </span>
+      )}
+      {imports > 0 && (
+        <span className={`${cls} bg-blue-900/40 text-blue-300`} title={`${imports} to import`}>
+          ↓{imports}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/plan-summary-badges.tsx
+++ b/web/src/components/plan-summary-badges.tsx
@@ -28,11 +28,9 @@ export function PlanSummaryBadges({ summary, size = 'md' }: Props) {
 
   const containerCls = `flex flex-wrap items-center gap-1.5 ${size === 'sm' ? '' : 'mb-4'}`
 
-  // Zero-count case: render nothing. Callers that want a "No changes"
-  // pill (e.g. inline on the runs list) wrap a small inline render
-  // around this; the run detail page already has its own No-changes
-  // callout block, so a duplicate pill would just be noise.
   if (total === 0) {
+    // Plan-only runs don't trigger the page-level "No changes." callout,
+    // so the badge row is the only indicator. Always render the pill.
     if (size === 'sm') {
       return (
         <span
@@ -43,7 +41,16 @@ export function PlanSummaryBadges({ summary, size = 'md' }: Props) {
         </span>
       )
     }
-    return null
+    return (
+      <div className={containerCls}>
+        <span
+          className="inline-flex items-center rounded-full bg-slate-700/40 text-slate-300 px-2.5 py-1 text-sm"
+          title="Plan reported no resource changes"
+        >
+          No changes
+        </span>
+      </div>
+    )
   }
 
   const cls =


### PR DESCRIPTION
## Summary

Extract resource-change counts from the JSON plan output the runner already uploads and render them on the UI next to the Confirm and Apply button so the operator can sanity-check the shape of the change before approving.

End-to-end verified in Tilt: a fresh plan-only run came back with `plan-summary: {add: 0, change: 0, destroy: 0, replace: 0, import: 0}` for a no-op plan; the runs list inline summary and run-detail badge row both render correctly.

### Server
- Migration: five nullable int columns on `runs` (`resource_additions`, `resource_changes`, `resource_destructions`, `resource_replacements`, `resource_imports`). Null = not yet computed; zero = computed and no resources of that kind.
- Parser (`services/plan_summary.py`): translates Terraform plan JSON into the five counts. Replacements are kept distinct from add+destroy (matches HCP/TFE behaviour). Imports are counted independently from the action bucket so an updated-but-imported resource shows up in both.
- Upload handler runs the parser via `asyncio.to_thread` (CLAUDE.md HARD REQUIREMENT — plan JSON can be multi-MB). Parse failures leave the count columns null and log a warning; the download URL is still served.
- API: `Run` JSON gains `plan-summary` (compact dict, null when not yet parsed). `Plan` JSON gains TFE-named `resource-additions / -changes / -destructions / -imports` for go-tfe compatibility.

### UI
- New `<PlanSummaryBadges>` component renders `+5 ~2 -1 ⟳3 ↓1` chips, hiding zero-count badges. Zero-total renders nothing on the detail view (the page already has a "No changes." callout block, no need to duplicate); the inline runs-list variant renders a small "no changes" pill so the column isn't empty.
- Run detail page renders the badge row above the action buttons.
- Workspace runs tab gains a Changes column.

### Tests
- 9 parser unit tests cover every action shape, malformed JSON, missing fields, importing flag, and unexpected entry shapes.
- Upload-handler tests cover the happy path (counts populated end-to-end) and malformed-input path (204 returned, counts stay null, download URL still works).
- Test fixtures updated in 3 other test files to default the new columns to `None` (otherwise `MagicMock` leaks into the JSON serializer).

## Test plan

- [x] `make test` — 1342 passing
- [x] `make lint` — clean
- [x] Tilt smoke: plan run completes, run detail page shows summary
- [ ] CI green