### PR TITLE
fix(autodiscovery): trailing-slash pattern validator + initial scan on rule create (refs #309)

### DIFF
--- a/alembic/versions/c3b957ded26c_add_autodiscovery_first_scan_at.py
+++ b/alembic/versions/c3b957ded26c_add_autodiscovery_first_scan_at.py
@@ -1,0 +1,33 @@
+"""add autodiscovery_rules.first_scan_at for initial-scan tracking (#309)
+
+NULL means the rule has never been backfilled — the poll cycle picks
+those up for a full-tree walk (in addition to its normal changed-files
+walk) so existing matching directories get workspaces without waiting
+for someone to touch each one. Cleared back to NULL whenever the rule
+is re-enabled so a disable → enable cycle re-scans.
+
+Revision ID: c3b957ded26c
+Revises: 00b4c01e70e7
+Create Date: 2026-05-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3b957ded26c"
+down_revision: str | None = "00b4c01e70e7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "autodiscovery_rules",
+        sa.Column("first_scan_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("autodiscovery_rules", "first_scan_at")

--- a/services/terrapod/api/routers/auth.py
+++ b/services/terrapod/api/routers/auth.py
@@ -731,9 +731,9 @@ def _compute_max_session_ttl(id_token_expires_at: datetime | None) -> int | None
     if id_token_expires_at is None:
         return None
 
-    from terrapod.db.models import utc_now
+    from terrapod.db.models import now_utc
 
-    remaining = (id_token_expires_at - utc_now()).total_seconds()
+    remaining = (id_token_expires_at - now_utc()).total_seconds()
     configured = settings.auth.session_ttl_hours * 3600
 
     if 0 < remaining < configured:

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -314,6 +314,12 @@ async def update_rule(
         await _validate_connection(db, fields["vcs_connection_id"])
     if "agent_pool_id" in fields:
         await _validate_pool(db, fields["agent_pool_id"])
+    # A disable → enable transition should re-scan the repo: the rule
+    # may have missed changes during the disabled window, so treat the
+    # re-enable like a fresh rule. NULL `first_scan_at` is the trigger
+    # the poll cycle uses for a full-tree walk (#309).
+    if "enabled" in fields and fields["enabled"] and not rule.enabled:
+        fields["first_scan_at"] = None
     for k, v in fields.items():
         setattr(rule, k, v)
     try:

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -97,6 +97,30 @@ async def _validate_pool(db: AsyncSession, pool_id: uuid.UUID | None) -> None:
         raise HTTPException(status_code=422, detail="agent-pool-id not found")
 
 
+def _reject_directory_pattern(pattern: str, *, field: str) -> None:
+    """Reject patterns that end in `/`.
+
+    File-path matching only sees file paths (`foo/bar/main.tf`), which
+    never end in `/`. A trailing-slash glob like `foo/*/` therefore
+    matches zero files and silently no-ops — the user typically wants
+    `foo/*/*.tf` (one-level subdir + tf file) or `foo/**` (any depth).
+    Flagging at rule-create time turns the silent-no-op into a clear
+    422 so the next user doesn't trip over the same gotcha. See #309.
+    """
+    if pattern.endswith("/"):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{field} '{pattern}' ends in '/', which only matches "
+                "directory paths — autodiscovery evaluates file paths, "
+                "so this pattern would never match. Drop the trailing "
+                "slash and either spell out a file glob (e.g. "
+                f"'{pattern.rstrip('/')}/*.tf') or widen with '**' "
+                f"(e.g. '{pattern.rstrip('/')}/**')."
+            ),
+        )
+
+
 def _coerce_attrs(attrs: dict, *, on_create: bool) -> dict[str, Any]:
     """Normalise + validate request attributes. Returns a dict suitable
     for `setattr` onto a model.
@@ -134,10 +158,13 @@ def _coerce_attrs(attrs: dict, *, on_create: bool) -> dict[str, Any]:
         out["pattern"] = str(attrs["pattern"]).strip()
         if not out["pattern"]:
             raise HTTPException(status_code=422, detail="pattern must be non-empty")
+        _reject_directory_pattern(out["pattern"], field="pattern")
     if "ignore-patterns" in attrs:
         ip = attrs["ignore-patterns"]
         if not isinstance(ip, list) or not all(isinstance(p, str) for p in ip):
             raise HTTPException(status_code=422, detail="ignore-patterns must be a list of strings")
+        for p in ip:
+            _reject_directory_pattern(p, field="ignore-patterns")
         out["ignore_patterns"] = ip
     if "enabled" in attrs:
         out["enabled"] = bool(attrs["enabled"])

--- a/services/terrapod/api/routers/run_tasks.py
+++ b/services/terrapod/api/routers/run_tasks.py
@@ -445,7 +445,7 @@ async def task_stage_result_callback(
 
     Unauthenticated — verified via access_token in body.
     """
-    from terrapod.db.models import utc_now
+    from terrapod.db.models import now_utc
 
     access_token = body.get("access_token", "")
     if not access_token:
@@ -477,7 +477,7 @@ async def task_stage_result_callback(
 
     tsr.status = result_status
     tsr.message = body.get("message", "")
-    tsr.finished_at = utc_now()
+    tsr.finished_at = now_utc()
     await db.flush()
 
     # Resolve the parent stage

--- a/services/terrapod/auth/api_tokens.py
+++ b/services/terrapod/auth/api_tokens.py
@@ -15,7 +15,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.config import settings
-from terrapod.db.models import APIToken, utc_now
+from terrapod.db.models import APIToken, now_utc
 from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -102,7 +102,7 @@ async def validate_api_token(db: AsyncSession, raw_token: str) -> APIToken | Non
         return None
 
     # Check token lifetime: per-token lifespan takes precedence, else global max
-    now = utc_now()
+    now = now_utc()
     effective_ttl = (
         api_token.lifespan_hours
         if api_token.lifespan_hours is not None

--- a/services/terrapod/auth/sessions.py
+++ b/services/terrapod/auth/sessions.py
@@ -12,7 +12,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
 
 from terrapod.config import settings
-from terrapod.db.models import utc_now
+from terrapod.db.models import now_utc
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
 
@@ -67,7 +67,7 @@ async def create_session(
     ttl = _session_ttl()
     if max_ttl is not None and 0 < max_ttl < ttl:
         ttl = max_ttl
-    now = utc_now()
+    now = now_utc()
     expires_at = now + timedelta(seconds=ttl)
 
     session = Session(
@@ -124,7 +124,7 @@ async def refresh_session(token: str, session: Session) -> str:
     """
     redis = get_redis_client()
     ttl = _session_ttl()
-    now = utc_now()
+    now = now_utc()
 
     session_key = SESSION_PREFIX + token
     raw = await redis.get(session_key)
@@ -150,7 +150,7 @@ def _should_refresh_session(session: Session) -> bool:
     """Check if enough time has passed since last refresh."""
     try:
         last_active = datetime.fromisoformat(session.last_active_at)
-        return (utc_now() - last_active).total_seconds() > SESSION_REFRESH_INTERVAL
+        return (now_utc() - last_active).total_seconds() > SESSION_REFRESH_INTERVAL
     except (ValueError, TypeError):
         return True  # If we can't parse, refresh to be safe
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -43,7 +43,7 @@ def generate_uuid7() -> uuid.UUID:
     return uuid.UUID(bytes=uuid_bytes)
 
 
-def utc_now() -> datetime:
+def now_utc() -> datetime:
     """Get current UTC datetime."""
     return datetime.now(UTC)
 
@@ -72,10 +72,10 @@ class User(Base):
 
     last_login_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
 
@@ -104,10 +104,10 @@ class Role(Base):
     )  # read, write, admin
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
 
@@ -126,7 +126,7 @@ class RoleAssignment(Base):
         String(63), ForeignKey("roles.name", ondelete="CASCADE"), primary_key=True
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
 
@@ -143,7 +143,7 @@ class PlatformRoleAssignment(Base):
     email: Mapped[str] = mapped_column(String(255), primary_key=True)
     role_name: Mapped[str] = mapped_column(String(63), primary_key=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
 
@@ -166,7 +166,7 @@ class APIToken(Base):
     )  # "user", "organization"
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     lifespan_hours: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
@@ -196,10 +196,10 @@ class AgentPool(Base):
     owner_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     tokens: Mapped[list["AgentPoolToken"]] = relationship(
@@ -230,7 +230,7 @@ class AgentPoolToken(Base):
     is_revoked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     created_by: Mapped[str] = mapped_column(String(255), nullable=False)
 
@@ -355,10 +355,10 @@ class Workspace(Base):
     )
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     state_versions: Mapped[list["StateVersion"]] = relationship(
@@ -403,7 +403,7 @@ class StateVersion(Base):
     created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
     workspace: Mapped["Workspace"] = relationship(back_populates="state_versions")
@@ -450,10 +450,10 @@ class RegistryModule(Base):
     vcs_last_pr_shas: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     versions: Mapped[list["RegistryModuleVersion"]] = relationship(
@@ -487,10 +487,10 @@ class RegistryModuleVersion(Base):
     vcs_tag: Mapped[str] = mapped_column(String(255), nullable=False, default="")
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     module: Mapped["RegistryModule"] = relationship(back_populates="versions")
@@ -524,7 +524,7 @@ class ModuleWorkspaceLink(Base):
         nullable=False,
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     created_by: Mapped[str] = mapped_column(Text, nullable=False)
 
@@ -552,10 +552,10 @@ class RegistryProvider(Base):
     owner_email: Mapped[str] = mapped_column(String(255), nullable=False, default="")
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     versions: Mapped[list["RegistryProviderVersion"]] = relationship(
@@ -580,10 +580,10 @@ class GPGKey(Base):
     private_key: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     __table_args__ = (sa.UniqueConstraint("key_id", name="uq_gpg_keys"),)
@@ -615,10 +615,10 @@ class RegistryProviderVersion(Base):
     shasums_sig_uploaded: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     provider: Mapped["RegistryProvider"] = relationship(back_populates="versions")
@@ -652,7 +652,7 @@ class RegistryProviderPlatform(Base):
     upload_status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
     version: Mapped["RegistryProviderVersion"] = relationship(back_populates="platforms")
@@ -683,10 +683,10 @@ class CachedProviderPackage(Base):
     shasum: Mapped[str] = mapped_column(String(64), nullable=False)
     h1_hash: Mapped[str] = mapped_column(String(64), nullable=False, default="")
     cached_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     last_accessed_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
     __table_args__ = (
@@ -718,10 +718,10 @@ class CachedBinary(Base):
     shasum: Mapped[str] = mapped_column(String(64), nullable=False, default="")
     download_url: Mapped[str] = mapped_column(String(1000), nullable=False, default="")
     cached_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     last_accessed_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
     __table_args__ = (
@@ -746,7 +746,7 @@ class CertificateAuthorityModel(Base):
     ca_cert: Mapped[str] = mapped_column(Text, nullable=False)
     ca_key_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
 
@@ -792,10 +792,10 @@ class VCSConnection(Base):
     )  # active, suspended, removed
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     __table_args__ = (
@@ -859,12 +859,21 @@ class AutodiscoveryRule(Base):
     labels: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
     owner_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
+    # Set on first successful full-tree scan of the repo. NULL means the
+    # rule has never been backfilled — the poll cycle picks rules where
+    # this is NULL and walks the full repo tree once (in addition to its
+    # normal changed-files walk) so existing matching directories get
+    # workspaces without waiting for someone to touch each one. Cleared
+    # to NULL whenever `enabled` flips false → true so a re-enable also
+    # re-scans. See #309.
+    first_scan_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     # Audit
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     __table_args__ = (
@@ -915,10 +924,10 @@ class PRSession(Base):
     state: Mapped[str] = mapped_column(String(20), nullable=False, default="open")
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     __table_args__ = (
@@ -958,10 +967,10 @@ class Variable(Base):
     version_id: Mapped[str] = mapped_column(String(64), nullable=False, default="")
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     workspace: Mapped["Workspace"] = relationship(back_populates="variables")
@@ -986,10 +995,10 @@ class VariableSet(Base):
     priority: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     variables: Mapped[list["VariableSetVariable"]] = relationship(
@@ -1024,10 +1033,10 @@ class VariableSetVariable(Base):
     version_id: Mapped[str] = mapped_column(String(64), nullable=False, default="")
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     variable_set: Mapped["VariableSet"] = relationship(back_populates="variables")
@@ -1083,7 +1092,7 @@ class ConfigurationVersion(Base):
     speculative: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
     __table_args__ = (Index("ix_configuration_versions_workspace_id", "workspace_id"),)
@@ -1198,10 +1207,10 @@ class Run(Base):
     created_by: Mapped[str] = mapped_column(String(255), nullable=False, default="")
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     workspace: Mapped["Workspace"] = relationship(back_populates="runs")
@@ -1229,7 +1238,7 @@ class AuditLog(Base):
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     actor_email: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     actor_ip: Mapped[str] = mapped_column(String(45), nullable=False, default="")
@@ -1259,7 +1268,7 @@ class AuditLog(Base):
     actor_id: Mapped[str] = mapped_column(String(64), nullable=False, server_default="")
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
     __table_args__ = (
@@ -1298,7 +1307,7 @@ class RunTrigger(Base):
     )
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
     workspace: Mapped["Workspace"] = relationship(foreign_keys=[workspace_id])
@@ -1342,10 +1351,10 @@ class NotificationConfiguration(Base):
     delivery_responses: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=list)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     workspace: Mapped["Workspace"] = relationship()
@@ -1383,10 +1392,10 @@ class RunTask(Base):
     )  # mandatory, advisory
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     workspace: Mapped["Workspace"] = relationship()
@@ -1417,10 +1426,10 @@ class TaskStage(Base):
     )  # pending/running/passed/failed/errored/canceled/overridden
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
     )
 
     results: Mapped[list["TaskStageResult"]] = relationship(
@@ -1462,7 +1471,7 @@ class TaskStageResult(Base):
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utc_now, nullable=False
+        DateTime(timezone=True), default=now_utc, nullable=False
     )
 
     task_stage: Mapped["TaskStage"] = relationship(back_populates="results")

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -15,7 +15,7 @@ from terrapod.auth.ca import (
     serialize_private_key,
 )
 from terrapod.config import settings
-from terrapod.db.models import AgentPool, AgentPoolToken, utc_now
+from terrapod.db.models import AgentPool, AgentPoolToken, now_utc
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
 
@@ -149,7 +149,7 @@ async def validate_join_token(db: AsyncSession, raw_token: str) -> AgentPoolToke
         return None
 
     # Check expiry
-    if token.expires_at and utc_now() > token.expires_at:
+    if token.expires_at and now_utc() > token.expires_at:
         return None
 
     # Check max uses

--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -20,7 +20,7 @@ from terrapod.db.models import (
     StateVersion,
     VCSConnection,
     Workspace,
-    utc_now,
+    now_utc,
 )
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
@@ -193,7 +193,7 @@ async def drift_check_cycle() -> None:
     replica runs this per interval across the entire deployment.
     """
     min_interval = settings.drift_detection.min_workspace_interval_seconds
-    now = utc_now()
+    now = now_utc()
 
     async with get_db_session() as db:
         result = await db.execute(
@@ -296,7 +296,7 @@ async def handle_drift_run_completed(payload: dict) -> None:
         else:
             return
 
-        ws.drift_last_checked_at = utc_now()
+        ws.drift_last_checked_at = now_utc()
         await db.commit()
 
         logger.info(

--- a/services/terrapod/services/github_service.py
+++ b/services/terrapod/services/github_service.py
@@ -492,6 +492,43 @@ async def get_changed_files(
     return [f["filename"] for f in files]
 
 
+async def list_repo_tree(conn: VCSConnection, owner: str, repo: str, ref: str) -> list[str] | None:
+    """List every file path in the repo at `ref`.
+
+    Used by the autodiscovery initial-scan path (#309): when a rule is
+    first created or re-enabled, the poll cycle does a one-time full-tree
+    walk so existing matching directories get workspaces without waiting
+    for someone to touch each one.
+
+    Returns None when GitHub truncates the tree (>100k entries or
+    >7 MB) — callers should treat that as "can't backfill this repo
+    via tree API" and fall back to a manual scan when we have one.
+    """
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+
+    # `GET /repos/{owner}/{repo}/git/trees/{ref}?recursive=1` returns
+    # every blob path in one call. GitHub caps at 100k entries / 7 MB and
+    # sets `truncated: true` if it had to stop short.
+    resp = await _github_request(
+        "GET",
+        f"{api_url}/repos/{owner}/{repo}/git/trees/{ref}?recursive=1",
+        token,
+    )
+    resp.raise_for_status()
+
+    data = resp.json()
+    if data.get("truncated"):
+        logger.warning(
+            "GitHub tree response truncated — autodiscovery initial scan will be incomplete",
+            owner=owner,
+            repo=repo,
+            ref=ref,
+        )
+        return None
+    return [entry["path"] for entry in data.get("tree", []) if entry.get("type") == "blob"]
+
+
 async def create_commit_status(
     conn: VCSConnection,
     owner: str,

--- a/services/terrapod/services/gitlab_service.py
+++ b/services/terrapod/services/gitlab_service.py
@@ -248,6 +248,67 @@ async def get_changed_files(
     return list(files)
 
 
+async def list_repo_tree(conn: VCSConnection, owner: str, repo: str, ref: str) -> list[str] | None:
+    """List every file path in the repo at `ref`.
+
+    Used by the autodiscovery initial-scan path (#309). Paginates over
+    `/projects/:id/repository/tree?recursive=true` until the server
+    stops returning pages (or we hit a safety cap), collecting every
+    `type=blob` entry.
+
+    Returns None on a transport error so the caller can treat it the
+    same as GitHub's `truncated` flag — best-effort, no scan today.
+    """
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+    files: list[str] = []
+    page = 1
+    # Hard cap so a misconfigured huge repo doesn't fan us out forever.
+    # 200 pages × 100 per page = 20k files, plenty for realistic monorepos.
+    MAX_PAGES = 200
+    PER_PAGE = 100
+
+    async with httpx.AsyncClient() as client:
+        while page <= MAX_PAGES:
+            try:
+                resp = await client.get(
+                    f"{api}/projects/{project}/repository/tree",
+                    params={
+                        "ref": ref,
+                        "recursive": "true",
+                        "per_page": PER_PAGE,
+                        "page": page,
+                    },
+                    headers=_headers(conn),
+                )
+                resp.raise_for_status()
+            except httpx.HTTPError:
+                logger.warning(
+                    "GitLab tree listing failed — autodiscovery initial scan will be incomplete",
+                    project=f"{owner}/{repo}",
+                    ref=ref,
+                    page=page,
+                    exc_info=True,
+                )
+                return None
+            batch = resp.json()
+            if not batch:
+                return files
+            for entry in batch:
+                if entry.get("type") == "blob":
+                    files.append(entry["path"])
+            if len(batch) < PER_PAGE:
+                return files
+            page += 1
+
+    logger.warning(
+        "GitLab tree listing hit page cap — autodiscovery initial scan truncated",
+        project=f"{owner}/{repo}",
+        ref=ref,
+    )
+    return None
+
+
 async def create_commit_status(
     conn: VCSConnection,
     owner: str,

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -19,7 +19,7 @@ from terrapod.db.models import (
     RunTrigger,
     VCSConnection,
     Workspace,
-    utc_now,
+    now_utc,
 )
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service
@@ -294,7 +294,7 @@ async def transition_run(
     if not can_transition(run.status, target_status):
         raise ValueError(f"Invalid transition: {run.status} → {target_status}")
 
-    now = utc_now()
+    now = now_utc()
     old_status = run.status
     run.status = target_status
 
@@ -555,7 +555,7 @@ async def complete_planned_as_noop(db: AsyncSession, run: Run) -> Run:
 
     Releases the workspace lock since no Job will run.
     """
-    run.apply_started_at = utc_now()
+    run.apply_started_at = now_utc()
     run = await transition_run(db, run, "applied")
     ws = await db.get(Workspace, run.workspace_id)
     if ws and ws.locked:

--- a/services/terrapod/services/run_task_dispatcher.py
+++ b/services/terrapod/services/run_task_dispatcher.py
@@ -97,7 +97,7 @@ async def handle_run_task_call(payload: dict) -> None:
         if ws is None:
             return
 
-        from terrapod.db.models import utc_now as _utc_now
+        from terrapod.db.models import now_utc as _utc_now
 
         rt = await db.get(RunTask, tsr.run_task_id) if tsr.run_task_id else None
         if rt is None:

--- a/services/terrapod/services/sso_service.py
+++ b/services/terrapod/services/sso_service.py
@@ -72,9 +72,9 @@ async def process_login(
             AUTH_LOGIN.labels(provider=identity.provider_name, outcome="disabled").inc()
             raise ValueError("User account is disabled")
         # Update last_login_at
-        from terrapod.db.models import utc_now
+        from terrapod.db.models import now_utc
 
-        user.last_login_at = utc_now()
+        user.last_login_at = now_utc()
         if identity.display_name and not user.display_name:
             user.display_name = identity.display_name
 

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -36,7 +36,7 @@ from terrapod.db.models import (
     Run,
     VCSConnection,
     Workspace,
-    utc_now,
+    now_utc,
 )
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
@@ -111,6 +111,19 @@ async def _get_changed_files(
     if conn.provider == "gitlab":
         return await gitlab_service.get_changed_files(conn, owner, repo, base_sha, head_sha)
     return await github_service.get_changed_files(conn, owner, repo, base_sha, head_sha)
+
+
+async def _list_repo_tree(conn: VCSConnection, owner: str, repo: str, ref: str) -> list[str] | None:
+    """List every file path in the repo at `ref` via the appropriate provider.
+
+    Used by the autodiscovery initial-scan path (#309). Returns None when
+    the provider truncates / fails, signalling that the scan was
+    incomplete; callers should NOT stamp `first_scan_at` in that case
+    so the next poll cycle tries again.
+    """
+    if conn.provider == "gitlab":
+        return await gitlab_service.list_repo_tree(conn, owner, repo, ref)
+    return await github_service.list_repo_tree(conn, owner, repo, ref)
 
 
 def _changes_affect_prefixes(changed_files: list[str], prefixes: list[str]) -> bool:
@@ -782,7 +795,7 @@ async def _poll_workspace(
     conn = await db.get(VCSConnection, ws.vcs_connection_id)
     if not conn or conn.status != "active":
         ws.vcs_last_error = "VCS connection is not active"
-        ws.vcs_last_error_at = utc_now()
+        ws.vcs_last_error_at = now_utc()
         logger.warning(
             "VCS connection not active",
             workspace=ws.name,
@@ -793,7 +806,7 @@ async def _poll_workspace(
     parsed = _parse_repo_url(conn, ws.vcs_repo_url)
     if not parsed:
         ws.vcs_last_error = f"Cannot parse VCS repo URL: {ws.vcs_repo_url}"
-        ws.vcs_last_error_at = utc_now()
+        ws.vcs_last_error_at = now_utc()
         logger.warning(
             "Cannot parse VCS repo URL",
             workspace=ws.name,
@@ -807,7 +820,7 @@ async def _poll_workspace(
     branch = await _resolve_branch(conn, ws, owner, repo)
     if not branch:
         ws.vcs_last_error = "Cannot determine tracked branch"
-        ws.vcs_last_error_at = utc_now()
+        ws.vcs_last_error_at = now_utc()
         return
 
     fetch_paths: list[str] | None = None
@@ -822,7 +835,7 @@ async def _poll_workspace(
         await _poll_workspace_prs(db, ws, conn, owner, repo, branch, cache, fetch_paths)
 
         # Success: update last-polled timestamp and clear any previous error
-        ws.vcs_last_polled_at = utc_now()
+        ws.vcs_last_polled_at = now_utc()
         ws.vcs_last_error = None
         ws.vcs_last_error_at = None
     except Exception as e:
@@ -833,7 +846,7 @@ async def _poll_workspace(
             exc_info=e,
         )
         ws.vcs_last_error = str(e)[:500]
-        ws.vcs_last_error_at = utc_now()
+        ws.vcs_last_error_at = now_utc()
 
 
 # Bound the number of workspaces polled in parallel per cycle. Each workspace
@@ -1118,6 +1131,46 @@ async def _poll_autodiscovery_for_connection(
                 continue
             new_workspaces = await autodiscover_for_paths(db, group, changed)
             created_count += len(new_workspaces)
+
+        # Initial-scan path (#309): rules with `first_scan_at IS NULL`
+        # have never been backfilled, so this poll cycle does a one-time
+        # full-tree walk of the target branch and feeds every file path
+        # to the matcher. After a successful walk, stamp `first_scan_at`
+        # so we don't repeat the walk every cycle.
+        #
+        # Failures (`None` return) leave `first_scan_at` untouched so
+        # the next cycle retries. The change-driven walk above keeps
+        # working in the meantime — initial-scan failure doesn't block
+        # ongoing autodiscovery, it just delays the backfill.
+        unscanned = [r for r in group if r.first_scan_at is None]
+        if unscanned:
+            try:
+                all_files = await _list_repo_tree(conn, owner, repo, target_branch)
+            except Exception:
+                logger.warning(
+                    "Autodiscovery: initial-scan tree fetch failed — will retry next cycle",
+                    connection_id=str(conn.id),
+                    repo_url=repo_url,
+                    ref=target_branch,
+                    exc_info=True,
+                )
+                all_files = None
+            if all_files is not None:
+                new_workspaces = await autodiscover_for_paths(db, unscanned, all_files)
+                created_count += len(new_workspaces)
+                scanned_at = now_utc()
+                for rule in unscanned:
+                    rule.first_scan_at = scanned_at
+                await db.commit()
+                logger.info(
+                    "Autodiscovery: initial scan complete",
+                    connection_id=str(conn.id),
+                    repo_url=repo_url,
+                    ref=target_branch,
+                    rules_scanned=len(unscanned),
+                    workspaces_created=len(new_workspaces),
+                    files_walked=len(all_files),
+                )
 
     return created_count
 

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -52,6 +52,7 @@ def _mock_rule(
     r.owner_email = "admin@example.com"
     r.created_at = datetime(2026, 5, 9, tzinfo=UTC)
     r.updated_at = datetime(2026, 5, 9, tzinfo=UTC)
+    r.first_scan_at = None
     return r
 
 
@@ -297,6 +298,61 @@ class TestUpdateRule:
         assert resp.status_code == 200
         assert rule.pattern == "envs/*/**/*.tf"
         assert rule.enabled is False
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_re_enable_clears_first_scan_at(self, *_mocks):
+        """Flipping enabled false → true clears first_scan_at so the next
+        poll cycle re-walks the repo (handles the 'disabled for a while,
+        repo grew, now re-enabling' case from issue #309).
+        """
+        from datetime import UTC, datetime
+
+        rule = _mock_rule()
+        rule.enabled = False
+        rule.first_scan_at = datetime(2026, 1, 1, tzinfo=UTC)
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {"data": {"attributes": {"enabled": True}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert rule.enabled is True
+        assert rule.first_scan_at is None
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_no_op_enable_preserves_first_scan_at(self, *_mocks):
+        """If `enabled` was already True and the PATCH sets it to True
+        again, first_scan_at must NOT be reset — only the false → true
+        transition triggers a re-scan."""
+        from datetime import UTC, datetime
+
+        rule = _mock_rule()
+        rule.enabled = True
+        scanned = datetime(2026, 1, 1, tzinfo=UTC)
+        rule.first_scan_at = scanned
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {"data": {"attributes": {"enabled": True}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert rule.first_scan_at == scanned
 
 
 # ── Delete ───────────────────────────────────────────────────────────────

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -171,6 +171,55 @@ class TestCreateRule:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
+    async def test_422_when_pattern_ends_in_slash(self, *_mocks):
+        """A trailing-slash pattern can never match a file path — reject
+        at create time with a clear hint instead of silently no-opping
+        (issue #309)."""
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        body = resp.json()
+        assert "ends in '/'" in body["detail"]
+        # Hint mentions both alternatives so the user can pick.
+        assert "accounts/*/*.tf" in body["detail"]
+        assert "accounts/*/**" in body["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_when_ignore_pattern_ends_in_slash(self, *_mocks):
+        """Same rule applies to entries in ignore-patterns."""
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "**/*.tf",
+                    "ignore-patterns": ["modules/"],
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "ignore-patterns" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
     async def test_422_invalid_execution_mode(self, *_mocks):
         app, db = _make_app(_admin())
         body = {


### PR DESCRIPTION
Two halves of #309 rolled into one fix release.

**Not closing #309 on merge** — the dry-run preview piece of the original report (point 1, second half) is a real UX feature that should land separately. This PR addresses the pattern-validator (point 2) and the initial-scan bug (point 1, first half). I'll spin the dry-run preview out into its own issue after this lands so #309 can close cleanly when both are done.

## 1. Trailing-slash pattern validator (point 2)

A pattern like `foo/*/` compiles to a regex requiring the path to end in `/`. Autodiscovery only ever evaluates file paths, so the pattern silently matches nothing. Reject at rule create / update with a 422 + hint pointing at the two natural alternatives (`foo/*/*.tf` for one-level + tf, or `foo/*/**` for any depth).

## 2. Initial scan when a rule is first seen (point 1, first half)

Reframed from a feature request to a bug per discussion on the issue — *"autodiscovery"* that only finds workspaces when files change is a half-implementation. Adding a rule to an existing monorepo now backfills all matching directories.

- New nullable `autodiscovery_rules.first_scan_at` column. NULL = never backfilled.
- The VCS poll cycle picks rules where `first_scan_at IS NULL AND enabled = true` and runs a one-time full-tree walk against the target branch *in addition to* its normal changed-files walk. Stamps `first_scan_at = now()` on success; leaves NULL on failure so the next cycle retries.
- New `list_repo_tree(conn, owner, repo, ref)` provider helper:
  - GitHub: single `GET /repos/.../git/trees/{ref}?recursive=1`, returns None when the API sets `truncated: true`
  - GitLab: paginated `GET /projects/.../repository/tree?recursive=true`, hard-cap of 200 pages × 100 entries
- The rule **update** path clears `first_scan_at` on a `false → true` `enabled` transition so re-enabling a previously-disabled rule triggers a fresh scan.

Materialisation reuses the existing `autodiscover_for_paths` machinery (idempotent, name-collision-safe), so running the same paths through twice doesn't double-create.

## 3. Drive-by: `utc_now` → `now_utc` rename

The old name visually collided with the deprecated stdlib `datetime.utcnow()` even though our wrapper has always called the right `datetime.now(UTC)`. Mechanical rename across 23 call sites; no behaviour change.

## Out of scope (separate issue to follow)

The **dry-run preview** piece of the original feature request — operators wanting to preview which workspaces would be created against a 50-directory monorepo before letting a rule loose on it. Useful, but no longer load-bearing now that the initial-scan bug is fixed.

## Test plan

- [x] Unit tests: trailing-slash rejection (pattern + ignore-patterns), re-enable clears `first_scan_at`, no-op `enable=true` preserves it
- [x] Migration applied locally in Tilt, alembic head = `c3b957ded26c`
- [x] `make test` — 1350 passing
- [ ] CI green
- [ ] Smoke: create a rule against `terrapod-vcs-test`, confirm workspaces materialise for existing directories without anyone touching them