### PR TITLE
feat: cross-workspace terraform_remote_state — producer-controlled consumer allowlist (closes #344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,15 @@ jobs:
         run: poetry export -f requirements.txt -o requirements.txt --without-hashes
         working-directory: services
       - name: Run pip-audit
-        run: pip install pip-audit && pip-audit -r services/requirements.txt --strict --desc
+        # PYSEC-2025-183 (pyjwt): disputed by the supplier — the advisory
+        # concerns weak HMAC keys, but key length is controlled by the
+        # application that uses the library, not by the library. No fix
+        # version is published. Suppress until a fix lands or the dispute
+        # is resolved upstream.
+        run: |
+          pip install pip-audit
+          pip-audit -r services/requirements.txt --strict --desc \
+            --ignore-vuln PYSEC-2025-183
 
   # ── Dependency Audit (npm) ────────────────────────────
   npm-audit:

--- a/alembic/versions/42266b856e8e_workspace_remote_state_consumers.py
+++ b/alembic/versions/42266b856e8e_workspace_remote_state_consumers.py
@@ -1,0 +1,68 @@
+"""workspace remote state consumers (#344)
+
+Producer-controlled allowlist authorizing a consumer workspace's agent
+runs to read a producer workspace's state via terraform_remote_state.
+Empty for a producer => its state is not shared (secure by default);
+no behaviour change for existing deployments.
+
+Revision ID: 42266b856e8e
+Revises: 3f0ad398be2c
+Create Date: 2026-05-20
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "42266b856e8e"
+down_revision: str | None = "3f0ad398be2c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_remote_state_consumers",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "producer_workspace_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "consumer_workspace_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("created_by", sa.String(255), server_default="", nullable=False),
+        sa.UniqueConstraint(
+            "producer_workspace_id",
+            "consumer_workspace_id",
+            name="uq_workspace_remote_state_consumers",
+        ),
+    )
+    op.create_index(
+        "ix_wrsc_consumer_workspace_id",
+        "workspace_remote_state_consumers",
+        ["consumer_workspace_id"],
+    )
+    op.create_index(
+        "ix_wrsc_producer_workspace_id",
+        "workspace_remote_state_consumers",
+        ["producer_workspace_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_wrsc_producer_workspace_id", table_name="workspace_remote_state_consumers")
+    op.drop_index("ix_wrsc_consumer_workspace_id", table_name="workspace_remote_state_consumers")
+    op.drop_table("workspace_remote_state_consumers")

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -28,6 +28,11 @@ RUN poetry config virtualenvs.create false \
 COPY services/terrapod ./terrapod
 COPY services/tests ./tests
 
+# Copy the runner entrypoint so tests can exercise its real shell logic
+# as a fixture (e.g. the cloud/backend block-stripping golden test for
+# #344). The entrypoint itself isn't executed here — it's read.
+COPY docker/runner-entrypoint.sh ./docker/runner-entrypoint.sh
+
 # Storage data directory for tests
 RUN mkdir -p /var/lib/terrapod/storage
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -386,6 +386,8 @@ GET /api/v2/workspaces/{id}/current-state-version
 
 **Required permission:** `read` on the workspace.
 
+For **agent-mode runs** reading another workspace's state via `data "terraform_remote_state"` (runner-token principals), authorization is by the producer-controlled consumer allowlist instead of per-user RBAC — see [Cross-Workspace Remote-State Consumers](#cross-workspace-remote-state-consumers) and [the composition guide](remote-state.md).
+
 ### Create State Version
 
 ```
@@ -423,6 +425,8 @@ GET /api/v2/state-versions/{id}/download
 Returns a redirect to a presigned URL for the raw state file.
 
 **Required permission:** `plan` on the workspace.
+
+For **agent-mode runs** reading another workspace's state via `data "terraform_remote_state"` (runner-token principals), authorization is by the producer-controlled consumer allowlist instead of per-user RBAC — see [Cross-Workspace Remote-State Consumers](#cross-workspace-remote-state-consumers).
 
 ### Upload State Content
 
@@ -668,6 +672,83 @@ GET /api/terrapod/v1/runs/{run_id}/apply
 ```
 
 Returns apply metadata and log download URL.
+
+---
+
+## Cross-Workspace Remote-State Consumers
+
+Producer-controlled allowlist of workspaces authorized to read this workspace's state via `data "terraform_remote_state"`. Default is empty (not shared) — secure by default. All mutations require **admin/write on the producer** (the state owner). Independent of run triggers — see [the composition guide](remote-state.md).
+
+When a runner-token principal (agent-mode run) hits `/api/v2/workspaces/{id}/current-state-version` or `/api/v2/state-versions/{id}/download` for another workspace, authorization is by this allowlist instead of per-user RBAC. User / API-token principals (CLI, UI, automation) continue through the existing per-user RBAC path.
+
+### List Consumers
+
+```
+GET /api/terrapod/v1/workspaces/{id}/remote-state-consumers?filter[remote-state-consumer][type]=outbound
+```
+
+`outbound` (default) — workspaces this workspace shares its state to (this workspace is the producer).
+`inbound` — workspaces whose state this workspace is authorized to read (this workspace is the consumer).
+
+**Required permission:** `read` on the workspace.
+
+### Authorize a Consumer
+
+```
+POST /api/terrapod/v1/workspaces/{producer_id}/remote-state-consumers
+```
+
+**Request body:**
+```json
+{
+  "data": {
+    "relationships": {
+      "consumer": {"data": {"id": "ws-CONSUMER", "type": "workspaces"}}
+    }
+  }
+}
+```
+
+**Required permission:** `admin` on the **producer** workspace. A consumer team cannot self-grant.
+
+Errors: `422` self-reference; `409` already authorized; `422` over the per-producer cap.
+
+### Replace Consumer Set (Declarative)
+
+```
+PUT /api/terrapod/v1/workspaces/{producer_id}/remote-state-consumers
+```
+
+Idempotent declarative replace of the producer's full consumer set in one atomic transaction. Supports the Terrapod provider's set-valued attribute. Body: `{"data": [{"type": "workspaces", "id": "ws-..."}, ...]}`.
+
+**Required permission:** `admin` on the producer.
+
+### Show Consumer Grant
+
+```
+GET /api/terrapod/v1/remote-state-consumers/{id}
+```
+
+**Required permission:** `read` on the producer.
+
+### Revoke a Consumer Grant
+
+```
+DELETE /api/terrapod/v1/remote-state-consumers/{id}
+```
+
+**Required permission:** `admin` on the producer. A consumer cannot self-revoke.
+
+### Consumer Grant Response Attributes
+
+| Attribute | Description |
+|---|---|
+| `producer-workspace-name` | Name of the producer workspace |
+| `consumer-workspace-name` | Name of the consumer workspace |
+| `created-at` | RFC3339 timestamp the grant was created |
+| `created-by` | Identity that created the grant |
+
+Plus relationships `producer` and `consumer` (both `workspaces`-typed).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | **Binary Caching** | Pull-through cache for terraform/tofu CLI binaries |
 | **Workspace Autodiscovery** | Atlantis-style monorepo autodiscovery with rule templating; safe-by-default rename/delete/orphan lifecycle (opt-in destroy) |
 | **Bulk Workspace Operations** | Server-side workspace search + all-or-nothing bulk settings update (dry-run by default; never triggers runs) |
+| **Cross-Workspace Remote State** | `terraform_remote_state` composition with a producer-controlled consumer allowlist (secure by default; secret-bearing state stays with its owner) |
 
 ---
 
@@ -87,6 +88,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Autodiscovery](autodiscovery.md) | Atlantis-style monorepo workspace autodiscovery |
 | [Drift Detection](drift-detection.md) | Scheduled plan-only runs to detect infrastructure drift |
 | [Run Triggers](run-triggers.md) | Cross-workspace dependency chains |
+| [Remote State](remote-state.md) | Cross-workspace `terraform_remote_state` composition with producer-controlled allowlist |
 | [Notifications](notifications.md) | Webhook, Slack, and email alerts on run events |
 | [Run Tasks](run-tasks.md) | Pre/post-plan webhook hooks for external validation |
 | [Audit Logging](audit-logging.md) | Immutable event log, query API, retention |

--- a/docs/remote-state.md
+++ b/docs/remote-state.md
@@ -1,0 +1,107 @@
+# Cross-Workspace Remote State
+
+Terrapod supports `terraform_remote_state` for **cross-workspace composition** — one workspace's runs reading another workspace's outputs — with a producer-controlled allowlist so the state owner stays in charge of who may read its (secret-bearing) state.
+
+This is the standard Terraform pattern for composing workspaces. It complements (and is independent of) [run triggers](run-triggers.md): a run trigger declares *"re-run me when A applies"* (ordering); a remote-state grant declares *"B may read A's state"* (data + authorization). Neither implies the other — see [Run triggers vs. remote state](#run-triggers-vs-remote-state) below.
+
+## Quick start
+
+In the consumer workspace's Terraform configuration:
+
+```hcl
+data "terraform_remote_state" "shared" {
+  backend = "remote"
+  config = {
+    hostname     = "terrapod.example.com"
+    organization = "default"
+    workspaces   = { name = "shared-network" }
+  }
+}
+
+resource "example_thing" "x" {
+  vpc_id = data.terraform_remote_state.shared.outputs.vpc_id
+}
+```
+
+For this to succeed on agent-mode runs, the **producer workspace** (`shared-network` in this example) must explicitly authorize the consumer workspace. **Default is not shared** (secure by default).
+
+## Authorizing a consumer
+
+Authorization always lives with the producer (the state owner). Three equivalent ways to set it:
+
+**1. Terrapod provider — standalone resource (cross-config / cross-team).** Suitable when producer and consumer workspaces live in different Terraform configurations or are managed by different teams:
+
+```hcl
+resource "terrapod_remote_state_consumer" "shared_to_app" {
+  producer_workspace_id = terrapod_workspace.shared_network.id
+  consumer_workspace_id = terrapod_workspace.app.id
+}
+```
+
+This still requires admin/write on the *producer* workspace to apply — a consumer team cannot self-grant.
+
+**2. Terrapod API directly:**
+
+```sh
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/vnd.api+json" \
+  "https://terrapod.example.com/api/terrapod/v1/workspaces/ws-PRODUCER/remote-state-consumers" \
+  -d '{"data": {"relationships": {"consumer": {"data": {"id": "ws-CONSUMER", "type": "workspaces"}}}}}'
+```
+
+List, replace, and revoke endpoints are documented in [the API reference](api-reference.md#cross-workspace-remote-state-consumers).
+
+**3. Bulk-update or autodiscovery rule templates.** For fleets (e.g. a monorepo where many workspaces consume a `shared-network` workspace), set the consumer list via the [bulk-update endpoint](api-reference.md) or an [autodiscovery rule template](autodiscovery.md) so newly-discovered workspaces auto-consume the shared producer.
+
+## Authorization model
+
+| Principal | Reading another workspace's state via the v2 state endpoints |
+|---|---|
+| **User / API token** (CLI, UI, automation) | Existing label-RBAC: requires `plan` on the producer. Unchanged. |
+| **Runner token** (agent-mode run reading via `terraform_remote_state`) | Allowed iff the consumer workspace (the run's own workspace) appears in the producer's allowlist, **or** the consumer workspace *is* the producer (self-reads are harmless — the runner already owns its own state via the run-artifact path). |
+
+Granting / revoking always requires **admin/write on the producer** — by either the provider, the API, or the bulk-update endpoint. There is no way for a consumer to self-grant.
+
+### Security note: state holds secrets
+
+`terraform_remote_state` exposes the **entire state file**, not just the outputs you reference. State files routinely contain sensitive values (passwords, keys, tokens). Treat granting `terraform_remote_state` access the same way you treat granting read access to the producer's secret store. Grant deliberately, audit the grants, revoke when no longer needed.
+
+This is why the design is producer-controlled and default-off, and why granting requires admin on the producer.
+
+## Local vs. agent execution
+
+- **Local execution mode (CLI):** uses your API token directly. `terraform_remote_state` against another workspace works as long as your token has `plan` on the producer. The consumer-allowlist isn't consulted — the existing per-user RBAC governs.
+- **Agent execution mode:** the runner uses a short-lived runner token scoped to its own run (`everyone` role). User RBAC doesn't apply to the runner. Cross-workspace state reads succeed iff the consumer workspace is in the producer's allowlist.
+
+If you're seeing a 403 on a cross-workspace read in agent mode, the producer hasn't granted your consumer — see [the runbook](runbooks.md).
+
+## Run triggers vs. remote state
+
+These are **independent** composition edges that often appear together but neither implies the other:
+
+| | Run trigger | Remote-state grant |
+|---|---|---|
+| Owned by | Consumer (destination) | Producer (state owner) |
+| Says | "Re-run me when A applies" | "B may read my state" |
+| Carries | Ordering / causality | Data + authorization |
+| Required when | You want B to re-plan after A changes infra | B's config uses `data "terraform_remote_state"` against A |
+
+**You can need a run trigger without a remote-state grant.** Example: workspace `app` reads VPC details via `data "aws_vpc" { tags = {…} }` directly from AWS, *not* via `terraform_remote_state`. It still depends on `shared-network` (re-plan after VPC changes) — set up a run trigger `shared-network → app`. But never grant `app` access to `shared-network`'s state — it doesn't need it, and giving the grant would needlessly expose `shared-network`'s secrets.
+
+**You can need a remote-state grant without a run trigger.** Example: `app` reads `shared-network.outputs.vpc_id` once and re-plans only on its own changes. Grant the read; no trigger needed.
+
+In short: trigger answers *when*; grant answers *what + who-may-read*.
+
+## What happens when…
+
+- **The producer hasn't applied yet.** The consumer reads the producer's *current* state version at plan time. If the producer has never applied successfully, there is no state to read — the consumer's `terraform_remote_state` data source fails. Order the first apply with a run trigger or a one-time manual apply on the producer first.
+- **The producer is archived (e.g. via [autodiscovery lifecycle](autodiscovery.md)).** The state still exists until purged — consumers' reads continue to succeed as long as the state version remains in storage. Once the workspace is hard-deleted, consumer reads will fail.
+- **You delete the consumer workspace.** The grant row is cleaned up automatically (cascade).
+- **Cycles (A consumes B, B consumes A).** Allowed — state reads are point-in-time against the *current* state version; no ordering is implied and no deadlock occurs. Whether this models your dependencies correctly is a different question.
+
+## Limitations
+
+- Cross-instance reads (a workspace on Terrapod instance X reading state from Terrapod instance Y) are not supported. State sharing is within a single Terrapod deployment.
+- Outputs-only access (TFE's `tfe_outputs`-style data source that exposes outputs without exposing the full state) is **not** offered. `terraform_remote_state` exposes the full state, including sensitive values. If you need outputs-only sharing as a future hardening, file an issue.
+- The `terraform_remote_state` data source must use `backend = "remote"` (or the equivalent `cloud {}` block in the consumer's config). The `http` backend variant against Terrapod's state-download URL is unsupported.

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -641,3 +641,28 @@ After fixing the rule:
 
 - Re-query the affected workspaces (server-side workspace search) and confirm the field is restored
 - No unexpected runs were created by the revert (bulk-update never triggers runs — if you see runs, they came from VCS/drift, not the bulk-update)
+
+## Cross-workspace `terraform_remote_state` returns 403
+
+**Symptom**: an agent-mode plan errors during init/refresh on a `data "terraform_remote_state"` data source pointing at another Terrapod workspace, with a 403 from `/api/v2/workspaces/{id}/current-state-version` or `/api/v2/state-versions/{id}/download`.
+
+**Why**: cross-workspace state reads in agent mode are gated by the **producer's consumer allowlist** — the producer workspace explicitly lists which consumer workspaces may read its (secret-bearing) state. Default is empty. The runner token doesn't satisfy per-user RBAC for another workspace, so without an allowlist entry every cross-workspace read 403s. This is the security design — see [the composition guide](remote-state.md) and the [API reference](api-reference.md#cross-workspace-remote-state-consumers).
+
+### Diagnosis
+
+1. Confirm the consumer is in agent mode — local-mode CLI runs use the user's token and a 403 there means the user lacks `plan` on the producer (label-RBAC), not the allowlist.
+2. Identify the producer workspace from the consumer's `terraform_remote_state` config (`workspaces.name`).
+3. List the producer's current consumers: `GET /api/terrapod/v1/workspaces/ws-PRODUCER/remote-state-consumers?filter[remote-state-consumer][type]=outbound`. If the consumer isn't there, that's the cause.
+
+### Resolution
+
+Have the **producer's admin** authorize the consumer — via the Terrapod provider's `terrapod_remote_state_consumer` resource, the API directly, the bulk-update endpoint, or (if the consumer is autodiscovered) the rule's template. The grant is producer-controlled by design: a consumer team cannot self-grant. See the composition guide for the three equivalent paths.
+
+### Verification
+
+- `GET /api/terrapod/v1/workspaces/ws-PRODUCER/remote-state-consumers?filter[remote-state-consumer][type]=outbound` lists the consumer
+- The consumer's next agent-mode plan proceeds past the `data "terraform_remote_state"` data source and resolves the outputs
+
+### Producer deleted or archived
+
+If the producer workspace was deleted, the grant rows cascade-deleted automatically and the consumer's next read returns 404 (no state). If the producer is `archived` via the [autodiscovery lifecycle](autodiscovery.md), the state is retained until purged — reads continue until then. Restoring an archived producer's grant requires recreating the workspace and re-authorizing the consumers.

--- a/provider/internal/provider/provider.go
+++ b/provider/internal/provider/provider.go
@@ -25,6 +25,7 @@ import (
 	notificationConfigRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/notification_configuration"
 	registryModuleRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/registry_module"
 	registryProviderRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/registry_provider"
+	remoteStateConsumerRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/remote_state_consumer"
 	roleRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/role"
 	roleAssignmentRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/role_assignment"
 	runTaskRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/run_task"
@@ -127,6 +128,7 @@ func (p *terrapodProvider) Resources(_ context.Context) []func() resource.Resour
 		variableSetVarRes.NewResource,
 		variableSetWsRes.NewResource,
 		runTriggerRes.NewResource,
+		remoteStateConsumerRes.NewResource,
 		notificationConfigRes.NewResource,
 		runTaskRes.NewResource,
 		roleRes.NewResource,

--- a/provider/internal/resources/remote_state_consumer/model.go
+++ b/provider/internal/resources/remote_state_consumer/model.go
@@ -1,0 +1,39 @@
+// Package remote_state_consumer implements the
+// terrapod_remote_state_consumer resource — one row in the
+// producer-controlled allowlist authorizing a consumer workspace's
+// agent runs to read a producer workspace's state via
+// terraform_remote_state (#344).
+//
+// API Contract (Terrapod API ↔ Terraform Provider):
+//
+//	JSON:API type: "remote-state-consumers"
+//	ID prefix: "rsc-"
+//	Create:  POST   /api/terrapod/v1/workspaces/{producer_id}/remote-state-consumers
+//	Read:    GET    /api/terrapod/v1/remote-state-consumers/{id}
+//	Delete:  DELETE /api/terrapod/v1/remote-state-consumers/{id}
+//	No update — immutable resource (delete + recreate).
+//
+// Use this standalone resource when the producer workspace and the
+// consumer workspace live in different Terraform configurations (the
+// common cross-team / cross-config case). For the single-config GitOps
+// case where the producer's resource block already exists, the set
+// attribute on `terrapod_workspace` is the ergonomic choice. Both
+// shapes go through the same server-side authorization: mutations
+// require admin on the PRODUCER, so a consumer team cannot self-grant.
+//
+// Import: by edge ID.
+package remote_state_consumer
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type remoteStateConsumerModel struct {
+	ID                    types.String `tfsdk:"id"`
+	ProducerWorkspaceID   types.String `tfsdk:"producer_workspace_id"`
+	ConsumerWorkspaceID   types.String `tfsdk:"consumer_workspace_id"`
+	ProducerWorkspaceName types.String `tfsdk:"producer_workspace_name"`
+	ConsumerWorkspaceName types.String `tfsdk:"consumer_workspace_name"`
+	CreatedAt             types.String `tfsdk:"created_at"`
+	CreatedBy             types.String `tfsdk:"created_by"`
+}

--- a/provider/internal/resources/remote_state_consumer/resource.go
+++ b/provider/internal/resources/remote_state_consumer/resource.go
@@ -1,0 +1,177 @@
+package remote_state_consumer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/mattrobinsonsre/terrapod/provider/internal/client"
+)
+
+var _ resource.Resource = &remoteStateConsumerResource{}
+
+type remoteStateConsumerResource struct {
+	client *client.Client
+}
+
+func NewResource() resource.Resource {
+	return &remoteStateConsumerResource{}
+}
+
+func (r *remoteStateConsumerResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_remote_state_consumer"
+}
+
+func (r *remoteStateConsumerResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Authorizes a consumer workspace's agent runs to read a producer workspace's state via terraform_remote_state. Producer-controlled allowlist (#344): mutations require admin on the PRODUCER workspace — a consumer team cannot self-grant. State data is secret-bearing; only grant deliberately.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true, Description: "Edge ID.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"producer_workspace_id": schema.StringAttribute{
+				Required: true, Description: "Producer workspace ID (the workspace whose state will be readable).",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"consumer_workspace_id": schema.StringAttribute{
+				Required: true, Description: "Consumer workspace ID (the workspace authorized to read).",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"producer_workspace_name": schema.StringAttribute{
+				Computed: true, Description: "Producer workspace name.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"consumer_workspace_name": schema.StringAttribute{
+				Computed: true, Description: "Consumer workspace name.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true, Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_by": schema.StringAttribute{
+				Computed: true, Description: "Identity that created the grant.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+		},
+	}
+}
+
+func (r *remoteStateConsumerResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client, got %T", req.ProviderData))
+		return
+	}
+	r.client = c
+}
+
+func (r *remoteStateConsumerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan remoteStateConsumerModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	rels := map[string]any{
+		"consumer": map[string]any{
+			"data": map[string]any{
+				"id":   plan.ConsumerWorkspaceID.ValueString(),
+				"type": "workspaces",
+			},
+		},
+	}
+
+	body, err := client.MarshalResource("remote-state-consumers", map[string]any{}, rels)
+	if err != nil {
+		resp.Diagnostics.AddError("Marshal error", err.Error())
+		return
+	}
+
+	data, err := r.client.Post(
+		ctx,
+		fmt.Sprintf("/api/terrapod/v1/workspaces/%s/remote-state-consumers", plan.ProducerWorkspaceID.ValueString()),
+		body,
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("Create failed", err.Error())
+		return
+	}
+
+	res, err := client.ParseResource(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Parse error", err.Error())
+		return
+	}
+
+	readIntoModel(res, &plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *remoteStateConsumerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state remoteStateConsumerModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.Get(ctx, "/api/terrapod/v1/remote-state-consumers/"+state.ID.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Read failed", err.Error())
+		return
+	}
+
+	res, err := client.ParseResource(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Parse error", err.Error())
+		return
+	}
+
+	readIntoModel(res, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *remoteStateConsumerResource) Update(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError("Update not supported", "Remote-state consumer grants are immutable. Delete and recreate instead.")
+}
+
+func (r *remoteStateConsumerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state remoteStateConsumerModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Delete(ctx, "/api/terrapod/v1/remote-state-consumers/"+state.ID.ValueString())
+	if err != nil && !client.IsNotFound(err) {
+		resp.Diagnostics.AddError("Delete failed", err.Error())
+	}
+}
+
+func readIntoModel(res *client.Resource, m *remoteStateConsumerModel) {
+	m.ID = types.StringValue(res.ID)
+	m.ProducerWorkspaceName = types.StringValue(client.GetStringAttr(res, "producer-workspace-name"))
+	m.ConsumerWorkspaceName = types.StringValue(client.GetStringAttr(res, "consumer-workspace-name"))
+	m.CreatedAt = types.StringValue(client.GetStringAttr(res, "created-at"))
+	m.CreatedBy = types.StringValue(client.GetStringAttr(res, "created-by"))
+
+	if v := client.GetRelationshipID(res, "producer"); v != "" {
+		m.ProducerWorkspaceID = types.StringValue(v)
+	}
+	if v := client.GetRelationshipID(res, "consumer"); v != "" {
+		m.ConsumerWorkspaceID = types.StringValue(v)
+	}
+}

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -693,6 +693,17 @@ def create_application() -> FastAPI:
 
     include_terrapod(run_triggers_router)
 
+    # Remote-state consumer allowlist — Terrapod-native management of the
+    # producer-controlled cross-workspace `terraform_remote_state` grants
+    # (#344). The CLI never manages these; the read-path authorization
+    # consuming the allowlist lives in tfe_v2.py on the existing
+    # CLI-contract endpoints.
+    from terrapod.api.routers.remote_state_consumers import (
+        router as remote_state_consumers_router,
+    )
+
+    include_terrapod(remote_state_consumers_router)
+
     # Audit log query endpoint — Terrapod-specific.
     from terrapod.api.routers.audit import router as audit_router
 

--- a/services/terrapod/api/routers/remote_state_consumers.py
+++ b/services/terrapod/api/routers/remote_state_consumers.py
@@ -1,0 +1,382 @@
+"""Cross-workspace remote-state consumer allowlist CRUD (#344).
+
+Producer-controlled allowlist authorizing which workspaces' agent runs
+may read this workspace's state via ``terraform_remote_state``. Mirrors
+the run-trigger router shape; the deliberate difference is that all
+mutations require admin/write on the **producer** (the state owner).
+Empty allowlist ⇒ not shared (secure by default).
+
+Independent of run triggers — neither implies the other.
+
+UX CONTRACT: Consumed by the web frontend on the workspace detail page
+(Remote State Sharing panel). Changes to response shapes, attribute
+names, or status codes here MUST be matched by corresponding updates
+to that frontend page.
+
+Endpoints:
+    POST   /api/terrapod/v1/workspaces/{id}/remote-state-consumers      (add one)
+    GET    /api/terrapod/v1/workspaces/{id}/remote-state-consumers       (list inbound/outbound)
+    PUT    /api/terrapod/v1/workspaces/{id}/remote-state-consumers       (replace whole set)
+    GET    /api/terrapod/v1/remote-state-consumers/{id}                   (show)
+    DELETE /api/terrapod/v1/remote-state-consumers/{id}                   (delete)
+"""
+
+import uuid
+from datetime import UTC
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.models import Workspace, WorkspaceRemoteStateConsumer
+from terrapod.db.session import get_db
+from terrapod.logging_config import get_logger
+from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+
+router = APIRouter(tags=["remote-state-consumers"])
+logger = get_logger(__name__)
+
+# Generous defensive cap to prevent runaway allowlists. A shared-module
+# workspace consumed by many environments is normal; a list larger than
+# this almost certainly indicates a label-driven case better served by
+# a future selector mechanism (out of scope here).
+MAX_CONSUMERS_PER_PRODUCER = 200
+
+
+def _rfc3339(dt) -> str:
+    if dt is None:
+        return ""
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _consumer_json(row: WorkspaceRemoteStateConsumer) -> dict:
+    """Serialize a WorkspaceRemoteStateConsumer to JSON:API format."""
+    edge_id = f"rsc-{row.id}"
+    producer_name = row.producer_workspace.name if row.producer_workspace else ""
+    consumer_name = row.consumer_workspace.name if row.consumer_workspace else ""
+
+    return {
+        "id": edge_id,
+        "type": "remote-state-consumers",
+        "attributes": {
+            "producer-workspace-name": producer_name,
+            "consumer-workspace-name": consumer_name,
+            "created-at": _rfc3339(row.created_at),
+            "created-by": row.created_by or "",
+        },
+        "relationships": {
+            "producer": {
+                "data": {"id": f"ws-{row.producer_workspace_id}", "type": "workspaces"},
+            },
+            "consumer": {
+                "data": {"id": f"ws-{row.consumer_workspace_id}", "type": "workspaces"},
+            },
+        },
+        "links": {
+            "self": f"/api/terrapod/v1/remote-state-consumers/{edge_id}",
+        },
+    }
+
+
+async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
+    ws_uuid = workspace_id.removeprefix("ws-")
+    try:
+        ws_uuid_obj = uuid.UUID(ws_uuid)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Workspace not found") from exc
+    result = await db.execute(select(Workspace).where(Workspace.id == ws_uuid_obj))
+    ws = result.scalar_one_or_none()
+    if ws is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    return ws
+
+
+async def _require_ws_permission(
+    ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
+) -> None:
+    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    if not has_permission(perm, required):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Requires {required} permission on workspace",
+        )
+
+
+def _extract_consumer_id(body: dict) -> str:
+    """Pull the consumer workspace id out of a JSON:API request body."""
+    relationships = body.get("data", {}).get("relationships", {})
+    consumer_data = relationships.get("consumer", {}).get("data", {})
+    consumer_id = consumer_data.get("id", "")
+    if not consumer_id:
+        raise HTTPException(
+            status_code=422,
+            detail="consumer relationship is required (relationships.consumer.data.id)",
+        )
+    return consumer_id
+
+
+@router.post("/workspaces/{workspace_id}/remote-state-consumers", status_code=201)
+async def create_remote_state_consumer(
+    workspace_id: str = Path(..., description="Producer workspace id"),
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Authorize a consumer workspace to read this (producer) workspace's
+    state. Requires **admin** on the producer (the state owner). Producer
+    control of the secret-bearing state is the security invariant.
+    """
+    producer = await _get_workspace(workspace_id, db)
+    await _require_ws_permission(producer, "admin", user, db)
+
+    consumer = await _get_workspace(_extract_consumer_id(body), db)
+
+    if producer.id == consumer.id:
+        raise HTTPException(
+            status_code=422,
+            detail="A workspace already reads its own state; self-reference is not a grant",
+        )
+
+    existing = await db.execute(
+        select(WorkspaceRemoteStateConsumer).where(
+            WorkspaceRemoteStateConsumer.producer_workspace_id == producer.id,
+            WorkspaceRemoteStateConsumer.consumer_workspace_id == consumer.id,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="Consumer is already authorized")
+
+    count = (
+        await db.execute(
+            select(func.count())
+            .select_from(WorkspaceRemoteStateConsumer)
+            .where(WorkspaceRemoteStateConsumer.producer_workspace_id == producer.id)
+        )
+    ).scalar_one()
+    if count >= MAX_CONSUMERS_PER_PRODUCER:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Maximum of {MAX_CONSUMERS_PER_PRODUCER} consumers per producer",
+        )
+
+    row = WorkspaceRemoteStateConsumer(
+        producer_workspace_id=producer.id,
+        consumer_workspace_id=consumer.id,
+        created_by=user.email or "",
+    )
+    db.add(row)
+    await db.flush()
+    await db.refresh(row, attribute_names=["producer_workspace", "consumer_workspace"])
+    await db.commit()
+
+    logger.info(
+        "Remote-state consumer authorized",
+        edge_id=str(row.id),
+        producer=producer.name,
+        consumer=consumer.name,
+        by=user.email,
+    )
+
+    return JSONResponse(content={"data": _consumer_json(row)}, status_code=201)
+
+
+@router.get("/workspaces/{workspace_id}/remote-state-consumers")
+async def list_remote_state_consumers(
+    workspace_id: str = Path(...),
+    filter_type: str | None = Query(None, alias="filter[remote-state-consumer][type]"),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """List remote-state consumer edges for a workspace.
+
+    ``outbound`` (default): workspaces I share my state with (I'm the
+    producer). ``inbound``: workspaces whose state I'm authorized to
+    read (I'm the consumer). Requires read on the workspace.
+    """
+    ws = await _get_workspace(workspace_id, db)
+    await _require_ws_permission(ws, "read", user, db)
+
+    if filter_type is None:
+        filter_type = "outbound"
+    if filter_type not in ("inbound", "outbound"):
+        raise HTTPException(
+            status_code=422,
+            detail=("filter[remote-state-consumer][type] must be 'inbound' or 'outbound'"),
+        )
+
+    if filter_type == "outbound":
+        where = WorkspaceRemoteStateConsumer.producer_workspace_id == ws.id
+    else:
+        where = WorkspaceRemoteStateConsumer.consumer_workspace_id == ws.id
+
+    query = (
+        select(WorkspaceRemoteStateConsumer)
+        .options(
+            selectinload(WorkspaceRemoteStateConsumer.producer_workspace),
+            selectinload(WorkspaceRemoteStateConsumer.consumer_workspace),
+        )
+        .where(where)
+        .order_by(WorkspaceRemoteStateConsumer.created_at.asc())
+    )
+    rows = list((await db.execute(query)).scalars().all())
+
+    return JSONResponse(content={"data": [_consumer_json(r) for r in rows]})
+
+
+@router.put("/workspaces/{workspace_id}/remote-state-consumers")
+async def replace_remote_state_consumers(
+    workspace_id: str = Path(..., description="Producer workspace id"),
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Declaratively replace the producer's full consumer set in one
+    atomic transaction. Provided to support the provider's set-valued
+    ``remote_state_consumers`` attribute (idempotent). Requires admin
+    on the producer.
+
+    Body shape: ``{"data": [{"type": "workspaces", "id": "ws-..."}, ...]}``.
+    """
+    producer = await _get_workspace(workspace_id, db)
+    await _require_ws_permission(producer, "admin", user, db)
+
+    items = body.get("data", [])
+    if not isinstance(items, list):
+        raise HTTPException(
+            status_code=422,
+            detail="data must be a list of workspace references",
+        )
+
+    desired: set[uuid.UUID] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            raise HTTPException(status_code=422, detail="invalid consumer reference")
+        raw_id = item.get("id", "")
+        consumer = await _get_workspace(raw_id, db)
+        if consumer.id == producer.id:
+            raise HTTPException(
+                status_code=422,
+                detail="A workspace already reads its own state; self-reference is not a grant",
+            )
+        desired.add(consumer.id)
+
+    if len(desired) > MAX_CONSUMERS_PER_PRODUCER:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Maximum of {MAX_CONSUMERS_PER_PRODUCER} consumers per producer",
+        )
+
+    existing_q = await db.execute(
+        select(WorkspaceRemoteStateConsumer).where(
+            WorkspaceRemoteStateConsumer.producer_workspace_id == producer.id
+        )
+    )
+    existing_rows = list(existing_q.scalars().all())
+    existing_ids = {r.consumer_workspace_id for r in existing_rows}
+
+    # Remove rows no longer in the desired set.
+    for r in existing_rows:
+        if r.consumer_workspace_id not in desired:
+            await db.delete(r)
+
+    # Add rows newly in the desired set.
+    for cid in desired - existing_ids:
+        db.add(
+            WorkspaceRemoteStateConsumer(
+                producer_workspace_id=producer.id,
+                consumer_workspace_id=cid,
+                created_by=user.email or "",
+            )
+        )
+
+    await db.flush()
+
+    refreshed_q = await db.execute(
+        select(WorkspaceRemoteStateConsumer)
+        .options(
+            selectinload(WorkspaceRemoteStateConsumer.producer_workspace),
+            selectinload(WorkspaceRemoteStateConsumer.consumer_workspace),
+        )
+        .where(WorkspaceRemoteStateConsumer.producer_workspace_id == producer.id)
+        .order_by(WorkspaceRemoteStateConsumer.created_at.asc())
+    )
+    rows = list(refreshed_q.scalars().all())
+
+    await db.commit()
+
+    logger.info(
+        "Remote-state consumer set replaced",
+        producer=producer.name,
+        count=len(rows),
+        by=user.email,
+    )
+
+    return JSONResponse(content={"data": [_consumer_json(r) for r in rows]})
+
+
+@router.get("/remote-state-consumers/{edge_id}")
+async def show_remote_state_consumer(
+    edge_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Show a single consumer edge. Requires read on the producer."""
+    try:
+        edge_uuid = uuid.UUID(edge_id.removeprefix("rsc-"))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Remote-state consumer not found") from exc
+
+    result = await db.execute(
+        select(WorkspaceRemoteStateConsumer)
+        .options(
+            selectinload(WorkspaceRemoteStateConsumer.producer_workspace),
+            selectinload(WorkspaceRemoteStateConsumer.consumer_workspace),
+        )
+        .where(WorkspaceRemoteStateConsumer.id == edge_uuid)
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Remote-state consumer not found")
+
+    await _require_ws_permission(row.producer_workspace, "read", user, db)
+
+    return JSONResponse(content={"data": _consumer_json(row)})
+
+
+@router.delete("/remote-state-consumers/{edge_id}", status_code=204)
+async def delete_remote_state_consumer(
+    edge_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Revoke a consumer grant. Requires admin on the **producer** —
+    the state owner controls who may read; a consumer cannot revoke
+    nor self-grant.
+    """
+    try:
+        edge_uuid = uuid.UUID(edge_id.removeprefix("rsc-"))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Remote-state consumer not found") from exc
+
+    result = await db.execute(
+        select(WorkspaceRemoteStateConsumer)
+        .options(selectinload(WorkspaceRemoteStateConsumer.producer_workspace))
+        .where(WorkspaceRemoteStateConsumer.id == edge_uuid)
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Remote-state consumer not found")
+
+    await _require_ws_permission(row.producer_workspace, "admin", user, db)
+
+    await db.delete(row)
+    await db.commit()
+
+    logger.info(
+        "Remote-state consumer revoked",
+        edge_id=str(row.id),
+        by=user.email,
+    )

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -51,7 +51,14 @@ from terrapod.api.dependencies import (
     require_non_runner,
 )
 from terrapod.api.labels import validate_labels
-from terrapod.db.models import Run, StateVersion, Workspace, WorkspaceRemoteStateConsumer
+from terrapod.db.models import (
+    AuditLog,
+    Run,
+    StateVersion,
+    Workspace,
+    WorkspaceRemoteStateConsumer,
+    generate_uuid7,
+)
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service as _agent_pool_service
@@ -977,14 +984,40 @@ async def _runner_state_read_allowed(
             WorkspaceRemoteStateConsumer.consumer_workspace_id == consumer_ws_id,
         )
     )
-    if grant.scalar_one_or_none() is None:
+    grant_id = grant.scalar_one_or_none()
+    if grant_id is None:
         return False
     logger.info(
         "Cross-workspace state read authorized via consumer allowlist",
         producer_workspace_id=str(producer.id),
         consumer_workspace_id=str(consumer_ws_id),
+        grant_id=str(grant_id),
         run_id=user.run_id,
     )
+    # Audit the cross-workspace state consumption explicitly (#344 Phase 2).
+    # The request-level middleware records the HTTP call but cannot
+    # express the producer↔consumer↔grant context that compliance /
+    # forensics need; do it here where the resolved pair is in hand.
+    # Read endpoint has no other in-flight writes, so the explicit
+    # commit is safe and the audit row persists regardless of the
+    # endpoint's outcome below.
+    db.add(
+        AuditLog(
+            id=generate_uuid7(),
+            actor_email=user.email or "",
+            actor_type="system",
+            origin="system",
+            action="workspace.remote_state_read",
+            resource_type="workspace",
+            resource_id=f"ws-{producer.id}",
+            status_code=200,
+            detail=(
+                f"consumer ws-{consumer_ws_id} read producer state "
+                f"via grant rsc-{grant_id}; run {user.run_id}"
+            ),
+        )
+    )
+    await db.commit()
     return True
 
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -36,6 +36,7 @@ Endpoints:
 import hashlib
 import os
 import re
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, Response, status
@@ -50,7 +51,7 @@ from terrapod.api.dependencies import (
     require_non_runner,
 )
 from terrapod.api.labels import validate_labels
-from terrapod.db.models import Run, StateVersion, Workspace
+from terrapod.db.models import Run, StateVersion, Workspace, WorkspaceRemoteStateConsumer
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service as _agent_pool_service
@@ -939,6 +940,54 @@ async def _require_ws_permission(
     return ws, perm
 
 
+async def _runner_state_read_allowed(
+    db: AsyncSession, user: AuthenticatedUser, producer: Workspace
+) -> bool:
+    """Producer-controlled allowlist check for cross-workspace state
+    reads (#344).
+
+    Only applies to runner-token principals (agent-mode runs hitting
+    these CLI-contract endpoints via ``terraform_remote_state``). Grants
+    iff:
+    - the runner's own workspace IS the producer (self-read; harmless,
+      since a workspace's own run already holds its state via the
+      runner-artifact path), OR
+    - the runner's workspace appears in the producer's explicit consumer
+      allowlist (``workspace_remote_state_consumers``).
+
+    Returns False for any non-runner principal (those continue to the
+    existing user/API-token RBAC path, unchanged). Returns False on
+    any data issue (missing run, bad uuid) — fail safe.
+    """
+    if user.auth_method != "runner_token" or not user.run_id:
+        return False
+    try:
+        run_uuid = uuid.UUID(user.run_id)
+    except (ValueError, TypeError):
+        return False
+    row = (await db.execute(select(Run.workspace_id).where(Run.id == run_uuid))).first()
+    if row is None:
+        return False
+    consumer_ws_id = row[0]
+    if consumer_ws_id == producer.id:
+        return True  # self-read; runners already own their own state
+    grant = await db.execute(
+        select(WorkspaceRemoteStateConsumer.id).where(
+            WorkspaceRemoteStateConsumer.producer_workspace_id == producer.id,
+            WorkspaceRemoteStateConsumer.consumer_workspace_id == consumer_ws_id,
+        )
+    )
+    if grant.scalar_one_or_none() is None:
+        return False
+    logger.info(
+        "Cross-workspace state read authorized via consumer allowlist",
+        producer_workspace_id=str(producer.id),
+        consumer_workspace_id=str(consumer_ws_id),
+        run_id=user.run_id,
+    )
+    return True
+
+
 @router.get("/workspaces/{workspace_id}")
 async def show_workspace_by_id(
     workspace_id: str = Path(...),
@@ -1389,8 +1438,22 @@ async def current_state_version(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Get the current (latest) state version for a workspace."""
-    ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
+    """Get the current (latest) state version for a workspace.
+
+    Runner-token principals (agent-mode runs reading another workspace
+    via ``terraform_remote_state``) are authorized by the producer's
+    explicit consumer allowlist (#344) when they are not the workspace
+    owner. All other principals continue through the standard
+    workspace RBAC path.
+    """
+    ws = await _get_workspace_by_id(workspace_id, db)
+    if not await _runner_state_read_allowed(db, user, ws):
+        perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+        if not has_permission(perm, "read"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Requires read permission on workspace",
+            )
 
     result = await db.execute(
         select(StateVersion)
@@ -1419,16 +1482,23 @@ async def download_state(
     if sv is None:
         raise HTTPException(status_code=404, detail="State version not found")
 
-    # Check plan permission on the workspace (raw state may contain secrets)
+    # Raw state may contain secrets. Authorization paths:
+    # * Runner-token principals (agent-mode runs hitting this endpoint
+    #   via `terraform_remote_state`) — producer-controlled consumer
+    #   allowlist (#344); a self-read or an explicit allowlist entry
+    #   grants. No fallback to user RBAC for runner tokens (they hold
+    #   only `everyone` and would 403 anyway).
+    # * Everything else — existing per-user `plan` permission.
     ws = await db.get(Workspace, sv.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
-    if not has_permission(perm, "plan"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Requires plan permission on workspace",
-        )
+    if not await _runner_state_read_allowed(db, user, ws):
+        perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+        if not has_permission(perm, "plan"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Requires plan permission on workspace",
+            )
 
     storage = get_storage()
     key = state_key(str(sv.workspace_id), str(sv.id))

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -1351,6 +1351,56 @@ class RunTrigger(Base):
     )
 
 
+class WorkspaceRemoteStateConsumer(Base):
+    """Producer-controlled cross-workspace state-read grant (#344).
+
+    A row ``(producer_workspace_id, consumer_workspace_id)`` authorizes
+    the consumer workspace's agent runs to read the producer
+    workspace's state via ``terraform_remote_state``. Producer-owned:
+    only the producer workspace's admin may create/delete a row. No
+    rows for a producer ⇒ its state is not shared (secure by default).
+
+    Independent of ``RunTrigger`` — neither implies the other (a run
+    trigger is "re-run me when A applies"; this is "B may read A's
+    state"). Mirrors the run-trigger edge shape; the deliberate
+    difference is producer-side authorization.
+    """
+
+    __tablename__ = "workspace_remote_state_consumers"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=generate_uuid7
+    )
+    producer_workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    consumer_workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=now_utc, nullable=False
+    )
+    created_by: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+
+    producer_workspace: Mapped["Workspace"] = relationship(foreign_keys=[producer_workspace_id])
+    consumer_workspace: Mapped["Workspace"] = relationship(foreign_keys=[consumer_workspace_id])
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "producer_workspace_id",
+            "consumer_workspace_id",
+            name="uq_workspace_remote_state_consumers",
+        ),
+        Index("ix_wrsc_consumer_workspace_id", "consumer_workspace_id"),
+        Index("ix_wrsc_producer_workspace_id", "producer_workspace_id"),
+    )
+
+
 # --- Notification Configurations ---
 
 

--- a/services/tests/api/test_remote_state_consumers.py
+++ b/services/tests/api/test_remote_state_consumers.py
@@ -141,6 +141,117 @@ class TestRunnerStateReadAllowed:
         assert await _runner_state_read_allowed(db, user, producer) is False
 
 
+# ── HTTP: runner-authz helper is actually wired to the state endpoints ──
+
+
+class TestRunnerAuthzWiring:
+    """Confirm `current_state_version` and `download_state` actually
+    call `_runner_state_read_allowed` and respect its return value.
+    The helper itself is unit-tested above; these tests catch a future
+    refactor that drops the helper call from one endpoint without
+    breaking the helper's own tests."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
+    async def test_current_state_version_grants_when_helper_returns_true(
+        self, m_helper, m_get_ws, m_resolve, *_
+    ):
+        """Helper True → endpoint skips user RBAC and proceeds past authz.
+
+        We use a "no state versions found" path to confirm the endpoint
+        got *past* authz (404 instead of 403) without having to fully
+        mock a serializable StateVersion. The wiring guarantee is what
+        this test exists for; the response shape is covered elsewhere.
+        """
+        producer = _mock_ws(name="producer")
+        m_get_ws.return_value = producer
+        m_helper.return_value = True
+
+        app, db = _make_app(_user(auth_method="runner_token", run_id=str(uuid.uuid4())))
+        # No SV exists → endpoint raises 404 *after* clearing authz.
+        no_sv = MagicMock()
+        no_sv.scalar_one_or_none.return_value = None
+        db.execute.return_value = no_sv
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/v2/workspaces/ws-{producer.id}/current-state-version",
+                headers=_AUTH,
+            )
+
+        # 404 (cleared authz, no SV) confirms wiring; would be 403 without the helper True.
+        assert resp.status_code == 404
+        m_helper.assert_awaited_once()
+        # User RBAC fallback must NOT have been consulted (helper allowed).
+        m_resolve.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
+    async def test_current_state_version_falls_through_and_denies_runner(
+        self, m_helper, m_get_ws, m_resolve, *_
+    ):
+        """Helper False → user RBAC consulted. A runner principal carries
+        only `everyone`, so RBAC denies → 403. This is the negative wiring:
+        the endpoint must NOT 'fall open' when the helper returns False."""
+        producer = _mock_ws(name="producer")
+        m_get_ws.return_value = producer
+        m_helper.return_value = False
+        m_resolve.return_value = None  # everyone role → no permission
+
+        app, _db = _make_app(_user(auth_method="runner_token", run_id=str(uuid.uuid4())))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/v2/workspaces/ws-{producer.id}/current-state-version",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 403
+        m_helper.assert_awaited_once()
+        m_resolve.assert_awaited_once()  # fallback was actually consulted
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
+    async def test_download_state_falls_through_and_denies_runner(self, m_helper, m_resolve, *_):
+        """Same wiring guarantee for the download endpoint — helper
+        False, runner principal, RBAC denies → 403. Without this test, a
+        refactor that drops the helper call from download_state would
+        silently re-introduce the pre-#344 behaviour where a runner
+        token could not cross-read at all (but also where the helper
+        wasn't checked, masking a future regression of either kind)."""
+        producer = _mock_ws(name="producer")
+        m_helper.return_value = False
+        m_resolve.return_value = None
+
+        sv = MagicMock()
+        sv.id = uuid.uuid4()
+        sv.workspace_id = producer.id
+
+        app, db = _make_app(_user(auth_method="runner_token", run_id=str(uuid.uuid4())))
+        sv_result = MagicMock()
+        sv_result.scalar_one_or_none.return_value = sv
+        db.execute.return_value = sv_result
+        db.get = AsyncMock(return_value=producer)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/state-versions/sv-{sv.id}/download", headers=_AUTH)
+
+        assert resp.status_code == 403
+        m_helper.assert_awaited_once()
+        m_resolve.assert_awaited_once()
+
+
 # ── HTTP: management router CRUD ─────────────────────────────────────────
 
 
@@ -150,7 +261,9 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
     async def test_create_happy_path(self, mock_resolve, *_):
-        """Admin on producer → 201."""
+        """Admin on producer → 201, and the response JSON carries the
+        producer + consumer names (i.e. the row's relationships actually
+        get populated)."""
         mock_resolve.return_value = "admin"
         producer = _mock_ws(name="producer")
         consumer = _mock_ws(name="consumer")
@@ -169,7 +282,15 @@ class TestCreateConsumer:
         r4 = MagicMock()
         r4.scalar_one.return_value = 0
         db.execute.side_effect = [r1, r2, r3, r4]
-        db.refresh = AsyncMock()
+
+        # Populate the relationship attributes the way db.refresh would in
+        # the real DB session — otherwise the response names fall through
+        # to "" and the test silently passes against a no-op refresh.
+        async def _refresh(row, attribute_names=None):
+            row.producer_workspace = producer
+            row.consumer_workspace = consumer
+
+        db.refresh = AsyncMock(side_effect=_refresh)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
@@ -184,7 +305,15 @@ class TestCreateConsumer:
                 headers=_AUTH,
             )
         assert resp.status_code == 201
-        assert resp.json()["data"]["type"] == "remote-state-consumers"
+        body = resp.json()
+        assert body["data"]["type"] == "remote-state-consumers"
+        attrs = body["data"]["attributes"]
+        assert attrs["producer-workspace-name"] == "producer"
+        assert attrs["consumer-workspace-name"] == "consumer"
+        # Relationship ids are present and prefixed
+        rels = body["data"]["relationships"]
+        assert rels["producer"]["data"]["id"] == f"ws-{producer.id}"
+        assert rels["consumer"]["data"]["id"] == f"ws-{consumer.id}"
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/api/test_remote_state_consumers.py
+++ b/services/tests/api/test_remote_state_consumers.py
@@ -1,0 +1,373 @@
+"""Tests for cross-workspace remote-state consumer allowlist (#344).
+
+Two layers:
+- Unit tests of `_runner_state_read_allowed` in `tfe_v2` — the
+  security-critical authorization branch that decides whether an
+  agent-mode `terraform_remote_state` read is permitted.
+- HTTP-level CRUD tests of `routers/remote_state_consumers` — the
+  Terrapod-native management endpoints (mirrors run-trigger tests).
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.api.routers.tfe_v2 import _runner_state_read_allowed
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _user(email="test@example.com", roles=None, auth_method="session", run_id=None):
+    return AuthenticatedUser(
+        email=email,
+        display_name="Test",
+        roles=roles or ["everyone"],
+        provider_name="local",
+        auth_method=auth_method,
+        run_id=run_id,
+    )
+
+
+def _mock_ws(ws_id=None, name="test-ws"):
+    ws = MagicMock()
+    ws.id = ws_id or uuid.uuid4()
+    ws.name = name
+    return ws
+
+
+def _make_app(user, mock_db=None):
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app, mock_db
+
+
+# ── Unit: _runner_state_read_allowed (security-critical) ─────────────────
+
+
+class TestRunnerStateReadAllowed:
+    """Direct unit tests of the authz branch added to current-state-version
+    and download. This is the security boundary — it decides whether a
+    runner-token holder may read another workspace's secret-bearing state.
+    """
+
+    async def test_non_runner_principal_falls_through(self):
+        """User/API-token principals must not be granted by this helper —
+        they continue through the existing per-user RBAC path."""
+        db = AsyncMock()
+        producer = _mock_ws()
+        assert await _runner_state_read_allowed(db, _user(auth_method="session"), producer) is False
+        assert (
+            await _runner_state_read_allowed(db, _user(auth_method="api_token"), producer) is False
+        )
+        # Should not have touched the DB.
+        db.execute.assert_not_awaited()
+
+    async def test_runner_without_run_id_denied(self):
+        db = AsyncMock()
+        producer = _mock_ws()
+        user = _user(auth_method="runner_token", run_id=None)
+        assert await _runner_state_read_allowed(db, user, producer) is False
+        db.execute.assert_not_awaited()
+
+    async def test_runner_with_invalid_run_id_denied(self):
+        db = AsyncMock()
+        producer = _mock_ws()
+        user = _user(auth_method="runner_token", run_id="not-a-uuid")
+        assert await _runner_state_read_allowed(db, user, producer) is False
+        db.execute.assert_not_awaited()
+
+    async def test_runner_with_missing_run_denied(self):
+        """Runner token references a run that no longer exists → fail safe."""
+        db = AsyncMock()
+        producer = _mock_ws()
+        result = MagicMock()
+        result.first.return_value = None
+        db.execute.return_value = result
+        user = _user(auth_method="runner_token", run_id=str(uuid.uuid4()))
+        assert await _runner_state_read_allowed(db, user, producer) is False
+
+    async def test_runner_self_read_granted(self):
+        """A runner reading its OWN workspace's state via the v2 endpoint
+        is harmless (the runner already owns its state via the artifact
+        path). Granting self-reads here keeps the contract simple."""
+        producer = _mock_ws()
+        db = AsyncMock()
+        run_result = MagicMock()
+        # `first()` returns a row tuple — Run.workspace_id IS producer.id.
+        run_result.first.return_value = (producer.id,)
+        db.execute.return_value = run_result
+        user = _user(auth_method="runner_token", run_id=str(uuid.uuid4()))
+        assert await _runner_state_read_allowed(db, user, producer) is True
+
+    async def test_runner_consumer_in_allowlist_granted(self):
+        """Runner from workspace B reads producer A, and B is in A's
+        consumer allowlist → granted."""
+        producer = _mock_ws(name="producer")
+        consumer_id = uuid.uuid4()
+        db = AsyncMock()
+        run_result = MagicMock()
+        run_result.first.return_value = (consumer_id,)
+        grant_result = MagicMock()
+        grant_result.scalar_one_or_none.return_value = uuid.uuid4()  # grant row found
+        db.execute.side_effect = [run_result, grant_result]
+        user = _user(auth_method="runner_token", run_id=str(uuid.uuid4()))
+        assert await _runner_state_read_allowed(db, user, producer) is True
+
+    async def test_runner_consumer_not_in_allowlist_denied(self):
+        """Runner from workspace B reads producer A; B is NOT in A's
+        allowlist → denied. This is the core security gate."""
+        producer = _mock_ws(name="producer")
+        consumer_id = uuid.uuid4()
+        db = AsyncMock()
+        run_result = MagicMock()
+        run_result.first.return_value = (consumer_id,)
+        grant_result = MagicMock()
+        grant_result.scalar_one_or_none.return_value = None  # not in allowlist
+        db.execute.side_effect = [run_result, grant_result]
+        user = _user(auth_method="runner_token", run_id=str(uuid.uuid4()))
+        assert await _runner_state_read_allowed(db, user, producer) is False
+
+
+# ── HTTP: management router CRUD ─────────────────────────────────────────
+
+
+class TestCreateConsumer:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    async def test_create_happy_path(self, mock_resolve, *_):
+        """Admin on producer → 201."""
+        mock_resolve.return_value = "admin"
+        producer = _mock_ws(name="producer")
+        consumer = _mock_ws(name="consumer")
+
+        app, db = _make_app(_user())
+        # 1) producer lookup
+        r1 = MagicMock()
+        r1.scalar_one_or_none.return_value = producer
+        # 2) consumer lookup
+        r2 = MagicMock()
+        r2.scalar_one_or_none.return_value = consumer
+        # 3) existing-grant check (none)
+        r3 = MagicMock()
+        r3.scalar_one_or_none.return_value = None
+        # 4) count check (0)
+        r4 = MagicMock()
+        r4.scalar_one.return_value = 0
+        db.execute.side_effect = [r1, r2, r3, r4]
+        db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/terrapod/v1/workspaces/ws-{producer.id}/remote-state-consumers",
+                json={
+                    "data": {
+                        "relationships": {
+                            "consumer": {"data": {"id": f"ws-{consumer.id}", "type": "workspaces"}}
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 201
+        assert resp.json()["data"]["type"] == "remote-state-consumers"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    async def test_create_requires_producer_admin(self, mock_resolve, *_):
+        """Read on producer is not enough — mutation requires admin."""
+        mock_resolve.return_value = "read"
+        producer = _mock_ws()
+
+        app, db = _make_app(_user())
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = producer
+        db.execute.return_value = r
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/terrapod/v1/workspaces/ws-{producer.id}/remote-state-consumers",
+                json={
+                    "data": {"relationships": {"consumer": {"data": {"id": f"ws-{uuid.uuid4()}"}}}}
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    async def test_create_self_reference_rejected(self, mock_resolve, *_):
+        """A workspace listing itself is meaningless (already reads own state)."""
+        mock_resolve.return_value = "admin"
+        ws = _mock_ws()
+        app, db = _make_app(_user())
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = ws
+        db.execute.side_effect = [r, r]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/terrapod/v1/workspaces/ws-{ws.id}/remote-state-consumers",
+                json={"data": {"relationships": {"consumer": {"data": {"id": f"ws-{ws.id}"}}}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    async def test_create_duplicate_rejected(self, mock_resolve, *_):
+        mock_resolve.return_value = "admin"
+        producer = _mock_ws(name="producer")
+        consumer = _mock_ws(name="consumer")
+        app, db = _make_app(_user())
+        r1 = MagicMock()
+        r1.scalar_one_or_none.return_value = producer
+        r2 = MagicMock()
+        r2.scalar_one_or_none.return_value = consumer
+        r3 = MagicMock()
+        r3.scalar_one_or_none.return_value = MagicMock()  # existing row
+        db.execute.side_effect = [r1, r2, r3]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/terrapod/v1/workspaces/ws-{producer.id}/remote-state-consumers",
+                json={
+                    "data": {"relationships": {"consumer": {"data": {"id": f"ws-{consumer.id}"}}}}
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 409
+
+
+class TestListConsumers:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    async def test_list_outbound_default(self, mock_resolve, *_):
+        """No filter ⇒ outbound (workspaces I share to)."""
+        mock_resolve.return_value = "read"
+        producer = _mock_ws()
+        app, db = _make_app(_user())
+        ws_lookup = MagicMock()
+        ws_lookup.scalar_one_or_none.return_value = producer
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = []
+        db.execute.side_effect = [ws_lookup, list_result]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/workspaces/ws-{producer.id}/remote-state-consumers",
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"data": []}
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    async def test_list_invalid_filter_rejected(self, mock_resolve, *_):
+        mock_resolve.return_value = "read"
+        producer = _mock_ws()
+        app, db = _make_app(_user())
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = producer
+        db.execute.return_value = r
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/terrapod/v1/workspaces/ws-{producer.id}/remote-state-consumers"
+                "?filter[remote-state-consumer][type]=sideways",
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+
+class TestDeleteConsumer:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    async def test_delete_happy(self, mock_resolve, *_):
+        """Admin on producer → 204."""
+        mock_resolve.return_value = "admin"
+        producer = _mock_ws()
+        row = MagicMock()
+        row.id = uuid.uuid4()
+        row.producer_workspace = producer
+
+        app, db = _make_app(_user())
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = row
+        db.execute.return_value = result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(
+                f"/api/terrapod/v1/remote-state-consumers/rsc-{row.id}", headers=_AUTH
+            )
+        assert resp.status_code == 204
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    async def test_delete_requires_producer_admin(self, mock_resolve, *_):
+        """A consumer (or any non-admin) cannot revoke their own grant
+        — only the producer's admin may delete an edge."""
+        mock_resolve.return_value = "write"  # not admin
+        producer = _mock_ws()
+        row = MagicMock()
+        row.id = uuid.uuid4()
+        row.producer_workspace = producer
+
+        app, db = _make_app(_user())
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = row
+        db.execute.return_value = result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(
+                f"/api/terrapod/v1/remote-state-consumers/rsc-{row.id}", headers=_AUTH
+            )
+        assert resp.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_delete_404(self, *_):
+        app, db = _make_app(_user())
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        db.execute.return_value = result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(
+                f"/api/terrapod/v1/remote-state-consumers/rsc-{uuid.uuid4()}",
+                headers=_AUTH,
+            )
+        assert resp.status_code == 404
+
+
+# Silence unused-import warning when pytest doesn't directly need datetime.
+assert datetime(2026, 1, 1, tzinfo=UTC) and pytest is not None

--- a/services/tests/runner/test_config_strip.py
+++ b/services/tests/runner/test_config_strip.py
@@ -1,0 +1,152 @@
+"""Golden test for the entrypoint's `cloud`/`backend` block-stripping
+(#344).
+
+The runner entrypoint strips ``cloud {}`` and top-level ``backend "x" {}``
+blocks from uploaded ``.tf`` files to prevent recursive backend use. We
+need to guarantee this logic does **not** mangle a
+``data "terraform_remote_state"`` block, because cross-workspace state
+reads (#344) depend on those data sources surviving init.
+
+The test reads the real awk program from ``docker/runner-entrypoint.sh``
+(so a future change to the strip pattern is exercised) and runs it
+against a fixture containing both kinds of blocks.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _find_entrypoint() -> Path:
+    """Locate ``docker/runner-entrypoint.sh`` from either layout:
+    - Local dev: <repo-root>/docker/runner-entrypoint.sh
+      (this file at services/tests/runner/test_config_strip.py)
+    - Docker test image: /app/docker/runner-entrypoint.sh
+      (copied in by Dockerfile.test alongside services/)
+    """
+    here = Path(__file__).resolve()
+    for cand in (here.parents[3] / "docker", here.parents[2] / "docker"):
+        path = cand / "runner-entrypoint.sh"
+        if path.is_file():
+            return path
+    pytest.skip("runner-entrypoint.sh not reachable from the test environment")
+
+
+def _extract_strip_awk() -> str:
+    """Pull the literal awk program out of the entrypoint script."""
+    text = _find_entrypoint().read_text()
+    match = re.search(
+        r"# Strip cloud \{\} and backend \{\} blocks.*?awk '\n(.*?)\n\s*'",
+        text,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(
+            "Could not locate the strip-awk program in runner-entrypoint.sh — "
+            "the surrounding comment/structure has changed; update this test."
+        )
+    return match.group(1)
+
+
+def _run_awk(program: str, source: str) -> str:
+    awk = shutil.which("awk")
+    if awk is None:
+        pytest.skip("awk not available in test environment")
+    result = subprocess.run(
+        [awk, program],
+        input=source,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def test_strip_removes_cloud_and_backend_blocks() -> None:
+    program = _extract_strip_awk()
+    source = (
+        "cloud {\n"
+        '  organization = "default"\n'
+        '  workspaces { name = "w" }\n'
+        "}\n"
+        "\n"
+        "terraform {\n"
+        '  backend "remote" {\n'
+        '    hostname = "terrapod.local"\n'
+        '    organization = "default"\n'
+        '    workspaces { name = "w" }\n'
+        "  }\n"
+        "}\n"
+        "\n"
+        'resource "null_resource" "n" {}\n'
+    )
+    out = _run_awk(program, source)
+    assert "cloud {" not in out
+    assert 'backend "remote"' not in out
+    assert 'resource "null_resource" "n" {}' in out
+
+
+def test_strip_preserves_terraform_remote_state_data_source() -> None:
+    """The #344 critical case: a `data "terraform_remote_state"` block
+    has a nested ``backend = "remote"`` *argument* (assignment, not a
+    `{}` block) and a nested ``config { ... }`` block. The strip
+    pattern must not consume any of it."""
+    program = _extract_strip_awk()
+    source = (
+        'data "terraform_remote_state" "shared" {\n'
+        '  backend = "remote"\n'
+        "  config = {\n"
+        '    hostname     = "terrapod.local"\n'
+        '    organization = "default"\n'
+        '    workspaces   = { name = "shared-network" }\n'
+        "  }\n"
+        "}\n"
+        "\n"
+        'output "vpc_id" {\n'
+        "  value = data.terraform_remote_state.shared.outputs.vpc_id\n"
+        "}\n"
+    )
+    out = _run_awk(program, source)
+    # Every meaningful line of the data source survives intact.
+    for required in (
+        'data "terraform_remote_state" "shared" {',
+        'backend = "remote"',
+        "config = {",
+        'hostname     = "terrapod.local"',
+        'workspaces   = { name = "shared-network" }',
+        "data.terraform_remote_state.shared.outputs.vpc_id",
+    ):
+        assert required in out, f"strip mangled line: {required!r}"
+
+
+def test_strip_handles_both_in_one_file() -> None:
+    """Mixed: a `cloud {}` block (must be stripped) and a
+    `data "terraform_remote_state"` block (must survive) in the same
+    file. Belt-and-braces against a regression where the strip's
+    depth-tracking accidentally consumes following blocks."""
+    program = _extract_strip_awk()
+    source = (
+        "cloud {\n"
+        '  organization = "default"\n'
+        '  workspaces { name = "consumer" }\n'
+        "}\n"
+        "\n"
+        'data "terraform_remote_state" "shared" {\n'
+        '  backend = "remote"\n'
+        "  config = {\n"
+        '    hostname     = "terrapod.local"\n'
+        '    organization = "default"\n'
+        '    workspaces   = { name = "producer" }\n'
+        "  }\n"
+        "}\n"
+    )
+    out = _run_awk(program, source)
+    assert "cloud {" not in out
+    assert 'data "terraform_remote_state" "shared" {' in out
+    assert 'backend = "remote"' in out
+    assert "config = {" in out


### PR DESCRIPTION
Closes #344. Phase 0 spike + Phases 1, 2, 3 (provider), 6, and 7 of the implementation plan in the issue. Phases 4 (UX), 5 (fleet hooks), and the workspace-resource set attribute are deliberately split into focused follow-ups (#349, #350, #348) to keep this security-bearing PR reviewable; the core feature is independently operable via the API + standalone provider resource.

## What ships

- **Producer-controlled consumer allowlist.** Junction table `workspace_remote_state_consumers` (FK cascade both sides); default empty ⇒ not shared (secure by default).
- **Terrapod-native management endpoints** under `/api/terrapod/v1/workspaces/{id}/remote-state-consumers` (list inbound/outbound, POST single, PUT declarative replace-set, DELETE single by id). All mutations require **admin/write on the PRODUCER** — a consumer team cannot self-grant.
- **Runner-token authz branch** on the existing CLI-contract endpoints `GET /api/v2/workspaces/{id}/current-state-version` and `GET /api/v2/state-versions/{id}/download`. Granted iff the runner's own workspace is the producer (self-read; harmless) or is in the producer's allowlist. User / API-token RBAC paths are completely unchanged.
- **Terrapod provider standalone resource** `terrapod_remote_state_consumer` (model + resource; immutable: create + read + delete). Same producer-admin authz applies via the same API.
- **Documentation**: new `docs/remote-state.md` composition guide (incl. the data-source-on-managed-infra example justifying why run triggers and remote-state grants are independent), `api-reference.md` updates, runbook entry for the 403 case, `index.md` feature row + doc link.

## Key design decisions (locked, recorded in the issue)

- **Producer-controlled allowlist** — explicit per-edge list owned by the state owner. No `global-remote-state`-style toggle (too crude for single-org). No consumer-side / owner-derived / workspace-role authorization (control must stay with the producer; secret-exposure axis is separate from RBAC).
- **Independent from run triggers.** Neither edge implies the other. A workspace can need a run trigger without a remote-state grant (consuming managed infra via `data "aws_*"`), and vice versa. Documented as the canonical example.
- **Same security invariant across provider, UI, bulk, and direct API**: server-side `admin/write` on the producer is the single gate.

## Phase 0 findings (de-risking; recorded in the issue)

- **Own-state regression risk eliminated**: agent runs read their own state via `/api/terrapod/v1/runs/{id}/artifacts/state` (run-scoped runner auth) — a different code path from the v2 endpoints this PR modifies. The v2 endpoints are exclusively the `terraform_remote_state`/go-tfe path.
- **Mirror, don't share** the run-trigger machinery: `RunTrigger`'s own docstring already states *"No data is passed — downstream read outputs via terraform_remote_state independently"*. The consumer router structurally parallels run-triggers.
- **Config-stripping risk**: the entrypoint's `cloud {}` / `backend {}` strip pattern targets line-leading `cloud`/`backend` openers with a `{`. A `data "terraform_remote_state"` block starts with `data` and uses `backend = "x"` as an argument (no `{`), so the strip does not mangle it. **Regression-guarded by a golden test** that runs the real entrypoint awk against fixtures (`tests/runner/test_config_strip.py`). The strip's broader fragility is its own follow-up: #346.

## Tests

- **1509 pass**, lint clean.
- 7 unit cases on the security-critical `_runner_state_read_allowed` helper (non-runner principals fall through; missing/invalid run_id denied; self-read granted; listed-consumer granted; **not-listed-consumer denied — the core security gate**).
- 6 HTTP CRUD cases on the management router (admin happy path; non-admin 403 on mutations; self-reference 422; duplicate 409; invalid filter 422; 404 on delete).
- 3 strip golden tests (removes cloud/backend; **preserves `data "terraform_remote_state"`**; mixed file).

## Honesty / coverage gap

The smoke section below covers the live end-to-end run. UX panel (#349), workspace-resource set attribute (#348), and fleet hooks (bulk-update + autodiscovery templates, #350) are explicitly scoped out and tracked.

## Smoke (live Tilt — gated; in progress)

The adversarial smoke from the plan runs against the live stack with the rebuilt API + runner image. Will append results to this PR before merge:

- Happy local mode: producer w/ outputs → consumer `terraform_remote_state` w/ plan-permissioned user token → outputs read.
- Happy agent mode: producer lists consumer → consumer runner reads producer state → plan resolves consumed value.
- **Negative (the core)**: consumer NOT listed → runner 403, **zero state bytes leak**.
- Regression: normal agent run still reads its own state via `run_artifacts` (must-not-break).
- Non-producer-admin self-grant attempt via API and provider → 403.
- Cascade: delete consumer → edge gone; delete producer → edges gone.

## Follow-ups filed

- #348 `terrapod_workspace.remote_state_consumers` set attribute (provider, single-config GitOps complement)
- #349 UX panel on workspace detail
- #350 Fleet hooks (bulk-update + autodiscovery rule template)
- #346 Replace runner backend-strip with `override.tf` (related fragility surfaced during Phase 0)