### PR TITLE
chore: v0.24.0 pre-release doc audit + coverage backfill

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1372,6 +1372,29 @@ POST /api/terrapod/v1/vcs-connections
 GET /api/terrapod/v1/vcs-connections/{id}
 ```
 
+### Update Connection
+
+```
+PATCH /api/terrapod/v1/vcs-connections/{id}
+```
+
+Partial update — only the attributes you include are changed. Notes:
+
+- `provider` is **immutable**. A different provider is a different connection; delete and recreate to change it (sending a different `provider` returns `422`).
+- Credentials (`private-key` for GitHub, `token` for GitLab) are **write-only**: they are never returned, and are only rotated when you send a non-empty value. Omit them to change the name/server-url/status without touching the stored credential.
+- Editable: `name`, `server-url`, `status` (`active`/`disabled`), and the GitHub App identifiers (`github-app-id`, `github-installation-id`, `github-account-login`, `github-account-type`). Changing `github-installation-id` to one already used by another connection returns `422`.
+
+```json
+{
+  "data": {
+    "type": "vcs-connections",
+    "attributes": { "name": "renamed", "server-url": "https://github.example.com/api/v3" }
+  }
+}
+```
+
+**Required permission:** Platform `admin`.
+
 ### Delete Connection
 
 ```
@@ -1429,6 +1452,8 @@ POST /api/terrapod/v1/autodiscovery-rules
 
 Returns `201` with the created rule, or `409` if a rule with that name already exists for the connection.
 
+> **Reserved label keys:** `labels` is validated like any other label write — reserved keys (`status`, `pool`, `mode`, `backend`, `owner`, `drift`, `version`, `vcs`, `locked`, `branch`) are rejected with `422`. This is enforced at rule create/update so the rule can't materialise workspaces that later become uneditable.
+
 ### Show Rule
 
 ```
@@ -1450,6 +1475,25 @@ DELETE /api/terrapod/v1/autodiscovery-rules/{id}
 ```
 
 Workspaces auto-created by this rule keep working — their `autodiscovery-rule-id` foreign key is set to NULL.
+
+### Preview (dry-run)
+
+Walk the repo and return exactly which workspaces a rule *would* create against the current state of the tracked branch, with no side effects. Used by the admin UI's "Preview" modal.
+
+```
+GET  /api/terrapod/v1/autodiscovery-rules/{id}/preview      # preview a saved rule
+POST /api/terrapod/v1/autodiscovery-rules/preview           # preview an unsaved rule (same attributes body as Create)
+```
+
+Each entry reports `workspace_name`, `working_directory`, `collision` (the row would no-op — a workspace is already bound to that directory or the derived name is taken), and `existing_autodiscovered` (the no-op is a reuse of a workspace this same rule already materialised). Returns `413` if the VCS provider truncated the repo tree (repo too large to scan in one pass).
+
+### Scan (on-demand materialise)
+
+```
+POST /api/terrapod/v1/autodiscovery-rules/{id}/scan
+```
+
+Runs the same walk as Preview but actually creates the workspaces (idempotent, collision-safe). Force-enables the rule for the duration of the call so an explicit operator action doesn't silently no-op on a disabled rule. New workspaces are seeded with the tracked-branch HEAD as their last-seen commit, so the first real plan+apply fires when the branch next advances (e.g. the PR merge) — not immediately against a branch where the directory doesn't exist yet.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ policies/{policy_set_id}/{version_id}.tar.gz              # Policy set bundles
 
 File uploads and downloads for the **registry** (module tarballs, provider binaries, state version content) use presigned URLs. The API generates time-limited URLs; clients upload/download directly to/from storage. This keeps large files off the API server.
 
