### PR TITLE
feat!: remove transitional /api/v2 aliases for Terrapod-native routes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1178,10 +1178,10 @@ All provider responses (show and list) include a `permissions` object:
 ### GPG Keys
 
 ```
-GET    /api/registry/private/v2/gpg-keys
-POST   /api/registry/private/v2/gpg-keys
-GET    /api/registry/private/v2/gpg-keys/{namespace}/{key_id}
-DELETE /api/registry/private/v2/gpg-keys/{namespace}/{key_id}
+GET    /api/terrapod/v1/gpg-keys
+POST   /api/terrapod/v1/gpg-keys
+GET    /api/terrapod/v1/gpg-keys/{namespace}/{key_id}
+DELETE /api/terrapod/v1/gpg-keys/{namespace}/{key_id}
 ```
 
 ---

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -404,7 +404,7 @@ Before publishing providers, register a GPG key for signature verification:
 gpg --armor --export your-key-id > public-key.asc
 
 # Register with Terrapod
-curl -X POST https://terrapod.example.com/api/registry/private/v2/gpg-keys \
+curl -X POST https://terrapod.example.com/api/terrapod/v1/gpg-keys \
   -H "Authorization: Bearer $TERRAPOD_TOKEN" \
   -H "Content-Type: application/vnd.api+json" \
   -d "{
