### PR TITLE
feat: optional split webhook ingress

### DIFF
--- a/docs/deployment-webhook-ingress.md
+++ b/docs/deployment-webhook-ingress.md
@@ -1,0 +1,124 @@
+# Optional split webhook ingress
+
+By default, every inbound request to Terrapod — UI loads, admin API calls, the entire CLI surface, **and** VCS webhooks + run-task callbacks — reaches the cluster through a single `Ingress`. That works fine when the management plane is allowed to be publicly reachable.
+
+When it isn't — when the management plane should be private (corporate VPN, Tailscale, IP allow-list, ACL) but webhooks still need to land from `github.com`, `gitlab.com`, and run-task services — Terrapod ships an optional **second Ingress** that exposes only the must-be-public-receivable surface. The primary `ingress:` block stays private; the new `webhookIngress:` block is the public hole.
+
+## Surface split
+
+Two endpoints have to accept connections from the public internet:
+
+| Endpoint | Caller | Auth on the request |
+|---|---|---|
+| `POST /api/terrapod/v1/vcs-events/github` (and future `/gitlab`) | github.com / gitlab.com webhook delivery | HMAC-SHA256 with the connection's `webhook_secret` |
+| `PATCH /api/terrapod/v1/task-stage-results/{id}/callback` | external run-task services (policy engines, scanners) | Short-lived HMAC-derived `access_token` bound to the specific result ID |
+
+Everything else stays on the management ingress:
+- The whole web UI
+- All admin API (`/api/terrapod/v1/*` apart from the two routes above)
+- `terraform login` and CLI cloud-block (`/api/v2/*`, `/.well-known/terraform.json`)
+- OIDC / SAML callbacks — these run in the **operator's browser**, not server-to-server, so they don't need to be publicly reachable; the operator's browser already has access to the management plane (that's how they hit the login page)
+- State uploads, agent-pool joins, listener heartbeats, the whole runner protocol
+
+## Helm values
+
+```yaml
+ingress:                    # private/restricted — management plane
+  enabled: true
+  className: nginx          # or "alb", or restricted-by-VPC ACL, or whatever
+  hostname: terrapod.internal.example.com
+  tls: true
+  annotations: {}           # plus your access-control annotations
+
+webhookIngress:             # OPTIONAL — public-internet inbound surface
+  enabled: true
+  className: tailscale      # or "nginx" with a public LB, "cloudflare", etc.
+  hostname: terrapod-webhooks.example.com
+  tls: true
+  annotations: {}
+  # paths defaults to the full allow-list; trim if you don't run external
+  # run tasks:
+  # paths:
+  #   - /api/terrapod/v1/vcs-events
+
+web:
+  enabled: true
+api:
+  enabled: true
+```
+
+When `webhookIngress.enabled` is true, the chart auto-derives `api.config.public_webhook_url` from `webhookIngress.hostname`. That's the base URL Terrapod hands to external services — the **run-task callback URL** the dispatcher builds, and (in a future UX iteration) the **VCS webhook URL** the UI displays to operators for copy-paste into GitHub App settings. Override it explicitly via `api.config.public_webhook_url` if needed.
+
+When `webhookIngress.enabled` is false (default), `public_webhook_url` falls back to `external_url` at the server side — single-ingress deployments behave exactly as before.
+
+## Mechanism-specific recipes
+
+### Tailscale Funnel
+
+[Tailscale Funnel](https://tailscale.com/docs/features/tailscale-funnel) exposes a tailnet service to the public internet via Tailscale's edge. Combined with the [Tailscale Kubernetes Operator](https://tailscale.com/kb/1236/kubernetes-operator), it's the cleanest "everything private except webhooks" deployment:
+
+```yaml
+ingress:
+  enabled: true
+  className: tailscale       # management plane on the tailnet
+  hostname: terrapod.example.ts.net
+  tls: false                 # operator provisions TLS
+
+webhookIngress:
+  enabled: true
+  className: tailscale
+  hostname: terrapod-webhooks.example.ts.net
+  tls: false
+  annotations:
+    tailscale.com/funnel: "true"     # this hostname gets the public Funnel cert
+  paths:
+    - /api/terrapod/v1/vcs-events     # trim out task-stage-results if unused
+```
+
+Prerequisites (operator-side, not chart-managed):
+- Tailscale Kubernetes Operator installed and watching `IngressClass: tailscale`.
+- Funnel enabled at the tailnet level (Admin Console → Settings → Funnel).
+- ACL allows the operator's tag to advertise Funnel.
+
+Note: Funnel only listens on ports 443, 8443, 10000; only allows HTTPS; and has an undocumented bandwidth cap. None of those constraints bite the webhook surface (kilobyte payloads), but if you ever want to run state uploads through the same hostname, switch back to a single ingress on a regular LB.
+
+### Public ALB + WAF
+
+For AWS deployments where the management plane is private but a webhook surface needs a public ALB with WAF protection:
+
+```yaml
+ingress:
+  enabled: true
+  className: alb
+  hostname: terrapod.internal.example.com
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internal
+    alb.ingress.kubernetes.io/load-balancer-attributes: "..."
+
+webhookIngress:
+  enabled: true
+  className: alb
+  hostname: terrapod-webhooks.example.com
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/wafv2-acl-arn: "arn:aws:wafv2:..."
+```
+
+### Cloudflare Tunnel
+
+Same shape — `className: nginx` plus a Cloudflare Tunnel running as a sidecar that fronts the public hostname.
+
+## What if I configure both ingresses with the same hostname?
+
+You can. The two Ingresses then become two `rules:` entries on the same name, and your Ingress controller has to merge them. For most controllers that "works" but it's not a useful split — set one of them with a `paths:` list (which the chart already does for `webhookIngress`) so the controller has clear path-priority semantics. Easier and clearer to use two distinct hostnames.
+
+## What if I don't configure webhookIngress at all?
+
+That's the default. All traffic, including webhooks, goes through `ingress`. If the management plane is itself public, that's fine. If it isn't, GitHub webhooks won't reach you — fall back to Terrapod's polling-first VCS integration (the poller runs every 60s by default and is the source of truth either way; webhooks are an accelerator on top of it).
+
+## See also
+
+- `helm/terrapod/values.yaml` — full `webhookIngress:` block schema.
+- `services/terrapod/api/routers/vcs_events.py` — GitHub webhook receiver (HMAC validated).
+- `services/terrapod/api/routers/run_tasks.py` — run-task callback receiver (token validated).
+- `services/terrapod/services/run_task_dispatcher.py:120` — the server-side site that hands out the callback URL using `public_webhook_url`.

--- a/helm/terrapod/templates/_helpers.tpl
+++ b/helm/terrapod/templates/_helpers.tpl
@@ -268,3 +268,39 @@ Validate ingress requires web UI to be enabled.
 {{- fail "Ingress is enabled but web.enabled is false. The Ingress routes to the web frontend — set web.enabled=true or disable the Ingress." -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validate the optional webhook Ingress:
+  - hostname is required when enabled (every public-internet caller resolves it)
+  - web.enabled is required (the webhook Ingress routes to the web BFF, same
+    as the management Ingress)
+  - paths must be non-empty (an empty allow-list is pointless and would
+    produce an unreachable Ingress)
+*/}}
+{{- define "terrapod.validateWebhookIngress" -}}
+{{- if .Values.webhookIngress.enabled -}}
+{{- if not .Values.webhookIngress.hostname -}}
+{{- fail "webhookIngress.enabled is true but webhookIngress.hostname is empty. Set the public hostname VCS webhooks (and any run-task callbacks) will reach Terrapod at." -}}
+{{- end -}}
+{{- if not .Values.web.enabled -}}
+{{- fail "webhookIngress.enabled is true but web.enabled is false. The webhook Ingress routes to the web frontend — set web.enabled=true." -}}
+{{- end -}}
+{{- if not .Values.webhookIngress.paths -}}
+{{- fail "webhookIngress.enabled is true but webhookIngress.paths is empty. The default allow-list ships in values.yaml; an empty list would produce an Ingress that accepts nothing." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the public webhook URL (no trailing slash, with scheme). Used by
+configmap-api.yaml to default `api.config.public_webhook_url` when the
+operator hasn't set it explicitly. Returns empty when no webhook Ingress
+is configured — the API server then falls back to `external_url` for
+webhook URL generation.
+*/}}
+{{- define "terrapod.publicWebhookURL" -}}
+{{- if and .Values.webhookIngress.enabled .Values.webhookIngress.hostname -}}
+{{- $scheme := ternary "https" "http" .Values.webhookIngress.tls -}}
+{{- printf "%s://%s" $scheme .Values.webhookIngress.hostname -}}
+{{- end -}}
+{{- end -}}

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -13,6 +13,20 @@ data:
     {{- if .Values.api.config.external_url }}
     external_url: {{ .Values.api.config.external_url | quote }}
     {{- end }}
+    {{- /*
+      public_webhook_url priority:
+        1. explicit api.config.public_webhook_url (operator override wins)
+        2. webhookIngress.hostname when webhookIngress.enabled
+           (auto-derived from the split-surface ingress)
+        3. omit (server-side falls back to external_url for webhook URLs)
+    */}}
+    {{- $publicWebhookURL := .Values.api.config.public_webhook_url }}
+    {{- if not $publicWebhookURL }}
+    {{- $publicWebhookURL = include "terrapod.publicWebhookURL" . }}
+    {{- end }}
+    {{- if $publicWebhookURL }}
+    public_webhook_url: {{ $publicWebhookURL | quote }}
+    {{- end }}
     {{- if .Values.api.config.database }}
     database:
       pool_size: {{ .Values.api.config.database.pool_size | default 10 }}

--- a/helm/terrapod/templates/ingress.yaml
+++ b/helm/terrapod/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "terrapod.validateWebhookIngress" . -}}
 {{- if .Values.ingress.enabled }}
 {{- include "terrapod.validateIngressWeb" . -}}
 apiVersion: networking.k8s.io/v1
