### PR TITLE
feat(chart): split-networking — internalIngress + listener.publicApiUrl

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -569,9 +569,26 @@ fi
 # matches credentials by the source-URL hostname, not the discovery
 # target. Without this the host{} redirect would resolve services but
 # terraform would still fail auth ("no credentials block for host X").
-if [ -n "$TP_PUBLIC_API_URL" ] && [ -n "$TF_CLI_CONFIG_FILE" ]; then
+#
+# Service URLs match what /.well-known/terraform.json advertises in
+# api/routers/oauth.py — modules.v1 = /api/v2/registry/modules/,
+# providers.v1 = /api/v2/registry/providers/ (the *registry* protocol;
+# /v1/providers/ is the separate network-mirror protocol).
+#
+# Port suffixes (e.g. host:8443) are stripped by the host extraction
+# regex below, so a public URL and internal URL that differ only by
+# port are treated as the same host — no redirect emitted. Acceptable:
+# terraform's host discovery is hostname-keyed, not host+port keyed.
+#
+# HTTP fallback note: when TP_API_URL is HTTP (no provider mirror in
+# the existing terraform.rc), the redirect still works — host{} only
+# affects service discovery. Provider DOWNLOAD via terraform's default
+# direct mode requires HTTPS, so an HTTP-only deployment can't serve
+# providers via this redirect; that's a pre-existing limitation.
+INTERNAL_HOST=$(echo "${TP_API_URL:-}" | sed -n 's|^https\{0,1\}://\([^/:]*\).*|\1|p')
+if [ -n "$TP_PUBLIC_API_URL" ] && [ -n "$TF_CLI_CONFIG_FILE" ] && [ -n "$INTERNAL_HOST" ]; then
     PUBLIC_HOST=$(echo "$TP_PUBLIC_API_URL" | sed -n 's|^https\{0,1\}://\([^/:]*\).*|\1|p')
