### PR TITLE
docs: v0.26.0 pre-release audit fixes

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -151,6 +151,14 @@ trap on_exit EXIT
 # storage error (e.g. an SSE-KMS bucket rejecting a SigV2 presigned
 # URL) the storage response body is logged to stderr so the operator
 # sees the real cause instead of a silent failure (#339).
+#
+# Manually follows redirects (vs `curl -L`) so the apply-phase lock-file
+# download against `/api/terrapod/v1/runs/{id}/artifacts/lock-file`
+# tolerates a 302 to presigned-URL storage and still surfaces the
+# original Authorization-bearing first hop in TP_LAST_HTTP for
+# diagnostics (#357). Cloud-storage redirect targets are left
+# untouched; same-server hostname rewrites (filesystem backend) are
+# normalised back to TP_API_URL.
 tp_curl_download() {
     # $1 = output file, remaining args = curl options (URL last)
     _out="$1"; shift

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -548,6 +548,17 @@ POST /api/v2/runs
 
 **Required permission:** `plan` for plan-only runs, `write` for apply runs.
 
+#### Configuration version resolution
+
+The `configuration-version` relationship is optional. Resolution rules:
+
+- **Explicit CV in the request body** → used as-is.
+- **No CV + workspace has a VCS connection** → Terrapod fetches the latest commit (or the branch/tag from `vcs-ref`) and creates a fresh CV automatically.
+- **No CV + non-VCS workspace** → falls back to the **latest fully-uploaded, non-speculative CV** for the workspace. This is the path the UI's "Queue Plan" button takes.
+- **No CV + non-VCS workspace + no upload has ever succeeded** → `422 Unprocessable Entity` with detail `"Workspace has no uploaded configuration. Upload one via 'tofu plan' / 'tofu apply' (CLI), or POST a configuration version + tarball before queueing a run."`. The same response covers the misconfigured-workspace edge case where `vcs_connection_id` is set but `vcs_repo_url` is empty.
+
+The CLI plan/apply flow always supplies a CV (it uploads one first), so it's unaffected by the fallback.
+
 #### Optional Run Attributes
 
 | Attribute | Type | Default | Description |
@@ -2250,7 +2261,7 @@ Overrides every failed/errored policy evaluation of a run and immediately re-dri
 GET /api/terrapod/v1/runs/{run_id}/policy-bundle
 ```
 
-Returns the applicable policy sets + run/workspace context for a run. Used by the runner during the plan phase to drive OPA evaluation locally. Response shape is a flat JSON document (not JSON:API — the runner is the only consumer):
+Returns the applicable policy sets + run/workspace context for a run. Used by the runner during the plan phase to drive OPA evaluation locally. A persistent fetch failure on the runner is **fatal** to the run (see [`docs/runners.md` — OPA Policy Evaluation](runners.md)) — there is no silent skip. Response shape is a flat JSON document (not JSON:API — the runner is the only consumer):
 
 ```json
 {

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -719,3 +719,36 @@ This usually means **the runner image is from before policy-as-code support / do
 
 - A fresh run on the same workspace shows the policy set with a real outcome (`passed` / `failed`) rather than the synthetic `errored` message.
 - The runner pod log includes `Fetching policy bundle...` / `Posting N policy evaluation result(s)` lines — confirms it's a post-#343 image.
+
+---
+
+## VCS commit status missing after run completion
+
+**Symptom**: a workspace run completes but the corresponding commit status / PR check on GitHub or GitLab stays in `pending` / `running` forever. The Terrapod UI shows the run as `applied` / `errored` / `planned`. The PR check never advances.
+
+**Why**: the dispatcher posting commit statuses (`vcs_status_dispatcher.py`) runs after a triggered task. Per-request retries (3 attempts on 429 / 5xx / transport errors) live in `github_service._github_request` and `gitlab_service._gitlab_request`. When those retries exhaust — typically a multi-minute VCS outage, an expired access token, or a token whose scopes were narrowed — the dispatcher logs an `error`-level line and moves on without re-enqueueing. The run itself is unaffected; only the upstream check display is.
+
+The structured fields on the error log are: `provider`, `target_status`, `workspace_id`, `sha` (first 12 chars), `error`. Alert on:
+
+```
+service=terrapod-api logger=terrapod.services.vcs_status_dispatcher
+  level=error
+  msg="Failed to post VCS commit status (transport retries exhausted)"
+```
+
+### Diagnosis
+
+1. **Check the access token validity.** For GitHub App connections, the App's installation token is fetched on-demand and cached for 50 minutes — if the App was uninstalled from the repo the next refresh 404s. For GitLab Project / Group access tokens, the token can expire or have its `read_repository` scope revoked.
+2. **Confirm the VCS provider isn't itself degraded.** Check the provider's status page (`status.github.com` / `status.gitlab.com`). If there's an ongoing incident, the retries are doing their job; the error is expected and self-clears.
+3. **Look for repeated entries for the same `(workspace_id, sha)`** — sustained failures across multiple runs point at auth, not transient. Single-run misses on different workspaces during the same window point at a VCS-side incident.
+
+### Resolution
+
+- **Token / scope issue**: rotate the token on the VCS connection (`/admin/vcs-connections`). For GitHub Apps, re-install the App with the necessary `Commit statuses: Write` permission.
+- **VCS-side incident**: nothing to do; status will not auto-recover for already-failed posts (no re-enqueue). The next run on the same SHA, or any branch update, posts a fresh status.
+- **Forcing a fresh post**: queue a no-op plan-only run on the same commit. This produces a new sequence of state transitions, each of which re-enqueues a commit-status update.
+
+### Verification
+
+- Run logs after the rotation show `level=info logger=terrapod.services.gitlab_service msg="GitLab commit status posted"` (or the equivalent for GitHub).
+- The PR check on the next pushed commit lands within ~30 seconds of the run completing.

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -224,7 +224,7 @@ Sequence inside `runner-entrypoint.sh`, after `tofu plan` completes successfully
    - `POST /api/terrapod/v1/runs/{id}/policy-results` — uploads the aggregated results. Persisted via Postgres `ON CONFLICT DO NOTHING` on `(run_id, policy_set_id)` so retries are idempotent.
 3. The runner posts `plan-result`. The API's post-plan gate is now a pure DB query — by this point the policy_evaluation rows already exist (or there were no applicable sets, which is the right answer too).
 
-If `tofu show -json` failed but the plan succeeded, the runner records an `errored` outcome for every applicable set (fail-closed for mandatory sets). The OPA binary itself is pinned + SHA-verified in `docker/Dockerfile.runner` and the version is kept in sync with `Dockerfile.api` and `Dockerfile.test`.
+If `tofu show -json` failed but the plan succeeded, the runner records an `errored` outcome for every applicable set (fail-closed for mandatory sets). The OPA binary is pinned + SHA-verified in `docker/Dockerfile.runner` and the version is kept in sync with `Dockerfile.api` and `Dockerfile.test` — currently **OPA v1.16.2** with the **Rego v1 syntax** (`package … if {}` form). Bumping requires editing the `ARG OPA_VERSION=` in all three Dockerfiles and the matching `OPA_SHA256_*` constants.
 
 This places eval workload exactly where the plan workload already lives — same pod, same resource budget, same K8s autoscaling. The API server stays out of the per-run hot path entirely; its only policy responsibilities are CRUD, write-time validation, the bundle endpoint, the results endpoint, and the gate query.
 


### PR DESCRIPTION
## Summary

Pre-release audit findings for v0.26.0. Audit was clean on the hard gate (no internal-reference leaks, Helm values↔schema in sync, OPA shipped without Helm knobs). Five docs gaps to fill before tagging.

## SHOULD-FIX

1. **`docs/api-reference.md` Create Run** — document the #358 configuration-version resolution rules: explicit CV → VCS auto-fetch → non-VCS fallback to latest uploaded CV → 422 with actionable message when no upload has succeeded. Same path covers the misconfigured-workspace edge case (`vcs_connection_id` set + `vcs_repo_url` empty).
2. **`docs/runbooks.md`** — new entry "VCS commit status missing after run completion" for the #360 retry-exhaustion error log. Covers the structured-field shape operators alert on, diagnostic checks (token validity, provider incident), how to force a fresh post.

## NICE-TO-HAVE

3. `docs/api-reference.md` `/policy-bundle` endpoint now cross-links to `runners.md`: a persistent fetch failure on the runner is **fatal** to the run.
4. `docs/runners.md` OPA section now names the pinned version (1.16.2) and the Rego v1 syntax requirement.
5. `docker/runner-entrypoint.sh` `tp_curl_download` docstring credits #357 and explains why we hand-roll redirect handling rather than using `curl -L`.

## Verification

- [x] `make test` — 1566 pass
- [x] `make lint` — clean
- [x] Internal-reference leak scan over `v0.25.0..HEAD` — clean