### PR TITLE
fix(ux): needs-confirm wins over state-diverged; ci: ghcr login retry

### DIFF
--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -1,0 +1,63 @@
+name: GHCR login (with retry)
+description: |
+  Authenticate the Docker CLI (and optionally Helm) against ghcr.io with
+  exponential backoff so transient GHCR / Docker Hub blips don't fail an
+  otherwise-healthy build. Replaces `docker/login-action@v4`, which has
+  no retry knob.
+
+inputs:
+  token:
+    description: GHCR token (typically secrets.GITHUB_TOKEN)
+    required: true
+  username:
+    description: GHCR username (typically github.actor)
+    required: true
+  helm:
+    description: Also run `helm registry login` (set 'true' for jobs that push the Helm chart)
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: docker login ghcr.io (with retry)
+      shell: bash
+      env:
+        GHCR_TOKEN: ${{ inputs.token }}
+        GHCR_USER: ${{ inputs.username }}
+        ALSO_HELM: ${{ inputs.helm }}
+      run: |
+        set -u
+
+        attempt() {
+          local kind="$1"
+          shift
+          local i wait
+          for i in 1 2 3 4 5; do
+            if "$@"; then
+              echo "✓ $kind login succeeded on attempt $i"
+              return 0
+            fi
+            if [ "$i" -eq 5 ]; then
+              echo "::error::$kind login failed after 5 attempts"
+              return 1
+            fi
+            # 5s, 10s, 20s, 40s — total <= 75s, well under any reasonable timeout
+            wait=$(( 5 * (2 ** (i - 1)) ))
+            echo "::warning::$kind login attempt $i failed; retrying in ${wait}s"
+            sleep "$wait"
+          done
+        }
+
+        do_docker_login() {
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+        }
+
+        do_helm_login() {
+          echo "$GHCR_TOKEN" | helm registry login ghcr.io --username "$GHCR_USER" --password-stdin
+        }
+
+        attempt "docker" do_docker_login
+        if [ "$ALSO_HELM" = "true" ]; then
+          attempt "helm" do_helm_login
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,10 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if images exist
         id: check
@@ -339,11 +338,10 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -372,11 +370,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull images
         run: |
@@ -457,11 +454,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Scan with Trivy
         uses: aquasecurity/trivy-action@v0.36.0
@@ -509,12 +505,13 @@ jobs:
       matrix:
         image: [terrapod-api, terrapod-web, terrapod-runner, terrapod-listener, terrapod-migrations]
     steps:
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create multi-arch manifest
         run: |
@@ -542,12 +539,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+
+      - name: Log in to GHCR (docker + helm)
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          helm: 'true'
 
       - name: Retag images with version
         run: |
@@ -562,15 +562,10 @@ jobs:
               "$REGISTRY/$image:sha-$sha_short"
           done
 
-      - name: Install Helm
-        uses: azure/setup-helm@v5
-
       - name: Publish Helm chart
         run: |
           version="${{ needs.prepare.outputs.version }}"
           chart_version="${version#v}"
-
-          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
 
           helm package helm/terrapod --destination dist/ \
             --version "$chart_version" --app-version "$version"

--- a/web/src/lib/workspace-status.ts
+++ b/web/src/lib/workspace-status.ts
@@ -6,10 +6,10 @@
 // auto-renders the new option, and the kebab-case `filter` value is
 // authoritative for `status:value` predicates in the workspace filter.
 //
-// Order matters: `resolveStatus` walks workspace-level conditions first
-// (`state-diverged`, `vcs-error`, `drifted`) then run statuses; the filter
-// dropdown shows the same order so the most operationally interesting
-// statuses surface at the top.
+// Order matters for the filter dropdown — most operationally interesting
+// statuses surface at the top. `resolveStatus` doesn't read this order
+// directly; see its docstring for the actual precedence rules
+// (`needs-confirm` wins over every workspace-level condition).
 
 export type StatusColor = 'red' | 'amber' | 'blue' | 'green' | 'slate' | 'gray'
 
