### PR TITLE
fix(autodiscovery): baseline new workspaces to tracked-branch HEAD

### DIFF
--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -451,7 +451,7 @@ async def preview_unsaved_rule(
     await _validate_pool(db, fields.get("agent_pool_id"))
 
     rule = _build_transient_rule(fields, conn)
-    file_paths, target_branch = await _walk_repo_for_rule(rule)
+    file_paths, target_branch, _head_sha = await _walk_repo_for_rule(rule)
     preview = await workspace_autodiscovery_service.preview_for_paths(db, rule, file_paths)
     return JSONResponse(
         content={
@@ -548,7 +548,18 @@ async def _walk_repo_for_rule(rule: AutodiscoveryRule) -> tuple[list[str], str]:
             ),
         )
 
-    return file_paths, target_branch
+    # Resolve the tracked-branch HEAD so /scan can baseline new
+    # workspaces (#313) — same rationale as the poller. None on
+    # failure: callers fall back to the prior NULL-seed behaviour.
+    try:
+        if conn.provider == "gitlab":
+            head_sha = await gitlab_service.get_branch_sha(conn, owner, repo, target_branch)
+        else:
+            head_sha = await github_service.get_repo_branch_sha(conn, owner, repo, target_branch)
+    except Exception:
+        head_sha = None
+
+    return file_paths, target_branch, head_sha
 
 
 @router.get("/autodiscovery-rules/{rule_id}/preview")
@@ -573,7 +584,7 @@ async def preview_rule(
     if rule is None:
         raise HTTPException(status_code=404, detail="autodiscovery rule not found")
 
-    file_paths, target_branch = await _walk_repo_for_rule(rule)
+    file_paths, target_branch, _head_sha = await _walk_repo_for_rule(rule)
     preview = await workspace_autodiscovery_service.preview_for_paths(db, rule, file_paths)
     return JSONResponse(
         content={
@@ -614,7 +625,7 @@ async def scan_rule(
     if rule is None:
         raise HTTPException(status_code=404, detail="autodiscovery rule not found")
 
-    file_paths, target_branch = await _walk_repo_for_rule(rule)
+    file_paths, target_branch, head_sha = await _walk_repo_for_rule(rule)
     # autodiscover_for_paths skips rules with enabled=False; force-enable
     # locally for the duration of this call so the explicit /scan action
     # doesn't silently no-op on a disabled rule. The returned list is
@@ -624,7 +635,7 @@ async def scan_rule(
     rule.enabled = True
     try:
         created = await workspace_autodiscovery_service.autodiscover_for_paths(
-            db, [rule], file_paths
+            db, [rule], file_paths, baseline_sha=head_sha
         )
     finally:
         rule.enabled = original_enabled

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -1103,6 +1103,13 @@ async def _poll_autodiscovery_for_connection(
                 )
                 continue
 
+        # Resolve the tracked-branch HEAD once. New workspaces are
+        # seeded with this so their first branch poll baselines instead
+        # of firing a premature plan+apply for a directory that only
+        # exists on the (still-open) PR branch (#313). None on failure —
+        # falls back to the prior NULL-seed behaviour.
+        baseline_sha = await _get_branch_sha(conn, owner, repo, target_branch)
+
         # Pull open PRs and the default-branch tip — both are sources of
         # discoverable changed files.
         try:
@@ -1129,7 +1136,9 @@ async def _poll_autodiscovery_for_connection(
                     exc_info=True,
                 )
                 continue
-            new_workspaces = await autodiscover_for_paths(db, group, changed)
+            new_workspaces = await autodiscover_for_paths(
+                db, group, changed, baseline_sha=baseline_sha
+            )
             created_count += len(new_workspaces)
 
         # Initial-scan path (#309): rules with `first_scan_at IS NULL`
@@ -1156,7 +1165,9 @@ async def _poll_autodiscovery_for_connection(
                 )
                 all_files = None
             if all_files is not None:
-                new_workspaces = await autodiscover_for_paths(db, unscanned, all_files)
+                new_workspaces = await autodiscover_for_paths(
+                    db, unscanned, all_files, baseline_sha=baseline_sha
+                )
                 created_count += len(new_workspaces)
                 scanned_at = now_utc()
                 for rule in unscanned:

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -187,11 +187,24 @@ async def find_or_autocreate_workspace(
     db: AsyncSession,
     rule: AutodiscoveryRule,
     root_directory: str,
+    baseline_sha: str | None = None,
 ) -> tuple[Workspace, bool]:
     """Look up the workspace this rule + directory should map to, or
     create it if it doesn't exist.
 
     Returns `(workspace, created)`.
+
+    `baseline_sha` seeds the new workspace's `vcs_last_commit_sha`
+    (#313). Autodiscovery is driven by *open PRs* — the directory
+    exists on the PR branch but not yet on the tracked branch. Without
+    a baseline, the next branch poll sees `vcs_last_commit_sha = NULL`,
+    treats the tracked-branch HEAD as "new", and fires a full
+    plan+apply for a directory that doesn't exist there yet — which
+    errors, racing the legitimate plan-only PR run. Seeding the current
+    tracked-branch HEAD baselines the branch path so the first real run
+    fires when the branch actually advances (the PR merge), and also
+    arms the subdirectory-change filter (skipped while `old_sha` is
+    None).
 
     Idempotent — concurrent autodiscovery on the same rule + path
     will not create duplicates. We commit the new workspace
@@ -261,6 +274,9 @@ async def find_or_autocreate_workspace(
         vcs_connection_id=rule.vcs_connection_id,
         vcs_repo_url=rule.repo_url,
         vcs_branch=rule.branch,
+        # Baseline against the tracked-branch HEAD so the branch poll
+        # doesn't fire a premature plan+apply before the PR merges (#313).
+        vcs_last_commit_sha=baseline_sha or None,
         autodiscovery_rule_id=rule.id,
         # trigger_prefixes scoped tightly to the discovered directory so
         # the regular VCS poller treats this workspace as a normal
@@ -418,12 +434,17 @@ async def autodiscover_for_paths(
     db: AsyncSession,
     rules: list[AutodiscoveryRule],
     changed_files: list[str],
+    baseline_sha: str | None = None,
 ) -> list[Workspace]:
     """For a set of changed files, return the list of workspaces that
     were *newly created* this call. Existing workspaces that the rule
     would map to are looked up (so subsequent VCS polls bind their runs
     to the right workspace) but excluded from the return — callers
     use the return length as a "created this cycle" count.
+
+    `baseline_sha` is the current tracked-branch HEAD; it seeds new
+    workspaces' `vcs_last_commit_sha` so the branch poll doesn't fire a
+    premature plan+apply before the PR merges (#313).
 
     Idempotent across repeated calls with the same inputs.
     """
@@ -445,7 +466,9 @@ async def autodiscover_for_paths(
     created: list[Workspace] = []
     for (_rule_id, root), rule in matches.items():
         try:
-            ws, was_created = await find_or_autocreate_workspace(db, rule, root)
+            ws, was_created = await find_or_autocreate_workspace(
+                db, rule, root, baseline_sha=baseline_sha
+            )
             if was_created:
                 created.append(ws)
         except AutodiscoveryNameCollision:

--- a/services/tests/services/test_workspace_autodiscovery_service.py
+++ b/services/tests/services/test_workspace_autodiscovery_service.py
@@ -9,13 +9,14 @@ integration tests that run against a real session.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from terrapod.services.workspace_autodiscovery_service import (
     _is_terraform_file,
     _match_glob,
+    autodiscover_for_paths,
     derive_root_directory,
     derive_workspace_name,
     preview_for_paths,
@@ -331,3 +332,40 @@ class TestPreviewForPaths:
         preview = await preview_for_paths(db, rule, files)
         assert len(preview) == 1
         assert preview[0]["working_directory"] == "accounts/alpha/network"
+
+
+class TestAutodiscoverBaselineSha:
+    """#313: the tracked-branch HEAD must be forwarded to
+    find_or_autocreate_workspace so new workspaces are baselined and
+    the branch poll doesn't fire a premature plan+apply.
+    """
+
+    @pytest.mark.asyncio
+    async def test_baseline_sha_forwarded_to_find_or_autocreate(self):
+        rule = _rule(pattern="accounts/*/**/*.tf")
+        db = AsyncMock()
+        with patch(
+            "terrapod.services.workspace_autodiscovery_service.find_or_autocreate_workspace",
+            new_callable=AsyncMock,
+        ) as foc:
+            foc.return_value = (MagicMock(), True)
+            await autodiscover_for_paths(
+                db,
+                [rule],
+                ["accounts/alpha/network/main.tf"],
+                baseline_sha="deadbeefcafe",
+            )
+        assert foc.await_count == 1
+        assert foc.await_args.kwargs["baseline_sha"] == "deadbeefcafe"
+
+    @pytest.mark.asyncio
+    async def test_baseline_sha_defaults_none(self):
+        rule = _rule(pattern="accounts/*/**/*.tf")
+        db = AsyncMock()
+        with patch(
+            "terrapod.services.workspace_autodiscovery_service.find_or_autocreate_workspace",
+            new_callable=AsyncMock,
+        ) as foc:
+            foc.return_value = (MagicMock(), True)
+            await autodiscover_for_paths(db, [rule], ["accounts/a/network/main.tf"])
+        assert foc.await_args.kwargs["baseline_sha"] is None


### PR DESCRIPTION
Closes #313. Ships in **v0.24.0**.

## Problem

Autodiscovery is driven by **open PRs** — the matched directory exists on the PR branch but not yet on the tracked branch. A newly created workspace had `vcs_last_commit_sha = NULL`, so the very next branch poll saw `HEAD != NULL`, treated the tracked-branch HEAD as a new commit, and fired a full **plan+apply** for a directory that doesn't exist on the tracked branch yet — which **errors**. That ran ~1s alongside the legitimate plan-only speculative run for the PR head, producing the "two runs, the plan+apply one errored, the plan-only one planned" pattern visible on every freshly discovered workspace in the report.

## Fix

Seed `vcs_last_commit_sha` with the tracked-branch HEAD at creation:

- `find_or_autocreate_workspace` / `autodiscover_for_paths` take a `baseline_sha`. The poller resolves it once per `(repo, branch)`; the `/scan` endpoint resolves it via `_walk_repo_for_rule` (now also returns the head sha).
- The branch poll then **baselines** instead of firing — the first real plan+apply happens when the branch actually advances (the PR merge), which is the intended lifecycle.
- Bonus: arms the subdirectory-change filter (previously skipped while `old_sha` was None), so unrelated commits no longer trigger the workspace.

Speculative PR run path is unaffected, so the reviewer's dry-run preview still happens.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1361 passed (+2: baseline forwarding / default-None)
- [x] Live Tilt + Postgres: scan-materialised workspace now carries the tracked-branch HEAD instead of NULL
- [ ] CI green