-    if [ -n "$PUBLIC_HOST" ] && [ "$PUBLIC_HOST" != "$MIRROR_HOST" ]; then
+    if [ -n "$PUBLIC_HOST" ] && [ "$PUBLIC_HOST" != "$INTERNAL_HOST" ]; then
         cat >> "$TF_CLI_CONFIG_FILE" <<TFEOF
 credentials "$PUBLIC_HOST" {
   token = "$TP_AUTH_TOKEN"
@@ -579,7 +596,7 @@ credentials "$PUBLIC_HOST" {
 host "$PUBLIC_HOST" {
   services = {
     "modules.v1"   = "${TP_API_URL}/api/v2/registry/modules/"
-    "providers.v1" = "${TP_API_URL}/v1/providers/"
+    "providers.v1" = "${TP_API_URL}/api/v2/registry/providers/"
   }
 }
 TFEOF

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -556,6 +556,37 @@ TFEOF
     esac
 fi
 
+# --- Public hostname redirect (split-networking deployments) ---
+# When the deployment uses a separate internal API URL for runners (see
+# the internalIngress + listener.publicApiUrl pattern in the Terrapod
+# Helm chart), the runner's TP_API_URL points at the internal hostname
+# while user code under `source = "..."` references the public/canonical
+# hostname. Add a terraform CLI `host{}` block redirecting public→
+# internal so module + provider registry discovery for the canonical
+# hostname resolves via the internal route.
+#
+# Credentials are also written for the public host because terraform
+# matches credentials by the source-URL hostname, not the discovery
+# target. Without this the host{} redirect would resolve services but
+# terraform would still fail auth ("no credentials block for host X").
+if [ -n "$TP_PUBLIC_API_URL" ] && [ -n "$TF_CLI_CONFIG_FILE" ]; then
+    PUBLIC_HOST=$(echo "$TP_PUBLIC_API_URL" | sed -n 's|^https\{0,1\}://\([^/:]*\).*|\1|p')
+    if [ -n "$PUBLIC_HOST" ] && [ "$PUBLIC_HOST" != "$MIRROR_HOST" ]; then
+        cat >> "$TF_CLI_CONFIG_FILE" <<TFEOF
+credentials "$PUBLIC_HOST" {
+  token = "$TP_AUTH_TOKEN"
+}
+host "$PUBLIC_HOST" {
+  services = {
+    "modules.v1"   = "${TP_API_URL}/api/v2/registry/modules/"
+    "providers.v1" = "${TP_API_URL}/v1/providers/"
+  }
+}
+TFEOF
+        log "[entrypoint] Configured host{} redirect: $PUBLIC_HOST → $TP_API_URL"
+    fi
+fi
+
 # --- Provider download timeouts ---
 # Increase registry client timeout (default 10s) and enable retries for
 # provider binary downloads. Covers first-request latency when the provider

--- a/docs/deployment-network-isolation.md
+++ b/docs/deployment-network-isolation.md
@@ -1,0 +1,180 @@
+# Split-networking deployments
+
+By default, every Terrapod consumer — a human's browser, the `terraform` CLI cloud block, listener pods in remote clusters, runner Jobs uploading state — reaches the API through a single `Ingress`. That works fine when the management plane is freely reachable from every network the consumers live in.
+
+It often isn't. Common shapes where it isn't:
+
+- Management plane lives on a **VPN-only or tailnet-only hostname** that operators can reach interactively, but pods in remote production clusters cannot resolve or route to.
+- Management plane sits behind a **public LB with an IP allow-list** that excludes Kubernetes node CIDRs.
+- Operators reach Terrapod via **Cloudflare/Tailscale Funnel** but agent pods are inside private VPCs.
+
+The fix isn't to give up on the private management plane — it's to add a **second** internal-only entry point that listener and runner pods can reach over the private network fabric (transit gateway, peered VPC, internal LB), while the management plane stays restricted. That's what the chart's `internalIngress:` block does.
+
+This is independent of the [webhook split](deployment-webhook-ingress.md). They compose: a deployment can have all three Ingresses, two of them, or just the primary.
+
+## Surface split — who needs to reach what?
+
+| Audience | Reaches | Auth | Chart block |
+|---|---|---|---|
+| Humans (browser, CLI) | UI, admin API, CLI cloud-block, SSO redirect | Session cookie / Bearer API token | `ingress` (primary) |
+| GitHub / GitLab / external run-task services | `/vcs-events`, `/task-stage-results/.../callback` | HMAC-signed payload | `webhookIngress` (optional) |
+| Listener pods + runner Jobs from other clusters | `/agent-pools/join`, `/listeners/.../events`, `/runs/.../artifacts/...`, registry downloads | X.509 listener cert / runner token | `internalIngress` (optional) |
+
+All three terminate at the same `<fullname>-web` Service — the Next.js BFF. The difference is **which network the request entered through**, not what API it talks to. Listener auth (bearer cert), runner-token auth, and TFE-V2 session auth all work uniformly regardless of Ingress.
+
+## Helm values
+
+```yaml
+ingress:                    # primary — humans + CLI + SSO redirect
+  enabled: true
+  className: tailscale      # or "nginx" with VPN-restricted LB, etc.
+  hostname: terrapod.example.com
+  tls: true
+
+webhookIngress:             # optional — public inbound (VCS webhooks)
+  enabled: true
+  className: nginx-public   # or "alb", "cloudflare", "tailscale" with funnel
+  hostname: terrapod-webhooks.example.com
+  tls: true
+
+internalIngress:            # optional — internal-only (listener + runner)
+  enabled: true
+  className: traefik-internal  # or internal-LB-class, "alb" with scheme=internal, etc.
+  hostname: terrapod-internal.example.com
+  tls: true
+  # paths defaults to ["/"] — the internal route is trusted, no allow-list needed
+```
+
+The chart validates each block:
+- `*.hostname` must be set when `*.enabled: true`.
+- `web.enabled: true` is required (every Ingress routes to the web BFF).
+- `webhookIngress.paths` must be non-empty when `webhookIngress.enabled` (default ships a path allow-list).
+- `internalIngress.paths` must be non-empty (default is `["/"]`).
+
+## Listener `apiUrl` + `publicApiUrl` — the runner-side asymmetry
+
+The listener Deployment carries two URL env vars:
+
+| Env var | Helm value | Meaning |
+|---|---|---|
+| `TERRAPOD_API_URL` | `listener.apiUrl` | The URL the listener (and the runners it spawns) **actually calls**. In a split-networking deployment, this is the `internalIngress` hostname. |
+| `TERRAPOD_PUBLIC_API_URL` | `listener.publicApiUrl` (default: `api.config.external_url`) | The **public/canonical** hostname users see in their browsers, in the CLI cloud block, and in `source = "..."` registry URLs in user `.tf` code. |
+
+When the two values differ, the listener forwards `TP_PUBLIC_API_URL` to each runner Job pod's env. The runner entrypoint detects the mismatch and appends a terraform CLI `host{}` block to `TF_CLI_CONFIG_FILE`:
+
+```hcl
+credentials "terrapod.example.com" {
+  token = "<runner token>"
+}
+host "terrapod.example.com" {
+  services = {
+    "modules.v1"   = "https://terrapod-internal.example.com/api/v2/registry/modules/"
+    "providers.v1" = "https://terrapod-internal.example.com/v1/providers/"
+  }
+}
+```
+
+That's terraform's [service-discovery override](https://developer.hashicorp.com/terraform/cli/config/config-file#provider-discovery) mechanism. It means:
+
+- User code can refer to `source = "terrapod.example.com/myorg/aws-vpc/aws"` — the **canonical** hostname they'd use from their laptop.
+- Humans on the network that can reach `terrapod.example.com` natively (e.g. on tailnet) hit it directly. No CLI config tweaks required.
+- Runners in remote clusters resolve the canonical hostname **as a label** but terraform routes the actual HTTPS requests to the internal URL the runner can actually reach.
+
+When the two URLs are the same (single-network deployments), no redirect is generated — `TP_PUBLIC_API_URL` is silently omitted from the Job spec.
+
+## Pattern recipes
+
+### A. Tailscale management, internal LB for agents, Funnel for webhooks
+
+```yaml
+ingress:
+  enabled: true
+  className: tailscale
+  hostname: terrapod.example.com         # tailnet-only
+  tls: true
+
+internalIngress:
+  enabled: true
+  className: traefik-internal            # cluster-wide internal Traefik, TG-routed
+  hostname: terrapod-internal.example.com
+  tls: true
+  annotations:
+    cert-manager.io/cluster-issuer: lets-encrypt-prod
+    external-dns.alpha.kubernetes.io/hostname: terrapod-internal.example.com
+
+webhookIngress:
+  enabled: true
+  className: tailscale                   # Tailscale Funnel
+  hostname: terrapod-webhooks.example.com
+  tls: true
+  annotations:
+    tailscale.com/funnel: "true"
+
+api:
+  config:
+    external_url: https://terrapod.example.com   # canonical, used for self-referential URLs
+
+listener:
+  apiUrl: https://terrapod-internal.example.com  # what listener pods call
+  # publicApiUrl defaults to api.config.external_url — no need to set
+```
+
+Runners receive `TP_API_URL=https://terrapod-internal.example.com` and `TP_PUBLIC_API_URL=https://terrapod.example.com`, auto-generate the host redirect.
+
+### B. Internal LB for everyone (no public surface)
+
+```yaml
+ingress:
+  enabled: true
+  className: internal-nginx
+  hostname: terrapod.internal.example.com
+  tls: true
+
+# No webhookIngress — no public webhook source. (E.g. VCS poller is the only
+# integration path, or webhooks come via a private network connector.)
+# No internalIngress — listener.apiUrl can just use the primary ingress.
+
+api:
+  config:
+    external_url: https://terrapod.internal.example.com
+
+listener:
+  apiUrl: https://terrapod.internal.example.com
+  # publicApiUrl == apiUrl == external_url — runner sees no asymmetry, no host{} redirect.
+```
+
+### C. Single public hostname (smallest deployment)
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hostname: terrapod.example.com
+  tls: true
+
+api:
+  config:
+    external_url: https://terrapod.example.com
+
+listener:
+  apiUrl: ""                  # defaults to in-cluster Service (same-release agents)
+  # publicApiUrl unset       # nothing for the runner to redirect
+```
+
+## Operational checks
+
+After enabling `internalIngress`:
+
+1. **Resource provisioned**: `kubectl get ingress -n terrapod` shows three Ingress objects (or two, if webhookIngress is off).
+2. **TLS cert issued**: if using cert-manager, `kubectl get certificate -n terrapod terrapod-internal-tls` shows `Ready=True` within ~30 s of the Ingress being created.
+3. **DNS record published**: if using external-dns, the configured private zone should have an A/AAAA record matching `internalIngress.hostname`.
+4. **Reachable from agent clusters**: `kubectl run -n default --rm -it --restart=Never --image=curlimages/curl debug -- curl -sSv https://terrapod-internal.example.com/api/terrapod/v1/health` from an agent cluster should return `{"status":"ok"}`.
+5. **Listener pods using the internal URL**: `kubectl get deploy -n terrapod -l app.kubernetes.io/component=listener -o jsonpath='{.items[0].spec.template.spec.containers[0].env[?(@.name=="TERRAPOD_API_URL")].value}'` matches the internal hostname.
+6. **Runner Job spec carries `TP_PUBLIC_API_URL`**: trigger a plan, then `kubectl get job -n terrapod-runners <job> -o yaml | grep TP_PUBLIC_API_URL` should show the canonical URL.
+7. **Runner `terraform.rc` includes the host block**: `kubectl logs -n terrapod-runners <pod> | grep "Configured host{} redirect"` confirms the entrypoint wrote it.
+
+## What this is not
+
+- **Not a multi-tenant networking model.** Terrapod is single-organisation by design. The three Ingresses serve different *audiences* of the same Terrapod instance, not different tenants.
+- **Not authentication.** Listener cert and runner-token auth apply on every endpoint regardless of which Ingress the request entered through. An attacker landing on the internal Ingress without a valid cert/token gets the same 401 as on the public one.
+- **Not a substitute for in-cluster reachability** for same-cluster deployments. Where the API runs in the same cluster as the listener, `listener.apiUrl: ""` (the chart's in-cluster Service default) is the right answer and no Ingress hop is needed.

--- a/docs/deployment-network-isolation.md
+++ b/docs/deployment-network-isolation.md
@@ -58,7 +58,7 @@ The listener Deployment carries two URL env vars:
 | Env var | Helm value | Meaning |
 |---|---|---|
 | `TERRAPOD_API_URL` | `listener.apiUrl` | The URL the listener (and the runners it spawns) **actually calls**. In a split-networking deployment, this is the `internalIngress` hostname. |
-| `TERRAPOD_PUBLIC_API_URL` | `listener.publicApiUrl` (default: `api.config.external_url`) | The **public/canonical** hostname users see in their browsers, in the CLI cloud block, and in `source = "..."` registry URLs in user `.tf` code. |
+| `TERRAPOD_PUBLIC_API_URL` | `listener.publicApiUrl` (default: `api.config.external_url`, or empty if both are unset) | The **public/canonical** hostname users see in their browsers, in the CLI cloud block, and in `source = "..."` registry URLs in user `.tf` code. Empty means "no redirect needed" — the listener still works, runner Jobs just don't get a `host{}` block. |
 
 When the two values differ, the listener forwards `TP_PUBLIC_API_URL` to each runner Job pod's env. The runner entrypoint detects the mismatch and appends a terraform CLI `host{}` block to `TF_CLI_CONFIG_FILE`:
 
@@ -74,7 +74,7 @@ host "terrapod.example.com" {
 }
 ```
 
-That's terraform's [service-discovery override](https://developer.hashicorp.com/terraform/cli/config/config-file#provider-discovery) mechanism. It means:
+That's terraform's [remote service discovery](https://developer.hashicorp.com/terraform/internals/remote-service-discovery) mechanism, overridden via a CLI `host{}` block. It means:
 
 - User code can refer to `source = "terrapod.example.com/myorg/aws-vpc/aws"` — the **canonical** hostname they'd use from their laptop.
 - Humans on the network that can reach `terrapod.example.com` natively (e.g. on tailnet) hit it directly. No CLI config tweaks required.
@@ -106,7 +106,10 @@ webhookIngress:
   enabled: true
   className: tailscale                   # Tailscale Funnel
   hostname: terrapod-webhooks.example.com
-  tls: true
+  tls: true                              # Tailscale Funnel terminates TLS at the edge;
+                                          # `tls: true` here just lets the chart render
+                                          # the spec's TLS block — the operator-managed
+                                          # Tailscale layer handles the cert.
   annotations:
     tailscale.com/funnel: "true"
 
@@ -168,7 +171,7 @@ After enabling `internalIngress`:
 1. **Resource provisioned**: `kubectl get ingress -n terrapod` shows three Ingress objects (or two, if webhookIngress is off).
 2. **TLS cert issued**: if using cert-manager, `kubectl get certificate -n terrapod terrapod-internal-tls` shows `Ready=True` within ~30 s of the Ingress being created.
 3. **DNS record published**: if using external-dns, the configured private zone should have an A/AAAA record matching `internalIngress.hostname`.
-4. **Reachable from agent clusters**: `kubectl run -n default --rm -it --restart=Never --image=curlimages/curl debug -- curl -sSv https://terrapod-internal.example.com/api/terrapod/v1/health` from an agent cluster should return `{"status":"ok"}`.
+4. **Reachable from agent clusters**: `kubectl run -n default --rm -it --restart=Never --image=curlimages/curl debug -- curl -sS https://terrapod-internal.example.com/.well-known/terraform.json` from an agent cluster should return the service-discovery JSON document. This endpoint is unauthenticated and goes through the BFF the same way listener and runner traffic does, so a 200 here proves both the Ingress routing and BFF→API proxy work.
 5. **Listener pods using the internal URL**: `kubectl get deploy -n terrapod -l app.kubernetes.io/component=listener -o jsonpath='{.items[0].spec.template.spec.containers[0].env[?(@.name=="TERRAPOD_API_URL")].value}'` matches the internal hostname.
 6. **Runner Job spec carries `TP_PUBLIC_API_URL`**: trigger a plan, then `kubectl get job -n terrapod-runners <job> -o yaml | grep TP_PUBLIC_API_URL` should show the canonical URL.
 7. **Runner `terraform.rc` includes the host block**: `kubectl logs -n terrapod-runners <pod> | grep "Configured host{} redirect"` confirms the entrypoint wrote it.

--- a/docs/deployment-webhook-ingress.md
+++ b/docs/deployment-webhook-ingress.md
@@ -118,6 +118,7 @@ That's the default. All traffic, including webhooks, goes through `ingress`. If 
 
 ## See also
 
+- [Split-networking deployments](deployment-network-isolation.md) — the complementary `internalIngress` block + listener/runner `publicApiUrl` pattern for the private side of the same split.
 - `helm/terrapod/values.yaml` — full `webhookIngress:` block schema.
 - `services/terrapod/api/routers/vcs_events.py` — GitHub webhook receiver (HMAC validated).
 - `services/terrapod/api/routers/run_tasks.py` — run-task callback receiver (token validated).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -485,6 +485,8 @@ listener:
 | `ingress.extraPaths` | `[]` | Extra paths prepended before the default catch-all |
 | `tls.existingSecret` | `""` | Existing TLS secret name |
 
+The chart supports up to three Ingresses. See [Split-networking deployments](deployment-network-isolation.md) for the `internalIngress` block (private path for listener + runner traffic) and [Optional split webhook ingress](deployment-webhook-ingress.md) for the `webhookIngress` block (public-must-reach surface).
+
 ### Database
 
 | Value | Default | Description |

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Monitoring](monitoring.md) | Prometheus metrics, scraping, recommended alerts |
 | [Deployment](deployment.md) | Production Helm deployment, storage backends, scaling |
 | [Split-networking deployments](deployment-network-isolation.md) | Three-Ingress model: management / webhook / internal agent path, with split-hostname runner config |
-| [Webhook ingress (split)](deployment-webhook-ingress.md) | Optional second Ingress for the public-must-reach surface (VCS webhooks, run-task callbacks) |
+| [Optional split webhook ingress](deployment-webhook-ingress.md) | Optional second Ingress for the public-must-reach surface (VCS webhooks, run-task callbacks) |
 | [Security Hardening](security-hardening.md) | TLS, secrets management, network policies, rate limiting |
 | [Production Checklist](production-checklist.md) | Step-by-step checklist for go-live readiness |
 | [Disaster Recovery](disaster-recovery.md) | Break-glass state recovery from object storage |

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,8 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Registry](registry.md) | Private module/provider registry, caching layers |
 | [Monitoring](monitoring.md) | Prometheus metrics, scraping, recommended alerts |
 | [Deployment](deployment.md) | Production Helm deployment, storage backends, scaling |
+| [Split-networking deployments](deployment-network-isolation.md) | Three-Ingress model: management / webhook / internal agent path, with split-hostname runner config |
+| [Webhook ingress (split)](deployment-webhook-ingress.md) | Optional second Ingress for the public-must-reach surface (VCS webhooks, run-task callbacks) |
 | [Security Hardening](security-hardening.md) | TLS, secrets management, network policies, rate limiting |
 | [Production Checklist](production-checklist.md) | Step-by-step checklist for go-live readiness |
 | [Disaster Recovery](disaster-recovery.md) | Break-glass state recovery from object storage |

--- a/helm/terrapod/templates/_helpers.tpl
+++ b/helm/terrapod/templates/_helpers.tpl
@@ -315,7 +315,7 @@ Validate the optional internal Ingress:
 {{- define "terrapod.validateInternalIngress" -}}
 {{- if .Values.internalIngress.enabled -}}
 {{- if not .Values.internalIngress.hostname -}}
-{{- fail "internalIngress.enabled is true but internalIngress.hostname is empty. Set the internal hostname listener pods and runner Jobs will reach Terrapod at." -}}
+{{- fail "internalIngress.enabled is true but internalIngress.hostname is empty. Set the internal hostname that listener pods and runner Jobs will use to reach Terrapod." -}}
 {{- end -}}
 {{- if not .Values.web.enabled -}}
 {{- fail "internalIngress.enabled is true but web.enabled is false. The internal Ingress routes to the web frontend — set web.enabled=true." -}}

--- a/helm/terrapod/templates/_helpers.tpl
+++ b/helm/terrapod/templates/_helpers.tpl
@@ -304,3 +304,38 @@ webhook URL generation.
 {{- printf "%s://%s" $scheme .Values.webhookIngress.hostname -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validate the optional internal Ingress:
+  - hostname is required when enabled (the internal route resolves to it)
+  - web.enabled is required (this Ingress routes to the web BFF, same as
+    the management Ingress)
+  - paths must be non-empty (default is "/")
+*/}}
+{{- define "terrapod.validateInternalIngress" -}}
+{{- if .Values.internalIngress.enabled -}}
+{{- if not .Values.internalIngress.hostname -}}
+{{- fail "internalIngress.enabled is true but internalIngress.hostname is empty. Set the internal hostname listener pods and runner Jobs will reach Terrapod at." -}}
+{{- end -}}
+{{- if not .Values.web.enabled -}}
+{{- fail "internalIngress.enabled is true but web.enabled is false. The internal Ingress routes to the web frontend — set web.enabled=true." -}}
+{{- end -}}
+{{- if not .Values.internalIngress.paths -}}
+{{- fail "internalIngress.enabled is true but internalIngress.paths is empty. The default (paths: [\"/\"]) ships in values.yaml; an empty list would produce an Ingress that accepts nothing." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the internal API URL (no trailing slash, with scheme). Returns
+empty when the internal Ingress isn't configured. Operators wire this
+into listener.apiUrl when they want listeners + runners to use the
+internal route while users + CLI traffic continue to enter through the
+primary `ingress`.
+*/}}
+{{- define "terrapod.internalAPIURL" -}}
+{{- if and .Values.internalIngress.enabled .Values.internalIngress.hostname -}}
+{{- $scheme := ternary "https" "http" .Values.internalIngress.tls -}}
+{{- printf "%s://%s" $scheme .Values.internalIngress.hostname -}}
+{{- end -}}
+{{- end -}}

--- a/helm/terrapod/templates/deployment-listener.yaml
+++ b/helm/terrapod/templates/deployment-listener.yaml
@@ -73,6 +73,15 @@ spec:
                   fieldPath: metadata.name
             - name: TERRAPOD_API_URL
               value: {{ .Values.listener.apiUrl | default (printf "http://%s-api:8000" (include "terrapod.fullname" .)) | quote }}
+            # Public/canonical API URL — what users see in their browsers,
+            # the CLI cloud block, and module/provider source URLs. When
+            # different from TERRAPOD_API_URL, the listener forwards it to
+            # runner Jobs as TP_PUBLIC_API_URL so the runner entrypoint can
+            # add a terraform host{} redirect (canonical → internal).
+            # Defaults to api.config.external_url; empty in single-network
+            # deployments where listener.apiUrl == the canonical URL.
+            - name: TERRAPOD_PUBLIC_API_URL
+              value: {{ .Values.listener.publicApiUrl | default .Values.api.config.external_url | default "" | quote }}
             # Cert TTL drives the renewal threshold (renew at 50% + splay).
             # Must match `api.config.agent_pools.listener_cert_ttl_seconds` so
             # pods anticipate renewal correctly. Values-local.yaml lowers

--- a/helm/terrapod/templates/ingress.yaml
+++ b/helm/terrapod/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- include "terrapod.validateWebhookIngress" . -}}
+{{- include "terrapod.validateInternalIngress" . -}}
 {{- if .Values.ingress.enabled }}
 {{- include "terrapod.validateIngressWeb" . -}}
 apiVersion: networking.k8s.io/v1