-**Runner artifacts** (config archives, state files, plan files, logs) use a different pattern: authenticated API endpoints at `/api/v2/runs/{run_id}/artifacts/*` that require a runner token. Downloads return 302 redirects to presigned storage URLs; uploads are received directly by the API and written to storage. This eliminates the need for presigned URL env vars in runner Jobs.
+**Runner artifacts** (config archives, state files, plan files, logs) use a different pattern: authenticated API endpoints at `/api/terrapod/v1/runs/{run_id}/artifacts/*` that require a runner token. Downloads return 302 redirects to presigned storage URLs; uploads are received directly by the API and written to storage. This eliminates the need for presigned URL env vars in runner Jobs.
 
 For the filesystem backend, URLs are HMAC-signed and served by `storage/filesystem_routes.py` endpoints on the API server itself.
 
@@ -384,9 +384,9 @@ Browser                  Next.js              API               IDP (OIDC/SAML)
   |-- Follow redirect ------------------------------------------------>|
   |<-- IDP login page ------------------------------------------------|
   |-- Authenticate -------------------------------------------------->|
-  |<-- 302 to /auth/callback?code=xxx&state=yyy ----------------------|
+  |<-- 302 to /api/terrapod/v1/auth/callback?code=xxx&state=yyy -------|
   |                         |                   |                     |
-  |-- GET /auth/callback?...                    |                     |
+  |-- GET /api/terrapod/v1/auth/callback?...    |                     |
   |                         |-- validate state -->                    |
   |                         |-- exchange code --->                    |
   |                         |<-- session token --|                    |

--- a/docs/autodiscovery.md
+++ b/docs/autodiscovery.md
@@ -58,7 +58,7 @@ Rules are scoped to a single VCS connection + repo. A rule has:
 | `terraform-version` | string | no | Default `1.11`. |
 | `resource-cpu` / `resource-memory` | string | no | Defaults `1` / `2Gi`. |
 | `auto-apply` | bool | no | Default `false`. |
-| `labels` | map | no | Inherited by created workspaces — feeds Terrapod's label-based RBAC and filtering. |
+| `labels` | map | no | Inherited by created workspaces — feeds Terrapod's label-based RBAC and filtering. Reserved keys (`status`, `pool`, `mode`, `backend`, `owner`, `drift`, `version`, `vcs`, `locked`, `branch`) are rejected with `422` at rule create/update — they are virtual filter terms and would otherwise produce workspaces that can't be saved. |
 | `owner-email` | string | no | Inherited by created workspaces; if unset, created workspaces have no owner and label-RBAC alone determines access. |
 
 ## Pattern syntax
@@ -99,6 +99,7 @@ A workspace created by a rule:
 - Has `working-directory` set to the matched file's parent.
 - Has `trigger-prefixes` set to `[working_directory]` so subsequent PRs that touch the same dir route to the same workspace via the regular PR-scan path (not via re-running autodiscovery).
 - Tracks `autodiscovery-rule-id` so you can audit which rule created it.
+- Is seeded with the **tracked-branch HEAD** as its last-seen commit (`vcs-last-commit-sha`). Autodiscovery is PR-driven — the matched directory exists on the PR branch but not yet on the tracked branch — so without this baseline the next branch poll would fire a full plan+apply against a branch where the directory doesn't exist, which errors. With the baseline, the speculative plan-only run for the open PR still happens, and the first real plan+apply fires when the tracked branch actually advances (typically the PR merge).
 
 If you delete the rule later, existing workspaces keep working — the foreign key sets to NULL on cascade.
 
