### PR TITLE
feat(chart): HSTS header on the BFF (on by default)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -484,6 +484,7 @@ listener:
 | `ingress.annotations` | `{}` | Ingress annotations |
 | `ingress.extraPaths` | `[]` | Extra paths prepended before the default catch-all |
 | `tls.existingSecret` | `""` | Existing TLS secret name |
+| `web.hsts.value` | `"max-age=63072000"` | `Strict-Transport-Security` header sent on every BFF response. Set to `""` to disable. Default is 2 years, no `includeSubDomains` (operator's call), no `preload`. |
 
 The chart supports up to three Ingresses. See [Split-networking deployments](deployment-network-isolation.md) for the `internalIngress` block (private path for listener + runner traffic) and [Optional split webhook ingress](deployment-webhook-ingress.md) for the `webhookIngress` block (public-must-reach surface).
 

--- a/helm/terrapod/templates/deployment-web.yaml
+++ b/helm/terrapod/templates/deployment-web.yaml
@@ -65,6 +65,13 @@ spec:
           env:
             - name: API_URL
               value: "http://{{ include "terrapod.fullname" . }}-api:8000"
+            # HSTS (Strict-Transport-Security). When non-empty, the
+            # web container sends this value on every response. Default
+            # is `max-age=63072000` (2 years, no includeSubDomains, no
+            # preload) — see values.yaml `web.hsts` for the rationale.
+            # Set to "" to disable.
+            - name: HSTS
+              value: {{ .Values.web.hsts.value | quote }}
             {{- with .Values.web.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -68,6 +68,13 @@
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 1 },
         "image": { "$ref": "#/$defs/imageSpec" },
+        "hsts": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "value": { "type": "string" }
+          }
+        },
         "startupProbe": { "type": "object" },
         "livenessProbe": { "type": "object" },
         "readinessProbe": { "type": "object" },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -445,6 +445,28 @@ web:
     tag: ""  # Defaults to appVersion
     pullPolicy: IfNotPresent
 
+  # HSTS (Strict-Transport-Security) header sent on every BFF response.
+  # On by default — Terrapod's deployed model is HTTPS-only and many
+  # ingress controllers (notably Tailscale) don't listen on port 80, so
+  # a typo like `http://<hostname>` would otherwise just fail. The
+  # header tells browsers to upgrade `http://<hostname>` to
+  # `https://<hostname>` for `max-age` seconds after the first HTTPS
+  # visit.
+  #
+  # Default `max-age=63072000` is 2 years. No `includeSubDomains`:
+  # Terrapod's hostname's parent zone (e.g. `ts.net`, a corporate
+  # internal zone) is almost always shared with sibling services that
+  # have their own HTTP policies — asserting the directive would force
+  # HTTPS on all of them, which is the deploying operator's call.
+  # No `preload`: that's a one-way commitment to the hsts-preload list.
+  #
+  # Set `value: ""` to disable the header entirely (e.g. dev or mixed
+  # http/https deployments). Operators who DO own the entire parent
+  # zone and want the broader assertion can add `; includeSubDomains`
+  # (and optionally `; preload`) explicitly.
+  hsts:
+    value: "max-age=63072000"
+
   # Service configuration
   service:
     type: ClusterIP

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,4 +1,28 @@
 /** @type {import('next').NextConfig} */
+
+// HSTS (Strict-Transport-Security). Tells browsers to remember "always
+// use HTTPS for THIS hostname" for max-age, so subsequent visits to
+// http://hostname auto-upgrade to https:// without trying port 80.
+// Set via the HSTS env var at runtime (the chart populates it from
+// `web.hsts.value`); default below is 2 years.
+//
+// NO `includeSubDomains`: Terrapod's HSTS assertion is scoped to the
+// hostname it's served at. The hostname's parent zone (e.g. `ts.net`
+// for Tailscale-hosted deployments, or a corporate-internal zone) is
+// almost always shared with other services that have their own HTTP
+// policies — asserting `includeSubDomains` would force HTTPS on every
+// sibling host the browser later visits, which is the deploying
+// operator's call, not ours. Operators who DO own the entire parent
+// zone can set `web.hsts.value` to include the directive explicitly.
+//
+// NO `preload`: that's a one-way commitment to the hsts-preload list
+// at https://hstspreload.org — also operator's call.
+//
+// Set HSTS="" to disable the header entirely (e.g. mixed http/https
+// deployments).
+const HSTS_DEFAULT = 'max-age=63072000'
+const hstsValue = process.env.HSTS ?? HSTS_DEFAULT
+
 const nextConfig = {
   output: 'standalone',
   allowedDevOrigins: ['terrapod.local'],
@@ -10,7 +34,7 @@ const nextConfig = {
   // SSE endpoints are all Terrapod-native at /api/terrapod/v1. The
   // transitional /api/v2 aliases (#269) were removed in v0.24.0 (#278).
   async headers() {
-    return [
+    const headers = [
       {
         source: '/api/terrapod/v1/listeners/:path*',
         headers: [{ key: 'Content-Encoding', value: 'none' }],
@@ -28,6 +52,13 @@ const nextConfig = {
         headers: [{ key: 'Content-Encoding', value: 'none' }],
       },
     ]
+    if (hstsValue) {
+      headers.push({
+        source: '/:path*',
+        headers: [{ key: 'Strict-Transport-Security', value: hstsValue }],
+      })
+    }
+    return headers
   },
 }
 


### PR DESCRIPTION
## Summary

Sets a \`Strict-Transport-Security\` header on every BFF response so browsers auto-upgrade subsequent \`http://<hostname>\` visits to \`https://\`. Matters because many ingress controllers (notably Tailscale) don't listen on port 80 — without HSTS, a typo'd \`http://\` just fails.

## Scope is deliberately narrow

- \`max-age=63072000\` (2 years, the standard floor).
- **No** \`includeSubDomains\`: Terrapod's hostname's parent zone (e.g. \`ts.net\`, a corporate internal zone) is almost always shared with sibling services that have their own HTTP policies. Asserting it would force HTTPS on every sibling host the browser later visits — operator's call, not ours.
- **No** \`preload\`: one-way commitment to the [HSTS preload list](https://hstspreload.org).

Operators who DO own the entire parent zone can set \`web.hsts.value\` to include those directives explicitly. \`value: ""\` disables the header entirely.

## Plumbing

- \`web/next.config.js\` — reads \`process.env.HSTS\`, appends the header when non-empty. Default value in JS so the image still works outside the chart.
- \`helm/terrapod/templates/deployment-web.yaml\` — sets \`HSTS\` env var from \`.Values.web.hsts.value\`.
- \`helm/terrapod/values.yaml\` — documents the rationale.
- \`helm/terrapod/values.schema.json\` — declares the key.
- \`docs/deployment.md\` — adds the row to the Ingress value table.

## Test plan

- [x] \`helm lint\` clean
- [x] \`helm template\` with default: \`HSTS\` env var present with value \`max-age=63072000\`
- [x] \`helm template\` with \`--set web.hsts.value=''\`: env var present with empty value
- [x] Frontend lint + tsc clean
- [ ] CI green