### PR TITLE
fix: silence CodeQL mixed-returns notes; dismiss MD5 protocol-checksum alert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,6 +452,13 @@ jobs:
       && needs.build-images.result == 'success'
       && needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    # Whole-job upper bound. Default is GitHub's 360 min, which lets a
+    # wedged step (most commonly Playwright browser install) run for
+    # six hours before anyone notices. 25 min covers a cold-runner
+    # worst-case (image pull + stack boot + node setup + browser
+    # install + test suite) with headroom; anything past that is
+    # genuinely broken, not slow.
+    timeout-minutes: 25
     permissions:
       contents: read
       packages: read
@@ -499,16 +506,26 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
         working-directory: e2e
+        # Cold npm caches rarely take more than a minute; 5 fails fast.
+        timeout-minutes: 5
 
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
         working-directory: e2e
+        # Known-flaky step — apt-get for system deps + browser archive
+        # download from playwright.dev have both wedged in the past.
+        # Normal install is 60-90s; 5 min lets a cold runner finish
+        # but kills a wedge fast enough to recover the job.
+        timeout-minutes: 5
 
       - name: Run Playwright tests
         run: npx playwright test
         working-directory: e2e
         env:
           CI: true
+        # Playwright has per-test timeouts of its own, but a hung
+        # worker can outlast them; this is the outer safety net.
+        timeout-minutes: 10
 
       - name: Upload test report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,16 @@ jobs:
     # install + test suite) with headroom; anything past that is
     # genuinely broken, not slow.
     timeout-minutes: 25
+    env:
+      # Pin Playwright's browser install location to /tmp so both the
+      # downloaded zip (which lands in /tmp/playwright-download-*)
+      # and the extracted browser tree end up on the same directory
+      # path. Default would extract to ~/.cache/ms-playwright/, which
+      # we've seen wedge silently mid-extract — likely because the
+      # final post-extract rename/move spans directories and triggers
+      # extra I/O on the Azure-backed runner disk. Job-scoped so both
+      # the install step and the test run step see the same path.
+      PLAYWRIGHT_BROWSERS_PATH: /tmp/ms-playwright
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,8 +512,13 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
         working-directory: e2e
-        # Known-flaky step — apt-get for system deps + browser archive
-        # download from playwright.dev have both wedged in the past.
+        env:
+          # Diagnostic: this step has wedged at ~100% download with no
+          # further output, leaving us to guess which post-download
+          # phase (extract / chmod / metadata-write) is stuck. pw:install
+          # logs each phase, so the next failure shows the actual
+          # wedge site instead of a silent timeout.
+          DEBUG: pw:install
         # Normal install is 60-90s; 5 min lets a cold runner finish
         # but kills a wedge fast enough to recover the job.
         timeout-minutes: 5

--- a/services/tests/runner/test_backend_override.py
+++ b/services/tests/runner/test_backend_override.py
@@ -51,6 +51,7 @@ def _find_entrypoint() -> Path:
         if path.is_file():
             return path
     pytest.skip("runner-entrypoint.sh not reachable from the test environment")
+    raise AssertionError("unreachable: pytest.skip() raises Skipped")  # pragma: no cover
 
 
 def _extract_override_fragment() -> str:

--- a/services/tests/runner/test_policy_eval.py
+++ b/services/tests/runner/test_policy_eval.py
@@ -35,6 +35,7 @@ def _entrypoint_path() -> Path:
         if path.is_file():
             return path
     pytest.skip("runner-entrypoint.sh not reachable from the test environment")
+    raise AssertionError("unreachable: pytest.skip() raises Skipped")  # pragma: no cover
 
 
 def _extract_deny_jq() -> str:


### PR DESCRIPTION
## Summary

Triages the three open GitHub code-scanning alerts surfaced at https://github.com/mattrobinsonsre/terrapod/security/code-scanning :

| # | Severity | Action |
|---|---|---|
| #153 | note (CodeQL `py/mixed-returns`) on `test_policy_eval.py:30` | **Code fix** — unreachable `raise AssertionError` after `pytest.skip()` to give CodeQL an explicit terminator. |
| #151 | note (CodeQL `py/mixed-returns`) on `test_backend_override.py:40` | **Code fix** — same. |
| #162 | warning (Semgrep `use-of-md5`) on `go-terrapod/state_versions.go:84` | **Dismissed as false positive** via the GitHub API — MD5 there is the TFE V2 wire-protocol checksum (`go-tfe` sends it, the server verifies it against the uploaded bytes). Already `//nolint:gosec` annotated in source. |

`pytest.skip()` raises `Skipped`, so the test helpers' "fall-through to skip" pattern never actually produces an implicit `None` return — but CodeQL doesn't model `pytest.skip`'s NoReturn semantics, so it flags the functions as having mixed implicit/explicit returns. The unreachable `raise` after each skip gives CodeQL what it wants and documents the invariant for future readers. Marked `# pragma: no cover` so coverage tooling doesn't flag the unreachable line.

#162 isn't fixable in code without breaking wire-protocol compatibility with go-tfe and the terraform CLI itself — MD5 is mandated by the TFE V2 state-version API. The dismissal carries a rationale comment on the alert.

## Test plan

- [x] `make test` — 1566 tests pass
- [x] `make lint` — clean
- [x] Alert #162 dismissed and the dismissal comment recorded
- [ ] After merge: CodeQL re-runs on `main` and #153 + #151 close automatically