@@ -78,6 +79,52 @@ spec:
           {{- range .Values.webhookIngress.paths }}
           - path: {{ . }}
             pathType: {{ $.Values.webhookIngress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "terrapod.fullname" $ }}-web
+                port:
+                  name: http
+          {{- end }}
+{{- end }}
+{{- if .Values.internalIngress.enabled }}
+---
+# Internal Ingress — the network-isolated route used by listener pods +
+# runner Jobs from other clusters. Routes to the same web Service (BFF
+# rule still holds) so listener auth (bearer cert), runner-token auth,
+# and TFE-V2 session auth all work uniformly regardless of which Ingress
+# the request entered through.
+#
+# Default `paths: ["/"]` because this Ingress is internal-trusted —
+# there's no security reason to allow-list paths. Operators can narrow
+# if their controller requires explicit declarations.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "terrapod.fullname" . }}-internal
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: internal
+  {{- with .Values.internalIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.internalIngress.className }}
+  ingressClassName: {{ .Values.internalIngress.className }}
+  {{- end }}
+  {{- if .Values.internalIngress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.internalIngress.hostname }}
+      secretName: {{ printf "%s-internal-tls" (include "terrapod.fullname" .) }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.internalIngress.hostname }}
+      http:
+        paths:
+          {{- range .Values.internalIngress.paths }}
+          - path: {{ . }}
+            pathType: {{ $.Values.internalIngress.pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ include "terrapod.fullname" $ }}-web

