### PR TITLE
feat: add external state mode for Atlantis migration coexistence

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_state_mode.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_state_mode.py
@@ -1,0 +1,33 @@
+"""Add state_mode to workspaces, runs, and autodiscovery_rules.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 42266b856e8e
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a1b2c3d4e5f6"
+down_revision = "42266b856e8e"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column("state_mode", sa.String(20), nullable=False, server_default="managed"),
+    )
+    op.add_column(
+        "runs",
+        sa.Column("state_mode", sa.String(20), nullable=False, server_default="managed"),
+    )
+    op.add_column(
+        "autodiscovery_rules",
+        sa.Column("state_mode", sa.String(20), nullable=False, server_default="managed"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("autodiscovery_rules", "state_mode")
+    op.drop_column("runs", "state_mode")
+    op.drop_column("workspaces", "state_mode")

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -302,50 +302,53 @@ if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
             STRIP_DIR="$WORK_DIR/$TP_WORKING_DIR"
         fi
 
-        # Force the runner to use the local backend by writing a terraform
-        # override file (#346). Override files (*_override.tf) are merged
-        # by terraform/tofu with replacement semantics: an override
-        # `terraform { backend "local" {} }` replaces the main config's
-        # `cloud {}` or `backend "x" {}` block, regardless of how the
-        # user wrote it. This avoids any in-place editing of user code.
-        #
-        # The runner MUST execute on the local backend — a remote backend
-        # inside the Job recurses straight back into Terrapod. So our
-        # override has to WIN, unconditionally. Two mechanisms:
-        #
-        #   1. Filename `zzzz_terrapod_backend_override.tf`. Override
-        #      files are merged in lexical order with the LAST file
-        #      winning, so the `zzzz` prefix makes ours win against a
-        #      user's `override.tf` or any realistic `*_override.tf`.
-        #      (We do NOT defer to a user-supplied backend override —
-        #      deferring to a user `cloud {}` / `backend "remote"` would
-        #      hand the runner a remote backend. Ours always wins.)
-        #
-        #   2. The post-init backstop below
-        #      (.terraform/terraform.tfstate backend.type check) — a
-        #      hard guarantee for the residual case of a user file that
-        #      sorts even later than ours.
-        #
-        # If the user did ship their own override file declaring a
-        # backend/cloud block, log it so the override is visible in the
-        # runner log — but still write (and win with) ours.
-        #
-        # NB: we DO keep the user's committed `.terraform.lock.hcl` if
-        # present. It pins provider versions across plan/apply (see #306);
-        # discarding it makes plan-init and apply-init independent
-        # resolutions of the version constraint, which can drift.
-        TP_OVERRIDE_FILE="$STRIP_DIR/zzzz_terrapod_backend_override.tf"
-        for tp_ov in "$STRIP_DIR"/override.tf "$STRIP_DIR"/*_override.tf; do
-            [ -f "$tp_ov" ] || continue
-            case "$tp_ov" in
-                "$TP_OVERRIDE_FILE") continue ;;
-            esac
-            if grep -qE '^[[:space:]]*terraform[[:space:]]*\{' "$tp_ov" \
-               && grep -qE '(^|[[:space:]])(backend[[:space:]]*"|cloud[[:space:]]*\{)' "$tp_ov"; then
-                log "[entrypoint] Note: user override $tp_ov declares a backend/cloud block — Terrapod's local-backend override takes precedence"
-            fi
-        done
-        cat > "$TP_OVERRIDE_FILE" <<'TPOVR'
+        if [ "${TP_STATE_MODE:-managed}" = "external" ]; then
+            log "[entrypoint] External state mode — preserving user's backend configuration"
+        else
+            # Force the runner to use the local backend by writing a terraform
+            # override file (#346). Override files (*_override.tf) are merged
+            # by terraform/tofu with replacement semantics: an override
+            # `terraform { backend "local" {} }` replaces the main config's
+            # `cloud {}` or `backend "x" {}` block, regardless of how the
+            # user wrote it. This avoids any in-place editing of user code.
+            #
+            # The runner MUST execute on the local backend — a remote backend
+            # inside the Job recurses straight back into Terrapod. So our
+            # override has to WIN, unconditionally. Two mechanisms:
+            #
+            #   1. Filename `zzzz_terrapod_backend_override.tf`. Override
+            #      files are merged in lexical order with the LAST file
+            #      winning, so the `zzzz` prefix makes ours win against a
+            #      user's `override.tf` or any realistic `*_override.tf`.
+            #      (We do NOT defer to a user-supplied backend override —
+            #      deferring to a user `cloud {}` / `backend "remote"` would
+            #      hand the runner a remote backend. Ours always wins.)
+            #
+            #   2. The post-init backstop below
+            #      (.terraform/terraform.tfstate backend.type check) — a
+            #      hard guarantee for the residual case of a user file that
+            #      sorts even later than ours.
+            #
+            # If the user did ship their own override file declaring a
+            # backend/cloud block, log it so the override is visible in the
+            # runner log — but still write (and win with) ours.
+            #
+            # NB: we DO keep the user's committed `.terraform.lock.hcl` if
+            # present. It pins provider versions across plan/apply (see #306);
+            # discarding it makes plan-init and apply-init independent
+            # resolutions of the version constraint, which can drift.
+            TP_OVERRIDE_FILE="$STRIP_DIR/zzzz_terrapod_backend_override.tf"
+            for tp_ov in "$STRIP_DIR"/override.tf "$STRIP_DIR"/*_override.tf; do
+                [ -f "$tp_ov" ] || continue
+                case "$tp_ov" in
+                    "$TP_OVERRIDE_FILE") continue ;;
+                esac
+                if grep -qE '^[[:space:]]*terraform[[:space:]]*\{' "$tp_ov" \
+                   && grep -qE '(^|[[:space:]])(backend[[:space:]]*"|cloud[[:space:]]*\{)' "$tp_ov"; then
+                    log "[entrypoint] Note: user override $tp_ov declares a backend/cloud block — Terrapod's local-backend override takes precedence"
+                fi
+            done
+            cat > "$TP_OVERRIDE_FILE" <<'TPOVR'
 # Terrapod runner: force local backend for in-runner execution.
 # Override files (*_override.tf) are merged by terraform/tofu with
 # replacement semantics over the main config — this displaces any
@@ -355,7 +358,8 @@ terraform {
   backend "local" {}
 }
 TPOVR
-        log "[entrypoint] Wrote $TP_OVERRIDE_FILE (forces local backend via override)"
+            log "[entrypoint] Wrote $TP_OVERRIDE_FILE (forces local backend via override)"
+        fi
     else
         log "[entrypoint] No configuration archive (HTTP ${TP_LAST_HTTP:-none})"
     fi
@@ -436,7 +440,8 @@ fi
 # Must run AFTER working directory change so terraform.tfstate ends up in the
 # directory where tofu init/plan/apply will execute (the working directory for
 # monorepo subdirectory setups, or $WORK_DIR for root-level workspaces).
-if [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
+# Skipped in external state mode — terraform reads state from its native backend.
+if [ "${TP_STATE_MODE:-managed}" != "external" ] && [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
     log "[entrypoint] Downloading current state..."
     tp_curl_download terraform.tfstate -H "$AUTH_HEADER" \
         "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/state" 2>/dev/null || true
@@ -481,18 +486,18 @@ fi
 # the override-file merge. As a hard guarantee against a pathological
 # user file that sorts even later, verify the backend that init actually
 # configured — it is recorded in .terraform/terraform.tfstate.
-TP_CONFIGURED_BACKEND=$(jq -r '.backend.type // "MISSING"' .terraform/terraform.tfstate 2>/dev/null || echo "MISSING")
-# jq on an empty file exits 0 with empty output — normalise to MISSING so
-# the diagnostic below reads sensibly (the != local check fails safe
-# either way).
-[ -n "$TP_CONFIGURED_BACKEND" ] || TP_CONFIGURED_BACKEND="MISSING"
-if [ "$TP_CONFIGURED_BACKEND" != "local" ]; then
-    log "[entrypoint] FATAL: expected the local backend after init, got '$TP_CONFIGURED_BACKEND'."
-    log "[entrypoint] A user-supplied override file appears to have displaced the Terrapod backend override."
-    log "[entrypoint] Remove any committed override.tf / *_override.tf that declares a 'backend' or 'cloud' block."
-    exit 1
+# Skipped in external state mode — the user's native backend is expected.
+if [ "${TP_STATE_MODE:-managed}" != "external" ]; then
+    TP_CONFIGURED_BACKEND=$(jq -r '.backend.type // "MISSING"' .terraform/terraform.tfstate 2>/dev/null || echo "MISSING")
+    [ -n "$TP_CONFIGURED_BACKEND" ] || TP_CONFIGURED_BACKEND="MISSING"
+    if [ "$TP_CONFIGURED_BACKEND" != "local" ]; then
+        log "[entrypoint] FATAL: expected the local backend after init, got '$TP_CONFIGURED_BACKEND'."
+        log "[entrypoint] A user-supplied override file appears to have displaced the Terrapod backend override."
+        log "[entrypoint] Remove any committed override.tf / *_override.tf that declares a 'backend' or 'cloud' block."
+        exit 1
+    fi
+    log "[entrypoint] Backend verified: local"
 fi
-log "[entrypoint] Backend verified: local"
 
 # --- Plan phase: upload the lock file produced (or augmented) by init ---
 # Apply phase will download this so its init resolves to the same
@@ -656,7 +661,8 @@ elif [ "$TP_PHASE" = "apply" ]; then
     [ -f /tmp/apply.log ] && cat /tmp/apply.log >> "$COMBINED_LOG"
 
     # Upload new state (FATAL — missing state = infrastructure/state divergence)
-    if [ -n "$TP_API_URL" ] && [ -f terraform.tfstate ]; then
+    # Skipped in external state mode — terraform wrote state to its native backend.
+    if [ "${TP_STATE_MODE:-managed}" != "external" ] && [ -n "$TP_API_URL" ] && [ -f terraform.tfstate ]; then
         if ! curl -sSf --max-time "$TP_UPLOAD_TIMEOUT" -X PUT -H "$AUTH_HEADER" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @terraform.tfstate \

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -453,14 +453,12 @@ fi
 # older runner that didn't upload a lock file, or an older API without
 # the /lock-file endpoint.
 if [ "$TP_PHASE" = "apply" ] && [ -n "$TP_API_URL" ] && [ -n "$TP_RUN_ID" ]; then
-    LOCK_DL_HTTP=$(curl -sS -o .terraform.lock.hcl -w "%{http_code}" \
-        -H "$AUTH_HEADER" \
-        "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/lock-file" 2>/dev/null || echo "000")
-    if [ "$LOCK_DL_HTTP" = "302" ] || [ "$LOCK_DL_HTTP" = "200" ]; then
+    if tp_curl_download .terraform.lock.hcl -H "$AUTH_HEADER" \
+        "${TP_API_URL}/api/terrapod/v1/runs/${TP_RUN_ID}/artifacts/lock-file" 2>/dev/null; then
         log "[entrypoint] Reusing .terraform.lock.hcl from plan phase"
     else
         rm -f .terraform.lock.hcl
-        log "[entrypoint] No plan-phase lock file available (HTTP $LOCK_DL_HTTP); apply init will resolve providers independently"
+        log "[entrypoint] No plan-phase lock file available (HTTP ${TP_LAST_HTTP:-none}); apply init will resolve providers independently"
     fi
 fi
 

--- a/services/pyproject-listener.toml
+++ b/services/pyproject-listener.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.13"
 dependencies = [
     "cryptography>=46.0.5,<48.0.0",
     "httpx>=0.28",
-    "kubernetes>=35.0",
+    "kubernetes>=35.0,<36.0",
     "prometheus-client>=0.24",
     "pydantic>=2.10",
     "pydantic-settings>=2.7",

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -69,6 +69,7 @@ def _rule_json(rule: AutodiscoveryRule) -> dict:
             "ignore-patterns": list(rule.ignore_patterns or []),
             "enabled": rule.enabled,
             "execution-mode": rule.execution_mode,
+            "state-mode": rule.state_mode,
             "execution-backend": rule.execution_backend,
             "agent-pool-id": str(rule.agent_pool_id) if rule.agent_pool_id else None,
             "terraform-version": rule.terraform_version,
@@ -191,6 +192,14 @@ def _coerce_attrs(attrs: dict, *, on_create: bool) -> dict[str, Any]:
                 detail="execution-mode must be 'agent' (autodiscovery is VCS-driven; local-mode workspaces have no executor for queued runs)",
             )
         out["execution_mode"] = em
+    if "state-mode" in attrs:
+        sm = str(attrs["state-mode"])
+        if sm not in ("managed", "external"):
+            raise HTTPException(
+                status_code=422,
+                detail="state-mode must be 'managed' or 'external'",
+            )
+        out["state_mode"] = sm
     if "execution-backend" in attrs:
         eb = str(attrs["execution-backend"])
         if eb not in _VALID_BACKENDS:
@@ -439,6 +448,7 @@ def _build_transient_rule(fields: dict[str, Any], conn: VCSConnection) -> Autodi
         # has NOT NULL constraints on some, so populate with reasonable
         # defaults to satisfy the in-memory construction.
         execution_mode=fields.get("execution_mode", "agent"),
+        state_mode=fields.get("state_mode", "managed"),
         execution_backend=fields.get("execution_backend", "tofu"),
         terraform_version=fields.get("terraform_version", "1.12"),
         resource_cpu=fields.get("resource_cpu", "1"),

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -119,6 +119,7 @@ def _run_json(
                 "terraform-version": run.terraform_version,
                 "resource-cpu": run.resource_cpu,
                 "resource-memory": run.resource_memory,
+                "state-mode": run.state_mode,
                 "error-message": run.error_message,
                 "target-addrs": run.target_addrs or [],
                 "replace-addrs": run.replace_addrs or [],

--- a/services/terrapod/api/routers/state_management.py
+++ b/services/terrapod/api/routers/state_management.py
@@ -210,6 +210,11 @@ async def upload_state_manual(
     from terrapod.api.routers.tfe_v2 import _get_workspace_by_id
 
     ws = await _get_workspace_by_id(workspace_id, db)
+    if ws.state_mode == "external":
+        raise HTTPException(
+            status_code=409,
+            detail="State managed externally — use the workspace's native backend",
+        )
     perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
     if not has_permission(perm, "write"):
         raise HTTPException(

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -590,6 +590,7 @@ def _workspace_json(
                 "name": ws.name,
                 "auto-apply": ws.auto_apply,
                 "execution-mode": ws.execution_mode,
+                "state-mode": ws.state_mode,
                 "operations": ws.execution_mode == "agent",
                 "execution-backend": ws.execution_backend,
                 "terraform-version": ws.terraform_version or "",
@@ -877,9 +878,17 @@ async def create_workspace(
             detail="execution-mode must be 'local' or 'agent'",
         )
 
+    state_mode = attrs.get("state-mode", "managed")
+    if state_mode not in ("managed", "external"):
+        raise HTTPException(
+            status_code=422,
+            detail="state-mode must be 'managed' or 'external'",
+        )
+
     ws = Workspace(
         name=name,
         execution_mode=execution_mode,
+        state_mode=state_mode,
         auto_apply=attrs.get("auto-apply", False),
         execution_backend=attrs.get("execution-backend", settings.default_execution_backend),
         terraform_version=attrs.get("terraform-version", settings.default_terraform_version),
@@ -1204,6 +1213,13 @@ async def update_workspace(
                 detail="execution-mode must be 'local' or 'agent'",
             )
         ws.execution_mode = attrs["execution-mode"]
+    if "state-mode" in attrs:
+        if attrs["state-mode"] not in ("managed", "external"):
+            raise HTTPException(
+                status_code=422,
+                detail="state-mode must be 'managed' or 'external'",
+            )
+        ws.state_mode = attrs["state-mode"]
     if "auto-apply" in attrs:
         ws.auto_apply = attrs["auto-apply"]
 
@@ -1450,6 +1466,9 @@ async def list_state_versions(
     """List all state versions for a workspace, ordered by serial DESC."""
     ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
 
+    if ws.state_mode == "external":
+        return JSONResponse(content={"data": []}, headers=_tfe_headers())
+
     result = await db.execute(
         select(StateVersion)
         .where(StateVersion.workspace_id == ws.id)
@@ -1480,6 +1499,8 @@ async def current_state_version(
     workspace RBAC path.
     """
     ws = await _get_workspace_by_id(workspace_id, db)