@@ -153,6 +154,18 @@ GET    /api/terrapod/v1/autodiscovery-rules/{id}
 PATCH  /api/terrapod/v1/autodiscovery-rules/{id}
 DELETE /api/terrapod/v1/autodiscovery-rules/{id}
 ```
+
+### Preview and on-demand scan
+
+Beyond passively waiting for the poller, you can dry-run a rule and provision on demand:
+
+```
+GET  /api/terrapod/v1/autodiscovery-rules/{id}/preview   # what a saved rule would create — no side effects
+POST /api/terrapod/v1/autodiscovery-rules/preview        # same, for an unsaved rule (Create body) — iterate before saving
+POST /api/terrapod/v1/autodiscovery-rules/{id}/scan      # walk now and actually create the workspaces (idempotent)
+```
+
+Preview walks the tracked branch and returns, per directory: `workspace_name`, `working_directory`, `collision` (would no-op — a workspace is already bound to that directory, or the derived name is taken), and `existing_autodiscovered` (the no-op is a reuse of a workspace this same rule already made). The admin UI surfaces this as a per-row badge (Create / Skip already-discovered / Skip name-collision) and a "Provision N workspaces" confirm whose count is exactly the non-colliding rows. A `413` means the provider truncated the repo tree (too large to scan in one pass). `scan` force-enables the rule for the call so an explicit operator action doesn't silently no-op on a disabled rule.
 
 JSON:API request body example:
 

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -410,3 +410,293 @@ class TestDeleteRule:
                 f"/api/terrapod/v1/autodiscovery-rules/{uuid.uuid4()}", headers=_AUTH
             )
         assert resp.status_code == 404
+
+
+# ── Preview / on-demand scan (#311 / #312 / #313 / #316) ─────────────────
+
+
+def _conn(provider="github"):
+    """A minimal VCSConnection-shaped object for the walk helper."""
+    c = MagicMock()
+    c.id = uuid.uuid4()
+    c.provider = provider
+    c.server_url = ""
+    c.token = "tok"
+    return c
+
+
+def _saved_rule_with_conn(provider="github"):
+    rule = _mock_rule()
+    rule.branch = ""  # force default-branch resolution
+    rule.vcs_connection = _conn(provider)
+    rule.vcs_connection_id = rule.vcs_connection.id
+    return rule
+
+
+class TestPreviewSavedRule:
+    @patch("terrapod.services.github_service.get_repo_branch_sha", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.list_repo_tree", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.get_repo_default_branch", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.parse_repo_url")
+    @patch(
+        "terrapod.services.workspace_autodiscovery_service.preview_for_paths",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_200_returns_entries(
+        self,
+        _init_db,
+        _init_redis,
+        _init_storage,
+        m_preview,
+        m_parse,
+        m_default_branch,
+        m_tree,
+        m_sha,
+    ):
+        rule = _saved_rule_with_conn()
+        m_parse.return_value = ("example", "repo")
+        m_default_branch.return_value = "main"
+        m_tree.return_value = ["accounts/a/main.tf", "accounts/b/main.tf"]
+        m_sha.return_value = "abc123"
+        m_preview.return_value = [
+            {"workspace_name": "a", "working_directory": "accounts/a", "collision": False},
+            {"workspace_name": "b", "working_directory": "accounts/b", "collision": False},
+        ]
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}/preview", headers=_AUTH
+            )
+        assert resp.status_code == 200, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["ref"] == "main"
+        assert attrs["files-walked"] == 2
+        assert len(attrs["entries"]) == 2
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_404_missing_rule(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/autodiscovery-rules/{uuid.uuid4()}/preview", headers=_AUTH
+            )
+        assert resp.status_code == 404
+
+
+class TestPreviewUnsavedRule:
+    @patch("terrapod.services.github_service.get_repo_branch_sha", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.list_repo_tree", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.get_repo_default_branch", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.parse_repo_url")
+    @patch(
+        "terrapod.services.workspace_autodiscovery_service.preview_for_paths",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_200_unsaved_body(
+        self,
+        _init_db,
+        _init_redis,
+        _init_storage,
+        m_preview,
+        m_parse,
+        m_default_branch,
+        m_tree,
+        m_sha,
+    ):
+        m_parse.return_value = ("example", "repo")
+        m_default_branch.return_value = "main"
+        m_tree.return_value = ["accounts/a/main.tf"]
+        m_sha.return_value = "deadbeef"
+        m_preview.return_value = [
+            {"workspace_name": "a", "working_directory": "accounts/a", "collision": False}
+        ]
+        conn_id = uuid.uuid4()
+        app, db = _make_app(_admin())
+        # _validate_connection uses db.get(VCSConnection, ...)
+        db.get = AsyncMock(return_value=_conn())
+
+        body = {
+            "data": {
+                "type": "autodiscovery-rules",
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{conn_id}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "ignore-patterns": ["modules/**"],
+                    "execution-mode": "agent",
+                },
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/autodiscovery-rules/preview", json=body, headers=_AUTH
+            )
+        assert resp.status_code == 200, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["ref"] == "main"
+        assert attrs["files-walked"] == 1
+        assert len(attrs["entries"]) == 1
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_reserved_label_key(self, *_mocks):
+        """#316: the unsaved-preview path must run the same reserved-key
+        label guard the create path runs — fail before any repo walk."""
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "labels": {"owner": "foundations"},
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/autodiscovery-rules/preview", json=body, headers=_AUTH
+            )
+        assert resp.status_code == 422
+        assert "owner" in resp.json()["detail"]
+
+
+class TestScanRule:
+    @patch(
+        "terrapod.services.workspace_autodiscovery_service.autodiscover_for_paths",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.github_service.get_repo_branch_sha", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.list_repo_tree", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.get_repo_default_branch", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.parse_repo_url")
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_scan_passes_head_sha_as_baseline(
+        self,
+        _init_db,
+        _init_redis,
+        _init_storage,
+        m_parse,
+        m_default_branch,
+        m_tree,
+        m_sha,
+        m_autodiscover,
+    ):
+        """#313: /scan must seed new workspaces with the resolved HEAD
+        sha so the branch poll doesn't fire a premature plan+apply."""
+        rule = _saved_rule_with_conn()
+        m_parse.return_value = ("example", "repo")
+        m_default_branch.return_value = "main"
+        m_tree.return_value = ["accounts/a/main.tf"]
+        m_sha.return_value = "cafef00d"
+        created_ws = MagicMock()
+        created_ws.id = uuid.uuid4()
+        m_autodiscover.return_value = [created_ws]
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        db.commit = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}/scan", headers=_AUTH
+            )
+        assert resp.status_code == 200, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["ref"] == "main"
+        assert attrs["files-walked"] == 1
+        assert attrs["workspaces-created"] == 1
+        assert attrs["workspace-ids"] == [f"ws-{created_ws.id}"]
+        # The #313 wiring: baseline_sha == the head sha from _walk_repo_for_rule.
+        m_autodiscover.assert_awaited_once()
+        assert m_autodiscover.await_args.kwargs["baseline_sha"] == "cafef00d"
+
+
+class TestWalkRepoErrorBranches:
+    @patch("terrapod.services.github_service.list_repo_tree", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.get_repo_default_branch", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.parse_repo_url")
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_413_tree_truncated(
+        self, _init_db, _init_redis, _init_storage, m_parse, m_default_branch, m_tree
+    ):
+        rule = _saved_rule_with_conn()
+        m_parse.return_value = ("example", "repo")
+        m_default_branch.return_value = "main"
+        m_tree.return_value = None  # provider truncated the tree
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}/preview", headers=_AUTH
+            )
+        assert resp.status_code == 413
+        assert "truncated" in resp.json()["detail"]
+
+    @patch("terrapod.services.github_service.parse_repo_url")
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_bad_repo_url(self, _init_db, _init_redis, _init_storage, m_parse):
+        rule = _saved_rule_with_conn()
+        m_parse.return_value = None  # unparseable repo URL
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}/preview", headers=_AUTH
+            )
+        assert resp.status_code == 422
+        assert "cannot parse repo URL" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_unknown_provider(self, *_mocks):
+        rule = _saved_rule_with_conn(provider="bitbucket")
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}/preview", headers=_AUTH
+            )
+        assert resp.status_code == 422
+        assert "unknown VCS provider" in resp.json()["detail"]
+
+    @patch("terrapod.services.github_service.get_repo_default_branch", new_callable=AsyncMock)
+    @patch("terrapod.services.github_service.parse_repo_url")
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_502_default_branch_failure(
+        self, _init_db, _init_redis, _init_storage, m_parse, m_default_branch
+    ):
+        rule = _saved_rule_with_conn()
+        m_parse.return_value = ("example", "repo")
+        m_default_branch.side_effect = RuntimeError("provider down")
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}/preview", headers=_AUTH
+            )
+        assert resp.status_code == 502
+        assert "default branch" in resp.json()["detail"]

--- a/services/tests/api/test_vcs_connections.py
+++ b/services/tests/api/test_vcs_connections.py
@@ -1,0 +1,542 @@
+"""Tests for VCS connection CRUD endpoints (admin-only, JSON:API).
+
+Covers the previously-untested router
+`terrapod.api.routers.vcs_connections`, including the #315 PATCH
+partial-update / credential-preservation surface.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, require_admin
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+def _admin():
+    return AuthenticatedUser(
+        email="admin@example.com",
+        display_name="Admin",
+        roles=["admin"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _make_app(user, mock_db=None):
+    app = create_app()
+    app.dependency_overrides[require_admin] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app, mock_db
+
+
+def _mock_conn(
+    conn_id=None,
+    provider="github",
+    name="prod-github",
+    server_url="",
+    token="-----BEGIN KEY-----",
+    github_app_id=12345,
+    github_installation_id=98765,
+    github_account_login="example",
+    github_account_type="Organization",
+    status="active",
+):
+    c = MagicMock()
+    c.id = conn_id or uuid.uuid4()
+    c.provider = provider
+    c.name = name
+    c.server_url = server_url
+    c.token = token
+    c.github_app_id = github_app_id
+    c.github_installation_id = github_installation_id
+    c.github_account_login = github_account_login
+    c.github_account_type = github_account_type
+    c.status = status
+    c.created_at = datetime(2026, 5, 9, tzinfo=UTC)
+    c.updated_at = datetime(2026, 5, 9, tzinfo=UTC)
+    return c
+
+
+def _scalar_result(value):
+    """A SQLAlchemy result-like whose scalar_one_or_none() returns `value`."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+def _list_result(values):
+    """A SQLAlchemy result-like whose scalars().all() returns `values`."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = values
+    return result
+
+
+# ── List ─────────────────────────────────────────────────────────────────
+
+
+class TestListConnections:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_returns_all_connections(self, *_mocks):
+        conns = [
+            _mock_conn(name="gh-a"),
+            _mock_conn(name="gl-b", provider="gitlab", token="glpat-xxx"),
+        ]
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_list_result(conns))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/vcs-connections", headers=_AUTH)
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert {d["attributes"]["name"] for d in data} == {"gh-a", "gl-b"}
+        # Credentials are never echoed; has-token reflects presence only.
+        for d in data:
+            assert "token" not in d["attributes"]
+            assert "private-key" not in d["attributes"]
+            assert d["attributes"]["has-token"] is True
+
+
+# ── Create ───────────────────────────────────────────────────────────────
+
+
+class TestCreateConnection:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_201_github_happy(self, *_mocks):
+        app, db = _make_app(_admin())
+        # Duplicate-installation check → none found.
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "prod-github",
+                    "provider": "github",
+                    "github-app-id": 12345,
+                    "github-installation-id": 98765,
+                    "private-key": "-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----",
+                    "github-account-login": "example",
+                    "github-account-type": "Organization",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 201, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["name"] == "prod-github"
+        assert attrs["provider"] == "github"
+        assert attrs["has-token"] is True
+        assert attrs["github-app-id"] == 12345
+        assert attrs["github-installation-id"] == 98765
+        # The PEM is never echoed back.
+        assert "private-key" not in attrs
+        assert "token" not in attrs
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_201_gitlab_happy(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "prod-gitlab",
+                    "provider": "gitlab",
+                    "token": "glpat-deadbeef",
+                    "server-url": "https://gitlab.example.com",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 201, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["name"] == "prod-gitlab"
+        assert attrs["provider"] == "gitlab"
+        assert attrs["server-url"] == "https://gitlab.example.com"
+        assert attrs["has-token"] is True
+        # GitHub-specific fields are not present for a gitlab connection.
+        assert "github-app-id" not in attrs
+        assert "token" not in attrs
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_missing_name(self, *_mocks):
+        app, _db = _make_app(_admin())
+        body = {"data": {"attributes": {"provider": "gitlab", "token": "x"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "name is required" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_unsupported_provider(self, *_mocks):
+        app, _db = _make_app(_admin())
+        body = {"data": {"attributes": {"name": "x", "provider": "bitbucket", "token": "x"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "Unsupported provider" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_github_missing_private_key(self, *_mocks):
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "gh",
+                    "provider": "github",
+                    "github-app-id": 1,
+                    "github-installation-id": 2,
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "private-key is required" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_gitlab_missing_token(self, *_mocks):
+        app, _db = _make_app(_admin())
+        body = {"data": {"attributes": {"name": "gl", "provider": "gitlab"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "token is required" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_duplicate_github_installation(self, *_mocks):
+        app, db = _make_app(_admin())
+        # Duplicate-installation check → an existing connection found.
+        db.execute = AsyncMock(return_value=_scalar_result(_mock_conn()))
+
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "dup",
+                    "provider": "github",
+                    "github-app-id": 1,
+                    "github-installation-id": 98765,
+                    "private-key": "-----BEGIN KEY-----",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "already connected" in resp.json()["detail"]
+
+
+# ── Show ─────────────────────────────────────────────────────────────────
+
+
+class TestShowConnection:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_200_when_exists(self, *_mocks):
+        conn = _mock_conn()
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attributes"]["name"] == "prod-github"
+        assert resp.json()["data"]["id"] == f"vcs-{conn.id}"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_404_when_missing(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/vcs-connections/vcs-{uuid.uuid4()}", headers=_AUTH
+            )
+        assert resp.status_code == 404
+
+
+# ── Update / PATCH (#315) ────────────────────────────────────────────────
+
+
+class TestUpdateConnection:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_partial_update_name_server_url_status(self, *_mocks):
+        conn = _mock_conn(name="old", server_url="", status="active")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "new-name",
+                    "server-url": "https://github.example.com",
+                    "status": "disabled",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn.name == "new-name"
+        assert conn.server_url == "https://github.example.com"
+        assert conn.status == "disabled"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_provider_change(self, *_mocks):
+        conn = _mock_conn(provider="github")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        body = {"data": {"attributes": {"provider": "gitlab"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "immutable" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_invalid_status(self, *_mocks):
+        conn = _mock_conn()
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        body = {"data": {"attributes": {"status": "paused"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "active" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_empty_name(self, *_mocks):
+        conn = _mock_conn(name="keep")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        body = {"data": {"attributes": {"name": "   "}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "cannot be empty" in resp.json()["detail"]
+        assert conn.name == "keep"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_credential_omitted_preserves_stored_token(self, *_mocks):
+        """No private-key in the body ⇒ stored token untouched and
+        has-token stays true (the #315 write-only credential contract)."""
+        conn = _mock_conn(provider="github", token="STORED-PEM")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {"data": {"attributes": {"name": "renamed"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn.token == "STORED-PEM"
+        assert resp.json()["data"]["attributes"]["has-token"] is True
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_empty_credential_does_not_rotate(self, *_mocks):
+        """An explicitly empty private-key must NOT wipe the stored
+        credential — only a non-empty value rotates it."""
+        conn = _mock_conn(provider="github", token="STORED-PEM")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {"data": {"attributes": {"private-key": ""}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn.token == "STORED-PEM"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_non_empty_private_key_rotates(self, *_mocks):
+        conn = _mock_conn(provider="github", token="OLD-PEM")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {"data": {"attributes": {"private-key": "NEW-PEM"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn.token == "NEW-PEM"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_non_empty_gitlab_token_rotates(self, *_mocks):
+        conn = _mock_conn(provider="gitlab", token="old-pat")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {"data": {"attributes": {"token": "new-pat"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn.token == "new-pat"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_installation_id_collision(self, *_mocks):
+        """Changing github-installation-id to one another connection
+        already uses must 422 (the #315 collision guard)."""
+        conn = _mock_conn(provider="github", github_installation_id=111)
+        other = _mock_conn(github_installation_id=222)
+        app, db = _make_app(_admin())
+        # First execute: load the target connection.
+        # Second execute: duplicate-installation lookup → other found.
+        db.execute = AsyncMock(side_effect=[_scalar_result(conn), _scalar_result(other)])
+        body = {"data": {"attributes": {"github-installation-id": 222}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "already connected" in resp.json()["detail"]
+        assert conn.github_installation_id == 111
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_installation_id_change_no_collision(self, *_mocks):
+        conn = _mock_conn(provider="github", github_installation_id=111)
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(side_effect=[_scalar_result(conn), _scalar_result(None)])
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {"data": {"attributes": {"github-installation-id": 333}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn.github_installation_id == 333
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_404_unknown_id(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        body = {"data": {"attributes": {"name": "x"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{uuid.uuid4()}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 404
+
+
+# ── Delete ───────────────────────────────────────────────────────────────
+
+
+class TestDeleteConnection:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_204_on_success(self, *_mocks):
+        conn = _mock_conn()
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(conn))
+        db.delete = AsyncMock()
+        db.commit = AsyncMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}", headers=_AUTH)
+        assert resp.status_code == 204
+        db.delete.assert_awaited_once_with(conn)
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_404_when_missing(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(
+                f"/api/terrapod/v1/vcs-connections/vcs-{uuid.uuid4()}", headers=_AUTH
+            )
+        assert resp.status_code == 404


### PR DESCRIPTION
Closes #319. Final gate before the v0.24.0 release.

A full exhaustive pre-release smoke + audit of the v0.24.0 change surface (#278 API-namespace removal, #312 autodiscovery dry-run, #313 baseline seeding, #315 vcs-connection PATCH, #316 reserved-label guard).

## Docs (audit fixes)
- **architecture.md** — stale `/api/v2/runs/{id}/artifacts/*` → `/api/terrapod/v1/...` (run artifacts are Terrapod-native; was an internal contradiction with api-reference.md); SSO sequence diagram now uses the full `/api/terrapod/v1/auth/callback`.
- **api-reference.md** — documents the new vcs-connections **PATCH** (#315), the autodiscovery **preview/scan** endpoints (#312), and the reserved label-key rejection at rule create/update (#316).
- **autodiscovery.md** — documents preview/scan, the tracked-branch-HEAD **baseline** behaviour (#313), and the reserved-key caveat (#316).

## Tests (coverage backfill)
The coverage audit found these net-new v0.24.0 paths at **0%**:
- `test_vcs_connections.py` (new) — the whole vcs-connections router incl. the #315 PATCH contract (provider immutable, write-only credentials, installation collision, status validation).
- `test_autodiscovery_rules.py` — #311/#312 preview (saved + unsaved) + scan, the #313 `baseline_sha` wiring, and `_walk_repo_for_rule` error branches (413/422/502).

**34 new tests; `make test` 1393 passed; `make lint` clean.**

## Live smoke (verified, not in this diff)
- `terraform` **and** `tofu` full `init`/`plan`/`apply` through the BFF on `/api/v2` — including go-tfe v1.95's no-Authorization state-upload PUT.
- Terrapod **provider** create + destroy via `/api/terrapod/v1` (dev_overrides, live stack).
- Every API router responds on its correct prefix; all 10 #278 legacy aliases now 404; CLI surface intact.
- 13+ UX pages (incl. the SSE-heavy workspace detail) render clean with zero console errors; the #315 Edit flow round-trips.

## Reported, not blocking v0.24.0 (pre-existing tech debt)
- Several non-v0.24.0 modules at 0–15% coverage (`module_impact_service`, `registry_vcs_poller`, `run_task_dispatcher`, `vcs_auto_merge`, `cli/bootstrap`, `provider_cache_service`). Overall suite ~57%. Worth a follow-up coverage initiative; not a v0.24.0 regression.

## Test plan
- [x] `make lint`, `make test` (1393)
- [x] terraform/tofu/provider live E2E
- [x] full API namespace sweep + UX sweep
- [ ] CI green