### PR TITLE
chore: exclude Alembic migrations from CodeQL (false positives)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -14,9 +14,18 @@
 # py/unnecessary-lambda                — FastAPI dependency overrides need fresh mock per request
 # py/multiple-definition               — intentional re-fetch after DB mutation
 # py/empty-except                      — intentional fail-open patterns (Redis, K8s, URL parsing)
+#
+# alembic/versions — Alembic migration boilerplate. The module globals
+# `revision`, `down_revision`, `branch_labels`, `depends_on` are required
+# by Alembic and read via module introspection, so CodeQL's
+# py/unused-global-variable flags every one as "unused" on every
+# migration. They are not unused and must not be removed; the whole
+# generated-migration directory is excluded rather than littering each
+# file with per-line suppressions on every new migration.
 
 paths-ignore:
   - e2e
+  - alembic/versions
 
 query-filters:
   - exclude:


### PR DESCRIPTION
Resolves the 12 open `py/unused-global-variable` code-scanning alerts (alerts 138–149).

## Why these are false positives

Every Alembic migration must define module-level `revision`, `down_revision`, `branch_labels`, `depends_on`. Alembic reads them via **module introspection**, not via code in the file, so CodeQL sees them as "unused globals." They are required and must not be removed — and the pattern recurs on **every new migration** (these 12 alerts span 3 recent migrations: `7dac5695bc0e`, `3547bfb4e898`, `3f0ad398be2c`).

## Fix

Add `alembic/versions` to `paths-ignore` in `.github/codeql/codeql-config.yml`, with a rationale comment matching the existing triaged-false-positive convention in that file. This is preferable to per-line `# codeql[...]` suppressions in every migration (which the config header already notes don't reliably close pre-existing alerts), and it future-proofs new migrations.

Scope is tight: only `alembic/versions` (generated migration boilerplate) is excluded; `alembic/env.py` is still analyzed.

## Effect

- CodeQL on this PR will no longer report the migration globals.
- After merge, the default-branch CodeQL run auto-closes alerts 138–149 (no longer found).

No code change; CI/config only.