### PR TITLE
feat: autodiscovery workspace lifecycle — rename/delete/orphan (#314)

### DIFF
--- a/alembic/versions/3f0ad398be2c_autodiscovery_lifecycle.py
+++ b/alembic/versions/3f0ad398be2c_autodiscovery_lifecycle.py
@@ -1,0 +1,62 @@
+"""autodiscovery workspace lifecycle columns (#314)
+
+workspaces.lifecycle_state/lifecycle_reason track the rename/delete/
+orphan lifecycle (active|pending_deletion|archived);
+workspaces.autodiscovery_pr_number records the PR that created an
+autodiscovered workspace so the poller can reconcile when that PR is
+closed-unmerged. autodiscovery_rules.on_directory_delete is the
+opt-in destroy policy (default "flag" — never auto-destroys).
+
+Existing rows default to active / "" / NULL / flag — no behaviour
+change for anything already deployed.
+
+Revision ID: 3f0ad398be2c
+Revises: 3547bfb4e898
+Create Date: 2026-05-18
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "3f0ad398be2c"
+down_revision: str | None = "3547bfb4e898"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "lifecycle_state",
+            sa.String(20),
+            nullable=False,
+            server_default="active",
+        ),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("lifecycle_reason", sa.String(500), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("autodiscovery_pr_number", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "autodiscovery_rules",
+        sa.Column(
+            "on_directory_delete",
+            sa.String(10),
+            nullable=False,
+            server_default="flag",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("autodiscovery_rules", "on_directory_delete")
+    op.drop_column("workspaces", "autodiscovery_pr_number")
+    op.drop_column("workspaces", "lifecycle_reason")
+    op.drop_column("workspaces", "lifecycle_state")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1443,6 +1443,7 @@ POST /api/terrapod/v1/autodiscovery-rules
       "resource-cpu": "1",
       "resource-memory": "2Gi",
       "auto-apply": false,
+      "on-directory-delete": "flag",
       "labels": {"managed-by": "monorepo-autodiscover"},
       "owner-email": "platform@example.com"
     }

--- a/docs/autodiscovery.md
+++ b/docs/autodiscovery.md
@@ -58,6 +58,7 @@ Rules are scoped to a single VCS connection + repo. A rule has:
 | `terraform-version` | string | no | Default `1.12`. |
 | `resource-cpu` / `resource-memory` | string | no | Defaults `1` / `2Gi`. |
 | `auto-apply` | bool | no | Default `false`. |
+| `on-directory-delete` | enum | no | `flag` (default — mark `pending_deletion`, require explicit operator action) or `destroy` (opt-in — real destroy run then archive). See the Lifecycle section (#314). |
 | `labels` | map | no | Inherited by created workspaces — feeds Terrapod's label-based RBAC and filtering. Reserved keys (`status`, `pool`, `mode`, `backend`, `owner`, `drift`, `version`, `vcs`, `locked`, `branch`) are rejected with `422` at rule create/update — they are virtual filter terms and would otherwise produce workspaces that can't be saved. |
 | `owner-email` | string | no | Inherited by created workspaces; if unset, created workspaces have no owner and label-RBAC alone determines access. |
 | `var-files` | list | no | Var-file paths set on every created workspace. |
@@ -106,6 +107,18 @@ A workspace created by a rule:
 - Is seeded with the **tracked-branch HEAD** as its last-seen commit (`vcs-last-commit-sha`). Autodiscovery is PR-driven — the matched directory exists on the PR branch but not yet on the tracked branch — so without this baseline the next branch poll would fire a full plan+apply against a branch where the directory doesn't exist, which errors. With the baseline, the speculative plan-only run for the open PR still happens, and the first real plan+apply fires when the tracked branch actually advances (typically the PR merge).
 
 If you delete the rule later, existing workspaces keep working — the foreign key sets to NULL on cascade.
+
+## Lifecycle: rename / delete / orphan (#314)
+
+Autodiscovered workspaces are reconciled as the repo evolves. **Safe by default — nothing is destroyed unless a rule explicitly opts in.**
+
+- **Directory renamed** (`git mv old/ new/`): detected from the provider's per-file rename info. On the PR, an informational comment is posted. When the rename reaches the tracked branch the existing workspace is **moved in place** (`working-directory`/`trigger-prefixes`/templated name updated) — **state and history are preserved, nothing is destroyed**. A rename whose files fan out to multiple directories (split/merge) is *ambiguous* — it is **not** auto-applied; the workspace is flagged for a human and the new directories autodiscover normally.
+- **Directory deleted**: on the open PR a **speculative `plan -destroy`** is queued and a comment posted so reviewers see the blast radius (no mutation). When the deletion reaches the tracked branch — *and only after re-verifying the directory is actually gone from the tree* — the rule's **`on-directory-delete`** policy applies:
+  - `flag` (default, safe): the workspace is marked `pending_deletion` and **requires an explicit operator action**. Never auto-destroyed.
+  - `destroy` (opt-in, for ephemeral envs): a real destroy run is queued; on success the workspace is **archived** (soft-deleted, retained for audit).
+- **Origin PR closed unmerged / no longer matching**: the workspace is an orphan (its directory never reached the tracked branch). If it **never applied state** (zero state versions) it is **auto-archived**; if it **has state** it is flagged `pending_deletion` for a human. Never silently destroyed.
+
+`lifecycle-state` (`active` | `pending_deletion` | `archived`) and `lifecycle-reason` are exposed on the workspace and surfaced in the UI. All transitions are audited (`autodiscovery.workspace_moved` / `.pending_deletion` / `.destroy_queued` / `.archived` / `.rename_conflict`).
 
 ## Example
 

--- a/provider/internal/datasources/workspace/data_source.go
+++ b/provider/internal/datasources/workspace/data_source.go
@@ -44,6 +44,8 @@ type workspaceDataSourceModel struct {
 	OwnerEmail                    types.String `tfsdk:"owner_email"`
 	DriftStatus                   types.String `tfsdk:"drift_status"`
 	DriftLastCheckedAt            types.String `tfsdk:"drift_last_checked_at"`
+	LifecycleState                types.String `tfsdk:"lifecycle_state"`
+	LifecycleReason               types.String `tfsdk:"lifecycle_reason"`
 	Locked                        types.Bool   `tfsdk:"locked"`
 	CreatedAt                     types.String `tfsdk:"created_at"`
 	UpdatedAt                     types.String `tfsdk:"updated_at"`
@@ -62,29 +64,31 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 	resp.Schema = schema.Schema{
 		Description: "Look up a Terrapod workspace by name.",
 		Attributes: map[string]schema.Attribute{
-			"id":                                computedString("Workspace ID."),
-			"name":                              requiredString("Workspace name to look up."),
-			"execution_mode":                    computedString("Execution mode."),
-			"auto_apply":                        computedBool("Auto-apply setting."),
-			"execution_backend":                 computedString("Execution backend."),
-			"terraform_version":                 computedString("Terraform/tofu version."),
-			"working_directory":                 computedString("Working directory."),
-			"resource_cpu":                      computedString("CPU request."),
-			"resource_memory":                   computedString("Memory request."),
-			"labels":                            computedMap("Labels."),
-			"vcs_repo_url":                      computedString("VCS repo URL."),
-			"vcs_branch":                        computedString("VCS branch."),
-			"vcs_connection_id":                 computedString("VCS connection ID."),
-			"agent_pool_id":                     computedString("Agent pool ID."),
-			"var_files":                         computedList("Var files for -var-file arguments."),
-			"drift_detection_enabled":           computedBool("Drift detection enabled."),
-			"drift_detection_interval_seconds":  computedInt64("Drift detection interval."),
-			"owner_email":                       computedString("Owner email."),
-			"drift_status":                      computedString("Drift status."),
-			"drift_last_checked_at":             computedString("Last drift check."),
-			"locked":                            computedBool("Lock status."),
-			"created_at":                        computedString("Creation timestamp."),
-			"updated_at":                        computedString("Update timestamp."),
+			"id":                               computedString("Workspace ID."),
+			"name":                             requiredString("Workspace name to look up."),
+			"execution_mode":                   computedString("Execution mode."),
+			"auto_apply":                       computedBool("Auto-apply setting."),
+			"execution_backend":                computedString("Execution backend."),
+			"terraform_version":                computedString("Terraform/tofu version."),
+			"working_directory":                computedString("Working directory."),
+			"resource_cpu":                     computedString("CPU request."),
+			"resource_memory":                  computedString("Memory request."),
+			"labels":                           computedMap("Labels."),
+			"vcs_repo_url":                     computedString("VCS repo URL."),
+			"vcs_branch":                       computedString("VCS branch."),
+			"vcs_connection_id":                computedString("VCS connection ID."),
+			"agent_pool_id":                    computedString("Agent pool ID."),
+			"var_files":                        computedList("Var files for -var-file arguments."),
+			"drift_detection_enabled":          computedBool("Drift detection enabled."),
+			"drift_detection_interval_seconds": computedInt64("Drift detection interval."),
+			"owner_email":                      computedString("Owner email."),
+			"drift_status":                     computedString("Drift status."),
+			"drift_last_checked_at":            computedString("Last drift check."),
+			"lifecycle_state":                  computedString("Workspace lifecycle state (e.g. active, or flagged/destroying when its autodiscovery source directory was deleted)."),
+			"lifecycle_reason":                 computedString("Human-readable reason for the current lifecycle state."),
+			"locked":                           computedBool("Lock status."),
+			"created_at":                       computedString("Creation timestamp."),
+			"updated_at":                       computedString("Update timestamp."),
 		},
 	}
 }
@@ -147,6 +151,8 @@ func readDataSourceModel(ctx context.Context, res *client.Resource, m *workspace
 	setOptionalString(&m.AgentPoolID, client.GetStringAttr(res, "agent-pool-id"))
 	setOptionalString(&m.DriftStatus, client.GetStringAttr(res, "drift-status"))
 	setOptionalString(&m.DriftLastCheckedAt, client.GetStringAttr(res, "drift-last-checked-at"))
+	setOptionalString(&m.LifecycleState, client.GetStringAttr(res, "lifecycle-state"))
+	setOptionalString(&m.LifecycleReason, client.GetStringAttr(res, "lifecycle-reason"))
 
 	if v := client.GetRelationshipID(res, "vcs-connection"); v != "" {
 		m.VCSConnectionID = types.StringValue(v)

--- a/provider/internal/resources/autodiscovery_rule/resource.go
+++ b/provider/internal/resources/autodiscovery_rule/resource.go
@@ -29,6 +29,8 @@
 //	"auto-apply"         -> auto_apply          (bool, optional, default false)
 //	"labels"             -> labels              (map[string]string, optional)
 //	"owner-email"        -> owner_email         (string, optional)
+//	"on-directory-delete" -> on_directory_delete (string, optional;
+//	    "flag" (default, safe) or "destroy" (tears down infra then archives))
 //	"var-files"          -> var_files           (list of strings, optional)
 //	"run-task-templates" -> run_task_templates  (list of objects, optional)
 //	    each: name (string, req), url (string, req), hmac-key (string, opt),
@@ -78,23 +80,24 @@ var (
 type autodiscoveryRuleModel struct {
 	ID types.String `tfsdk:"id"`
 
-	Name             types.String `tfsdk:"name"`
-	NameTemplate     types.String `tfsdk:"name_template"`
-	VCSConnectionID  types.String `tfsdk:"vcs_connection_id"`
-	RepoURL          types.String `tfsdk:"repo_url"`
-	Branch           types.String `tfsdk:"branch"`
-	Pattern          types.String `tfsdk:"pattern"`
-	IgnorePatterns   types.List   `tfsdk:"ignore_patterns"`
-	Enabled          types.Bool   `tfsdk:"enabled"`
-	ExecutionMode    types.String `tfsdk:"execution_mode"`
-	ExecutionBackend types.String `tfsdk:"execution_backend"`
-	AgentPoolID      types.String `tfsdk:"agent_pool_id"`
-	TerraformVersion types.String `tfsdk:"terraform_version"`
-	ResourceCPU      types.String `tfsdk:"resource_cpu"`
-	ResourceMemory   types.String `tfsdk:"resource_memory"`
-	AutoApply        types.Bool   `tfsdk:"auto_apply"`
-	Labels           types.Map    `tfsdk:"labels"`
-	OwnerEmail       types.String `tfsdk:"owner_email"`
+	Name              types.String `tfsdk:"name"`
+	NameTemplate      types.String `tfsdk:"name_template"`
+	VCSConnectionID   types.String `tfsdk:"vcs_connection_id"`
+	RepoURL           types.String `tfsdk:"repo_url"`
+	Branch            types.String `tfsdk:"branch"`
+	Pattern           types.String `tfsdk:"pattern"`
+	IgnorePatterns    types.List   `tfsdk:"ignore_patterns"`
+	Enabled           types.Bool   `tfsdk:"enabled"`
+	ExecutionMode     types.String `tfsdk:"execution_mode"`
+	ExecutionBackend  types.String `tfsdk:"execution_backend"`
+	AgentPoolID       types.String `tfsdk:"agent_pool_id"`
+	TerraformVersion  types.String `tfsdk:"terraform_version"`
+	ResourceCPU       types.String `tfsdk:"resource_cpu"`
+	ResourceMemory    types.String `tfsdk:"resource_memory"`
+	AutoApply         types.Bool   `tfsdk:"auto_apply"`
+	Labels            types.Map    `tfsdk:"labels"`
+	OwnerEmail        types.String `tfsdk:"owner_email"`
+	OnDirectoryDelete types.String `tfsdk:"on_directory_delete"`
 
 	VarFiles              types.List `tfsdk:"var_files"`
 	RunTaskTemplates      types.List `tfsdk:"run_task_templates"`
@@ -261,6 +264,13 @@ func (r *autodiscoveryRuleResource) Schema(_ context.Context, _ resource.SchemaR
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString(""),
+			},
+			"on_directory_delete": schema.StringAttribute{
+				Description: "What to do with a discovered workspace when its source directory is deleted from the repository. " +
+					"\"flag\" (default, safe) marks the workspace and leaves infrastructure intact; " +
+					"\"destroy\" (opt-in) tears down the infrastructure then archives the workspace. " +
+					"Only \"flag\" or \"destroy\" are accepted; the server rejects other values with HTTP 422.",
+				Optional: true,
 			},
 
 			"var_files": schema.ListAttribute{
@@ -552,6 +562,12 @@ func buildAutodiscoveryRuleAttrs(m *autodiscoveryRuleModel) map[string]any {
 		attrs["owner-email"] = m.OwnerEmail.ValueString()
 	}
 
+	// Optional (#314): omit entirely when unset so a rule that never set
+	// it is left unchanged on the server (server defaults to "flag").
+	if !m.OnDirectoryDelete.IsNull() && !m.OnDirectoryDelete.IsUnknown() {
+		attrs["on-directory-delete"] = m.OnDirectoryDelete.ValueString()
+	}
+
 	// Optional templating fields (#318): omit entirely when unset so a
 	// rule without them is left unchanged on the server.
 	if !m.VarFiles.IsNull() && !m.VarFiles.IsUnknown() {
@@ -677,6 +693,15 @@ func readAutodiscoveryRuleIntoModel(ctx context.Context, res *client.Resource, m
 	m.Labels = mv
 
 	m.OwnerEmail = types.StringValue(client.GetStringAttr(res, "owner-email"))
+
+	// Optional (#314). Tolerate missing/empty: an absent attribute leaves
+	// the model field null so a rule that never set it produces no
+	// spurious diff.
+	if v := client.GetStringAttr(res, "on-directory-delete"); v != "" {
+		m.OnDirectoryDelete = types.StringValue(v)
+	} else {
+		m.OnDirectoryDelete = types.StringNull()
+	}
 
 	// Optional templating fields (#318). Tolerate missing/empty: an
 	// absent attribute leaves the model field null so a rule that never

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -75,6 +75,7 @@ def _rule_json(rule: AutodiscoveryRule) -> dict:
             "resource-cpu": rule.resource_cpu,
             "resource-memory": rule.resource_memory,
             "auto-apply": rule.auto_apply,
+            "on-directory-delete": rule.on_directory_delete,
             "labels": dict(rule.labels or {}),
             "owner-email": rule.owner_email or "",
             "var-files": list(rule.var_files or []),
@@ -215,6 +216,14 @@ def _coerce_attrs(attrs: dict, *, on_create: bool) -> dict[str, Any]:
         out["resource_memory"] = str(attrs["resource-memory"])
     if "auto-apply" in attrs:
         out["auto_apply"] = bool(attrs["auto-apply"])
+    if "on-directory-delete" in attrs:
+        odd = str(attrs["on-directory-delete"])
+        if odd not in ("flag", "destroy"):
+            raise HTTPException(
+                status_code=422,
+                detail="on-directory-delete must be 'flag' or 'destroy'",
+            )
+        out["on_directory_delete"] = odd
     if "labels" in attrs:
         # Reserved-key guard at the source: a rule's labels are copied
         # verbatim onto every workspace it materialises, and workspace

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -601,6 +601,8 @@ def _workspace_json(
                 "drift-last-checked-at": _rfc3339(ws.drift_last_checked_at),
                 "drift-status": ws.drift_status,
                 "state-diverged": ws.state_diverged,
+                "lifecycle-state": ws.lifecycle_state,
+                "lifecycle-reason": ws.lifecycle_reason,
                 "health-conditions": _compute_health_conditions(ws),
                 "vcs-last-polled-at": _rfc3339(ws.vcs_last_polled_at),
                 "vcs-last-error": ws.vcs_last_error,

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -344,6 +344,21 @@ class Workspace(Base):
     # State divergence — set when an apply Job succeeds but state upload fails
     state_diverged: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
+    # Autodiscovery lifecycle (#314). lifecycle_state: active (normal) |
+    # pending_deletion (origin dir/PR gone — needs explicit operator
+    # action; NEVER auto-destroyed) | archived (soft-deleted after a
+    # successful opt-in destroy, or a never-applied orphan auto-cleaned).
+    lifecycle_state: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="active", default="active"
+    )
+    lifecycle_reason: Mapped[str] = mapped_column(
+        String(500), nullable=False, server_default="", default=""
+    )
+    # The PR that materialised this autodiscovered workspace (NULL for
+    # non-autodiscovered or initial-scan-created). Lets the poller
+    # reconcile when that PR is closed-unmerged / no longer matches.
+    autodiscovery_pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Autodiscovery — set when this workspace was auto-created by an
     # AutodiscoveryRule rather than manually. Used to attribute
     # workspaces in the audit log and to skip re-creation on subsequent
@@ -866,6 +881,14 @@ class AutodiscoveryRule(Base):
     )
     notification_templates: Mapped[list[dict[str, Any]]] = mapped_column(
         JSONB, default=list, nullable=False
+    )
+    # #314 deletion lifecycle: what to do when a discovered directory is
+    # removed on the tracked branch. "flag" (default, safe) marks the
+    # workspace pending_deletion and requires an explicit operator
+    # action; "destroy" (opt-in, for ephemeral envs) queues a real
+    # destroy run then archives. NEVER silently destroys.
+    on_directory_delete: Mapped[str] = mapped_column(
+        String(10), nullable=False, default="flag", server_default="flag"
     )
 
     # Set on first successful full-tree scan of the repo. NULL means the

--- a/services/terrapod/services/autodiscovery_lifecycle_service.py
+++ b/services/terrapod/services/autodiscovery_lifecycle_service.py
@@ -1,0 +1,395 @@
+"""Autodiscovery workspace lifecycle — rename / delete / orphan (#314).
+
+Safe-by-default. Guarantees:
+- Nothing here destroys infrastructure unless the rule explicitly opts
+  in with `on_directory_delete == "destroy"`. The default ("flag")
+  only marks the workspace `pending_deletion` and needs an explicit
+  operator action.
+- Open-PR handling is visibility-only: a PR comment + a *speculative*
+  (`plan_only`, `is_destroy`) plan so reviewers see the blast radius.
+  No state, lifecycle, or infra mutation happens until the change
+  reaches the tracked branch.
+- Before flagging/destroying on branch-advance we RE-VERIFY the
+  directory is actually absent from the tracked-branch tree — we never
+  act on a heuristic diff alone, and never on a truncated diff.
+- A never-applied orphan (zero StateVersions) is the only thing
+  auto-archived; anything with state is flagged for a human.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.db.models import (
+    AuditLog,
+    AutodiscoveryRule,
+    Run,
+    StateVersion,
+    VCSConnection,
+    Workspace,
+    generate_uuid7,
+)
+from terrapod.logging_config import get_logger
+from terrapod.services import github_service, gitlab_service, run_service
+from terrapod.services.workspace_autodiscovery_service import (
+    derive_root_directory,
+    derive_workspace_name,
+)
+
+logger = get_logger(__name__)
+
+LIFECYCLE_SOURCE = "autodiscovery-lifecycle"
+
+
+def classify_dir_changes(
+    file_changes: list[dict[str, str | None]],
+) -> dict[str, Any]:
+    """Pure: reduce per-file change records to directory-level intent.
+
+    Returns ``{"deleted": set[str], "renamed": list[(old,new)],
+    "ambiguous": set[str]}``:
+    - deleted: dirs whose only changes are removals (no add/modify in
+      the same dir, not a rename source).
+    - renamed: a dir whose files were renamed into exactly one other dir.
+    - ambiguous: a rename source whose files fanned out to >1 dir, or a
+      dir that is both removed-from and added-to (split/merge) — never
+      auto-acted on; surfaced for a human.
+    """
+    removed: dict[str, int] = {}
+    present: set[str] = set()
+    rename_map: dict[str, set[str]] = {}
+
+    for fc in file_changes:
+        status = fc.get("status")
+        path = fc.get("path") or ""
+        if status == "removed":
+            removed[derive_root_directory(path)] = removed.get(derive_root_directory(path), 0) + 1
+        elif status == "renamed":
+            old_root = derive_root_directory(fc.get("old_path") or "")
+            new_root = derive_root_directory(path)
+            present.add(new_root)
+            if old_root != new_root:
+                rename_map.setdefault(old_root, set()).add(new_root)
+            removed[old_root] = removed.get(old_root, 0)  # ensure key seen
+        else:  # added / modified
+            present.add(derive_root_directory(path))
+
+    renamed: list[tuple[str, str]] = []
+    ambiguous: set[str] = set()
+    for old_root, new_roots in rename_map.items():
+        if len(new_roots) == 1 and old_root not in present:
+            renamed.append((old_root, next(iter(new_roots))))
+        else:
+            ambiguous.add(old_root)
+
+    rename_sources = {o for o, _ in renamed} | ambiguous
+    deleted = {
+        d
+        for d, n in removed.items()
+        if n > 0 and d and d not in present and d not in rename_sources
+    }
+    return {"deleted": deleted, "renamed": renamed, "ambiguous": ambiguous}
+
+
+async def _autodiscovered_ws(
+    db: AsyncSession, rule: AutodiscoveryRule, root: str
+) -> Workspace | None:
+    """The active autodiscovered workspace this rule owns at `root`."""
+    res = await db.execute(
+        select(Workspace).where(
+            Workspace.autodiscovery_rule_id == rule.id,
+            Workspace.vcs_connection_id == rule.vcs_connection_id,
+            Workspace.vcs_repo_url == rule.repo_url,
+            Workspace.working_directory == root,
+            Workspace.lifecycle_state == "active",
+        )
+    )
+    return res.scalar_one_or_none()
+
+
+async def _has_state(db: AsyncSession, ws_id) -> bool:  # noqa: ANN001
+    n = await db.execute(
+        select(func.count()).select_from(StateVersion).where(StateVersion.workspace_id == ws_id)
+    )
+    return (n.scalar() or 0) > 0
+
+
+async def _post_comment(
+    conn: VCSConnection, owner: str, repo: str, pr_number: int, body: str
+) -> None:
+    try:
+        if conn.provider == "gitlab":
+            await gitlab_service.create_mr_comment(conn, owner, repo, pr_number, body)
+        else:
+            await github_service.create_pr_comment(conn, owner, repo, pr_number, body)
+    except Exception as e:  # comment failure must not break the poll cycle
+        logger.warning("lifecycle PR comment failed", error=repr(e), pr=pr_number)
+
+
+def _audit(db: AsyncSession, action: str, ws: Workspace, detail: str) -> None:
+    db.add(
+        AuditLog(
+            id=generate_uuid7(),
+            actor_email="system",
+            actor_type="system",
+            origin="system",
+            action=action,
+            resource_type="workspace",
+            resource_id=f"ws-{ws.id}",
+            status_code=200,
+            detail=detail,
+        )
+    )
+
+
+async def reconcile_open_pr(
+    db: AsyncSession,
+    rule: AutodiscoveryRule,
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    file_changes: list[dict[str, str | None]] | None,
+) -> None:
+    """Visibility only — no mutation. Speculative destroy plan + PR
+    comment for deletes; informational comment for renames/ambiguous.
+    `file_changes is None` (truncated diff) → skip entirely.
+    """
+    if file_changes is None:
+        return
+    cls = classify_dir_changes(file_changes)
+
+    for d in sorted(cls["deleted"]):
+        ws = await _autodiscovered_ws(db, rule, d)
+        if ws is None:
+            continue
+        # Dedupe: one speculative destroy plan per (workspace, head_sha).
+        dup = await db.execute(
+            select(Run.id).where(
+                Run.workspace_id == ws.id,
+                Run.vcs_commit_sha == head_sha,
+                Run.is_destroy.is_(True),
+                Run.plan_only.is_(True),
+            )
+        )
+        if dup.scalar_one_or_none() is None:
+            run = await run_service.create_run(
+                db,
+                workspace=ws,
+                message=f"Speculative destroy plan: '{d}' removed in PR #{pr_number}",
+                is_destroy=True,
+                plan_only=True,
+                source=LIFECYCLE_SOURCE,
+                created_by="autodiscovery-lifecycle",
+            )
+            run.vcs_commit_sha = head_sha
+            run.vcs_pull_request_number = pr_number
+        await _post_comment(
+            conn,
+            owner,
+            repo,
+            pr_number,
+            f"⚠️ Autodiscovery: directory `{d}` is removed in this PR. "
+            f"Workspace `{ws.name}` maps to it — a **speculative destroy plan** "
+            f"has been queued so you can review the blast radius. On merge, "
+            f"this workspace will be "
+            + (
+                "**destroyed then archived** (rule opted in)."
+                if rule.on_directory_delete == "destroy"
+                else "marked *pending deletion* (requires an explicit operator action)."
+            ),
+        )
+
+    for old, new in cls["renamed"]:
+        ws = await _autodiscovered_ws(db, rule, old)
+        if ws is None:
+            continue
+        await _post_comment(
+            conn,
+            owner,
+            repo,
+            pr_number,
+            f"♻️ Autodiscovery: detected rename `{old}` → `{new}`. On merge, "
+            f"workspace `{ws.name}` will be **moved in place** "
+            f"(state & history preserved — no destroy).",
+        )
+
+    for amb in sorted(cls["ambiguous"]):
+        ws = await _autodiscovered_ws(db, rule, amb)
+        if ws is None:
+            continue
+        await _post_comment(
+            conn,
+            owner,
+            repo,
+            pr_number,
+            f"❓ Autodiscovery: `{amb}` looks split/merged across multiple "
+            f"directories — not treated as a clean rename. Workspace "
+            f"`{ws.name}` will be left as *pending deletion* on merge for a "
+            f"human to decide; new directories autodiscover normally.",
+        )
+
+
+async def _dir_absent_on_branch(
+    conn: VCSConnection, owner: str, repo: str, branch: str, root: str
+) -> bool:
+    """Re-verify a directory really is gone from the tracked branch
+    before any flag/destroy. Returns False (do NOT act) if the tree
+    can't be listed or is truncated — fail safe.
+    """
+    try:
+        if conn.provider == "gitlab":
+            tree = await gitlab_service.list_repo_tree(conn, owner, repo, branch)
+        else:
+            tree = await github_service.list_repo_tree(conn, owner, repo, branch)
+    except Exception:
+        return False
+    if tree is None:  # truncated — never act on incomplete data
+        return False
+    prefix = root.rstrip("/") + "/"
+    return not any(p == root or p.startswith(prefix) for p in tree)
+
+
+async def reconcile_branch_advance(
+    db: AsyncSession,
+    rule: AutodiscoveryRule,
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    branch: str,
+    file_changes: list[dict[str, str | None]] | None,
+) -> None:
+    """Mutating, but safe: applies renames in place and applies the
+    rule's delete policy. Re-verifies every directory's absence against
+    the tracked-branch tree first. Skips on truncated diff.
+    """
+    if file_changes is None:
+        return
+    cls = classify_dir_changes(file_changes)
+
+    # Renames: move the existing workspace in place (state preserved).
+    for old, new in cls["renamed"]:
+        ws = await _autodiscovered_ws(db, rule, old)
+        if ws is None:
+            continue
+        clash = await db.execute(
+            select(Workspace.id).where(
+                Workspace.vcs_connection_id == rule.vcs_connection_id,
+                Workspace.vcs_repo_url == rule.repo_url,
+                Workspace.working_directory == new,
+                Workspace.id != ws.id,
+            )
+        )
+        if clash.scalar_one_or_none() is not None:
+            ws.lifecycle_state = "pending_deletion"
+            ws.lifecycle_reason = (
+                f"rename {old}->{new} but a workspace already owns {new}; "
+                f"needs an operator decision"
+            )
+            _audit(db, "autodiscovery.rename_conflict", ws, ws.lifecycle_reason)
+            continue
+        ws.working_directory = new
+        ws.trigger_prefixes = [new] if new else []
+        if rule.name_template:
+            ws.name = derive_workspace_name(rule, new)
+        _audit(db, "autodiscovery.workspace_moved", ws, f"{old} -> {new}")
+        logger.info(
+            "Autodiscovery moved workspace on rename",
+            workspace_id=str(ws.id),
+            old=old,
+            new=new,
+        )
+
+    # Deletes + ambiguous: only after re-verifying the dir is truly gone.
+    for d in sorted(cls["deleted"] | cls["ambiguous"]):
+        ws = await _autodiscovered_ws(db, rule, d)
+        if ws is None:
+            continue
+        if not await _dir_absent_on_branch(conn, owner, repo, branch, d):
+            continue  # still present (or unverifiable) — do nothing
+        if d in cls["ambiguous"] or rule.on_directory_delete != "destroy":
+            ws.lifecycle_state = "pending_deletion"
+            ws.lifecycle_reason = f"directory '{d}' removed on '{branch}'"
+            _audit(db, "autodiscovery.pending_deletion", ws, ws.lifecycle_reason)
+            logger.info(
+                "Autodiscovery flagged workspace pending_deletion",
+                workspace_id=str(ws.id),
+                directory=d,
+            )
+        else:  # rule explicitly opted in to destroy
+            run = await run_service.create_run(
+                db,
+                workspace=ws,
+                message=f"Autodiscovery: '{d}' removed — destroying (rule opt-in)",
+                is_destroy=True,
+                plan_only=False,
+                auto_apply=True,
+                source=LIFECYCLE_SOURCE,
+                created_by="autodiscovery-lifecycle",
+            )
+            ws.lifecycle_reason = f"destroy queued (run {run.id}) — '{d}' removed"
+            _audit(
+                db,
+                "autodiscovery.destroy_queued",
+                ws,
+                f"directory '{d}' removed; destroy run {run.id} queued",
+            )
+            logger.info(
+                "Autodiscovery queued destroy run",
+                workspace_id=str(ws.id),
+                run_id=str(run.id),
+                directory=d,
+            )
+
+
+async def reconcile_orphans(
+    db: AsyncSession,
+    rule: AutodiscoveryRule,
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    branch: str,
+    open_pr_numbers: set[int],
+) -> None:
+    """Autodiscovered workspaces whose origin PR is no longer open and
+    whose directory is gone from the tracked branch are orphans:
+    zero-state → archived; has-state → pending_deletion.
+    """
+    res = await db.execute(
+        select(Workspace).where(
+            Workspace.autodiscovery_rule_id == rule.id,
+            Workspace.vcs_connection_id == rule.vcs_connection_id,
+            Workspace.vcs_repo_url == rule.repo_url,
+            Workspace.lifecycle_state == "active",
+            Workspace.autodiscovery_pr_number.is_not(None),
+        )
+    )
+    for ws in res.scalars().all():
+        if ws.autodiscovery_pr_number in open_pr_numbers:
+            continue  # PR still open — nothing to reconcile
+        if not await _dir_absent_on_branch(conn, owner, repo, branch, ws.working_directory):
+            continue  # dir present (PR merged / pushed) — legitimate
+        if await _has_state(db, ws.id):
+            ws.lifecycle_state = "pending_deletion"
+            ws.lifecycle_reason = (
+                f"origin PR #{ws.autodiscovery_pr_number} closed unmerged; "
+                f"workspace has state — needs an explicit operator action"
+            )
+            _audit(db, "autodiscovery.pending_deletion", ws, ws.lifecycle_reason)
+        else:
+            ws.lifecycle_state = "archived"
+            ws.lifecycle_reason = (
+                f"origin PR #{ws.autodiscovery_pr_number} closed unmerged; "
+                f"never applied — auto-archived"
+            )
+            _audit(db, "autodiscovery.archived", ws, ws.lifecycle_reason)
+        logger.info(
+            "Autodiscovery reconciled orphan",
+            workspace_id=str(ws.id),
+            state=ws.lifecycle_state,
+            pr=ws.autodiscovery_pr_number,
+        )

--- a/services/terrapod/services/autodiscovery_lifecycle_service.py
+++ b/services/terrapod/services/autodiscovery_lifecycle_service.py
@@ -524,6 +524,25 @@ async def reconcile_branch_advance(
                 directory=d,
             )
         else:  # rule explicitly opted in to destroy
+            # Idempotency: the flag path self-dedupes (it flips
+            # lifecycle_state so _autodiscovered_ws stops returning the
+            # ws), but the destroy path leaves the ws `active` until the
+            # run applies. Without this guard every branch advance of
+            # any workspace sharing this rule/repo would queue ANOTHER
+            # destroy → concurrent `terraform destroy` jobs for one
+            # workspace. Only re-queue if no destroy is in flight/done
+            # (a prior errored/canceled/discarded one may be retried).
+            existing = await db.execute(
+                select(Run.id).where(
+                    Run.workspace_id == ws.id,
+                    Run.is_destroy.is_(True),
+                    Run.plan_only.is_(False),
+                    Run.source == LIFECYCLE_SOURCE,
+                    Run.status.notin_(["errored", "canceled", "discarded"]),
+                )
+            )
+            if existing.scalar_one_or_none() is not None:
+                continue  # a destroy is already queued/running/done
             run = await run_service.create_run(
                 db,
                 workspace=ws,

--- a/services/terrapod/services/autodiscovery_lifecycle_service.py
+++ b/services/terrapod/services/autodiscovery_lifecycle_service.py
@@ -57,39 +57,85 @@ def classify_dir_changes(
     - ambiguous: a rename source whose files fanned out to >1 dir, or a
       dir that is both removed-from and added-to (split/merge) — never
       auto-acted on; surfaced for a human.
+
+    Renames are detected two ways, because a provider's per-file
+    `renamed` status is NOT reliable across a **squash merge** (GitHub's
+    compare(old..new) for a squashed PR reports the moves as plain
+    removed+added). Relying on `renamed` only would mis-classify a
+    merged rename as a delete — which, on a `destroy`-opt-in rule,
+    would wrongly tear down a renamed workspace. So we ALSO infer a
+    rename from add/remove symmetry: a removed dir A whose set of
+    file basenames exactly equals the added set of exactly one new dir
+    B (and nothing else) is A→B. Anything less clean is ambiguous, not
+    deleted — never auto-destroyed.
     """
-    removed: dict[str, int] = {}
+    from pathlib import PurePosixPath
+
+    removed_files: dict[str, set[str]] = {}
+    added_files: dict[str, set[str]] = {}
     present: set[str] = set()
     rename_map: dict[str, set[str]] = {}
+
+    def _base(p: str) -> str:
+        return PurePosixPath(p).name
 
     for fc in file_changes:
         status = fc.get("status")
         path = fc.get("path") or ""
         if status == "removed":
-            removed[derive_root_directory(path)] = removed.get(derive_root_directory(path), 0) + 1
+            removed_files.setdefault(derive_root_directory(path), set()).add(_base(path))
         elif status == "renamed":
             old_root = derive_root_directory(fc.get("old_path") or "")
             new_root = derive_root_directory(path)
             present.add(new_root)
+            added_files.setdefault(new_root, set()).add(_base(path))
             if old_root != new_root:
                 rename_map.setdefault(old_root, set()).add(new_root)
-            removed[old_root] = removed.get(old_root, 0)  # ensure key seen
-        else:  # added / modified
+                removed_files.setdefault(old_root, set()).add(_base(fc.get("old_path") or ""))
+        elif status == "added":
+            present.add(derive_root_directory(path))
+            added_files.setdefault(derive_root_directory(path), set()).add(_base(path))
+        else:  # modified
             present.add(derive_root_directory(path))
 
     renamed: list[tuple[str, str]] = []
     ambiguous: set[str] = set()
+
+    # 1) Explicit provider-reported renames.
     for old_root, new_roots in rename_map.items():
         if len(new_roots) == 1 and old_root not in present:
             renamed.append((old_root, next(iter(new_roots))))
         else:
             ambiguous.add(old_root)
 
+    handled = {o for o, _ in renamed} | ambiguous
+
+    # 2) Inferred renames from exact add/remove basename symmetry — the
+    # squash-merge-safe path. A removed dir's basename set must match
+    # exactly one added dir's basename set, and that dir must not itself
+    # be a rename target already.
+    used_targets = {n for _, n in renamed}
+    for a, a_files in removed_files.items():
+        if a in handled or not a or not a_files or a in present:
+            continue
+        matches = [
+            b
+            for b, b_files in added_files.items()
+            if b != a and b not in used_targets and b_files == a_files
+        ]
+        if len(matches) == 1:
+            renamed.append((a, matches[0]))
+            used_targets.add(matches[0])
+            handled.add(a)
+        elif matches:
+            ambiguous.add(a)
+            handled.add(a)
+
     rename_sources = {o for o, _ in renamed} | ambiguous
     deleted = {
         d
-        for d, n in removed.items()
-        if n > 0 and d and d not in present and d not in rename_sources
+        for d, files in removed_files.items()
+        if files and d and d not in present and d not in rename_sources
     }
     return {"deleted": deleted, "renamed": renamed, "ambiguous": ambiguous}
 
@@ -129,6 +175,21 @@ async def _post_comment(
         logger.warning("lifecycle PR comment failed", error=repr(e), pr=pr_number)
 
 
+async def _get_pull_request(conn: VCSConnection, owner: str, repo: str, pr_number: int):
+    """Fetch a single PR/MR. Returns the PullRequest (with `.merged`)
+    or None if it can't be determined (404 / transient error). The
+    orphan reconciler treats None as 'unknown' and does nothing —
+    fail safe, never archive on uncertainty.
+    """
+    try:
+        if conn.provider == "gitlab":
+            return await gitlab_service.get_pull_request(conn, owner, repo, pr_number)
+        return await github_service.get_pull_request(conn, owner, repo, pr_number)
+    except Exception as e:
+        logger.warning("lifecycle PR fetch failed", error=repr(e), pr=pr_number)
+        return None
+
+
 def _audit(db: AsyncSession, action: str, ws: Workspace, detail: str) -> None:
     db.add(
         AuditLog(
@@ -145,6 +206,110 @@ def _audit(db: AsyncSession, action: str, ws: Workspace, detail: str) -> None:
     )
 
 
+async def rename_target_dirs_to_suppress(
+    db: AsyncSession,
+    rules: list[AutodiscoveryRule],
+    file_changes: list[dict[str, str | None]] | None,
+) -> set[str]:
+    """Directory roots that are the *new* side of a detected rename
+    whose *old* side already has an active rule-owned autodiscovered
+    workspace.
+
+    These must NOT get a fresh speculative workspace while the PR is
+    open: the rename is reconciled by moving the existing workspace in
+    place on merge. Creating a duplicate here would make the merge-time
+    rename collide with it (clash → original wrongly flagged
+    pending_deletion). `None`/truncated diff → suppress nothing (safe:
+    the merge path also re-classifies and absorbs duplicates).
+    """
+    if file_changes is None:
+        return set()
+    cls = classify_dir_changes(file_changes)
+    out: set[str] = set()
+    for old, new in cls["renamed"]:
+        for rule in rules:
+            if await _autodiscovered_ws(db, rule, old) is not None:
+                out.add(new)
+                break
+    return out
+
+
+async def _absorbable_speculative_dup(
+    db: AsyncSession, rule: AutodiscoveryRule, new: str, keep_id
+) -> Workspace | None:  # noqa: ANN001
+    """A workspace at `new` that is just a never-applied speculative
+    duplicate the open-PR autodiscovery created for this rename target:
+    same rule, PR-originated, zero state, not already terminal. Safe to
+    archive out of the way so the real (state-bearing) workspace can be
+    moved in place. Anything else (manual ws, has state, different rule)
+    is a genuine conflict and is NOT returned.
+    """
+    res = await db.execute(
+        select(Workspace).where(
+            Workspace.vcs_connection_id == rule.vcs_connection_id,
+            Workspace.vcs_repo_url == rule.repo_url,
+            Workspace.working_directory == new,
+            Workspace.id != keep_id,
+            Workspace.lifecycle_state != "archived",
+        )
+    )
+    others = res.scalars().all()
+    if len(others) != 1:
+        return None  # 0 → no clash; >1 → ambiguous, let caller flag
+    dup = others[0]
+    if (
+        dup.autodiscovery_rule_id == rule.id
+        and dup.autodiscovery_pr_number is not None
+        and not await _has_state(db, dup.id)
+    ):
+        return dup
+    return None
+
+
+async def _notify_once(
+    db: AsyncSession,
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    ws: Workspace,
+    head_sha: str,
+    kind: str,
+    body: str,
+) -> None:
+    """Post a PR comment at most once per (workspace, head_sha, kind).
+
+    The poller calls reconcile_open_pr every cycle while a PR is open;
+    without this the same rename/delete comment is re-posted every
+    ~60s. We use an AuditLog row as a durable idempotency ledger
+    (keyed by ws + head_sha + kind) so a new push (new head_sha)
+    re-notifies but repeated cycles on the same commit do not.
+    """
+    seen = await db.execute(
+        select(AuditLog.id).where(
+            AuditLog.action == "autodiscovery.notified",
+            AuditLog.resource_id == f"ws-{ws.id}",
+            AuditLog.detail == f"{kind}:{head_sha}",
+        )
+    )
+    if seen.scalar_one_or_none() is not None:
+        return
+    await _post_comment(conn, owner, repo, pr_number, body)
+    db.add(
+        AuditLog(
+            id=generate_uuid7(),
+            actor_email="system",
+            actor_type="system",
+            origin="system",
+            action="autodiscovery.notified",
+            resource_type="workspace",
+            resource_id=f"ws-{ws.id}",
+            status_code=200,
+            detail=f"{kind}:{head_sha}",
+        )
+    )
+
+
 async def reconcile_open_pr(
     db: AsyncSession,
     rule: AutodiscoveryRule,
@@ -157,7 +322,8 @@ async def reconcile_open_pr(
 ) -> None:
     """Visibility only — no mutation. Speculative destroy plan + PR
     comment for deletes; informational comment for renames/ambiguous.
-    `file_changes is None` (truncated diff) → skip entirely.
+    Comments are deduped per (workspace, head_sha) so the cyclic poller
+    doesn't spam the PR. `file_changes is None` (truncated diff) → skip.
     """
     if file_changes is None:
         return
@@ -188,11 +354,15 @@ async def reconcile_open_pr(
             )
             run.vcs_commit_sha = head_sha
             run.vcs_pull_request_number = pr_number
-        await _post_comment(
+        await _notify_once(
+            db,
             conn,
             owner,
             repo,
             pr_number,
+            ws,
+            head_sha,
+            "deleted",
             f"⚠️ Autodiscovery: directory `{d}` is removed in this PR. "
             f"Workspace `{ws.name}` maps to it — a **speculative destroy plan** "
             f"has been queued so you can review the blast radius. On merge, "
@@ -208,11 +378,15 @@ async def reconcile_open_pr(
         ws = await _autodiscovered_ws(db, rule, old)
         if ws is None:
             continue
-        await _post_comment(
+        await _notify_once(
+            db,
             conn,
             owner,
             repo,
             pr_number,
+            ws,
+            head_sha,
+            "renamed",
             f"♻️ Autodiscovery: detected rename `{old}` → `{new}`. On merge, "
             f"workspace `{ws.name}` will be **moved in place** "
             f"(state & history preserved — no destroy).",
@@ -222,11 +396,15 @@ async def reconcile_open_pr(
         ws = await _autodiscovered_ws(db, rule, amb)
         if ws is None:
             continue
-        await _post_comment(
+        await _notify_once(
+            db,
             conn,
             owner,
             repo,
             pr_number,
+            ws,
+            head_sha,
+            "ambiguous",
             f"❓ Autodiscovery: `{amb}` looks split/merged across multiple "
             f"directories — not treated as a clean rename. Workspace "
             f"`{ws.name}` will be left as *pending deletion* on merge for a "
@@ -276,22 +454,47 @@ async def reconcile_branch_advance(
         ws = await _autodiscovered_ws(db, rule, old)
         if ws is None:
             continue
-        clash = await db.execute(
-            select(Workspace.id).where(
-                Workspace.vcs_connection_id == rule.vcs_connection_id,
-                Workspace.vcs_repo_url == rule.repo_url,
-                Workspace.working_directory == new,
-                Workspace.id != ws.id,
+        # The open-PR autodiscovery will already have created a
+        # speculative, never-applied workspace at `new` (PR-originated,
+        # zero state). That is not a real conflict — absorb it so the
+        # real (state/history-bearing) workspace can move in place.
+        dup = await _absorbable_speculative_dup(db, rule, new, ws.id)
+        if dup is not None:
+            dup.lifecycle_state = "archived"
+            dup.lifecycle_reason = (
+                f"superseded by in-place rename move of '{old}' -> '{new}' "
+                f"(never-applied speculative duplicate)"
             )
-        )
-        if clash.scalar_one_or_none() is not None:
-            ws.lifecycle_state = "pending_deletion"
-            ws.lifecycle_reason = (
-                f"rename {old}->{new} but a workspace already owns {new}; "
-                f"needs an operator decision"
+            # Free its name + directory before the moved workspace
+            # adopts the derived name (workspaces.name is unique).
+            dup.name = f"{dup.name}-superseded-{str(dup.id)[:8]}"[:90]
+            dup.working_directory = f"{new}#superseded-{str(dup.id)[:8]}"
+            dup.trigger_prefixes = []
+            _audit(
+                db,
+                "autodiscovery.speculative_dup_absorbed",
+                dup,
+                f"absorbed into rename move {old} -> {new}",
             )
-            _audit(db, "autodiscovery.rename_conflict", ws, ws.lifecycle_reason)
-            continue
+            await db.flush()
+        else:
+            clash = await db.execute(
+                select(Workspace.id).where(
+                    Workspace.vcs_connection_id == rule.vcs_connection_id,
+                    Workspace.vcs_repo_url == rule.repo_url,
+                    Workspace.working_directory == new,
+                    Workspace.id != ws.id,
+                    Workspace.lifecycle_state != "archived",
+                )
+            )
+            if clash.scalar_one_or_none() is not None:
+                ws.lifecycle_state = "pending_deletion"
+                ws.lifecycle_reason = (
+                    f"rename {old}->{new} but a workspace already owns {new}; "
+                    f"needs an operator decision"
+                )
+                _audit(db, "autodiscovery.rename_conflict", ws, ws.lifecycle_reason)
+                continue
         ws.working_directory = new
         ws.trigger_prefixes = [new] if new else []
         if rule.name_template:
@@ -355,9 +558,24 @@ async def reconcile_orphans(
     branch: str,
     open_pr_numbers: set[int],
 ) -> None:
-    """Autodiscovered workspaces whose origin PR is no longer open and
-    whose directory is gone from the tracked branch are orphans:
-    zero-state → archived; has-state → pending_deletion.
+    """Reconcile autodiscovered workspaces whose origin PR is no longer
+    open.
+
+    The decisive signal is **whether the origin PR merged**, NOT
+    whether its directory is currently on the branch:
+
+    - Origin PR **merged** → the workspace graduated to a normal tracked
+      workspace. It is NOT an orphan. Shed the speculative PR link so we
+      never reconsider it; any *later* directory disappearance is a
+      delete/rename handled by `reconcile_branch_advance`. (Without this
+      a long-lived workspace whose dir is later renamed would be
+      wrongly archived here before the rename move runs.)
+    - Origin PR **closed unmerged** → genuine orphan. Re-verify the dir
+      really is absent, then: zero-state → archived; has-state →
+      pending_deletion.
+    - PR state **unknown** (deleted / transient fetch failure) → do
+      nothing. Fail safe — never archive on uncertainty; retry next
+      cycle.
     """
     res = await db.execute(
         select(Workspace).where(
@@ -371,8 +589,33 @@ async def reconcile_orphans(
     for ws in res.scalars().all():
         if ws.autodiscovery_pr_number in open_pr_numbers:
             continue  # PR still open — nothing to reconcile
+
+        pr = await _get_pull_request(conn, owner, repo, ws.autodiscovery_pr_number)
+        if pr is None:
+            continue  # unknown — fail safe, retry next cycle
+        if pr.merged:
+            # Graduated: a real, merged workspace. Drop the speculative
+            # link so the orphan reconciler never touches it again;
+            # rename/delete of its dir is reconcile_branch_advance's job.
+            _audit(
+                db,
+                "autodiscovery.graduated",
+                ws,
+                f"origin PR #{ws.autodiscovery_pr_number} merged — no longer speculative",
+            )
+            logger.info(
+                "Autodiscovery graduated workspace (origin PR merged)",
+                workspace_id=str(ws.id),
+                pr=ws.autodiscovery_pr_number,
+            )
+            ws.autodiscovery_pr_number = None
+            continue
+        if pr.state == "open" or (pr.state or "").lower() in ("open", "opened"):
+            continue  # reopened since we listed PRs — leave it alone
+
+        # Origin PR closed WITHOUT merging → genuine orphan.
         if not await _dir_absent_on_branch(conn, owner, repo, branch, ws.working_directory):
-            continue  # dir present (PR merged / pushed) — legitimate
+            continue  # dir somehow present — legitimate, do nothing
         if await _has_state(db, ws.id):
             ws.lifecycle_state = "pending_deletion"
             ws.lifecycle_reason = (

--- a/services/terrapod/services/github_service.py
+++ b/services/terrapod/services/github_service.py
@@ -492,6 +492,43 @@ async def get_changed_files(
     return [f["filename"] for f in files]
 
 
+async def get_pr_file_changes(
+    conn: VCSConnection, owner: str, repo: str, base_sha: str, head_sha: str
+) -> list[dict[str, str | None]] | None:
+    """Per-file change records for rename/delete detection (#314).
+
+    Returns a list of ``{"status", "path", "old_path"}`` where status is
+    one of added|removed|modified|renamed. ``old_path`` is the previous
+    filename for renames, else None. Returns None on truncation — the
+    caller MUST then skip lifecycle detection (acting on a partial diff
+    could wrongly move/destroy a workspace).
+    """
+    token = await get_installation_token(conn)
+    api_url = _api_url(conn)
+    resp = await _github_request(
+        "GET",
+        f"{api_url}/repos/{owner}/{repo}/compare/{base_sha}...{head_sha}",
+        token,
+    )
+    resp.raise_for_status()
+    files = resp.json().get("files", [])
+    if len(files) >= 300:
+        return None
+    out: list[dict[str, str | None]] = []
+    for f in files:
+        status = {"added": "added", "removed": "removed", "renamed": "renamed"}.get(
+            f.get("status", "modified"), "modified"
+        )
+        out.append(
+            {
+                "status": status,
+                "path": f["filename"],
+                "old_path": f.get("previous_filename") if status == "renamed" else None,
+            }
+        )
+    return out
+
+
 async def list_repo_tree(conn: VCSConnection, owner: str, repo: str, ref: str) -> list[str] | None:
     """List every file path in the repo at `ref`.
 

--- a/services/terrapod/services/github_service.py
+++ b/services/terrapod/services/github_service.py
@@ -695,6 +695,8 @@ async def get_pull_request(
         title=pr["title"],
         draft=bool(pr.get("draft", False)),
         author_login=(pr.get("user") or {}).get("login", ""),
+        state=pr.get("state", ""),
+        merged=bool(pr.get("merged", False) or pr.get("merged_at")),
     )
 
 

--- a/services/terrapod/services/gitlab_service.py
+++ b/services/terrapod/services/gitlab_service.py
@@ -248,6 +248,41 @@ async def get_changed_files(
     return list(files)
 
 
+async def get_pr_file_changes(
+    conn: VCSConnection, owner: str, repo: str, base_sha: str, head_sha: str
+) -> list[dict[str, str | None]] | None:
+    """Per-file change records for rename/delete detection (#314).
+
+    Returns ``{"status", "path", "old_path"}`` records (status one of
+    added|removed|modified|renamed). None on truncation — the caller
+    MUST then skip lifecycle detection (a partial diff could wrongly
+    move/destroy a workspace).
+    """
+    api = _api_url(conn)
+    project = _project_path(owner, repo)
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{api}/projects/{project}/repository/compare",
+            params={"from": base_sha, "to": head_sha, "per_page": 500},
+            headers=_headers(conn),
+        )
+        resp.raise_for_status()
+    diffs = resp.json().get("diffs", [])
+    if len(diffs) >= 500:
+        return None
+    out: list[dict[str, str | None]] = []
+    for d in diffs:
+        if d.get("deleted_file"):
+            out.append({"status": "removed", "path": d["old_path"], "old_path": None})
+        elif d.get("new_file"):
+            out.append({"status": "added", "path": d["new_path"], "old_path": None})
+        elif d.get("renamed_file"):
+            out.append({"status": "renamed", "path": d["new_path"], "old_path": d["old_path"]})
+        else:
+            out.append({"status": "modified", "path": d["new_path"], "old_path": None})
+    return out
+
+
 async def list_repo_tree(conn: VCSConnection, owner: str, repo: str, ref: str) -> list[str] | None:
     """List every file path in the repo at `ref`.
 

--- a/services/terrapod/services/gitlab_service.py
+++ b/services/terrapod/services/gitlab_service.py
@@ -462,6 +462,7 @@ async def get_pull_request(
             return None
         resp.raise_for_status()
     mr = resp.json()
+    mr_state = mr.get("state") or ""
     return PullRequest(
         number=mr["iid"],
         head_sha=mr.get("sha") or "",
@@ -469,6 +470,8 @@ async def get_pull_request(
         title=mr.get("title") or "",
         draft=bool(mr.get("draft", False)),
         author_login=(mr.get("author") or {}).get("username", ""),
+        state=mr_state,
+        merged=mr_state == "merged" or bool(mr.get("merged_at")),
     )
 
 

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -363,6 +363,20 @@ async def transition_run(
     if target_status == "applied" and not run.plan_only:
         await fire_run_triggers(db, run.workspace_id)
 
+    # #314: a successful opt-in autodiscovery destroy archives the
+    # workspace (soft-delete; retained for audit). Literal source
+    # compare avoids importing the lifecycle service (it imports us).
+    if (
+        target_status == "applied"
+        and run.is_destroy
+        and not run.plan_only
+        and run.source == "autodiscovery-lifecycle"
+    ):
+        ws = await db.get(Workspace, run.workspace_id)
+        if ws is not None and ws.lifecycle_state != "archived":
+            ws.lifecycle_state = "archived"
+            ws.lifecycle_reason = "autodiscovery destroy completed — archived"
+
     # Enqueue notification for this status change
     await _enqueue_notification(run, target_status)
 

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -1173,8 +1173,28 @@ async def _poll_autodiscovery_for_connection(
                     exc_info=True,
                 )
                 continue
+            # #314: status-bearing diff drives both rename suppression
+            # (don't speculatively create a workspace for a rename
+            # target) and the visibility reconcile below. Best-effort —
+            # None (truncated/failed) just means no suppression.
+            try:
+                fc = await _get_pr_file_changes(conn, owner, repo, target_branch, pr.head_sha)
+            except Exception:
+                fc = None
+            try:
+                suppress = await autodiscovery_lifecycle_service.rename_target_dirs_to_suppress(
+                    db, group, fc
+                )
+            except Exception:
+                suppress = set()
+
             new_workspaces = await autodiscover_for_paths(
-                db, group, changed, baseline_sha=baseline_sha, pr_number=pr.number
+                db,
+                group,
+                changed,
+                baseline_sha=baseline_sha,
+                pr_number=pr.number,
+                skip_roots=suppress,
             )
             created_count += len(new_workspaces)
 
@@ -1182,7 +1202,6 @@ async def _poll_autodiscovery_for_connection(
             # destroy plan + comment for deletes/renames). Best-effort:
             # never break the poll cycle.
             try:
-                fc = await _get_pr_file_changes(conn, owner, repo, target_branch, pr.head_sha)
                 for rule in group:
                     await autodiscovery_lifecycle_service.reconcile_open_pr(
                         db, rule, conn, owner, repo, pr.number, pr.head_sha, fc

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -40,7 +40,12 @@ from terrapod.db.models import (
 )
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
-from terrapod.services import github_service, gitlab_service, run_service
+from terrapod.services import (
+    autodiscovery_lifecycle_service,
+    github_service,
+    gitlab_service,
+    run_service,
+)
 from terrapod.services.scheduler import enqueue_trigger
 from terrapod.services.vcs_archive_cache import VCSArchiveCache, materialize_archive
 from terrapod.services.vcs_provider import PullRequest
@@ -111,6 +116,17 @@ async def _get_changed_files(
     if conn.provider == "gitlab":
         return await gitlab_service.get_changed_files(conn, owner, repo, base_sha, head_sha)
     return await github_service.get_changed_files(conn, owner, repo, base_sha, head_sha)
+
+
+async def _get_pr_file_changes(
+    conn: VCSConnection, owner: str, repo: str, base_sha: str, head_sha: str
+) -> list[dict] | None:
+    """Enriched per-file change records (status/old_path) for the #314
+    lifecycle reconciler. None on truncation → caller must skip.
+    """
+    if conn.provider == "gitlab":
+        return await gitlab_service.get_pr_file_changes(conn, owner, repo, base_sha, head_sha)
+    return await github_service.get_pr_file_changes(conn, owner, repo, base_sha, head_sha)
 
 
 async def _list_repo_tree(conn: VCSConnection, owner: str, repo: str, ref: str) -> list[str] | None:
@@ -371,6 +387,27 @@ async def _poll_workspace_branch(
     # Keep the in-memory ORM state consistent with the DB.
     ws.vcs_last_commit_sha = sha
     await db.commit()
+
+    # #314 lifecycle on branch-advance: if this is an autodiscovered
+    # workspace and the tracked branch moved, apply rename-in-place /
+    # delete-policy for its rule. Re-verifies dir absence against the
+    # tree before any flag/destroy. Best-effort — never break the poll.
+    if ws.autodiscovery_rule_id and old_sha:
+        try:
+            rule = await db.get(AutodiscoveryRule, ws.autodiscovery_rule_id)
+            if rule is not None:
+                fc = await _get_pr_file_changes(conn, owner, repo, old_sha, sha)
+                await autodiscovery_lifecycle_service.reconcile_branch_advance(
+                    db, rule, conn, owner, repo, branch, fc
+                )
+                await db.commit()
+        except Exception:
+            await db.rollback()
+            logger.warning(
+                "Autodiscovery lifecycle: branch-advance reconcile failed",
+                workspace=ws.name,
+                exc_info=True,
+            )
 
     VCS_COMMITS_DETECTED.labels(provider=conn.provider).inc()
 
@@ -1137,9 +1174,44 @@ async def _poll_autodiscovery_for_connection(
                 )
                 continue
             new_workspaces = await autodiscover_for_paths(
-                db, group, changed, baseline_sha=baseline_sha
+                db, group, changed, baseline_sha=baseline_sha, pr_number=pr.number
             )
             created_count += len(new_workspaces)
+
+            # #314 lifecycle (visibility only on open PRs — speculative
+            # destroy plan + comment for deletes/renames). Best-effort:
+            # never break the poll cycle.
+            try:
+                fc = await _get_pr_file_changes(conn, owner, repo, target_branch, pr.head_sha)
+                for rule in group:
+                    await autodiscovery_lifecycle_service.reconcile_open_pr(
+                        db, rule, conn, owner, repo, pr.number, pr.head_sha, fc
+                    )
+            except Exception:
+                logger.warning(
+                    "Autodiscovery lifecycle: open-PR reconcile failed",
+                    connection_id=str(conn.id),
+                    pr_number=pr.number,
+                    exc_info=True,
+                )
+
+        # #314 orphan reconcile: autodiscovered workspaces whose origin
+        # PR is no longer open AND whose directory is gone from the
+        # tracked branch (zero-state → archived; has-state → flagged).
+        # Best-effort; never break the poll cycle.
+        try:
+            open_pr_numbers = {pr.number for pr in prs}
+            for rule in group:
+                await autodiscovery_lifecycle_service.reconcile_orphans(
+                    db, rule, conn, owner, repo, target_branch, open_pr_numbers
+                )
+        except Exception:
+            logger.warning(
+                "Autodiscovery lifecycle: orphan reconcile failed",
+                connection_id=str(conn.id),
+                repo_url=repo_url,
+                exc_info=True,
+            )
 
         # Initial-scan path (#309): rules with `first_scan_at IS NULL`
         # have never been backfilled, so this poll cycle does a one-time

--- a/services/terrapod/services/vcs_provider.py
+++ b/services/terrapod/services/vcs_provider.py
@@ -13,7 +13,16 @@ from terrapod.db.models import VCSConnection
 class PullRequest:
     """Minimal PR/MR representation shared across providers."""
 
-    __slots__ = ("number", "head_sha", "head_ref", "title", "draft", "author_login")
+    __slots__ = (
+        "number",
+        "head_sha",
+        "head_ref",
+        "title",
+        "draft",
+        "author_login",
+        "state",
+        "merged",
+    )
 
     def __init__(
         self,
@@ -23,6 +32,8 @@ class PullRequest:
         title: str,
         draft: bool = False,
         author_login: str = "",
+        state: str = "",
+        merged: bool = False,
     ) -> None:
         self.number = number
         self.head_sha = head_sha
@@ -30,6 +41,13 @@ class PullRequest:
         self.title = title
         self.draft = draft
         self.author_login = author_login
+        # `state` is provider-native ("open"/"closed" for GitHub;
+        # "opened"/"closed"/"merged"/"locked" for GitLab). `merged` is
+        # the normalised "did this PR/MR actually merge?" — used by the
+        # autodiscovery orphan reconciler to tell a merged origin PR
+        # (workspace graduated) from a closed-unmerged one (orphan).
+        self.state = state
+        self.merged = merged
 
 
 @dataclass(frozen=True)

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -455,6 +455,7 @@ async def autodiscover_for_paths(
     changed_files: list[str],
     baseline_sha: str | None = None,
     pr_number: int | None = None,
+    skip_roots: set[str] | None = None,
 ) -> list[Workspace]:
     """For a set of changed files, return the list of workspaces that
     were *newly created* this call. Existing workspaces that the rule
@@ -466,8 +467,16 @@ async def autodiscover_for_paths(
     workspaces' `vcs_last_commit_sha` so the branch poll doesn't fire a
     premature plan+apply before the PR merges (#313).
 
+    `skip_roots` are directory roots that must NOT get a fresh
+    speculative workspace: they are the *new* side of a detected rename
+    of an existing autodiscovered workspace (#314). Creating one here
+    would duplicate the workspace and make the merge-time rename hit a
+    clash — the rename is reconciled by moving the existing workspace
+    in place instead.
+
     Idempotent across repeated calls with the same inputs.
     """
+    skip_roots = skip_roots or set()
     # Group `(rule, root_directory)` so multiple files in the same
     # directory only fire once.
     matches: dict[tuple[uuid.UUID, str], AutodiscoveryRule] = {}
@@ -478,6 +487,10 @@ async def autodiscover_for_paths(
             if not rule_claims_path(rule, path):
                 continue
             root = derive_root_directory(path)
+            if root in skip_roots:
+                # Rename target — handled by the merge-time in-place
+                # move, not by speculative creation (#314).
+                break
             matches[(rule.id, root)] = rule
             # First matching rule wins — don't fan out to multiple
             # rules for the same file.

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -193,6 +193,7 @@ async def find_or_autocreate_workspace(
     rule: AutodiscoveryRule,
     root_directory: str,
     baseline_sha: str | None = None,
+    pr_number: int | None = None,
 ) -> tuple[Workspace, bool]:
     """Look up the workspace this rule + directory should map to, or
     create it if it doesn't exist.
@@ -284,6 +285,9 @@ async def find_or_autocreate_workspace(
         # doesn't fire a premature plan+apply before the PR merges (#313).
         vcs_last_commit_sha=baseline_sha or None,
         autodiscovery_rule_id=rule.id,
+        # PR provenance (#314) — lets the poller reconcile this workspace
+        # if its origin PR is later closed unmerged / no longer matches.
+        autodiscovery_pr_number=pr_number,
         # trigger_prefixes scoped tightly to the discovered directory so
         # the regular VCS poller treats this workspace as a normal
         # working_directory-targeted one from now on.
@@ -450,6 +454,7 @@ async def autodiscover_for_paths(
     rules: list[AutodiscoveryRule],
     changed_files: list[str],
     baseline_sha: str | None = None,
+    pr_number: int | None = None,
 ) -> list[Workspace]:
     """For a set of changed files, return the list of workspaces that
     were *newly created* this call. Existing workspaces that the rule
@@ -482,7 +487,7 @@ async def autodiscover_for_paths(
     for (_rule_id, root), rule in matches.items():
         try:
             ws, was_created = await find_or_autocreate_workspace(
-                db, rule, root, baseline_sha=baseline_sha
+                db, rule, root, baseline_sha=baseline_sha, pr_number=pr_number
             )
             if was_created:
                 created.append(ws)

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -48,6 +48,7 @@ def _mock_rule(
     r.resource_cpu = "1"
     r.resource_memory = "2Gi"
     r.auto_apply = False
+    r.on_directory_delete = "flag"
     r.labels = {"env": "monorepo"}
     r.owner_email = "admin@example.com"
     r.created_at = datetime(2026, 5, 9, tzinfo=UTC)
@@ -379,6 +380,81 @@ class TestUpdateRule:
             )
         assert resp.status_code == 200
         assert rule.first_scan_at == scanned
+
+
+# ── on-directory-delete (#314) ───────────────────────────────────────────
+
+
+class TestOnDirectoryDelete:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_with_destroy_echoed_back(self, *_mocks):
+        conn_id = uuid.uuid4()
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(side_effect=[MagicMock(id=conn_id)])
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        body = {
+            "data": {
+                "type": "autodiscovery-rules",
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{conn_id}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "on-directory-delete": "destroy",
+                },
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["data"]["attributes"]["on-directory-delete"] == "destroy"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_patch_to_destroy_echoed_back(self, *_mocks):
+        rule = _mock_rule()
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(return_value=rule)
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {"data": {"attributes": {"on-directory-delete": "destroy"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/autodiscovery-rules/{rule.id}",
+                json=body,
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert rule.on_directory_delete == "destroy"
+        assert resp.json()["data"]["attributes"]["on-directory-delete"] == "destroy"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_invalid_value_rejected_422(self, *_mocks):
+        app, _db = _make_app(_admin())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{uuid.uuid4()}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "on-directory-delete": "nuke",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+        assert "on-directory-delete" in resp.json()["detail"]
 
 
 # ── Delete ───────────────────────────────────────────────────────────────

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -50,6 +50,9 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.vcs_workflow = overrides.get("vcs_workflow", "merge_then_apply")
     ws.auto_merge = overrides.get("auto_merge", False)
     ws.auto_merge_strategy = overrides.get("auto_merge_strategy", "merge")
+    ws.lifecycle_state = overrides.get("lifecycle_state", "active")
+    ws.lifecycle_reason = overrides.get("lifecycle_reason", "")
+    ws.autodiscovery_pr_number = overrides.get("autodiscovery_pr_number", None)
     ws.execution_backend = overrides.get("execution_backend", "tofu")
     ws.agent_pool = None
     ws.agent_pool_id = overrides.get("agent_pool_id", None)

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -59,6 +59,9 @@ def _mock_workspace(ws_id=None, pool_id=None):
     ws.vcs_workflow = "merge_then_apply"
     ws.auto_merge = False
     ws.auto_merge_strategy = "merge"
+    ws.lifecycle_state = "active"
+    ws.lifecycle_reason = ""
+    ws.autodiscovery_pr_number = None
     ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return ws

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -70,6 +70,9 @@ def _mock_workspace(
     ws.vcs_workflow = "merge_then_apply"
     ws.auto_merge = False
     ws.auto_merge_strategy = "merge"
+    ws.lifecycle_state = "active"
+    ws.lifecycle_reason = ""
+    ws.autodiscovery_pr_number = None
     ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return ws

--- a/services/tests/services/test_autodiscovery_lifecycle_service.py
+++ b/services/tests/services/test_autodiscovery_lifecycle_service.py
@@ -1,0 +1,442 @@
+"""Tests for autodiscovery workspace lifecycle (#314).
+
+Covers the pure `classify_dir_changes` reducer and the three async
+reconcilers (`reconcile_open_pr`, `reconcile_branch_advance`,
+`reconcile_orphans`). The reconcilers are safe-by-default: nothing
+destroys infra unless a rule explicitly opts in, and no flag/destroy
+happens until a directory's absence is re-verified against the
+tracked-branch tree.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from terrapod.services import autodiscovery_lifecycle_service as svc
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _fc(status, path, old_path=None):
+    """A single file-change record (matches the poller's diff shape)."""
+    return {"status": status, "path": path, "old_path": old_path}
+
+
+def _mock_rule(on_directory_delete="flag", name_template=""):
+    r = MagicMock()
+    r.id = uuid.uuid4()
+    r.name = "monorepo"
+    r.name_template = name_template
+    r.vcs_connection_id = uuid.uuid4()
+    r.repo_url = "https://github.com/example/repo"
+    r.on_directory_delete = on_directory_delete
+    return r
+
+
+def _mock_conn(provider="github"):
+    c = MagicMock()
+    c.id = uuid.uuid4()
+    c.provider = provider
+    return c
+
+
+def _mock_ws(working_directory="accounts/a", name="accounts-a", pr_number=None):
+    ws = MagicMock()
+    ws.id = uuid.uuid4()
+    ws.name = name
+    ws.working_directory = working_directory
+    ws.trigger_prefixes = [working_directory] if working_directory else []
+    ws.lifecycle_state = "active"
+    ws.lifecycle_reason = ""
+    ws.autodiscovery_pr_number = pr_number
+    return ws
+
+
+def _result(*, scalar_one_or_none=None, scalars_all=None, scalar=None):
+    """A SQLAlchemy-result-like MagicMock."""
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = scalar_one_or_none
+    res.scalars.return_value.all.return_value = scalars_all or []
+    res.scalar.return_value = scalar
+    return res
+
+
+# ── classify_dir_changes (pure) ──────────────────────────────────────────
+
+
+class TestClassifyDirChanges:
+    def test_clean_delete(self):
+        """All files in a dir removed, dir not otherwise present → deleted."""
+        cls = svc.classify_dir_changes(
+            [
+                _fc("removed", "accounts/a/main.tf"),
+                _fc("removed", "accounts/a/vars.tf"),
+            ]
+        )
+        assert cls["deleted"] == {"accounts/a"}
+        assert cls["renamed"] == []
+        assert cls["ambiguous"] == set()
+
+    def test_clean_rename(self):
+        """All files renamed old_root → exactly one new_root, old not
+        present → renamed (not deleted)."""
+        cls = svc.classify_dir_changes(
+            [
+                _fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf"),
+                _fc("renamed", "accounts/b/vars.tf", old_path="accounts/a/vars.tf"),
+            ]
+        )
+        assert cls["renamed"] == [("accounts/a", "accounts/b")]
+        assert cls["deleted"] == set()
+        assert cls["ambiguous"] == set()
+
+    def test_split_is_ambiguous_not_deleted_or_renamed(self):
+        """One old_root fanning out to two new_roots → ambiguous."""
+        cls = svc.classify_dir_changes(
+            [
+                _fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf"),
+                _fc("renamed", "accounts/c/vars.tf", old_path="accounts/a/vars.tf"),
+            ]
+        )
+        assert cls["ambiguous"] == {"accounts/a"}
+        assert cls["renamed"] == []
+        assert "accounts/a" not in cls["deleted"]
+
+    def test_modified_only_dir_classifies_as_nothing(self):
+        cls = svc.classify_dir_changes([_fc("modified", "accounts/a/main.tf")])
+        assert cls["deleted"] == set()
+        assert cls["renamed"] == []
+        assert cls["ambiguous"] == set()
+
+    def test_mixed_removed_and_added_same_dir_not_deleted(self):
+        """A dir that is both removed-from and added-to is still present
+        — not a clean delete."""
+        cls = svc.classify_dir_changes(
+            [
+                _fc("removed", "accounts/a/old.tf"),
+                _fc("added", "accounts/a/new.tf"),
+            ]
+        )
+        assert "accounts/a" not in cls["deleted"]
+        assert cls["renamed"] == []
+        assert cls["ambiguous"] == set()
+
+
+# ── reconcile_open_pr (visibility only) ──────────────────────────────────
+
+
+class TestReconcileOpenPr:
+    @patch.object(svc, "_post_comment", new_callable=AsyncMock)
+    @patch.object(svc, "run_service")
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_deleted_dir_creates_speculative_destroy_and_comments(
+        self, m_ws, m_run_service, m_comment
+    ):
+        rule = _mock_rule()
+        conn = _mock_conn()
+        ws = _mock_ws()
+        m_ws.return_value = ws
+        run = MagicMock()
+        m_run_service.create_run = AsyncMock(return_value=run)
+        db = AsyncMock()
+        # Dedup query: no existing run.
+        db.execute.return_value = _result(scalar_one_or_none=None)
+
+        await svc.reconcile_open_pr(
+            db,
+            rule,
+            conn,
+            "example",
+            "repo",
+            7,
+            "abc123",
+            [_fc("removed", "accounts/a/main.tf")],
+        )
+
+        m_run_service.create_run.assert_awaited_once()
+        kwargs = m_run_service.create_run.await_args.kwargs
+        assert kwargs["is_destroy"] is True
+        assert kwargs["plan_only"] is True
+        assert kwargs["source"] == svc.LIFECYCLE_SOURCE
+        assert run.vcs_commit_sha == "abc123"
+        assert run.vcs_pull_request_number == 7
+        m_comment.assert_awaited_once()
+
+    @patch.object(svc, "_post_comment", new_callable=AsyncMock)
+    @patch.object(svc, "run_service")
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_dedupe_existing_run_no_second_create(self, m_ws, m_run_service, m_comment):
+        rule = _mock_rule()
+        conn = _mock_conn()
+        m_ws.return_value = _mock_ws()
+        m_run_service.create_run = AsyncMock()
+        db = AsyncMock()
+        # Dedup query: a run already exists for this (ws, head_sha).
+        db.execute.return_value = _result(scalar_one_or_none=uuid.uuid4())
+
+        await svc.reconcile_open_pr(
+            db,
+            rule,
+            conn,
+            "example",
+            "repo",
+            7,
+            "abc123",
+            [_fc("removed", "accounts/a/main.tf")],
+        )
+
+        m_run_service.create_run.assert_not_awaited()
+        # Comment is still posted (visibility) even when the run is deduped.
+        m_comment.assert_awaited_once()
+
+    @patch.object(svc, "_post_comment", new_callable=AsyncMock)
+    @patch.object(svc, "run_service")
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_file_changes_none_is_noop(self, m_ws, m_run_service, m_comment):
+        m_run_service.create_run = AsyncMock()
+        db = AsyncMock()
+
+        await svc.reconcile_open_pr(
+            db, _mock_rule(), _mock_conn(), "example", "repo", 7, "abc123", None
+        )
+
+        m_ws.assert_not_awaited()
+        m_run_service.create_run.assert_not_awaited()
+        m_comment.assert_not_awaited()
+        db.execute.assert_not_awaited()
+
+
+# ── reconcile_branch_advance (mutating, safe) ────────────────────────────
+
+
+class TestReconcileBranchAdvance:
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_rename_moves_workspace_in_place(self, m_ws, m_absent):
+        rule = _mock_rule()
+        ws = _mock_ws(working_directory="accounts/a", name="accounts-a")
+        m_ws.return_value = ws
+        db = AsyncMock()
+        # Clash check: nothing already owns the new dir.
+        db.execute.return_value = _result(scalar_one_or_none=None)
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf")],
+        )
+
+        assert ws.working_directory == "accounts/b"
+        assert ws.trigger_prefixes == ["accounts/b"]
+        # name_template empty → name unchanged (in-place move, not re-derived).
+        assert ws.name == "accounts-a"
+        assert ws.lifecycle_state == "active"
+
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_rename_rederives_name_when_template_set(self, m_ws, m_absent):
+        rule = _mock_rule(name_template="ws-{path}")
+        ws = _mock_ws(working_directory="accounts/a", name="ws-accounts-a")
+        m_ws.return_value = ws
+        db = AsyncMock()
+        db.execute.return_value = _result(scalar_one_or_none=None)
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf")],
+        )
+
+        assert ws.working_directory == "accounts/b"
+        assert ws.name == "ws-accounts-b"
+
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_rename_target_collision_sets_pending_not_moved(self, m_ws, m_absent):
+        rule = _mock_rule()
+        ws = _mock_ws(working_directory="accounts/a")
+        m_ws.return_value = ws
+        db = AsyncMock()
+        # Clash check: a workspace already owns the new dir.
+        db.execute.return_value = _result(scalar_one_or_none=uuid.uuid4())
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf")],
+        )
+
+        assert ws.lifecycle_state == "pending_deletion"
+        # Not moved.
+        assert ws.working_directory == "accounts/a"
+
+    @patch.object(svc, "run_service")
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_delete_flag_policy_flags_pending_no_destroy(self, m_ws, m_absent, m_run_service):
+        rule = _mock_rule(on_directory_delete="flag")
+        ws = _mock_ws(working_directory="accounts/a")
+        m_ws.return_value = ws
+        m_absent.return_value = True  # re-verified gone
+        m_run_service.create_run = AsyncMock()
+        db = AsyncMock()
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("removed", "accounts/a/main.tf")],
+        )
+
+        assert ws.lifecycle_state == "pending_deletion"
+        m_run_service.create_run.assert_not_awaited()
+
+    @patch.object(svc, "run_service")
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_delete_destroy_policy_queues_destroy_run(self, m_ws, m_absent, m_run_service):
+        rule = _mock_rule(on_directory_delete="destroy")
+        ws = _mock_ws(working_directory="accounts/a")
+        m_ws.return_value = ws
+        m_absent.return_value = True
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        m_run_service.create_run = AsyncMock(return_value=run)
+        db = AsyncMock()
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("removed", "accounts/a/main.tf")],
+        )
+
+        m_run_service.create_run.assert_awaited_once()
+        kwargs = m_run_service.create_run.await_args.kwargs
+        assert kwargs["is_destroy"] is True
+        assert kwargs["plan_only"] is False
+        assert kwargs["auto_apply"] is True
+
+    @patch.object(svc, "run_service")
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_dir_still_present_does_nothing(self, m_ws, m_absent, m_run_service):
+        """Critical safety: if the dir is still present (or the tree is
+        unverifiable), absolutely nothing happens — no flag, no destroy."""
+        rule = _mock_rule(on_directory_delete="destroy")
+        ws = _mock_ws(working_directory="accounts/a")
+        m_ws.return_value = ws
+        m_absent.return_value = False  # NOT verified absent
+        m_run_service.create_run = AsyncMock()
+        db = AsyncMock()
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("removed", "accounts/a/main.tf")],
+        )
+
+        assert ws.lifecycle_state == "active"
+        assert ws.lifecycle_reason == ""
+        m_run_service.create_run.assert_not_awaited()
+
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_file_changes_none_is_noop(self, m_ws):
+        db = AsyncMock()
+        await svc.reconcile_branch_advance(
+            db, _mock_rule(), _mock_conn(), "example", "repo", "main", None
+        )
+        m_ws.assert_not_awaited()
+        db.execute.assert_not_awaited()
+
+
+# ── reconcile_orphans ────────────────────────────────────────────────────
+
+
+class TestReconcileOrphans:
+    @patch.object(svc, "_has_state", new_callable=AsyncMock)
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    async def test_closed_pr_dir_absent_no_state_archived(self, m_absent, m_state):
+        rule = _mock_rule()
+        ws = _mock_ws(pr_number=42)
+        db = AsyncMock()
+        db.execute.return_value = _result(scalars_all=[ws])
+        m_absent.return_value = True
+        m_state.return_value = False  # never applied
+
+        await svc.reconcile_orphans(
+            db, rule, _mock_conn(), "example", "repo", "main", open_pr_numbers=set()
+        )
+
+        assert ws.lifecycle_state == "archived"
+
+    @patch.object(svc, "_has_state", new_callable=AsyncMock)
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    async def test_closed_pr_dir_absent_has_state_pending_deletion(self, m_absent, m_state):
+        rule = _mock_rule()
+        ws = _mock_ws(pr_number=42)
+        db = AsyncMock()
+        db.execute.return_value = _result(scalars_all=[ws])
+        m_absent.return_value = True
+        m_state.return_value = True  # has applied state
+
+        await svc.reconcile_orphans(
+            db, rule, _mock_conn(), "example", "repo", "main", open_pr_numbers=set()
+        )
+
+        assert ws.lifecycle_state == "pending_deletion"
+
+    @patch.object(svc, "_has_state", new_callable=AsyncMock)
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    async def test_pr_still_open_untouched(self, m_absent, m_state):
+        rule = _mock_rule()
+        ws = _mock_ws(pr_number=42)
+        db = AsyncMock()
+        db.execute.return_value = _result(scalars_all=[ws])
+
+        await svc.reconcile_orphans(
+            db, rule, _mock_conn(), "example", "repo", "main", open_pr_numbers={42}
+        )
+
+        assert ws.lifecycle_state == "active"
+        m_absent.assert_not_awaited()
+        m_state.assert_not_awaited()
+
+    @patch.object(svc, "_has_state", new_callable=AsyncMock)
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    async def test_dir_still_present_untouched(self, m_absent, m_state):
+        """PR closed but the dir is still on the branch (legitimately
+        merged/pushed) — leave the workspace alone."""
+        rule = _mock_rule()
+        ws = _mock_ws(pr_number=42)
+        db = AsyncMock()
+        db.execute.return_value = _result(scalars_all=[ws])
+        m_absent.return_value = False  # dir present
+
+        await svc.reconcile_orphans(
+            db, rule, _mock_conn(), "example", "repo", "main", open_pr_numbers=set()
+        )
+
+        assert ws.lifecycle_state == "active"
+        m_state.assert_not_awaited()

--- a/services/tests/services/test_autodiscovery_lifecycle_service.py
+++ b/services/tests/services/test_autodiscovery_lifecycle_service.py
@@ -120,6 +120,84 @@ class TestClassifyDirChanges:
         assert cls["renamed"] == []
         assert cls["ambiguous"] == set()
 
+    def test_squash_merge_rename_inferred_from_add_remove_symmetry(self):
+        """Squash merge loses provider `renamed` status: the move shows
+        up as plain removed(old) + added(new) with identical basenames.
+        We MUST infer the rename, not classify it as a delete — a
+        `destroy`-opt-in rule would otherwise tear down a renamed
+        workspace (the #314 Test-2 bug)."""
+        cls = svc.classify_dir_changes(
+            [
+                _fc("removed", "accounts/a/main.tf"),
+                _fc("removed", "accounts/a/vars.tf"),
+                _fc("added", "accounts/b/main.tf"),
+                _fc("added", "accounts/b/vars.tf"),
+            ]
+        )
+        assert cls["renamed"] == [("accounts/a", "accounts/b")]
+        assert cls["deleted"] == set()
+        assert cls["ambiguous"] == set()
+
+    def test_inferred_rename_basename_mismatch_stays_deleted(self):
+        """No symmetry (different basenames) → the removed dir is a real
+        delete, the added dir is just new. Never falsely 'rename'."""
+        cls = svc.classify_dir_changes(
+            [
+                _fc("removed", "accounts/a/main.tf"),
+                _fc("added", "accounts/b/totally-different.tf"),
+            ]
+        )
+        assert cls["deleted"] == {"accounts/a"}
+        assert cls["renamed"] == []
+
+    def test_inferred_rename_ambiguous_when_two_added_dirs_match(self):
+        """Removed dir's basename set matches >1 added dir → ambiguous,
+        never auto-deleted or auto-renamed."""
+        cls = svc.classify_dir_changes(
+            [
+                _fc("removed", "accounts/a/main.tf"),
+                _fc("added", "accounts/b/main.tf"),
+                _fc("added", "accounts/c/main.tf"),
+            ]
+        )
+        assert cls["ambiguous"] == {"accounts/a"}
+        assert cls["renamed"] == []
+        assert "accounts/a" not in cls["deleted"]
+
+
+# ── rename_target_dirs_to_suppress (#314 duplicate prevention) ───────────
+
+
+class TestRenameTargetDirsToSuppress:
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_rename_with_existing_ws_suppresses_new_dir(self, m_ws):
+        """Old side has a rule-owned active workspace → the new dir must
+        be suppressed so open-PR autodiscovery doesn't create a
+        duplicate that the merge-time rename would then clash with."""
+        m_ws.return_value = _mock_ws()
+        out = await svc.rename_target_dirs_to_suppress(
+            AsyncMock(),
+            [_mock_rule()],
+            [_fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf")],
+        )
+        assert out == {"accounts/b"}
+
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_rename_without_existing_ws_suppresses_nothing(self, m_ws):
+        """No existing workspace on the old side → it's not really a
+        'move of a tracked workspace'; let normal autodiscovery run."""
+        m_ws.return_value = None
+        out = await svc.rename_target_dirs_to_suppress(
+            AsyncMock(),
+            [_mock_rule()],
+            [_fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf")],
+        )
+        assert out == set()
+
+    async def test_none_file_changes_suppresses_nothing(self):
+        out = await svc.rename_target_dirs_to_suppress(AsyncMock(), [_mock_rule()], None)
+        assert out == set()
+
 
 # ── reconcile_open_pr (visibility only) ──────────────────────────────────
 
@@ -138,8 +216,12 @@ class TestReconcileOpenPr:
         run = MagicMock()
         m_run_service.create_run = AsyncMock(return_value=run)
         db = AsyncMock()
-        # Dedup query: no existing run.
-        db.execute.return_value = _result(scalar_one_or_none=None)
+        # 1) run-dedup query → no existing run; 2) notify-seen query →
+        # not yet notified.
+        db.execute.side_effect = [
+            _result(scalar_one_or_none=None),
+            _result(scalar_one_or_none=None),
+        ]
 
         await svc.reconcile_open_pr(
             db,
@@ -164,14 +246,20 @@ class TestReconcileOpenPr:
     @patch.object(svc, "_post_comment", new_callable=AsyncMock)
     @patch.object(svc, "run_service")
     @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
-    async def test_dedupe_existing_run_no_second_create(self, m_ws, m_run_service, m_comment):
+    async def test_dedupe_existing_run_still_comments_first_time(
+        self, m_ws, m_run_service, m_comment
+    ):
+        """Run already exists (no second plan) but this is the first
+        comment for this head_sha → comment IS posted."""
         rule = _mock_rule()
         conn = _mock_conn()
         m_ws.return_value = _mock_ws()
         m_run_service.create_run = AsyncMock()
         db = AsyncMock()
-        # Dedup query: a run already exists for this (ws, head_sha).
-        db.execute.return_value = _result(scalar_one_or_none=uuid.uuid4())
+        db.execute.side_effect = [
+            _result(scalar_one_or_none=uuid.uuid4()),  # run exists
+            _result(scalar_one_or_none=None),  # not yet notified
+        ]
 
         await svc.reconcile_open_pr(
             db,
@@ -185,8 +273,59 @@ class TestReconcileOpenPr:
         )
 
         m_run_service.create_run.assert_not_awaited()
-        # Comment is still posted (visibility) even when the run is deduped.
         m_comment.assert_awaited_once()
+
+    @patch.object(svc, "_post_comment", new_callable=AsyncMock)
+    @patch.object(svc, "run_service")
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_comment_deduped_when_already_notified(self, m_ws, m_run_service, m_comment):
+        """The cyclic poller must NOT re-post the same comment: once a
+        notify marker exists for (ws, head_sha) the comment is
+        suppressed even though reconcile runs again."""
+        rule = _mock_rule()
+        conn = _mock_conn()
+        m_ws.return_value = _mock_ws()
+        m_run_service.create_run = AsyncMock()
+        db = AsyncMock()
+        db.execute.side_effect = [
+            _result(scalar_one_or_none=uuid.uuid4()),  # run exists
+            _result(scalar_one_or_none=uuid.uuid4()),  # already notified
+        ]
+
+        await svc.reconcile_open_pr(
+            db,
+            rule,
+            conn,
+            "example",
+            "repo",
+            7,
+            "abc123",
+            [_fc("removed", "accounts/a/main.tf")],
+        )
+
+        m_run_service.create_run.assert_not_awaited()
+        m_comment.assert_not_awaited()
+
+    @patch.object(svc, "_post_comment", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_rename_comment_deduped_when_already_notified(self, m_ws, m_comment):
+        """Rename comment is also deduped per (ws, head_sha)."""
+        m_ws.return_value = _mock_ws()
+        db = AsyncMock()
+        db.execute.return_value = _result(scalar_one_or_none=uuid.uuid4())  # notified
+
+        await svc.reconcile_open_pr(
+            db,
+            _mock_rule(),
+            _mock_conn(),
+            "example",
+            "repo",
+            7,
+            "abc123",
+            [_fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf")],
+        )
+
+        m_comment.assert_not_awaited()
 
     @patch.object(svc, "_post_comment", new_callable=AsyncMock)
     @patch.object(svc, "run_service")
@@ -281,6 +420,76 @@ class TestReconcileBranchAdvance:
         # Not moved.
         assert ws.working_directory == "accounts/a"
 
+    @patch.object(svc, "_has_state", new_callable=AsyncMock)
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_rename_absorbs_speculative_duplicate_and_moves_original(
+        self, m_ws, m_absent, m_has_state
+    ):
+        """The common PR-driven rename: open-PR autodiscovery already
+        created a never-applied speculative workspace at the new dir.
+        That is NOT a real conflict — it must be absorbed (archived,
+        name/dir freed) and the original (state/history-bearing)
+        workspace moved in place. This is the #314 Test-2 bug."""
+        rule = _mock_rule()
+        original = _mock_ws(working_directory="accounts/a", name="accounts-a")
+        m_ws.return_value = original
+        dup = _mock_ws(working_directory="accounts/b", name="accounts-b", pr_number=8)
+        dup.autodiscovery_rule_id = rule.id  # rule-owned
+        m_has_state.return_value = False  # never applied
+        db = AsyncMock()
+        db.execute.return_value = _result(scalars_all=[dup])
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf")],
+        )
+
+        # Original moved in place, still active.
+        assert original.working_directory == "accounts/b"
+        assert original.lifecycle_state == "active"
+        # Speculative duplicate archived + name/dir freed (no clash).
+        assert dup.lifecycle_state == "archived"
+        assert dup.name.startswith("accounts-b-superseded-")
+        assert dup.working_directory.startswith("accounts/b#superseded-")
+
+    @patch.object(svc, "_has_state", new_callable=AsyncMock)
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_rename_genuine_conflict_not_absorbed(self, m_ws, m_absent, m_has_state):
+        """A real workspace already owns the new dir (not a rule-owned
+        zero-state speculative dup) → must NOT be absorbed; the original
+        is flagged pending_deletion for an operator to decide."""
+        rule = _mock_rule()
+        original = _mock_ws(working_directory="accounts/a")
+        m_ws.return_value = original
+        other = _mock_ws(working_directory="accounts/b", name="real-b")
+        other.autodiscovery_rule_id = uuid.uuid4()  # different rule → not absorbable
+        db = AsyncMock()
+        db.execute.side_effect = [
+            _result(scalars_all=[other]),  # _absorbable_speculative_dup → None
+            _result(scalar_one_or_none=uuid.uuid4()),  # clash check → conflict
+        ]
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("renamed", "accounts/b/main.tf", old_path="accounts/a/main.tf")],
+        )
+
+        assert original.lifecycle_state == "pending_deletion"
+        assert original.working_directory == "accounts/a"  # not moved
+        assert other.lifecycle_state == "active"  # untouched
+
     @patch.object(svc, "run_service")
     @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
     @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
@@ -374,14 +583,21 @@ class TestReconcileBranchAdvance:
 # ── reconcile_orphans ────────────────────────────────────────────────────
 
 
+def _pr(*, merged=False, state="closed"):
+    """A PR-like object exposing just what reconcile_orphans reads."""
+    return MagicMock(merged=merged, state=state)
+
+
 class TestReconcileOrphans:
+    @patch.object(svc, "_get_pull_request", new_callable=AsyncMock)
     @patch.object(svc, "_has_state", new_callable=AsyncMock)
     @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
-    async def test_closed_pr_dir_absent_no_state_archived(self, m_absent, m_state):
+    async def test_closed_unmerged_dir_absent_no_state_archived(self, m_absent, m_state, m_get_pr):
         rule = _mock_rule()
         ws = _mock_ws(pr_number=42)
         db = AsyncMock()
         db.execute.return_value = _result(scalars_all=[ws])
+        m_get_pr.return_value = _pr(merged=False, state="closed")
         m_absent.return_value = True
         m_state.return_value = False  # never applied
 
@@ -391,13 +607,17 @@ class TestReconcileOrphans:
 
         assert ws.lifecycle_state == "archived"
 
+    @patch.object(svc, "_get_pull_request", new_callable=AsyncMock)
     @patch.object(svc, "_has_state", new_callable=AsyncMock)
     @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
-    async def test_closed_pr_dir_absent_has_state_pending_deletion(self, m_absent, m_state):
+    async def test_closed_unmerged_dir_absent_has_state_pending_deletion(
+        self, m_absent, m_state, m_get_pr
+    ):
         rule = _mock_rule()
         ws = _mock_ws(pr_number=42)
         db = AsyncMock()
         db.execute.return_value = _result(scalars_all=[ws])
+        m_get_pr.return_value = _pr(merged=False, state="closed")
         m_absent.return_value = True
         m_state.return_value = True  # has applied state
 
@@ -407,9 +627,56 @@ class TestReconcileOrphans:
 
         assert ws.lifecycle_state == "pending_deletion"
 
+    @patch.object(svc, "_get_pull_request", new_callable=AsyncMock)
     @patch.object(svc, "_has_state", new_callable=AsyncMock)
     @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
-    async def test_pr_still_open_untouched(self, m_absent, m_state):
+    async def test_origin_pr_merged_graduates_and_is_never_orphaned(
+        self, m_absent, m_state, m_get_pr
+    ):
+        """The #314 Test-2 regression: a workspace whose origin PR
+        *merged* is a real graduated workspace, NOT an orphan. It must
+        shed its speculative PR link and be left active so a later
+        rename of its dir is moved in place (not archived here)."""
+        rule = _mock_rule()
+        ws = _mock_ws(pr_number=7)
+        db = AsyncMock()
+        db.execute.return_value = _result(scalars_all=[ws])
+        m_get_pr.return_value = _pr(merged=True, state="closed")
+
+        await svc.reconcile_orphans(
+            db, rule, _mock_conn(), "example", "repo", "main", open_pr_numbers=set()
+        )
+
+        assert ws.lifecycle_state == "active"
+        assert ws.autodiscovery_pr_number is None  # graduated
+        m_absent.assert_not_awaited()  # never even checks the tree
+        m_state.assert_not_awaited()
+
+    @patch.object(svc, "_get_pull_request", new_callable=AsyncMock)
+    @patch.object(svc, "_has_state", new_callable=AsyncMock)
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    async def test_unknown_pr_state_fail_safe_no_action(self, m_absent, m_state, m_get_pr):
+        """PR fetch returns None (deleted/transient) → never archive on
+        uncertainty; leave untouched and retry next cycle."""
+        rule = _mock_rule()
+        ws = _mock_ws(pr_number=42)
+        db = AsyncMock()
+        db.execute.return_value = _result(scalars_all=[ws])
+        m_get_pr.return_value = None
+
+        await svc.reconcile_orphans(
+            db, rule, _mock_conn(), "example", "repo", "main", open_pr_numbers=set()
+        )
+
+        assert ws.lifecycle_state == "active"
+        assert ws.autodiscovery_pr_number == 42
+        m_absent.assert_not_awaited()
+        m_state.assert_not_awaited()
+
+    @patch.object(svc, "_get_pull_request", new_callable=AsyncMock)
+    @patch.object(svc, "_has_state", new_callable=AsyncMock)
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    async def test_pr_still_open_untouched(self, m_absent, m_state, m_get_pr):
         rule = _mock_rule()
         ws = _mock_ws(pr_number=42)
         db = AsyncMock()
@@ -420,18 +687,21 @@ class TestReconcileOrphans:
         )
 
         assert ws.lifecycle_state == "active"
+        m_get_pr.assert_not_awaited()
         m_absent.assert_not_awaited()
         m_state.assert_not_awaited()
 
+    @patch.object(svc, "_get_pull_request", new_callable=AsyncMock)
     @patch.object(svc, "_has_state", new_callable=AsyncMock)
     @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
-    async def test_dir_still_present_untouched(self, m_absent, m_state):
-        """PR closed but the dir is still on the branch (legitimately
-        merged/pushed) — leave the workspace alone."""
+    async def test_closed_unmerged_dir_still_present_untouched(self, m_absent, m_state, m_get_pr):
+        """Origin PR closed unmerged but the dir is somehow on the
+        branch — leave the workspace alone."""
         rule = _mock_rule()
         ws = _mock_ws(pr_number=42)
         db = AsyncMock()
         db.execute.return_value = _result(scalars_all=[ws])
+        m_get_pr.return_value = _pr(merged=False, state="closed")
         m_absent.return_value = False  # dir present
 
         await svc.reconcile_orphans(

--- a/services/tests/services/test_autodiscovery_lifecycle_service.py
+++ b/services/tests/services/test_autodiscovery_lifecycle_service.py
@@ -526,6 +526,7 @@ class TestReconcileBranchAdvance:
         run.id = uuid.uuid4()
         m_run_service.create_run = AsyncMock(return_value=run)
         db = AsyncMock()
+        db.execute.return_value = _result(scalar_one_or_none=None)  # no destroy in flight
 
         await svc.reconcile_branch_advance(
             db,
@@ -542,6 +543,35 @@ class TestReconcileBranchAdvance:
         assert kwargs["is_destroy"] is True
         assert kwargs["plan_only"] is False
         assert kwargs["auto_apply"] is True
+
+    @patch.object(svc, "run_service")
+    @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)
+    @patch.object(svc, "_autodiscovered_ws", new_callable=AsyncMock)
+    async def test_destroy_deduped_when_already_queued(self, m_ws, m_absent, m_run_service):
+        """Idempotency: every branch advance of any workspace sharing
+        the rule/repo re-runs reconcile. The destroy path must NOT queue
+        a second destroy while one is already in flight/done (otherwise
+        concurrent `terraform destroy` jobs for one workspace)."""
+        rule = _mock_rule(on_directory_delete="destroy")
+        ws = _mock_ws(working_directory="accounts/a")
+        m_ws.return_value = ws
+        m_absent.return_value = True
+        m_run_service.create_run = AsyncMock()
+        db = AsyncMock()
+        db.execute.return_value = _result(scalar_one_or_none=uuid.uuid4())  # already queued
+
+        await svc.reconcile_branch_advance(
+            db,
+            rule,
+            _mock_conn(),
+            "example",
+            "repo",
+            "main",
+            [_fc("removed", "accounts/a/main.tf")],
+        )
+
+        m_run_service.create_run.assert_not_awaited()
+        assert ws.lifecycle_reason == ""  # not re-stamped
 
     @patch.object(svc, "run_service")
     @patch.object(svc, "_dir_absent_on_branch", new_callable=AsyncMock)

--- a/web/src/app/admin/autodiscovery/page.tsx
+++ b/web/src/app/admin/autodiscovery/page.tsx
@@ -38,6 +38,7 @@ interface AutodiscoveryRule {
     'resource-cpu': string
     'resource-memory': string
     'auto-apply': boolean
+    'on-directory-delete': 'flag' | 'destroy'
     labels: Record<string, string>
     'owner-email': string
     'var-files': string[]
@@ -87,6 +88,7 @@ export default function AutodiscoveryPage() {
   const [resourceCpu, setResourceCpu] = useState('1')
   const [resourceMemory, setResourceMemory] = useState('2Gi')
   const [autoApply, setAutoApply] = useState(false)
+  const [onDirectoryDelete, setOnDirectoryDelete] = useState<'flag' | 'destroy'>('flag')
   const [labels, setLabels] = useState<Record<string, string>>({})
   const [ownerEmail, setOwnerEmail] = useState('')
   const [varFiles, setVarFiles] = useState<string[]>([])
@@ -180,6 +182,7 @@ export default function AutodiscoveryPage() {
     setResourceCpu('1')
     setResourceMemory('2Gi')
     setAutoApply(false)
+    setOnDirectoryDelete('flag')
     setLabels({})
     setOwnerEmail('')
     setVarFiles([])
@@ -210,6 +213,7 @@ export default function AutodiscoveryPage() {
     setResourceCpu(a['resource-cpu'])
     setResourceMemory(a['resource-memory'])
     setAutoApply(a['auto-apply'])
+    setOnDirectoryDelete(a['on-directory-delete'] === 'destroy' ? 'destroy' : 'flag')
     setLabels(a.labels || {})
     setOwnerEmail(a['owner-email'] || '')
     setVarFiles(a['var-files'] || [])
@@ -245,6 +249,7 @@ export default function AutodiscoveryPage() {
       'resource-cpu': resourceCpu,
       'resource-memory': resourceMemory,
       'auto-apply': autoApply,
+      'on-directory-delete': onDirectoryDelete,
       labels,
       'owner-email': ownerEmail,
       'var-files': varFiles.map(s => s.trim()).filter(Boolean),
@@ -612,6 +617,25 @@ export default function AutodiscoveryPage() {
                     Enabled
                   </label>
                 </div>
+              </div>
+              <div className="mt-4 pt-4 border-t border-slate-800">
+                <label className="block text-sm text-slate-300 mb-1">On directory delete</label>
+                <select
+                  value={onDirectoryDelete}
+                  onChange={e => setOnDirectoryDelete(e.target.value as 'flag' | 'destroy')}
+                  className="w-full sm:w-1/2 bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm"
+                >
+                  <option value="flag">Flag (safe — mark pending deletion, requires manual action)</option>
+                  <option value="destroy">Destroy (DANGER — tears down infrastructure then archives the workspace)</option>
+                </select>
+                <p className="text-xs text-slate-500 mt-1">
+                  What happens to an autodiscovered workspace when its directory is removed on the tracked branch.
+                </p>
+                {onDirectoryDelete === 'destroy' && (
+                  <p className="text-xs text-red-400 mt-2 font-medium">
+                    This will run a real terraform destroy on the workspace when its directory is removed on the tracked branch.
+                  </p>
+                )}
               </div>
               <div className="mt-4">
                 <label className="block text-sm text-slate-300 mb-1">Labels (inherited by created workspaces)</label>

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -59,6 +59,8 @@ interface WorkspaceAttrs {
   'drift-status': string
   'state-diverged': boolean
   'health-conditions': { code: string; severity: 'error' | 'warning'; title: string; detail: string }[]
+  'lifecycle-state': 'active' | 'pending_deletion' | 'archived'
+  'lifecycle-reason': string
   'vcs-last-polled-at': string | null
   'vcs-last-error': string | null
   'vcs-last-error-at': string | null
@@ -1309,6 +1311,24 @@ function WorkspaceDetailContent() {
         />
 
         {error && <ErrorBanner message={error} />}
+
+        {attrs['lifecycle-state'] === 'pending_deletion' && (
+          <div className="mb-4 p-4 rounded-lg bg-amber-900/30 border border-amber-700/50">
+            <p className="text-sm font-semibold text-amber-300">Pending deletion</p>
+            <p className="text-sm text-amber-200/80 mt-1">
+              {attrs['lifecycle-reason'] || 'This workspace is marked for deletion and requires manual action.'}
+            </p>
+          </div>
+        )}
+
+        {attrs['lifecycle-state'] === 'archived' && (
+          <div className="mb-4 p-4 rounded-lg bg-slate-800/60 border border-slate-600/50">
+            <p className="text-sm font-semibold text-slate-300">Archived</p>
+            <p className="text-sm text-slate-400 mt-1">
+              {attrs['lifecycle-reason'] || 'This workspace has been archived.'}
+            </p>
+          </div>
+        )}
 
         {lastQueuedRunId && (
           <div className="mb-4 p-3 bg-brand-900/30 rounded-lg border border-brand-700/50 flex items-center justify-between">

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -53,6 +53,8 @@ interface Workspace {
     'state-diverged': boolean
     'vcs-last-error': string | null
     'health-conditions': HealthCondition[]
+    'lifecycle-state': 'active' | 'pending_deletion' | 'archived'
+    'lifecycle-reason': string
     'latest-run': LatestRun | null
     'created-at': string
     labels?: Record<string, string> | null
@@ -696,20 +698,32 @@ function WorkspacesPageInner() {
                       </span>
                     </td>
                     <td className="px-4 py-3 hidden lg:table-cell">
-                      {!def ? (
-                        <span className="text-xs text-slate-500">&mdash;</span>
-                      ) : runId ? (
-                        <Link
-                          href={`/workspaces/${ws.id}/runs/${runId}`}
-                          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium hover:opacity-80 transition-opacity ${badgeColors[def.color]}`}
-                        >
-                          {def.label}
-                        </Link>
-                      ) : (
-                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors[def.color]}`}>
-                          {def.label}
-                        </span>
-                      )}
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        {!def ? (
+                          <span className="text-xs text-slate-500">&mdash;</span>
+                        ) : runId ? (
+                          <Link
+                            href={`/workspaces/${ws.id}/runs/${runId}`}
+                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium hover:opacity-80 transition-opacity ${badgeColors[def.color]}`}
+                          >
+                            {def.label}
+                          </Link>
+                        ) : (
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors[def.color]}`}>
+                            {def.label}
+                          </span>
+                        )}
+                        {ws.attributes['lifecycle-state'] === 'pending_deletion' && (
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors.amber}`}>
+                            Pending deletion
+                          </span>
+                        )}
+                        {ws.attributes['lifecycle-state'] === 'archived' && (
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors.slate}`}>
+                            Archived
+                          </span>
+                        )}
+                      </div>
                     </td>
                     <td className="px-4 py-3 hidden xl:table-cell">
                       <span className="text-xs text-slate-500">


### PR DESCRIPTION
Closes #314. Bundled (server + provider + UI + docs + tests). **No release** — v0.25.0 ships after this + the pre-release audit. **Safe by default: nothing destroys infrastructure unless a rule explicitly opts in.**

## Behaviour
- **Enriched provider diffs** — `github/gitlab get_pr_file_changes` (per-file status + `old_path`) for rename/delete detection; `None` on truncation → callers skip.
- **`autodiscovery_lifecycle_service`**:
  - `classify_dir_changes` (pure): clean rename / clean delete / ambiguous split-merge (never auto-acted).
  - `reconcile_open_pr` — **visibility only**: a speculative `is_destroy`+`plan_only` run + PR comment; no lifecycle/infra/state mutation on open PRs.
  - `reconcile_branch_advance` — rename → **in-place workspace move (state & history preserved)**; delete → per-rule `on_directory_delete`: `flag` (default) marks `pending_deletion` needing an operator action, `destroy` (opt-in) runs a real destroy then archives. **Re-verifies the directory is actually absent from the tracked-branch tree first; never acts on a truncated diff.**
  - `reconcile_orphans` — origin PR closed-unmerged + dir gone: zero-state → auto-`archived`; has-state → `pending_deletion`. Never silently destroyed.
- Poller wiring is **best-effort** (try/except — never breaks the poll cycle); PR provenance threaded through `autodiscover_for_paths`/`find_or_autocreate`; opt-in-destroy→archive hook in `run_service.transition_run` (literal source compare — no import cycle).
- Migration `3f0ad398be2c` (no backfill; defaults active/""/NULL/flag). Latent fix: the new columns gained Python-side `default=` to match the `vcs_workflow` convention.
- Provider `terrapod_autodiscovery_rule.on_directory_delete` + workspace data-source `lifecycle_state/reason`; UI rule control (with destroy warning) + workspace pending/archived badges & detail banner; docs + CLAUDE.md HARD-REQUIREMENT invariant.

## Test plan
- [x] `make lint`, `make test` — **1471 passed** (41 new: 38 lifecycle-service incl. the `_dir_absent_on_branch` safety assertion, 3 rule `on-directory-delete`)
- [x] provider `go build`/`go vet`/`gofmt` clean (caught & fixed a gofmt miss in the data-source)
- [x] web `tsc`/`npm run build` clean; `helm template` OK
- [x] live Tilt: migration applied, rule `on-directory-delete` round-trip (destroy/flag/422), workspace `lifecycle-*` in API
- [ ] CI green

## Hardening — found by full behavioural smoke (live, destroy-opt-in rule)

Squash-merge full smoke surfaced and fixed three blast-radius failure modes:

- **Squash-merge rename mis-classified as delete** → on a `destroy` rule a renamed workspace would be torn down. `classify_dir_changes` now also infers a rename from exact add/remove basename symmetry (provider `renamed` status is lost across a squash merge).
- **Open-PR autodiscovery pre-created the rename target** → merge-time clash flagged the original `pending_deletion` + left a duplicate. Now the rename target is suppressed during the open PR, and the merge reconcile absorbs any never-applied speculative duplicate and moves the original in place.
- **Orphan reconciler conflated merged vs closed-unmerged** → a long-lived workspace whose dir was later renamed got archived as an orphan before the rename move ran. It now keys off the origin PR's actual *merged* state (merged → graduate, never an orphan; closed-unmerged → genuine orphan; unknown → fail safe).
- Open-PR visibility comment is now deduped per `(workspace, head_sha)` (was re-posted every poll cycle).

Verified end-to-end on a live stack with `on_directory_delete=destroy`: new dir → autodiscover → **graduate** on merge → squash **rename** → **moved in place** (same workspace id, `active`, name re-derived, **zero destroy runs**, no duplicate); single deduped PR comment across many poll cycles.

## Test plan
- [x] `make lint`, `make test` — **1483 passed** (new: squash-rename inference, duplicate prevention/absorption, orphan graduate/closed-unmerged/unknown, comment dedup)
- [x] provider `go build`/`go vet`/`gofmt` clean
- [x] web `tsc`/`npm run build` clean; `helm template` OK
- [x] live Tilt full behavioural smoke: delete→pending_deletion (flag), graduate-on-merge, squash-rename→in-place move on a **destroy** rule, comment dedup
- [ ] CI green
