### PR TITLE
fix(ux): send TFE-spec actions to /api/v2/, not /api/terrapod/v1/

### DIFF
--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -826,7 +826,8 @@ function WorkspaceDetailContent() {
     if (!workspace) return
     const action = workspace.attributes.locked ? 'unlock' : 'lock'
     try {
-      const res = await apiFetch(`/api/terrapod/v1/workspaces/${workspaceId}/actions/${action}`, {
+      // lock/unlock are TFE V2 CLI-contract endpoints — only at /api/v2/.
+      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/actions/${action}`, {
         method: 'POST',
       })
       if (!res.ok) throw new Error(`Failed to ${action} workspace`)

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -464,9 +464,13 @@ export default function RunDetailPage() {
     setActionLoading(action)
     setError('')
     try {
-      // TFE V2 API uses "apply" to confirm a planned run
+      // TFE V2 API uses "apply" to confirm a planned run.
+      // confirm / discard / cancel are on the TFE V2 CLI contract surface
+      // (terraform/go-tfe call them) and live permanently at /api/v2/.
+      // retry is a Terrapod extension and lives at /api/terrapod/v1/.
       const apiAction = action === 'confirm' ? 'apply' : action
-      const res = await apiFetch(`/api/terrapod/v1/runs/${runId}/actions/${apiAction}`, { method: 'POST' })
+      const prefix = action === 'retry' ? '/api/terrapod/v1' : '/api/v2'
+      const res = await apiFetch(`${prefix}/runs/${runId}/actions/${apiAction}`, { method: 'POST' })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
         throw new Error(data.detail || `Failed to ${action} run`)


### PR DESCRIPTION
## Summary

Hotfix for v0.23.0: the run **Confirm & Apply / Discard / Cancel** buttons and the workspace **Lock / Unlock** action all return 404 because the frontend hits `/api/terrapod/v1/...` for endpoints that only exist at `/api/v2/`.

## Why

PR #281 moved Terrapod-native routes to `/api/terrapod/v1/` and added a legacy `/api/v2/` alias for each. The TFE-V2-spec routes (those on the CLI contract surface in `docs/tfe-cli-surface.md`) deliberately stay at `/api/v2/` only — no dual mount, because the CLI contract is their permanent home.

Run `actions/{apply,discard,cancel}` and workspace `actions/{lock,unlock}` are on the TFE V2 spec router (`prefix=/api/v2`). The frontend was updated to call `/api/terrapod/v1/...` for both, so those buttons 404 on v0.23.0.

## Fix

- `web/src/app/workspaces/[id]/runs/[runId]/page.tsx` — confirm/discard/cancel now hit `/api/v2/`. retry stays at `/api/terrapod/v1/` (it's a Terrapod extension on the dual-mounted extensions router).
- `web/src/app/workspaces/[id]/page.tsx` — lock/unlock hits `/api/v2/`.

Audited the remaining `/api/terrapod/v1/` callsites in the frontend; everything else (workspace DELETE, vcs-refs, dismiss-drift, state-versions manage/rollback, manual state upload, configuration-versions download-ticket/diff, notification-configurations, run-tasks, runs/{id}/plan|apply, workspaces/{id}/runs/events SSE) is on a Terrapod extensions router with dual mounts at both prefixes — those are fine.

## Test plan

- [ ] Tilt: Confirm & Apply, Discard, Cancel, Lock, Unlock all work
- [ ] CI green

Targeting v0.23.1 patch release.