### PR TITLE
fix(migrate): emit relative path for implicit local backend, --workspace follow up

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -209,7 +209,7 @@ The following are detected and listed but **not** rewritten because the
 substitutions aren't mechanical:
 
 - `provider "tfe" {}` declarations and `resource "tfe_*" {}` / `data
-"tfe_*" {}` blocks — different attribute shapes.
+  "tfe_*" {}` blocks — different attribute shapes.
 
 Module source rewriting is **opt-in** via `--rewrite-modules` on the
 `rewrite` subcommand. Module pins are higher-blast-radius than backend
@@ -225,7 +225,7 @@ consciously. When `--rewrite-modules` is set, the rewriter walks every
   can't fulfil it). `--allow-missing-module-mapping` downgrades to a
   warning.
 - **Git form** (`"git::https://..."`) — looks up the matching `module
-register` record by git URL. Same hard-error-by-default behaviour.
+  register` record by git URL. Same hard-error-by-default behaviour.
 - **Public registry form** (`"hashicorp/aws"`) — ignored, never
   rewritten.
 - **Local path** (`"./modules/vpc"`) — ignored, never rewritten.

--- a/migrate/cmd/terrapod-migrate/apply_test.go
+++ b/migrate/cmd/terrapod-migrate/apply_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,6 +80,65 @@ projects:
 		if ws.VCSConnectionRef != connSourceID {
 			t.Errorf("workspace %q vcs ref = %q, want %q", ws.Name, ws.VCSConnectionRef, connSourceID)
 		}
