### PR TITLE
feat: batch workspace updates + expanded autodiscovery templating (#318)

### DIFF
--- a/alembic/versions/3547bfb4e898_autodiscovery_rule_templates.py
+++ b/alembic/versions/3547bfb4e898_autodiscovery_rule_templates.py
@@ -1,0 +1,37 @@
+"""autodiscovery_rules: var_files + run_task/notification templates (#318)
+
+Lets a rule provision run tasks, notification configs and var files on
+every workspace it materialises, so autodiscovered workspaces are fully
+configured at creation (no second pass). Existing rows default to empty
+lists.
+
+Revision ID: 3547bfb4e898
+Revises: 7dac5695bc0e
+Create Date: 2026-05-18
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "3547bfb4e898"
+down_revision: str | None = "7dac5695bc0e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_EMPTY = sa.text("'[]'::jsonb")
+
+
+def upgrade() -> None:
+    for col in ("var_files", "run_task_templates", "notification_templates"):
+        op.add_column(
+            "autodiscovery_rules",
+            sa.Column(col, JSONB, nullable=False, server_default=_EMPTY),
+        )
+
+
+def downgrade() -> None:
+    for col in ("notification_templates", "run_task_templates", "var_files"):
+        op.drop_column("autodiscovery_rules", col)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1495,6 +1495,83 @@ POST /api/terrapod/v1/autodiscovery-rules/{id}/scan
 
 Runs the same walk as Preview but actually creates the workspaces (idempotent, collision-safe). Force-enables the rule for the duration of the call so an explicit operator action doesn't silently no-op on a disabled rule. New workspaces are seeded with the tracked-branch HEAD as their last-seen commit, so the first real plan+apply fires when the branch next advances (e.g. the PR merge) — not immediately against a branch where the directory doesn't exist yet.
 
+### Rule templating (run tasks / notifications / var files)
+
+`POST`/`PATCH` rule bodies accept three additional attributes that are **materialised onto every workspace the rule creates**, so autodiscovered workspaces are fully configured at creation:
+
+- `var-files` — list of var-file paths.
+- `run-task-templates` — list of run-task specs (same shape as the bulk-update `run-tasks`, below): `{name, url, hmac-key?, stage, enforcement-level?, enabled?}`.
+- `notification-templates` — list of notification specs: `{name, destination-type, url?, token?, triggers?, email-addresses?, enabled?}`.
+
+These use the **identical spec shape** as the bulk-update endpoint, so a run task defined once can be applied to existing workspaces (bulk-update) *and* auto-applied to future ones (this template).
+
+---
+
+## Bulk Workspace Operations
+
+Terrapod-native, **admin only**. Server-side selection + atomic fleet updates (#318).
+
+### Search
+
+```
+POST /api/terrapod/v1/workspaces/actions/search
+```
+
+Resolve a structured filter to the matching workspaces — no side effects (the discovery half of the bulk workflow).
+
+```json
+{ "filter": {
+    "labels": {"team": "foundations"},
+    "name-prefix": "terrapod-testing-",
+    "execution-backend": "terraform",
+    "agent-pool-id": "apool-...", "vcs-connection-id": "vcs-...",
+    "owner-email": "...", "drift-status": "...", "locked": false, "has-vcs": true,
+    "workspace-ids": ["ws-..."],
+    "all": false } }
+```
+
+Dimensions are **AND-combined** (narrower = safer). An empty/omitted `filter` is a `422` (typo guard); matching the whole fleet requires explicit `"all": true`. Returns `{matched, workspaces:[...]}`.
+
+### Bulk Update
+
+```
+POST /api/terrapod/v1/workspaces/actions/bulk-update
+```
+
+Apply `update` to every workspace matching `filter`, in a **single all-or-nothing transaction**.
+
+```json
+{ "filter": { "labels": {"team": "foundations"} },
+  "update": {
+    "terraform-version": "1.12",
+    "execution-backend": "tofu",
+    "auto-apply": false,
+    "agent-pool-id": "apool-...",
+    "resource-cpu": "1", "resource-memory": "2Gi",
+    "var-files": ["envs/prod.tfvars"],
+    "labels": {"reviewed": "2026-q2"},
+    "run-tasks": [
+      { "name": "opa-policy-check", "url": "http://opa:8080/webhook",
+        "hmac-key": "secret", "stage": "post_plan", "enforcement-level": "mandatory" }
+    ],
+    "notification-configurations": [
+      { "name": "slack-prod", "destination-type": "slack",
+        "url": "https://hooks.slack.com/...", "triggers": ["run:errored"] }
+    ]
+  },
+  "dry_run": true }
+```
+
+Semantics:
+
+- **Validated once up front** — field enums, `labels` reserved-key check, run-task/notification specs, and `agent-pool-id` existence + caller pool-`write` RBAC. Any error ⇒ `422`, **zero mutation**.
+- `run-tasks` / `notification-configurations` **upsert by `(workspace, name)`**: created if absent, updated in place if present (so re-running with a changed `url` rotates it across the fleet).
+- **All-or-nothing**: the whole batch commits or nothing does. `dry_run` (default `true`, not enforced) runs the identical code path and rolls back — the preview is exactly what apply would do, with provably zero side effects.
+- **Triggers no runs** — pure config write; the change lands on each workspace's next normal run. Reversible (it only writes settings rows).
+- Per-workspace audit entries.
+
+Response: dry-run `{dry_run:true, matched, would_change:[{id,name,diff}], unchanged}`; apply `{dry_run:false, matched, applied, changes, unchanged, errors:[]}`; any failure ⇒ `409`/`422` and **nothing applied**.
+
 ---
 
 ## VCS Events (Webhooks)

--- a/docs/autodiscovery.md
+++ b/docs/autodiscovery.md
@@ -60,6 +60,9 @@ Rules are scoped to a single VCS connection + repo. A rule has:
 | `auto-apply` | bool | no | Default `false`. |
 | `labels` | map | no | Inherited by created workspaces — feeds Terrapod's label-based RBAC and filtering. Reserved keys (`status`, `pool`, `mode`, `backend`, `owner`, `drift`, `version`, `vcs`, `locked`, `branch`) are rejected with `422` at rule create/update — they are virtual filter terms and would otherwise produce workspaces that can't be saved. |
 | `owner-email` | string | no | Inherited by created workspaces; if unset, created workspaces have no owner and label-RBAC alone determines access. |
+| `var-files` | list | no | Var-file paths set on every created workspace. |
+| `run-task-templates` | list | no | Run-task specs (`{name, url, hmac-key?, stage, enforcement-level?, enabled?}`) materialised onto every created workspace — same shape as the bulk-update `run-tasks`. Define a policy gate once; it auto-applies to all future workspaces (#318). |
+| `notification-templates` | list | no | Notification specs (`{name, destination-type, url?, token?, triggers?, email-addresses?, enabled?}`) materialised onto every created workspace. |
 
 ## Pattern syntax
 
@@ -95,6 +98,7 @@ name-template: "ws-{root}"         →  ws-accounts-alpha-network  ({root} prese
 
 A workspace created by a rule:
 - Inherits all template fields above.
+- Has its `var-files`, plus a `run-task` / `notification-configuration` for each entry in the rule's `run-task-templates` / `notification-templates`, materialised at creation — so the workspace is fully configured with no second pass (#318).
 - Has `vcs-connection-id`, `vcs-repo-url`, `vcs-branch` set from the rule.
 - Has `working-directory` set to the matched file's parent.
 - Has `trigger-prefixes` set to `[working_directory]` so subsequent PRs that touch the same dir route to the same workspace via the regular PR-scan path (not via re-running autodiscovery).

--- a/provider/internal/resources/autodiscovery_rule/resource.go
+++ b/provider/internal/resources/autodiscovery_rule/resource.go
@@ -29,6 +29,16 @@
 //	"auto-apply"         -> auto_apply          (bool, optional, default false)
 //	"labels"             -> labels              (map[string]string, optional)
 //	"owner-email"        -> owner_email         (string, optional)
+//	"var-files"          -> var_files           (list of strings, optional)
+//	"run-task-templates" -> run_task_templates  (list of objects, optional)
+//	    each: name (string, req), url (string, req), hmac-key (string, opt),
+//	          stage (string, req), enforcement-level (string, opt),
+//	          enabled (bool, opt)
+//	"notification-templates" -> notification_templates (list of objects, optional)
+//	    each: name (string, req), destination-type (string, req),
+//	          url (string, opt), token (string, opt),
+//	          triggers (list of strings, opt),
+//	          email-addresses (list of strings, opt), enabled (bool, opt)
 //
 // Read-only:
 //
@@ -40,8 +50,10 @@ package autodiscovery_rule
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -84,8 +96,35 @@ type autodiscoveryRuleModel struct {
 	Labels           types.Map    `tfsdk:"labels"`
 	OwnerEmail       types.String `tfsdk:"owner_email"`
 
+	VarFiles              types.List `tfsdk:"var_files"`
+	RunTaskTemplates      types.List `tfsdk:"run_task_templates"`
+	NotificationTemplates types.List `tfsdk:"notification_templates"`
+
 	CreatedAt types.String `tfsdk:"created_at"`
 	UpdatedAt types.String `tfsdk:"updated_at"`
+}
+
+// runTaskTemplateAttrTypes is the object attribute type map for a single
+// element of run_task_templates. Used for nested list (un)marshalling.
+var runTaskTemplateAttrTypes = map[string]attr.Type{
+	"name":              types.StringType,
+	"url":               types.StringType,
+	"hmac_key":          types.StringType,
+	"stage":             types.StringType,
+	"enforcement_level": types.StringType,
+	"enabled":           types.BoolType,
+}
+
+// notificationTemplateAttrTypes is the object attribute type map for a
+// single element of notification_templates.
+var notificationTemplateAttrTypes = map[string]attr.Type{
+	"name":             types.StringType,
+	"destination_type": types.StringType,
+	"url":              types.StringType,
+	"token":            types.StringType,
+	"triggers":         types.ListType{ElemType: types.StringType},
+	"email_addresses":  types.ListType{ElemType: types.StringType},
+	"enabled":          types.BoolType,
 }
 
 type autodiscoveryRuleResource struct {
@@ -222,6 +261,84 @@ func (r *autodiscoveryRuleResource) Schema(_ context.Context, _ resource.SchemaR
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString(""),
+			},
+
+			"var_files": schema.ListAttribute{
+				Description: "List of .tfvars file paths inherited by created workspaces as -var-file arguments.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"run_task_templates": schema.ListNestedAttribute{
+				Description: "Run task definitions auto-applied to workspaces created by this rule.",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "Run task name.",
+							Required:    true,
+						},
+						"url": schema.StringAttribute{
+							Description: "Run task webhook URL.",
+							Required:    true,
+						},
+						"hmac_key": schema.StringAttribute{
+							Description: "Optional HMAC signing key for the run task webhook.",
+							Optional:    true,
+							Sensitive:   true,
+						},
+						"stage": schema.StringAttribute{
+							Description: "Run stage the task runs at (e.g. pre_plan, post_plan, pre_apply).",
+							Required:    true,
+						},
+						"enforcement_level": schema.StringAttribute{
+							Description: "Enforcement level: mandatory or advisory. Defaults to mandatory.",
+							Optional:    true,
+						},
+						"enabled": schema.BoolAttribute{
+							Description: "Whether the run task is enabled. Defaults to true.",
+							Optional:    true,
+						},
+					},
+				},
+			},
+			"notification_templates": schema.ListNestedAttribute{
+				Description: "Notification configurations auto-applied to workspaces created by this rule.",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "Notification name.",
+							Required:    true,
+						},
+						"destination_type": schema.StringAttribute{
+							Description: "Destination type: generic, slack, or email.",
+							Required:    true,
+						},
+						"url": schema.StringAttribute{
+							Description: "Webhook URL (for generic/slack destination types).",
+							Optional:    true,
+						},
+						"token": schema.StringAttribute{
+							Description: "Optional HMAC or auth token.",
+							Optional:    true,
+							Sensitive:   true,
+						},
+						"triggers": schema.ListAttribute{
+							Description: "Run event triggers.",
+							Optional:    true,
+							ElementType: types.StringType,
+						},
+						"email_addresses": schema.ListAttribute{
+							Description: "Email addresses (for the email destination type).",
+							Optional:    true,
+							ElementType: types.StringType,
+						},
+						"enabled": schema.BoolAttribute{
+							Description: "Whether the notification is enabled. Defaults to true.",
+							Optional:    true,
+						},
+					},
+				},
 			},
 
 			// Read-only
@@ -435,7 +552,89 @@ func buildAutodiscoveryRuleAttrs(m *autodiscoveryRuleModel) map[string]any {
 		attrs["owner-email"] = m.OwnerEmail.ValueString()
 	}
 
+	// Optional templating fields (#318): omit entirely when unset so a
+	// rule without them is left unchanged on the server.
+	if !m.VarFiles.IsNull() && !m.VarFiles.IsUnknown() {
+		varFiles := make([]string, 0, len(m.VarFiles.Elements()))
+		for _, v := range m.VarFiles.Elements() {
+			varFiles = append(varFiles, v.(types.String).ValueString())
+		}
+		attrs["var-files"] = varFiles
+	}
+
+	if !m.RunTaskTemplates.IsNull() && !m.RunTaskTemplates.IsUnknown() {
+		tasks := make([]map[string]any, 0, len(m.RunTaskTemplates.Elements()))
+		for _, e := range m.RunTaskTemplates.Elements() {
+			obj := e.(types.Object)
+			a := obj.Attributes()
+			task := map[string]any{
+				"name":  objStr(a, "name"),
+				"url":   objStr(a, "url"),
+				"stage": objStr(a, "stage"),
+			}
+			// Server validators read the hyphenated input keys.
+			if s, ok := a["hmac_key"].(types.String); ok && !s.IsNull() && !s.IsUnknown() {
+				task["hmac-key"] = s.ValueString()
+			}
+			if s, ok := a["enforcement_level"].(types.String); ok && !s.IsNull() && !s.IsUnknown() && s.ValueString() != "" {
+				task["enforcement-level"] = s.ValueString()
+			}
+			if b, ok := a["enabled"].(types.Bool); ok && !b.IsNull() && !b.IsUnknown() {
+				task["enabled"] = b.ValueBool()
+			}
+			tasks = append(tasks, task)
+		}
+		attrs["run-task-templates"] = tasks
+	}
+
+	if !m.NotificationTemplates.IsNull() && !m.NotificationTemplates.IsUnknown() {
+		notifs := make([]map[string]any, 0, len(m.NotificationTemplates.Elements()))
+		for _, e := range m.NotificationTemplates.Elements() {
+			obj := e.(types.Object)
+			a := obj.Attributes()
+			notif := map[string]any{
+				"name":             objStr(a, "name"),
+				"destination-type": objStr(a, "destination_type"),
+			}
+			if s, ok := a["url"].(types.String); ok && !s.IsNull() && !s.IsUnknown() {
+				notif["url"] = s.ValueString()
+			}
+			if s, ok := a["token"].(types.String); ok && !s.IsNull() && !s.IsUnknown() {
+				notif["token"] = s.ValueString()
+			}
+			if l, ok := a["triggers"].(types.List); ok && !l.IsNull() && !l.IsUnknown() {
+				notif["triggers"] = objStrList(l)
+			}
+			if l, ok := a["email_addresses"].(types.List); ok && !l.IsNull() && !l.IsUnknown() {
+				notif["email-addresses"] = objStrList(l)
+			}
+			if b, ok := a["enabled"].(types.Bool); ok && !b.IsNull() && !b.IsUnknown() {
+				notif["enabled"] = b.ValueBool()
+			}
+			notifs = append(notifs, notif)
+		}
+		attrs["notification-templates"] = notifs
+	}
+
 	return attrs
+}
+
+// objStr reads a required string field out of a nested object's attribute
+// map, returning "" if absent/null.
+func objStr(a map[string]attr.Value, key string) string {
+	if s, ok := a[key].(types.String); ok && !s.IsNull() && !s.IsUnknown() {
+		return s.ValueString()
+	}
+	return ""
+}
+
+// objStrList flattens a types.List of strings into a []string.
+func objStrList(l types.List) []string {
+	out := make([]string, 0, len(l.Elements()))
+	for _, v := range l.Elements() {
+		out = append(out, v.(types.String).ValueString())
+	}
+	return out
 }
 
 // readAutodiscoveryRuleIntoModel maps a JSON:API resource into the
@@ -478,8 +677,132 @@ func readAutodiscoveryRuleIntoModel(ctx context.Context, res *client.Resource, m
 	m.Labels = mv
 
 	m.OwnerEmail = types.StringValue(client.GetStringAttr(res, "owner-email"))
+
+	// Optional templating fields (#318). Tolerate missing/empty: an
+	// absent attribute leaves the model field null so a rule that never
+	// set them produces no spurious diff.
+	if varFiles := client.GetListAttr(res, "var-files"); len(varFiles) > 0 {
+		v, d := types.ListValueFrom(ctx, types.StringType, varFiles)
+		diags.Append(d...)
+		m.VarFiles = v
+	} else {
+		m.VarFiles = types.ListNull(types.StringType)
+	}
+
+	rtObjType := types.ObjectType{AttrTypes: runTaskTemplateAttrTypes}
+	if rawTasks := parseRawObjectList(res, "run-task-templates"); len(rawTasks) > 0 {
+		elems := make([]attr.Value, 0, len(rawTasks))
+		for _, t := range rawTasks {
+			ov, d := types.ObjectValue(runTaskTemplateAttrTypes, map[string]attr.Value{
+				"name":              rawStr(t, "name"),
+				"url":               rawStr(t, "url"),
+				"hmac_key":          rawStr(t, "hmac_key", "hmac-key"),
+				"stage":             rawStr(t, "stage"),
+				"enforcement_level": rawStr(t, "enforcement_level", "enforcement-level"),
+				"enabled":           rawBool(t, "enabled"),
+			})
+			diags.Append(d...)
+			elems = append(elems, ov)
+		}
+		lv, d := types.ListValue(rtObjType, elems)
+		diags.Append(d...)
+		m.RunTaskTemplates = lv
+	} else {
+		m.RunTaskTemplates = types.ListNull(rtObjType)
+	}
+
+	ntObjType := types.ObjectType{AttrTypes: notificationTemplateAttrTypes}
+	if rawNotifs := parseRawObjectList(res, "notification-templates"); len(rawNotifs) > 0 {
+		elems := make([]attr.Value, 0, len(rawNotifs))
+		for _, n := range rawNotifs {
+			trig, dt := rawStrList(ctx, n, "triggers")
+			diags.Append(dt...)
+			emails, de := rawStrList(ctx, n, "email_addresses", "email-addresses")
+			diags.Append(de...)
+			ov, d := types.ObjectValue(notificationTemplateAttrTypes, map[string]attr.Value{
+				"name":             rawStr(n, "name"),
+				"destination_type": rawStr(n, "destination_type", "destination-type"),
+				"url":              rawStr(n, "url"),
+				"token":            rawStr(n, "token"),
+				"triggers":         trig,
+				"email_addresses":  emails,
+				"enabled":          rawBool(n, "enabled"),
+			})
+			diags.Append(d...)
+			elems = append(elems, ov)
+		}
+		lv, d := types.ListValue(ntObjType, elems)
+		diags.Append(d...)
+		m.NotificationTemplates = lv
+	} else {
+		m.NotificationTemplates = types.ListNull(ntObjType)
+	}
+
 	m.CreatedAt = types.StringValue(client.GetStringAttr(res, "created-at"))
 	m.UpdatedAt = types.StringValue(client.GetStringAttr(res, "updated-at"))
 
 	return diags
+}
+
+// parseRawObjectList decodes a JSON:API attribute that is a list of
+// objects into a slice of generic maps. Returns nil on missing/empty/
+// non-list so callers can null the model field.
+func parseRawObjectList(res *client.Resource, key string) []map[string]any {
+	raw, ok := res.Attributes[key]
+	if !ok || len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// rawStr reads the first present string key from a decoded object,
+// returning a null types.String if none of the keys are present or the
+// value is not a string.
+func rawStr(m map[string]any, keys ...string) types.String {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			if s, ok := v.(string); ok {
+				return types.StringValue(s)
+			}
+		}
+	}
+	return types.StringNull()
+}
+
+// rawBool reads a bool key from a decoded object, returning a null
+// types.Bool if absent or not a bool.
+func rawBool(m map[string]any, key string) types.Bool {
+	if v, ok := m[key]; ok && v != nil {
+		if b, ok := v.(bool); ok {
+			return types.BoolValue(b)
+		}
+	}
+	return types.BoolNull()
+}
+
+// rawStrList reads the first present list-of-strings key from a decoded
+// object into a types.List. Absent/empty yields a null list.
+func rawStrList(ctx context.Context, m map[string]any, keys ...string) (types.List, diag.Diagnostics) {
+	for _, k := range keys {
+		v, ok := m[k]
+		if !ok || v == nil {
+			continue
+		}
+		arr, ok := v.([]any)
+		if !ok || len(arr) == 0 {
+			continue
+		}
+		strs := make([]string, 0, len(arr))
+		for _, e := range arr {
+			if s, ok := e.(string); ok {
+				strs = append(strs, s)
+			}
+		}
+		return types.ListValueFrom(ctx, types.StringType, strs)
+	}
+	return types.ListNull(types.StringType), nil
 }

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -667,6 +667,12 @@ def create_application() -> FastAPI:
 
     app.include_router(autodiscovery_rules_router, prefix=TERRAPOD_PREFIX)
 
+    # Bulk workspace operations — Terrapod-native admin (#318): search +
+    # all-or-nothing bulk-update of fields/run-tasks/notifications.
+    from terrapod.api.routers.workspace_bulk import router as workspace_bulk_router
+
+    app.include_router(workspace_bulk_router, prefix=TERRAPOD_PREFIX)
+
     # VCS webhook event receiver — Terrapod-specific.
     from terrapod.api.routers.vcs_events import router as vcs_events_router
 

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -33,6 +33,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, require_admin
 from terrapod.api.labels import validate_labels
+from terrapod.api.routers.workspace_bulk import (
+    validate_notification_specs,
+    validate_run_task_specs,
+)
 from terrapod.db.models import AgentPool, AutodiscoveryRule, VCSConnection
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -73,6 +77,9 @@ def _rule_json(rule: AutodiscoveryRule) -> dict:
             "auto-apply": rule.auto_apply,
             "labels": dict(rule.labels or {}),
             "owner-email": rule.owner_email or "",
+            "var-files": list(rule.var_files or []),
+            "run-task-templates": list(rule.run_task_templates or []),
+            "notification-templates": list(rule.notification_templates or []),
             "created-at": _rfc3339(rule.created_at),
             "updated-at": _rfc3339(rule.updated_at),
         },
@@ -217,6 +224,18 @@ def _coerce_attrs(attrs: dict, *, on_create: bool) -> dict[str, Any]:
         out["labels"] = validate_labels(attrs["labels"])
     if "owner-email" in attrs:
         out["owner_email"] = (str(attrs["owner-email"]) or "").strip() or None
+    if "var-files" in attrs:
+        vf = attrs["var-files"]
+        if not isinstance(vf, list):
+            raise HTTPException(status_code=422, detail="var-files must be a list")
+        out["var_files"] = [str(x) for x in vf]
+    # Run-task / notification templates use the SAME spec shape the
+    # bulk-update endpoint accepts (#318) — define the hook once, drive
+    # both "apply to existing" (bulk) and "auto-apply to future" (here).
+    if "run-task-templates" in attrs:
+        out["run_task_templates"] = validate_run_task_specs(attrs["run-task-templates"])
+    if "notification-templates" in attrs:
+        out["notification_templates"] = validate_notification_specs(attrs["notification-templates"])
 
     return out
 

--- a/services/terrapod/api/routers/workspace_bulk.py
+++ b/services/terrapod/api/routers/workspace_bulk.py
@@ -1,0 +1,419 @@
+"""Bulk workspace operations (#318) — Terrapod-native admin surface.
+
+Two endpoints:
+  POST /api/terrapod/v1/workspaces/actions/search
+       — server-side workspace selection (the canonical structured filter).
+  POST /api/terrapod/v1/workspaces/actions/bulk-update
+       — apply a settings/run-task/notification change across every
+         matched workspace in a single all-or-nothing transaction.
+
+Hard guarantees:
+  * Validation happens ONCE up front — an invalid `update` returns 422
+    with zero mutation.
+  * All-or-nothing: the whole batch commits, or nothing does. `dry_run`
+    runs the exact same code path and `rollback()`s instead of
+    `commit()`, so the preview is provably what apply would do.
+  * Bulk-update triggers NO runs — it is a pure config write; the change
+    lands on each workspace's next normal run.
+  * Reversible by construction (it only writes settings rows); operators
+    are trusted to choose the match set (explicit `all: true` allowed).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.api.dependencies import AuthenticatedUser, require_admin
+from terrapod.api.labels import validate_labels
+from terrapod.db.models import (
+    AgentPool,
+    AuditLog,
+    NotificationConfiguration,
+    RunTask,
+    Workspace,
+    generate_uuid7,
+)
+from terrapod.db.session import get_db
+from terrapod.logging_config import get_logger
+from terrapod.services import pool_rbac_service
+from terrapod.services.notification_service import VALID_TRIGGERS
+from terrapod.services.run_task_service import VALID_ENFORCEMENT_LEVELS, VALID_STAGES
+from terrapod.services.workspace_search_service import (
+    WorkspaceFilterError,
+    build_workspace_query,
+    parse_filter,
+)
+
+router = APIRouter(tags=["workspace-bulk"])
+logger = get_logger(__name__)
+
+_VALID_BACKENDS = frozenset({"terraform", "tofu"})
+_VALID_MODES = frozenset({"local", "agent"})
+_VALID_DEST_TYPES = frozenset({"generic", "slack", "email"})
+
+# Workspace column fields the bulk update may set, mapped to their ORM attr.
+_FIELD_MAP: dict[str, str] = {
+    "terraform-version": "terraform_version",
+    "execution-backend": "execution_backend",
+    "execution-mode": "execution_mode",
+    "auto-apply": "auto_apply",
+    "agent-pool-id": "agent_pool_id",
+    "resource-cpu": "resource_cpu",
+    "resource-memory": "resource_memory",
+    "var-files": "var_files",
+    "labels": "labels",
+}
+
+
+def _ws_summary(ws: Workspace) -> dict[str, Any]:
+    return {
+        "id": f"ws-{ws.id}",
+        "name": ws.name,
+        "execution-mode": ws.execution_mode,
+        "execution-backend": ws.execution_backend,
+        "terraform-version": ws.terraform_version,
+        "agent-pool-id": f"apool-{ws.agent_pool_id}" if ws.agent_pool_id else None,
+        "labels": ws.labels or {},
+    }
+
+
+def validate_run_task_specs(items: Any) -> list[dict]:
+    if not isinstance(items, list):
+        raise HTTPException(status_code=422, detail="run-tasks must be a list")
+    out: list[dict] = []
+    for i, it in enumerate(items):
+        if not isinstance(it, dict):
+            raise HTTPException(status_code=422, detail=f"run-tasks[{i}] must be an object")
+        name = str(it.get("name", "")).strip()
+        url = str(it.get("url", "")).strip()
+        if not name:
+            raise HTTPException(status_code=422, detail=f"run-tasks[{i}].name is required")
+        if not url:
+            raise HTTPException(status_code=422, detail=f"run-tasks[{i}].url is required")
+        stage = it.get("stage", "")
+        if stage not in VALID_STAGES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"run-tasks[{i}].stage must be one of: {', '.join(sorted(VALID_STAGES))}",
+            )
+        enf = it.get("enforcement-level", "mandatory")
+        if enf not in VALID_ENFORCEMENT_LEVELS:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"run-tasks[{i}].enforcement-level must be one of: "
+                    f"{', '.join(sorted(VALID_ENFORCEMENT_LEVELS))}"
+                ),
+            )
+        out.append(
+            {
+                "name": name,
+                "url": url,
+                "hmac_key": (it.get("hmac-key") or None),
+                "stage": stage,
+                "enforcement_level": enf,
+                "enabled": bool(it.get("enabled", True)),
+            }
+        )
+    return out
+
+
+def validate_notification_specs(items: Any) -> list[dict]:
+    if not isinstance(items, list):
+        raise HTTPException(status_code=422, detail="notification-configurations must be a list")
+    out: list[dict] = []
+    for i, it in enumerate(items):
+        if not isinstance(it, dict):
+            raise HTTPException(
+                status_code=422,
+                detail=f"notification-configurations[{i}] must be an object",
+            )
+        name = str(it.get("name", "")).strip()
+        if not name:
+            raise HTTPException(
+                status_code=422,
+                detail=f"notification-configurations[{i}].name is required",
+            )
+        dest = it.get("destination-type", "")
+        if dest not in _VALID_DEST_TYPES:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"notification-configurations[{i}].destination-type must be one of: "
+                    f"{', '.join(sorted(_VALID_DEST_TYPES))}"
+                ),
+            )
+        triggers = it.get("triggers", [])
+        if not isinstance(triggers, list):
+            raise HTTPException(
+                status_code=422,
+                detail=f"notification-configurations[{i}].triggers must be a list",
+            )
+        bad = set(triggers) - VALID_TRIGGERS
+        if bad:
+            raise HTTPException(
+                status_code=422,
+                detail=f"notification-configurations[{i}] invalid triggers: {', '.join(sorted(bad))}",
+            )
+        out.append(
+            {
+                "name": name,
+                "destination_type": dest,
+                "url": str(it.get("url", "")),
+                "token": (it.get("token") or None),
+                "triggers": triggers,
+                "email_addresses": it.get("email-addresses", []),
+                "enabled": bool(it.get("enabled", True)),
+            }
+        )
+    return out
+
+
+async def _validate_update(
+    update: dict, db: AsyncSession, user: AuthenticatedUser
+) -> dict[str, Any]:
+    """Validate the homogeneous `update` payload ONCE (it is applied
+    identically to every matched workspace). Raises HTTP 422 with zero
+    mutation on any problem. Returns a normalised plan.
+    """
+    if not isinstance(update, dict) or not update:
+        raise HTTPException(status_code=422, detail="'update' must be a non-empty object")
+
+    fields: dict[str, Any] = {}
+    for key, attr in _FIELD_MAP.items():
+        if key not in update:
+            continue
+        val = update[key]
+        if key == "execution-backend" and val not in _VALID_BACKENDS:
+            raise HTTPException(
+                status_code=422, detail="execution-backend must be 'terraform' or 'tofu'"
+            )
+        if key == "execution-mode" and val not in _VALID_MODES:
+            raise HTTPException(status_code=422, detail="execution-mode must be 'local' or 'agent'")
+        if key == "terraform-version" and not str(val).strip():
+            raise HTTPException(status_code=422, detail="terraform-version cannot be empty")
+        if key == "labels":
+            val = validate_labels(val)  # reserved-key chokepoint (#316) → 422
+        if key == "auto-apply":
+            val = bool(val)
+        if key == "var-files":
+            if not isinstance(val, list):
+                raise HTTPException(status_code=422, detail="var-files must be a list")
+        if key == "agent-pool-id":
+            if val in (None, ""):
+                val = None
+            else:
+                try:
+                    pid = uuid.UUID(str(val).removeprefix("apool-"))
+                except ValueError as e:
+                    raise HTTPException(
+                        status_code=422, detail="agent-pool-id is not a UUID"
+                    ) from e
+                pool = await db.get(AgentPool, pid)
+                if pool is None:
+                    raise HTTPException(status_code=422, detail="agent-pool-id not found")
+                # Assigning a pool requires pool `write` (platform admin bypass) —
+                # mirrors the single-workspace rule.
+                if "admin" not in user.roles:
+                    perm = await pool_rbac_service.resolve_pool_permission(
+                        db, user.email, user.roles, pool.name, pool.labels, pool.owner_email
+                    )
+                    if not pool_rbac_service.has_pool_permission(perm, "write"):
+                        raise HTTPException(
+                            status_code=403,
+                            detail=f"write permission on agent pool '{pool.name}' is required",
+                        )
+                val = pid
+        fields[attr] = val
+
+    run_tasks = validate_run_task_specs(update["run-tasks"]) if "run-tasks" in update else None
+    notifications = (
+        validate_notification_specs(update["notification-configurations"])
+        if "notification-configurations" in update
+        else None
+    )
+
+    if not fields and run_tasks is None and notifications is None:
+        raise HTTPException(
+            status_code=422,
+            detail="'update' had no recognised keys to apply",
+        )
+    return {"fields": fields, "run_tasks": run_tasks, "notifications": notifications}
+
+
+@router.post("/workspaces/actions/search")
+async def search_workspaces(
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Resolve a structured filter to the matching workspaces. Admin only.
+    No side effects — this is the discovery half of the bulk workflow.
+    """
+    try:
+        wf = parse_filter(body.get("filter"))
+        query = build_workspace_query(wf)
+    except WorkspaceFilterError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    rows = (await db.execute(query)).scalars().all()
+    return JSONResponse(
+        content={"matched": len(rows), "workspaces": [_ws_summary(w) for w in rows]}
+    )
+
+
+def _diff_for(ws: Workspace, plan: dict[str, Any]) -> dict[str, Any]:
+    """Compute the per-workspace change set without mutating."""
+    diff: dict[str, Any] = {}
+    for attr, new in plan["fields"].items():
+        old = getattr(ws, attr)
+        if old != new:
+            diff[attr] = {"from": _jsonable(old), "to": _jsonable(new)}
+    if plan["run_tasks"]:
+        diff["run-tasks"] = [rt["name"] for rt in plan["run_tasks"]]
+    if plan["notifications"]:
+        diff["notification-configurations"] = [n["name"] for n in plan["notifications"]]
+    return diff
+
+
+def _jsonable(v: Any) -> Any:
+    return f"apool-{v}" if isinstance(v, uuid.UUID) else v
+
+
+async def _apply(
+    db: AsyncSession,
+    workspaces: list[Workspace],
+    plan: dict[str, Any],
+    actor: str,
+) -> tuple[list[dict], list[dict]]:
+    """Apply the plan to every workspace. Caller owns the transaction
+    (commit for apply, rollback for dry-run). Run-tasks/notifications
+    upsert by (workspace_id, name).
+    """
+    changed: list[dict] = []
+    unchanged: list[dict] = []
+    for ws in workspaces:
+        diff = _diff_for(ws, plan)
+
+        for attr, new in plan["fields"].items():
+            setattr(ws, attr, new)
+
+        for spec in plan["run_tasks"] or []:
+            existing = (
+                await db.execute(
+                    select(RunTask).where(
+                        RunTask.workspace_id == ws.id, RunTask.name == spec["name"]
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing is None:
+                db.add(RunTask(workspace_id=ws.id, **spec))
+            else:
+                for k, v in spec.items():
+                    setattr(existing, k, v)
+
+        for spec in plan["notifications"] or []:
+            existing = (
+                await db.execute(
+                    select(NotificationConfiguration).where(
+                        NotificationConfiguration.workspace_id == ws.id,
+                        NotificationConfiguration.name == spec["name"],
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing is None:
+                db.add(NotificationConfiguration(workspace_id=ws.id, **spec))
+            else:
+                for k, v in spec.items():
+                    setattr(existing, k, v)
+
+        if diff:
+            changed.append({"id": f"ws-{ws.id}", "name": ws.name, "diff": diff})
+            # Audit row is added INTO the same transaction (no commit) —
+            # NOT via audit_service.log_audit_event, which commits
+            # internally and would break both the all-or-nothing apply
+            # and the dry-run "rollback, zero side-effects" guarantee.
+            db.add(
+                AuditLog(
+                    id=generate_uuid7(),
+                    actor_email=actor,
+                    action="workspace.bulk_update",
+                    resource_type="workspace",
+                    resource_id=f"ws-{ws.id}",
+                    status_code=200,
+                    detail=f"bulk-update: {sorted(diff.keys())}",
+                )
+            )
+        else:
+            unchanged.append({"id": f"ws-{ws.id}", "name": ws.name})
+    return changed, unchanged
+
+
+@router.post("/workspaces/actions/bulk-update")
+async def bulk_update_workspaces(
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Apply `update` to every workspace matching `filter`, atomically.
+
+    `dry_run` (default true) runs the identical code path and rolls back,
+    so the preview is exactly what an apply would change. Admin only.
+    """
+    dry_run = bool(body.get("dry_run", True))
+    try:
+        wf = parse_filter(body.get("filter"))
+        query = build_workspace_query(wf)
+    except WorkspaceFilterError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    # Up-front validation — 422 here means zero mutation.
+    plan = await _validate_update(body.get("update", {}), db, user)
+
+    workspaces = list((await db.execute(query)).scalars().all())
+
+    try:
+        changed, unchanged = await _apply(db, workspaces, plan, user.email)
+        if dry_run:
+            await db.rollback()
+            return JSONResponse(
+                content={
+                    "dry_run": True,
+                    "matched": len(workspaces),
+                    "would_change": changed,
+                    "unchanged": unchanged,
+                }
+            )
+        await db.commit()
+    except HTTPException:
+        await db.rollback()
+        raise
+    except Exception as e:
+        await db.rollback()
+        logger.warning("bulk-update failed; rolled back", error=repr(e))
+        raise HTTPException(
+            status_code=409,
+            detail=f"bulk-update failed and was rolled back (nothing changed): {e}",
+        ) from e
+
+    logger.info(
+        "bulk-update applied",
+        matched=len(workspaces),
+        changed=len(changed),
+        actor=user.email,
+    )
+    return JSONResponse(
+        content={
+            "dry_run": False,
+            "matched": len(workspaces),
+            "applied": len(changed),
+            "changes": changed,
+            "unchanged": unchanged,
+            "errors": [],
+        }
+    )

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -858,6 +858,15 @@ class AutodiscoveryRule(Base):
     auto_apply: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     labels: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
     owner_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # #318: settings provisioned on every workspace this rule materialises,
+    # so autodiscovered workspaces are fully configured at creation.
+    var_files: Mapped[list[str]] = mapped_column(JSONB, default=list, nullable=False)
+    run_task_templates: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, default=list, nullable=False
+    )
+    notification_templates: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, default=list, nullable=False
+    )
 
     # Set on first successful full-tree scan of the repo. NULL means the
     # rule has never been backfilled — the poll cycle picks rules where

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -36,7 +36,12 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from terrapod.db.models import AutodiscoveryRule, Workspace
+from terrapod.db.models import (
+    AutodiscoveryRule,
+    NotificationConfiguration,
+    RunTask,
+    Workspace,
+)
 from terrapod.logging_config import get_logger
 from terrapod.services.label_validation import sanitize_labels
 
