### PR TITLE
fix(runner): report meaningful error when OPA fails with empty stderr

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -303,7 +303,11 @@ tp_evaluate_policies() {
             fi
 
             if [ "$_opa_exit" != "0" ]; then
-                _err_msg=$(head -c 1000 /tmp/opa-err.txt | jq -Rs .)
+                _err_raw=$(head -c 1000 /tmp/opa-err.txt 2>/dev/null || true)
+                if [ -z "$_err_raw" ]; then
+                    _err_raw="OPA evaluation failed with exit code $_opa_exit (no stderr output)"
+                fi
+                _err_msg=$(printf '%s' "$_err_raw" | jq -Rs .)
                 _policies_json=$(echo "$_policies_json" | jq \
                     --arg name "$_p_name" --argjson err "$_err_msg" \
                     '. + [{policy: $name, passed: false, violations: [], warnings: [], error: $err}]')


### PR DESCRIPTION
When OPA evaluation fails with exit code != 0 but produces no stderr
output, the runner now reports 'OPA evaluation failed with exit code X
(no stderr output)' instead of an empty string. Previously this left
policy evaluations with no visible error message in the UI.