### PR TITLE
fix(autodiscovery): guard every label-write path against reserved keys

### DIFF
--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -32,6 +32,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, require_admin
+from terrapod.api.labels import validate_labels
 from terrapod.db.models import AgentPool, AutodiscoveryRule, VCSConnection
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -208,10 +209,12 @@ def _coerce_attrs(attrs: dict, *, on_create: bool) -> dict[str, Any]:
     if "auto-apply" in attrs:
         out["auto_apply"] = bool(attrs["auto-apply"])
     if "labels" in attrs:
-        labels = attrs["labels"]
-        if not isinstance(labels, dict):
-            raise HTTPException(status_code=422, detail="labels must be an object")
-        out["labels"] = labels
+        # Reserved-key guard at the source: a rule's labels are copied
+        # verbatim onto every workspace it materialises, and workspace
+        # PATCH re-validates labels — so a reserved key here (e.g.
+        # "owner") would create workspaces that are uneditable in the UI
+        # (#316). Reject it when the rule is defined instead.
+        out["labels"] = validate_labels(attrs["labels"])
     if "owner-email" in attrs:
         out["owner_email"] = (str(attrs["owner-email"]) or "").strip() or None
 

--- a/services/terrapod/services/label_validation.py
+++ b/services/terrapod/services/label_validation.py
@@ -88,3 +88,32 @@ def validate_labels(labels: dict | None) -> dict:
             )
         clean[k] = v
     return clean
+
+
+def sanitize_labels(labels: dict | None) -> tuple[dict[str, str], list[str]]:
+    """Best-effort variant of `validate_labels` for non-interactive
+    label-write paths that must not abort on bad input.
+
+    Returns `(clean_labels, dropped_keys)` — entries that fail the
+    shape/size/reserved checks are dropped rather than raising. Use this
+    only where rejecting would break an automated flow (e.g. autodiscovery
+    materialising a workspace from a rule that predates the create-time
+    reserved-key guard, #316). Interactive create/update paths must keep
+    using `validate_labels` so the operator is told to fix the input.
+    """
+    if not labels or not isinstance(labels, dict):
+        return {}, []
+    clean: dict[str, str] = {}
+    dropped: list[str] = []
+    for k, v in list(labels.items())[:MAX_LABELS]:
+        if (
+            not isinstance(k, str)
+            or not isinstance(v, str)
+            or len(k) > MAX_LABEL_KEY_LEN
+            or len(v) > MAX_LABEL_VALUE_LEN
+            or k in RESERVED_LABEL_KEYS
+        ):
+            dropped.append(str(k))
+            continue
+        clean[k] = v
+    return clean, dropped

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -38,6 +38,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.db.models import AutodiscoveryRule, Workspace
 from terrapod.logging_config import get_logger
+from terrapod.services.label_validation import sanitize_labels
 
 logger = get_logger(__name__)
 
@@ -229,6 +230,21 @@ async def find_or_autocreate_workspace(
         )
         raise AutodiscoveryNameCollision(name)
 