--- a/helm/terrapod/templates/ingress.yaml
+++ b/helm/terrapod/templates/ingress.yaml
@@ -116,12 +116,15 @@ spec:
   tls:
     - hosts:
         - {{ .Values.internalIngress.hostname }}
-      secretName: {{ printf "%s-internal-tls" (include "terrapod.fullname" .) }}
+      secretName: {{ .Values.internalIngress.existingSecret | default (printf "%s-internal-tls" (include "terrapod.fullname" .)) }}
   {{- end }}
   rules:
     - host: {{ .Values.internalIngress.hostname }}
       http:
         paths:
+          {{- with .Values.internalIngress.extraPaths }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- range .Values.internalIngress.paths }}
           - path: {{ . }}
             pathType: {{ $.Values.internalIngress.pathType | default "Prefix" }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -134,6 +134,7 @@
         "name": { "type": "string" },
         "healthPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "apiUrl": { "type": "string" },
+        "publicApiUrl": { "type": "string" },
         "joinToken": { "type": "string" },
         "existingSecret": { "type": "string" },
         "joinTokenKey": { "type": "string" },
@@ -180,6 +181,20 @@
     },
 
     "webhookIngress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "hostname": { "type": "string" },
+        "tls": { "type": "boolean" },
+        "pathType": { "type": "string", "enum": ["Prefix", "Exact", "ImplementationSpecific"] },
+        "annotations": { "type": "object" },
+        "paths": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
+    "internalIngress": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -202,9 +202,11 @@
         "className": { "type": "string" },
         "hostname": { "type": "string" },
         "tls": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
         "pathType": { "type": "string", "enum": ["Prefix", "Exact", "ImplementationSpecific"] },
         "annotations": { "type": "object" },