@@ -271,6 +276,7 @@ async def find_or_autocreate_workspace(
         agent_pool_id=rule.agent_pool_id,
         labels=safe_labels,
         owner_email=rule.owner_email or "",
+        var_files=list(rule.var_files or []),
         vcs_connection_id=rule.vcs_connection_id,
         vcs_repo_url=rule.repo_url,
         vcs_branch=rule.branch,
@@ -303,6 +309,15 @@ async def find_or_autocreate_workspace(
             return ws, False
         # Different integrity violation we don't expect — surface it.
         raise exc
+
+    # #318: materialise the rule's run-task / notification templates onto
+    # the new workspace, so it's fully configured at creation (same spec
+    # shape the bulk-update endpoint applies to existing workspaces).
+    for spec in rule.run_task_templates or []:
+        db.add(RunTask(workspace_id=ws.id, **spec))
+    for spec in rule.notification_templates or []:
+        db.add(NotificationConfiguration(workspace_id=ws.id, **spec))
+
     await db.commit()
 
     logger.info(

--- a/services/terrapod/services/workspace_search_service.py
+++ b/services/terrapod/services/workspace_search_service.py
@@ -1,0 +1,174 @@
+"""Server-side workspace search/selection (#318).
+
+The UI's rich filter bar is client-side only (`web/src/lib/workspace-filter.ts`);
+the only pre-existing server-side filtering was the go-tfe cloud-block
+`search[tags]`/`search[name]` on the workspace list. This service is the
+canonical server-side selector: a structured, AND-combined filter that
+backs the bulk-update endpoint (and is reusable by a future UI migration).
+
+Design notes:
+- Dimensions are AND-combined — narrower is safer.
+- An empty/omitted filter is a caller error (`WorkspaceFilterError`), never
+  an implicit match-all. Matching the whole fleet requires explicit
+  `all: true` (operators are trusted to ask for it on purpose).
+- `all: true` short-circuits — other dimensions are ignored.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import Select, select
+
+from terrapod.db.models import Workspace
+
+
+class WorkspaceFilterError(ValueError):
+    """Raised when a filter is empty or structurally invalid. Routers
+    translate this to HTTP 422.
+    """
+
+
+def _strip_uuid(value: str, prefix: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(str(value).removeprefix(prefix))
+    except ValueError as e:
+        raise WorkspaceFilterError(f"{value!r} is not a valid id") from e
+
+
+def _glob_to_like(pattern: str) -> str:
+    """Translate a simple `*`/`?` glob to a SQL LIKE pattern, escaping
+    LIKE metacharacters in the literal portions.
+    """
+    out: list[str] = []
+    for ch in pattern:
+        if ch == "*":
+            out.append("%")
+        elif ch == "?":
+            out.append("_")
+        elif ch in ("%", "_", "\\"):
+            out.append("\\" + ch)
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+class WorkspaceFilter(BaseModel):
+    """Structured workspace selector. All present dimensions are
+    AND-combined unless `all` is true.
+    """
+
+    workspace_ids: list[str] | None = None
+    labels: dict[str, str] | None = None
+    name_prefix: str | None = None
+    name_glob: str | None = None
+    execution_backend: str | None = None
+    execution_mode: str | None = None
+    terraform_version: str | None = None
+    agent_pool_id: str | None = None
+    vcs_connection_id: str | None = None
+    owner_email: str | None = None
+    drift_status: str | None = None
+    locked: bool | None = None
+    has_vcs: bool | None = None
+    all: bool = Field(default=False)
+
+    def _explicit_dimensions(self) -> list[str]:
+        return [
+            k
+            for k in (
+                "workspace_ids",
+                "labels",
+                "name_prefix",
+                "name_glob",
+                "execution_backend",
+                "execution_mode",
+                "terraform_version",
+                "agent_pool_id",
+                "vcs_connection_id",
+                "owner_email",
+                "drift_status",
+                "locked",
+                "has_vcs",
+            )
+            if getattr(self, k) not in (None, [], {})
+        ]
+
+
+def build_workspace_query(f: WorkspaceFilter) -> Select[tuple[Workspace]]:
+    """Build the workspace SELECT for a filter.
+
+    Raises `WorkspaceFilterError` (→ HTTP 422) if the filter neither sets
+    `all: true` nor provides at least one dimension — this is the only
+    blast-radius guard: it stops a typo'd/empty filter from silently
+    matching the whole fleet, while still letting an operator who means
+    it pass `all: true`.
+    """
+    q: Select[tuple[Workspace]] = select(Workspace).order_by(Workspace.name)
+
+    if f.all:
+        return q
+
+    dims = f._explicit_dimensions()
+    if not dims:
+        raise WorkspaceFilterError(
+            "filter must set at least one selector, or 'all': true to match every workspace"
+        )
+
+    if f.workspace_ids is not None:
+        ids = [_strip_uuid(w, "ws-") for w in f.workspace_ids]
+        q = q.where(Workspace.id.in_(ids))
+    if f.labels:
+        for k, v in f.labels.items():
+            q = q.where(Workspace.labels.contains({k: v}))
+    if f.name_prefix:
+        q = q.where(Workspace.name.ilike(_glob_to_like(f.name_prefix) + "%", escape="\\"))
+    if f.name_glob:
+        q = q.where(Workspace.name.ilike(_glob_to_like(f.name_glob), escape="\\"))
+    if f.execution_backend is not None:
+        q = q.where(Workspace.execution_backend == f.execution_backend)
+    if f.execution_mode is not None:
+        q = q.where(Workspace.execution_mode == f.execution_mode)
+    if f.terraform_version is not None:
+        q = q.where(Workspace.terraform_version == f.terraform_version)
+    if f.agent_pool_id is not None:
+        q = q.where(Workspace.agent_pool_id == _strip_uuid(f.agent_pool_id, "apool-"))
+    if f.vcs_connection_id is not None:
+        q = q.where(Workspace.vcs_connection_id == _strip_uuid(f.vcs_connection_id, "vcs-"))
+    if f.owner_email is not None:
+        q = q.where(Workspace.owner_email == f.owner_email)
+    if f.drift_status is not None:
+        q = q.where(Workspace.drift_status == f.drift_status)
+    if f.locked is not None:
+        q = q.where(Workspace.locked.is_(f.locked))
+    if f.has_vcs is not None:
+        if f.has_vcs:
+            q = q.where(Workspace.vcs_connection_id.is_not(None))
+        else:
+            q = q.where(Workspace.vcs_connection_id.is_(None))
+
+    return q
+
+
+def parse_filter(raw: dict[str, Any] | None) -> WorkspaceFilter:
+    """Parse a JSON:API-ish filter dict (hyphenated keys accepted) into a
+    `WorkspaceFilter`. Unknown keys are rejected so a typo'd selector
+    can't silently widen the match.
+    """
+    if not raw or not isinstance(raw, dict):
+        raise WorkspaceFilterError(
+            "a non-empty 'filter' is required (use 'all': true to match all)"
+        )
+    norm = {k.replace("-", "_"): v for k, v in raw.items()}
+    allowed = set(WorkspaceFilter.model_fields)
+    unknown = set(norm) - allowed
+    if unknown:
+        raise WorkspaceFilterError(f"unknown filter key(s): {', '.join(sorted(unknown))}")
+    try:
+        return WorkspaceFilter(**norm)
+    except WorkspaceFilterError:
+        raise
+    except Exception as e:  # pydantic validation
+        raise WorkspaceFilterError(str(e)) from e

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -700,3 +700,146 @@ class TestWalkRepoErrorBranches:
             )
         assert resp.status_code == 502
         assert "default branch" in resp.json()["detail"]
+
+
+# ── #318: run-task / notification / var-file templates ───────────────────
+
+
+class TestRuleTemplates318:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_201_with_templates_echoed_back(self, *_mocks):
+        """#318: a rule can carry run-task / notification / var-file
+        templates; `_rule_json` round-trips them in the create response."""
+        conn_id = uuid.uuid4()
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(side_effect=[MagicMock(id=conn_id)])
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        body = {
+            "data": {
+                "type": "autodiscovery-rules",
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{conn_id}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "var-files": ["common.tfvars", "env/prod.tfvars"],
+                    "run-task-templates": [
+                        {
+                            "name": "policy-scan",
+                            "url": "https://scanner.example.com/hook",
+                            "stage": "pre_plan",
+                            "enforcement-level": "mandatory",
+                        }
+                    ],
+                    "notification-templates": [
+                        {
+                            "name": "slack-alerts",
+                            "destination-type": "slack",
+                            "url": "https://hooks.slack.com/x",
+                            "triggers": ["run:errored"],
+                        }
+                    ],
+                },
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 201, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["var-files"] == ["common.tfvars", "env/prod.tfvars"]
+        assert len(attrs["run-task-templates"]) == 1
+        rt = attrs["run-task-templates"][0]
+        assert rt["name"] == "policy-scan"
+        assert rt["url"] == "https://scanner.example.com/hook"
+        assert rt["stage"] == "pre_plan"
+        assert rt["enforcement_level"] == "mandatory"
+        assert len(attrs["notification-templates"]) == 1
+        nt = attrs["notification-templates"][0]
+        assert nt["name"] == "slack-alerts"
+        assert nt["destination_type"] == "slack"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_invalid_run_task_template_bad_stage(self, *_mocks):
+        """A run-task template with an unknown stage is rejected at rule
+        create time (same `validate_run_task_specs` chokepoint as bulk)."""
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "run-task-templates": [
+                        {
+                            "name": "scan",
+                            "url": "https://x",
+                            "stage": "post_apply",
+                        }
+                    ],
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "stage" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_invalid_notification_template_bad_destination(self, *_mocks):
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "notification-templates": [{"name": "n1", "destination-type": "smoke-signal"}],
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "destination-type" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_reserved_label_key_still_rejected_with_templates(self, *_mocks):
+        """#316 guard is unaffected by the #318 template additions — a
+        reserved label key is still a 422 even when templates are present.
+        """
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "labels": {"owner": "foundations"},
+                    "var-files": ["common.tfvars"],
+                    "run-task-templates": [
+                        {"name": "scan", "url": "https://x", "stage": "pre_plan"}
+                    ],
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "owner" in resp.json()["detail"]

--- a/services/tests/api/test_workspace_bulk.py
+++ b/services/tests/api/test_workspace_bulk.py
@@ -1,0 +1,643 @@
+"""Tests for the bulk workspace operations router (#318, admin-only).
+
+Covers `POST /api/terrapod/v1/workspaces/actions/search` and
+`POST /api/terrapod/v1/workspaces/actions/bulk-update`, including the
+zero-mutation validation contract, the dry-run/apply transaction
+guarantee, run-task upsert, failure rollback, and pool RBAC.
+
+Harness mirrors `test_vcs_connections.py` / `test_autodiscovery_rules.py`.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, require_admin
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+def _admin():
+    return AuthenticatedUser(
+        email="admin@example.com",
+        display_name="Admin",
+        roles=["admin"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _non_admin():
+    """Passes the `require_admin` override (tests inject it) but carries
+    no `admin` role, so the in-handler pool-write check actually runs."""
+    return AuthenticatedUser(
+        email="dev@example.com",
+        display_name="Dev",
+        roles=["everyone"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _make_app(user, mock_db=None):
+    app = create_app()
+    app.dependency_overrides[require_admin] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app, mock_db
+
+
+def _mock_ws(
+    ws_id=None,
+    name="prod-net",
+    execution_mode="agent",
+    execution_backend="tofu",
+    terraform_version="1.12",
+    agent_pool_id=None,
+    labels=None,
+    auto_apply=False,
+    var_files=None,
+):
+    w = MagicMock()
+    w.id = ws_id or uuid.uuid4()
+    w.name = name
+    w.execution_mode = execution_mode
+    w.execution_backend = execution_backend
+    w.terraform_version = terraform_version
+    w.agent_pool_id = agent_pool_id
+    w.labels = labels if labels is not None else {}
+    w.auto_apply = auto_apply
+    w.var_files = var_files if var_files is not None else []
+    return w
+
+
+def _list_result(values):
+    """A SQLAlchemy result-like whose scalars().all() returns `values`."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = values
+    return result
+
+
+def _scalar_result(value):
+    """A SQLAlchemy result-like whose scalar_one_or_none() returns `value`."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+# ── search ───────────────────────────────────────────────────────────────
+
+
+class TestSearch:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_matched_list_shape(self, *_mocks):
+        wss = [_mock_ws(name="a"), _mock_ws(name="b")]
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_list_result(wss))
+
+        body = {"filter": {"execution-backend": "tofu"}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/search", json=body, headers=_AUTH
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["matched"] == 2
+        assert {w["name"] for w in data["workspaces"]} == {"a", "b"}
+        first = data["workspaces"][0]
+        assert first["id"].startswith("ws-")
+        assert "execution-backend" in first
+        assert "labels" in first
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_empty_filter_422(self, *_mocks):
+        app, _db = _make_app(_admin())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/search", json={}, headers=_AUTH
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_no_dimensions_422(self, *_mocks):
+        app, _db = _make_app(_admin())
+        body = {"filter": {}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/search", json=body, headers=_AUTH
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_all_true_returns_everything(self, *_mocks):
+        wss = [_mock_ws(name="a")]
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_list_result(wss))
+        body = {"filter": {"all": True}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/search", json=body, headers=_AUTH
+            )
+        assert resp.status_code == 200
+        assert resp.json()["matched"] == 1
+
+
+# ── bulk-update: validation (zero mutation) ──────────────────────────────
+
+
+class TestBulkUpdateValidation:
+    async def _post(self, body, db_setup=None, user=None):
+        app, db = _make_app(user or _admin())
+        db.execute = AsyncMock(return_value=_list_result([]))
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+        if db_setup:
+            db_setup(db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        return resp, db
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_bad_execution_backend_422_no_commit(self, *_mocks):
+        body = {
+            "filter": {"all": True},
+            "update": {"execution-backend": "puppet"},
+        }
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        assert "execution-backend" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_bad_execution_mode_422(self, *_mocks):
+        body = {"filter": {"all": True}, "update": {"execution-mode": "remote"}}
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_reserved_label_key_422(self, *_mocks):
+        """#316 chokepoint: a reserved label key in update.labels is
+        rejected before any mutation."""
+        body = {
+            "filter": {"all": True},
+            "update": {"labels": {"owner": "x", "team": "y"}},
+        }
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        assert "owner" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_run_task_missing_url_422(self, *_mocks):
+        body = {
+            "filter": {"all": True},
+            "update": {
+                "run-tasks": [{"name": "scan", "stage": "pre_plan"}],
+            },
+        }
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        assert "url is required" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_run_task_bad_stage_422(self, *_mocks):
+        body = {
+            "filter": {"all": True},
+            "update": {
+                "run-tasks": [{"name": "scan", "url": "https://x", "stage": "post_apply"}],
+            },
+        }
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        assert "stage" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_run_task_bad_enforcement_422(self, *_mocks):
+        body = {
+            "filter": {"all": True},
+            "update": {
+                "run-tasks": [
+                    {
+                        "name": "scan",
+                        "url": "https://x",
+                        "stage": "pre_plan",
+                        "enforcement-level": "blocking",
+                    }
+                ],
+            },
+        }
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        assert "enforcement-level" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_notification_bad_destination_type_422(self, *_mocks):
+        body = {
+            "filter": {"all": True},
+            "update": {
+                "notification-configurations": [
+                    {"name": "n1", "destination-type": "carrier-pigeon"}
+                ],
+            },
+        }
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        assert "destination-type" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_notification_bad_trigger_422(self, *_mocks):
+        body = {
+            "filter": {"all": True},
+            "update": {
+                "notification-configurations": [
+                    {
+                        "name": "n1",
+                        "destination-type": "slack",
+                        "triggers": ["run:exploded"],
+                    }
+                ],
+            },
+        }
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        assert "invalid triggers" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_empty_update_422(self, *_mocks):
+        body = {"filter": {"all": True}, "update": {}}
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_update_with_no_recognised_keys_422(self, *_mocks):
+        body = {"filter": {"all": True}, "update": {"not-a-field": 1}}
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        assert "no recognised keys" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_unknown_filter_422(self, *_mocks):
+        body = {
+            "filter": {"bogus-selector": "x"},
+            "update": {"execution-backend": "tofu"},
+        }
+        resp, db = await self._post(body)
+        assert resp.status_code == 422
+        db.commit.assert_not_awaited()
+
+
+# ── bulk-update: dry-run ─────────────────────────────────────────────────
+
+
+class TestBulkUpdateDryRun:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_dry_run_default_rolls_back(self, _db, _redis, _storage):
+        """`dry_run` defaults to true: the diff is computed, rollback is
+        called, commit is NOT — the no-side-effect guarantee. Audit rows
+        are added into the same transaction (no internal commit), so they
+        roll back too; nothing persists."""
+        ws = _mock_ws(name="w1", execution_backend="terraform")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_list_result([ws]))
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+
+        body = {"filter": {"all": True}, "update": {"execution-backend": "tofu"}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["dry_run"] is True
+        assert data["matched"] == 1
+        assert len(data["would_change"]) == 1
+        diff = data["would_change"][0]["diff"]
+        assert diff["execution_backend"] == {"from": "terraform", "to": "tofu"}
+        db.rollback.assert_awaited()
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_dry_run_true_explicit(self, _db, _redis, _storage):
+        ws = _mock_ws(name="w1", terraform_version="1.10")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_list_result([ws]))
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+        body = {
+            "filter": {"all": True},
+            "update": {"terraform-version": "1.12"},
+            "dry_run": True,
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert resp.json()["dry_run"] is True
+        db.rollback.assert_awaited()
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_dry_run_no_change_lists_unchanged(self, *_mocks):
+        """A workspace already at the target value lands in `unchanged`,
+        with an empty `would_change`."""
+        ws = _mock_ws(name="w1", execution_backend="tofu")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_list_result([ws]))
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+        body = {"filter": {"all": True}, "update": {"execution-backend": "tofu"}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["would_change"] == []
+        assert len(data["unchanged"]) == 1
+        db.commit.assert_not_awaited()
+
+
+# ── bulk-update: apply ───────────────────────────────────────────────────
+
+
+class TestBulkUpdateApply:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_apply_commits_and_mutates(self, _db, _redis, _storage):
+        ws = _mock_ws(name="w1", execution_backend="terraform")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_list_result([ws]))
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+        body = {
+            "filter": {"all": True},
+            "update": {"execution-backend": "tofu"},
+            "dry_run": False,
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["dry_run"] is False
+        assert data["applied"] == 1
+        assert len(data["changes"]) == 1
+        # The ORM object was actually mutated.
+        assert ws.execution_backend == "tofu"
+        db.commit.assert_awaited_once()
+        db.rollback.assert_not_awaited()
+        # The audit row is added into the same transaction (not via the
+        # committing helper) — assert one was queued for this change.
+        assert any(
+            getattr(c.args[0], "action", None) == "workspace.bulk_update"
+            for c in db.add.call_args_list
+        )
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_run_task_inserted_when_absent(self, _db, _redis, _storage):
+        """Apply with a run-task spec and NO existing RunTask → db.add()
+        is called with a freshly built RunTask."""
+        ws = _mock_ws(name="w1")
+        app, db = _make_app(_admin())
+        # 1st execute: workspace selection; 2nd: RunTask upsert lookup → none.
+        db.execute = AsyncMock(side_effect=[_list_result([ws]), _scalar_result(None)])
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+        body = {
+            "filter": {"all": True},
+            "update": {"run-tasks": [{"name": "scan", "url": "https://x", "stage": "pre_plan"}]},
+            "dry_run": False,
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        # db.add is also called for the per-workspace AuditLog row — scope
+        # the assertion to the RunTask that was inserted.
+        added = [c.args[0] for c in db.add.call_args_list if type(c.args[0]).__name__ == "RunTask"]
+        assert len(added) == 1
+        assert added[0].name == "scan"
+        assert added[0].workspace_id == ws.id
+        db.commit.assert_awaited_once()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_run_task_mutated_when_present(self, _db, _redis, _storage):
+        """Apply with a run-task spec and an EXISTING RunTask → the
+        existing row's attributes are set in place; no *RunTask* is
+        added (an AuditLog row still is)."""
+        ws = _mock_ws(name="w1")
+        existing_rt = MagicMock()
+        existing_rt.name = "scan"
+        existing_rt.url = "https://old"
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(side_effect=[_list_result([ws]), _scalar_result(existing_rt)])
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+        body = {
+            "filter": {"all": True},
+            "update": {"run-tasks": [{"name": "scan", "url": "https://new", "stage": "pre_plan"}]},
+            "dry_run": False,
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert not any(type(c.args[0]).__name__ == "RunTask" for c in db.add.call_args_list)
+        assert existing_rt.url == "https://new"
+        assert existing_rt.stage == "pre_plan"
+        db.commit.assert_awaited_once()
+
+
+# ── bulk-update: failure rollback ────────────────────────────────────────
+
+
+class TestBulkUpdateFailureRollback:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_apply_failure_rolls_back_409(self, _db, _redis, _storage):
+        """If the apply transaction fails (here: the single commit raises)
+        the endpoint returns 409 and rolls back — nothing is left
+        partially applied."""
+        ws = _mock_ws(name="w1", execution_backend="terraform")
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_list_result([ws]))
+        db.commit = AsyncMock(side_effect=RuntimeError("db down"))
+        db.rollback = AsyncMock()
+        body = {
+            "filter": {"all": True},
+            "update": {"execution-backend": "tofu"},
+            "dry_run": False,
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 409, resp.text
+        assert "rolled back" in resp.json()["detail"]
+        db.rollback.assert_awaited()
+        db.commit.assert_awaited()  # it was attempted, raised, then rolled back
+
+
+# ── bulk-update: pool RBAC ───────────────────────────────────────────────
+
+
+class TestBulkUpdatePoolRbac:
+    @patch("terrapod.api.routers.workspace_bulk.pool_rbac_service.has_pool_permission")
+    @patch(
+        "terrapod.api.routers.workspace_bulk.pool_rbac_service.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_non_admin_without_pool_write_403(self, _db, _redis, _storage, m_resolve, m_has):
+        """A non-admin assigning an agent pool needs pool `write`; without
+        it the update is rejected 403 with zero mutation."""
+        pool = MagicMock()
+        pool.id = uuid.uuid4()
+        pool.name = "aws-prod"
+        pool.labels = {}
+        pool.owner_email = "someone-else@example.com"
+        m_resolve.return_value = "read"
+        m_has.return_value = False
+
+        app, db = _make_app(_non_admin())
+        db.get = AsyncMock(return_value=pool)
+        db.execute = AsyncMock(return_value=_list_result([]))
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+
+        body = {
+            "filter": {"all": True},
+            "update": {"agent-pool-id": f"apool-{pool.id}"},
+            "dry_run": False,
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 403, resp.text
+        assert "write permission on agent pool" in resp.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @patch("terrapod.api.routers.workspace_bulk.pool_rbac_service.has_pool_permission")
+    @patch(
+        "terrapod.api.routers.workspace_bulk.pool_rbac_service.resolve_pool_permission",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_non_admin_with_pool_write_allowed(self, _db, _redis, _storage, m_resolve, m_has):
+        pool = MagicMock()
+        pool.id = uuid.uuid4()
+        pool.name = "aws-prod"
+        pool.labels = {}
+        pool.owner_email = "someone-else@example.com"
+        m_resolve.return_value = "write"
+        m_has.return_value = True
+
+        ws = _mock_ws(name="w1", agent_pool_id=None)
+        app, db = _make_app(_non_admin())
+        db.get = AsyncMock(return_value=pool)
+        db.execute = AsyncMock(return_value=_list_result([ws]))
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+
+        body = {
+            "filter": {"all": True},
+            "update": {"agent-pool-id": f"apool-{pool.id}"},
+            "dry_run": False,
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/workspaces/actions/bulk-update",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert ws.agent_pool_id == pool.id
+        db.commit.assert_awaited_once()

--- a/services/tests/services/test_workspace_search_service.py
+++ b/services/tests/services/test_workspace_search_service.py
@@ -1,0 +1,179 @@
+"""Tests for the server-side workspace search/selection engine (#318).
+
+Pure-logic — no DB. We construct `WorkspaceFilter` directly and inspect
+the generated SQLAlchemy `Select` (compiled string / whereclause) rather
+than executing it.
+"""
+
+import uuid
+
+import pytest
+
+from terrapod.services.workspace_search_service import (
+    WorkspaceFilter,
+    WorkspaceFilterError,
+    build_workspace_query,
+    parse_filter,
+)
+
+# ── parse_filter ─────────────────────────────────────────────────────────
+
+
+class TestParseFilter:
+    def test_none_raises(self):
+        with pytest.raises(WorkspaceFilterError):
+            parse_filter(None)
+
+    def test_empty_dict_raises(self):
+        with pytest.raises(WorkspaceFilterError):
+            parse_filter({})
+
+    def test_non_dict_raises(self):
+        with pytest.raises(WorkspaceFilterError):
+            parse_filter(["not", "a", "dict"])
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(WorkspaceFilterError) as e:
+            parse_filter({"bogus-selector": "x"})
+        assert "unknown filter key" in str(e.value)
+        assert "bogus_selector" in str(e.value)
+
+    def test_hyphenated_keys_normalised(self):
+        """JSON:API-ish hyphenated keys map onto the snake_case model."""
+        wf = parse_filter(
+            {
+                "name-prefix": "prod-",
+                "execution-backend": "tofu",
+                "agent-pool-id": "apool-1",
+                "has-vcs": True,
+            }
+        )
+        assert wf.name_prefix == "prod-"
+        assert wf.execution_backend == "tofu"
+        assert wf.agent_pool_id == "apool-1"
+        assert wf.has_vcs is True
+
+    def test_all_true_parses(self):
+        wf = parse_filter({"all": True})
+        assert wf.all is True
+
+    def test_bad_type_translated_to_filter_error(self):
+        """A pydantic validation failure surfaces as WorkspaceFilterError,
+        not a raw pydantic ValidationError."""
+        with pytest.raises(WorkspaceFilterError):
+            parse_filter({"locked": "definitely-not-a-bool"})
+
+
+# ── build_workspace_query — blast-radius guard ───────────────────────────
+
+
+class TestBuildQueryGuard:
+    def test_no_dimensions_not_all_raises(self):
+        with pytest.raises(WorkspaceFilterError) as e:
+            build_workspace_query(WorkspaceFilter())
+        assert "at least one selector" in str(e.value)
+
+    def test_empty_collections_count_as_no_dimensions(self):
+        """`labels: {}` / `workspace_ids: []` are not real selectors —
+        they must not slip past the empty-filter guard."""
+        with pytest.raises(WorkspaceFilterError):
+            build_workspace_query(WorkspaceFilter(labels={}, workspace_ids=[]))
+
+    def test_all_true_short_circuits_no_error(self):
+        """`all: true` returns the base query and never raises, even with
+        no other dimension set."""
+        q = build_workspace_query(WorkspaceFilter(all=True))
+        # Base query: SELECT over workspaces, ordered by name, no WHERE.
+        assert q.whereclause is None
+        compiled = str(q)
+        assert "workspaces" in compiled
+        assert "ORDER BY" in compiled.upper()
+
+    def test_all_true_ignores_other_dimensions(self):
+        """`all` short-circuits before any dimension is appended."""
+        q = build_workspace_query(WorkspaceFilter(all=True, name_prefix="prod-", locked=True))
+        assert q.whereclause is None
+
+
+# ── build_workspace_query — per-dimension WHERE ──────────────────────────
+
+
+class TestBuildQueryDimensions:
+    def test_name_prefix_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(name_prefix="prod-"))
+        assert q.whereclause is not None
+        assert "lower(workspaces.name) LIKE lower" in str(q)
+
+    def test_name_glob_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(name_glob="*-staging"))
+        assert q.whereclause is not None
+        assert "workspaces.name" in str(q)
+
+    def test_execution_backend_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(execution_backend="tofu"))
+        assert "workspaces.execution_backend" in str(q)
+
+    def test_execution_mode_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(execution_mode="agent"))
+        assert "workspaces.execution_mode" in str(q)
+
+    def test_terraform_version_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(terraform_version="1.12"))
+        assert "workspaces.terraform_version" in str(q)
+
+    def test_owner_email_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(owner_email="a@example.com"))
+        assert "workspaces.owner_email" in str(q)
+
+    def test_drift_status_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(drift_status="drifted"))
+        assert "workspaces.drift_status" in str(q)
+
+    def test_locked_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(locked=True))
+        assert "workspaces.locked" in str(q)
+
+    def test_labels_adds_where(self):
+        q = build_workspace_query(WorkspaceFilter(labels={"team": "platform"}))
+        assert q.whereclause is not None
+        assert "workspaces.labels" in str(q)
+
+    def test_workspace_ids_adds_where(self):
+        wid = uuid.uuid4()
+        q = build_workspace_query(WorkspaceFilter(workspace_ids=[f"ws-{wid}"]))
+        assert q.whereclause is not None
+        assert "workspaces.id IN" in str(q)
+
+    def test_workspace_ids_bad_uuid_raises(self):
+        with pytest.raises(WorkspaceFilterError):
+            build_workspace_query(WorkspaceFilter(workspace_ids=["ws-not-a-uuid"]))
+
+    def test_agent_pool_id_adds_where(self):
+        pid = uuid.uuid4()
+        q = build_workspace_query(WorkspaceFilter(agent_pool_id=f"apool-{pid}"))
+        assert "workspaces.agent_pool_id" in str(q)
+
+    def test_agent_pool_id_bad_uuid_raises(self):
+        with pytest.raises(WorkspaceFilterError):
+            build_workspace_query(WorkspaceFilter(agent_pool_id="apool-nope"))
+
+    def test_vcs_connection_id_adds_where(self):
+        cid = uuid.uuid4()
+        q = build_workspace_query(WorkspaceFilter(vcs_connection_id=f"vcs-{cid}"))
+        assert "workspaces.vcs_connection_id" in str(q)
+
+    def test_has_vcs_true_adds_is_not_null(self):
+        q = build_workspace_query(WorkspaceFilter(has_vcs=True))
+        assert "workspaces.vcs_connection_id IS NOT NULL" in str(q)
+
+    def test_has_vcs_false_adds_is_null(self):
+        q = build_workspace_query(WorkspaceFilter(has_vcs=False))
+        assert "workspaces.vcs_connection_id IS NULL" in str(q)
+
+    def test_multiple_dimensions_are_anded(self):
+        """Two dimensions → both columns appear in the WHERE (AND-combined)."""
+        q = build_workspace_query(WorkspaceFilter(execution_backend="tofu", locked=True))
+        compiled = str(q)
+        assert "workspaces.execution_backend" in compiled
+        assert "workspaces.locked" in compiled
+        assert " AND " in compiled

--- a/web/src/app/admin/autodiscovery/page.tsx
+++ b/web/src/app/admin/autodiscovery/page.tsx
@@ -9,6 +9,13 @@ import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
 import { LabelsEditor } from '@/components/labels-editor'
+import {
+  StringListEditor,
+  RunTaskTemplatesEditor,
+  NotificationTemplatesEditor,
+  type RunTaskSpec,
+  type NotificationSpec,
+} from '@/components/template-editors'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
@@ -33,6 +40,9 @@ interface AutodiscoveryRule {
     'auto-apply': boolean
     labels: Record<string, string>
     'owner-email': string
+    'var-files': string[]
+    'run-task-templates': RunTaskSpec[]
+    'notification-templates': NotificationSpec[]
     'created-at': string
     'updated-at': string
   }
@@ -79,6 +89,9 @@ export default function AutodiscoveryPage() {
   const [autoApply, setAutoApply] = useState(false)
   const [labels, setLabels] = useState<Record<string, string>>({})
   const [ownerEmail, setOwnerEmail] = useState('')
+  const [varFiles, setVarFiles] = useState<string[]>([])
+  const [runTaskTemplates, setRunTaskTemplates] = useState<RunTaskSpec[]>([])
+  const [notificationTemplates, setNotificationTemplates] = useState<NotificationSpec[]>([])
   const [submitting, setSubmitting] = useState(false)
 
   const [deleteId, setDeleteId] = useState<string | null>(null)
@@ -169,6 +182,9 @@ export default function AutodiscoveryPage() {
     setAutoApply(false)
     setLabels({})
     setOwnerEmail('')
+    setVarFiles([])
+    setRunTaskTemplates([])
+    setNotificationTemplates([])
   }
 
   function openCreateForm() {
@@ -196,6 +212,9 @@ export default function AutodiscoveryPage() {
     setAutoApply(a['auto-apply'])
     setLabels(a.labels || {})
     setOwnerEmail(a['owner-email'] || '')
+    setVarFiles(a['var-files'] || [])
+    setRunTaskTemplates(a['run-task-templates'] || [])
+    setNotificationTemplates(a['notification-templates'] || [])
     setShowForm(true)
   }
 
@@ -228,6 +247,9 @@ export default function AutodiscoveryPage() {
       'auto-apply': autoApply,
       labels,
       'owner-email': ownerEmail,
+      'var-files': varFiles.map(s => s.trim()).filter(Boolean),
+      'run-task-templates': runTaskTemplates,
+      'notification-templates': notificationTemplates,
     }
 
     try {
@@ -594,6 +616,27 @@ export default function AutodiscoveryPage() {
               <div className="mt-4">
                 <label className="block text-sm text-slate-300 mb-1">Labels (inherited by created workspaces)</label>
                 <LabelsEditor labels={labels} onChange={setLabels} />
+              </div>
+              <div className="mt-4 pt-4 border-t border-slate-800">
+                <label className="block text-sm text-slate-300 mb-1">Var files (inherited by created workspaces)</label>
+                <p className="text-xs text-slate-500 mb-2">Relative <code>.tfvars</code> paths passed to plan/apply.</p>
+                <StringListEditor
+                  values={varFiles}
+                  onChange={setVarFiles}
+                  placeholder="env/prod.tfvars"
+                  addLabel="Add var file"
+                />
+              </div>
+              <div className="mt-4 pt-4 border-t border-slate-800">
+                <label className="block text-sm text-slate-300 mb-1">Run task templates (created on each new workspace)</label>
+                <RunTaskTemplatesEditor items={runTaskTemplates} onChange={setRunTaskTemplates} />
+              </div>
+              <div className="mt-4 pt-4 border-t border-slate-800">
+                <label className="block text-sm text-slate-300 mb-1">Notification templates (created on each new workspace)</label>
+                <NotificationTemplatesEditor
+                  items={notificationTemplates}
+                  onChange={setNotificationTemplates}
+                />
               </div>
             </details>
 

--- a/web/src/app/admin/bulk-update/page.tsx
+++ b/web/src/app/admin/bulk-update/page.tsx
@@ -1,0 +1,697 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import NavBar from '@/components/nav-bar'
+import { PageHeader } from '@/components/page-header'
+import { ErrorBanner } from '@/components/error-banner'
+import { EmptyState } from '@/components/empty-state'
+import { LabelsEditor } from '@/components/labels-editor'
+import {
+  StringListEditor,
+  RunTaskTemplatesEditor,
+  NotificationTemplatesEditor,
+  type RunTaskSpec,
+  type NotificationSpec,
+} from '@/components/template-editors'
+import { getAuthState, isAdmin } from '@/lib/auth'
+import { apiFetch } from '@/lib/api'
+
+interface WorkspaceSummary {
+  id: string
+  name: string
+  'execution-mode': string
+  'execution-backend': string
+  'terraform-version': string
+  'agent-pool-id': string | null
+  labels: Record<string, string>
+}
+
+interface SearchResult {
+  matched: number
+  workspaces: WorkspaceSummary[]
+}
+
+interface DiffEntry {
+  id: string
+  name: string
+  diff: Record<string, { from: unknown; to: unknown } | unknown>
+}
+
+interface DryRunResult {
+  dry_run: true
+  matched: number
+  would_change: DiffEntry[]
+  unchanged: { id: string; name: string }[]
+}
+
+interface ApplyResult {
+  dry_run: false
+  matched: number
+  applied: number
+  changes: DiffEntry[]
+  unchanged: { id: string; name: string }[]
+  errors: { id?: string; name?: string; error: string }[]
+}
+
+interface AgentPool {
+  id: string
+  attributes: { name: string }
+}
+
+interface VCSConnection {
+  id: string
+  attributes: { name: string; provider: string }
+}
+
+const inputCls =
+  'w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent'
+const labelCls = 'block text-sm font-medium text-slate-300 mb-1'
+
+function fmtVal(v: unknown): string {
+  if (v === null || v === undefined) return '(none)'
+  if (typeof v === 'object') return JSON.stringify(v)
+  return String(v)
+}
+
+export default function BulkUpdatePage() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [pools, setPools] = useState<AgentPool[]>([])
+  const [connections, setConnections] = useState<VCSConnection[]>([])
+
+  // ---- Filter form state ----
+  const [fLabels, setFLabels] = useState<Record<string, string>>({})
+  const [fNamePrefix, setFNamePrefix] = useState('')
+  const [fExecBackend, setFExecBackend] = useState('')
+  const [fAgentPoolId, setFAgentPoolId] = useState('')
+  const [fVcsConnId, setFVcsConnId] = useState('')
+  const [fOwnerEmail, setFOwnerEmail] = useState('')
+  const [fAll, setFAll] = useState(false)
+
+  const [searching, setSearching] = useState(false)
+  const [searchResult, setSearchResult] = useState<SearchResult | null>(null)
+
+  // ---- Update form state ----
+  const [uTfVersion, setUTfVersion] = useState('')
+  const [uExecBackend, setUExecBackend] = useState('')
+  const [uExecMode, setUExecMode] = useState('')
+  const [uAutoApply, setUAutoApply] = useState('')
+  const [uAgentPoolId, setUAgentPoolId] = useState('')
+  const [uResourceCpu, setUResourceCpu] = useState('')
+  const [uResourceMemory, setUResourceMemory] = useState('')
+  const [uSetLabels, setUSetLabels] = useState(false)
+  const [uLabels, setULabels] = useState<Record<string, string>>({})
+  const [uSetVarFiles, setUSetVarFiles] = useState(false)
+  const [uVarFiles, setUVarFiles] = useState<string[]>([])
+  const [uSetRunTasks, setUSetRunTasks] = useState(false)
+  const [uRunTasks, setURunTasks] = useState<RunTaskSpec[]>([])
+  const [uSetNotifications, setUSetNotifications] = useState(false)
+  const [uNotifications, setUNotifications] = useState<NotificationSpec[]>([])
+
+  const [dryRun, setDryRun] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [confirmApply, setConfirmApply] = useState(false)
+  const [dryResult, setDryResult] = useState<DryRunResult | null>(null)
+  const [applyResult, setApplyResult] = useState<ApplyResult | null>(null)
+
+  useEffect(() => {
+    if (!getAuthState()) {
+      router.push('/login')
+      return
+    }
+    if (!isAdmin()) {
+      router.push('/')
+      return
+    }
+    loadRefs()
+  }, [router])
+
+  async function loadRefs() {
+    setLoading(true)
+    try {
+      const [poolsRes, connsRes] = await Promise.all([
+        apiFetch('/api/terrapod/v1/agent-pools'),
+        apiFetch('/api/terrapod/v1/vcs-connections'),
+      ])
+      if (poolsRes.ok) setPools((await poolsRes.json()).data || [])
+      if (connsRes.ok) setConnections((await connsRes.json()).data || [])
+    } catch {
+      // refs are convenience-only; the page still works with manual ids
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function buildFilter(): Record<string, unknown> {
+    if (fAll) return { all: true }
+    const f: Record<string, unknown> = {}
+    if (Object.keys(fLabels).length > 0) f.labels = fLabels
+    if (fNamePrefix.trim()) f['name-prefix'] = fNamePrefix.trim()
+    if (fExecBackend) f['execution-backend'] = fExecBackend
+    if (fAgentPoolId) f['agent-pool-id'] = fAgentPoolId
+    if (fVcsConnId) f['vcs-connection-id'] = fVcsConnId
+    if (fOwnerEmail.trim()) f['owner-email'] = fOwnerEmail.trim()
+    return f
+  }
+
+  function buildUpdate(): Record<string, unknown> {
+    const u: Record<string, unknown> = {}
+    if (uTfVersion.trim()) u['terraform-version'] = uTfVersion.trim()
+    if (uExecBackend) u['execution-backend'] = uExecBackend
+    if (uExecMode) u['execution-mode'] = uExecMode
+    if (uAutoApply) u['auto-apply'] = uAutoApply === 'true'
+    if (uAgentPoolId) u['agent-pool-id'] = uAgentPoolId
+    if (uResourceCpu.trim()) u['resource-cpu'] = uResourceCpu.trim()
+    if (uResourceMemory.trim()) u['resource-memory'] = uResourceMemory.trim()
+    if (uSetLabels) u.labels = uLabels
+    if (uSetVarFiles) u['var-files'] = uVarFiles.map((s) => s.trim()).filter(Boolean)
+    if (uSetRunTasks) u['run-tasks'] = uRunTasks
+    if (uSetNotifications) u['notification-configurations'] = uNotifications
+    return u
+  }
+
+  async function handleSearch(e: React.FormEvent) {
+    e.preventDefault()
+    setSearching(true)
+    setError('')
+    setSearchResult(null)
+    try {
+      const res = await apiFetch('/api/terrapod/v1/workspaces/actions/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filter: buildFilter() }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.detail || `Search failed (${res.status})`)
+      }
+      setSearchResult(await res.json())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Search failed')
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  async function runBulkUpdate(isDryRun: boolean) {
+    setSubmitting(true)
+    setError('')
+    setDryResult(null)
+    setApplyResult(null)
+    try {
+      const res = await apiFetch('/api/terrapod/v1/workspaces/actions/bulk-update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          filter: buildFilter(),
+          update: buildUpdate(),
+          dry_run: isDryRun,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.detail || `Bulk update failed (${res.status})`)
+      }
+      const json = await res.json()
+      if (json.dry_run) setDryResult(json as DryRunResult)
+      else setApplyResult(json as ApplyResult)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Bulk update failed')
+    } finally {
+      setSubmitting(false)
+      setConfirmApply(false)
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (dryRun) {
+      runBulkUpdate(true)
+      return
+    }
+    // Destructive apply requires an explicit confirm click.
+    if (!confirmApply) {
+      setConfirmApply(true)
+      return
+    }
+    runBulkUpdate(false)
+  }
+
+  function renderDiffTable(entries: DiffEntry[], title: string) {
+    if (entries.length === 0) return null
+    return (
+      <div className="mb-6">
+        <h3 className="text-sm font-semibold text-slate-200 mb-2">
+          {title} ({entries.length})
+        </h3>
+        <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-700/50 text-left text-xs text-slate-400 uppercase">
+                <th className="px-4 py-2">Workspace</th>
+                <th className="px-4 py-2">Changes</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-700/30">
+              {entries.map((e) => (
+                <tr key={e.id}>
+                  <td className="px-4 py-3 text-slate-200 align-top">{e.name}</td>
+                  <td className="px-4 py-3">
+                    <ul className="space-y-1">
+                      {Object.entries(e.diff).map(([k, v]) => {
+                        const fv = v as { from?: unknown; to?: unknown }
+                        const isFromTo =
+                          v !== null &&
+                          typeof v === 'object' &&
+                          'from' in (v as object) &&
+                          'to' in (v as object)
+                        return (
+                          <li key={k} className="font-mono text-xs">
+                            <span className="text-slate-400">{k}</span>:{' '}
+                            {isFromTo ? (
+                              <>
+                                <span className="text-red-300">{fmtVal(fv.from)}</span>
+                                <span className="text-slate-500"> &rarr; </span>
+                                <span className="text-green-300">{fmtVal(fv.to)}</span>
+                              </>
+                            ) : (
+                              <span className="text-green-300">{fmtVal(v)}</span>
+                            )}
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <NavBar />
+      <main className="px-4 sm:px-6 lg:px-8 py-8 max-w-6xl mx-auto">
+        <PageHeader
+          title="Bulk Update"
+          description="Select workspaces by filter, then apply a settings change across all of them"
+        />
+
+        {error && <ErrorBanner message={error} />}
+
+        {/* ---- Filter ---- */}
+        <form
+          onSubmit={handleSearch}
+          className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6 space-y-3"
+        >
+          <h2 className="text-lg font-semibold text-slate-100">1. Select workspaces</h2>
+          <label className="flex items-center gap-2 text-sm text-slate-300">
+            <input
+              type="checkbox"
+              checked={fAll}
+              onChange={(e) => setFAll(e.target.checked)}
+            />
+            Match <strong>all</strong> workspaces (ignores the filters below)
+          </label>
+          <fieldset
+            disabled={fAll}
+            className={fAll ? 'opacity-40 pointer-events-none space-y-3' : 'space-y-3'}
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div>
+                <label className={labelCls}>Name prefix</label>
+                <input
+                  type="text"
+                  value={fNamePrefix}
+                  onChange={(e) => setFNamePrefix(e.target.value)}
+                  placeholder="prod-"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Execution backend</label>
+                <select
+                  value={fExecBackend}
+                  onChange={(e) => setFExecBackend(e.target.value)}
+                  className={inputCls}
+                >
+                  <option value="">(any)</option>
+                  <option value="tofu">tofu</option>
+                  <option value="terraform">terraform</option>
+                </select>
+              </div>
+              <div>
+                <label className={labelCls}>Owner email</label>
+                <input
+                  type="text"
+                  value={fOwnerEmail}
+                  onChange={(e) => setFOwnerEmail(e.target.value)}
+                  placeholder="platform@example.com"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Agent pool</label>
+                <select
+                  value={fAgentPoolId}
+                  onChange={(e) => setFAgentPoolId(e.target.value)}
+                  className={inputCls}
+                >
+                  <option value="">(any)</option>
+                  {pools.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.attributes.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className={labelCls}>VCS connection</label>
+                <select
+                  value={fVcsConnId}
+                  onChange={(e) => setFVcsConnId(e.target.value)}
+                  className={inputCls}
+                >
+                  <option value="">(any)</option>
+                  {connections.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.attributes.name} ({c.attributes.provider})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className={labelCls}>Labels</label>
+              <LabelsEditor labels={fLabels} onChange={setFLabels} />
+            </div>
+          </fieldset>
+          <button
+            type="submit"
+            disabled={searching || loading}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors"
+          >
+            {searching ? 'Searching...' : 'Search'}
+          </button>
+        </form>
+
+        {searchResult && (
+          <div className="mb-6">
+            <p className="text-sm text-slate-400 mb-2">
+              Matched <strong className="text-slate-200">{searchResult.matched}</strong>{' '}
+              workspace(s).
+            </p>
+            {searchResult.workspaces.length === 0 ? (
+              <EmptyState message="No workspaces matched this filter." />
+            ) : (
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-700/50 text-left text-xs text-slate-400 uppercase">
+                      <th className="px-4 py-2">Name</th>
+                      <th className="px-4 py-2">Mode</th>
+                      <th className="px-4 py-2">Backend</th>
+                      <th className="px-4 py-2 hidden sm:table-cell">TF version</th>
+                      <th className="px-4 py-2 hidden md:table-cell">Labels</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-700/30">
+                    {searchResult.workspaces.map((w) => (
+                      <tr key={w.id} className="hover:bg-slate-700/20">
+                        <td className="px-4 py-3 text-slate-200">{w.name}</td>
+                        <td className="px-4 py-3 text-slate-400">{w['execution-mode']}</td>
+                        <td className="px-4 py-3 text-slate-400">{w['execution-backend']}</td>
+                        <td className="px-4 py-3 text-slate-400 hidden sm:table-cell">
+                          {w['terraform-version']}
+                        </td>
+                        <td className="px-4 py-3 hidden md:table-cell">
+                          <LabelsEditor labels={w.labels || {}} readOnly />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ---- Update ---- */}
+        <form
+          onSubmit={handleSubmit}
+          className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6 space-y-4"
+        >
+          <h2 className="text-lg font-semibold text-slate-100">2. Apply changes</h2>
+          <p className="text-xs text-slate-500">
+            Only fields you set below are changed. The filter above selects which
+            workspaces receive the change.
+          </p>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label className={labelCls}>Terraform version</label>
+              <input
+                type="text"
+                value={uTfVersion}
+                onChange={(e) => setUTfVersion(e.target.value)}
+                placeholder="(unchanged)"
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>Execution backend</label>
+              <select
+                value={uExecBackend}
+                onChange={(e) => setUExecBackend(e.target.value)}
+                className={inputCls}
+              >
+                <option value="">(unchanged)</option>
+                <option value="tofu">tofu</option>
+                <option value="terraform">terraform</option>
+              </select>
+            </div>
+            <div>
+              <label className={labelCls}>Execution mode</label>
+              <select
+                value={uExecMode}
+                onChange={(e) => setUExecMode(e.target.value)}
+                className={inputCls}
+              >
+                <option value="">(unchanged)</option>
+                <option value="local">local</option>
+                <option value="agent">agent</option>
+              </select>
+            </div>
+            <div>
+              <label className={labelCls}>Auto-apply</label>
+              <select
+                value={uAutoApply}
+                onChange={(e) => setUAutoApply(e.target.value)}
+                className={inputCls}
+              >
+                <option value="">(unchanged)</option>
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select>
+            </div>
+            <div>
+              <label className={labelCls}>Agent pool</label>
+              <select
+                value={uAgentPoolId}
+                onChange={(e) => setUAgentPoolId(e.target.value)}
+                className={inputCls}
+              >
+                <option value="">(unchanged)</option>
+                {pools.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.attributes.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={labelCls}>CPU request</label>
+              <input
+                type="text"
+                value={uResourceCpu}
+                onChange={(e) => setUResourceCpu(e.target.value)}
+                placeholder="(unchanged)"
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>Memory request</label>
+              <input
+                type="text"
+                value={uResourceMemory}
+                onChange={(e) => setUResourceMemory(e.target.value)}
+                placeholder="(unchanged)"
+                className={inputCls}
+              />
+            </div>
+          </div>
+
+          <div className="pt-3 border-t border-slate-800">
+            <label className="flex items-center gap-2 text-sm text-slate-300 mb-2">
+              <input
+                type="checkbox"
+                checked={uSetLabels}
+                onChange={(e) => setUSetLabels(e.target.checked)}
+              />
+              Set labels (replaces the labels map on every matched workspace)
+            </label>
+            {uSetLabels && <LabelsEditor labels={uLabels} onChange={setULabels} />}
+          </div>
+
+          <div className="pt-3 border-t border-slate-800">
+            <label className="flex items-center gap-2 text-sm text-slate-300 mb-2">
+              <input
+                type="checkbox"
+                checked={uSetVarFiles}
+                onChange={(e) => setUSetVarFiles(e.target.checked)}
+              />
+              Set var files
+            </label>
+            {uSetVarFiles && (
+              <StringListEditor
+                values={uVarFiles}
+                onChange={setUVarFiles}
+                placeholder="env/prod.tfvars"
+                addLabel="Add var file"
+              />
+            )}
+          </div>
+
+          <div className="pt-3 border-t border-slate-800">
+            <label className="flex items-center gap-2 text-sm text-slate-300 mb-2">
+              <input
+                type="checkbox"
+                checked={uSetRunTasks}
+                onChange={(e) => setUSetRunTasks(e.target.checked)}
+              />
+              Set run tasks (upserted by name on every matched workspace)
+            </label>
+            {uSetRunTasks && (
+              <RunTaskTemplatesEditor items={uRunTasks} onChange={setURunTasks} />
+            )}
+          </div>
+
+          <div className="pt-3 border-t border-slate-800">
+            <label className="flex items-center gap-2 text-sm text-slate-300 mb-2">
+              <input
+                type="checkbox"
+                checked={uSetNotifications}
+                onChange={(e) => setUSetNotifications(e.target.checked)}
+              />
+              Set notification configurations (upserted by name)
+            </label>
+            {uSetNotifications && (
+              <NotificationTemplatesEditor
+                items={uNotifications}
+                onChange={setUNotifications}
+              />
+            )}
+          </div>
+
+          <div className="pt-3 border-t border-slate-800 flex flex-wrap items-center gap-4">
+            <label className="flex items-center gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={dryRun}
+                onChange={(e) => {
+                  setDryRun(e.target.checked)
+                  setConfirmApply(false)
+                }}
+              />
+              Dry run (preview only — no changes written)
+            </label>
+            {!dryRun && confirmApply ? (
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-amber-300">
+                  This writes changes to every matched workspace.
+                </span>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="px-4 py-2 rounded-lg text-sm font-medium bg-red-700 hover:bg-red-600 disabled:opacity-50 text-white transition-colors"
+                >
+                  {submitting ? 'Applying...' : 'Confirm apply'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmApply(false)}
+                  className="px-3 py-2 rounded-lg text-sm bg-slate-700 hover:bg-slate-600 text-slate-200"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                type="submit"
+                disabled={submitting}
+                className={`px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 ${
+                  dryRun
+                    ? 'bg-brand-600 hover:bg-brand-500'
+                    : 'bg-amber-700 hover:bg-amber-600'
+                }`}
+              >
+                {submitting
+                  ? 'Working...'
+                  : dryRun
+                    ? 'Preview (dry run)'
+                    : 'Apply changes'}
+              </button>
+            )}
+          </div>
+        </form>
+
+        {dryResult && (
+          <div className="mb-6">
+            <h2 className="text-lg font-semibold text-slate-100 mb-1">Dry run result</h2>
+            <p className="text-sm text-slate-400 mb-3">
+              Matched <strong className="text-slate-200">{dryResult.matched}</strong>;{' '}
+              <strong className="text-slate-200">{dryResult.would_change.length}</strong>{' '}
+              would change; {dryResult.unchanged.length} unchanged. Nothing was written.
+            </p>
+            {renderDiffTable(dryResult.would_change, 'Would change')}
+            {dryResult.would_change.length === 0 && (
+              <EmptyState message="No workspaces would change with this update." />
+            )}
+          </div>
+        )}
+
+        {applyResult && (
+          <div className="mb-6">
+            <h2 className="text-lg font-semibold text-slate-100 mb-1">Apply result</h2>
+            <p className="text-sm text-slate-400 mb-3">
+              Matched <strong className="text-slate-200">{applyResult.matched}</strong>;{' '}
+              <strong className="text-green-300">{applyResult.applied}</strong> applied;{' '}
+              {applyResult.unchanged.length} unchanged;{' '}
+              {applyResult.errors.length} error(s).
+            </p>
+            {applyResult.errors.length > 0 && (
+              <div className="mb-4 p-3 bg-red-900/30 text-red-300 rounded-lg text-sm border border-red-800/50">
+                <ul className="space-y-1">
+                  {applyResult.errors.map((er, i) => (
+                    <li key={i}>
+                      {er.name || er.id || '(workspace)'}: {er.error}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {renderDiffTable(applyResult.changes, 'Applied')}
+            {applyResult.applied === 0 && applyResult.errors.length === 0 && (
+              <EmptyState message="No workspaces changed." />
+            )}
+          </div>
+        )}
+      </main>
+    </>
+  )
+}

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, FileText, BookOpen, Code, LogOut, Menu, X, Tags, Compass } from 'lucide-react'
+import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, FileText, BookOpen, Code, LogOut, Menu, X, Tags, Compass, Wrench } from 'lucide-react'
 import { clearAuth, isAdmin, isAdminOrAudit } from '@/lib/auth'
 import { SessionExpiryBanner } from '@/components/session-expiry-banner'
 
@@ -108,6 +108,10 @@ export default function NavBar() {
           <NavLink href="/admin/autodiscovery" onClick={closeMenu}>
             <Compass size={16} />
             Autodiscovery
+          </NavLink>
+          <NavLink href="/admin/bulk-update" onClick={closeMenu}>
+            <Wrench size={16} />
+            Bulk Update
           </NavLink>
         </>
       )}

--- a/web/src/components/template-editors.tsx
+++ b/web/src/components/template-editors.tsx
@@ -1,0 +1,382 @@
+'use client'
+
+/**
+ * Repeatable nested editors shared by the autodiscovery rule form (#318)
+ * and the bulk-update page (#318). Each editor owns a JS array in the
+ * parent's form state and renders add/remove "card" rows. The card object
+ * shapes match the JSON:API attribute contracts exactly:
+ *
+ *   - var-files                → string[]
+ *   - run-task-templates       → RunTaskSpec[]   (also bulk-update `run-tasks`)
+ *   - notification-templates   → NotificationSpec[]
+ *                                (also bulk-update `notification-configurations`)
+ *
+ * The hyphenated wire keys (`hmac-key`, `enforcement-level`,
+ * `destination-type`, `email-addresses`) are kept verbatim on the spec
+ * objects so the parent can drop the array straight into the request body.
+ */
+
+export type RunTaskSpec = {
+  name: string
+  url: string
+  'hmac-key': string
+  stage: string
+  'enforcement-level': string
+  enabled: boolean
+}
+
+export type NotificationSpec = {
+  name: string
+  'destination-type': string
+  url: string
+  token: string
+  triggers: string[]
+  'email-addresses': string[]
+  enabled: boolean
+}
+
+export const RUN_TASK_STAGES = ['pre_plan', 'post_plan', 'pre_apply'] as const
+export const RUN_TASK_ENFORCEMENT = ['mandatory', 'advisory'] as const
+export const NOTIFICATION_DEST_TYPES = ['generic', 'slack', 'email'] as const
+export const NOTIFICATION_TRIGGERS = [
+  'run:created',
+  'run:planning',
+  'run:needs_attention',
+  'run:planned',
+  'run:applying',
+  'run:completed',
+  'run:errored',
+  'run:drift_detected',
+] as const
+
+export function emptyRunTask(): RunTaskSpec {
+  return {
+    name: '',
+    url: '',
+    'hmac-key': '',
+    stage: 'post_plan',
+    'enforcement-level': 'mandatory',
+    enabled: true,
+  }
+}
+
+export function emptyNotification(): NotificationSpec {
+  return {
+    name: '',
+    'destination-type': 'generic',
+    url: '',
+    token: '',
+    triggers: [],
+    'email-addresses': [],
+    enabled: true,
+  }
+}
+
+const inputCls =
+  'w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent'
+const labelCls = 'block text-xs font-medium text-slate-400 mb-1'
+
+function AddButton({ onClick, label }: { onClick: () => void; label: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="px-3 py-1.5 text-xs rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-100 transition-colors"
+    >
+      {label}
+    </button>
+  )
+}
+
+function RemoveButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-xs text-red-400 hover:text-red-300"
+    >
+      Remove
+    </button>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* var-files: repeatable single-string rows                            */
+/* ------------------------------------------------------------------ */
+
+export function StringListEditor({
+  values,
+  onChange,
+  placeholder = 'value',
+  addLabel = 'Add',
+}: {
+  values: string[]
+  onChange: (next: string[]) => void
+  placeholder?: string
+  addLabel?: string
+}) {
+  function setAt(i: number, v: string) {
+    const next = values.slice()
+    next[i] = v
+    onChange(next)
+  }
+  function removeAt(i: number) {
+    onChange(values.filter((_, idx) => idx !== i))
+  }
+  return (
+    <div className="space-y-2">
+      {values.map((v, i) => (
+        <div key={i} className="flex gap-2 items-center">
+          <input
+            type="text"
+            value={v}
+            onChange={(e) => setAt(i, e.target.value)}
+            placeholder={placeholder}
+            className={`${inputCls} font-mono`}
+          />
+          <RemoveButton onClick={() => removeAt(i)} />
+        </div>
+      ))}
+      <AddButton onClick={() => onChange([...values, ''])} label={addLabel} />
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* run-task-templates / run-tasks: repeatable card rows                */
+/* ------------------------------------------------------------------ */
+
+export function RunTaskTemplatesEditor({
+  items,
+  onChange,
+}: {
+  items: RunTaskSpec[]
+  onChange: (next: RunTaskSpec[]) => void
+}) {
+  function patch(i: number, patch: Partial<RunTaskSpec>) {
+    const next = items.slice()
+    next[i] = { ...next[i], ...patch }
+    onChange(next)
+  }
+  function removeAt(i: number) {
+    onChange(items.filter((_, idx) => idx !== i))
+  }
+  return (
+    <div className="space-y-3">
+      {items.map((it, i) => (
+        <div
+          key={i}
+          className="p-3 rounded-lg bg-slate-900/60 border border-slate-700/60 space-y-3"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls}>Name</label>
+              <input
+                type="text"
+                value={it.name}
+                onChange={(e) => patch(i, { name: e.target.value })}
+                placeholder="security-scan"
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>URL</label>
+              <input
+                type="text"
+                value={it.url}
+                onChange={(e) => patch(i, { url: e.target.value })}
+                placeholder="https://hooks.example.com/task"
+                className={inputCls}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label className={labelCls}>HMAC key (optional)</label>
+              <input
+                type="password"
+                value={it['hmac-key']}
+                onChange={(e) => patch(i, { 'hmac-key': e.target.value })}
+                placeholder="shared secret"
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>Stage</label>
+              <select
+                value={it.stage}
+                onChange={(e) => patch(i, { stage: e.target.value })}
+                className={inputCls}
+              >
+                {RUN_TASK_STAGES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={labelCls}>Enforcement</label>
+              <select
+                value={it['enforcement-level']}
+                onChange={(e) => patch(i, { 'enforcement-level': e.target.value })}
+                className={inputCls}
+              >
+                {RUN_TASK_ENFORCEMENT.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="flex items-center justify-between">
+            <label className="flex items-center gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={it.enabled}
+                onChange={(e) => patch(i, { enabled: e.target.checked })}
+              />
+              Enabled
+            </label>
+            <RemoveButton onClick={() => removeAt(i)} />
+          </div>
+        </div>
+      ))}
+      <AddButton onClick={() => onChange([...items, emptyRunTask()])} label="Add run task" />
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* notification-templates / notification-configurations: card rows     */
+/* ------------------------------------------------------------------ */
+
+export function NotificationTemplatesEditor({
+  items,
+  onChange,
+}: {
+  items: NotificationSpec[]
+  onChange: (next: NotificationSpec[]) => void
+}) {
+  function patch(i: number, patch: Partial<NotificationSpec>) {
+    const next = items.slice()
+    next[i] = { ...next[i], ...patch }
+    onChange(next)
+  }
+  function removeAt(i: number) {
+    onChange(items.filter((_, idx) => idx !== i))
+  }
+  function toggleTrigger(i: number, trig: string) {
+    const cur = items[i].triggers
+    const next = cur.includes(trig)
+      ? cur.filter((t) => t !== trig)
+      : [...cur, trig]
+    patch(i, { triggers: next })
+  }
+  return (
+    <div className="space-y-3">
+      {items.map((it, i) => (
+        <div
+          key={i}
+          className="p-3 rounded-lg bg-slate-900/60 border border-slate-700/60 space-y-3"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls}>Name</label>
+              <input
+                type="text"
+                value={it.name}
+                onChange={(e) => patch(i, { name: e.target.value })}
+                placeholder="slack-alerts"
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>Destination type</label>
+              <select
+                value={it['destination-type']}
+                onChange={(e) => patch(i, { 'destination-type': e.target.value })}
+                className={inputCls}
+              >
+                {NOTIFICATION_DEST_TYPES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {it['destination-type'] !== 'email' && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className={labelCls}>URL</label>
+                <input
+                  type="text"
+                  value={it.url}
+                  onChange={(e) => patch(i, { url: e.target.value })}
+                  placeholder="https://hooks.slack.com/services/..."
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Token (optional)</label>
+                <input
+                  type="password"
+                  value={it.token}
+                  onChange={(e) => patch(i, { token: e.target.value })}
+                  placeholder="HMAC / auth token"
+                  className={inputCls}
+                />
+              </div>
+            </div>
+          )}
+          {it['destination-type'] === 'email' && (
+            <div>
+              <label className={labelCls}>Email addresses</label>
+              <StringListEditor
+                values={it['email-addresses']}
+                onChange={(next) => patch(i, { 'email-addresses': next })}
+                placeholder="ops@example.com"
+                addLabel="Add email"
+              />
+            </div>
+          )}
+          <div>
+            <label className={labelCls}>Triggers</label>
+            <div className="flex flex-wrap gap-2">
+              {NOTIFICATION_TRIGGERS.map((trig) => (
+                <label
+                  key={trig}
+                  className="flex items-center gap-1.5 text-xs text-slate-300 px-2 py-1 rounded border border-slate-700 bg-slate-800/60"
+                >
+                  <input
+                    type="checkbox"
+                    checked={it.triggers.includes(trig)}
+                    onChange={() => toggleTrigger(i, trig)}
+                  />
+                  {trig}
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center justify-between">
+            <label className="flex items-center gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={it.enabled}
+                onChange={(e) => patch(i, { enabled: e.target.checked })}
+              />
+              Enabled
+            </label>
+            <RemoveButton onClick={() => removeAt(i)} />
+          </div>
+        </div>
+      ))}
+      <AddButton
+        onClick={() => onChange([...items, emptyNotification()])}
+        label="Add notification"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #318. Bundled (server + provider + UI + docs + tests). **No release** — v0.25.0 ships after #314 + the pre-release audit.

Delivers **both halves** of the ask, including the headline use case ("register an OPA policy-check run task across all existing workspaces in one call, and auto-apply it to future ones").

## 1. Server-side workspace search (net-new)
`services/terrapod/services/workspace_search_service.py` + `POST /api/terrapod/v1/workspaces/actions/search` (admin). Structured, AND-combined filter (ids, labels, name prefix/glob, structural attrs, virtual booleans). Empty/omitted filter → 422; matching the fleet needs explicit `"all": true`. The prior server-side filtering was only the go-tfe cloud-block tag filter; the UI filter bar is client-side (migrating it is a tracked follow-up).

## 2. Bulk update
`POST /api/terrapod/v1/workspaces/actions/bulk-update` (admin). `update` = workspace fields **+ `run-tasks` + `notification-configurations`** (upsert by `(workspace, name)`).
- Validated **once up front** (enums, `validate_labels` #316 reserved-key chokepoint, `agent-pool-id` exists + caller pool-`write` RBAC) → 422, **zero mutation**.
- **All-or-nothing single transaction.** `dry_run` (default on, not enforced) runs the identical code path and `rollback()`s — preview == apply, provably zero side-effects.
- **Triggers no runs** — pure settings write; reversible; the change lands on each workspace's next normal run. Per-workspace audit rows are added *into the same transaction*.

## 3. Expanded autodiscovery templating
`autodiscovery_rules` gains `var_files` + `run_task_templates` + `notification_templates` (migration `3547bfb4e898`, no backfill). Materialised onto every workspace the rule creates, using the **identical spec shape** as the bulk `update` — define once, apply to existing (bulk) *and* auto-apply to future (autodiscovery).

## Provider / UI / docs
- `terrapod_autodiscovery_rule` resource gains the three template attributes (`ListNestedAttribute`).
- Admin **Bulk Update** screen (filter → dry-run diff → two-click confirm apply) + the rule-template fields on the autodiscovery page + nav link; shared `template-editors.tsx`.
- `docs/api-reference.md`, `docs/autodiscovery.md`, CLAUDE.md invariant.

## Correctness note
`audit_service.log_audit_event` commits internally; calling it per-workspace would have broken **both** the all-or-nothing apply (incremental commits) **and** the dry-run zero-side-effect guarantee. Bulk-update therefore adds `AuditLog` rows directly into the single transaction. (Surfaced by the test suite; fixed in the implementation, not papered over in the tests.)

## Test plan
- [x] `make lint`, `make test` — **1449 passed** (61 new: search service, bulk-update validation/dry-run/all-or-nothing/upsert/RBAC, autodiscovery templating)
- [x] provider `go build`/`go vet` clean; changed file `gofmt`-clean
- [x] web `tsc`/`npm run build` clean; `/admin/bulk-update` route present
- [x] `helm template` OK
- [ ] CI green
- [ ] live Tilt smoke (running in parallel with CI)