@@ -37,4 +38,50 @@ spec:
                 name: {{ include "terrapod.fullname" . }}-web
                 port:
                   name: http
+{{- end }}
+{{- if .Values.webhookIngress.enabled }}
+---
+# Public webhook Ingress — restricted to the inbound-from-public-internet
+# allow-list (VCS webhooks, run-task callbacks). The management surface
+# (UI, admin API, CLI, SSO callback, state uploads) stays on the primary
+# `ingress` block above, which the operator can keep private/restricted.
+#
+# Routes to the same web Service (BFF rule still holds) — Next.js
+# rewrites the matched paths to the API service internally. Auth on
+# these routes is HMAC- or token-based per endpoint, not session-based,
+# so they're safe to receive directly from off-tailnet callers.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "terrapod.fullname" . }}-webhooks
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhooks
+  {{- with .Values.webhookIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.webhookIngress.className }}
+  ingressClassName: {{ .Values.webhookIngress.className }}
+  {{- end }}
+  {{- if .Values.webhookIngress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.webhookIngress.hostname }}
+      secretName: {{ printf "%s-webhooks-tls" (include "terrapod.fullname" .) }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.webhookIngress.hostname }}
+      http:
+        paths:
+          {{- range .Values.webhookIngress.paths }}
+          - path: {{ . }}
+            pathType: {{ $.Values.webhookIngress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "terrapod.fullname" $ }}-web
+                port:
+                  name: http
+          {{- end }}
 {{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -179,6 +179,20 @@
       }
     },
 
