### PR TITLE
ci: extend ghcr retry to image retag + helm push; extract shared retry script

### DIFF
--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -28,36 +28,21 @@ runs:
         ALSO_HELM: ${{ inputs.helm }}
       run: |
         set -u
-
-        attempt() {
-          local kind="$1"
-          shift
-          local i wait
-          for i in 1 2 3 4 5; do
-            if "$@"; then
-              echo "✓ $kind login succeeded on attempt $i"
-              return 0
-            fi
-            if [ "$i" -eq 5 ]; then
-              echo "::error::$kind login failed after 5 attempts"
-              return 1
-            fi
-            # 5s, 10s, 20s, 40s — total <= 75s, well under any reasonable timeout
-            wait=$(( 5 * (2 ** (i - 1)) ))
-            echo "::warning::$kind login attempt $i failed; retrying in ${wait}s"
-            sleep "$wait"
-          done
-        }
-
+        # docker / helm don't accept stdin pipes through `bash -c "..."`
+        # cleanly when invoked via with-retry.sh's `"$@"`, so wrap each
+        # login in a local shell function.
         do_docker_login() {
           echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
         }
-
         do_helm_login() {
           echo "$GHCR_TOKEN" | helm registry login ghcr.io --username "$GHCR_USER" --password-stdin
         }
+        export -f do_docker_login do_helm_login
 
-        attempt "docker" do_docker_login
+        "$GITHUB_WORKSPACE/.github/scripts/with-retry.sh" "docker login" -- \
+          bash -c do_docker_login
+
         if [ "$ALSO_HELM" = "true" ]; then
-          attempt "helm" do_helm_login
+          "$GITHUB_WORKSPACE/.github/scripts/with-retry.sh" "helm login" -- \
+            bash -c do_helm_login
         fi

--- a/.github/scripts/with-retry.sh
+++ b/.github/scripts/with-retry.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run a command with exponential-backoff retry for transient infrastructure flakes.
+#
+# Usage:   .github/scripts/with-retry.sh "<label>" -- cmd args...
+#
+# Five attempts at 5s, 10s, 20s, 40s intervals (total cap ~75s). Emits
+# GitHub Actions `::warning::` lines between attempts and `::error::`
+# on terminal failure so flakes show up annotated in the run summary.
+#
+# Used from .github/workflows/ci.yml for GHCR-touching ops that the
+# upstream action / CLI doesn't retry itself (docker login is wrapped
+# by .github/actions/ghcr-login; this script covers `docker buildx
+# imagetools create`, `helm push`, etc.).
+set -u
+
+if [ "$#" -lt 3 ] || [ "$2" != "--" ]; then
+  echo "usage: with-retry.sh '<label>' -- <command> [args...]" >&2
+  exit 2
+fi
+
+label="$1"
+shift 2  # drop label + '--'
+
+for i in 1 2 3 4 5; do
+  if "$@"; then
+    exit 0
+  fi
+  if [ "$i" -eq 5 ]; then
+    echo "::error::$label failed after 5 attempts"
+    exit 1
+  fi
+  wait=$(( 5 * (2 ** (i - 1)) ))
+  echo "::warning::$label attempt $i failed; retrying in ${wait}s"
+  sleep "$wait"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,12 +554,15 @@ jobs:
           sha_short="${{ needs.prepare.outputs.sha_short }}"
           version="${{ needs.prepare.outputs.version }}"
 
+          # GHCR occasionally returns 5xx on manifest reads/writes during
+          # a retag — wrap with the shared 5/10/20/40s backoff helper.
           for image in terrapod-api terrapod-web terrapod-runner terrapod-listener terrapod-migrations; do
             echo "Retagging $image:sha-$sha_short -> $version + latest"
-            docker buildx imagetools create \
-              -t "$REGISTRY/$image:$version" \
-              -t "$REGISTRY/$image:latest" \
-              "$REGISTRY/$image:sha-$sha_short"
+            .github/scripts/with-retry.sh "imagetools create $image" -- \
+              docker buildx imagetools create \
+                -t "$REGISTRY/$image:$version" \
+                -t "$REGISTRY/$image:latest" \
+                "$REGISTRY/$image:sha-$sha_short"
           done
 
       - name: Publish Helm chart
@@ -570,7 +573,8 @@ jobs:
           helm package helm/terrapod --destination dist/ \
             --version "$chart_version" --app-version "$version"
 
-          helm push "dist/terrapod-${chart_version}.tgz" "oci://$REGISTRY"
+          .github/scripts/with-retry.sh "helm push" -- \
+            helm push "dist/terrapod-${chart_version}.tgz" "oci://$REGISTRY"
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary

Follow-up to #304. The v0.23.2 tag pipeline failed at the **retag** step (\`docker buildx imagetools create\`) with a GHCR \`502 Bad Gateway\` — same class of transient failure the login retry was designed to absorb, but the retry only wrapped login.

## Changes

- New \`.github/scripts/with-retry.sh\` — single source of truth for retry/backoff (5 attempts, 5/10/20/40s exponential, GitHub Actions \`::warning::\` / \`::error::\` annotations).
- Release job's per-image \`docker buildx imagetools create\` call and the \`helm push\` call both wrapped with the shared helper.
- \`.github/actions/ghcr-login\` composite action switches its inline retry function to the shared script.

## Test plan

- [ ] CI green
- [ ] Once merged, re-tag \`v0.23.2\` (auto-deleted by Cleanup Tag when the previous release failed)