### PR TITLE
feat(vcs): edit VCS connections in the GUI

### DIFF
--- a/services/terrapod/api/routers/vcs_connections.py
+++ b/services/terrapod/api/routers/vcs_connections.py
@@ -198,6 +198,93 @@ async def show_connection(
     return JSONResponse(content={"data": _connection_json(conn)})
 
 
+@router.patch("/vcs-connections/{connection_id}")
+async def update_connection(
+    connection_id: str = Path(...),
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Update a VCS connection (admin only).
+
+    Partial update — only attributes present in the request are
+    changed. `provider` is immutable (a different provider is a
+    different connection; delete + recreate instead). Credentials are
+    write-only: pass `private-key` (GitHub) or `token` (GitLab) to
+    rotate; omit them to leave the stored credential untouched. Editable
+    fields: name, server-url, status, and the GitHub App identifiers.
+    """
+    conn_uuid = uuid.UUID(connection_id.removeprefix("vcs-"))
+    conn = await _get_connection(db, conn_uuid)
+    if conn is None:
+        raise HTTPException(status_code=404, detail="VCS connection not found")
+
+    attrs = body.get("data", {}).get("attributes", {})
+
+    if "provider" in attrs and attrs["provider"] != conn.provider:
+        raise HTTPException(
+            status_code=422,
+            detail="provider is immutable — delete and recreate to change it",
+        )
+
+    if "name" in attrs:
+        new_name = (attrs.get("name") or "").strip()
+        if not new_name:
+            raise HTTPException(status_code=422, detail="Connection name cannot be empty")
+        conn.name = new_name
+    if "server-url" in attrs:
+        conn.server_url = attrs.get("server-url") or ""
+    if "status" in attrs:
+        status = attrs.get("status") or ""
+        if status not in ("active", "disabled"):
+            raise HTTPException(status_code=422, detail="status must be 'active' or 'disabled'")
+        conn.status = status
+
+    if conn.provider == "github":
+        if "github-app-id" in attrs:
+            conn.github_app_id = int(attrs.get("github-app-id") or 0)
+        if "github-account-login" in attrs:
+            conn.github_account_login = attrs.get("github-account-login") or ""
+        if "github-account-type" in attrs:
+            conn.github_account_type = attrs.get("github-account-type") or ""
+        if "github-installation-id" in attrs:
+            new_install = int(attrs.get("github-installation-id") or 0)
+            if new_install != conn.github_installation_id:
+                dup = await db.execute(
+                    select(VCSConnection).where(
+                        VCSConnection.provider == "github",
+                        VCSConnection.github_installation_id == new_install,
+                        VCSConnection.id != conn.id,
+                    )
+                )
+                if dup.scalar_one_or_none():
+                    raise HTTPException(
+                        status_code=422,
+                        detail=f"GitHub installation {new_install} is already connected",
+                    )
+                conn.github_installation_id = new_install
+        # Credential rotation: only when a non-empty key is supplied.
+        new_key = attrs.get("private-key") or ""
+        if new_key:
+            conn.token = new_key
+    elif conn.provider == "gitlab":
+        new_token = attrs.get("token") or ""
+        if new_token:
+            conn.token = new_token
+
+    await db.commit()
+    await db.refresh(conn)
+
+    logger.info(
+        "VCS connection updated",
+        connection_id=str(conn.id),
+        name=conn.name,
+        provider=conn.provider,
+    )
+
+    return JSONResponse(content={"data": _connection_json(conn)})
+
+
 @router.delete("/vcs-connections/{connection_id}", status_code=204)
 async def delete_connection(
     connection_id: str = Path(...),

--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -396,7 +396,7 @@ export default function AgentPoolDetailPage() {
                   <dt className="text-xs text-slate-500">Name</dt>
                   {editing ? (
                     <input type="text" value={editName} onChange={(e) => setEditName(e.target.value)}
-                      pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                      pattern="[a-zA-Z0-9][a-zA-Z0-9_\-]*"
                       title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                       className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                   ) : (

--- a/web/src/app/admin/agent-pools/page.tsx
+++ b/web/src/app/admin/agent-pools/page.tsx
@@ -144,7 +144,7 @@ export default function AgentPoolsPage() {
               <div>
                 <label htmlFor="pool-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                 <input id="pool-name" type="text" value={name} onChange={(e) => setName(e.target.value)} required
-                  pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                  pattern="[a-zA-Z0-9][a-zA-Z0-9_\-]*"
                   title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                   placeholder="aws-prod"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -395,7 +395,7 @@ export default function RolesPage() {
                   <div>
                     <label htmlFor="r-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                     <input id="r-name" type="text" value={roleName} onChange={(e) => setRoleName(e.target.value)} required placeholder="developer"
-                      pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                      pattern="[a-zA-Z0-9][a-zA-Z0-9_\-]*"
                       title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                       className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                   </div>

--- a/web/src/app/admin/variable-sets/page.tsx
+++ b/web/src/app/admin/variable-sets/page.tsx
@@ -136,7 +136,7 @@ export default function VariableSetsPage() {
               <div>
                 <label htmlFor="vs-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                 <input id="vs-name" type="text" value={name} onChange={(e) => setName(e.target.value)} required
-                  pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                  pattern="[a-zA-Z0-9][a-zA-Z0-9_\-]*"
                   title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                   placeholder="aws-credentials"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />

--- a/web/src/app/admin/vcs-connections/page.tsx
+++ b/web/src/app/admin/vcs-connections/page.tsx
@@ -51,9 +51,34 @@ export default function VCSConnectionsPage() {
   // GitLab fields
   const [token, setToken] = useState('')
   const [creating, setCreating] = useState(false)
+  // When set, the form is editing this connection (PATCH) rather than creating.
+  const [editId, setEditId] = useState<string | null>(null)
 
   // Delete confirmation
   const [deleteId, setDeleteId] = useState<string | null>(null)
+
+  function resetForm() {
+    setName(''); setServerUrl(''); setAppId(''); setInstallationId('')
+    setPrivateKey(''); setToken(''); setProvider('github'); setEditId(null)
+  }
+
+  function startEdit(conn: VCSConnection) {
+    setEditId(conn.id)
+    setName(conn.attributes.name)
+    setProvider(conn.attributes.provider as 'github' | 'gitlab')
+    setServerUrl(conn.attributes['server-url'] || '')
+    setAppId(conn.attributes['github-app-id'] ? String(conn.attributes['github-app-id']) : '')
+    setInstallationId(
+      conn.attributes['github-installation-id']
+        ? String(conn.attributes['github-installation-id'])
+        : '',
+    )
+    // Credentials are write-only — never returned. Leave blank = keep.
+    setPrivateKey('')
+    setToken('')
+    setShowCreate(true)
+    setError(''); setSuccess('')
+  }
 
   const vcsAccessor = useCallback((item: VCSConnection, key: VCSSortKey) => {
     switch (key) {
@@ -91,41 +116,46 @@ export default function VCSConnectionsPage() {
     }
   }
 
-  async function handleCreate(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setCreating(true)
     setError('')
     setSuccess('')
     try {
-      const attrs: Record<string, unknown> = { name, provider }
-      if (serverUrl) attrs['server-url'] = serverUrl
+      const editing = editId !== null
+      const attrs: Record<string, unknown> = { name }
+      if (!editing) attrs.provider = provider
+      if (serverUrl || editing) attrs['server-url'] = serverUrl
       if (provider === 'github') {
         attrs['github-app-id'] = appId
         attrs['github-installation-id'] = installationId
-        attrs['private-key'] = privateKey
+        // On edit, credentials are optional — only send when rotating.
+        if (privateKey) attrs['private-key'] = privateKey
+        else if (!editing) attrs['private-key'] = privateKey
       } else {
-        attrs.token = token
+        if (token) attrs.token = token
+        else if (!editing) attrs.token = token
       }
-      const res = await apiFetch('/api/terrapod/v1/vcs-connections', {
-        method: 'POST',
+      const url = editing
+        ? `/api/terrapod/v1/vcs-connections/${editId}`
+        : '/api/terrapod/v1/vcs-connections'
+      const res = await apiFetch(url, {
+        method: editing ? 'PATCH' : 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
         body: JSON.stringify({ data: { type: 'vcs-connections', attributes: attrs } }),
       })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
-        throw new Error(data.detail || `Failed to create connection (${res.status})`)
+        throw new Error(
+          data.detail || `Failed to ${editing ? 'update' : 'create'} connection (${res.status})`,
+        )
       }
-      setSuccess(`VCS connection "${name}" created`)
-      setName('')
-      setServerUrl('')
-      setAppId('')
-      setInstallationId('')
-      setPrivateKey('')
-      setToken('')
+      setSuccess(`VCS connection "${name}" ${editing ? 'updated' : 'created'}`)
+      resetForm()
       setShowCreate(false)
       await loadConnections()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create connection')
+      setError(err instanceof Error ? err.message : 'Failed to save connection')
     } finally {
       setCreating(false)
     }
@@ -166,7 +196,10 @@ export default function VCSConnectionsPage() {
           description="Manage version control system integrations"
           actions={
             <button
-              onClick={() => setShowCreate(!showCreate)}
+              onClick={() => {
+                if (showCreate) { setShowCreate(false); resetForm() }
+                else { resetForm(); setShowCreate(true) }
+              }}
               className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors btn-smoke"
             >
               {showCreate ? 'Cancel' : 'New Connection'}
@@ -180,20 +213,22 @@ export default function VCSConnectionsPage() {
         )}
 
         {showCreate && (
-          <form onSubmit={handleCreate} className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6 space-y-3">
+          <form onSubmit={handleSubmit} className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6 space-y-3">
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div>
                 <label htmlFor="vcs-name" className="block text-sm font-medium text-slate-300 mb-1">Name</label>
                 <input id="vcs-name" type="text" value={name} onChange={(e) => setName(e.target.value)} required
-                  pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                  pattern="[a-zA-Z0-9][a-zA-Z0-9_\-]*"
                   title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                   placeholder="my-github-app"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
               </div>
               <div>
                 <label htmlFor="vcs-provider" className="block text-sm font-medium text-slate-300 mb-1">Provider</label>
-                <select id="vcs-provider" value={provider} onChange={(e) => setProvider(e.target.value as 'github' | 'gitlab')}
-                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent">
+                <select id="vcs-provider" value={provider} disabled={editId !== null}
+                  onChange={(e) => setProvider(e.target.value as 'github' | 'gitlab')}
+                  title={editId !== null ? 'Provider is immutable — delete and recreate to change it' : undefined}
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent">
                   <option value="github">GitHub</option>
                   <option value="gitlab">GitLab</option>
                 </select>
@@ -236,8 +271,10 @@ export default function VCSConnectionsPage() {
                     <input ref={pemFileRef} type="file" accept=".pem,.key" className="hidden"
                       onChange={(e) => { const f = e.target.files?.[0]; if (f) f.text().then(t => setPrivateKey(t)) }} />
                   </div>
-                  <textarea id="gh-key" value={privateKey} onChange={(e) => setPrivateKey(e.target.value)} required rows={4}
-                    placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;&#10;Drop a .pem file here or click Browse"
+                  <textarea id="gh-key" value={privateKey} onChange={(e) => setPrivateKey(e.target.value)} required={editId === null} rows={4}
+                    placeholder={editId !== null
+                      ? 'Leave blank to keep the current key — paste a new PEM to rotate'
+                      : '-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;&#10;Drop a .pem file here or click Browse'}
                     className={`w-full px-3 py-2 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent font-mono text-xs transition-colors ${pemDragOver ? 'border-2 border-dashed border-brand-400 bg-brand-900/20' : 'border border-slate-600'}`}
                     onDragOver={(e) => { e.preventDefault(); setPemDragOver(true) }}
                     onDragLeave={() => setPemDragOver(false)}
@@ -253,15 +290,17 @@ export default function VCSConnectionsPage() {
             ) : (
               <div>
                 <label htmlFor="gl-token" className="block text-sm font-medium text-slate-300 mb-1">Access Token</label>
-                <input id="gl-token" type="password" value={token} onChange={(e) => setToken(e.target.value)} required
-                  placeholder="glpat-..."
+                <input id="gl-token" type="password" value={token} onChange={(e) => setToken(e.target.value)} required={editId === null}
+                  placeholder={editId !== null ? 'Leave blank to keep the current token' : 'glpat-...'}
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
               </div>
             )}
 
             <button type="submit" disabled={creating}
               className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors">
-              {creating ? 'Creating...' : 'Create Connection'}
+              {creating
+                ? (editId !== null ? 'Saving...' : 'Creating...')
+                : (editId !== null ? 'Save Changes' : 'Create Connection')}
             </button>
           </form>
         )}
@@ -310,7 +349,10 @@ export default function VCSConnectionsPage() {
                           <button onClick={() => handleDelete(conn.id)} className="text-xs text-red-400 hover:text-red-300">Confirm</button>
                         </div>
                       ) : (
-                        <button onClick={() => setDeleteId(conn.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
+                        <div className="flex justify-end gap-3">
+                          <button onClick={() => startEdit(conn)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
+                          <button onClick={() => setDeleteId(conn.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
+                        </div>
                       )}
                     </td>
                   </tr>

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1373,7 +1373,7 @@ function WorkspaceDetailContent() {
                   <dt className="text-xs text-slate-500">Name</dt>
                   {editing ? (
                     <input type="text" value={editName} onChange={(e) => setEditName(e.target.value)}
-                      pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*" maxLength={90}
+                      pattern="[a-zA-Z0-9][a-zA-Z0-9_\-]*" maxLength={90}
                       title="Letters, numbers, hyphens, underscores. Must start with a letter or number."
                       className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
                   ) : (

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -344,7 +344,7 @@ function WorkspacesPageInner() {
                   value={newName}
                   onChange={(e) => setNewName(e.target.value)}
                   required
-                  pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                  pattern="[a-zA-Z0-9][a-zA-Z0-9_\-]*"
                   title="Letters, numbers, hyphens, and underscores only. Must start with a letter or number."
                   placeholder="my-workspace"
                   className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"


### PR DESCRIPTION
Closes #315. Ships in **v0.24.0**.

## Problem

VCS connections could only be created or deleted — changing a name, server URL, or rotating a token/PEM meant delete-and-recreate (or a direct DB edit). There was no PATCH endpoint and no edit UI.

## Changes

- **`PATCH /api/terrapod/v1/vcs-connections/{id}`** — partial update. `provider` is immutable (a different provider is a different connection — delete + recreate). Credentials (`private-key` / `token`) are **write-only**: only rotated when a non-empty value is supplied, so editing an unrelated field never wipes the stored secret. Duplicate GitHub-installation guard mirrors create (excluding self).
- **Admin UI** — per-row **Edit** reuses the existing connection form: prefilled fields, provider select locked, credential field shows a "leave blank to keep" hint, button becomes **Save Changes**, wired to PATCH.

## Incidental fix (encountered during UI verification)

The name `pattern` attribute `[a-zA-Z0-9][a-zA-Z0-9_-]*` is an **invalid regex under the browser's modern unicodeSets (`v`) flag** — the unescaped `-` in the character class throws `Invalid regular expression` in the console on every page that uses it. Escaped to `[a-zA-Z0-9_\-]*` across all 7 affected forms (workspaces ×2, agent pools ×2, roles, variable sets, vcs connections).

## Test plan

- [x] `make lint` (ruff + tsc) clean
- [x] `make test` — 1361 passed
- [x] `npm run build` — compiles successfully
- [x] Live Tilt API: PATCH update, provider-immutable → 422, credential preserved when omitted
- [x] Playwright UI: Edit prefills + provider disabled + Save Changes round-trips; console clean after the regex fix
- [ ] CI green