+	}
+}
+
+func TestLoadDirectWorkspacePlan_Shape(t *testing.T) {
+	plan, stateReader, err := loadDirectWorkspacePlan("/tmp/fake", "my-workspace", atlantis.StateOptions{})
+	if err != nil {
+		t.Fatalf("loadDirectWorkspacePlan: %v", err)
+	}
+	if plan.Source != "atlantis" {
+		t.Errorf("plan.Source = %q, want %q", plan.Source, "atlantis")
+	}
+	if plan.SourceMetadata["mode"] != "direct-workspace" {
+		t.Errorf("metadata mode = %q", plan.SourceMetadata["mode"])
+	}
+	if plan.SourceMetadata["workspace"] != "my-workspace" {
+		t.Errorf("metadata workspace = %q", plan.SourceMetadata["workspace"])
+	}
+	if len(plan.Workspaces) != 1 {
+		t.Fatalf("expected 1 workspace, got %d", len(plan.Workspaces))
+	}
+	ws := plan.Workspaces[0]
+	if ws.SourceID != "direct:my-workspace" {
+		t.Errorf("SourceID = %q, want %q", ws.SourceID, "direct:my-workspace")
+	}
+	if ws.Name != "my-workspace" {
+		t.Errorf("Name = %q", ws.Name)
+	}
+	if stateReader == nil {
+		t.Fatal("stateReader is nil")
+	}
+}
+
+func TestLoadDirectWorkspacePlan_StateReaderCallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte("terraform {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	state := `{"version":4,"lineage":"direct-test-abc","serial":42,"terraform_version":"1.12.0","outputs":{},"resources":[]}`
+	if err := os.WriteFile(filepath.Join(dir, "terraform.tfstate"), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stateReader, err := loadDirectWorkspacePlan(dir, "ws", atlantis.StateOptions{})
+	if err != nil {
+		t.Fatalf("loadDirectWorkspacePlan: %v", err)
+	}
+
+	raw, lineage, serial, err := stateReader(context.Background(), "ignored-source-id")
+	if err != nil {
+		t.Fatalf("stateReader: %v", err)
+	}
+	if string(raw) != state {
+		t.Errorf("raw mismatch")
+	}
+	if lineage != "direct-test-abc" {
+		t.Errorf("lineage = %q", lineage)
+	}
+	if serial != 42 {
+		t.Errorf("serial = %d", serial)
 	}
 }
 

--- a/migrate/internal/hcl/backend.go
+++ b/migrate/internal/hcl/backend.go
@@ -168,7 +168,7 @@ func DetectBackend(dir string) (*Backend, error) {
 	// state-reader doesn't need a "no backend means local" branch.
 	return &Backend{
 		Kind:       BackendLocal,
-		Settings:   map[string]string{"path": filepath.Join(dir, "terraform.tfstate")},
+		Settings:   map[string]string{"path": "terraform.tfstate"},
 		SourceFile: "",
 	}, nil
 }

--- a/migrate/internal/hcl/backend_test.go
+++ b/migrate/internal/hcl/backend_test.go
@@ -111,9 +111,8 @@ variable "x" {}
 	if b.Kind != BackendLocal {
 		t.Errorf("Kind = %q, want %q", b.Kind, BackendLocal)
 	}
-	wantPath := filepath.Join(dir, "terraform.tfstate")
-	if b.Settings["path"] != wantPath {
-		t.Errorf("Settings[path] = %q, want %q", b.Settings["path"], wantPath)
+	if b.Settings["path"] != "terraform.tfstate" {
+		t.Errorf("Settings[path] = %q, want %q", b.Settings["path"], "terraform.tfstate")
 	}
 	if b.SourceFile != "" {
 		t.Errorf("SourceFile should be empty for implicit local, got %q", b.SourceFile)

--- a/migrate/internal/sources/atlantis/state_test.go
+++ b/migrate/internal/sources/atlantis/state_test.go
@@ -1,0 +1,113 @@
+package atlantis
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mattrobinsonsre/terrapod/migrate/internal/writer"
+)
+
+const validState = `{"version":4,"lineage":"abc-123","serial":7,"terraform_version":"1.12.0","outputs":{},"resources":[]}`
+
+func TestReadStateFromDir_ImplicitLocalBackend(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.tf", "terraform {}\n")
+	writeFile(t, dir, "terraform.tfstate", validState)
+
+	raw, lineage, serial, err := ReadStateFromDir(context.Background(), dir, StateOptions{})
+	if err != nil {
+		t.Fatalf("ReadStateFromDir: %v", err)
+	}
+	if string(raw) != validState {
+		t.Errorf("raw state mismatch: got %q", string(raw))
+	}
+	if lineage != "abc-123" {
+		t.Errorf("lineage = %q, want %q", lineage, "abc-123")
+	}
+	if serial != 7 {
+		t.Errorf("serial = %d, want 7", serial)
+	}
+}
+
+func TestReadStateFromDir_ExplicitLocalBackend(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.tf", `
+terraform {
+  backend "local" {
+    path = "state/my.tfstate"
+  }
+}
+`)
+	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "state/my.tfstate", validState)
+
+	raw, lineage, serial, err := ReadStateFromDir(context.Background(), dir, StateOptions{})
+	if err != nil {
+		t.Fatalf("ReadStateFromDir: %v", err)
+	}
+	if string(raw) != validState {
+		t.Errorf("raw state mismatch")
+	}
+	if lineage != "abc-123" {
+		t.Errorf("lineage = %q", lineage)
+	}
+	if serial != 7 {
+		t.Errorf("serial = %d", serial)
+	}
+}
+
+func TestReadStateFromDir_NoStateFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.tf", "terraform {}\n")
+
+	_, _, _, err := ReadStateFromDir(context.Background(), dir, StateOptions{})
+	if err == nil {
+		t.Fatal("expected error for missing state file")
+	}
+	var noState *writer.ErrNoStateForWorkspace
+	if !errors.As(err, &noState) {
+		t.Errorf("expected ErrNoStateForWorkspace, got: %v", err)
+	}
+}
+
+func TestReadStateFromDir_EmptyStateFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.tf", "terraform {}\n")
+	writeFile(t, dir, "terraform.tfstate", "")
+
+	_, _, _, err := ReadStateFromDir(context.Background(), dir, StateOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty state file")
+	}
+	var noState *writer.ErrNoStateForWorkspace
+	if !errors.As(err, &noState) {
+		t.Errorf("expected ErrNoStateForWorkspace, got: %v", err)
+	}
+}
+
+func TestReadStateFromDir_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.tf", "terraform {}\n")
+	writeFile(t, dir, "terraform.tfstate", `{"lineage": broken}`)
+
+	_, _, _, err := ReadStateFromDir(context.Background(), dir, StateOptions{})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestReadStateFromDir_MissingLineage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.tf", "terraform {}\n")
+	writeFile(t, dir, "terraform.tfstate", `{"version":4,"serial":1}`)
+
+	_, _, _, err := ReadStateFromDir(context.Background(), dir, StateOptions{})
+	if err == nil {
+		t.Fatal("expected error for missing lineage")
+	}
+}


### PR DESCRIPTION
## Summary
- Fix latent bug in `DetectBackend`: implicit-local-backend fallback emitted an absolute path, but `readLocalState` rejects absolute paths as a traversal guard
- Add unit tests for `ReadStateFromDir` (local backend happy path, missing/empty state, invalid JSON, missing lineage)
- Add unit tests for `loadDirectWorkspacePlan` (plan shape, state reader call-through)