+    if ws.state_mode == "external":
+        raise HTTPException(status_code=404, detail="State managed externally")
     if not await _runner_state_read_allowed(db, user, ws):
         perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
         if not has_permission(perm, "read"):
@@ -1616,6 +1637,12 @@ async def create_state_version(
 ) -> JSONResponse:
     """Create a new state version. Requires write permission."""
     ws, _ = await _require_ws_permission(workspace_id, "write", user, db)
+
+    if ws.state_mode == "external":
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot create state versions for external-state workspaces",
+        )
 
     body = await request.json()
     attrs = body.get("data", {}).get("attributes", {})

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -344,6 +344,12 @@ class Workspace(Base):
     # State divergence — set when an apply Job succeeds but state upload fails
     state_diverged: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
+    # External state mode — "managed" (terrapod owns state) or "external"
+    # (runner uses the code's native backend block, e.g. S3+DynamoDB).
+    state_mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="managed", default="managed"
+    )  # managed, external
+
     # Autodiscovery lifecycle (#314). lifecycle_state: active (normal) |
     # pending_deletion (origin dir/PR gone — needs explicit operator
     # action; NEVER auto-destroyed) | archived (soft-deleted after a
@@ -868,6 +874,9 @@ class AutodiscoveryRule(Base):
     )
     execution_backend: Mapped[str] = mapped_column(String(20), nullable=False, default="tofu")
     terraform_version: Mapped[str] = mapped_column(String(50), nullable=False, default="1.12")
