### PR TITLE
fix: provider terrapod_workspace Delete calls Terrapod-native path (closes #353)

### DIFF
--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -359,7 +359,10 @@ func (r *workspaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
-	err := r.client.Delete(ctx, "/api/v2/workspaces/"+state.ID.ValueString())
+	// Workspace delete lives on the Terrapod-native prefix (it isn't a
+	// CLI-consumed surface; the v2 alias was removed in #278). Calling
+	// /api/v2/workspaces/{id} returns 405 — see #353.
+	err := r.client.Delete(ctx, "/api/terrapod/v1/workspaces/"+state.ID.ValueString())
 	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Failed to delete workspace", err.Error())
 	}


### PR DESCRIPTION
Closes #353. One-line provider fix exposed during the #348 spike.

## The bug

The provider's `terrapod_workspace` Delete called `DELETE /api/v2/workspaces/{id}` and got `HTTP 405 Method Not Allowed`. Workspace delete was moved to `/api/terrapod/v1/workspaces/{id}` in #278 (it isn't on the CLI-consumed surface; the v2 alias was deliberately removed). The provider wasn't updated, so `terraform destroy` of any IaC-managed workspace failed and workspaces became effectively immortal once Terraform managed them.

## The fix

Switch the provider's Delete to `/api/terrapod/v1/workspaces/{id}`. One line + an explanatory comment pointing at #278/#353 so future maintainers don't re-introduce.

## Live verification

The 3 stranded `spike348-*` workspaces left over from the #348 smoke were destroyed cleanly via the fixed provider (each "Destruction complete after 0s"); server-side DB confirmed zero `spike348-*` workspaces remain.

## Bonus — full provider→server path/method audit

While in this code I did a systematic scan of every HTTP call the provider makes (`r.client.{Get,Post,Patch,Put,Delete,DeleteWithBody}`) against every server-side handler decorator (accounting for router prefixes, `extensions_router`, `management_router`, `workspace_links_router`, etc.). **64 calls across all 21 resources + 6 datasources verified, no other mismatches.** Documented in #353 in case anyone else hunts here.

## Tests

`go build / vet / gofmt` clean; Python suite 1512 pass (provider-only change). No new test files — the repo precedent for provider resources is live smoke against Tilt, and live smoke is exactly what surfaced this.