### PR TITLE
chore(deps): batch 5 dependabot bumps

### DIFF
--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "terrapod"}]
 [tool.poetry.dependencies]
 python = "^3.13"
 fastapi = ">=0.135.2,!=0.136.3,<0.137.0"
-uvicorn = {extras = ["standard"], version = ">=0.42,<0.48"}
+uvicorn = {extras = ["standard"], version = ">=0.42,<0.49"}
 pydantic = "^2.10.0"
 pydantic-settings = "^2.13.1"
 structlog = "^25.5.0"
@@ -37,7 +37,7 @@ cryptography = ">=46.0.5,<49.0.0"
 zxcvbn = "^4.4.28"
 python-multipart = ">=0.0.26,<0.0.30"
 # Kubernetes (runner listener)
-kubernetes = "^35.0.0"
+kubernetes = ">=35,<37"
 # GPG key parsing for provider registry
 pgpy = "^0.6.0"
 # GitHub App JWT signing for VCS integration

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,14 +21,14 @@
         "next": "^16.2.6",
         "prom-client": "^15.1.3",
         "react": "^19.2.6",
-        "react-dom": "^19.2.5",
+        "react-dom": "^19.2.6",
         "react-hot-toast": "^2.6.0",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
-        "@types/node": "^25.8.0",
-        "@types/react": "^19.2.14",
+        "@types/node": "^25.9.1",
+        "@types/react": "^19.2.15",
         "@types/react-dom": "^19",
         "eslint": "^9.27.0",
         "eslint-config-next": "^16.2.6",
@@ -2278,9 +2278,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
-      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2288,9 +2288,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -6327,15 +6327,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-hot-toast": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,14 +23,14 @@
     "next": "^16.2.6",
     "prom-client": "^15.1.3",
     "react": "^19.2.6",
-    "react-dom": "^19.2.5",
+    "react-dom": "^19.2.6",
     "react-hot-toast": "^2.6.0",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",
-    "@types/node": "^25.8.0",
-    "@types/react": "^19.2.14",
+    "@types/node": "^25.9.1",
+    "@types/react": "^19.2.15",
     "@types/react-dom": "^19",
     "eslint": "^9.27.0",
     "eslint-config-next": "^16.2.6",


### PR DESCRIPTION
## Summary

Consolidates 5 open dependabot PRs into a single manual PR — merging them one-by-one would force each to rebase onto the others' lock-file changes.

**Python** (`services/pyproject.toml`)
- `uvicorn`: `>=0.42,<0.48` → `>=0.42,<0.49` (closes #365)
- `kubernetes`: `^35.0.0` → `>=35,<37` (closes #366)

**Frontend** (`web/package.json` + `web/package-lock.json`)
- `@types/react`: `^19.2.14` → `^19.2.15` (closes #362)
- `@types/node`: `^25.8.0` → `^25.9.1` (closes #363)
- `react-dom`: `^19.2.5` → `^19.2.6` (closes #364)

## Verification

- [x] `make test` — 1554 tests pass
- [x] `npm run build` in `web/` — Next.js build OK