+    "webhookIngress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "hostname": { "type": "string" },
+        "tls": { "type": "boolean" },
+        "pathType": { "type": "string", "enum": ["Prefix", "Exact", "ImplementationSpecific"] },
+        "annotations": { "type": "object" },
+        "paths": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
     "tls": {
       "type": "object",
       "additionalProperties": false,
@@ -387,6 +401,7 @@
           "enum": ["debug", "info", "warning", "error", "critical"]
         },
         "external_url": { "type": "string" },
+        "public_webhook_url": { "type": "string" },
         "database": {
           "type": "object",
           "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -86,6 +86,20 @@ api:
     # outbound references back to the UI. Example: https://terrapod.example.com
     external_url: ""
 
+    # Public webhook URL — the base URL Terrapod hands to EXTERNAL
+    # services that call back into us from the public internet (VCS
+    # webhook URL displayed in the connection edit screen; run-task
+    # callback URL in the dispatched webhook payload). Independent
+    # of `external_url` so deployments can put the management plane
+    # on a private/restricted ingress while exposing only the webhook
+    # surface publicly. When left empty, falls back to `external_url`
+    # (acceptable when the management plane is itself public).
+    #
+    # Auto-derived by the chart when `webhookIngress.enabled` is true
+    # (uses `webhookIngress.hostname`); operators can override
+    # explicitly here.
+    public_webhook_url: ""
+
     # SQLAlchemy connection pool settings for RDS Proxy / pgBouncer compatibility.
     # Tune these if using a connection pooler or high-availability PostgreSQL.
     database:
@@ -749,6 +763,44 @@ ingress:
   #       name: my-health-service
   #       port:
   #         name: http
+
+# ── Webhook Ingress (optional) ────────────────────────────────────────────────
+# Optional SECOND Ingress for the public-internet-inbound surface only:
+# VCS webhooks and run-task callbacks. Lets operators keep the management
+# plane (UI, admin API, CLI, SSO callback, state uploads, the whole BFF)
+# on a private/restricted ingress while exposing only the must-be-public
+# webhook receivers separately.
+#
+# Mechanism-agnostic: set `className` to whatever Ingress controller
+# handles the public surface — `nginx`, `alb`, `tailscale`, `cloudflare`,
+# etc. — and pass any mechanism-specific options via `annotations`. The
+# chart wires the path allow-list; the operator wires the reachability.
+#
+# Without this block (default), all traffic — including webhooks — has to
+# go through `ingress` above. That's fine for deployments where the
+# management plane is itself public; the split exists for the case where
+# it isn't.
+#
+# Server-side, `api.config.public_webhook_url` is auto-derived from this
+# block's hostname so the URLs Terrapod hands out to external services
+# (VCS webhook URL in the connection edit screen, run-task callback URL
+# in the dispatched webhook payload) point at the public hostname rather
+# than the private management one. Operators can override explicitly via
+# `api.config.public_webhook_url`.
+webhookIngress:
+  enabled: false
+  className: ""
+  hostname: ""  # Required when enabled: e.g., terrapod-webhooks.example.com
+  tls: true
+  pathType: Prefix
+  annotations: {}
+  # Path allow-list. Each entry is rendered as a separate `path:` rule
+  # routing to the web Service (the BFF). Defaults to the full set of
+  # inbound-from-public-internet endpoints Terrapod exposes; operators
+  # who don't use external run tasks can trim that out.
+  paths:
+    - /api/terrapod/v1/vcs-events       # GitHub / GitLab webhook receivers
+    - /api/terrapod/v1/task-stage-results # external run-task callback receiver
 
 # ── TLS ───────────────────────────────────────────────────────────────────────
 tls:

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -680,6 +680,17 @@ class Settings(BaseSettings):
         description="Public-facing Terrapod URL (e.g. https://terrapod.example.com). "
         "Used for commit status links, notification URLs, and any outbound links back to the UI.",
     )