@@ -75,31 +75,33 @@ export interface ResolvedStatus {
 
 /** Resolve a workspace's effective status from its signals.
  *
- * Workspace-level conditions (`state-diverged`, `vcs-error`, `drifted`)
- * take precedence over run statuses — they reflect divergence between the
- * desired state and reality, which is more urgent than any in-flight run.
+ * A planned non-plan-only run awaiting confirmation (`needs-confirm`) wins
+ * over every workspace-level condition: the operator has a button to click
+ * that resolves the divergence directly, and `needs-confirm` implicitly
+ * signals the state is divergent anyway (otherwise there'd be nothing to
+ * apply). Showing the alarm pill would just bury the actionable signal.
+ *
+ * Otherwise workspace-level conditions (`state-diverged`, `vcs-error`,
+ * `drifted`) take precedence over run statuses — they reflect divergence
+ * between the desired state and reality, which is more urgent than any
+ * other in-flight or completed run.
  *
  * Returns `def: null, runId: null` when there's no run and no condition
  * (typically a freshly-created workspace with no plan yet).
  */
 export function resolveStatus(ws: ResolveInput): ResolvedStatus {
   const a = ws.attributes
+  const run = a['latest-run']
+  // needs-confirm wins — actionable beats alarm.
+  if (run && run.status === 'planned' && !run['plan-only']) {
+    return { def: STATUS_BY_FILTER.get('needs-confirm') ?? null, runId: run.id }
+  }
   if (a['state-diverged']) return { def: STATUS_BY_FILTER.get('state-diverged') ?? null, runId: null }
   if (a['vcs-last-error']) return { def: STATUS_BY_FILTER.get('vcs-error') ?? null, runId: null }
   if (a['drift-status'] === 'drifted') return { def: STATUS_BY_FILTER.get('drifted') ?? null, runId: null }
-  const run = a['latest-run']
   if (!run) return { def: null, runId: null }
-  const planOnly = run['plan-only']
-  // Map run.status → status filter token. `planned` is special: a non
-  // plan-only planned run is awaiting confirmation; a plan-only one is
-  // a successful read of the world.
-  let filter: string
-  switch (run.status) {
-    case 'planned':
-      filter = planOnly ? 'planned' : 'needs-confirm'
-      break
-    default:
-      filter = run.status
-  }
+  // plan-only `planned` is a successful read of the world, not an
+  // awaiting-confirm signal.
+  const filter = run.status === 'planned' ? 'planned' : run.status
   return { def: STATUS_BY_FILTER.get(filter) ?? null, runId: run.id }
 }


### PR DESCRIPTION
Two unrelated bundled changes — both ship in v0.23.2.

## Status-pill precedence (UX)

A non-plan-only `planned` run (i.e. \"needs confirm\") now takes precedence over every workspace-level condition (`state-diverged`, `vcs-error`, `drifted`) when picking the status pill on the workspace list page.

Why: `state-diverged` on its own isn't actionable from the workspace list — the operator can't fix it without going into the workspace. `needs-confirm` *is* actionable: click Confirm & Apply and the divergence resolves directly. Burying the actionable signal under the alarm hides the work that needs doing. `needs-confirm` also implicitly signals the state is divergent — otherwise there'd be nothing to apply — so we're not losing information. Workspace-level conditions still take precedence over every other run status (applied / errored / etc), and the workspace-detail page still surfaces `state-diverged` prominently via the banner.

## GHCR login retry (CI)

`docker/login-action@v4` does a single `docker login` with no retry, so transient GHCR / Docker Hub blips fail an otherwise-healthy build. New composite action `.github/actions/ghcr-login` wraps docker login (and optionally helm registry login) in an exponential-backoff retry loop: 5 attempts at 5s, 10s, 20s, 40s.

All 6 GHCR-login sites in `ci.yml` (prepare, build-images, e2e-test, scan-images, create-manifests, release) switch to `uses: ./.github/actions/ghcr-login`. The release job also folds the inline `helm registry login` into the same action via `helm: 'true'` so the retry covers chart publishing too. `create-manifests` gains a `actions/checkout` step so the local composite action is resolvable.

## Test plan

- [ ] CI green (this PR's own pipeline exercises the new retry path)
- [ ] On a workspace with both `state-diverged: true` and a planned non-plan-only run, the list pill shows \"Needs Confirm\" (amber)
- [ ] On a workspace with `state-diverged: true` and no pending run, the list pill still shows \"State Diverged\" (red)