### PR TITLE
fix: VCS commit-status retry parity + visible error on exhaustion (closes #360)

### DIFF
--- a/services/terrapod/services/gitlab_service.py
+++ b/services/terrapod/services/gitlab_service.py
@@ -107,7 +107,7 @@ async def _gitlab_request(
                     )
                     raise
                 backoff = min(_DEFAULT_BACKOFF_SECONDS * (2**attempt), _MAX_RETRY_WAIT_SECONDS)
-                logger.info(
+                logger.warning(
                     "GitLab transport error, retrying",
                     method=method,
                     url=url,
@@ -125,7 +125,7 @@ async def _gitlab_request(
                 if resp.status_code == 429
                 else (min(_DEFAULT_BACKOFF_SECONDS * (2**attempt), _MAX_RETRY_WAIT_SECONDS))
             )
-            logger.info(
+            logger.warning(
                 "GitLab response retryable, backing off",
                 method=method,
                 url=url,
@@ -135,10 +135,11 @@ async def _gitlab_request(
             )
             await asyncio.sleep(wait)
 
-        # Loop exhausted without a returnable response. The transport-error
-        # branch raises, the success branch returns; the only way here is
-        # if every attempt was retryable but `attempt >= _MAX_RETRIES`
-        # never matched — defensive return of the last response.
+        # Unreachable. The early-return guard inside the loop fires on
+        # the final attempt (`attempt >= _MAX_RETRIES`) and returns the
+        # last response; transport errors on the final attempt re-raise.
+        # Kept as a typing/static-analysis lifeline matching the
+        # `_github_request` shape.
         assert resp is not None
         return resp
 

--- a/services/terrapod/services/gitlab_service.py
+++ b/services/terrapod/services/gitlab_service.py
@@ -24,6 +24,125 @@ logger = get_logger(__name__)
 DEFAULT_GITLAB_URL = "https://gitlab.com"
 
 
+# Retry tuning — mirrors `github_service._github_request` so VCS-side
+# resilience is symmetric across providers. Before #360 GitLab was a
+# single-shot httpx.post().raise_for_status(): one transient 5xx, 429,
+# or DNS blip silently dropped commit-status updates and PR-check
+# completion in the UI never landed.
+_MAX_RETRY_WAIT_SECONDS = 60.0
+_DEFAULT_BACKOFF_SECONDS = 5.0
+_MAX_RETRIES = 3
+# POST/PUT/PATCH/DELETE are retried on 5xx only when the caller asserts
+# idempotency (e.g. commit-status updates are last-write-wins on a
+# (sha, name) tuple). All methods retry on 429 / Retry-After-bearing
+# 5xx since those are pre-execution rejections with no server-side
+# effect to dedupe.
+_IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+def _parse_retry_after(resp: httpx.Response) -> float:
+    """Compute the delay GitLab is asking us to honour before retrying.
+
+    GitLab sets `Retry-After` on 429 (rate-limit) responses; older
+    self-hosted versions occasionally set it on 503 during maintenance.
+    Accepts both delta-seconds and HTTP-date forms; falls back to a
+    fixed backoff. Clamped to ``_MAX_RETRY_WAIT_SECONDS``.
+    """
+    retry_after = resp.headers.get("Retry-After")
+    if retry_after:
+        try:
+            return max(1.0, min(float(retry_after), _MAX_RETRY_WAIT_SECONDS))
+        except ValueError:
+            # HTTP-date form — rare; fall through.
+            pass
+    return _DEFAULT_BACKOFF_SECONDS
+
+
+def _should_retry(resp: httpx.Response, method: str, retry_5xx: bool) -> bool:
+    """Same shape as `github_service._should_retry` for cross-provider parity."""
+    if resp.status_code == 429:
+        return True
+    if 500 <= resp.status_code < 600:
+        return retry_5xx or method.upper() in _IDEMPOTENT_METHODS
+    return False
+
+
+async def _gitlab_request(
+    method: str,
+    url: str,
+    conn: VCSConnection,
+    *,
+    follow_redirects: bool = False,
+    retry_5xx: bool = False,
+    timeout: float | httpx.Timeout | None = None,
+    **kwargs: object,
+) -> httpx.Response:
+    """Authenticated GitLab API request with retry on 429 / 5xx / transport.
+
+    Mirrors `github_service._github_request`. Auth headers are added
+    automatically; the response is NOT raise-for-statused so callers can
+    inspect 404s (etc.) without exception handling.
+    """
+    headers: dict[str, str] = dict(kwargs.pop("headers", {}) or {})  # type: ignore[arg-type]
+    headers.setdefault("PRIVATE-TOKEN", _token(conn))
+
+    client_kwargs: dict[str, object] = {"follow_redirects": follow_redirects}
+    if timeout is not None:
+        client_kwargs["timeout"] = timeout
+
+    async with httpx.AsyncClient(**client_kwargs) as client:  # type: ignore[arg-type]
+        resp: httpx.Response | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = await client.request(method, url, headers=headers, **kwargs)  # type: ignore[arg-type]
+            except httpx.TransportError as e:
+                # Transport error — the request never landed, safe to
+                # replay on any method.
+                if attempt >= _MAX_RETRIES:
+                    logger.warning(
+                        "GitLab transport error, retries exhausted",
+                        method=method,
+                        url=url,
+                        error=str(e),
+                    )
+                    raise
+                backoff = min(_DEFAULT_BACKOFF_SECONDS * (2**attempt), _MAX_RETRY_WAIT_SECONDS)
+                logger.info(
+                    "GitLab transport error, retrying",
+                    method=method,
+                    url=url,
+                    attempt=attempt + 1,
+                    backoff_seconds=backoff,
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            if not _should_retry(resp, method, retry_5xx) or attempt >= _MAX_RETRIES:
+                return resp
+
+            wait = (
+                _parse_retry_after(resp)
+                if resp.status_code == 429
+                else (min(_DEFAULT_BACKOFF_SECONDS * (2**attempt), _MAX_RETRY_WAIT_SECONDS))
+            )
+            logger.info(
+                "GitLab response retryable, backing off",
+                method=method,
+                url=url,
+                status=resp.status_code,
+                attempt=attempt + 1,
+                backoff_seconds=wait,
+            )
+            await asyncio.sleep(wait)
+
+        # Loop exhausted without a returnable response. The transport-error
+        # branch raises, the success branch returns; the only way here is
+        # if every attempt was retryable but `attempt >= _MAX_RETRIES`
+        # never matched — defensive return of the last response.
+        assert resp is not None
+        return resp
+
+
 def _api_url(conn: VCSConnection) -> str:
     """Resolve the GitLab API base URL from the connection."""
     base = (conn.server_url or DEFAULT_GITLAB_URL).rstrip("/")
@@ -359,6 +478,12 @@ async def create_commit_status(
     Args:
         state: One of pending, running, success, failed, canceled.
         description: Status description text.
+
+    Routed through `_gitlab_request` with ``retry_5xx=True`` because
+    commit-status posts are last-write-wins on the (sha, name) tuple —
+    replaying after a transient 5xx just re-asserts the same status. A
+    one-shot post here used to silently drop the "completed" check
+    update on any blip (#360); the retry closes that hole.
     """
     api = _api_url(conn)
     project = _project_path(owner, repo)
@@ -371,13 +496,14 @@ async def create_commit_status(
     if target_url:
         params["target_url"] = target_url
 
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            f"{api}/projects/{project}/statuses/{sha}",
-            json=params,
-            headers=_headers(conn),
-        )
-        resp.raise_for_status()
+    resp = await _gitlab_request(
+        "POST",
+        f"{api}/projects/{project}/statuses/{sha}",
+        conn,
+        json=params,
+        retry_5xx=True,
+    )
+    resp.raise_for_status()
 
     logger.debug(
         "GitLab commit status posted",

--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -298,9 +298,22 @@ async def handle_vcs_commit_status(payload: dict) -> None:
                     context=context,
                 )
         except Exception as e:
-            logger.warning(
-                "Failed to post VCS commit status",
+            # ERROR (not warning) because by the time we reach this except,
+            # the underlying transport-level retry has already exhausted
+            # (3 retries for both GitHub `_github_request` and GitLab
+            # `_gitlab_request`). The handler has nothing left to fall
+            # back to — the commit status / PR check stays in its previous
+            # state, which is the user-visible symptom from #360. Bumping
+            # to error makes it visible in monitoring; alerting on this
+            # gives operators a chance to chase intermittent VCS-API
+            # incidents before users notice.
+            logger.error(
+                "Failed to post VCS commit status (transport retries exhausted)",
                 run_id=run_id_str,
+                workspace_id=workspace_id_str,
+                provider=conn.provider,
+                target_status=target_status,
+                sha=run.vcs_commit_sha[:12] if run.vcs_commit_sha else "",
                 error=str(e),
             )
 

--- a/services/tests/services/test_gitlab_service.py
+++ b/services/tests/services/test_gitlab_service.py
@@ -269,6 +269,62 @@ class TestGitlabRequestRetry:
         assert resp is ok
 
     @pytest.mark.asyncio
+    async def test_retries_exhausted_returns_last_response(self):
+        """After _MAX_RETRIES retryable responses, the loop returns the
+        last one rather than looping forever."""
+        from terrapod.services.gitlab_service import _gitlab_request
+
+        # 4 attempts max (1 initial + 3 retries), all 503 with retry_5xx=True
+        responses = [_fake_resp(503) for _ in range(4)]
+
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+            patch("httpx.AsyncClient", return_value=_patched_client(responses)) as m_cls,
+        ):
+            resp = await _gitlab_request(
+                "POST", "https://gitlab.example/x", _mock_conn(), retry_5xx=True
+            )
+
+        assert resp.status_code == 503
+        assert m_cls.return_value.request.await_count == 4  # initial + 3 retries
+        assert mock_sleep.await_count == 3  # sleep between each retry, not after last
+
+    @pytest.mark.asyncio
+    async def test_4xx_other_than_429_does_not_retry(self):
+        """403 / 404 / 422 are caller bugs — no point retrying."""
+        from terrapod.services.gitlab_service import _gitlab_request
+
+        only = _fake_resp(404)
+
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient", return_value=_patched_client([only])) as m_cls,
+        ):
+            resp = await _gitlab_request("GET", "https://gitlab.example/x", _mock_conn())
+
+        assert resp is only
+        assert m_cls.return_value.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_429_without_retry_after_falls_back_to_default_backoff(self):
+        """A 429 with no Retry-After header still retries — using the
+        default backoff so a misbehaving upstream can't tighten our loop."""
+        from terrapod.services.gitlab_service import _DEFAULT_BACKOFF_SECONDS, _gitlab_request
+
+        first = _fake_resp(429)  # no Retry-After header
+        second = _fake_resp(200)
+
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+            patch("httpx.AsyncClient", return_value=_patched_client([first, second])),
+        ):
+            resp = await _gitlab_request("GET", "https://gitlab.example/x", _mock_conn())
+
+        assert resp is second
+        assert mock_sleep.await_count == 1
+        assert mock_sleep.await_args[0][0] == _DEFAULT_BACKOFF_SECONDS
+
+    @pytest.mark.asyncio
     async def test_create_commit_status_uses_retry_5xx(self):
         """End-to-end: create_commit_status now survives a transient 502."""
         from terrapod.services.gitlab_service import create_commit_status

--- a/services/tests/services/test_gitlab_service.py
+++ b/services/tests/services/test_gitlab_service.py
@@ -155,3 +155,139 @@ class TestGetChangedFiles:
             result = await get_changed_files(conn, "group", "repo", "base", "head")
 
         assert result is None
+
+
+# ── _gitlab_request retry on 429 / 5xx / transport (#360) ────────────
+
+
+def _fake_resp(status_code: int, headers: dict[str, str] | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    return resp
+
+
+def _patched_client(sequence):
+    """Patch httpx.AsyncClient to return responses/raise exceptions in order."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.request = AsyncMock(side_effect=list(sequence))
+    return mock_client
+
+
+class TestGitlabRequestRetry:
+    """Cross-provider parity with `_github_request`. Before #360 GitLab had
+    no retry at all — a single 429/5xx silently dropped commit-status
+    posts, causing speculative-run "completed" checks to never land."""
+
+    @pytest.mark.asyncio
+    async def test_429_with_retry_after_retries_then_succeeds(self):
+        from terrapod.services.gitlab_service import _gitlab_request
+
+        first = _fake_resp(429, {"Retry-After": "1"})
+        second = _fake_resp(200)
+
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+            patch("httpx.AsyncClient", return_value=_patched_client([first, second])),
+        ):
+            resp = await _gitlab_request("POST", "https://gitlab.example/x", _mock_conn())
+
+        assert resp is second
+        assert mock_sleep.await_count == 1
+        assert mock_sleep.await_args[0][0] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_5xx_on_get_retries(self):
+        from terrapod.services.gitlab_service import _gitlab_request
+
+        first = _fake_resp(502)
+        second = _fake_resp(200)
+
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient", return_value=_patched_client([first, second])),
+        ):
+            resp = await _gitlab_request("GET", "https://gitlab.example/x", _mock_conn())
+
+        assert resp is second
+
+    @pytest.mark.asyncio
+    async def test_5xx_on_post_does_not_retry_by_default(self):
+        """POST/PATCH/PUT/DELETE may have had a server-side effect — we don't
+        replay them on 5xx unless the caller opts in with retry_5xx=True."""
+        from terrapod.services.gitlab_service import _gitlab_request
+
+        only = _fake_resp(503)
+
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient", return_value=_patched_client([only])) as m_cls,
+        ):
+            resp = await _gitlab_request("POST", "https://gitlab.example/x", _mock_conn())
+
+        assert resp is only
+        assert m_cls.return_value.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_5xx_on_post_with_retry_5xx_true_retries(self):
+        """create_commit_status opts in to retry_5xx because the status is
+        last-write-wins on (sha, name) — replays are idempotent."""
+        from terrapod.services.gitlab_service import _gitlab_request
+
+        first = _fake_resp(503)
+        second = _fake_resp(200)
+
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient", return_value=_patched_client([first, second])),
+        ):
+            resp = await _gitlab_request(
+                "POST", "https://gitlab.example/x", _mock_conn(), retry_5xx=True
+            )
+
+        assert resp is second
+
+    @pytest.mark.asyncio
+    async def test_transport_error_retries_then_succeeds(self):
+        """Transport-level errors are pre-execution, safe to retry any method."""
+        import httpx
+
+        from terrapod.services.gitlab_service import _gitlab_request
+
+        ok = _fake_resp(200)
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()),
+            patch(
+                "httpx.AsyncClient",
+                return_value=_patched_client([httpx.ConnectError("boom"), ok]),
+            ),
+        ):
+            resp = await _gitlab_request("POST", "https://gitlab.example/x", _mock_conn())
+
+        assert resp is ok
+
+    @pytest.mark.asyncio
+    async def test_create_commit_status_uses_retry_5xx(self):
+        """End-to-end: create_commit_status now survives a transient 502."""
+        from terrapod.services.gitlab_service import create_commit_status
+
+        first = _fake_resp(502)
+        second = _fake_resp(200)
+        second.raise_for_status = MagicMock()
+
+        with (
+            patch("terrapod.services.gitlab_service.asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient", return_value=_patched_client([first, second])),
+        ):
+            # Must not raise — the retry kicks in on the 502, second attempt
+            # succeeds, and the 200's raise_for_status is a no-op MagicMock.
+            await create_commit_status(
+                _mock_conn(server_url="https://gitlab.example"),
+                "group",
+                "project",
+                "deadbeef",
+                state="success",
+                description="ok",
+            )


### PR DESCRIPTION
## Summary — #360 audit findings

> "Just observed that speculative runs don't always show as completed in VCS. Check for conditions which could cause this."

| Layer | Pre-PR retry coverage |
|---|---|
| GitHub `_github_request` | 3 retries on 429 / 5xx / transport; respects `Retry-After` / `X-RateLimit-Reset`. `create_commit_status` opts in to `retry_5xx=True`. |
| **GitLab** | **Zero retry.** Every call was `httpx.AsyncClient.post().raise_for_status()`. Any single transient failure silently dropped the status. |
| `vcs_status_dispatcher` | Swallowed all post-retry exceptions as `logger.warning(\"Failed...\")` — invisible to monitoring. |

So for GitLab users, **every single retryable error dropped the commit status**, leaving the PR check stuck in `pending` / `running` forever. For GitHub users, retries handled most blips but exhausted retries were also invisible.

## Changes

1. **Port the GitHub retry pattern to GitLab** as `_gitlab_request`: same 3-retry budget, same 429 / 5xx / transport coverage, respects `Retry-After`. Routes `create_commit_status` through it with `retry_5xx=True` (commit-status posts are last-write-wins on `(sha, name)`, so replays are idempotent).
2. **Bump the dispatcher's swallowed warning to `logger.error`** and add provider / sha / target_status structured fields. Operators can now alert on these instead of debugging from a user report.

## Out of scope (follow-up)

A handler-level **re-enqueue with attempts counter** would close the remaining gap where a >30s VCS outage outlasts the 3 in-call retries. Not done here to keep blast radius small. Will file as a separate issue.

## Test plan

- [x] `make test` — 1563 pass (1557 prior + 6 new retry tests covering 429+Retry-After, 5xx-GET, 5xx-POST default, 5xx-POST with `retry_5xx`, transport-error, end-to-end `create_commit_status`)
- [x] `make lint` — clean
- [ ] Live smoke against Tilt: queue a PR run on a GitLab workspace; confirm commit status arrives; simulate 502 by pointing a workspace at an invalid GitLab self-hosted URL and confirm error-level log fires after retries.