### PR TITLE
docs: scrub internal repo + workspace-naming refs from examples

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -165,18 +165,18 @@ If you'd rather select a workspace at run time (typical when a single repo backs
 
 ```hcl
 workspaces {
-  tags = ["core"]                    # any workspace whose labels include "core"
+  tags = ["network"]                 # any workspace whose labels include "network"
   # or, for an exact match:
-  tags = { repo = "tf-aws-core" }
+  tags = { repo = "aws-infra" }
 }
 ```
 
 Then pick a specific workspace per invocation:
 
 ```zsh
-TF_WORKSPACE=core-stg-eu1 tofu plan
+TF_WORKSPACE=network-staging tofu plan
 # or
-tofu workspace select core-stg-eu1
+tofu workspace select network-staging
 ```
 
 If you have not already run `tofu login`:

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -345,7 +345,7 @@ terraform {
     workspaces {
       tags = ["core"]                    # all workspaces with label key "core"
       # or
-      tags = { repo = "tf-aws-core" }    # all workspaces with label repo=tf-aws-core
+      tags = { repo = "aws-infra" }      # all workspaces with label repo=aws-infra
     }
   }
 }
@@ -359,7 +359,7 @@ Both forms are accepted:
 | List, key=value | `tags = ["env=prod"]` | workspaces with `env: prod` exactly |
 | Map | `tags = { env = "prod" }` | workspaces with `env: prod` exactly |
 
-Pick the workspace at run time with `terraform workspace select <name>` or the `TF_WORKSPACE` environment variable. This is how a single repo with multiple environments (e.g. `core-dev-eu1`, `core-stg-eu1`, `core-prod-eu1`) can use one `cloud {}` block and pick the env per CLI invocation.
+Pick the workspace at run time with `terraform workspace select <name>` or the `TF_WORKSPACE` environment variable. This is how a single repo with multiple environments (e.g. `network-dev`, `network-staging`, `network-prod`) can use one `cloud {}` block and pick the env per CLI invocation.
 
 The web UI displays this field as **"Labels (tags)"** to make the dual purpose explicit.
 


### PR DESCRIPTION
PII / internal-reference cleanup. CLAUDE.md HARD REQUIREMENT bans references to internal repo names and the internal `{category}-{env}-{region}` workspace naming pattern in source / docs. Two slipped into docs/ as code examples:

- `tf-aws-core` (internal repo) → `aws-infra` (generic)
- `core-{dev,stg,prod}-eu1` (internal workspace naming) → `network-{dev,staging,prod}` (generic)

Touches `docs/getting-started.md` and `docs/rbac.md`.

## Screenshot audit

OCR'd all 33 PNGs under `docs/images/` (with tesseract); no internal hostname, repo name, cluster name, or company name found in any of them. Clean.

## Test plan

- [ ] CI green