@@ -423,7 +423,7 @@ The key ID is automatically extracted from the ASCII armor using `pgpy` (pure Py
 ### Listing GPG Keys
 
 ```zsh
-curl https://terrapod.example.com/api/registry/private/v2/gpg-keys \
+curl https://terrapod.example.com/api/terrapod/v1/gpg-keys \
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -171,7 +171,7 @@ api:
       auth_requests_per_minute: 10
 ```
 
-Auth endpoints (`/api/v2/auth/*`, `/oauth/*`) have a separate, lower limit to protect against credential stuffing. Health, readiness, and metrics endpoints are exempt.
+Auth endpoints (`/api/terrapod/v1/auth/*`, `/oauth/*`) have a separate, lower limit to protect against credential stuffing. Health, readiness, and metrics endpoints are exempt.
 
 Rate limiting uses Redis for distributed counting across replicas and fails open if Redis is unavailable.
 

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -287,7 +287,7 @@ api:
       # artifact uploads — throttling them causes plan failures. Raise if
       # you need a hard cap on a specific cluster.
       runner_requests_per_minute: 0
-      # Auth endpoints (/api/terrapod/v1/auth/*, /api/v2/auth/*, /oauth/*) — brute-force defence,
+      # Auth endpoints (/api/terrapod/v1/auth/*, /oauth/*) — brute-force defence,
       # applies to all callers regardless of credentials.
       auth_requests_per_minute: 10
 

--- a/provider/internal/datasources/agent_pool/data_source.go
+++ b/provider/internal/datasources/agent_pool/data_source.go
@@ -1,6 +1,6 @@
 // Package agent_pool implements the terrapod_agent_pool data source.
 //
-// API Contract: GET /api/v2/organizations/default/agent-pools
+// API Contract: GET /api/terrapod/v1/agent-pools
 // Lists all pools, filters by name client-side.
 package agent_pool
 
@@ -74,7 +74,7 @@ func (d *agentPoolDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	data, err := d.client.Get(ctx, "/api/v2/organizations/default/agent-pools")
+	data, err := d.client.Get(ctx, "/api/terrapod/v1/agent-pools")
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to list agent pools", err.Error())
 		return

--- a/provider/internal/resources/agent_pool/resource.go
+++ b/provider/internal/resources/agent_pool/resource.go
@@ -4,10 +4,10 @@
 //
 //	JSON:API type: "agent-pools"
 //	ID prefix: "apool-"
-//	Create:  POST   /api/v2/organizations/default/agent-pools
-//	Read:    GET    /api/v2/agent-pools/{id}
-//	Update:  PATCH  /api/v2/agent-pools/{id}
-//	Delete:  DELETE /api/v2/agent-pools/{id}
+//	Create:  POST   /api/terrapod/v1/agent-pools
+//	Read:    GET    /api/terrapod/v1/agent-pools/{id}
+//	Update:  PATCH  /api/terrapod/v1/agent-pools/{id}
+//	Delete:  DELETE /api/terrapod/v1/agent-pools/{id}
 //
 // Attribute mapping (JSON:API attribute -> Terraform schema attribute):
 //
@@ -158,7 +158,7 @@ func (r *agentPoolResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	data, err := r.client.Post(ctx, "/api/v2/organizations/default/agent-pools", body)
+	data, err := r.client.Post(ctx, "/api/terrapod/v1/agent-pools", body)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create agent pool", err.Error())
 		return
@@ -181,7 +181,7 @@ func (r *agentPoolResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	data, err := r.client.Get(ctx, "/api/v2/agent-pools/"+state.ID.ValueString())
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/agent-pools/"+state.ID.ValueString())
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -222,7 +222,7 @@ func (r *agentPoolResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	data, err := r.client.Patch(ctx, "/api/v2/agent-pools/"+state.ID.ValueString(), body)
+	data, err := r.client.Patch(ctx, "/api/terrapod/v1/agent-pools/"+state.ID.ValueString(), body)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update agent pool", err.Error())
 		return
@@ -245,7 +245,7 @@ func (r *agentPoolResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/v2/agent-pools/"+state.ID.ValueString())
+	err := r.client.Delete(ctx, "/api/terrapod/v1/agent-pools/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Failed to delete agent pool", err.Error())
 	}

--- a/provider/internal/resources/agent_pool_token/resource.go
+++ b/provider/internal/resources/agent_pool_token/resource.go
@@ -4,9 +4,9 @@
 //
 //	JSON:API type: "authentication-tokens"
 //	ID prefix: "at-"
-//	Create:  POST   /api/v2/agent-pools/{pool_id}/tokens
-//	Read:    GET    /api/v2/agent-pools/{pool_id}/tokens (list, find by ID)
-//	Delete:  DELETE /api/v2/agent-pools/{pool_id}/tokens/{token_id}
+//	Create:  POST   /api/terrapod/v1/agent-pools/{pool_id}/tokens
+//	Read:    GET    /api/terrapod/v1/agent-pools/{pool_id}/tokens (list, find by ID)
+//	Delete:  DELETE /api/terrapod/v1/agent-pools/{pool_id}/tokens/{token_id}
 //
 // This resource is immutable — there is no update (PATCH) endpoint.
 // Any attribute change forces replacement.
@@ -187,7 +187,7 @@ func (r *agentPoolTokenResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	endpoint := "/api/v2/agent-pools/" + plan.PoolID.ValueString() + "/tokens"
+	endpoint := "/api/terrapod/v1/agent-pools/" + plan.PoolID.ValueString() + "/tokens"
 	data, err := r.client.Post(ctx, endpoint, body)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create agent pool token", err.Error())
@@ -219,7 +219,7 @@ func (r *agentPoolTokenResource) Read(ctx context.Context, req resource.ReadRequ
 
 	// The API does not have a single-token GET endpoint. List all tokens
 	// for the pool and find the one matching our ID.
-	endpoint := "/api/v2/agent-pools/" + state.PoolID.ValueString() + "/tokens"
+	endpoint := "/api/terrapod/v1/agent-pools/" + state.PoolID.ValueString() + "/tokens"
 	data, err := r.client.Get(ctx, endpoint)
 	if err != nil {
 		if client.IsNotFound(err) {
@@ -274,7 +274,7 @@ func (r *agentPoolTokenResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	endpoint := "/api/v2/agent-pools/" + state.PoolID.ValueString() + "/tokens/" + state.ID.ValueString()
+	endpoint := "/api/terrapod/v1/agent-pools/" + state.PoolID.ValueString() + "/tokens/" + state.ID.ValueString()
 	err := r.client.Delete(ctx, endpoint)
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Failed to delete agent pool token", err.Error())

--- a/provider/internal/resources/notification_configuration/model.go
+++ b/provider/internal/resources/notification_configuration/model.go
@@ -5,9 +5,9 @@
 //	JSON:API type: "notification-configurations"
 //	ID prefix: "nc-"
 //	Create:  POST   /api/v2/workspaces/{workspace_id}/notification-configurations
-//	Read:    GET    /api/v2/notification-configurations/{id}
-//	Update:  PATCH  /api/v2/notification-configurations/{id}
-//	Delete:  DELETE /api/v2/notification-configurations/{id}
+//	Read:    GET    /api/terrapod/v1/notification-configurations/{id}
+//	Update:  PATCH  /api/terrapod/v1/notification-configurations/{id}
+//	Delete:  DELETE /api/terrapod/v1/notification-configurations/{id}
 //
 // Attribute mapping:
 //

--- a/provider/internal/resources/notification_configuration/resource.go
+++ b/provider/internal/resources/notification_configuration/resource.go
@@ -111,7 +111,7 @@ func (r *notificationConfigResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	data, err := r.client.Post(ctx, fmt.Sprintf("/api/v2/workspaces/%s/notification-configurations", plan.WorkspaceID.ValueString()), body)
+	data, err := r.client.Post(ctx, fmt.Sprintf("/api/terrapod/v1/workspaces/%s/notification-configurations", plan.WorkspaceID.ValueString()), body)
 	if err != nil {
 		resp.Diagnostics.AddError("Create failed", err.Error())
 		return
@@ -134,7 +134,7 @@ func (r *notificationConfigResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	data, err := r.client.Get(ctx, "/api/v2/notification-configurations/"+state.ID.ValueString())
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/notification-configurations/"+state.ID.ValueString())
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -174,7 +174,7 @@ func (r *notificationConfigResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	data, err := r.client.Patch(ctx, "/api/v2/notification-configurations/"+state.ID.ValueString(), body)
+	data, err := r.client.Patch(ctx, "/api/terrapod/v1/notification-configurations/"+state.ID.ValueString(), body)
 	if err != nil {
 		resp.Diagnostics.AddError("Update failed", err.Error())
 		return
@@ -197,7 +197,7 @@ func (r *notificationConfigResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/v2/notification-configurations/"+state.ID.ValueString())
+	err := r.client.Delete(ctx, "/api/terrapod/v1/notification-configurations/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Delete failed", err.Error())
 	}

--- a/provider/internal/resources/registry_module/resource.go
+++ b/provider/internal/resources/registry_module/resource.go
@@ -4,10 +4,10 @@
 //
 //	JSON:API type: "registry-modules"
 //	ID: UUID (no prefix)
-//	Create:  POST   /api/v2/organizations/default/registry-modules
-//	Read:    GET    /api/v2/organizations/default/registry-modules/private/default/{name}/{provider}
-//	Update:  PATCH  /api/v2/organizations/default/registry-modules/private/default/{name}/{provider}
-//	Delete:  DELETE /api/v2/organizations/default/registry-modules/private/default/{name}/{provider}
+//	Create:  POST   /api/terrapod/v1/registry-modules
+//	Read:    GET    /api/terrapod/v1/registry-modules/private/default/{name}/{provider}
+//	Update:  PATCH  /api/terrapod/v1/registry-modules/private/default/{name}/{provider}
+//	Delete:  DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{provider}
 //
 // Attribute mapping:
 //
@@ -144,7 +144,7 @@ func (r *registryModuleResource) Configure(_ context.Context, req resource.Confi
 }
 
 func (r *registryModuleResource) modulePath(m *registryModuleModel) string {
-	return fmt.Sprintf("/api/v2/organizations/default/registry-modules/private/default/%s/%s",
+	return fmt.Sprintf("/api/terrapod/v1/registry-modules/private/default/%s/%s",
 		m.Name.ValueString(), m.ProviderName.ValueString())
 }
 
@@ -162,7 +162,7 @@ func (r *registryModuleResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	data, err := r.client.Post(ctx, "/api/v2/organizations/default/registry-modules", body)
+	data, err := r.client.Post(ctx, "/api/terrapod/v1/registry-modules", body)
 	if err != nil {
 		resp.Diagnostics.AddError("Create failed", err.Error())
 		return

--- a/provider/internal/resources/registry_provider/resource.go
+++ b/provider/internal/resources/registry_provider/resource.go
@@ -4,10 +4,10 @@
 //
 //	JSON:API type: "registry-providers"
 //	ID: UUID (no prefix)
-//	Create:  POST   /api/v2/organizations/default/registry-providers
-//	Read:    GET    /api/v2/organizations/default/registry-providers/private/default/{name}
-//	Update:  PATCH  /api/v2/organizations/default/registry-providers/private/default/{name}
-//	Delete:  DELETE /api/v2/organizations/default/registry-providers/private/default/{name}
+//	Create:  POST   /api/terrapod/v1/registry-providers
+//	Read:    GET    /api/terrapod/v1/registry-providers/private/default/{name}
+//	Update:  PATCH  /api/terrapod/v1/registry-providers/private/default/{name}
+//	Delete:  DELETE /api/terrapod/v1/registry-providers/private/default/{name}
 //
 // Attribute mapping:
 //
@@ -114,7 +114,7 @@ func (r *registryProviderResource) Configure(_ context.Context, req resource.Con
 }
 
 func providerPath(name string) string {
-	return fmt.Sprintf("/api/v2/organizations/default/registry-providers/private/default/%s", name)
+	return fmt.Sprintf("/api/terrapod/v1/registry-providers/private/default/%s", name)
 }
 
 func (r *registryProviderResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -131,7 +131,7 @@ func (r *registryProviderResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	data, err := r.client.Post(ctx, "/api/v2/organizations/default/registry-providers", body)
+	data, err := r.client.Post(ctx, "/api/terrapod/v1/registry-providers", body)
 	if err != nil {
 		resp.Diagnostics.AddError("Create failed", err.Error())
 		return

--- a/provider/internal/resources/run_task/model.go
+++ b/provider/internal/resources/run_task/model.go
@@ -5,9 +5,9 @@
 //	JSON:API type: "run-tasks"
 //	ID prefix: "task-"
 //	Create:  POST   /api/v2/workspaces/{workspace_id}/run-tasks
-//	Read:    GET    /api/v2/run-tasks/{id}
-//	Update:  PATCH  /api/v2/run-tasks/{id}
-//	Delete:  DELETE /api/v2/run-tasks/{id}
+//	Read:    GET    /api/terrapod/v1/run-tasks/{id}
+//	Update:  PATCH  /api/terrapod/v1/run-tasks/{id}
+//	Delete:  DELETE /api/terrapod/v1/run-tasks/{id}
 //
 // Attribute mapping:
 //

--- a/provider/internal/resources/run_task/resource.go
+++ b/provider/internal/resources/run_task/resource.go
@@ -104,7 +104,7 @@ func (r *runTaskResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	data, err := r.client.Post(ctx, fmt.Sprintf("/api/v2/workspaces/%s/run-tasks", plan.WorkspaceID.ValueString()), body)
+	data, err := r.client.Post(ctx, fmt.Sprintf("/api/terrapod/v1/workspaces/%s/run-tasks", plan.WorkspaceID.ValueString()), body)
 	if err != nil {
 		resp.Diagnostics.AddError("Create failed", err.Error())
 		return
@@ -127,7 +127,7 @@ func (r *runTaskResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	data, err := r.client.Get(ctx, "/api/v2/run-tasks/"+state.ID.ValueString())
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/run-tasks/"+state.ID.ValueString())
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -167,7 +167,7 @@ func (r *runTaskResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	data, err := r.client.Patch(ctx, "/api/v2/run-tasks/"+state.ID.ValueString(), body)
+	data, err := r.client.Patch(ctx, "/api/terrapod/v1/run-tasks/"+state.ID.ValueString(), body)
 	if err != nil {
 		resp.Diagnostics.AddError("Update failed", err.Error())
 		return
@@ -190,7 +190,7 @@ func (r *runTaskResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/v2/run-tasks/"+state.ID.ValueString())
+	err := r.client.Delete(ctx, "/api/terrapod/v1/run-tasks/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Delete failed", err.Error())
 	}

--- a/provider/internal/resources/run_trigger/model.go
+++ b/provider/internal/resources/run_trigger/model.go
@@ -5,8 +5,8 @@
 //	JSON:API type: "run-triggers"
 //	ID prefix: "rt-"
 //	Create:  POST   /api/v2/workspaces/{workspace_id}/run-triggers
-//	Read:    GET    /api/v2/run-triggers/{id}
-//	Delete:  DELETE /api/v2/run-triggers/{id}
+//	Read:    GET    /api/terrapod/v1/run-triggers/{id}
+//	Delete:  DELETE /api/terrapod/v1/run-triggers/{id}
 //	No update — immutable resource (delete + recreate).
 //
 // Attribute mapping:

--- a/provider/internal/resources/run_trigger/resource.go
+++ b/provider/internal/resources/run_trigger/resource.go
@@ -93,7 +93,7 @@ func (r *runTriggerResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	data, err := r.client.Post(ctx, fmt.Sprintf("/api/v2/workspaces/%s/run-triggers", plan.WorkspaceID.ValueString()), body)
+	data, err := r.client.Post(ctx, fmt.Sprintf("/api/terrapod/v1/workspaces/%s/run-triggers", plan.WorkspaceID.ValueString()), body)
 	if err != nil {
 		resp.Diagnostics.AddError("Create failed", err.Error())
 		return
@@ -116,7 +116,7 @@ func (r *runTriggerResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	data, err := r.client.Get(ctx, "/api/v2/run-triggers/"+state.ID.ValueString())
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/run-triggers/"+state.ID.ValueString())
 	if err != nil {
 		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -147,7 +147,7 @@ func (r *runTriggerResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/v2/run-triggers/"+state.ID.ValueString())
+	err := r.client.Delete(ctx, "/api/terrapod/v1/run-triggers/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Delete failed", err.Error())
 	}

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -401,33 +401,6 @@ def create_application() -> FastAPI:
 
         return response
 
-    # Deprecation-headers middleware. Stamps RFC 8594 Deprecation + Link
-    # headers on responses for routes flagged `deprecated=True` in the
-    # OpenAPI schema, plus a custom X-Removed-In header naming the version
-    # that drops the alias (RFC 8594's Sunset wants an HTTP-date which
-    # we'd rather not commit to for a release-train product).
-    #
-    # Also emits a structlog warning per legacy-path request so operators
-    # can grep their logs for any client still pointed at the old paths
-    # before the v0.24.0 cutover (see issues #269 + #278).
-    @app.middleware("http")
-    async def deprecation_headers(request: Request, call_next):  # type: ignore[no-untyped-def]
-        response = await call_next(request)
-        route = request.scope.get("route")
-        if route is not None and getattr(route, "deprecated", False):
-            response.headers["Deprecation"] = "true"
-            response.headers["Link"] = (
-                '<https://github.com/mattrobinsonsre/terrapod/issues/278>; rel="deprecation"'
-            )
-            response.headers["X-Removed-In"] = "v0.24.0"
-            logger.warning(
-                "Deprecated API path used",
-                path=request.url.path,
-                method=request.method,
-                user_agent=request.headers.get("user-agent", ""),
-            )
-        return response
-
     # Audit logging middleware
     @app.middleware("http")
     async def audit_logging(request: Request, call_next):  # type: ignore[no-untyped-def]
@@ -497,87 +470,37 @@ def create_application() -> FastAPI:
     #   sessions, etc.). All Terrapod-only endpoints live here from
     #   v0.23.0 onward.
     #
-    # During the v0.23.x deprecation window every Terrapod-only route is
-    # ALSO registered at its original `/api/v2/` location with FastAPI's
-    # `deprecated=True` flag — this lets v0.X-1 listeners/runners/the
-    # provider still hit a v0.X API while operators stagger upgrades.
-    # The legacy mounts get dropped in v0.24.0 (see #278). Internal code
-    # always targets the canonical `/api/terrapod/v1/` path.
+    # The legacy `/api/v2/` aliases for Terrapod-only routes (the
+    # transitional dual-mount #269 introduced and the v0.23.x release
+    # window kept) were removed in v0.24.0 — see #278. Terrapod-native
+    # endpoints are served *only* at `/api/terrapod/v1/`. `/api/v2/`
+    # remains the permanent home for the TFE V2 CLI surface that
+    # `terraform` / `tofu` / `tfci` consume (see docs/tfe-cli-surface.md);
+    # that is not deprecated and is unaffected by #278.
     TERRAPOD_PREFIX = "/api/terrapod/v1"
-    TFE_PREFIX = settings.api_prefix  # "/api/v2"
 
-    def include_with_org_legacy(router) -> None:
-        """Register a Terrapod-native router that pre-v0.23 lived under
-        `/api/v2/organizations/default/{resource}`.
-
-        Two mounts:
-        - Canonical: `/api/terrapod/v1/{resource}` (no
-          `organizations/default/` — see CLAUDE.md rule #9 and
-          `docs/tfe-cli-surface.md`).
-        - Legacy alias: `/api/v2/organizations/default/{resource}`
-          (the pre-v0.23 path, kept for v0.22.x callers).
-
-        We deliberately do NOT register a `/api/v2/{resource}` alias —
-        that shape was never published, isn't a TFE-V2 shape, and isn't
-        something we want to preserve. The router's own `prefix=` and
-        each route's path stack on these prefixes as usual.
-
-        Legacy mount is hidden from OpenAPI and emits Deprecation
-        headers via the middleware. Removed in v0.24.0 (#278).
+    def include_terrapod(router) -> None:
+        """Mount a Terrapod-native router at the canonical
+        `/api/terrapod/v1/` prefix. Any prefix on the router itself
+        stacks (e.g. audit's own `prefix="/admin"` becomes
+        `/api/terrapod/v1/admin/...`).
         """
         app.include_router(router, prefix=TERRAPOD_PREFIX)
-        app.include_router(
-            router,
-            prefix="/api/v2/organizations/default",
-            deprecated=True,
-            include_in_schema=False,
-        )
-
-    def include_moved(router, legacy_prefix: str = TFE_PREFIX) -> None:
-        """Register a router under both the canonical Terrapod prefix and
-        a legacy alias.
-
-        `legacy_prefix` defaults to `/api/v2/` since that's where every
-        TFE-V2-shaped route used to live; pass a different prefix for
-        routes that historically used a non-`/api/v2/` path (e.g. GPG
-        keys lived at `/api/registry/private/v2/`).
-
-        The legacy mount is `deprecated=True` (so the middleware emits
-        Deprecation/Link/X-Removed-In response headers + a structlog
-        warning per legacy-path request) AND `include_in_schema=False`
-        so the alias paths are hidden from OpenAPI / Swagger UI / ReDoc /
-        generated clients. The canonical `/api/terrapod/v1/...` paths
-        are the only ones documented; the alias is a transitional
-        compatibility-only mount.
-
-        Any prefix on the router itself stacks (e.g. audit's own
-        `prefix="/admin"` becomes `/api/terrapod/v1/admin/...` and
-        `/api/v2/admin/...`).
-        """
-        app.include_router(router, prefix=TERRAPOD_PREFIX)
-        app.include_router(
-            router,
-            prefix=legacy_prefix,
-            deprecated=True,
-            include_in_schema=False,
-        )
 
     # Health endpoints (no prefix)
     app.include_router(health_router)
 
     # Filesystem storage routes (presigned URL handlers) — Terrapod-only
-    # dev backend. Dual-mounted: filesystem.py emits canonical
-    # /api/terrapod/v1 URLs for new presigns; the /api/v2 alias keeps
-    # any URLs already in flight (or generated by older replicas during
-    # rollout) resolvable until v0.24.0 (#278).
+    # dev backend. Canonical at /api/terrapod/v1; filesystem.py emits
+    # presigned URLs under that prefix.
     from terrapod.storage.filesystem_routes import router as fs_router
 
-    include_moved(fs_router)
+    include_terrapod(fs_router)
 
     # Auth routes — Terrapod-specific session/SSO management.
     from terrapod.api.routers.auth import router as auth_router
 
-    include_moved(auth_router)
+    include_terrapod(auth_router)
 
     # OAuth2 routes (terraform login flow). The OAuth + service-discovery
     # paths stay at their canonical locations (/.well-known/terraform.json,
@@ -591,19 +514,19 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(oauth_router)
-    include_moved(oauth_extensions_router)
+    include_terrapod(oauth_extensions_router)
 
     # Workspace extension routes (SSE, vcs-refs) — Terrapod-specific.
     # MUST come before tfe_v2 so /workspace-events isn't matched as a
     # workspace_id parameter on either prefix.
     from terrapod.api.routers.workspace_extensions import router as workspace_extensions_router
 
-    include_moved(workspace_extensions_router)
+    include_terrapod(workspace_extensions_router)
 
     # TFE V2 CLI-contract routes — the verified subset of the TFE V2 spec
     # that terraform/tofu/tfci consume (see docs/tfe-cli-surface.md).
     # The one workspace-management path the CLI doesn't call (DELETE by
-    # id) lives in extensions_router and dual-mounts under /api/terrapod/v1.
+    # id) lives in extensions_router, mounted only under /api/terrapod/v1.
     from terrapod.api.routers.tfe_v2 import (
         extensions_router as tfe_v2_extensions_router,
     )
@@ -612,23 +535,23 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(tfe_v2_router)
-    include_moved(tfe_v2_extensions_router)
+    include_terrapod(tfe_v2_extensions_router)
 
     # State management routes — Terrapod-specific (delete, rollback, upload).
     from terrapod.api.routers.state_management import router as state_management_router
 
-    include_moved(state_management_router)
+    include_terrapod(state_management_router)
 
     # Token CRUD routes — Terrapod-native management surface (the CLI
     # creates tokens via the /oauth flow, never via these endpoints).
     from terrapod.api.routers.tokens import router as tokens_router
 
-    include_moved(tokens_router)
+    include_terrapod(tokens_router)
 
     # Registry routes — module CLI download protocol stays at /api/v2 (the
-    # CLI hits this on `terraform init`). Module management (org-scoped CRUD
-    # on private modules + version + /vcs) and workspace-links are
-    # Terrapod-native and dual-mount under /api/terrapod/v1.
+    # CLI hits this on `terraform init`). Module management (private-module
+    # CRUD + version + /vcs) and workspace-links are Terrapod-native and
+    # mounted only under /api/terrapod/v1.
     from terrapod.api.routers.registry_modules import (
         management_router as registry_modules_management_router,
     )
@@ -640,11 +563,11 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(registry_modules_router)
-    include_with_org_legacy(registry_modules_management_router)
-    include_with_org_legacy(module_workspace_links_router)
+    include_terrapod(registry_modules_management_router)
+    include_terrapod(module_workspace_links_router)
 
-    # Provider registry — CLI download protocol stays at /api/v2; org-scoped
-    # management dual-mounts under /api/terrapod/v1.
+    # Provider registry — CLI download protocol stays at /api/v2; provider
+    # management is Terrapod-native under /api/terrapod/v1.
     from terrapod.api.routers.registry_providers import (
         management_router as registry_providers_management_router,
     )
@@ -653,15 +576,15 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(registry_providers_router)
-    include_with_org_legacy(registry_providers_management_router)
+    include_terrapod(registry_providers_management_router)
 
     # GPG keys — Terrapod-native (the CLI reads provider GPG keys from the
     # provider download response, not via this admin endpoint). Canonical
-    # under /api/terrapod/v1; the historical TFE path /api/registry/private/v2
-    # is dual-mounted as the deprecated alias.
+    # under /api/terrapod/v1; the historical TFE path
+    # /api/registry/private/v2/gpg-keys was removed in v0.24.0 (#278).
     from terrapod.api.routers.gpg_keys import router as gpg_keys_router
 
-    include_moved(gpg_keys_router, legacy_prefix="/api/registry/private/v2")
+    include_terrapod(gpg_keys_router)
 
     # Caching routes (provider mirror, binary cache)
     from terrapod.api.routers.provider_mirror import router as provider_mirror_router
@@ -670,7 +593,7 @@ def create_application() -> FastAPI:
 
     from terrapod.api.routers.binary_cache import router as binary_cache_router
 
-    include_moved(binary_cache_router)
+    include_terrapod(binary_cache_router)
 
     # Variable endpoints
     from terrapod.api.routers.variables import router as variables_router
@@ -680,12 +603,7 @@ def create_application() -> FastAPI:
     # Agent pool endpoints — Terrapod-native management (pool CRUD,
     # token CRUD, listener-protocol). The CLI never manages pools, so
     # canonical paths drop the /organizations/default/ segment (Terrapod
-    # is single-org — see CLAUDE.md rule #9). Pre-v0.23 path shapes are
-    # preserved as deprecated aliases via legacy_router (mounted only on
-    # /api/v2).
-    from terrapod.api.routers.agent_pools import (
-        legacy_router as agent_pools_legacy_router,
-    )
+    # is single-org — see CLAUDE.md rule #9).
     from terrapod.api.routers.agent_pools import (
         listener_router as listener_protocol_router,
     )
@@ -694,22 +612,16 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(agent_pools_router, prefix=TERRAPOD_PREFIX)
-    app.include_router(
-        agent_pools_legacy_router,
-        prefix=TFE_PREFIX,
-        deprecated=True,
-        include_in_schema=False,
-    )
-    include_moved(listener_protocol_router)
+    include_terrapod(listener_protocol_router)
 
     # Read-only labels browser (cross-entity: workspaces, pools, modules, providers).
     from terrapod.api.routers.labels import router as labels_router
 
-    include_moved(labels_router)
+    include_terrapod(labels_router)
 
     # Run endpoints — TFE-spec stays at /api/v2; Terrapod-only extensions
     # (listener protocol, runner-driven completion, SSE streams, retry)
-    # move to /api/terrapod/v1 with a deprecated /api/v2 alias.
+    # are Terrapod-native under /api/terrapod/v1.
     from terrapod.api.routers.runs import (
         extensions_router as runs_extensions_router,
     )
@@ -718,15 +630,16 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(runs_router)
-    include_moved(runs_extensions_router)
+    include_terrapod(runs_extensions_router)
 
     # Run artifact endpoints (runner token auth) — Terrapod runner protocol.
     from terrapod.api.routers.run_artifacts import router as run_artifacts_router
 
-    include_moved(run_artifacts_router)
+    include_terrapod(run_artifacts_router)
 
     # Configuration version endpoints — TFE-spec stays at /api/v2; the
-    # Terrapod download/diff/ticket extensions move to /api/terrapod/v1.
+    # Terrapod download/diff/ticket extensions are Terrapod-native under
+    # /api/terrapod/v1.
     from terrapod.api.routers.config_versions import (
         extensions_router as config_version_extensions_router,
     )
@@ -735,26 +648,15 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(config_versions_router)
-    include_moved(config_version_extensions_router)
+    include_terrapod(config_version_extensions_router)
 
     # VCS connection endpoints — Terrapod-native. Canonical paths at
-    # /api/terrapod/v1/vcs-connections{,/{id}}; legacy_router preserves
-    # the pre-v0.23 list/create at /api/v2/organizations/default/vcs-connections
-    # and by-id at /api/v2/vcs-connections/{id}.
-    from terrapod.api.routers.vcs_connections import (
-        legacy_router as vcs_connections_legacy_router,
-    )
+    # /api/terrapod/v1/vcs-connections{,/{id}}.
     from terrapod.api.routers.vcs_connections import (
         router as vcs_connections_router,
     )
 
     app.include_router(vcs_connections_router, prefix=TERRAPOD_PREFIX)
-    app.include_router(
-        vcs_connections_legacy_router,
-        prefix=TFE_PREFIX,
-        deprecated=True,
-        include_in_schema=False,
-    )
 
     # Autodiscovery rules — Terrapod-native, introduced in v0.24 (#283).
     # No legacy alias: this surface didn't exist in v0.22, so /api/v2 has
@@ -768,58 +670,47 @@ def create_application() -> FastAPI:
     # VCS webhook event receiver — Terrapod-specific.
     from terrapod.api.routers.vcs_events import router as vcs_events_router
 
-    include_moved(vcs_events_router)
+    include_terrapod(vcs_events_router)
 
     # Role CRUD — Terrapod-specific RBAC.
     from terrapod.api.routers.roles import router as roles_router
 
-    include_moved(roles_router)
+    include_terrapod(roles_router)
 
     # Role assignment management — Terrapod-specific RBAC.
     from terrapod.api.routers.role_assignments import router as role_assignments_router
 
-    include_moved(role_assignments_router)
+    include_terrapod(role_assignments_router)
 
     # Run trigger endpoints — Terrapod-native management (CLI doesn't use).
     from terrapod.api.routers.run_triggers import router as run_triggers_router
 
-    include_moved(run_triggers_router)
+    include_terrapod(run_triggers_router)
 
     # Audit log query endpoint — Terrapod-specific.
     from terrapod.api.routers.audit import router as audit_router
 
-    include_moved(audit_router)
+    include_terrapod(audit_router)
 
     # User management endpoints — Terrapod-native. Canonical paths at
-    # /api/terrapod/v1/users{,/{email}}; legacy_router preserves
-    # pre-v0.23 list/create at /api/v2/organizations/default/users and
-    # by-email at /api/v2/users/{email}.
-    from terrapod.api.routers.users import (
-        legacy_router as users_legacy_router,
-    )
+    # /api/terrapod/v1/users{,/{email}}.
     from terrapod.api.routers.users import (
         router as users_router,
     )
 
     app.include_router(users_router, prefix=TERRAPOD_PREFIX)
-    app.include_router(
-        users_legacy_router,
-        prefix=TFE_PREFIX,
-        deprecated=True,
-        include_in_schema=False,
-    )
 
     # Notification configuration endpoints — Terrapod-native management.
     from terrapod.api.routers.notification_configurations import (
         router as notification_configurations_router,
     )
 
-    include_moved(notification_configurations_router)
+    include_terrapod(notification_configurations_router)
 
     # Run task endpoints — task-stages (read + override) stay at /api/v2
     # because the CLI's cloud backend reads them on every run; everything
     # else (workspace-scoped task definition CRUD + callback receiver) is
-    # Terrapod-native and dual-mounts under /api/terrapod/v1.
+    # Terrapod-native under /api/terrapod/v1.
     from terrapod.api.routers.run_tasks import (
         extensions_router as run_tasks_extensions_router,
     )
@@ -828,7 +719,7 @@ def create_application() -> FastAPI:
     )
 
     app.include_router(run_tasks_router)
-    include_moved(run_tasks_extensions_router)
+    include_terrapod(run_tasks_extensions_router)
 
     return app
 

--- a/services/terrapod/api/rate_limit.py
+++ b/services/terrapod/api/rate_limit.py
@@ -19,10 +19,11 @@ logger = get_logger(__name__)
 # Paths exempt from rate limiting
 _EXEMPT_PATHS = frozenset({"/health", "/ready", "/metrics"})
 
-# Auth endpoint prefixes (lower rate limit). Both the canonical
-# /api/terrapod/v1/auth/* and the deprecated /api/v2/auth/* aliases are
-# covered until the legacy paths are removed in v0.24.0 (see #278).
-_AUTH_PREFIXES = ("/api/terrapod/v1/auth/", "/api/v2/auth/", "/oauth/")
+# Auth endpoint prefixes (lower rate limit). Auth is Terrapod-native:
+# canonical /api/terrapod/v1/auth/* (the OAuth/SAML callback included —
+# its URL is built from terrapod_prefix as of #278) plus the /oauth/*
+# terraform-login flow.
+_AUTH_PREFIXES = ("/api/terrapod/v1/auth/", "/oauth/")
 
 
 def _is_auth_path(path: str) -> bool:
@@ -54,7 +55,7 @@ class RateLimitMiddleware:
       Interactive users and API-token automation rarely approach this, but
       it stops one noisy client taking the pool.
     - Unauthenticated: base limit (`requests_per_minute`).
-    - Auth endpoints (`/api/terrapod/v1/auth/*`, `/api/v2/auth/*`, `/oauth/*`): always `auth_requests_per_minute`
+    - Auth endpoints (`/api/terrapod/v1/auth/*`, `/oauth/*`): always `auth_requests_per_minute`
       regardless of who's calling — brute-force defence on login.
     """
 

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -851,31 +851,3 @@ async def renew_listener_cert(
     )
 
     return JSONResponse(content={"data": result})
-
-
-# ── Legacy alias router (v0.22 → v0.24 deprecation window) ─────────────
-# Mounted only at /api/v2 by app.py with deprecated=True and
-# include_in_schema=False. Pre-v0.23 path shapes:
-#   - list/create: /api/v2/organizations/default/agent-pools
-#   - by-id, tokens: /api/v2/agent-pools/{pool_id}[/tokens[/{token_id}]]
-# Removed in v0.24.0 (#278).
-legacy_router = APIRouter(tags=["agent-pools-legacy"])
-legacy_router.add_api_route("/organizations/default/agent-pools", list_pools, methods=["GET"])
-legacy_router.add_api_route(
-    "/organizations/default/agent-pools", create_pool, methods=["POST"], status_code=201
-)
-legacy_router.add_api_route("/agent-pools/{pool_id}", show_pool, methods=["GET"])
-legacy_router.add_api_route("/agent-pools/{pool_id}", update_pool, methods=["PATCH"])
-legacy_router.add_api_route(
-    "/agent-pools/{pool_id}", delete_pool, methods=["DELETE"], status_code=204
-)
-legacy_router.add_api_route("/agent-pools/{pool_id}/tokens", list_pool_tokens, methods=["GET"])
-legacy_router.add_api_route(
-    "/agent-pools/{pool_id}/tokens", create_pool_token, methods=["POST"], status_code=201
-)
-legacy_router.add_api_route(
-    "/agent-pools/{pool_id}/tokens/{token_id}",
-    delete_pool_token,
-    methods=["DELETE"],
-    status_code=204,
-)

--- a/services/terrapod/api/routers/auth.py
+++ b/services/terrapod/api/routers/auth.py
@@ -158,7 +158,7 @@ async def authorize(
     idp_state = generate_state()
 
     # Build callback URL for the IDP
-    callback_url = f"{settings.auth.callback_base_url}{settings.api_prefix}/auth/callback"
+    callback_url = f"{settings.auth.callback_base_url}{settings.terrapod_prefix}/auth/callback"
 
     # Build authorization request to the provider
     auth_request = await connector.build_authorization_request(
@@ -344,7 +344,7 @@ async def cli_sso_redirect(
         )
 
     idp_state = generate_state()
-    callback_url = f"{settings.auth.callback_base_url}{settings.api_prefix}/auth/callback"
+    callback_url = f"{settings.auth.callback_base_url}{settings.terrapod_prefix}/auth/callback"
 
     auth_request = await connector.build_authorization_request(
         callback_url=callback_url,
@@ -393,7 +393,7 @@ async def callback(
             detail=f"Provider {auth_state.provider_name} no longer configured",
         )
 
-    callback_url = f"{settings.auth.callback_base_url}{settings.api_prefix}/auth/callback"
+    callback_url = f"{settings.auth.callback_base_url}{settings.terrapod_prefix}/auth/callback"
 
     try:
         identity = await connector.handle_callback(
@@ -478,7 +478,7 @@ async def saml_acs(
             detail=f"Provider {auth_state.provider_name} no longer configured",
         )
 
-    acs_url = f"{settings.auth.callback_base_url}{settings.api_prefix}/auth/saml/acs"
+    acs_url = f"{settings.auth.callback_base_url}{settings.terrapod_prefix}/auth/saml/acs"
 
     try:
         identity = await connector.handle_callback(

--- a/services/terrapod/api/routers/gpg_keys.py
+++ b/services/terrapod/api/routers/gpg_keys.py
@@ -5,8 +5,8 @@ public keys from the provider download response, not from a separate
 admin endpoint. They're Terrapod-native management surface and live at
 `/api/terrapod/v1/gpg-keys`.
 
-The historical TFE path was `/api/registry/private/v2/gpg-keys`. That
-form is dual-mounted as a deprecated alias until v0.24.0 (see #278).
+The historical TFE-shaped path was `/api/registry/private/v2/gpg-keys`;
+it was removed in v0.24.0 (see #278) and is no longer routable.
 
 Endpoints (canonical):
     POST   /api/terrapod/v1/gpg-keys              — create

--- a/services/terrapod/api/routers/oauth.py
+++ b/services/terrapod/api/routers/oauth.py
@@ -29,8 +29,8 @@ from terrapod.redis.client import get_redis_client
 
 router = APIRouter(tags=["oauth"])
 
-# Terrapod-only CLI login completion check. Dual-mounted under
-# /api/terrapod/v1 (canonical) and /api/v2 (deprecated, removed in
+# Terrapod-only CLI login completion check. Terrapod-native: mounted
+# only under /api/terrapod/v1 (the /api/v2 alias was removed in
 # v0.24.0 — see #278).
 extensions_router = APIRouter(tags=["oauth-extensions"])
 logger = get_logger(__name__)

--- a/services/terrapod/api/routers/users.py
+++ b/services/terrapod/api/routers/users.py
@@ -256,19 +256,3 @@ async def delete_user(
     await db.delete(target)
     await db.commit()
     logger.info("Deleted user", target_email=email, by=user.email)
-
-
-# ── Legacy alias router (v0.22 → v0.24 deprecation window) ─────────────
-# Mounted only at /api/v2 by app.py with deprecated=True and
-# include_in_schema=False. Preserves the *exact* path shapes that
-# existed in v0.22 — list/create at /organizations/default/users,
-# by-email at /users/{email} — for clients still using those paths.
-# Removed in v0.24.0 (#278).
-legacy_router = APIRouter(tags=["users-legacy"])
-legacy_router.add_api_route(
-    "/organizations/default/users", create_user, methods=["POST"], status_code=201
-)
-legacy_router.add_api_route("/organizations/default/users", list_users, methods=["GET"])
-legacy_router.add_api_route("/users/{email}", show_user, methods=["GET"])
-legacy_router.add_api_route("/users/{email}", update_user, methods=["PATCH"])
-legacy_router.add_api_route("/users/{email}", delete_user, methods=["DELETE"], status_code=204)

--- a/services/terrapod/api/routers/vcs_connections.py
+++ b/services/terrapod/api/routers/vcs_connections.py
@@ -212,21 +212,3 @@ async def delete_connection(
     await db.delete(conn)
     await db.commit()
     logger.info("VCS connection deleted", connection_id=str(conn.id))
-
-
-# ── Legacy alias router (v0.22 → v0.24 deprecation window) ─────────────
-# Mounted only at /api/v2 by app.py with deprecated=True and
-# include_in_schema=False. Preserves pre-v0.23 path shapes:
-# list/create were at /organizations/default/vcs-connections,
-# by-id at /vcs-connections/{id}. Removed in v0.24.0 (#278).
-legacy_router = APIRouter(tags=["vcs-connections-legacy"])
-legacy_router.add_api_route(
-    "/organizations/default/vcs-connections", list_connections, methods=["GET"]
-)
-legacy_router.add_api_route(
-    "/organizations/default/vcs-connections", create_connection, methods=["POST"], status_code=201
-)
-legacy_router.add_api_route("/vcs-connections/{connection_id}", show_connection, methods=["GET"])
-legacy_router.add_api_route(
-    "/vcs-connections/{connection_id}", delete_connection, methods=["DELETE"], status_code=204
-)

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -741,7 +741,13 @@ class Settings(BaseSettings):
     )
 
     # API
+    # `api_prefix` is the TFE V2 CLI-contract surface (terraform / tofu /
+    # tfci / go-tfe). `terrapod_prefix` is the Terrapod-native surface
+    # (auth, admin, registry mgmt, etc.). The OAuth/SAML callback lives
+    # on the Terrapod-native surface — see auth.py — so its URL is built
+    # from `terrapod_prefix`, not `api_prefix`.
     api_prefix: str = Field(default="/api/v2")
+    terrapod_prefix: str = Field(default="/api/terrapod/v1")
 
     @classmethod
     def settings_customise_sources(

--- a/services/terrapod/services/audit_service.py
+++ b/services/terrapod/services/audit_service.py
@@ -47,8 +47,9 @@ def parse_resource(path: str) -> tuple[str, str]:
         /api/terrapod/v1/users/admin@example.com → ("users", "admin@example.com")
         /oauth/authorize → ("oauth", "")
 
-    Both /api/v2 (CLI surface + deprecated aliases during the v0.23.x
-    window) and /api/terrapod/v1 (canonical) prefixes are recognised.
+    Both /api/v2 (the permanent TFE V2 CLI surface) and
+    /api/terrapod/v1 (the Terrapod-native surface) prefixes are
+    recognised so mutations on either are attributed in the audit log.
     """
     m = _RESOURCE_PATTERN.match(path)
     if m:

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -180,7 +180,7 @@ class TestListenerHeartbeat:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
             res = await client.post(
-                f"/api/v2/listeners/{uuid.uuid4()}/heartbeat",
+                f"/api/terrapod/v1/listeners/{uuid.uuid4()}/heartbeat",
                 json={"capacity": 1},
             )
 
@@ -1176,7 +1176,7 @@ class TestRenewListenerCert:
         app.dependency_overrides[get_db] = lambda: AsyncMock()
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
-            res = await client.post(f"/api/v2/listeners/{uuid.uuid4()}/renew")
+            res = await client.post(f"/api/terrapod/v1/listeners/{uuid.uuid4()}/renew")
 
         assert res.status_code == 401
         assert "X-Terrapod-Client-Cert" in res.json()["detail"]

--- a/services/tests/api/test_api_namespace.py
+++ b/services/tests/api/test_api_namespace.py
@@ -1,35 +1,23 @@
-"""Tests for the /api/v2 → /api/terrapod/v1 dual-mount and deprecation contract.
+"""Tests for the Terrapod-native vs TFE-CLI API namespace split.
 
-These tests assert the runtime behaviour of `include_moved` (in app.py):
-canonical and legacy paths both serve traffic; only the legacy path
-emits the deprecation headers; only the canonical path appears in
-OpenAPI; the CLI surface stays put on /api/v2.
+Post-#278 there is no dual-mount: Terrapod-native routes live *only*
+at /api/terrapod/v1/. /api/v2/ is the permanent TFE V2 CLI-contract
+surface (terraform / tofu / tfci / go-tfe) and is unaffected.
 
-When the legacy aliases are removed in v0.24.0 (#278) most of these
-will fail — the dual-serve assertions are exactly what a future
-maintainer should drop.
+These assert: canonical Terrapod paths are in the schema and routable;
+the CLI surface stays at /api/v2/; the Terrapod surface never carries
+an /organizations/default/ segment; and the old /api/v2/ aliases of
+moved routes are well and truly gone (the #278 regression guard).
 """
 
 from __future__ import annotations
 
-import httpx
-import pytest
-
 from terrapod.api.app import app
 
 
-@pytest.fixture
-def client() -> httpx.AsyncClient:
-    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
-
-
 class TestOpenAPIVisibility:
-    """Deprecated aliases must not pollute the OpenAPI schema."""
-
     def test_canonical_paths_in_schema(self) -> None:
         schema = app.openapi()
-        # Pick a few canonical Terrapod-native paths that should be in the
-        # schema (one per major moved router).
         for path in (
             "/api/terrapod/v1/labels",
             "/api/terrapod/v1/auth/providers",
@@ -38,18 +26,6 @@ class TestOpenAPIVisibility:
             "/api/terrapod/v1/admin/audit-log",
         ):
             assert path in schema["paths"], f"canonical path {path} missing from OpenAPI"
-
-    def test_deprecated_aliases_not_in_schema(self) -> None:
-        """The /api/v2 aliases of moved routes must NOT show in OpenAPI."""
-        schema = app.openapi()
-        for path in (
-            "/api/v2/labels",
-            "/api/v2/auth/providers",
-            "/api/v2/listeners/{listener_id}/heartbeat",
-        ):
-            assert path not in schema["paths"], (
-                f"deprecated alias {path} leaked into OpenAPI — include_in_schema=False missing?"
-            )
 
     def test_cli_surface_stays_at_v2_in_schema(self) -> None:
         """CLI/tfci-consumed paths are at /api/v2/ in the schema, not under /api/terrapod/v1/."""
@@ -63,7 +39,6 @@ class TestOpenAPIVisibility:
             "/api/v2/varsets/{varset_id}",
         ):
             assert path in schema["paths"], f"CLI surface path {path} missing from OpenAPI"
-        # And these CLI paths must not also show under the Terrapod prefix.
         for path in (
             "/api/terrapod/v1/runs",
             "/api/terrapod/v1/varsets/{varset_id}",
@@ -73,39 +48,9 @@ class TestOpenAPIVisibility:
 
 
 class TestRouteTopology:
-    """The actual app.routes table must include both canonical and legacy mounts.
-
-    OpenAPI schema visibility is decoupled (asserted above); these checks
-    are about whether requests can route at all.
-    """
-
-    def test_canonical_and_legacy_both_routable(self) -> None:
-        """Every dual-mounted path resolves on both prefixes."""
-        paths = {getattr(r, "path", "") for r in app.routes}
-        for canonical, legacy in (
-            ("/api/terrapod/v1/labels", "/api/v2/labels"),
-            ("/api/terrapod/v1/auth/providers", "/api/v2/auth/providers"),
-            (
-                "/api/terrapod/v1/listeners/{listener_id}/heartbeat",
-                "/api/v2/listeners/{listener_id}/heartbeat",
-            ),
-        ):
-            assert canonical in paths, f"canonical {canonical} not routable"
-            assert legacy in paths, f"legacy alias {legacy} not routable"
-
-    def test_gpg_keys_legacy_alias_uses_historical_prefix(self) -> None:
-        """gpg_keys lived at /api/registry/private/v2/, not /api/v2/."""
-        paths = {getattr(r, "path", "") for r in app.routes}
-        assert "/api/terrapod/v1/gpg-keys" in paths
-        assert "/api/registry/private/v2/gpg-keys" in paths
-        # NOT at /api/v2 — it never lived there.
-        assert "/api/v2/gpg-keys" not in paths
-
     def test_terrapod_native_paths_have_no_org_segment(self) -> None:
-        """Per CLAUDE.md rule #9, the canonical /api/terrapod/v1 surface
-        must never carry an `organizations/default/` segment — Terrapod
-        is single-org and the segment is dead weight outside the
-        TFE-compat layer.
+        """Per CLAUDE.md rule #9, the Terrapod-native surface must never
+        carry an `organizations/default/` segment.
         """
         paths = {getattr(r, "path", "") for r in app.routes}
         for path in (
@@ -120,95 +65,40 @@ class TestRouteTopology:
                 f"paths must use the short form (e.g. /api/terrapod/v1/users)"
             )
 
-    def test_legacy_aliases_preserve_pre_v0_23_shapes(self) -> None:
-        """For routers that pre-v0.23 lived under
-        /api/v2/organizations/default/{resource}, the legacy alias at
-        that exact path must keep working through v0.23.x for v0.22
-        clients. We do NOT introduce /api/v2/{resource} (without the
-        org segment) — that path never existed pre-v0.23 and has no
-        callers.
+    def test_legacy_v2_aliases_removed(self) -> None:
+        """#278 regression guard: the transitional /api/v2/ aliases of
+        Terrapod-native routes are gone. Only the CLI surface remains at
+        /api/v2/.
         """
         paths = {getattr(r, "path", "") for r in app.routes}
-        # Pre-v0.23 paths still routable.
         for path in (
+            # moved-router aliases
+            "/api/v2/labels",
+            "/api/v2/auth/providers",
+            "/api/v2/auth/callback",
+            "/api/v2/listeners/{listener_id}/heartbeat",
+            "/api/v2/admin/audit-log",
+            "/api/v2/gpg-keys",
+            # org-scoped pre-v0.23 shapes
             "/api/v2/organizations/default/users",
             "/api/v2/organizations/default/vcs-connections",
             "/api/v2/organizations/default/agent-pools",
             "/api/v2/organizations/default/registry-modules",
             "/api/v2/organizations/default/registry-providers",
-        ):
-            assert path in paths, f"legacy alias {path} missing — v0.22 callers will break"
-        # /api/v2/{resource} (without org) was never published — must not
-        # exist as a deprecated alias.
-        for path in (
-            "/api/v2/users",
-            "/api/v2/vcs-connections",
-            "/api/v2/registry-modules",
-            "/api/v2/registry-providers",
+            # gpg keys' historical non-/api/v2 prefix
+            "/api/registry/private/v2/gpg-keys",
         ):
             assert path not in paths, (
-                f"{path} should not exist — pre-v0.23 callers used the "
-                f"/organizations/default/ form, and {path} was never published"
+                f"legacy alias {path} is still routable — #278 removes all "
+                f"Terrapod-native /api/v2 aliases"
             )
 
-    def test_workspace_delete_only_at_canonical(self) -> None:
-        """Same path under both prefixes for different methods is fine —
-        but we assert specifically that the DELETE on /workspaces/{id}
-        isn't accidentally back on the TFE-spec router."""
-        # The route exists under both /api/v2 (deprecated alias) and
-        # /api/terrapod/v1 (canonical) for the DELETE method.
-        delete_routes = [
-            r
-            for r in app.routes
-            if getattr(r, "path", "")
-            in (
-                "/api/v2/workspaces/{workspace_id}",
-                "/api/terrapod/v1/workspaces/{workspace_id}",
-            )
-            and "DELETE" in getattr(r, "methods", set())
-        ]
-        # Two routes total: canonical + deprecated alias.
-        assert len(delete_routes) == 2, (
-            f"expected DELETE on both prefixes, got {len(delete_routes)}: {delete_routes}"
-        )
-
-
-class TestDeprecationHeaders:
-    """The middleware must emit Deprecation/Link/X-Removed-In on legacy
-    paths only — not on canonical paths or on CLI-surface /api/v2 routes.
-    """
-
-    @pytest.mark.asyncio
-    async def test_legacy_alias_emits_deprecation_headers(self, client: httpx.AsyncClient) -> None:
-        async with client:
-            # /auth/providers doesn't require DB or Redis — pure connector
-            # registry lookup — so it works in unit-test context. We're
-            # only asserting on response headers, not body.
-            resp = await client.get("/api/v2/auth/providers")
-        assert resp.headers.get("Deprecation") == "true", (
-            f"missing Deprecation header on legacy alias; headers: {dict(resp.headers)}"
-        )
-        assert 'rel="deprecation"' in resp.headers.get("Link", "")
-        assert resp.headers.get("X-Removed-In") == "v0.24.0"
-
-    @pytest.mark.asyncio
-    async def test_canonical_path_does_not_emit_deprecation_headers(
-        self, client: httpx.AsyncClient
-    ) -> None:
-        async with client:
-            resp = await client.get("/api/terrapod/v1/auth/providers")
-        assert "Deprecation" not in resp.headers, (
-            f"canonical path leaking deprecation header: {dict(resp.headers)}"
-        )
-        assert "X-Removed-In" not in resp.headers
-
-    @pytest.mark.asyncio
-    async def test_cli_surface_v2_path_does_not_emit_deprecation_headers(
-        self, client: httpx.AsyncClient
-    ) -> None:
-        """/api/v2/ping is permanent CLI surface — not deprecated even
-        though it's under /api/v2."""
-        async with client:
-            resp = await client.get("/api/v2/ping")
-        assert "Deprecation" not in resp.headers
-        assert "X-Removed-In" not in resp.headers
+    def test_auth_callback_only_on_terrapod_prefix(self) -> None:
+        """The OAuth/SAML callback is Terrapod-native; it must resolve at
+        /api/terrapod/v1/auth/* and nowhere under /api/v2/.
+        """
+        paths = {getattr(r, "path", "") for r in app.routes}
+        assert "/api/terrapod/v1/auth/callback" in paths
+        assert "/api/terrapod/v1/auth/saml/acs" in paths
+        assert "/api/v2/auth/callback" not in paths
+        assert "/api/v2/auth/saml/acs" not in paths

--- a/services/tests/api/test_notification_configurations.py
+++ b/services/tests/api/test_notification_configurations.py
@@ -337,7 +337,7 @@ class TestShowNotificationConfiguration:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/notification-configurations/nc-{uuid.uuid4()}",
+                f"/api/terrapod/v1/notification-configurations/nc-{uuid.uuid4()}",
                 headers=_AUTH,
             )
         assert resp.status_code == 404

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -565,7 +565,7 @@ class TestRoleAssignments:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(
-                "/api/v2/role-assignments/local/user@test.com/admin",
+                "/api/terrapod/v1/role-assignments/local/user@test.com/admin",
                 headers=_AUTH,
             )
         assert resp.status_code == 204
@@ -581,7 +581,7 @@ class TestRoleAssignments:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(
-                "/api/v2/role-assignments/local/nobody@test.com/admin",
+                "/api/terrapod/v1/role-assignments/local/nobody@test.com/admin",
                 headers=_AUTH,
             )
         assert resp.status_code == 404

--- a/services/tests/api/test_run_tasks.py
+++ b/services/tests/api/test_run_tasks.py
@@ -297,7 +297,7 @@ class TestShowRunTask:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(
-                f"/api/v2/run-tasks/task-{uuid.uuid4()}",
+                f"/api/terrapod/v1/run-tasks/task-{uuid.uuid4()}",
                 headers=_AUTH,
             )
         assert resp.status_code == 404
@@ -432,7 +432,7 @@ class TestCallback:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                f"/api/v2/task-stage-results/tsr-{uuid.uuid4()}/callback",
+                f"/api/terrapod/v1/task-stage-results/tsr-{uuid.uuid4()}/callback",
                 json={
                     "access_token": "bad-token",
                     "status": "passed",
@@ -474,7 +474,7 @@ class TestCallback:
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
-                f"/api/v2/task-stage-results/tsr-{uuid.uuid4()}/callback",
+                f"/api/terrapod/v1/task-stage-results/tsr-{uuid.uuid4()}/callback",
                 json={"status": "passed"},
             )
         assert resp.status_code == 401

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -367,7 +367,7 @@ class TestShowRunTrigger:
         mock_db.execute.return_value = mock_result
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get(f"/api/v2/run-triggers/rt-{uuid.uuid4()}", headers=_AUTH)
+            resp = await c.get(f"/api/terrapod/v1/run-triggers/rt-{uuid.uuid4()}", headers=_AUTH)
         assert resp.status_code == 404
 
 

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -7,12 +7,10 @@ const nextConfig = {
   // streaming. Setting Content-Encoding: none tells the compression
   // middleware to pass these responses through unmodified.
   //
-  // SSE endpoints all moved from /api/v2 to /api/terrapod/v1 in #269. The
-  // /api/v2 entries are kept until the deprecated alias is dropped in
-  // v0.24.0 (#278).
+  // SSE endpoints are all Terrapod-native at /api/terrapod/v1. The
+  // transitional /api/v2 aliases (#269) were removed in v0.24.0 (#278).
   async headers() {
     return [
-      // Canonical /api/terrapod/v1 SSE paths
       {
         source: '/api/terrapod/v1/listeners/:path*',
         headers: [{ key: 'Content-Encoding', value: 'none' }],
@@ -27,23 +25,6 @@ const nextConfig = {
       },
       {
         source: '/api/terrapod/v1/agent-pools/:path*/events',
-        headers: [{ key: 'Content-Encoding', value: 'none' }],
-      },
-      // Deprecated /api/v2 aliases — kept until v0.24.0 (#278)
-      {
-        source: '/api/v2/listeners/:path*',
-        headers: [{ key: 'Content-Encoding', value: 'none' }],
-      },
-      {
-        source: '/api/v2/workspaces/:path*/runs/events',
-        headers: [{ key: 'Content-Encoding', value: 'none' }],
-      },
-      {
-        source: '/api/v2/workspace-events',
-        headers: [{ key: 'Content-Encoding', value: 'none' }],
-      },
-      {
-        source: '/api/v2/agent-pools/:path*/events',
         headers: [{ key: 'Content-Encoding', value: 'none' }],
       },
     ]


### PR DESCRIPTION
Closes #278. Ships in **v0.24.0** alongside #312 (autodiscovery dry-run preview).

## Summary

#269 moved the Terrapod-native management surface to `/api/terrapod/v1` while keeping the transitional `/api/v2` aliases (both the org-scoped `…/organizations/default/…` shapes and the short forms) routable through the v0.23.x window. This removes those aliases. Terrapod-native endpoints are now served **only** at `/api/terrapod/v1`. `/api/v2` is left untouched as the **permanent TFE V2 CLI-contract surface** that `terraform` / `tofu` / `tfci` / `go-tfe` consume (see `docs/tfe-cli-surface.md`).

- **app.py** — deletes the RFC 8594 deprecation-header middleware and every legacy dual-mount block; a single `include_terrapod()` helper mounts the native surface at `/api/terrapod/v1` only.
- **auth** — the OIDC/SAML IDP callback URL is now built from a new `terrapod_prefix` setting → `/api/terrapod/v1/auth/callback`. The `terraform login` flow (`/.well-known/terraform.json` + `/oauth/*`) is root-mounted and **unaffected**.
- **gpg-keys** — the historical `/api/registry/private/v2/gpg-keys` form is removed; canonical `/api/terrapod/v1/gpg-keys` only.
- **rate limiter** — auth tier now keyed on `/api/terrapod/v1/auth/` + `/oauth/`.
- **Terraform provider** — agent-pool, notification-configuration, run-task, run-trigger, and registry module/provider resource clients repointed to `/api/terrapod/v1`. Workspace / varset / variable clients stay on the unchanged `/api/v2` CLI surface.
- **docs + `next.config.js`** SSE headers updated to canonical paths; `test_api_namespace` rewritten as a #278 regression guard.

## Breaking Changes

- The `/api/v2` aliases for Terrapod-native routes (vcs-connections, users, agent-pools, roles, role-assignments, registry module/provider management, notification-configurations, run-tasks, run-triggers, labels, audit-log, gpg-keys, auth) **no longer resolve**.
- **IDP redirect URI moves** to `https://<host>/api/terrapod/v1/auth/callback` and must be registered as an Allowed Callback URL with the identity provider. Operators upgrading from v0.23.x must update their IDP application before the upgrade. Release notes must call this out.

## Test plan

- [x] `make lint` — ruff (Python) + `tsc` (frontend) clean
- [x] `make test` — 1344 passed
- [x] `go build ./...` + `go vet ./...` (Terraform provider) clean
- [x] `npm run build` (web) — production build succeeds
- [x] Regression guard: `test_api_namespace::test_legacy_v2_aliases_removed` + `test_auth_callback_only_on_terrapod_prefix`
- [ ] Post-merge: cut v0.24.0 (with #312), update wrapper chart, flag breaking auth-callback path in release notes