### PR TITLE
fix(rate-limit): treat X-Terrapod-Client-Cert as authenticated

### DIFF
--- a/services/terrapod/api/rate_limit.py
+++ b/services/terrapod/api/rate_limit.py
@@ -104,13 +104,16 @@ class RateLimitMiddleware:
             is_runner = verify_runner_token(token) is not None
 
         is_auth_endpoint = _is_auth_path(path)
-        # Any Authorization header bumps the tier. We don't verify the
-        # credential here — the downstream auth dependency will 401 bogus
-        # tokens — but presence is enough to separate interactive /
-        # machine-integration traffic from unauthenticated traffic.
-        # (The web UI also sends Bearer tokens from localStorage; there
-        # is no session cookie in Terrapod.)
-        is_authenticated = bool(auth_header)
+        # Any Authorization header OR an X-Terrapod-Client-Cert header
+        # bumps the tier. We don't verify the credential here — the
+        # downstream auth dependency will 401 bogus tokens / certs — but
+        # presence is enough to separate interactive / machine-
+        # integration traffic from unauthenticated traffic. (The web UI
+        # sends Bearer tokens from localStorage; listener pods send
+        # X-Terrapod-Client-Cert with their X.509 cert; there is no
+        # session cookie in Terrapod.)
+        listener_cert = request.headers.get("x-terrapod-client-cert", "")
+        is_authenticated = bool(auth_header) or bool(listener_cert)
 
         if is_auth_endpoint:
             limit = self.auth_requests_per_minute

--- a/services/tests/api/test_rate_limit.py
+++ b/services/tests/api/test_rate_limit.py
@@ -227,6 +227,27 @@ class TestRateLimitMiddleware:
         assert "api_authn" not in key
         assert response.headers["X-Ratelimit-Limit"] == "5"
 
+    def test_listener_cert_uses_authenticated_tier(self):
+        """X-Terrapod-Client-Cert (listener auth) maps to authenticated tier.
+
+        Listener pods don't send Authorization; they auth with their X.509
+        cert via X-Terrapod-Client-Cert. Without recognising this header,
+        listener traffic falls into the unauthenticated 100/min bucket and
+        all listeners across the fleet sharing a NAT-source IP DoS each
+        other on rollout.
+        """
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, rpm=5, authenticated_rpm=500)
+        client = TestClient(app)
+        response = client.get(
+            "/api/terrapod/v1/workspaces",
+            headers={"X-Terrapod-Client-Cert": "base64-cert-bytes-here"},
+        )
+        assert response.status_code == 200
+        incr_call = mock_redis.pipeline.return_value.incr.call_args
+        assert "api_authn" in incr_call[0][0]
+        assert response.headers["X-Ratelimit-Limit"] == "500"
+
     def test_zero_limit_means_unlimited(self):
         """rpm=0 should bypass the Redis bucket entirely."""
         mock_redis = _make_redis_mock(count=9999)


### PR DESCRIPTION
## Summary

Listener pods auth with their X.509 cert via \`X-Terrapod-Client-Cert\`, not \`Authorization: Bearer\`. The rate-limit middleware only checked Authorization, so listener traffic fell into the **unauthenticated 100/min bucket**. Every listener across the fleet that reaches the API through the same Ingress-controller pod shares one bucket via that pod's IP.

## Reproduction (today, post-v0.28.1 rollout)

After the chart rollout every listener replica restarted, re-joined, and re-opened SSE at roughly the same time. The shared bucket exhausted within seconds; listeners hit 429, backed off 5s, retried into the same 429, and deadlocked. Live logs showed every pod looping on:

\`\`\`
"event": "SSE connection failed", "error": "Client error '429 Too Many Requests' for url '.../api/terrapod/v1/listeners/.../events'"
"event": "Poll fallback failed",  "error": "Client error '429 Too Many Requests' for url '.../api/terrapod/v1/listeners/.../runs/next'"
\`\`\`

Workspace run \`019e6a0b-2ad5-77bb-ab9e-d82ffe3f0100\` stuck in \`planning\` with no Job created because no listener could get the SSE event to claim it.

## Fix

Recognise the cert header in the rate-limit tier selection. We don't verify the cert here — downstream auth dependency does — but presence is enough to bump from the 100/min unauthenticated tier to the 1000/min authenticated tier (same trust assumption as the existing Bearer-header path).

\`\`\`python
listener_cert = request.headers.get("x-terrapod-client-cert", "")
is_authenticated = bool(auth_header) or bool(listener_cert)
\`\`\`

## Follow-up (not in this PR)

A second bucket-sharing issue remains: all listeners hitting through the same Ingress-controller pod share the bucket via that pod's IP. Honouring \`X-Forwarded-For\` would give each listener pod its own bucket. Separate hardening change; this fix alone unblocks the immediate fire.

## Test plan

- [x] New \`test_listener_cert_uses_authenticated_tier\` asserts the \`X-Terrapod-Client-Cert\` header maps to \`api_authn\` bucket with the authenticated rpm limit
- [x] All 16 \`test_rate_limit.py\` tests pass
- [ ] Live: after v0.28.2 rolls, listener 429 loop clears