### PR TITLE
feat(migrate): add --workspace flag for direct state migration without atlantis.yaml

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,8 +6,10 @@ platforms are supported:
 
 - **HCP Terraform / Terraform Enterprise (TFE)** — one TFE organization
   maps to one Terrapod deployment (Terrapod is single-org).
-- **Atlantis** — `atlantis.yaml` v3 schema; one or more repos map to
-  Terrapod workspaces or autodiscovery rules.
+- **Atlantis** — `atlantis.yaml` v3 schema, or autodiscovery mode
+  (no `atlantis.yaml` — use `--workspace` for direct per-workspace
+  state migration); one or more repos map to Terrapod workspaces or
+  autodiscovery rules.
 
 The CLI is a Go binary distributed alongside the Terrapod provider on
 every Terrapod release. Each release publishes:
@@ -131,6 +133,27 @@ for ad-hoc rewriting without a migration record.
   and listed in the skipped-items report.
 - **PR comment history** — out of scope.
 
+### Autodiscovery mode (no `atlantis.yaml`)
+
+Many Atlantis deployments run in autodiscovery mode — Atlantis discovers
+terraform directories automatically without an `atlantis.yaml` file. For
+these setups, use the `--workspace` flag to target an existing Terrapod
+workspace directly:
+
+```
+terrapod-migrate apply \
+  --source=atlantis \
+  --source-dir /path/to/terraform/project \
+  --workspace my-workspace-name \
+  --target https://terrapod.example.com \
+  --apply
+```
+
+This bypasses `atlantis.yaml` parsing entirely. The tool detects the
+backend from HCL in `--source-dir`, reads state from that backend, and
+pushes it to the named Terrapod workspace. The workspace must already
+exist (created via Terrapod's autodiscovery rules, the UI, or the API).
+
 ### State migration
 
 Atlantis itself doesn't store state — the operator's HCL declares a
@@ -186,7 +209,7 @@ The following are detected and listed but **not** rewritten because the
 substitutions aren't mechanical:
 
 - `provider "tfe" {}` declarations and `resource "tfe_*" {}` / `data
-  "tfe_*" {}` blocks — different attribute shapes.
+"tfe_*" {}` blocks — different attribute shapes.
 
 Module source rewriting is **opt-in** via `--rewrite-modules` on the
 `rewrite` subcommand. Module pins are higher-blast-radius than backend
@@ -202,7 +225,7 @@ consciously. When `--rewrite-modules` is set, the rewriter walks every
   can't fulfil it). `--allow-missing-module-mapping` downgrades to a
   warning.
 - **Git form** (`"git::https://..."`) — looks up the matching `module
-  register` record by git URL. Same hard-error-by-default behaviour.
+register` record by git URL. Same hard-error-by-default behaviour.
 - **Public registry form** (`"hashicorp/aws"`) — ignored, never
   rewritten.
 - **Local path** (`"./modules/vpc"`) — ignored, never rewritten.

--- a/migrate/cmd/terrapod-migrate/apply.go
+++ b/migrate/cmd/terrapod-migrate/apply.go
@@ -137,6 +137,26 @@ func applyCmd(args []string) int {
 		return 1
 	}
 
+	// --workspace mode: pre-seed the state file with the existing
+	// workspace's Terrapod ID so the writer takes the "reused" path
+	// (state push only, no create attempt).
+	if *workspace != "" {
+		sourceID := "direct:" + *workspace
+		if state.WorkspaceBySourceID(sourceID) == nil {
+			existing, lookupErr := c.GetWorkspaceByName(context.Background(), *workspace)
+			if lookupErr != nil {
+				fmt.Fprintf(os.Stderr, "apply: --workspace %q not found in Terrapod: %v\n", *workspace, lookupErr)
+				return 1
+			}
+			state.Workspaces = append(state.Workspaces, framework.WorkspaceRecord{
+				SourceID:   sourceID,
+				SourceName: *workspace,
+				TerrapodID: existing.ID,
+				State:      "created",
+			})
+		}
+	}
+
 	// Resolve plan VCS connections to Terrapod-side connection IDs by
 	// listing existing connections and matching on server URL +
 	// provider. The migrator never creates connections — operators

--- a/migrate/cmd/terrapod-migrate/apply.go
+++ b/migrate/cmd/terrapod-migrate/apply.go
@@ -35,6 +35,7 @@ func applyCmd(args []string) int {
 		source       = fs.String("source", "", "Source platform: 'atlantis' or 'tfe' (required)")
 		sourceDir    = fs.String("source-dir", "", "Local atlantis-repo clone (required when --source=atlantis)")
 		atlantisYAML = fs.String("atlantis-yaml-path", "", "Override path to atlantis.yaml (default: <source-dir>/atlantis.yaml)")
+		workspace    = fs.String("workspace", "", "Target an existing Terrapod workspace directly (state-push only, no atlantis.yaml needed)")
 		tfeAddress   = fs.String("tfe-address", os.Getenv("TFE_ADDRESS"), "TFE API address (or TFE_ADDRESS; default: https://app.terraform.io)")
 		tfeToken     = fs.String("tfe-token", os.Getenv("TFE_TOKEN"), "TFE API token (or TFE_TOKEN; org-owner preferred for sensitive-variable visibility)")
 		tfeOrg       = fs.String("tfe-org", os.Getenv("TFE_ORG"), "TFE organisation to migrate (or TFE_ORG)")
@@ -84,11 +85,24 @@ func applyCmd(args []string) int {
 			fmt.Fprintln(os.Stderr, "apply: --source-dir is required for --source=atlantis")
 			return 2
 		}
-		plan, stateReader, err = loadAtlantisPlan(*sourceDir, *atlantisYAML, atlantis.StateOptions{
-			S3Endpoint:       *s3Endpoint,
-			S3ForcePathStyle: *s3PathStyle,
-			S3Region:         *s3Region,
-		})
+		if *workspace != "" {
+			// Direct state-push mode: target an existing workspace,
+			// skip atlantis.yaml parsing entirely. The workspace must
+			// already exist in Terrapod (created via UI, API, or
+			// autodiscovery). We just detect the backend from HCL in
+			// source-dir and push the state.
+			plan, stateReader, err = loadDirectWorkspacePlan(*sourceDir, *workspace, atlantis.StateOptions{
+				S3Endpoint:       *s3Endpoint,
+				S3ForcePathStyle: *s3PathStyle,
+				S3Region:         *s3Region,
+			})
+		} else {
+			plan, stateReader, err = loadAtlantisPlan(*sourceDir, *atlantisYAML, atlantis.StateOptions{
+				S3Endpoint:       *s3Endpoint,
+				S3ForcePathStyle: *s3PathStyle,
+				S3Region:         *s3Region,
+			})
+		}
 	case "tfe":
 		plan, stateReader, err = loadTFEPlan(context.Background(), *tfeAddress, *tfeToken, *tfeOrg)
 	default:
@@ -272,6 +286,34 @@ func loadAtlantisPlan(sourceDir, yamlPath string, stateOpts atlantis.StateOption
 		Skipped:    skipped,
 	}
 	return plan, src.StateReader(stateOpts), nil
+}
+
+// loadDirectWorkspacePlan builds a minimal Plan targeting a single,
+// already-existing Terrapod workspace. No atlantis.yaml needed — the
+// tool detects the backend from HCL in sourceDir and provides a state
+// reader. The workspace must already exist in Terrapod; the writer
+// pushes state to it by name match.
+func loadDirectWorkspacePlan(sourceDir, workspaceName string, stateOpts atlantis.StateOptions) (ir.Plan, writer.StateReader, error) {
+	plan := ir.Plan{
+		Source: "atlantis",
+		SourceMetadata: map[string]string{
+			"mode":       "direct-workspace",
+			"clone_path": sourceDir,
+			"workspace":  workspaceName,
+		},
+		Workspaces: []ir.Workspace{
+			{
+				SourceID: "direct:" + workspaceName,
+				Name:     workspaceName,
+			},
+		},
+	}
+
+	stateReader := func(ctx context.Context, _ string) ([]byte, string, int64, error) {
+		return atlantis.ReadStateFromDir(ctx, sourceDir, stateOpts)
+	}
+
+	return plan, stateReader, nil
 }
 
 func loadTFEPlan(ctx context.Context, address, token, org string) (ir.Plan, writer.StateReader, error) {

--- a/migrate/internal/sources/atlantis/state.go
+++ b/migrate/internal/sources/atlantis/state.go
@@ -61,6 +61,26 @@ type StateOptions struct {
 	S3Region string
 }
 
+// ReadStateFromDir detects the backend from HCL in the given directory
+// and returns the state bytes, lineage, and serial. This is the public
+// entry point for callers that don't need a full Source (e.g. the
+// --workspace direct-migration path).
+func ReadStateFromDir(ctx context.Context, dir string, opts StateOptions) ([]byte, string, int64, error) {
+	backend, err := hcl.DetectBackend(dir)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("detect backend in %s: %w", dir, err)
+	}
+	raw, err := fetchStateForBackend(ctx, backend, dir, opts)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	lineage, serial, err := parseLineageAndSerial(raw)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("parse state from %s: %w", dir, err)
+	}
+	return raw, lineage, serial, nil
+}
+
 // StateReader returns a writer.StateReader that resolves
 // "<repo-url>:<dir>" SourceIDs (the shape Emit stamps on each
 // workspace) to the underlying backend's state bytes.


### PR DESCRIPTION
Atlantis deployments running in autodiscovery mode have no atlantis.yaml
file. The --workspace flag lets operators target an existing Terrapod
workspace directly — the tool detects the backend from HCL in the
source directory and pushes state without needing atlantis.yaml.

Usage:
  terrapod-migrate apply --source=atlantis \\
    --source-dir /path/to/terraform/dir \\
    --workspace my-workspace \\
    --target https://terrapod.example.com \\
    --apply

The workspace must already exist in Terrapod (created via autodiscovery,
UI, or API). This is the state-push-only path for teams that manage
workspace creation separately from state migration.

Adds ReadStateFromDir as a public entry point on the atlantis package
for callers that don't need a full Source struct.