### PR TITLE
fix: pin exact terraform/tofu version at run creation (#338)

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -203,6 +203,24 @@ if [ -n "$TP_API_URL" ] && [ -n "$TP_VERSION" ]; then
     log "[entrypoint] Downloading $TP_BACKEND $TP_VERSION ($TP_OS/$TP_ARCH) from binary cache..."
     if ! tp_curl_download "/tmp/${TP_BACKEND}.zip" -H "$AUTH_HEADER" "$BINARY_URL"; then
         log "[entrypoint] Binary cache unavailable, downloading from upstream..."
+        # The upstream release artifact only exists for a fully-qualified
+        # x.y.z. The API resolves a partial workspace version (e.g.
+        # "1.11") to an exact one and pins it on the run, so TP_VERSION
+        # should already be exact here. If it isn't (older API, or
+        # resolution was unreachable at run creation), fail with an
+        # actionable message instead of a bare curl 404 (#338).
+        case "$TP_VERSION" in
+            [0-9]*.[0-9]*.[0-9]*) : ;;  # x.y.z (optionally -rc/-beta) — OK
+            *)
+                log "[entrypoint] ERROR: upstream fallback needs a fully-qualified" \
+                    "version but got '$TP_VERSION'. The binary cache normally" \
+                    "resolves partial versions; a non-exact version here means the" \
+                    "cache request failed AND the version was never pinned. Set the" \
+                    "workspace version to an exact x.y.z, or fix the runner->API" \
+                    "binary-cache path. See terrapod issue #338."
+                exit 1
+                ;;
+        esac
         if [ "$TP_BACKEND" = "terraform" ]; then
             _upstream="https://releases.hashicorp.com/terraform/${TP_VERSION}/terraform_${TP_VERSION}_${TP_OS}_${TP_ARCH}.zip"
         else

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -241,6 +241,29 @@ async def create_run(
 
     pool_id = workspace.agent_pool_id
 
+    # Pin the execution version to an exact x.y.z at run creation, the
+    # same way CPU/memory are snapshotted. The workspace stores the
+    # operator's intent (e.g. "1.11" = "track the latest 1.11.x"); the
+    # run must carry a concrete version because a bare "1.11" only
+    # resolves inside the binary-cache API call — the runner's
+    # upstream fallback interpolates it verbatim into a release-artifact
+    # URL that requires x.y.z and 404s otherwise (#338). resolve_version
+    # is Redis-cached and returns its input unchanged if it can't reach
+    # the upstream index, so this never blocks run creation.
+    requested_version = terraform_version or workspace.terraform_version
+    from terrapod.services.binary_cache_service import resolve_version
+
+    try:
+        pinned_version = await resolve_version(workspace.execution_backend, requested_version)
+    except Exception:  # never block run creation on version resolution
+        logger.warning(
+            "Execution version resolution failed; pinning requested version as-is",
+            requested=requested_version,
+            backend=workspace.execution_backend,
+            exc_info=True,
+        )
+        pinned_version = requested_version
+
     run = Run(
         workspace_id=workspace.id,
         configuration_version_id=configuration_version_id,
@@ -251,7 +274,7 @@ async def create_run(
         plan_only=plan_only,
         source=source,
         execution_backend=workspace.execution_backend,
-        terraform_version=terraform_version or workspace.terraform_version,
+        terraform_version=pinned_version,
         resource_cpu=workspace.resource_cpu,
         resource_memory=workspace.resource_memory,
         pool_id=pool_id,

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -277,6 +277,44 @@ class TestCreateRun:
         await create_run(db, ws)
         assert MockRun.call_args[1]["pool_id"] == pool_id
 
+    @patch("terrapod.services.binary_cache_service.resolve_version", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service.Run")
+    async def test_partial_version_resolved_and_pinned_on_run(self, MockRun, m_resolve):
+        """A workspace's partial version (e.g. '1.11') is resolved to an
+        exact x.y.z and snapshotted onto the run, so the runner's
+        upstream fallback gets a version that actually exists (#338)."""
+        db = AsyncMock(spec=AsyncSession)
+        ws = _mock_workspace(terraform_version="1.11")
+        ws.execution_backend = "tofu"
+        m_resolve.return_value = "1.11.9"
+        instance = MockRun.return_value
+        instance.id = uuid.uuid4()
+        instance.status = "pending"
+
+        await create_run(db, ws)
+
+        m_resolve.assert_awaited_once_with("tofu", "1.11")
+        assert MockRun.call_args[1]["terraform_version"] == "1.11.9"
+
+    @patch("terrapod.services.binary_cache_service.resolve_version", new_callable=AsyncMock)
+    @patch("terrapod.services.run_service.Run")
+    async def test_version_resolution_failure_falls_back_to_requested(self, MockRun, m_resolve):
+        """Resolution must never block run creation — on failure the run
+        is still created, pinned to the requested version as-is."""
+        db = AsyncMock(spec=AsyncSession)
+        ws = _mock_workspace(terraform_version="1.12")
+        ws.execution_backend = "tofu"
+        m_resolve.side_effect = RuntimeError("upstream index unreachable")
+        instance = MockRun.return_value
+        instance.id = uuid.uuid4()
+        instance.status = "pending"
+
+        await create_run(db, ws)
+
+        MockRun.assert_called_once()
+        assert MockRun.call_args[1]["terraform_version"] == "1.12"
+        db.add.assert_called_once_with(instance)
+
 
 # ── confirm_run / discard_run / cancel_run ─────────────────────────────
 


### PR DESCRIPTION
Fixes the upstream-fallback half of #338.

## Root cause

A workspace's `terraform_version`/`tofu` version may be **partial** (`1.11` = "track the latest `1.11.x`"). That partial was snapshotted onto the run verbatim and **only ever resolved inside the binary-cache API call**. The runner entrypoint's upstream fallback —

```sh
# "Binary cache unavailable, downloading from upstream..."
_upstream="https://releases.hashicorp.com/terraform/${TP_VERSION}/terraform_${TP_VERSION}_${TP_OS}_${TP_ARCH}.zip"
```

— interpolates `TP_VERSION` straight into a release-artifact URL that requires a fully-qualified `x.y.z`. So a partial version **always 404s** on the fallback path. Any deployment whose binary cache isn't working has been permanently broken for `x.y` workspace versions.

## Fix

- **Resolve + pin at run creation** (`run_service.create_run`): resolve the workspace version to an exact `x.y.z` and snapshot the *resolved* value onto `Run.terraform_version` — same pattern as CPU/memory snapshotting. Both the cache path and the upstream fallback now always get a concrete version. `resolve_version` is Redis-cached and returns its input unchanged if the upstream index is unreachable, so it **never blocks run creation**.
- **Defense-in-depth** (`runner-entrypoint.sh`): the upstream fallback now hard-fails with an actionable message if `TP_VERSION` is still not fully qualified (older API, or resolution was unreachable at creation), instead of a bare `curl` 404.

## Scope / honesty

This fixes the **`404` from upstream**. It does **not** by itself explain the **`400` from the binary cache** in the report — that points at a separate runner→API / environment problem in the reporter's deployment (the binary cache resolves partials fine in a healthy setup). Triaged on the issue with diagnostic questions; this PR closes the genuine robustness bug it exposed.

## Test plan
- [x] `make lint`, `make test` — **1486 passed** (2 new: partial→exact pin on the run; resolution-failure falls back without blocking run creation)
- [ ] CI green