+    # Defensive reserved-key guard (#316). Rule create/update rejects
+    # reserved label keys at the source, but a rule that predates that
+    # guard may still carry one — copying it verbatim would create a
+    # workspace that's uneditable via PATCH. Strip-and-log rather than
+    # raise, so a legacy rule doesn't break the autodiscovery poll cycle.
+    safe_labels, dropped = sanitize_labels(rule.labels)
+    if dropped:
+        logger.warning(
+            "Autodiscovery dropped reserved/invalid label keys from rule",
+            rule_id=str(rule.id),
+            rule_name=rule.name,
+            dropped_keys=dropped,
+            working_directory=root_directory,
+        )
+
     ws = Workspace(
         id=uuid.uuid4(),  # generate_uuid7 default also fine; explicit for log clarity
         name=name,
@@ -240,7 +256,7 @@ async def find_or_autocreate_workspace(
         auto_apply=rule.auto_apply,
         working_directory=root_directory,
         agent_pool_id=rule.agent_pool_id,
-        labels=dict(rule.labels or {}),
+        labels=safe_labels,
         owner_email=rule.owner_email or "",
         vcs_connection_id=rule.vcs_connection_id,
         vcs_repo_url=rule.repo_url,

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -152,6 +152,32 @@ class TestCreateRule:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
+    async def test_422_reserved_label_key(self, *_mocks):
+        """#316: a reserved label key on the rule is rejected at the
+        source — otherwise every workspace it materialises carries the
+        key and becomes uneditable via PATCH.
+        """
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "labels": {"owner": "foundations", "team": "x"},
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "owner" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
     async def test_422_when_connection_does_not_exist(self, *_mocks):
         app, db = _make_app(_admin())
         db.get = AsyncMock(return_value=None)  # connection missing

--- a/services/tests/services/test_label_validation.py
+++ b/services/tests/services/test_label_validation.py
@@ -8,6 +8,7 @@ from terrapod.services.label_validation import (
     MAX_LABELS,
     RESERVED_LABEL_KEYS,
     LabelValidationError,
+    sanitize_labels,
     validate_labels,
 )
 
@@ -116,3 +117,36 @@ class TestReservedKeys:
             "managed-by": "terrapod-provider",
         }
         assert validate_labels(labels) == labels
+
+
+class TestSanitizeLabels:
+    """Best-effort variant for non-interactive paths (#316): drops bad
+    keys instead of raising, and reports what was dropped.
+    """
+
+    def test_none_and_non_dict_return_empty(self):
+        assert sanitize_labels(None) == ({}, [])
+        assert sanitize_labels("nope") == ({}, [])
+
+    def test_clean_labels_pass_through_nothing_dropped(self):
+        labels = {"team": "platform", "env": "prod"}
+        assert sanitize_labels(labels) == (labels, [])
+
+    def test_reserved_key_dropped_not_raised(self):
+        clean, dropped = sanitize_labels({"owner": "foundations", "team": "x"})
+        assert clean == {"team": "x"}
+        assert dropped == ["owner"]
+
+    def test_every_reserved_key_dropped(self):
+        bad = dict.fromkeys(RESERVED_LABEL_KEYS, "v")
+        bad["keepme"] = "yes"
+        clean, dropped = sanitize_labels(bad)
+        assert clean == {"keepme": "yes"}
+        assert sorted(dropped) == sorted(RESERVED_LABEL_KEYS)
+
+    def test_oversize_and_non_string_dropped(self):
+        clean, dropped = sanitize_labels(
+            {"k" * (MAX_LABEL_KEY_LEN + 1): "v", "ok": "v", "bad": 123}
+        )
+        assert clean == {"ok": "v"}
+        assert set(dropped) == {"k" * (MAX_LABEL_KEY_LEN + 1), "bad"}


### PR DESCRIPTION
Closes #316. Ships in **v0.24.0**.

## Problem

Workspace create/update, registry, and agent-pool label writes all run labels through `validate_labels` (reserved-key guard → 422). **Autodiscovery did not.** The rule create/update path only did an `isinstance` check, so a rule could be created with a reserved label key (e.g. `owner`), and `find_or_autocreate_workspace` copied `rule.labels` onto the workspace verbatim. Because the workspace **PATCH** path *does* re-validate labels, any later edit (even an unrelated field like terraform version) returned 422 — the autodiscovered workspace became permanently uneditable in the UI.

## Fix

`owner` stays reserved (it maps to `owner_email`, a real concept). The reserved-key guard is now a chokepoint on **every** label-write path:

- **Autodiscovery rule create/update** runs labels through `validate_labels` — reserved key rejected with HTTP 422 at the source, consistent with every other writer.
- **Workspace materialisation** runs `rule.labels` through a new `sanitize_labels()` — strip-and-log rather than raise, so a rule that predates this guard doesn't break the autodiscovery poll cycle and the workspace it creates is editable.

Documented as a CLAUDE.md invariant so future label-write paths don't reintroduce the gap.

## Test plan

- [x] `make lint` (ruff + tsc) clean
- [x] `make test` — 1359 passed (+6: `sanitize_labels` cases, rule-create reserved-key 422)
- [x] Live Tilt: rule create with `labels.owner` → 422; clean labels → 201
- [ ] CI green