### PR TITLE
fix(provider-cache): handle IntegrityError on concurrent cache-miss INSERT

### DIFF
--- a/services/terrapod/services/provider_cache_service.py
+++ b/services/terrapod/services/provider_cache_service.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 
 import httpx
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.metrics import PROVIDER_CACHE_REQUESTS
@@ -277,7 +278,16 @@ async def fetch_and_cache_single_platform(
             shasum = stream.sha256_hex
             size_bytes = stream.size
 
-    # Record in database
+    # Record in database. Two API replicas can race on the same
+    # cache-miss when a `tofu init` downloads N providers in parallel
+    # against an empty cache — both successfully stream the binary
+    # into object storage (object writes are idempotent: same content,
+    # same key) but only the first INSERT wins on the
+    # `uq_cached_provider_packages` unique constraint. The loser gets
+    # a `UniqueViolationError`; we treat that as "lost the race, the
+    # winner's row is already there" rather than letting it bubble out
+    # as a 500 to the runner (which then fails `tofu init` entirely).
+    # Mirror of the same handling in binary_cache_service.py.
     entry = CachedProviderPackage(
         hostname=hostname,
         namespace=namespace,
@@ -289,16 +299,26 @@ async def fetch_and_cache_single_platform(
         shasum=shasum,
     )
     db.add(entry)
-    await db.flush()
-
-    logger.info(
-        "Provider binary cached (on-demand)",
-        hostname=hostname,
-        provider=f"{namespace}/{type_}",
-        version=version,
-        platform=platform_key,
-        size_bytes=size_bytes,
-    )
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        logger.info(
+            "Provider cache race — another fetcher won; serving from existing row",
+            hostname=hostname,
+            provider=f"{namespace}/{type_}",
+            version=version,
+            platform=platform_key,
+        )
+    else:
+        logger.info(
+            "Provider binary cached (on-demand)",
+            hostname=hostname,
+            provider=f"{namespace}/{type_}",
+            version=version,
+            platform=platform_key,
+            size_bytes=size_bytes,
+        )
 
     presigned = await storage.presigned_get_url(key)
     return presigned.url

--- a/services/tests/services/test_provider_cache_service.py
+++ b/services/tests/services/test_provider_cache_service.py
@@ -1,0 +1,90 @@
+"""Tests for the provider network-mirror cache service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from terrapod.services.provider_cache_service import fetch_and_cache_single_platform
+
+
+class TestConcurrentCacheMissRace:
+    """Two concurrent cache-miss callers (typical when `tofu init` downloads
+    several providers in parallel against an empty cache) both stream the
+    binary into object storage, then both try to INSERT the
+    cached_provider_packages row. The unique constraint on
+    (hostname, namespace, type, version, os, arch) catches the second one;
+    the service swallows the IntegrityError and falls back to serving from
+    the row the winner just inserted, rather than letting the 5xx bubble out
+    to the runner (which would otherwise fail `tofu init`).
+
+    Regression for the data-pipelines-dev-us1 run that 500'd on
+    hashicorp/dns + clickhouse/clickhouse + hashicorp/aws cache misses.
+    """
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.provider_cache_service._get_cached_metadata", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.provider_cache_service._fetch_platform_download", new_callable=AsyncMock
+    )
+    @patch("terrapod.services.provider_cache_service.httpx.AsyncClient")
+    @patch("terrapod.services.provider_cache_service.HashingStream")
+    async def test_integrity_error_on_flush_falls_back_to_presigned_get(
+        self,
+        mock_hashing_stream: MagicMock,
+        mock_async_client: MagicMock,
+        mock_fetch_download: AsyncMock,
+        mock_get_cached_metadata: AsyncMock,
+    ) -> None:
+        # Empty Redis cache + upstream returns a download URL.
+        mock_get_cached_metadata.return_value = None
+        mock_fetch_download.return_value = {
+            "download_url": "https://upstream/example.zip",
+            "filename": "terraform-provider-dns_3.4.3_linux_amd64.zip",
+        }
+
+        # Streaming download: a single-pass HashingStream wraps the response.
+        stream_obj = MagicMock()
+        stream_obj.sha256_hex = "e2ecc873" * 8
+        stream_obj.size = 12_345_678
+        mock_hashing_stream.return_value = stream_obj
+
+        # httpx.AsyncClient().stream() context manager + AsyncClient() context manager.
+        client_ctx = AsyncMock()
+        client_ctx.__aenter__.return_value = client_ctx
+        client_ctx.__aexit__.return_value = None
+        mock_async_client.return_value = client_ctx
+        stream_ctx = AsyncMock()
+        stream_resp = MagicMock()
+        stream_resp.raise_for_status = MagicMock()
+        stream_ctx.__aenter__.return_value = stream_resp
+        stream_ctx.__aexit__.return_value = None
+        client_ctx.stream = MagicMock(return_value=stream_ctx)
+
+        # DB: simulate the unique-constraint violation on flush.
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.flush.side_effect = IntegrityError(
+            "INSERT", {}, Exception("uq_cached_provider_packages")
+        )
+
+        storage = AsyncMock()
+        storage.put_stream = AsyncMock()
+        presigned = MagicMock()
+        presigned.url = "https://example/presigned/dns.zip"
+        storage.presigned_get_url = AsyncMock(return_value=presigned)
+
+        url = await fetch_and_cache_single_platform(
+            db,
+            storage,
+            hostname="registry.opentofu.org",
+            namespace="hashicorp",
+            type_="dns",
+            version="3.4.3",
+            os_="linux",
+            arch="amd64",
+        )
+
+        # The race is handled: presigned URL is returned, not propagated as 500.
+        assert url == "https://example/presigned/dns.zip"
+        db.rollback.assert_awaited_once()


### PR DESCRIPTION
## Problem

When `tofu init` downloads several providers in parallel against an empty cache, two API replicas can both serve the same `/v1/providers/.../<provider>/<version>.json` cache-miss request at the same moment. Both stream the binary into object storage (idempotent — same content, same key) and both try to `INSERT INTO cached_provider_packages`; the unique constraint on `(hostname, namespace, type, version, os, arch)` lets the first commit succeed, the second hits `UniqueViolationError`, the SQLAlchemy session goes into `PendingRollbackError`, and the handler returns **500**. The runner then fails `tofu init` outright.

Caught in production when a workspace whose root module pulled four providers in parallel hit the network mirror — three of the four returned 500 within milliseconds of each other while the fourth (which happened to win every race) succeeded.

The binary cache service already handles exactly this race (see `binary_cache_service.py:170-181`); the provider cache just never got the same treatment.

## Fix

Mirror the binary cache pattern exactly — same comment, same try/except, same log shape. The loser of the race rolls back, logs at info, and proceeds to presign from the row the winner just wrote (which IS in the DB at that point).

Before:

\`\`\`python
db.add(entry)
await db.flush()
\`\`\`

After:

\`\`\`python
db.add(entry)
try:
    await db.flush()
except IntegrityError:
    await db.rollback()
    logger.info("Provider cache race — another fetcher won; serving from existing row", ...)
else:
    logger.info("Provider binary cached (on-demand)", ...)
\`\`\`

## Tests

New regression test in `tests/services/test_provider_cache_service.py` mirrors `test_binary_cache_service.py::TestConcurrentCacheMissRace` — makes `db.flush` raise `IntegrityError`, verifies that the function still returns the presigned URL (not a 5xx propagation) and that `db.rollback` was awaited.

Full test suite passes (`1573 passed`).

## Notes

- The downloaded binary in object storage is unaffected: both writers PUT to the same content-addressed key. The "lost" insert just means the row was already in state.
- Server-side stack trace from the production incident:
  \`\`\`
  duplicate key value violates unique constraint "uq_cached_provider_packages"
  DETAIL: Key (hostname, namespace, type, version, os, arch)
         =(<host>, <ns>, <type>, <version>, linux, amd64) already exists.
  \`\`\`