+    state_mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="managed", default="managed"
+    )  # managed, external — inherited by auto-created workspaces
     resource_cpu: Mapped[str] = mapped_column(String(20), nullable=False, default="1")
     resource_memory: Mapped[str] = mapped_column(String(20), nullable=False, default="2Gi")
     auto_apply: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
@@ -1167,6 +1176,9 @@ class Run(Base):
     terraform_version: Mapped[str] = mapped_column(String(20), nullable=False, default="")
     resource_cpu: Mapped[str] = mapped_column(String(20), nullable=False, default="1")
     resource_memory: Mapped[str] = mapped_column(String(20), nullable=False, default="2Gi")
+    state_mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="managed", default="managed"
+    )  # managed, external — snapshotted from workspace at creation
     pool_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("agent_pools.id", ondelete="SET NULL"),

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -59,6 +59,7 @@ def build_job_spec(
     allow_empty_apply: bool = False,
     is_destroy: bool = False,
     working_directory: str = "",
+    state_mode: str = "managed",
 ) -> dict:
     """Build a K8s Job spec for a run phase.
 
@@ -124,6 +125,8 @@ def build_job_spec(
         container_env.append({"name": "TP_DESTROY", "value": "true"})
     if working_directory:
         container_env.append({"name": "TP_WORKING_DIR", "value": working_directory})
+    if state_mode == "external":
+        container_env.append({"name": "TP_STATE_MODE", "value": "external"})
 
     # Termination grace period — passed to entrypoint for time-budgeted shutdown
     container_env.append(

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -648,6 +648,7 @@ class RunnerListener:
             allow_empty_apply=attrs.get("allow-empty-apply", False),
             is_destroy=attrs.get("is-destroy", False),
             working_directory=attrs.get("working-directory", ""),
+            state_mode=attrs.get("state-mode", "managed"),
         )
 
         namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -277,6 +277,7 @@ async def create_run(
         terraform_version=pinned_version,
         resource_cpu=workspace.resource_cpu,
         resource_memory=workspace.resource_memory,
+        state_mode=workspace.state_mode,
         pool_id=pool_id,
         created_by=created_by,
         is_drift_detection=is_drift_detection,

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -268,6 +268,7 @@ async def find_or_autocreate_workspace(
         id=uuid.uuid4(),  # generate_uuid7 default also fine; explicit for log clarity
         name=name,
         execution_mode=rule.execution_mode,
+        state_mode=rule.state_mode,
         execution_backend=rule.execution_backend,
         terraform_version=rule.terraform_version,
         resource_cpu=rule.resource_cpu,

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -47,6 +47,7 @@ def _mock_rule(
     r.terraform_version = "1.11"
     r.resource_cpu = "1"
     r.resource_memory = "2Gi"
+    r.state_mode = "managed"
     r.auto_apply = False
     r.on_directory_delete = "flag"
     r.labels = {"env": "monorepo"}

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -47,6 +47,7 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.drift_last_checked_at = overrides.get("drift_last_checked_at", None)
     ws.drift_status = overrides.get("drift_status", "")
     ws.state_diverged = overrides.get("state_diverged", False)
+    ws.state_mode = overrides.get("state_mode", "managed")
     ws.vcs_workflow = overrides.get("vcs_workflow", "merge_then_apply")
     ws.auto_merge = overrides.get("auto_merge", False)
     ws.auto_merge_strategy = overrides.get("auto_merge_strategy", "merge")
@@ -212,6 +213,7 @@ class TestRunDriftAttributes:
         run.allow_empty_apply = False
         run.resource_cpu = "1"
         run.resource_memory = "2Gi"
+        run.state_mode = "managed"
         run.module_overrides = None
         run.created_by = "test@example.com"
         run.resource_additions = None

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -122,6 +122,7 @@ def _mock_run(
     run.allow_empty_apply = False
     run.resource_cpu = "1"
     run.resource_memory = "2Gi"
+    run.state_mode = "managed"
     run.configuration_version_id = None
     run.created_by = "test@example.com"
     run.resource_additions = None

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -64,6 +64,7 @@ def _mock_run(
     run.allow_empty_apply = False
     run.resource_cpu = "1"
     run.resource_memory = "2Gi"
+    run.state_mode = "managed"
     run.configuration_version_id = None
     run.module_overrides = None
     run.created_by = "test@example.com"

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -56,6 +56,7 @@ def _mock_workspace(ws_id=None, pool_id=None):
     ws.drift_last_checked_at = None
     ws.drift_status = ""
     ws.state_diverged = False
+    ws.state_mode = "managed"
     ws.vcs_workflow = "merge_then_apply"
     ws.auto_merge = False
     ws.auto_merge_strategy = "merge"

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -67,6 +67,7 @@ def _mock_workspace(
     ws.drift_last_checked_at = None
     ws.drift_status = ""
     ws.state_diverged = False
+    ws.state_mode = "managed"
     ws.vcs_workflow = "merge_then_apply"
     ws.auto_merge = False
     ws.auto_merge_strategy = "merge"

--- a/services/tests/runner/test_backend_override.py
+++ b/services/tests/runner/test_backend_override.py
@@ -204,7 +204,7 @@ def _extract_backstop_fragment() -> str:
     """Pull the post-init backend backstop fragment from the entrypoint."""
     text = _find_entrypoint().read_text()
     match = re.search(
-        r'(TP_CONFIGURED_BACKEND=\$\(jq.*?\nlog "\[entrypoint\] Backend verified: local")',
+        r'(TP_CONFIGURED_BACKEND=\$\(jq.*?\n\s*log "\[entrypoint\] Backend verified: local")',
         text,
         re.DOTALL,
     )

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -33,6 +33,7 @@ interface WorkspacePermissions {
 interface WorkspaceAttrs {
   name: string
   'execution-mode': string
+  'state-mode': 'managed' | 'external'
   'execution-backend': string
   'auto-apply': boolean
   'terraform-version': string
@@ -241,6 +242,7 @@ function WorkspaceDetailContent() {
   const [editMemory, setEditMemory] = useState('')
   const [editAutoApply, setEditAutoApply] = useState(false)
   const [editExecMode, setEditExecMode] = useState('')
+  const [editStateMode, setEditStateMode] = useState<'managed' | 'external'>('managed')
   const [editBackend, setEditBackend] = useState('')
   const [editVersion, setEditVersion] = useState('')
   const [editPoolId, setEditPoolId] = useState<string | null>(null)
@@ -823,6 +825,7 @@ function WorkspaceDetailContent() {
     setEditMemory(workspace.attributes['resource-memory'])
     setEditAutoApply(workspace.attributes['auto-apply'])
     setEditExecMode(workspace.attributes['execution-mode'])
+    setEditStateMode(workspace.attributes['state-mode'] || 'managed')
     setEditBackend(workspace.attributes['execution-backend'] || 'tofu')
     setEditVersion(workspace.attributes['terraform-version'] || '')
     setEditPoolId(workspace.attributes['agent-pool-id'])
@@ -882,6 +885,7 @@ function WorkspaceDetailContent() {
               'resource-memory': editMemory,
               'auto-apply': editAutoApply,
               'execution-mode': editExecMode,
+              'state-mode': editStateMode,
               'execution-backend': editBackend,
               'terraform-version': editVersion,
               'agent-pool-id': editPoolId,
@@ -1510,6 +1514,17 @@ function WorkspaceDetailContent() {
                     </select>
                   ) : (
                     <dd className="mt-1 text-sm text-slate-200">{attrs['execution-mode']}</dd>
+                  )}
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">State Mode</dt>
+                  {editing ? (
+                    <select value={editStateMode} onChange={(e) => setEditStateMode(e.target.value as 'managed' | 'external')} className="mt-1 w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500">
+                      <option value="managed">Managed</option>
+                      <option value="external">External</option>
+                    </select>
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">{attrs['state-mode'] === 'external' ? 'External' : 'Managed'}</dd>
                   )}
                 </div>
                 <div>
@@ -2408,6 +2423,13 @@ function WorkspaceDetailContent() {
         {/* State Tab */}
         {activeTab === 'state' && (
           <div>
+            {attrs['state-mode'] === 'external' ? (
+              <div className="rounded-md bg-amber-900/30 border border-amber-700/50 p-4">
+                <p className="text-sm text-amber-200">
+                  State is managed externally by Terraform&apos;s configured backend. State history is not available in Terrapod.
+                </p>
+              </div>
+            ) : (<>
             {/* Confirmation dialog */}
             {confirmStateAction && (
               <div className="bg-red-900/30 border border-red-700/50 rounded-lg p-4 mb-4">
@@ -2587,6 +2609,7 @@ function WorkspaceDetailContent() {
                 </table>
               </div>
             )}
+            </>)}
           </div>
         )}
 

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -140,6 +140,7 @@ function WorkspacesPageInner() {
   const [showCreate, setShowCreate] = useState(false)
   const [newName, setNewName] = useState('')
   const [newExecMode, setNewExecMode] = useState('local')
+  const [newStateMode, setNewStateMode] = useState<'managed' | 'external'>('managed')
   const [newAutoApply, setNewAutoApply] = useState(false)
   const [newBackend, setNewBackend] = useState('tofu')
   const [newVersion, setNewVersion] = useState('1.11')
@@ -271,6 +272,7 @@ function WorkspacesPageInner() {
             attributes: {
               name: newName,
               'execution-mode': newExecMode,
+              'state-mode': newStateMode,
               'execution-backend': newBackend,
               'terraform-version': newVersion,
               'auto-apply': newAutoApply,
@@ -374,6 +376,18 @@ function WorkspacesPageInner() {
                 >
                   <option value="tofu">OpenTofu</option>
                   <option value="terraform">Terraform</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="ws-state-mode" className="block text-sm font-medium text-slate-300 mb-1">State Mode</label>
+                <select
+                  id="ws-state-mode"
+                  value={newStateMode}
+                  onChange={(e) => setNewStateMode(e.target.value as 'managed' | 'external')}
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                >
+                  <option value="managed">Managed</option>
+                  <option value="external">External</option>
                 </select>
               </div>
               <div>


### PR DESCRIPTION
## Problem

State migration is the single most painful part of adopting Terrapod. Today, to move a workspace from Atlantis to Terrapod you must:

1. Import all state files into terrapod (and hope nothing gets lost)
2. Change all `backend "s3" {}` blocks to `cloud {}` in every repo
3. Coordinate the cutover so nothing applies to the wrong state during transition
4. Disable Atlantis — with no easy way back if something goes wrong

This is a hard, irreversible cutover that blocks adoption for teams with hundreds of workspaces.

## Solution: External State Mode

This PR adds a workspace-level `state_mode` setting (`managed` | `external`) that lets Terrapod orchestrate runs while preserving the code's native backend block. The runner uses `backend "s3" {}` directly — same state file, same bucket, same DynamoDB lock as Atlantis.

**This enables:**
- **Side-by-side deployment** — run Terrapod and Atlantis against the same repos, switching between them per-workspace
- **Zero-migration onboarding** — point Terrapod at existing repos with no code changes, no state migration
- **Gradual adoption** — move workspaces one at a time, validate each one, roll back instantly if needed
- **Future bulk migration path** — once confident, bulk-import state into Terrapod and flip workspaces to managed mode

## Scope

- Currently supports S3+DynamoDB backends (the Atlantis standard)
- Other backends (GCS, Azure) can be added later with the same pattern
- This is phase 1 of a migration toolkit. Future work:
  - Bulk state import into Terrapod workspaces
  - Automated PR submission to swap backend blocks across repos

## How It Works

When `state_mode=external`:
- Runner preserves the user's `backend "s3" {}` block (no override file written)
- Skips state download from Terrapod and state upload after apply
- Terraform handles lock/read/write/unlock directly against S3+DynamoDB
- State endpoints return 404/409 (state not managed by Terrapod)
- Drift detection works naturally via `plan -detailed-exitcode`

When `state_mode=managed` (default):
- Unchanged — today's behavior

## Changes

- **Model:** `state_mode` on Workspace, Run (snapshotted at creation), AutodiscoveryRule
- **Migration:** adds `state_mode` column to all three tables
- **API:** workspace create/update accepts `state-mode`, state endpoints guarded
- **Runner dispatch:** `TP_STATE_MODE` env var flows listener → job_template → runner Job
- **Entrypoint:** conditionals skip backend override, state download, backend backstop, state upload
- **UI:** State Mode dropdown on create form + workspace settings, amber banner on State tab
- **Autodiscovery:** rules inherit `state_mode` to auto-created workspaces
- **Tests:** all existing tests updated and passing

## Test Plan
- [x] Local test with `backend "local"` — runner preserves backend, skips state ops
- [x] Local test with `backend "s3"` (real GovCloud bucket) — plan + apply succeed, state written to S3
- [x] State endpoint guards — 404 on current-state-version, empty list on state-versions, 409 on upload
- [x] UI — State Mode dropdown visible on create + settings, amber banner on State tab
- [x] Managed mode unchanged — existing workspaces still work normally
- [x] All unit tests passing (1466 passed)