+    public_webhook_url: str = Field(
+        default="",
+        description=(
+            "Base URL Terrapod hands to EXTERNAL services that call back into us "
+            "from the public internet (VCS webhook URL displayed in the connection "
+            "edit screen; run-task callback URL in the dispatched webhook payload). "
+            "Independent of `external_url` so deployments can put the management "
+            "plane on a private/restricted ingress while exposing only the webhook "
+            "surface publicly. When empty, callers fall back to `external_url`."
+        ),
+    )
 
     # Database
     database_url: PostgresDsn = Field(

--- a/services/terrapod/services/run_task_dispatcher.py
+++ b/services/terrapod/services/run_task_dispatcher.py
@@ -115,8 +115,19 @@ async def handle_run_task_call(payload: dict) -> None:
         tsr.started_at = _utc_now()
         await db.flush()
 
-        # Build callback URL
-        base = settings.auth.callback_base_url.rstrip("/")
+        # Build callback URL. Priority chain:
+        #   1. public_webhook_url — set when the deployment uses a split
+        #      webhook ingress (the URL external services can reach from
+        #      the public internet)
+        #   2. external_url — set when the management plane is itself
+        #      public-reachable (no split)
+        #   3. callback_base_url — last-resort fallback (also the SSO
+        #      callback host; legacy path)
+        # External run-task services call back from off-network, so they
+        # need a base they can actually resolve and connect to.
+        base = (
+            settings.public_webhook_url or settings.external_url or settings.auth.callback_base_url
+        ).rstrip("/")
         callback_url = f"{base}/api/terrapod/v1/task-stage-results/tsr-{tsr.id}/callback"
 
         # Build payload


### PR DESCRIPTION
## Summary

Adds an opt-in second Ingress (`webhookIngress:` Helm block) that exposes only the public-must-reach surface — VCS webhook receivers and run-task callback receivers — so operators can keep the primary management Ingress private while still allowing GitHub/GitLab webhooks to land.

Mechanism-agnostic: any IngressClass + annotations the operator wants (nginx, alb, tailscale + Funnel, Cloudflare Tunnel, ngrok, ...). The chart wires the path allow-list; the operator wires the public reachability.

## Surface split

| On `webhookIngress` (public) | On `ingress` (private/management) |
|---|---|
| `/api/terrapod/v1/vcs-events` | UI, admin API, CLI cloud-block, state uploads |
| `/api/terrapod/v1/task-stage-results` | OIDC/SAML callbacks (browser-driven, not server-to-server) |
| | Agent-pool join, listener heartbeats, full runner protocol |

## Server-side wiring

- New `api.config.public_webhook_url` Pydantic field. Chart auto-derives from `webhookIngress.hostname`.
- `run_task_dispatcher.py` uses it for the external callback URL (priority: `public_webhook_url` → `external_url` → `auth.callback_base_url`).
- Single-ingress deployments behave identically — `public_webhook_url` empty → falls back to `external_url`.

## Mechanism examples (docs)

`docs/deployment-webhook-ingress.md` covers Tailscale Funnel, public ALB + WAF, and Cloudflare Tunnel as concrete shapes.

## Test plan

- [x] `helm lint` clean
- [x] `helm template` renders both ingresses with the right shape (single + dual scenarios)
- [x] Validation fires when `enabled` without `hostname`
- [x] Validation fires when both ingresses are configured but `web.enabled=false`
- [x] Default path allow-list renders correctly
- [x] Custom `paths:` override renders correctly (verified the wrapper-chart use case where task-stage-results is trimmed out)
- [x] 1566 Python tests pass
- [x] Frontend + Python lint pass
- [ ] End-to-end deploy on Tilt — local Tilt doesn't have a Tailscale Operator, so dual-ingress smoke is config-only; will verify on a live cluster after merge