### PR TITLE
fix(security): pick up CVE-2026-27135 Debian fix in api/listener/migrations images

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -38,7 +38,15 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # Runtime-only system libraries (no gcc, no -dev headers)
 # apt-get upgrade picks up security patches for base OS packages (e.g. glibc)
 # `git` is required for VCS sparse fetch (subprocess driver in services/git_fetch.py).
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+#
+# Bump APT_REFRESH to invalidate the cached layer and re-pull Debian
+# security patches (e.g. libnghttp2-14 1.64.0-1.1+deb13u1 for
+# CVE-2026-27135). Without this the apt-upgrade layer is reused from
+# before the patch was published — same cache-staleness issue the
+# runner image's APK_REFRESH solves.
+ARG APT_REFRESH=2026-05-15
+RUN echo "apt-refresh=${APT_REFRESH}" \
+    && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     git \
     xmlsec1 \

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -19,7 +19,11 @@ RUN pip install --no-cache-dir .
 FROM python:3.14-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+# Bump APT_REFRESH to bust the cached apt layer and re-pull Debian
+# security patches (CVE-2026-27135 etc.) — see Dockerfile.api.
+ARG APT_REFRESH=2026-05-15
+RUN echo "apt-refresh=${APT_REFRESH}" \
+    && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -18,12 +18,12 @@ RUN pip install --no-cache-dir .
 FROM python:3.14-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
-# Pick up post-publish Debian security patches. Other Dockerfiles
-# (api, runner) already do this in their runtime stage; the migrations
-# image was inconsistent and inherited whatever security state the
-# python:3.14-slim base was published with at the moment Docker Hub
-# last republished. No new packages installed — just upgrades.
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+# Pick up post-publish Debian security patches. Bump APT_REFRESH to
+# bust the cached apt layer and re-pull patches (CVE-2026-27135 etc.) —
+# see Dockerfile.api. No new packages installed — just upgrades.
+ARG APT_REFRESH=2026-05-15
+RUN echo "apt-refresh=${APT_REFRESH}" \
+    && apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

`CVE-2026-27135` (nghttp2 HTTP/2 DoS) now has a Debian 13 fix: `libnghttp2-14 1.64.0-1.1+deb13u1`. The api/listener/migrations images run `apt-get upgrade -y`, but the build layer was **cached** from before the patched package was published — so rebuilt images still ship the vulnerable `1.64.0-1.1` and the Trivy image scan fails on every PR and on main.

Same cache-staleness class the runner image's `APK_REFRESH` already solves. Adds a dated `ARG APT_REFRESH=2026-05-15` to the runtime-stage apt RUN in all three Debian Dockerfiles; bumping the date invalidates the cached layer and forces a fresh `apt update && upgrade` that pulls the security patch.

Verified locally: `trivy image` on a freshly-built api image goes `Total: 1 (HIGH: 1)` → clean once the layer rebuilds against the current Debian security repo.

This blocks all other PRs (it's a base-image issue, not branch-specific), so it ships first as a standalone patch. #312 / #278 rebase on top.

## Test plan

- [ ] CI green (image scans in particular)
- [x] Local trivy confirms the CVE clears with the rebuilt layer