### PR TITLE
fix: pin S3 SigV4 for presigned URLs + surface storage errors (#339)

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -147,12 +147,23 @@ trap on_exit EXIT
 # terrapod.local) which may not resolve from inside the cluster. In that case
 # we rewrite the URL to use TP_API_URL (the internal service name) so the
 # download works.
+# Sets TP_LAST_HTTP to the most relevant HTTP status observed. On a
+# storage error (e.g. an SSE-KMS bucket rejecting a SigV2 presigned
+# URL) the storage response body is logged to stderr so the operator
+# sees the real cause instead of a silent failure (#339).
 tp_curl_download() {
     # $1 = output file, remaining args = curl options (URL last)
     _out="$1"; shift
-    # First request: don't follow redirects, capture Location header
-    _headers=$(curl -sSf -D - -o /dev/null "$@" 2>/dev/null)
+    TP_LAST_HTTP=""
+    # First request: don't follow redirects, capture Location header.
+    # No `-f` and no `2>/dev/null` — we want the status and any error
+    # surfaced, not swallowed.
+    if ! _headers=$(curl -sS -D - -o /dev/null "$@"); then
+        echo "[entrypoint] download: initial request failed (network/TLS/DNS)" >&2
+        return 1
+    fi
     _code=$(echo "$_headers" | head -1 | awk '{print $2}')
+    TP_LAST_HTTP="$_code"
     case "$_code" in
         301|302|303|307|308)
             _location=$(echo "$_headers" | grep -i '^location:' | sed 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r')
@@ -175,15 +186,34 @@ tp_curl_download() {
                     esac
                 fi
             fi
-            # Follow any further redirects (e.g. S3 region/path-style redirects)
-            curl -sSfL -o "$_out" "$_location"
+            # Follow any further redirects (e.g. S3 region/path-style
+            # redirects). NO `-f`: on a 4xx/5xx we want the response
+            # body (e.g. the S3 InvalidArgument XML) written out so we
+            # can show it, not a bare "curl: (22) ... 400".
+            _final=$(curl -sSL -o "$_out" -w '%{http_code}' "$_location" 2>/dev/null || echo 000)
+            TP_LAST_HTTP="$_final"
+            case "$_final" in
+                2*) : ;;  # success
+                *)
+                    echo "[entrypoint] download: storage returned HTTP $_final for the presigned URL" >&2
+                    echo "[entrypoint] storage response body (first 2KB):" >&2
+                    head -c 2048 "$_out" 2>/dev/null >&2 || true
+                    echo >&2
+                    rm -f "$_out"
+                    return 1
+                    ;;
+            esac
             ;;
         200)
             # No redirect — re-fetch with output (rare, but handle it)
-            curl -sSf -o "$_out" "$@"
+            if ! curl -sS -o "$_out" "$@"; then
+                echo "[entrypoint] download: direct fetch failed (HTTP $_code)" >&2
+                return 1
+            fi
             ;;
         *)
-            echo "[entrypoint] Unexpected HTTP $_code" >&2
+            echo "[entrypoint] download: unexpected HTTP $_code from ${*##* }" >&2
+            echo "$_headers" | head -1 >&2
             return 1
             ;;
     esac
@@ -251,8 +281,14 @@ fi
 # --- Download configuration archive ---
 if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
     log "[entrypoint] Downloading configuration..."
-    tp_curl_download /tmp/config.tar.gz -H "$AUTH_HEADER" \
-        "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/config" 2>/dev/null || true
+    # No `2>/dev/null || true`: a storage auth failure here (e.g. an
+    # SSE-KMS bucket rejecting a SigV2 presigned URL) must be visible,
+    # not masked into a later misleading "working directory not found"
+    # (#339). tp_curl_download surfaces the real status + body itself.
+    if ! tp_curl_download /tmp/config.tar.gz -H "$AUTH_HEADER" \
+        "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/config"; then
+        log "[entrypoint] Configuration archive download failed (HTTP ${TP_LAST_HTTP:-unknown}) — see storage error above"
+    fi
     if [ -f /tmp/config.tar.gz ] && [ -s /tmp/config.tar.gz ]; then
         # --no-same-owner: don't try to restore original UIDs (we run as non-root)
         # BusyBox tar returns non-zero on harmless utime/chmod warnings for "."
@@ -283,7 +319,7 @@ if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
         # resolutions of the version constraint, which can drift.
         log "[entrypoint] Stripped cloud/backend blocks from uploaded config"
     else