-        "paths": { "type": "array", "items": { "type": "string" } }
+        "paths": { "type": "array", "items": { "type": "string" } },
+        "extraPaths": { "type": "array", "items": { "type": "object" } }
       }
     },
 

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -646,6 +646,21 @@ listener:
   # Also used as the default for runners.serverUrl when that value is empty.
   apiUrl: ""
 
+  # Public/canonical API URL — the hostname users see in their browsers,
+  # the CLI cloud block, and in module/provider `source = "..."` URLs.
+  # Distinct from `apiUrl` (the URL the listener and runner pods actually
+  # call). When set AND different from `apiUrl`, the runner auto-generates
+  # a terraform CLI `host{}` block redirecting the public hostname to the
+  # internal one, so user code can keep referring to the canonical
+  # hostname while runners traverse the internal route.
+  #
+  # Defaults to `api.config.external_url` (the chart-wide public URL) when
+  # unset. Leave empty in single-network deployments where the listener
+  # reaches the same hostname users do.
+  #
+  # See docs/deployment-network-isolation.md for the full pattern.
+  publicApiUrl: ""
+
   # Join token for pool registration.
   # Either set joinToken directly or reference an existing K8s Secret (recommended).
   # The token is obtained by creating an agent pool + join token via the API.
@@ -801,6 +816,49 @@ webhookIngress:
   paths:
     - /api/terrapod/v1/vcs-events       # GitHub / GitLab webhook receivers
     - /api/terrapod/v1/task-stage-results # external run-task callback receiver
