### PR TITLE
fix: use redirect-aware download for apply-phase lock file

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -453,14 +453,12 @@ fi
 # older runner that didn't upload a lock file, or an older API without
 # the /lock-file endpoint.
 if [ "$TP_PHASE" = "apply" ] && [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
-    LOCK_DL_HTTP=$(curl -sS -o .terraform.lock.hcl -w "%{http_code}" \
-        -H "$AUTH_HEADER" \
-        "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/lock-file" 2>/dev/null || echo "000")
-    if [ "$LOCK_DL_HTTP" = "302" ] || [ "$LOCK_DL_HTTP" = "200" ]; then
+    if tp_curl_download .terraform.lock.hcl -H "$AUTH_HEADER" \
+        "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/lock-file" 2>/dev/null; then
         log "[entrypoint] Reusing .terraform.lock.hcl from plan phase"
     else
         rm -f .terraform.lock.hcl
-        log "[entrypoint] No plan-phase lock file available (HTTP $LOCK_DL_HTTP); apply init will resolve providers independently"
+        log "[entrypoint] No plan-phase lock file available (HTTP ${TP_LAST_HTTP:-none}); apply init will resolve providers independently"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- Apply-phase lock file download used raw `curl -o` which doesn't follow 302 redirects
- Artifact endpoints return 302 → presigned URL; without following, the file is empty
- Terraform ignores the empty lock file, resolves providers fresh, creating a lock file mismatch with the saved plan
- Switched to `tp_curl_download` (the same redirect-aware wrapper used by state/config/plan downloads)

## Test plan
- [x] Run agent-mode plan+apply with a provider dependency (`null_resource`)
- [x] Verify apply phase logs show "Reusing .terraform.lock.hcl from plan phase"
- [x] Verify apply phase init says "Reusing previous version of..." (not "Finding latest version...")
- [x] Verify apply completes successfully without "Inconsistent dependency lock file" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)