### PR TITLE
feat: default new workspaces to OpenTofu 1.12 (now GA)

### DIFF
--- a/alembic/versions/7dac5695bc0e_default_tofu_1_12.py
+++ b/alembic/versions/7dac5695bc0e_default_tofu_1_12.py
@@ -1,0 +1,56 @@
+"""bump default terraform_version 1.11 -> 1.12 (OpenTofu 1.12 GA, #325)
+
+Only the column server_default changes. Existing rows are NOT touched:
+a workspace or rule explicitly pinned to 1.11 stays on 1.11 — the
+default only applies to new rows that don't specify a version. The
+ORM-side default and config default move in lockstep in the same
+change.
+
+Revision ID: 7dac5695bc0e
+Revises: c3b957ded26c
+Create Date: 2026-05-17
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "7dac5695bc0e"
+down_revision: str | None = "c3b957ded26c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "workspaces",
+        "terraform_version",
+        existing_type=sa.String(20),
+        existing_nullable=False,
+        server_default="1.12",
+    )
+    op.alter_column(
+        "autodiscovery_rules",
+        "terraform_version",
+        existing_type=sa.String(50),
+        existing_nullable=False,
+        server_default="1.12",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "workspaces",
+        "terraform_version",
+        existing_type=sa.String(20),
+        existing_nullable=False,
+        server_default="1.11",
+    )
+    op.alter_column(
+        "autodiscovery_rules",
+        "terraform_version",
+        existing_type=sa.String(50),
+        existing_nullable=False,
+        server_default="1.11",
+    )

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1439,7 +1439,7 @@ POST /api/terrapod/v1/autodiscovery-rules
       "execution-mode": "agent",
       "execution-backend": "tofu",
       "agent-pool-id": "apool-019e01db-...",
-      "terraform-version": "1.11",
+      "terraform-version": "1.12",
       "resource-cpu": "1",
       "resource-memory": "2Gi",
       "auto-apply": false,

--- a/docs/autodiscovery.md
+++ b/docs/autodiscovery.md
@@ -55,7 +55,7 @@ Rules are scoped to a single VCS connection + repo. A rule has:
 | `execution-mode` | enum | no | Must be `agent` (default). Autodiscovery is VCS-driven; `local` mode would create workspaces with queued runs and no executor. |
 | `agent-pool-id` | UUID | no | Inherited by created workspaces in `agent` mode. |
 | `execution-backend` | enum | no | `tofu` or `terraform`. Default `tofu`. |
-| `terraform-version` | string | no | Default `1.11`. |
+| `terraform-version` | string | no | Default `1.12`. |
 | `resource-cpu` / `resource-memory` | string | no | Defaults `1` / `2Gi`. |
 | `auto-apply` | bool | no | Default `false`. |
 | `labels` | map | no | Inherited by created workspaces — feeds Terrapod's label-based RBAC and filtering. Reserved keys (`status`, `pool`, `mode`, `backend`, `owner`, `drift`, `version`, `vcs`, `locked`, `branch`) are rejected with `422` at rule create/update — they are virtual filter terms and would otherwise produce workspaces that can't be saved. |

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -237,7 +237,7 @@ data:
       module_overrides_retention_days: {{ .Values.api.config.artifact_retention.module_overrides_retention_days | default 14 }}
     {{- end }}
     default_execution_backend: {{ .Values.api.config.default_execution_backend | default "tofu" | quote }}
-    default_terraform_version: {{ .Values.api.config.default_terraform_version | default "1.11" | quote }}
+    default_terraform_version: {{ .Values.api.config.default_terraform_version | default "1.12" | quote }}
     {{- if .Values.api.config.cors.allow_origins }}
     cors:
       allow_origins:

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -99,7 +99,7 @@ api:
 
     # Default execution backend and version for new workspaces
     default_execution_backend: tofu  # tofu | terraform
-    default_terraform_version: "1.11"
+    default_terraform_version: "1.12"
 
     # Storage configuration — exactly one backend must be configured.
     # IMPORTANT: Filesystem storage is for dev/single-instance only.

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -412,7 +412,7 @@ def _build_transient_rule(fields: dict[str, Any], conn: VCSConnection) -> Autodi
         # defaults to satisfy the in-memory construction.
         execution_mode=fields.get("execution_mode", "agent"),
         execution_backend=fields.get("execution_backend", "tofu"),
-        terraform_version=fields.get("terraform_version", "1.11"),
+        terraform_version=fields.get("terraform_version", "1.12"),
         resource_cpu=fields.get("resource_cpu", "1"),
         resource_memory=fields.get("resource_memory", "2Gi"),
         auto_apply=fields.get("auto_apply", False),

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -49,7 +49,7 @@ class RunnerConfig(BaseModel):
         description="Internal API URL for runner Jobs (e.g. http://terrapod-api:8000). "
         "Used as base URL for presigned storage URLs. Falls back to TERRAPOD_API_URL env var.",
     )
-    default_terraform_version: str = Field(default="1.11")
+    default_terraform_version: str = Field(default="1.12")
     default_execution_backend: str = Field(default="tofu")
     service_account_name: str = Field(default="")
     azure_workload_identity: bool = Field(default=False)
@@ -736,7 +736,7 @@ class Settings(BaseSettings):
         description="Default execution backend for new workspaces (tofu or terraform)",
     )
     default_terraform_version: str = Field(
-        default="1.11",
+        default="1.12",
         description="Default terraform/tofu version for new workspaces",
     )
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -258,7 +258,7 @@ class Workspace(Base):
     execution_backend: Mapped[str] = mapped_column(
         String(20), nullable=False, default="tofu"
     )  # tofu, terraform
-    terraform_version: Mapped[str] = mapped_column(String(20), nullable=False, default="1.11")
+    terraform_version: Mapped[str] = mapped_column(String(20), nullable=False, default="1.12")
     working_directory: Mapped[str] = mapped_column(String(500), nullable=False, default="")
     locked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     lock_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -852,7 +852,7 @@ class AutodiscoveryRule(Base):
         nullable=True,
     )
     execution_backend: Mapped[str] = mapped_column(String(20), nullable=False, default="tofu")
-    terraform_version: Mapped[str] = mapped_column(String(50), nullable=False, default="1.11")
+    terraform_version: Mapped[str] = mapped_column(String(50), nullable=False, default="1.12")
     resource_cpu: Mapped[str] = mapped_column(String(20), nullable=False, default="1")
     resource_memory: Mapped[str] = mapped_column(String(20), nullable=False, default="2Gi")
     auto_apply: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)


### PR DESCRIPTION
Closes #325. Merge to main; **no release** (will ride the next minor).

OpenTofu 1.12 is GA, so the default `terraform_version` for new workspaces moves `1.11 → 1.12`. Default execution backend is already `tofu`.

## Changes
- `config.py` — both the Settings and runner-config `default_terraform_version` defaults.
- `db/models.py` — `Workspace` and `AutodiscoveryRule` ORM `terraform_version` defaults.
- `autodiscovery_rules.py` — rule-create fallback.
- Helm `values.yaml` + `configmap-api.yaml` fallback.
- `docs/autodiscovery.md`, `docs/api-reference.md` examples.
- **New migration `7dac5695bc0e`** — flips `server_default` on `workspaces.terraform_version` and `autodiscovery_rules.terraform_version` `1.11 → 1.12`. **No backfill**: rows explicitly pinned to 1.11 stay on 1.11; only the default for new/unspecified rows changes.

## Test plan
- [x] `make lint`, `make test` (1393 — no test relied on 1.11 as the default; fixtures pin it explicitly)
- [x] `helm template` OK
- [ ] CI green → merge to main