### PR TITLE
docs: v0.25.0 pre-release audit

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -320,6 +320,18 @@ The following read-only attributes are included in workspace responses when drif
 | `drift-last-checked-at` | string (RFC3339) or null | Timestamp of the last completed drift detection check |
 | `drift-status` | string | Current drift status: `""` (never checked), `"no_drift"`, `"drifted"`, or `"errored"` |
 
+### Lifecycle Attributes (Autodiscovery)
+
+Workspaces created by autodiscovery carry read-only lifecycle attributes that track rename/delete/orphan reconciliation. They are included in workspace responses and surfaced by the UI as a banner on the workspace detail page and a badge on the workspace list.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `lifecycle-state` | string | `"active"` (normal), `"pending_deletion"` (the source directory was removed or the workspace was orphaned and the rule did not opt in to destroy — needs an explicit operator action), or `"archived"` (terminal: never-applied orphan auto-archived, or destroyed via an opt-in `destroy` rule, or a superseded speculative rename duplicate) |
+| `lifecycle-reason` | string | Human-readable explanation of the current state (e.g. `directory 'accounts/x' removed on 'main'`, `origin PR #14 closed unmerged; never applied — auto-archived`). Empty for `active` workspaces |
+| `autodiscovery-pr-number` | integer or null | The PR that created the workspace, while it is still speculative. Cleared (graduated) once that PR merges; `null` for non-autodiscovered workspaces |
+
+The owning autodiscovery rule's `on-directory-delete` policy (`flag` default, or opt-in `destroy`) governs what happens when a tracked directory is removed — see [autodiscovery.md](autodiscovery.md). A rename of a tracked directory moves the existing workspace in place (state and history preserved); it never destroys, even on a `destroy` rule.
+
 ### State Divergence Flag
 
 Workspaces also expose a read-only `state-diverged` boolean. It is set to `true` when the runner reports it could not upload state after a successful apply (the apply ran against the real provider, but the corresponding state version did not land in Terrapod), so Terrapod's view of the workspace state and the real-world infrastructure may have drifted. The UI surfaces this as a banner on the workspace detail page. Clear it by running a fresh apply or by manually uploading a state version that matches reality.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,8 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | **Workspace Health** | Per-workspace health conditions with status indicators on workspace list |
 | **Cloud Credentials** | Dynamic provider credentials via Kubernetes workload identity (AWS IRSA, GCP WIF, Azure WI) |
 | **Binary Caching** | Pull-through cache for terraform/tofu CLI binaries |
+| **Workspace Autodiscovery** | Atlantis-style monorepo autodiscovery with rule templating; safe-by-default rename/delete/orphan lifecycle (opt-in destroy) |
+| **Bulk Workspace Operations** | Server-side workspace search + all-or-nothing bulk settings update (dry-run by default; never triggers runs) |
 
 ---
 

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -598,3 +598,46 @@ After fixing the rule:
 - Push a new commit to the test PR (small change to the `.tf` file is enough)
 - Within 60s (or sooner via webhook), see the workspace appear in the list
 - Workspace's `autodiscovery-rule-id` attribute references the rule
+
+## Autodiscovered workspace stuck in `pending_deletion`
+
+**Symptom**: an autodiscovered workspace shows a `Pending deletion` badge/banner and is not being acted on. This is **by design** — `pending_deletion` is the safe default (`on_directory_delete: flag`) and the terminal action is left to a human.
+
+### Diagnosis
+
+1. Read `lifecycle-reason` on the workspace (API attribute or the detail-page banner). Common reasons:
+   - `directory '<dir>' removed on '<branch>'` — the tracked directory was deleted on the branch and the rule did **not** opt in to destroy.
+   - `origin PR #<n> closed unmerged; workspace has state — needs an explicit operator action` — a speculative workspace that had already applied state, then its PR was abandoned.
+   - `rename <old>-><new> but a workspace already owns <new>; needs an operator decision` — an ambiguous rename collision.
+2. Decide intent: is the underlying infrastructure meant to be torn down, or was the directory removal a mistake?
+
+### Resolution
+
+- **Infra should be destroyed**: queue a destroy run on the workspace yourself (it still has its state), let it apply, then delete/archive the workspace. Do **not** flip the rule to `destroy` retroactively expecting it to pick up this workspace — the delete decision already happened; the rule policy is evaluated at branch-advance time.
+- **Removal was a mistake**: restore the directory on the branch. The workspace stays as-is (lifecycle reconcile never auto-resurrects); set `lifecycle_state` back to `active` via a direct update once the directory is back, or recreate the workspace.
+- Never bulk-destroy `pending_deletion` workspaces blindly — that state exists precisely so a human checks each one.
+
+### Verification
+
+- `lifecycle-state` is `active` (restored) or the workspace is gone (intentionally destroyed + deleted)
+- No orphaned state versions remain for a destroyed workspace
+
+## Reverting (or recovering from) a bad bulk-update
+
+**Symptom**: a fleet `POST /api/terrapod/v1/workspaces/actions/bulk-update` applied an unintended change across many workspaces.
+
+### Diagnosis
+
+1. The bulk-update is **all-or-nothing in a single transaction** and **never triggers runs** — it is a pure settings write. So the blast radius is the settings delta only; no plans/applies were kicked off by the bulk-update itself. The change lands on each workspace's *next normal run*.
+2. `dry_run` defaults to **on**. Confirm whether the offending call actually committed (`dry_run: false`) or was a preview.
+3. Identify the exact field(s) changed and the selection filter used (audit log captures the bulk-update call).
+
+### Resolution
+
+- Re-issue the inverse bulk-update with the **same selection filter** and the previous values (settings are reversible — Terrapod keeps versioned state, and no run was triggered, so reverting the setting before the next run is a no-op in infra terms).
+- If a normal run already picked up the unintended setting and applied it, treat that like any other unwanted apply: roll the workspace's state version back or apply a corrective change.
+
+### Verification
+
+- Re-query the affected workspaces (server-side workspace search) and confirm the field is restored
+- No unexpected runs were created by the revert (bulk-update never triggers runs — if you see runs, they came from VCS/drift, not the bulk-update)


### PR DESCRIPTION
Pre-release documentation audit for **v0.25.0**, which ships:
- #325 — new workspaces default to OpenTofu 1.12 (GA)
- #318 — server-side workspace search + all-or-nothing bulk-update + expanded autodiscovery rule templating
- #314 — autodiscovery workspace lifecycle (safe-by-default rename/delete/orphan, opt-in destroy)
- #335 — consolidated dependency bumps

## Audit outcome

Docs, Helm values↔schema, and test coverage were otherwise in good shape; **no internal-reference leaks** in the v0.24.0..HEAD range or any doc. Three doc gaps fixed here:

- **api-reference.md** — document the read-only workspace lifecycle attributes (`lifecycle-state`, `lifecycle-reason`, `autodiscovery-pr-number`) that the UI consumes (API↔UX contract), mirroring the drift-attributes block.
- **runbooks.md** — operator runbooks for the two new high-blast-radius surfaces: a workspace stuck in `pending_deletion`, and reverting/recovering from a bad fleet `bulk-update`.
- **index.md** — feature-table rows for Workspace Autodiscovery (lifecycle) and Bulk Workspace Operations.

## Test plan
- [x] docs-only change; markdown reviewed
- [ ] CI green