+
+# ── Internal Ingress (optional) ─────────────────────────────────────────────
+# Optional THIRD Ingress for the internal-only surface: listener pods
+# joining + heartbeating, runner Jobs uploading artifacts and pulling the
+# binary/provider/module caches. Use this when listener and runner pods
+# live in clusters that cannot reach the primary `ingress` hostname (e.g.
+# the management plane is on a Tailscale/VPN ingress that pod networks
+# don't traverse, but a private LB or internal LB shared across the VPC
+# fabric is reachable).
+#
+# Mechanism-agnostic — same as `webhookIngress`. Set `className` to your
+# internal Ingress controller (`traefik-internal`, internal-only nginx,
+# `alb` with `scheme: internal`, etc.) and pass operator-specific options
+# via `annotations`.
+#
+# Three audiences, three Ingresses, one BFF:
+#
+#   ingress         → humans (UI), CLI cloud block, SSO redirect
+#   webhookIngress  → public-must-reach (VCS webhooks, run-task callbacks)
+#   internalIngress → listener + runner traffic from other clusters
+#
+# All three terminate at `<fullname>-web` (the BFF). The difference is
+# WHERE the request landed, not what it does. Listener auth (bearer cert)
+# and runner-token auth still apply on every endpoint.
+#
+# When this block is enabled, set `listener.publicApiUrl` (or leave it
+# unset to default to `api.config.external_url`) so the runner knows that
+# the public hostname in user `.tf` code (e.g. `source = "..."` registry
+# URLs) differs from `listener.apiUrl` — the runner auto-generates a
+# terraform `host{}` block redirecting the public hostname to the
+# internal URL it actually calls. See docs/deployment-network-isolation.md.
+internalIngress:
+  enabled: false
+  className: ""
+  hostname: ""  # Required when enabled: e.g., terrapod-internal.example.com
+  tls: true
+  pathType: Prefix
+  annotations: {}
+  # Path allow-list. Defaults to all paths — this Ingress is the internal-
+  # trusted route, so there's no security reason to restrict it. Operators
+  # can narrow if their controller requires explicit path declarations.
+  paths:
+    - /
 
 # ── TLS ───────────────────────────────────────────────────────────────────────
 tls:

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -852,6 +852,11 @@ internalIngress:
   className: ""
   hostname: ""  # Required when enabled: e.g., terrapod-internal.example.com
   tls: true