-        log "[entrypoint] No configuration archive (HTTP $HTTP_CODE)"
+        log "[entrypoint] No configuration archive (HTTP ${TP_LAST_HTTP:-none})"
     fi
 fi
 

--- a/services/terrapod/storage/s3.py
+++ b/services/terrapod/storage/s3.py
@@ -1,9 +1,13 @@
 """
 AWS S3 storage backend for Terrapod.
 
-Uses aioboto3 for async I/O. Presigned URLs use SigV4 local signature
-generation (no API call). Auth relies on the SDK credential chain
-(IRSA in K8s, env vars or profile locally).
+Uses aioboto3 for async I/O. The S3 client is pinned to Signature
+Version 4 (`s3v4`) — botocore's implicit default varies by region,
+endpoint and SDK version, and a SigV2 presigned URL is rejected by S3
+for any SSE-KMS-encrypted object (and outright in GovCloud / newer
+regions). Pinning s3v4 makes presigned URLs deterministic and is
+universally backward-compatible. Auth relies on the SDK credential
+chain (IRSA in K8s, env vars or profile locally).
 """
 
 from __future__ import annotations
@@ -13,6 +17,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import aioboto3
+from botocore.config import Config
 
 from terrapod.logging_config import get_logger
 from terrapod.storage.protocol import (
@@ -70,6 +75,10 @@ class S3Store:
                 "s3",
                 region_name=self._region,
                 endpoint_url=self._endpoint_url,
+                # Pin SigV4: required for presigned GETs of SSE-KMS
+                # objects and in GovCloud/newer regions; harmless
+                # everywhere else (#339).
+                config=Config(signature_version="s3v4"),
             ).__aenter__()
             logger.info(
                 "S3 client initialized",

--- a/services/tests/storage/test_s3.py
+++ b/services/tests/storage/test_s3.py
@@ -45,6 +45,31 @@ class TestS3StoreUnit:
             S3Store(bucket="test", presigned_url_expiry_seconds=7200)
             mock_logger.warning.assert_called_once()
 
+    async def test_client_pins_sigv4(self, store: S3Store) -> None:
+        """The S3 client must be created with signature_version=s3v4.
+
+        botocore's implicit default varies by region/endpoint/SDK
+        version; a SigV2 presigned URL is rejected by S3 for any
+        SSE-KMS object and outright in GovCloud/newer regions (#339).
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        captured: dict = {}
+
+        def _client(*args, **kwargs):
+            captured.update(kwargs)
+            cm = MagicMock()
+            cm.__aenter__ = AsyncMock(return_value=MagicMock())
+            return cm
+
+        store._session = MagicMock()
+        store._session.client = _client
+
+        await store._get_client()
+
+        assert "config" in captured, "S3 client created without a botocore Config"
+        assert captured["config"].signature_version == "s3v4"
+
     async def test_put_stream_multipart(self, store: S3Store) -> None:
         """put_stream should use S3 multipart upload."""
         from unittest.mock import AsyncMock
@@ -146,4 +171,16 @@ class TestS3StoreIntegration:
         assert len(keys) == 2
         assert "integration/list/a.txt" in keys
         assert "integration/list/b.txt" in keys
+        await store.close()
+
+    async def test_presigned_url_is_sigv4(self, store: S3Store | None) -> None:
+        """A real presigned GET URL must be SigV4 (X-Amz-Algorithm=
+        AWS4-HMAC-SHA256), never SigV2 (AWSAccessKeyId=) — SigV2 is
+        rejected by S3 for SSE-KMS objects and in GovCloud (#339)."""
+        if store is None:
+            return
+        await store.put("integration/presign.txt", b"data")
+        presigned = await store.presigned_get_url("integration/presign.txt")
+        assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in presigned.url, presigned.url
+        assert "AWSAccessKeyId=" not in presigned.url, "SigV2 presigned URL generated"
         await store.close()

--- a/services/tests/storage/test_s3.py
+++ b/services/tests/storage/test_s3.py
@@ -70,6 +70,51 @@ class TestS3StoreUnit:
         assert "config" in captured, "S3 client created without a botocore Config"
         assert captured["config"].signature_version == "s3v4"
 
+    async def test_presigned_url_is_sigv4_offline(self, monkeypatch) -> None:
+        """The REAL signing path emits SigV4 — no AWS, no LocalStack.
+
+        `generate_presigned_url` signs locally (HMAC over the request);
+        with static fake creds it needs no network or real bucket. This
+        is the always-on regression guard for #339: a SigV2 URL
+        (`AWSAccessKeyId=`) is rejected by S3 for SSE-KMS objects and in
+        GovCloud; SigV4 (`X-Amz-Algorithm=AWS4-HMAC-SHA256`) is not.
+        """
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+        store = S3Store(bucket="kms-bucket", region="us-east-1", prefix="terrapod")
+        try:
+            get_url = (await store.presigned_get_url("state/ws/v1.tfstate")).url
+            put_url = (await store.presigned_put_url("config/cv/archive.tgz")).url
+        finally:
+            await store.close()
+
+        for url in (get_url, put_url):
+            assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in url, f"not SigV4: {url}"
+            assert "AWSAccessKeyId=" not in url, f"SigV2 leaked: {url}"
+
+    async def test_sigv2_is_detectably_different(self, monkeypatch) -> None:
+        """Discriminating negative: a client explicitly forced to the
+        legacy `s3` signer DOES emit `AWSAccessKeyId=` — proving the
+        SigV4 assertion above is meaningful, not vacuous."""
+        from botocore.config import Config
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+        store = S3Store(bucket="kms-bucket", region="us-east-1")
+        # Force the client to the legacy SigV2 signer.
+        store._client = await store._session.client(
+            "s3", region_name="us-east-1", config=Config(signature_version="s3")
+        ).__aenter__()
+        try:
+            url = (await store.presigned_get_url("k")).url
+        finally:
+            await store.close()
+        assert "AWSAccessKeyId=" in url and "X-Amz-Algorithm=" not in url
+
     async def test_put_stream_multipart(self, store: S3Store) -> None:
         """put_stream should use S3 multipart upload."""
         from unittest.mock import AsyncMock


### PR DESCRIPTION
Closes #339. Credit to @the3venthoriz0n for an excellent, fully-diagnosed report that pinpointed the file, line, and fix.

## Primary bug — SigV2 presigned URLs

`S3Store._get_client()` created the aioboto3 client with **no `signature_version`**, despite the module docstring claiming *"Presigned URLs use SigV4."* botocore's implicit default varies by region / endpoint / SDK version and can emit a **SigV2** presigned URL (`AWSAccessKeyId=` / `Signature=`). S3 rejects a SigV2 presigned GET for **any SSE-KMS-encrypted object** (`InvalidArgument: Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4`) and rejects SigV2 outright in **GovCloud / newer regions**. Result: every binary-cache and config-archive download `400`s — even with a fully-qualified version.

**Fix:** pin `Config(signature_version="s3v4")` on the client. SigV4 is universally backward-compatible and AWS-recommended; makes the docstring true; deterministic regardless of region/endpoint/SDK default.

## Secondary — why it was undiagnosable

The runner entrypoint masked the real error:
- `tp_curl_download` followed the presigned URL with `curl -sSfL` (`-f` → no body on 4xx).
- The config download added `2>/dev/null || true`, then logged `No configuration archive (HTTP )` against an **unset variable**, and the run limped on to a misleading `working directory '...' not found in config` — pointing the operator at VCS/branch config instead of S3 auth.

**Fix:** `tp_curl_download` now follows the presigned URL **without `-f`**, captures the real HTTP status (`TP_LAST_HTTP`), and logs the storage response body (e.g. the S3 `InvalidArgument` XML) to stderr. The config caller no longer swallows it and reports the accurate status.

## Relationship to #338

This is the root cause of what was actually breaking this operator on **both** tickets — their #338 `400` (even with exact `1.15.3`) was this SigV2/KMS failure, not partial-version resolution. #338's partial-version bug was real-but-separate and is fixed independently in #340. Posting a corrected diagnosis on #338.

## Honesty / scope

The SigV4 fix is verified by a **LocalStack integration test** (a real presigned URL is now `AWS4-HMAC-SHA256`, not `AWSAccessKeyId=`) plus a unit test. It is **not** reproduced against an actual SSE-KMS / GovCloud bucket (none available here) — the reporter independently verified `s3v4` works against their KMS bucket. The residual unknown (*why* botocore emitted SigV2 in their env) does not affect correctness: explicit `s3v4` is right regardless.

## Test plan
- [x] `make lint`, `make test` — **1488 passed** (unit: client pinned to s3v4; LocalStack integration: presigned URL is SigV4)
- [ ] CI green