+  # Name of an existing TLS Secret to reuse (e.g. a wildcard cert
+  # covering both the public and internal hostnames). If empty, the
+  # chart uses `<fullname>-internal-tls` (typically issued by
+  # cert-manager via the annotations below).
+  existingSecret: ""
   pathType: Prefix
   annotations: {}
   # Path allow-list. Defaults to all paths — this Ingress is the internal-
@@ -859,6 +864,10 @@ internalIngress:
   # can narrow if their controller requires explicit path declarations.
   paths:
     - /
+  # Extra paths prepended before the path allow-list above. Same shape
+  # and use as `ingress.extraPaths` (e.g. a controller-specific health-
+  # check path that needs an explicit backend).
+  extraPaths: []
 
 # ── TLS ───────────────────────────────────────────────────────────────────────
 tls:

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -83,13 +83,11 @@ def build_job_spec(
     job_name = f"tprun-{run_short}-{phase}"
 
     # Build container env vars
+    api_url = os.environ.get("TERRAPOD_API_URL", "http://terrapod-api:8000")
     container_env = [
         {"name": "TP_RUN_ID", "value": run_id},
         {"name": "TP_PHASE", "value": phase},
-        {
-            "name": "TP_API_URL",
-            "value": os.environ.get("TERRAPOD_API_URL", "http://terrapod-api:8000"),
-        },
+        {"name": "TP_API_URL", "value": api_url},
         {
             "name": "TP_AUTH_TOKEN",
             "valueFrom": {
@@ -107,8 +105,13 @@ def build_job_spec(
     # type in `source = "..."` URLs and SSO callbacks) to TP_API_URL (the
     # internal URL the runner actually traverses). Skipped when same so
     # there's no needless self-redirect.
+    #
+    # Trailing slashes are normalised here so values that only differ by
+    # a trailing `/` ("https://x.example/" vs "https://x.example") don't
+    # trigger a no-op redirect — the entrypoint's host-extraction re-
+    # checks at hostname level either way, this is just a tighter guard.
     public_api_url = os.environ.get("TERRAPOD_PUBLIC_API_URL", "").strip()
-    if public_api_url and public_api_url != container_env[2]["value"]:
+    if public_api_url and public_api_url.rstrip("/") != api_url.rstrip("/"):
         container_env.append({"name": "TP_PUBLIC_API_URL", "value": public_api_url})
 
     # Terraform version + backend

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -101,6 +101,16 @@ def build_job_spec(
         },
     ]
 
+    # Public/canonical API URL — only forwarded to the runner when it
+    # differs from TP_API_URL. The entrypoint uses it to add a terraform
+    # CLI host{} block redirecting the canonical hostname (the one users
+    # type in `source = "..."` URLs and SSO callbacks) to TP_API_URL (the
+    # internal URL the runner actually traverses). Skipped when same so
+    # there's no needless self-redirect.
+    public_api_url = os.environ.get("TERRAPOD_PUBLIC_API_URL", "").strip()
+    if public_api_url and public_api_url != container_env[2]["value"]:
+        container_env.append({"name": "TP_PUBLIC_API_URL", "value": public_api_url})
+
     # Terraform version + backend
     version = terraform_version or runner_config.default_terraform_version
     backend = execution_backend or runner_config.default_execution_backend

--- a/services/tests/runner/test_job_template.py
+++ b/services/tests/runner/test_job_template.py
@@ -234,3 +234,16 @@ class TestPublicApiUrl:
         )
         env_names = {e["name"] for e in env}
         assert "TP_PUBLIC_API_URL" not in env_names
+
+    def test_public_api_url_omitted_when_trailing_slash_only_difference(self, monkeypatch):
+        # Operators may set publicApiUrl with a trailing slash while
+        # apiUrl has none (or vice versa). That's not a real difference;
+        # the runner entrypoint's host extraction would discard them too.
+        # Verifies the .rstrip("/") guard in build_job_spec.
+        env = self._build(
+            monkeypatch,
+            api_url="https://terrapod.example.com",
+            public_api_url="https://terrapod.example.com/",
+        )
+        env_names = {e["name"] for e in env}
+        assert "TP_PUBLIC_API_URL" not in env_names

--- a/services/tests/runner/test_job_template.py
+++ b/services/tests/runner/test_job_template.py
@@ -172,3 +172,65 @@ class TestAuthTokenInjection:
         assert "valueFrom" in auth_env
         assert auth_env["valueFrom"]["secretKeyRef"]["name"] == "tprun-abc12345-auth"
         assert auth_env["valueFrom"]["secretKeyRef"]["key"] == "token"
+
+
+class TestPublicApiUrl:
+    """Split-networking: TP_PUBLIC_API_URL only emitted when distinct from TP_API_URL."""
+
+    def _build(self, monkeypatch, api_url, public_api_url):
+        from terrapod.runner.job_template import build_job_spec
+
+        monkeypatch.setenv("TERRAPOD_API_URL", api_url)
+        if public_api_url is None:
+            monkeypatch.delenv("TERRAPOD_PUBLIC_API_URL", raising=False)
+        else:
+            monkeypatch.setenv("TERRAPOD_PUBLIC_API_URL", public_api_url)
+        spec = build_job_spec(
+            run_id="abc123",
+            phase="plan",
+            runner_config=_runner_config(),
+            auth_secret_name="tprun-abc12345-auth",
+            env_vars=[],
+            terraform_vars=[],
+        )
+        return spec["spec"]["template"]["spec"]["containers"][0]["env"]
+
+    def test_public_api_url_emitted_when_different(self, monkeypatch):
+        env = self._build(
+            monkeypatch,
+            api_url="https://terrapod-internal.example.com",
+            public_api_url="https://terrapod.example.com",
+        )
+        env_dict = {e["name"]: e.get("value") for e in env if "value" in e}
+        assert env_dict["TP_API_URL"] == "https://terrapod-internal.example.com"
+        assert env_dict["TP_PUBLIC_API_URL"] == "https://terrapod.example.com"
+
+    def test_public_api_url_omitted_when_same(self, monkeypatch):
+        env = self._build(
+            monkeypatch,
+            api_url="https://terrapod.example.com",
+            public_api_url="https://terrapod.example.com",
+        )
+        env_names = {e["name"] for e in env}
+        assert "TP_API_URL" in env_names
+        assert "TP_PUBLIC_API_URL" not in env_names
+
+    def test_public_api_url_omitted_when_unset(self, monkeypatch):
+        env = self._build(
+            monkeypatch,
+            api_url="https://terrapod.example.com",
+            public_api_url=None,
+        )
+        env_names = {e["name"] for e in env}
+        assert "TP_PUBLIC_API_URL" not in env_names
+
+    def test_public_api_url_omitted_when_empty_string(self, monkeypatch):
+        # The Helm template renders "" when neither listener.publicApiUrl
+        # nor api.config.external_url is set — must be treated as "unset".
+        env = self._build(
+            monkeypatch,
+            api_url="https://terrapod.example.com",
+            public_api_url="",
+        )
+        env_names = {e["name"] for e in env}
+        assert "TP_PUBLIC_API_URL" not in env_names


### PR DESCRIPTION
## Summary

Adds two related primitives for **split-networking deployments** — where listener pods and runner Jobs cannot reach the same hostname users see in their browsers.

Common shapes this unblocks:
- Management plane lives on a VPN-only / tailnet-only hostname; agent pods in remote VPCs cannot resolve or route to it.
- Public LB with IP allow-list that excludes K8s node CIDRs.
- Operators on a Tailscale Funnel hostname while agent pods are in private VPCs.

## What's added

1. **`internalIngress` block** — optional third Ingress on the chart. Mirrors the existing `webhookIngress` shape (same validation helper pattern, same schema style). Routes to the same `<fullname>-web` BFF as the primary Ingress; default paths `["/"]` because this is the internal-trusted route. Operators set the class to whatever exposes their internal-only network path: `traefik-internal`, internal-LB-class, `alb` with `scheme: internal`, etc.

2. **`listener.publicApiUrl`** — public/canonical API URL, distinct from `listener.apiUrl` (the URL listeners and runners actually call). Defaults to `api.config.external_url`. Forwarded to runner Job pods as `TP_PUBLIC_API_URL`; the runner entrypoint auto-generates a terraform CLI `host{}` block redirecting the public hostname to the internal URL via terraform's [service-discovery override](https://developer.hashicorp.com/terraform/cli/config/config-file#provider-discovery) mechanism. User `.tf` code can keep referring to the canonical hostname.

`TP_PUBLIC_API_URL` is **only** emitted when distinct from `TP_API_URL` — single-network deployments are completely untouched.

## Three-Ingress model

| Audience | Reaches | Chart block |
|---|---|---|
| Humans (browser, CLI) | UI, admin API, CLI cloud-block, SSO redirect | `ingress` (primary) |
| GitHub / GitLab / external run-task services | webhook + callback endpoints | `webhookIngress` (optional) |
| Listener pods + runner Jobs from other clusters | join, SSE, heartbeat, artifact upload, registry | `internalIngress` (optional, NEW) |

All three terminate at the same BFF. The difference is which network the request entered through.

## Docs

New `docs/deployment-network-isolation.md` covers:
- The three-Ingress model + when each makes sense
- The dual-hostname runner pattern + how the host-block redirect is generated
- Three recipe configurations (Tailscale + internal LB + Funnel / Internal-only / Single public)
- Operational checks for verifying the internal Ingress is live and listeners use it

Cross-linked from `deployment.md`, `index.md`, and `deployment-webhook-ingress.md`.

## Test plan

- [x] Helm lint clean
- [x] `helm template` renders correctly with internalIngress off / on / on-with-webhookIngress (1 / 2 / 3 Ingress resources respectively)
- [x] Schema rejects unknown keys under `internalIngress` (`additionalProperties: false`)
- [x] Validation helper fires on `internalIngress.enabled=true` without hostname
- [x] 4 new tests in `test_job_template.py`: `TP_PUBLIC_API_URL` emission for different / same / unset / empty cases — all pass
- [x] Full python test suite (1570 passed)
- [ ] Manual smoke after merge: Tilt with internalIngress disabled (default path) → existing behaviour unchanged
- [ ] Manual smoke after release: a deployment uses both internalIngress + publicApiUrl → runner logs show `Configured host{} redirect: <public> → <internal>`

## Out of scope

- This PR doesn't change any existing deployment behaviour — both new values default to disabled / empty.
- Release tagging (would be v0.28.0) is a separate step after merge per the documented release process.