### PR TITLE
feat: display module inputs/outputs in registry

### DIFF
--- a/alembic/versions/00b4c01e70e7_add_plan_summary_counts.py
+++ b/alembic/versions/00b4c01e70e7_add_plan_summary_counts.py
@@ -28,8 +28,12 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.add_column("runs", sa.Column("resource_additions", sa.Integer(), nullable=True))
     op.add_column("runs", sa.Column("resource_changes", sa.Integer(), nullable=True))
-    op.add_column("runs", sa.Column("resource_destructions", sa.Integer(), nullable=True))
-    op.add_column("runs", sa.Column("resource_replacements", sa.Integer(), nullable=True))
+    op.add_column(
+        "runs", sa.Column("resource_destructions", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "runs", sa.Column("resource_replacements", sa.Integer(), nullable=True)
+    )
     op.add_column("runs", sa.Column("resource_imports", sa.Integer(), nullable=True))
 
 

--- a/alembic/versions/1253815f7106_initial_schema.py
+++ b/alembic/versions/1253815f7106_initial_schema.py
@@ -25,7 +25,9 @@ def upgrade() -> None:
         sa.Column("email", sa.String(255), primary_key=True),
         sa.Column("display_name", sa.String(255), nullable=True),
         sa.Column("password_hash", sa.String(255), nullable=True),
-        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
         sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column(
             "created_at",
@@ -63,8 +65,12 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("'{}'::jsonb"),
         ),
-        sa.Column("deny_names", JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")),
-        sa.Column("workspace_permission", sa.String(20), nullable=False, server_default="read"),
+        sa.Column(
+            "deny_names", JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")
+        ),
+        sa.Column(
+            "workspace_permission", sa.String(20), nullable=False, server_default="read"
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -135,7 +141,9 @@ def upgrade() -> None:
         sa.Column("id", UUID(as_uuid=True), primary_key=True),
         sa.Column("name", sa.String(63), unique=True, nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("service_account_name", sa.String(63), nullable=False, server_default=""),
+        sa.Column(
+            "service_account_name", sa.String(63), nullable=False, server_default=""
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -163,8 +171,12 @@ def upgrade() -> None:
         sa.Column("description", sa.String(255), nullable=False, server_default=""),
         sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("max_uses", sa.Integer(), nullable=True),
-        sa.Column("use_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("is_revoked", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "use_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "is_revoked", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -174,7 +186,9 @@ def upgrade() -> None:
         sa.Column("created_by", sa.String(255), nullable=False),
     )
     op.create_index("ix_agent_pool_tokens_pool_id", "agent_pool_tokens", ["pool_id"])
-    op.create_index("ix_agent_pool_tokens_token_hash", "agent_pool_tokens", ["token_hash"])
+    op.create_index(
+        "ix_agent_pool_tokens_token_hash", "agent_pool_tokens", ["token_hash"]
+    )
 
     op.create_table(
         "runner_listeners",
@@ -233,15 +247,21 @@ def upgrade() -> None:
         sa.Column("name", sa.String(255), nullable=False),
         sa.Column("server_url", sa.String(500), nullable=False, server_default=""),
         sa.Column("token", sa.Text(), nullable=True),
-        sa.Column("github_app_id", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "github_app_id", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
         sa.Column(
             "github_installation_id",
             sa.Integer(),
             nullable=False,
             server_default=sa.text("0"),
         ),
-        sa.Column("github_account_login", sa.String(255), nullable=False, server_default=""),
-        sa.Column("github_account_type", sa.String(20), nullable=False, server_default=""),
+        sa.Column(
+            "github_account_login", sa.String(255), nullable=False, server_default=""
+        ),
+        sa.Column(
+            "github_account_type", sa.String(20), nullable=False, server_default=""
+        ),
         sa.Column("status", sa.String(20), nullable=False, server_default="active"),
         sa.Column(
             "created_at",
@@ -266,12 +286,24 @@ def upgrade() -> None:
         "workspaces",
         sa.Column("id", UUID(as_uuid=True), primary_key=True),
         sa.Column("name", sa.String(90), nullable=False),
-        sa.Column("execution_mode", sa.String(20), nullable=False, server_default="local"),
-        sa.Column("auto_apply", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("execution_backend", sa.String(20), nullable=False, server_default="tofu"),
-        sa.Column("terraform_version", sa.String(20), nullable=False, server_default="1.9"),
-        sa.Column("working_directory", sa.String(500), nullable=False, server_default=""),
-        sa.Column("locked", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "execution_mode", sa.String(20), nullable=False, server_default="local"
+        ),
+        sa.Column(
+            "auto_apply", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "execution_backend", sa.String(20), nullable=False, server_default="tofu"
+        ),
+        sa.Column(
+            "terraform_version", sa.String(20), nullable=False, server_default="1.9"
+        ),
+        sa.Column(
+            "working_directory", sa.String(500), nullable=False, server_default=""
+        ),
+        sa.Column(
+            "locked", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column("lock_id", sa.String(255), nullable=True),
         sa.Column(
             "agent_pool_id",
@@ -280,9 +312,13 @@ def upgrade() -> None:
             nullable=True,
         ),
         sa.Column("resource_cpu", sa.String(20), nullable=False, server_default="1"),
-        sa.Column("resource_memory", sa.String(20), nullable=False, server_default="2Gi"),
+        sa.Column(
+            "resource_memory", sa.String(20), nullable=False, server_default="2Gi"
+        ),
         # RBAC
-        sa.Column("labels", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column(
+            "labels", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")
+        ),
         sa.Column("owner_email", sa.String(255), nullable=False, server_default=""),
         # VCS
         sa.Column(
@@ -293,8 +329,12 @@ def upgrade() -> None:
         ),
         sa.Column("vcs_repo_url", sa.String(500), nullable=False, server_default=""),
         sa.Column("vcs_branch", sa.String(255), nullable=False, server_default=""),
-        sa.Column("vcs_working_directory", sa.String(500), nullable=False, server_default=""),
-        sa.Column("vcs_last_commit_sha", sa.String(40), nullable=False, server_default=""),
+        sa.Column(
+            "vcs_working_directory", sa.String(500), nullable=False, server_default=""
+        ),
+        sa.Column(
+            "vcs_last_commit_sha", sa.String(40), nullable=False, server_default=""
+        ),
         # Drift detection
         sa.Column(
             "drift_detection_enabled",
@@ -338,7 +378,9 @@ def upgrade() -> None:
         sa.Column("serial", sa.Integer(), nullable=False),
         sa.Column("lineage", sa.String(63), nullable=False, server_default=""),
         sa.Column("md5", sa.String(32), nullable=False, server_default=""),
-        sa.Column("state_size", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "state_size", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -347,7 +389,9 @@ def upgrade() -> None:
         ),
         sa.UniqueConstraint("workspace_id", "serial", name="uq_state_versions"),
     )
-    op.create_index("ix_state_versions_workspace_id", "state_versions", ["workspace_id"])
+    op.create_index(
+        "ix_state_versions_workspace_id", "state_versions", ["workspace_id"]
+    )
 
     # --- Registry ---
 
@@ -358,7 +402,9 @@ def upgrade() -> None:
         sa.Column("name", sa.String(63), nullable=False),
         sa.Column("provider", sa.String(63), nullable=False),
         sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
-        sa.Column("labels", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column(
+            "labels", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")
+        ),
         sa.Column("owner_email", sa.String(255), nullable=False, server_default=""),
         # VCS source tracking
         sa.Column("source", sa.String(20), nullable=False, server_default="upload"),
@@ -370,7 +416,9 @@ def upgrade() -> None:
         ),
         sa.Column("vcs_repo_url", sa.String(500), nullable=False, server_default=""),
         sa.Column("vcs_branch", sa.String(255), nullable=False, server_default=""),
-        sa.Column("vcs_tag_pattern", sa.String(255), nullable=False, server_default="v*"),
+        sa.Column(
+            "vcs_tag_pattern", sa.String(255), nullable=False, server_default="v*"
+        ),
         sa.Column("vcs_last_tag", sa.String(255), nullable=False, server_default=""),
         sa.Column(
             "created_at",
@@ -384,7 +432,9 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint("namespace", "name", "provider", name="uq_registry_modules"),
+        sa.UniqueConstraint(
+            "namespace", "name", "provider", name="uq_registry_modules"
+        ),
     )
 
     op.create_table(
@@ -397,7 +447,9 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("version", sa.String(63), nullable=False),
-        sa.Column("upload_status", sa.String(20), nullable=False, server_default="pending"),
+        sa.Column(
+            "upload_status", sa.String(20), nullable=False, server_default="pending"
+        ),
         sa.Column("vcs_commit_sha", sa.String(64), nullable=False, server_default=""),
         sa.Column("vcs_tag", sa.String(255), nullable=False, server_default=""),
         sa.Column(
@@ -420,7 +472,9 @@ def upgrade() -> None:
         sa.Column("id", UUID(as_uuid=True), primary_key=True),
         sa.Column("namespace", sa.String(63), nullable=False),
         sa.Column("name", sa.String(63), nullable=False),
-        sa.Column("labels", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column(
+            "labels", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")
+        ),
         sa.Column("owner_email", sa.String(255), nullable=False, server_default=""),
         sa.Column(
             "created_at",
@@ -506,7 +560,9 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint("provider_id", "version", name="uq_registry_provider_versions"),
+        sa.UniqueConstraint(
+            "provider_id", "version", name="uq_registry_provider_versions"
+        ),
     )
 
     op.create_table(
@@ -522,14 +578,18 @@ def upgrade() -> None:
         sa.Column("arch", sa.String(20), nullable=False),
         sa.Column("shasum", sa.String(64), nullable=False, server_default=""),
         sa.Column("filename", sa.String(255), nullable=False, server_default=""),
-        sa.Column("upload_status", sa.String(20), nullable=False, server_default="pending"),
+        sa.Column(
+            "upload_status", sa.String(20), nullable=False, server_default="pending"
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint("version_id", "os", "arch", name="uq_registry_provider_platforms"),
+        sa.UniqueConstraint(
+            "version_id", "os", "arch", name="uq_registry_provider_platforms"
+        ),
     )
 
     # --- Cache ---
@@ -600,9 +660,13 @@ def upgrade() -> None:
         sa.Column("key", sa.String(255), nullable=False),
         sa.Column("value", sa.Text(), nullable=False, server_default=""),
         sa.Column("description", sa.Text(), nullable=False, server_default=""),
-        sa.Column("category", sa.String(20), nullable=False, server_default="terraform"),
+        sa.Column(
+            "category", sa.String(20), nullable=False, server_default="terraform"
+        ),
         sa.Column("hcl", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("sensitive", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "sensitive", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column("version_id", sa.String(64), nullable=False, server_default=""),
         sa.Column(
             "created_at",
@@ -625,8 +689,12 @@ def upgrade() -> None:
         sa.Column("id", UUID(as_uuid=True), primary_key=True),
         sa.Column("name", sa.String(255), nullable=False),
         sa.Column("description", sa.Text(), nullable=False, server_default=""),
-        sa.Column("global_set", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("priority", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "global_set", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "priority", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -654,9 +722,13 @@ def upgrade() -> None:
         sa.Column("key", sa.String(255), nullable=False),
         sa.Column("value", sa.Text(), nullable=False, server_default=""),
         sa.Column("description", sa.Text(), nullable=False, server_default=""),
-        sa.Column("category", sa.String(20), nullable=False, server_default="terraform"),
+        sa.Column(
+            "category", sa.String(20), nullable=False, server_default="terraform"
+        ),
         sa.Column("hcl", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("sensitive", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "sensitive", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column("version_id", sa.String(64), nullable=False, server_default=""),
         sa.Column(
             "created_at",
@@ -713,7 +785,9 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("true"),
         ),
-        sa.Column("speculative", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "speculative", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -746,14 +820,26 @@ def upgrade() -> None:
         ),
         sa.Column("status", sa.String(30), nullable=False, server_default="pending"),
         sa.Column("message", sa.Text(), nullable=False, server_default=""),
-        sa.Column("is_destroy", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("auto_apply", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("plan_only", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "is_destroy", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "auto_apply", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "plan_only", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column("source", sa.String(30), nullable=False, server_default="tfe-api"),
-        sa.Column("execution_backend", sa.String(20), nullable=False, server_default="tofu"),
-        sa.Column("terraform_version", sa.String(20), nullable=False, server_default=""),
+        sa.Column(
+            "execution_backend", sa.String(20), nullable=False, server_default="tofu"
+        ),
+        sa.Column(
+            "terraform_version", sa.String(20), nullable=False, server_default=""
+        ),
         sa.Column("resource_cpu", sa.String(20), nullable=False, server_default="1"),
-        sa.Column("resource_memory", sa.String(20), nullable=False, server_default="2Gi"),
+        sa.Column(
+            "resource_memory", sa.String(20), nullable=False, server_default="2Gi"
+        ),
         sa.Column(
             "pool_id",
             UUID(as_uuid=True),
@@ -819,7 +905,9 @@ def upgrade() -> None:
         sa.Column("resource_id", sa.String(255), nullable=False, server_default=""),
         sa.Column("status_code", sa.Integer(), nullable=False),
         sa.Column("request_id", sa.String(63), nullable=False, server_default=""),
-        sa.Column("duration_ms", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "duration_ms", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
         sa.Column("detail", sa.Text(), nullable=False, server_default=""),
         sa.Column(
             "created_at",
@@ -830,7 +918,9 @@ def upgrade() -> None:
     )
     op.create_index("ix_audit_logs_timestamp", "audit_logs", ["timestamp"])
     op.create_index("ix_audit_logs_actor_email", "audit_logs", ["actor_email"])
-    op.create_index("ix_audit_logs_resource", "audit_logs", ["resource_type", "resource_id"])
+    op.create_index(
+        "ix_audit_logs_resource", "audit_logs", ["resource_type", "resource_id"]
+    )
 
     # --- Run Triggers ---
 
@@ -855,9 +945,13 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.UniqueConstraint("workspace_id", "source_workspace_id", name="uq_run_triggers"),
+        sa.UniqueConstraint(
+            "workspace_id", "source_workspace_id", name="uq_run_triggers"
+        ),
     )
-    op.create_index("ix_run_triggers_source_workspace_id", "run_triggers", ["source_workspace_id"])
+    op.create_index(
+        "ix_run_triggers_source_workspace_id", "run_triggers", ["source_workspace_id"]
+    )
 
     # --- Notification Configurations ---
 
@@ -874,8 +968,12 @@ def upgrade() -> None:
         sa.Column("destination_type", sa.String(20), nullable=False),
         sa.Column("url", sa.String(2000), nullable=False, server_default=""),
         sa.Column("token", sa.Text(), nullable=True),
-        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("triggers", JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")),
+        sa.Column(
+            "enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "triggers", JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")
+        ),
         sa.Column(
             "email_addresses",
             JSONB(),
@@ -921,7 +1019,9 @@ def upgrade() -> None:
         sa.Column("name", sa.String(255), nullable=False),
         sa.Column("url", sa.String(2000), nullable=False),
         sa.Column("hmac_key", sa.Text(), nullable=True),
-        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
         sa.Column("stage", sa.String(20), nullable=False),
         sa.Column(
             "enforcement_level",
@@ -997,7 +1097,9 @@ def upgrade() -> None:
             server_default=sa.func.now(),
         ),
     )
-    op.create_index("ix_task_stage_results_task_stage_id", "task_stage_results", ["task_stage_id"])
+    op.create_index(
+        "ix_task_stage_results_task_stage_id", "task_stage_results", ["task_stage_id"]
+    )
 
 
 def downgrade() -> None:

--- a/alembic/versions/1b7bc2b4e011_add_module_impact_analysis.py
+++ b/alembic/versions/1b7bc2b4e011_add_module_impact_analysis.py
@@ -41,7 +41,9 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("created_by", sa.Text(), nullable=False),
-        sa.UniqueConstraint("module_id", "workspace_id", name="uq_module_workspace_links"),
+        sa.UniqueConstraint(
+            "module_id", "workspace_id", name="uq_module_workspace_links"
+        ),
     )
     op.create_index(
         "ix_module_workspace_links_module_id",

--- a/alembic/versions/1f15ac58564c_drop_agent_pool_service_account_name.py
+++ b/alembic/versions/1f15ac58564c_drop_agent_pool_service_account_name.py
@@ -24,5 +24,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.add_column(
         "agent_pools",
-        sa.Column("service_account_name", sa.String(63), nullable=False, server_default=""),
+        sa.Column(
+            "service_account_name", sa.String(63), nullable=False, server_default=""
+        ),
     )

--- a/alembic/versions/355a27a76df4_add_api_token_lifespan_hours.py
+++ b/alembic/versions/355a27a76df4_add_api_token_lifespan_hours.py
@@ -13,7 +13,9 @@ down_revision = "1f15ac58564c"
 
 
 def upgrade() -> None:
-    op.add_column("api_tokens", sa.Column("lifespan_hours", sa.Integer(), nullable=True))
+    op.add_column(
+        "api_tokens", sa.Column("lifespan_hours", sa.Integer(), nullable=True)
+    )
 
 
 def downgrade() -> None:

--- a/alembic/versions/3efe17078298_add_vcs_error_tracking.py
+++ b/alembic/versions/3efe17078298_add_vcs_error_tracking.py
@@ -19,7 +19,9 @@ def upgrade() -> None:
         "workspaces",
         sa.Column("vcs_last_polled_at", sa.DateTime(timezone=True), nullable=True),
     )
-    op.add_column("workspaces", sa.Column("vcs_last_error", sa.String(500), nullable=True))
+    op.add_column(
+        "workspaces", sa.Column("vcs_last_error", sa.String(500), nullable=True)
+    )
     op.add_column(
         "workspaces",
         sa.Column("vcs_last_error_at", sa.DateTime(timezone=True), nullable=True),

--- a/alembic/versions/3f0ad398be2c_autodiscovery_lifecycle.py
+++ b/alembic/versions/3f0ad398be2c_autodiscovery_lifecycle.py
@@ -38,7 +38,9 @@ def upgrade() -> None:
     )
     op.add_column(
         "workspaces",
-        sa.Column("lifecycle_reason", sa.String(500), nullable=False, server_default=""),
+        sa.Column(
+            "lifecycle_reason", sa.String(500), nullable=False, server_default=""
+        ),
     )
     op.add_column(
         "workspaces",

--- a/alembic/versions/42266b856e8e_workspace_remote_state_consumers.py
+++ b/alembic/versions/42266b856e8e_workspace_remote_state_consumers.py
@@ -63,6 +63,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("ix_wrsc_producer_workspace_id", table_name="workspace_remote_state_consumers")
-    op.drop_index("ix_wrsc_consumer_workspace_id", table_name="workspace_remote_state_consumers")
+    op.drop_index(
+        "ix_wrsc_producer_workspace_id", table_name="workspace_remote_state_consumers"
+    )
+    op.drop_index(
+        "ix_wrsc_consumer_workspace_id", table_name="workspace_remote_state_consumers"
+    )
     op.drop_table("workspace_remote_state_consumers")

--- a/alembic/versions/5a173d4b4e20_policy_sets.py
+++ b/alembic/versions/5a173d4b4e20_policy_sets.py
@@ -37,7 +37,9 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("enabled", sa.Boolean(), server_default=sa.true(), nullable=False),
-        sa.Column("global_scope", sa.Boolean(), server_default=sa.false(), nullable=False),
+        sa.Column(
+            "global_scope", sa.Boolean(), server_default=sa.false(), nullable=False
+        ),
         sa.Column("allow_labels", JSONB(), server_default="{}", nullable=False),
         sa.Column("allow_names", JSONB(), server_default="[]", nullable=False),
         sa.Column("deny_labels", JSONB(), server_default="{}", nullable=False),
@@ -113,14 +115,20 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
-        sa.UniqueConstraint("run_id", "policy_set_id", name="uq_policy_evaluations_run_set"),
+        sa.UniqueConstraint(
+            "run_id", "policy_set_id", name="uq_policy_evaluations_run_set"
+        ),
     )
     op.create_index("ix_policy_evaluations_run_id", "policy_evaluations", ["run_id"])
-    op.create_index("ix_policy_evaluations_policy_set_id", "policy_evaluations", ["policy_set_id"])
+    op.create_index(
+        "ix_policy_evaluations_policy_set_id", "policy_evaluations", ["policy_set_id"]
+    )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_policy_evaluations_policy_set_id", table_name="policy_evaluations")
+    op.drop_index(
+        "ix_policy_evaluations_policy_set_id", table_name="policy_evaluations"
+    )
     op.drop_index("ix_policy_evaluations_run_id", table_name="policy_evaluations")
     op.drop_table("policy_evaluations")
     op.drop_index("ix_policies_policy_set_id", table_name="policies")

--- a/alembic/versions/6e2f3a8b9c10_add_module_interface.py
+++ b/alembic/versions/6e2f3a8b9c10_add_module_interface.py
@@ -17,7 +17,9 @@ depends_on = None
 
 def upgrade() -> None:
     op.add_column("registry_module_versions", sa.Column("inputs", JSONB, nullable=True))
-    op.add_column("registry_module_versions", sa.Column("outputs", JSONB, nullable=True))
+    op.add_column(
+        "registry_module_versions", sa.Column("outputs", JSONB, nullable=True)
+    )
 
 
 def downgrade() -> None:

--- a/alembic/versions/6e2f3a8b9c10_add_module_interface.py
+++ b/alembic/versions/6e2f3a8b9c10_add_module_interface.py
@@ -1,0 +1,25 @@
+"""add_module_interface
+
+Revision ID: 6e2f3a8b9c10
+Revises: 5a173d4b4e20
+Create Date: 2026-05-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "6e2f3a8b9c10"
+down_revision: str | None = "5a173d4b4e20"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("registry_module_versions", sa.Column("inputs", JSONB, nullable=True))
+    op.add_column("registry_module_versions", sa.Column("outputs", JSONB, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("registry_module_versions", "outputs")
+    op.drop_column("registry_module_versions", "inputs")

--- a/alembic/versions/8bb13bfef824_add_workspace_autodiscovery_rules.py
+++ b/alembic/versions/8bb13bfef824_add_workspace_autodiscovery_rules.py
@@ -28,7 +28,9 @@ down_revision = "ad9e14fa1469"
 def upgrade() -> None:
     op.create_table(
         "autodiscovery_rules",
-        sa.Column("id", sa.UUID(), nullable=False, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "id", sa.UUID(), nullable=False, server_default=sa.text("gen_random_uuid()")
+        ),
         # Scoping
         sa.Column("vcs_connection_id", sa.UUID(), nullable=False),
         sa.Column("repo_url", sa.String(2048), nullable=False),
@@ -39,15 +41,27 @@ def upgrade() -> None:
         # Identity
         sa.Column("name", sa.String(255), nullable=False),
         sa.Column("name_template", sa.String(255), nullable=False, server_default=""),
-        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
         # Workspace template
-        sa.Column("execution_mode", sa.String(20), nullable=False, server_default="agent"),
+        sa.Column(
+            "execution_mode", sa.String(20), nullable=False, server_default="agent"
+        ),
         sa.Column("agent_pool_id", sa.UUID(), nullable=True),
-        sa.Column("execution_backend", sa.String(20), nullable=False, server_default="tofu"),
-        sa.Column("terraform_version", sa.String(50), nullable=False, server_default="1.11"),
+        sa.Column(
+            "execution_backend", sa.String(20), nullable=False, server_default="tofu"
+        ),
+        sa.Column(
+            "terraform_version", sa.String(50), nullable=False, server_default="1.11"
+        ),
         sa.Column("resource_cpu", sa.String(20), nullable=False, server_default="1"),
-        sa.Column("resource_memory", sa.String(20), nullable=False, server_default="2Gi"),
-        sa.Column("auto_apply", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "resource_memory", sa.String(20), nullable=False, server_default="2Gi"
+        ),
+        sa.Column(
+            "auto_apply", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column("labels", JSONB, nullable=False, server_default="{}"),
         sa.Column("owner_email", sa.String(255), nullable=True),
         # Audit
@@ -64,9 +78,15 @@ def upgrade() -> None:
             server_default=sa.func.now(),
         ),
         sa.PrimaryKeyConstraint("id"),
-        sa.ForeignKeyConstraint(["vcs_connection_id"], ["vcs_connections.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["agent_pool_id"], ["agent_pools.id"], ondelete="SET NULL"),
-        sa.UniqueConstraint("vcs_connection_id", "name", name="uq_autodiscovery_rule_name"),
+        sa.ForeignKeyConstraint(
+            ["vcs_connection_id"], ["vcs_connections.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_pool_id"], ["agent_pools.id"], ondelete="SET NULL"
+        ),
+        sa.UniqueConstraint(
+            "vcs_connection_id", "name", name="uq_autodiscovery_rule_name"
+        ),
     )
     op.create_index(
         "ix_autodiscovery_rules_repo",
@@ -91,7 +111,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_constraint("fk_workspaces_autodiscovery_rule_id", "workspaces", type_="foreignkey")
+    op.drop_constraint(
+        "fk_workspaces_autodiscovery_rule_id", "workspaces", type_="foreignkey"
+    )
     op.drop_column("workspaces", "autodiscovery_rule_id")
     op.drop_index("ix_autodiscovery_rules_repo", table_name="autodiscovery_rules")
     op.drop_table("autodiscovery_rules")

--- a/alembic/versions/ad9e14fa1469_add_agent_pool_rbac.py
+++ b/alembic/versions/ad9e14fa1469_add_agent_pool_rbac.py
@@ -18,13 +18,19 @@ down_revision = "cc6a19db3ee3"
 
 def upgrade() -> None:
     # AgentPool additions
-    op.add_column("agent_pools", sa.Column("labels", JSONB, nullable=False, server_default="{}"))
-    op.add_column("agent_pools", sa.Column("owner_email", sa.String(255), nullable=True))
+    op.add_column(
+        "agent_pools", sa.Column("labels", JSONB, nullable=False, server_default="{}")
+    )
+    op.add_column(
+        "agent_pools", sa.Column("owner_email", sa.String(255), nullable=True)
+    )
 
     # Role addition
     op.add_column(
         "roles",
-        sa.Column("pool_permission", sa.String(20), nullable=False, server_default="read"),
+        sa.Column(
+            "pool_permission", sa.String(20), nullable=False, server_default="read"
+        ),
     )
 
     # Backward compat: existing pools get access=everyone so they remain

--- a/alembic/versions/b43b10a4da62_add_workspace_var_files.py
+++ b/alembic/versions/b43b10a4da62_add_workspace_var_files.py
@@ -18,7 +18,9 @@ depends_on = None
 def upgrade() -> None:
     op.add_column(
         "workspaces",
-        sa.Column("var_files", ARRAY(sa.String(500)), nullable=False, server_default="{}"),
+        sa.Column(
+            "var_files", ARRAY(sa.String(500)), nullable=False, server_default="{}"
+        ),
     )
 
 

--- a/alembic/versions/c17aecf92ac8_add_apply_then_merge_schema.py
+++ b/alembic/versions/c17aecf92ac8_add_apply_then_merge_schema.py
@@ -87,9 +87,13 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("now()"),
         ),
-        sa.UniqueConstraint("vcs_connection_id", "repo", "pr_number", name="uq_pr_session"),
+        sa.UniqueConstraint(
+            "vcs_connection_id", "repo", "pr_number", name="uq_pr_session"
+        ),
     )
-    op.create_index("ix_pr_sessions_open", "pr_sessions", ["vcs_connection_id", "state"])
+    op.create_index(
+        "ix_pr_sessions_open", "pr_sessions", ["vcs_connection_id", "state"]
+    )
 
 
 def downgrade() -> None:

--- a/alembic/versions/cc6a19db3ee3_rename_execution_mode_remote_to_agent.py
+++ b/alembic/versions/cc6a19db3ee3_rename_execution_mode_remote_to_agent.py
@@ -13,8 +13,12 @@ from alembic import op  # noqa: E402
 
 
 def upgrade() -> None:
-    op.execute("UPDATE workspaces SET execution_mode = 'agent' WHERE execution_mode = 'remote'")
+    op.execute(
+        "UPDATE workspaces SET execution_mode = 'agent' WHERE execution_mode = 'remote'"
+    )
 
 
 def downgrade() -> None:
-    op.execute("UPDATE workspaces SET execution_mode = 'remote' WHERE execution_mode = 'agent'")
+    op.execute(
+        "UPDATE workspaces SET execution_mode = 'remote' WHERE execution_mode = 'agent'"
+    )

--- a/alembic/versions/f3e984cc98cf_drop_runner_listeners.py
+++ b/alembic/versions/f3e984cc98cf_drop_runner_listeners.py
@@ -17,9 +17,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Drop FK constraint on runs.listener_id (keep column as bare UUID)
-    op.drop_constraint(
-        "runs_listener_id_fkey", "runs", type_="foreignkey"
-    )
+    op.drop_constraint("runs_listener_id_fkey", "runs", type_="foreignkey")
 
     # Drop runner_listeners table and its index
     op.drop_index("ix_runner_listeners_pool_id", table_name="runner_listeners")
@@ -59,9 +57,7 @@ def downgrade() -> None:
             server_default=sa.func.now(),
         ),
     )
-    op.create_index(
-        "ix_runner_listeners_pool_id", "runner_listeners", ["pool_id"]
-    )
+    op.create_index("ix_runner_listeners_pool_id", "runner_listeners", ["pool_id"])
 
     # Re-add FK constraint on runs.listener_id
     op.create_foreign_key(

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -284,8 +284,19 @@ When a module version is published (via upload or VCS tag), Terrapod parses the 
 
 | Block | Fields |
 |---|---|
-| `variable` | name, type, description, default, required, sensitive |
+| `variable` | name, type, type_schema, description, default, required, sensitive |
 | `output` | name, description, sensitive |
+
+`type` is the human-readable HCL type expression (e.g. `map(string)`). `type_schema` is the equivalent JSON Schema object, ready for client-side input validation without a server round-trip:
+
+| HCL type | `type_schema` |
+|---|---|
+| `string` | `{"type": "string"}` |
+| `number` | `{"type": "number"}` |
+| `bool` | `{"type": "boolean"}` |
+| `list(string)` | `{"type": "array", "items": {"type": "string"}}` |
+| `map(string)` | `{"type": "object", "additionalProperties": {"type": "string"}}` |
+| `object({name = string})` | `{"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}` |
 
 **API endpoint:**
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -276,6 +276,37 @@ Each version exposes VCS metadata in the API response:
 | `vcs-commit-sha` | The git commit SHA this version was built from (empty for manual uploads) |
 | `vcs-tag` | The tag name that matched (e.g. `v1.2.3`; empty for manual uploads) |
 
+### Module Interface (Inputs & Outputs)
+
+When a module version is published (via upload or VCS tag), Terrapod parses the `.tf` files at the module root to extract Terraform `variable` and `output` declarations. This metadata is stored with the version and displayed in the web UI as an expandable "Inputs & Outputs" card on the module detail page.
+
+**Extracted fields:**
+
+| Block | Fields |
+|---|---|
+| `variable` | name, type, description, default, required, sensitive |
+| `output` | name, description, sensitive |
+
+**API endpoint:**
+
+```text
+GET /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/{version}/interface
+```
+
+Returns `inputs` and `outputs` arrays. Returns `null` for versions published before this feature was enabled or when the feature is disabled.
+
+**Configuration:**
+
+```yaml
+api:
+  config:
+    registry:
+      module_interface:
+        enabled: true   # set to false to disable extraction and hide the endpoint
+```
+
+When disabled, the endpoint returns 404 and no HCL parsing occurs during ingest. The web UI gracefully shows "No interface data available" for versions without interface data.
+
 ---
 
 ## Module Impact Analysis

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -593,6 +593,13 @@
                   "enum": ["none", "rc", "beta", "alpha", "dev"]
                 }
               }
+            },
+            "module_interface": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" }
+              }
             }
           }
         },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -227,6 +227,8 @@ api:
         # in dev/staging to try upcoming releases like terraform 1.15-rc or
         # tofu 1.12-beta before they GA.
         allow_prerelease: none
+      module_interface:
+        enabled: true
 
     # GPG signing key for provider registry
     # ASCII-armored GPG private key. If set, used to sign all provider SHA256SUMS.

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -28,6 +28,8 @@ gcloud-aio-storage = "^9.6.4"
 sqlalchemy = {extras = ["asyncio"], version = "^2.0"}
 asyncpg = "^0.31.0"
 alembic = "^1.14.0"
+# HCL parsing (module interface extraction)
+python-hcl2 = "^7.0.0"
 # Redis
 redis = "^7.4.0"
 # Auth

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -34,7 +34,7 @@ from sqlalchemy.orm import selectinload
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_non_runner
 from terrapod.api.labels import validate_labels
-from terrapod.db.models import ModuleWorkspaceLink, Workspace
+from terrapod.db.models import ModuleWorkspaceLink, RegistryModuleVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.registry_module_service import (
@@ -354,6 +354,56 @@ async def show_module_endpoint(
         raise HTTPException(status_code=404, detail="Module not found")
 
     return JSONResponse(content={"data": _module_to_jsonapi(module, perm)})
+
+
+@management_router.get(
+    "/registry-modules/private/default/{name}/{provider}/{version}/interface"
+)
+async def module_interface_endpoint(
+    name: str,
+    provider: str,
+    version: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Get the inputs/outputs interface for a specific module version."""
+    module = await get_module(db, "default", name, provider)
+    if module is None:
+        raise HTTPException(status_code=404, detail="Module not found")
+
+    perm = await resolve_registry_permission(
+        db,
+        user.email,
+        user.roles,
+        module.name,
+        module.labels or {},
+        module.owner_email,
+        auth_method=user.auth_method,
+    )
+    if not has_registry_permission(perm, "read"):
+        raise HTTPException(status_code=404, detail="Module not found")
+
+    result = await db.execute(
+        select(RegistryModuleVersion).where(
+            RegistryModuleVersion.module_id == module.id,
+            RegistryModuleVersion.version == version,
+        )
+    )
+    mod_version = result.scalars().first()
+    if mod_version is None:
+        raise HTTPException(status_code=404, detail="Version not found")
+
+    return JSONResponse(content={
+        "data": {
+            "type": "module-interface",
+            "id": f"modver-{mod_version.id}",
+            "attributes": {
+                "version": mod_version.version,
+                "inputs": mod_version.inputs,
+                "outputs": mod_version.outputs,
+            },
+        }
+    })
 
 
 @management_router.delete("/registry-modules/private/default/{name}/{provider}")

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -367,6 +367,11 @@ async def module_interface_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Get the inputs/outputs interface for a specific module version."""
+    from terrapod.config import settings
+
+    if not settings.registry.module_interface.enabled:
+        raise HTTPException(status_code=404, detail="Module interface extraction is disabled")
+
     module = await get_module(db, "default", name, provider)
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -356,9 +356,7 @@ async def show_module_endpoint(
     return JSONResponse(content={"data": _module_to_jsonapi(module, perm)})
 
 
-@management_router.get(
-    "/registry-modules/private/default/{name}/{provider}/{version}/interface"
-)
+@management_router.get("/registry-modules/private/default/{name}/{provider}/{version}/interface")
 async def module_interface_endpoint(
     name: str,
     provider: str,
@@ -398,17 +396,19 @@ async def module_interface_endpoint(
     if mod_version is None:
         raise HTTPException(status_code=404, detail="Version not found")
 
-    return JSONResponse(content={
-        "data": {
-            "type": "module-interface",
-            "id": f"modver-{mod_version.id}",
-            "attributes": {
-                "version": mod_version.version,
-                "inputs": mod_version.inputs,
-                "outputs": mod_version.outputs,
-            },
+    return JSONResponse(
+        content={
+            "data": {
+                "type": "module-interface",
+                "id": f"modver-{mod_version.id}",
+                "attributes": {
+                    "version": mod_version.version,
+                    "inputs": mod_version.inputs,
+                    "outputs": mod_version.outputs,
+                },
+            }
         }
-    })
+    )
 
 
 @management_router.delete("/registry-modules/private/default/{name}/{provider}")

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -360,6 +360,12 @@ class BinaryCacheConfig(BaseModel):
     )
 
 
+class ModuleInterfaceConfig(BaseModel):
+    """Module interface extraction (inputs/outputs from HCL)."""
+
+    enabled: bool = Field(default=True)
+
+
 class RegistryConfig(BaseModel):
     """Private registry and caching configuration."""
 
@@ -373,6 +379,7 @@ class RegistryConfig(BaseModel):
     )
     provider_cache: ProviderCacheConfig = Field(default_factory=ProviderCacheConfig)
     binary_cache: BinaryCacheConfig = Field(default_factory=BinaryCacheConfig)
+    module_interface: ModuleInterfaceConfig = Field(default_factory=ModuleInterfaceConfig)
 
 
 # --- VCS Configuration ---

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -501,6 +501,9 @@ class RegistryModuleVersion(Base):
     vcs_commit_sha: Mapped[str] = mapped_column(String(64), nullable=False, default="")
     vcs_tag: Mapped[str] = mapped_column(String(255), nullable=False, default="")
 
+    inputs: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    outputs: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False
     )

--- a/services/terrapod/services/module_hcl_parser.py
+++ b/services/terrapod/services/module_hcl_parser.py
@@ -97,14 +97,18 @@ def _extract_variables(parsed: dict) -> list[dict]:
     for var_block in parsed.get("variable", []):
         for var_name, var_config in var_block.items():
             has_default = "default" in var_config
-            variables.append({
-                "name": var_name,
-                "type": _type_to_string(var_config.get("type")),
-                "description": var_config.get("description", ""),
-                "default": _serialize_default(var_config.get("default")) if has_default else None,
-                "required": not has_default,
-                "sensitive": bool(var_config.get("sensitive", False)),
-            })
+            variables.append(
+                {
+                    "name": var_name,
+                    "type": _type_to_string(var_config.get("type")),
+                    "description": var_config.get("description", ""),
+                    "default": _serialize_default(var_config.get("default"))
+                    if has_default
+                    else None,
+                    "required": not has_default,
+                    "sensitive": bool(var_config.get("sensitive", False)),
+                }
+            )
     return variables
 
 
@@ -113,9 +117,11 @@ def _extract_outputs(parsed: dict) -> list[dict]:
     outputs = []
     for out_block in parsed.get("output", []):
         for out_name, out_config in out_block.items():
-            outputs.append({
-                "name": out_name,
-                "description": out_config.get("description", ""),
-                "sensitive": bool(out_config.get("sensitive", False)),
-            })
+            outputs.append(
+                {
+                    "name": out_name,
+                    "description": out_config.get("description", ""),
+                    "sensitive": bool(out_config.get("sensitive", False)),
+                }
+            )
     return outputs

--- a/services/terrapod/services/module_hcl_parser.py
+++ b/services/terrapod/services/module_hcl_parser.py
@@ -1,0 +1,111 @@
+"""Extract Terraform variable and output declarations from module tarballs."""
+
+import io
+import json
+import tarfile
+
+import hcl2
+
+from terrapod.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def extract_module_interface(tarball_bytes: bytes) -> dict:
+    """Parse .tf files from a module tarball and extract variable/output blocks.
+
+    Returns {"inputs": [...], "outputs": [...]}.
+    Returns {"inputs": [], "outputs": []} on parse failure.
+    """
+    inputs: list[dict] = []
+    outputs: list[dict] = []
+
+    try:
+        tf_contents = _read_root_tf_files(tarball_bytes)
+        for content in tf_contents:
+            parsed = _parse_hcl(content)
+            if parsed is None:
+                continue
+            inputs.extend(_extract_variables(parsed))
+            outputs.extend(_extract_outputs(parsed))
+    except Exception:
+        logger.warning("Failed to extract module interface", exc_info=True)
+        return {"inputs": [], "outputs": []}
+
+    return {"inputs": inputs, "outputs": outputs}
+
+
+def _read_root_tf_files(tarball_bytes: bytes) -> list[str]:
+    """Read all .tf files at the root level of the tarball."""
+    contents = []
+    with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            if not member.isfile():
+                continue
+            if "/" in member.name:
+                continue
+            if not member.name.endswith(".tf"):
+                continue
+            f = tar.extractfile(member)
+            if f is None:
+                continue
+            contents.append(f.read().decode("utf-8", errors="replace"))
+    return contents
+
+
+def _parse_hcl(content: str) -> dict | None:
+    """Parse HCL content, returning None on failure."""
+    try:
+        return hcl2.loads(content)
+    except Exception:
+        return None
+
+
+def _serialize_default(value) -> str | None:
+    """Serialize a default value to a JSON-friendly string representation."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+def _type_to_string(type_val) -> str:
+    """Convert a python-hcl2 type representation to a readable string."""
+    if type_val is None:
+        return "any"
+    if isinstance(type_val, str):
+        return type_val
+    if isinstance(type_val, list) and len(type_val) > 0:
+        return str(type_val[0]) if len(type_val) == 1 else str(type_val)
+    return str(type_val)
+
+
+def _extract_variables(parsed: dict) -> list[dict]:
+    """Extract variable blocks from parsed HCL."""
+    variables = []
+    for var_block in parsed.get("variable", []):
+        for var_name, var_config in var_block.items():
+            has_default = "default" in var_config
+            variables.append({
+                "name": var_name,
+                "type": _type_to_string(var_config.get("type")),
+                "description": var_config.get("description", ""),
+                "default": _serialize_default(var_config.get("default")) if has_default else None,
+                "required": not has_default,
+                "sensitive": bool(var_config.get("sensitive", False)),
+            })
+    return variables
+
+
+def _extract_outputs(parsed: dict) -> list[dict]:
+    """Extract output blocks from parsed HCL."""
+    outputs = []
+    for out_block in parsed.get("output", []):
+        for out_name, out_config in out_block.items():
+            outputs.append({
+                "name": out_name,
+                "description": out_config.get("description", ""),
+                "sensitive": bool(out_config.get("sensitive", False)),
+            })
+    return outputs

--- a/services/terrapod/services/module_hcl_parser.py
+++ b/services/terrapod/services/module_hcl_parser.py
@@ -35,6 +35,9 @@ def extract_module_interface(tarball_bytes: bytes) -> dict:
     return {"inputs": inputs, "outputs": outputs}
 
 
+_MAX_TF_FILE_BYTES = 5 * 1024 * 1024  # 5 MB per file
+
+
 def _read_root_tf_files(tarball_bytes: bytes) -> list[str]:
     """Read all .tf files at the root level of the tarball."""
     contents = []
@@ -45,6 +48,13 @@ def _read_root_tf_files(tarball_bytes: bytes) -> list[str]:
             if "/" in member.name:
                 continue
             if not member.name.endswith(".tf"):
+                continue
+            if member.size > _MAX_TF_FILE_BYTES:
+                logger.warning(
+                    "Skipping oversized .tf file",
+                    file=member.name,
+                    size=member.size,
+                )
                 continue
             f = tar.extractfile(member)
             if f is None:

--- a/services/terrapod/services/module_hcl_parser.py
+++ b/services/terrapod/services/module_hcl_parser.py
@@ -80,15 +80,101 @@ def _serialize_default(value) -> str | None:
     return json.dumps(value)
 
 
-def _type_to_string(type_val) -> str:
-    """Convert a python-hcl2 type representation to a readable string."""
+def _normalize_type_expr(type_val) -> str:
+    """Normalize a python-hcl2 type value to a clean type expression string.
+
+    python-hcl2 returns types in varied forms:
+      - "string" (simple primitives)
+      - "${map(string)}" (interpolation-wrapped complex types)
+      - ["map", "string"] (list form in some versions)
+    This normalizes all forms to e.g. "string", "map(string)", "list(number)".
+    """
     if type_val is None:
         return "any"
     if isinstance(type_val, str):
+        if type_val.startswith("${") and type_val.endswith("}"):
+            return type_val[2:-1]
         return type_val
     if isinstance(type_val, list) and len(type_val) > 0:
         return str(type_val[0]) if len(type_val) == 1 else str(type_val)
     return str(type_val)
+
+
+def _type_expr_to_json_schema(expr: str) -> dict:
+    """Convert a normalized type expression to JSON Schema."""
+    expr = expr.strip()
+
+    if expr == "string":
+        return {"type": "string"}
+    if expr == "number":
+        return {"type": "number"}
+    if expr == "bool":
+        return {"type": "boolean"}
+    if expr == "any":
+        return {}
+
+    if expr.startswith("map(") and expr.endswith(")"):
+        return {"type": "object", "additionalProperties": _type_expr_to_json_schema(expr[4:-1])}
+
+    if expr.startswith("list(") and expr.endswith(")"):
+        return {"type": "array", "items": _type_expr_to_json_schema(expr[5:-1])}
+
+    if expr.startswith("set(") and expr.endswith(")"):
+        return {
+            "type": "array",
+            "uniqueItems": True,
+            "items": _type_expr_to_json_schema(expr[4:-1]),
+        }
+
+    if expr.startswith("tuple(") and expr.endswith(")"):
+        return {"type": "array"}
+
+    if expr.startswith("object(") and expr.endswith(")"):
+        return _parse_object_schema(expr[7:-1].strip())
+
+    return {}
+
+
+def _parse_object_schema(inner: str) -> dict:
+    """Parse an object type's inner block into JSON Schema properties."""
+    inner = inner.strip()
+    if inner.startswith("{") and inner.endswith("}"):
+        inner = inner[1:-1].strip()
+
+    if not inner:
+        return {"type": "object"}
+
+    properties = {}
+    for field in _split_object_fields(inner):
+        field = field.strip()
+        if "=" not in field:
+            continue
+        key, val = field.split("=", 1)
+        properties[key.strip()] = _type_expr_to_json_schema(val.strip())
+
+    return {"type": "object", "properties": properties, "required": list(properties.keys())}
+
+
+def _split_object_fields(inner: str) -> list[str]:
+    """Split object fields respecting nested parentheses/braces."""
+    fields = []
+    depth = 0
+    current = ""
+    for ch in inner:
+        if ch in ("(", "{", "["):
+            depth += 1
+            current += ch
+        elif ch in (")", "}", "]"):
+            depth -= 1
+            current += ch
+        elif ch == "," and depth == 0:
+            fields.append(current)
+            current = ""
+        else:
+            current += ch
+    if current.strip():
+        fields.append(current)
+    return fields
 
 
 def _extract_variables(parsed: dict) -> list[dict]:
@@ -98,11 +184,12 @@ def _extract_variables(parsed: dict) -> list[dict]:
         for var_name, var_config in var_block.items():
             has_default = "default" in var_config
             type_val = var_config.get("type")
+            type_expr = _normalize_type_expr(type_val)
             variables.append(
                 {
                     "name": var_name,
-                    "type": _type_to_string(type_val),
-                    "type_raw": type_val,
+                    "type": type_expr,
+                    "type_schema": _type_expr_to_json_schema(type_expr),
                     "description": var_config.get("description", ""),
                     "default": _serialize_default(var_config.get("default"))
                     if has_default

--- a/services/terrapod/services/module_hcl_parser.py
+++ b/services/terrapod/services/module_hcl_parser.py
@@ -97,10 +97,12 @@ def _extract_variables(parsed: dict) -> list[dict]:
     for var_block in parsed.get("variable", []):
         for var_name, var_config in var_block.items():
             has_default = "default" in var_config
+            type_val = var_config.get("type")
             variables.append(
                 {
                     "name": var_name,
-                    "type": _type_to_string(var_config.get("type")),
+                    "type": _type_to_string(type_val),
+                    "type_raw": type_val,
                     "description": var_config.get("description", ""),
                     "default": _serialize_default(var_config.get("default"))
                     if has_default

--- a/services/terrapod/services/registry_module_service.py
+++ b/services/terrapod/services/registry_module_service.py
@@ -176,6 +176,16 @@ async def upload_module_tarball(
     await storage.put(key, data, "application/gzip")
 
     mod_version.upload_status = "uploaded"
+
+    from terrapod.services.module_hcl_parser import extract_module_interface
+
+    try:
+        interface = extract_module_interface(data)
+        mod_version.inputs = interface["inputs"]
+        mod_version.outputs = interface["outputs"]
+    except Exception:
+        logger.warning("Failed to extract module interface on upload", exc_info=True)
+
     module.status = "setup_complete"
     await db.flush()
 

--- a/services/terrapod/services/registry_module_service.py
+++ b/services/terrapod/services/registry_module_service.py
@@ -177,14 +177,17 @@ async def upload_module_tarball(
 
     mod_version.upload_status = "uploaded"
 
-    from terrapod.services.module_hcl_parser import extract_module_interface
+    from terrapod.config import settings
 
-    try:
-        interface = extract_module_interface(data)
-        mod_version.inputs = interface["inputs"]
-        mod_version.outputs = interface["outputs"]
-    except Exception:
-        logger.warning("Failed to extract module interface on upload", exc_info=True)
+    if settings.registry.module_interface.enabled:
+        from terrapod.services.module_hcl_parser import extract_module_interface
+
+        try:
+            interface = extract_module_interface(data)
+            mod_version.inputs = interface["inputs"]
+            mod_version.outputs = interface["outputs"]
+        except Exception:
+            logger.warning("Failed to extract module interface on upload", exc_info=True)
 
     module.status = "setup_complete"
     await db.flush()

--- a/services/terrapod/services/registry_module_service.py
+++ b/services/terrapod/services/registry_module_service.py
@@ -180,10 +180,12 @@ async def upload_module_tarball(
     from terrapod.config import settings
 
     if settings.registry.module_interface.enabled:
+        import asyncio
+
         from terrapod.services.module_hcl_parser import extract_module_interface
 
         try:
-            interface = extract_module_interface(data)
+            interface = await asyncio.to_thread(extract_module_interface, data)
             mod_version.inputs = interface["inputs"]
             mod_version.outputs = interface["outputs"]
         except Exception:

--- a/services/terrapod/services/registry_vcs_poller.py
+++ b/services/terrapod/services/registry_vcs_poller.py
@@ -209,12 +209,16 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
         # Strip top-level directory wrapper from VCS archive before storing
         archive_bytes = await strip_archive_top_level_dir_async(archive_bytes)
 
-        from terrapod.services.module_hcl_parser import extract_module_interface
+        from terrapod.config import settings
 
-        try:
-            interface = extract_module_interface(archive_bytes)
-        except Exception:
-            interface = {"inputs": [], "outputs": []}
+        interface = None
+        if settings.registry.module_interface.enabled:
+            from terrapod.services.module_hcl_parser import extract_module_interface
+
+            try:
+                interface = extract_module_interface(archive_bytes)
+            except Exception:
+                interface = {"inputs": [], "outputs": []}
 
         # Store tarball (overwrites existing if tag was moved)
         key = module_tarball_key(module.namespace, module.name, module.provider, version_str)
@@ -224,8 +228,9 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
             # Tag moved to a different commit — update existing record
             existing.vcs_commit_sha = tag_sha
             existing.vcs_tag = tag_name
-            existing.inputs = interface["inputs"]
-            existing.outputs = interface["outputs"]
+            if interface:
+                existing.inputs = interface["inputs"]
+                existing.outputs = interface["outputs"]
             logger.info(
                 "Module version updated (tag moved)",
                 module_name=module.name,
@@ -242,8 +247,8 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
                 upload_status="uploaded",
                 vcs_commit_sha=tag_sha,
                 vcs_tag=tag_name,
-                inputs=interface["inputs"],
-                outputs=interface["outputs"],
+                inputs=interface["inputs"] if interface else None,
+                outputs=interface["outputs"] if interface else None,
             )
             db.add(mod_version)
             existing_versions[version_str] = mod_version

--- a/services/terrapod/services/registry_vcs_poller.py
+++ b/services/terrapod/services/registry_vcs_poller.py
@@ -209,6 +209,13 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
         # Strip top-level directory wrapper from VCS archive before storing
         archive_bytes = await strip_archive_top_level_dir_async(archive_bytes)
 
+        from terrapod.services.module_hcl_parser import extract_module_interface
+
+        try:
+            interface = extract_module_interface(archive_bytes)
+        except Exception:
+            interface = {"inputs": [], "outputs": []}
+
         # Store tarball (overwrites existing if tag was moved)
         key = module_tarball_key(module.namespace, module.name, module.provider, version_str)
         await storage.put(key, archive_bytes, "application/gzip")
@@ -217,6 +224,8 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
             # Tag moved to a different commit — update existing record
             existing.vcs_commit_sha = tag_sha
             existing.vcs_tag = tag_name
+            existing.inputs = interface["inputs"]
+            existing.outputs = interface["outputs"]
             logger.info(
                 "Module version updated (tag moved)",
                 module_name=module.name,
@@ -233,6 +242,8 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
                 upload_status="uploaded",
                 vcs_commit_sha=tag_sha,
                 vcs_tag=tag_name,
+                inputs=interface["inputs"],
+                outputs=interface["outputs"],
             )
             db.add(mod_version)
             existing_versions[version_str] = mod_version

--- a/services/terrapod/services/registry_vcs_poller.py
+++ b/services/terrapod/services/registry_vcs_poller.py
@@ -213,10 +213,12 @@ async def _poll_module(db: AsyncSession, storage, module: RegistryModule) -> Non
 
         interface = None
         if settings.registry.module_interface.enabled:
+            import asyncio
+
             from terrapod.services.module_hcl_parser import extract_module_interface
 
             try:
-                interface = extract_module_interface(archive_bytes)
+                interface = await asyncio.to_thread(extract_module_interface, archive_bytes)
             except Exception:
                 interface = {"inputs": [], "outputs": []}
 

--- a/services/tests/api/test_registry_module_interface.py
+++ b/services/tests/api/test_registry_module_interface.py
@@ -67,13 +67,24 @@ class TestModuleInterfaceEndpoint:
         app, db = _make_app()
         module = _mock_module()
         version = _mock_version(
-            inputs=[{"name": "cidr", "type": "string", "description": "", "default": None, "required": True, "sensitive": False}],
+            inputs=[
+                {
+                    "name": "cidr",
+                    "type": "string",
+                    "description": "",
+                    "default": None,
+                    "required": True,
+                    "sensitive": False,
+                }
+            ],
             outputs=[{"name": "id", "description": "The VPC ID", "sensitive": False}],
         )
         db.execute = AsyncMock(side_effect=[_scalar_result(module), _scalar_result(version)])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/terrapod/v1/registry-modules/private/default/vpc/aws/1.0.0/interface")
+            resp = await c.get(
+                "/api/terrapod/v1/registry-modules/private/default/vpc/aws/1.0.0/interface"
+            )
         assert resp.status_code == 200
         data = resp.json()["data"]
         assert data["attributes"]["inputs"][0]["name"] == "cidr"
@@ -88,7 +99,9 @@ class TestModuleInterfaceEndpoint:
         db.execute = AsyncMock(return_value=_scalar_result(None))
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/terrapod/v1/registry-modules/private/default/nope/aws/1.0.0/interface")
+            resp = await c.get(
+                "/api/terrapod/v1/registry-modules/private/default/nope/aws/1.0.0/interface"
+            )
         assert resp.status_code == 404
 
     @pytest.mark.asyncio
@@ -101,5 +114,7 @@ class TestModuleInterfaceEndpoint:
         db.execute = AsyncMock(side_effect=[_scalar_result(module), _scalar_result(None)])
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get("/api/terrapod/v1/registry-modules/private/default/vpc/aws/9.9.9/interface")
+            resp = await c.get(
+                "/api/terrapod/v1/registry-modules/private/default/vpc/aws/9.9.9/interface"
+            )
         assert resp.status_code == 404

--- a/services/tests/api/test_registry_module_interface.py
+++ b/services/tests/api/test_registry_module_interface.py
@@ -1,0 +1,105 @@
+"""Tests for the module interface endpoint."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+
+
+def _admin():
+    return AuthenticatedUser(
+        email="admin@example.com",
+        display_name="Admin",
+        roles=["admin"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _make_app():
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: _admin()
+    db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: db
+    return app, db
+
+
+def _mock_module(name="vpc", provider="aws"):
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.name = name
+    m.namespace = "default"
+    m.provider = provider
+    m.labels = {}
+    m.owner_email = "admin@example.com"
+    return m
+
+
+def _mock_version(inputs=None, outputs=None):
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.version = "1.0.0"
+    v.inputs = inputs
+    v.outputs = outputs
+    return v
+
+
+def _scalar_result(value):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    result.scalars.return_value.first.return_value = value
+    return result
+
+
+class TestModuleInterfaceEndpoint:
+    @pytest.mark.asyncio
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_200_returns_interface(self, *_mocks):
+        app, db = _make_app()
+        module = _mock_module()
+        version = _mock_version(
+            inputs=[{"name": "cidr", "type": "string", "description": "", "default": None, "required": True, "sensitive": False}],
+            outputs=[{"name": "id", "description": "The VPC ID", "sensitive": False}],
+        )
+        db.execute = AsyncMock(side_effect=[_scalar_result(module), _scalar_result(version)])
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/registry-modules/private/default/vpc/aws/1.0.0/interface")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["attributes"]["inputs"][0]["name"] == "cidr"
+        assert data["attributes"]["outputs"][0]["name"] == "id"
+
+    @pytest.mark.asyncio
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_404_module_not_found(self, *_mocks):
+        app, db = _make_app()
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/registry-modules/private/default/nope/aws/1.0.0/interface")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_404_version_not_found(self, *_mocks):
+        app, db = _make_app()
+        module = _mock_module()
+        db.execute = AsyncMock(side_effect=[_scalar_result(module), _scalar_result(None)])
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/registry-modules/private/default/vpc/aws/9.9.9/interface")
+        assert resp.status_code == 404

--- a/services/tests/services/test_module_hcl_parser.py
+++ b/services/tests/services/test_module_hcl_parser.py
@@ -20,15 +20,17 @@ def _make_tarball(files: dict[str, str]) -> bytes:
 
 class TestExtractModuleInterface:
     def test_extracts_basic_variable(self):
-        tarball = _make_tarball({
-            "variables.tf": '''
+        tarball = _make_tarball(
+            {
+                "variables.tf": """
 variable "vpc_cidr" {
   type        = string
   description = "CIDR block for the VPC"
   default     = "10.0.0.0/16"
 }
-''',
-        })
+""",
+            }
+        )
         result = extract_module_interface(tarball)
         assert len(result["inputs"]) == 1
         inp = result["inputs"][0]
@@ -40,14 +42,16 @@ variable "vpc_cidr" {
         assert inp["sensitive"] is False
 
     def test_extracts_required_variable(self):
-        tarball = _make_tarball({
-            "variables.tf": '''
+        tarball = _make_tarball(
+            {
+                "variables.tf": """
 variable "region" {
   type        = string
   description = "AWS region"
 }
-''',
-        })
+""",
+            }
+        )
         result = extract_module_interface(tarball)
         inp = result["inputs"][0]
         assert inp["name"] == "region"
@@ -55,27 +59,31 @@ variable "region" {
         assert inp["default"] is None
 
     def test_extracts_sensitive_variable(self):
-        tarball = _make_tarball({
-            "variables.tf": '''
+        tarball = _make_tarball(
+            {
+                "variables.tf": """
 variable "db_password" {
   type      = string
   sensitive = true
 }
-''',
-        })
+""",
+            }
+        )
         result = extract_module_interface(tarball)
         inp = result["inputs"][0]
         assert inp["sensitive"] is True
 
     def test_extracts_output(self):
-        tarball = _make_tarball({
-            "outputs.tf": '''
+        tarball = _make_tarball(
+            {
+                "outputs.tf": """
 output "vpc_id" {
   value       = module.vpc.id
   description = "ID of the created VPC"
 }
-''',
-        })
+""",
+            }
+        )
         result = extract_module_interface(tarball)
         assert len(result["outputs"]) == 1
         out = result["outputs"][0]
@@ -84,44 +92,50 @@ output "vpc_id" {
         assert out["sensitive"] is False
 
     def test_extracts_sensitive_output(self):
-        tarball = _make_tarball({
-            "outputs.tf": '''
+        tarball = _make_tarball(
+            {
+                "outputs.tf": """
 output "secret" {
   value     = var.secret
   sensitive = true
 }
-''',
-        })
+""",
+            }
+        )
         result = extract_module_interface(tarball)
         assert result["outputs"][0]["sensitive"] is True
 
     def test_multiple_files(self):
-        tarball = _make_tarball({
-            "variables.tf": '''
+        tarball = _make_tarball(
+            {
+                "variables.tf": """
 variable "name" {
   type = string
 }
-''',
-            "outputs.tf": '''
+""",
+                "outputs.tf": """
 output "id" {
   value = aws_instance.main.id
 }
-''',
-            "main.tf": '''
+""",
+                "main.tf": """
 resource "aws_instance" "main" {
   ami = "ami-123"
 }
-''',
-        })
+""",
+            }
+        )
         result = extract_module_interface(tarball)
         assert len(result["inputs"]) == 1
         assert len(result["outputs"]) == 1
 
     def test_ignores_nested_tf_files(self):
-        tarball = _make_tarball({
-            "variables.tf": 'variable "top" { type = string }',
-            "modules/sub/variables.tf": 'variable "nested" { type = string }',
-        })
+        tarball = _make_tarball(
+            {
+                "variables.tf": 'variable "top" { type = string }',
+                "modules/sub/variables.tf": 'variable "nested" { type = string }',
+            }
+        )
         result = extract_module_interface(tarball)
         assert len(result["inputs"]) == 1
         assert result["inputs"][0]["name"] == "top"
@@ -137,15 +151,17 @@ resource "aws_instance" "main" {
         assert result == {"inputs": [], "outputs": []}
 
     def test_complex_type(self):
-        tarball = _make_tarball({
-            "variables.tf": '''
+        tarball = _make_tarball(
+            {
+                "variables.tf": """
 variable "tags" {
   type        = map(string)
   description = "Resource tags"
   default     = {}
 }
-''',
-        })
+""",
+            }
+        )
         result = extract_module_interface(tarball)
         inp = result["inputs"][0]
         assert inp["name"] == "tags"

--- a/services/tests/services/test_module_hcl_parser.py
+++ b/services/tests/services/test_module_hcl_parser.py
@@ -36,7 +36,7 @@ variable "vpc_cidr" {
         inp = result["inputs"][0]
         assert inp["name"] == "vpc_cidr"
         assert inp["type"] == "string"
-        assert inp["type_raw"] == "string"
+        assert inp["type_schema"] == {"type": "string"}
         assert inp["description"] == "CIDR block for the VPC"
         assert inp["default"] == "10.0.0.0/16"
         assert inp["required"] is False
@@ -167,26 +167,25 @@ variable "tags" {
         inp = result["inputs"][0]
         assert inp["name"] == "tags"
         assert inp["required"] is False
-        assert inp["type_raw"] is not None
-        assert isinstance(inp["type_raw"], list)
+        assert inp["type"] == "map(string)"
+        assert inp["type_schema"] == {"type": "object", "additionalProperties": {"type": "string"}}
 
-    def test_type_raw_preserves_structure(self):
+    def test_type_schema_for_list(self):
         tarball = _make_tarball(
             {
                 "variables.tf": """
 variable "simple" {
   type = string
 }
-variable "complex" {
-  type = list(string)
+variable "items" {
+  type = list(number)
 }
 """,
             }
         )
         result = extract_module_interface(tarball)
         simple = next(i for i in result["inputs"] if i["name"] == "simple")
-        complex_var = next(i for i in result["inputs"] if i["name"] == "complex")
-        assert simple["type_raw"] == "string"
-        assert simple["type"] == "string"
-        assert isinstance(complex_var["type_raw"], list)
-        assert complex_var["type"] != complex_var["type_raw"]
+        items = next(i for i in result["inputs"] if i["name"] == "items")
+        assert simple["type_schema"] == {"type": "string"}
+        assert items["type_schema"] == {"type": "array", "items": {"type": "number"}}
+        assert items["type"] == "list(number)"

--- a/services/tests/services/test_module_hcl_parser.py
+++ b/services/tests/services/test_module_hcl_parser.py
@@ -1,0 +1,152 @@
+"""Unit tests for module HCL parser."""
+
+import io
+import tarfile
+
+from terrapod.services.module_hcl_parser import extract_module_interface
+
+
+def _make_tarball(files: dict[str, str]) -> bytes:
+    """Create an in-memory gzipped tarball with the given path->content mapping."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for path, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=path)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+class TestExtractModuleInterface:
+    def test_extracts_basic_variable(self):
+        tarball = _make_tarball({
+            "variables.tf": '''
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC"
+  default     = "10.0.0.0/16"
+}
+''',
+        })
+        result = extract_module_interface(tarball)
+        assert len(result["inputs"]) == 1
+        inp = result["inputs"][0]
+        assert inp["name"] == "vpc_cidr"
+        assert inp["type"] == "string"
+        assert inp["description"] == "CIDR block for the VPC"
+        assert inp["default"] == "10.0.0.0/16"
+        assert inp["required"] is False
+        assert inp["sensitive"] is False
+
+    def test_extracts_required_variable(self):
+        tarball = _make_tarball({
+            "variables.tf": '''
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+''',
+        })
+        result = extract_module_interface(tarball)
+        inp = result["inputs"][0]
+        assert inp["name"] == "region"
+        assert inp["required"] is True
+        assert inp["default"] is None
+
+    def test_extracts_sensitive_variable(self):
+        tarball = _make_tarball({
+            "variables.tf": '''
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+''',
+        })
+        result = extract_module_interface(tarball)
+        inp = result["inputs"][0]
+        assert inp["sensitive"] is True
+
+    def test_extracts_output(self):
+        tarball = _make_tarball({
+            "outputs.tf": '''
+output "vpc_id" {
+  value       = module.vpc.id
+  description = "ID of the created VPC"
+}
+''',
+        })
+        result = extract_module_interface(tarball)
+        assert len(result["outputs"]) == 1
+        out = result["outputs"][0]
+        assert out["name"] == "vpc_id"
+        assert out["description"] == "ID of the created VPC"
+        assert out["sensitive"] is False
+
+    def test_extracts_sensitive_output(self):
+        tarball = _make_tarball({
+            "outputs.tf": '''
+output "secret" {
+  value     = var.secret
+  sensitive = true
+}
+''',
+        })
+        result = extract_module_interface(tarball)
+        assert result["outputs"][0]["sensitive"] is True
+
+    def test_multiple_files(self):
+        tarball = _make_tarball({
+            "variables.tf": '''
+variable "name" {
+  type = string
+}
+''',
+            "outputs.tf": '''
+output "id" {
+  value = aws_instance.main.id
+}
+''',
+            "main.tf": '''
+resource "aws_instance" "main" {
+  ami = "ami-123"
+}
+''',
+        })
+        result = extract_module_interface(tarball)
+        assert len(result["inputs"]) == 1
+        assert len(result["outputs"]) == 1
+
+    def test_ignores_nested_tf_files(self):
+        tarball = _make_tarball({
+            "variables.tf": 'variable "top" { type = string }',
+            "modules/sub/variables.tf": 'variable "nested" { type = string }',
+        })
+        result = extract_module_interface(tarball)
+        assert len(result["inputs"]) == 1
+        assert result["inputs"][0]["name"] == "top"
+
+    def test_returns_empty_on_no_tf_files(self):
+        tarball = _make_tarball({"README.md": "# Module"})
+        result = extract_module_interface(tarball)
+        assert result == {"inputs": [], "outputs": []}
+
+    def test_returns_empty_on_malformed_hcl(self):
+        tarball = _make_tarball({"variables.tf": "this is not { valid hcl ["})
+        result = extract_module_interface(tarball)
+        assert result == {"inputs": [], "outputs": []}
+
+    def test_complex_type(self):
+        tarball = _make_tarball({
+            "variables.tf": '''
+variable "tags" {
+  type        = map(string)
+  description = "Resource tags"
+  default     = {}
+}
+''',
+        })
+        result = extract_module_interface(tarball)
+        inp = result["inputs"][0]
+        assert inp["name"] == "tags"
+        assert inp["required"] is False

--- a/services/tests/services/test_module_hcl_parser.py
+++ b/services/tests/services/test_module_hcl_parser.py
@@ -36,6 +36,7 @@ variable "vpc_cidr" {
         inp = result["inputs"][0]
         assert inp["name"] == "vpc_cidr"
         assert inp["type"] == "string"
+        assert inp["type_raw"] == "string"
         assert inp["description"] == "CIDR block for the VPC"
         assert inp["default"] == "10.0.0.0/16"
         assert inp["required"] is False
@@ -166,3 +167,26 @@ variable "tags" {
         inp = result["inputs"][0]
         assert inp["name"] == "tags"
         assert inp["required"] is False
+        assert inp["type_raw"] is not None
+        assert isinstance(inp["type_raw"], list)
+
+    def test_type_raw_preserves_structure(self):
+        tarball = _make_tarball(
+            {
+                "variables.tf": """
+variable "simple" {
+  type = string
+}
+variable "complex" {
+  type = list(string)
+}
+""",
+            }
+        )
+        result = extract_module_interface(tarball)
+        simple = next(i for i in result["inputs"] if i["name"] == "simple")
+        complex_var = next(i for i in result["inputs"] if i["name"] == "complex")
+        assert simple["type_raw"] == "string"
+        assert simple["type"] == "string"
+        assert isinstance(complex_var["type_raw"], list)
+        assert complex_var["type"] != complex_var["type_raw"]

--- a/web/src/app/registry/modules/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[name]/[provider]/page.tsx
@@ -167,7 +167,7 @@ export default function ModuleDetailPage() {
 
   // Module interface (inputs/outputs)
   const [interfaceData, setInterfaceData] = useState<{
-    inputs: { name: string; type: string; type_raw: unknown; description: string; default: string | null; required: boolean; sensitive: boolean }[] | null
+    inputs: { name: string; type: string; type_schema: object; description: string; default: string | null; required: boolean; sensitive: boolean }[] | null
     outputs: { name: string; description: string; sensitive: boolean }[] | null
   } | null>(null)
   const [interfaceLoading, setInterfaceLoading] = useState(false)

--- a/web/src/app/registry/modules/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[name]/[provider]/page.tsx
@@ -165,6 +165,16 @@ export default function ModuleDetailPage() {
   const [vcsTagPattern, setVcsTagPattern] = useState('v*')
   const [savingVcs, setSavingVcs] = useState(false)
 
+  // Module interface (inputs/outputs)
+  const [interfaceData, setInterfaceData] = useState<{
+    inputs: { name: string; type: string; description: string; default: string | null; required: boolean; sensitive: boolean }[] | null
+    outputs: { name: string; description: string; sensitive: boolean }[] | null
+  } | null>(null)
+  const [interfaceLoading, setInterfaceLoading] = useState(false)
+  const [interfaceExpanded, setInterfaceExpanded] = useState(false)
+  const [interfaceVersion, setInterfaceVersion] = useState('')
+  const [versionsExpanded, setVersionsExpanded] = useState(false)
+
   // Metadata editing (labels/owner)
   const [editingMeta, setEditingMeta] = useState(false)
   const [editLabels, setEditLabels] = useState<Record<string, string>>({})
@@ -218,6 +228,14 @@ export default function ModuleDetailPage() {
         setVcsRepoUrl(attrs['vcs-repo-url'] || '')
         setVcsBranch(attrs['vcs-branch'] || '')
         setVcsTagPattern(attrs['vcs-tag-pattern'] || 'v*')
+
+        // Load interface for latest uploaded version
+        const versions = (attrs['version-statuses'] || []) as VersionStatus[]
+        const latestUploaded = versions.find((v: VersionStatus) => v.status === 'uploaded')
+        if (latestUploaded && latestUploaded.version !== interfaceVersion) {
+          setInterfaceVersion(latestUploaded.version)
+          loadInterface(latestUploaded.version)
+        }
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load module')
@@ -249,6 +267,26 @@ export default function ModuleDetailPage() {
       }
     } catch {
       // Non-critical
+    }
+  }
+
+  async function loadInterface(ver: string) {
+    if (!ver) return
+    setInterfaceLoading(true)
+    try {
+      const res = await apiFetch(
+        `/api/terrapod/v1/registry-modules/private/default/${name}/${provider}/${ver}/interface`
+      )
+      if (res.ok) {
+        const data = await res.json()
+        setInterfaceData(data.data.attributes)
+      } else {
+        setInterfaceData(null)
+      }
+    } catch {
+      setInterfaceData(null)
+    } finally {
+      setInterfaceLoading(false)
     }
   }
 
@@ -835,71 +873,218 @@ export default function ModuleDetailPage() {
               )}
             </div>
 
-            <h2 className="text-lg font-semibold text-slate-200 mb-3">Versions</h2>
-            {(module.attributes['version-statuses'] || []).length === 0 ? (
-              <EmptyState message={
-                isVcsSource
-                  ? `No versions yet. Push a semver tag matching "${module.attributes['vcs-tag-pattern'] || 'v*'}" to the connected repository to publish a version.`
-                  : 'No versions yet. Upload a module or connect VCS to get started.'
-              } />
-            ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-slate-700/50">
-                      <th className="text-left px-4 py-3 text-slate-400 font-medium">Version</th>
-                      <th className="text-left px-4 py-3 text-slate-400 font-medium">Status</th>
-                      {isVcsSource && (
-                        <th className="text-left px-4 py-3 text-slate-400 font-medium">Source</th>
+            {/* Inputs & Outputs */}
+            <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden mb-6">
+              <button
+                onClick={() => setInterfaceExpanded(!interfaceExpanded)}
+                className="w-full flex items-center justify-between px-5 py-4 text-left"
+              >
+                <div className="flex items-center gap-3">
+                  <h3 className="text-sm font-semibold text-slate-200">Inputs & Outputs</h3>
+                  {interfaceData && (
+                    <span className="text-xs text-slate-500">
+                      {interfaceData.inputs?.length ?? 0} inputs, {interfaceData.outputs?.length ?? 0} outputs
+                    </span>
+                  )}
+                </div>
+                <svg
+                  className={`w-4 h-4 text-slate-400 transition-transform ${interfaceExpanded ? 'rotate-180' : ''}`}
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+
+              {interfaceExpanded && (
+                <div className="px-5 pb-5 space-y-4 border-t border-slate-700/50 pt-4">
+                  {/* Version selector */}
+                  <div className="flex items-center gap-2">
+                    <label className="text-xs text-slate-500">Version:</label>
+                    <select
+                      value={interfaceVersion}
+                      onChange={(e) => { setInterfaceVersion(e.target.value); loadInterface(e.target.value) }}
+                      className="px-2 py-1 text-xs border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    >
+                      {(module?.attributes['version-statuses'] || [])
+                        .filter((v: VersionStatus) => v.status === 'uploaded')
+                        .map((v: VersionStatus) => (
+                          <option key={v.version} value={v.version}>{v.version}</option>
+                        ))}
+                    </select>
+                  </div>
+
+                  {interfaceLoading ? (
+                    <LoadingSpinner />
+                  ) : !interfaceData || (interfaceData.inputs === null && interfaceData.outputs === null) ? (
+                    <p className="text-sm text-slate-500">No interface data available for this version.</p>
+                  ) : (
+                    <>
+                      {/* Inputs table */}
+                      {interfaceData.inputs && interfaceData.inputs.length > 0 && (
+                        <div>
+                          <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Inputs</h4>
+                          <div className="overflow-x-auto">
+                            <table className="w-full text-sm">
+                              <thead>
+                                <tr className="text-xs text-slate-500 border-b border-slate-700/50">
+                                  <th className="text-left py-2 pr-4">Name</th>
+                                  <th className="text-left py-2 pr-4">Type</th>
+                                  <th className="text-left py-2 pr-4">Description</th>
+                                  <th className="text-left py-2 pr-4">Default</th>
+                                  <th className="text-left py-2">Required</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {interfaceData.inputs.map((inp) => (
+                                  <tr key={inp.name} className="border-b border-slate-700/30">
+                                    <td className="py-2 pr-4 font-mono text-xs text-slate-200">{inp.name}</td>
+                                    <td className="py-2 pr-4 font-mono text-xs text-slate-400">{inp.type}</td>
+                                    <td className="py-2 pr-4 text-slate-300">{inp.description}</td>
+                                    <td className="py-2 pr-4 font-mono text-xs text-slate-400">{inp.default ?? '—'}</td>
+                                    <td className="py-2">
+                                      {inp.required ? (
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-900/50 text-amber-300">required</span>
+                                      ) : (
+                                        <span className="text-xs text-slate-500">optional</span>
+                                      )}
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
                       )}
-                      <th className="text-right px-4 py-3 text-slate-400 font-medium">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {module.attributes['version-statuses'].map((v) => (
-                      <tr key={v.version} className="border-b border-slate-700/30 last:border-0">
-                        <td className="px-4 py-3 text-slate-200 font-mono">{v.version}</td>
-                        <td className="px-4 py-3">
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                            v.status === 'uploaded'
-                              ? 'bg-green-900/50 text-green-300'
-                              : 'bg-amber-900/50 text-amber-300'
-                          }`}>
-                            {v.status}
-                          </span>
-                        </td>
-                        {isVcsSource && (
-                          <td className="px-4 py-3">
-                            {v['vcs-tag'] ? (
-                              <span className="text-slate-300 text-xs">
-                                <span className="font-mono">{v['vcs-tag']}</span>
-                                {v['vcs-commit-sha'] && (
-                                  <span className="text-slate-500 ml-1.5" title={v['vcs-commit-sha']}>
-                                    ({v['vcs-commit-sha'].slice(0, 7)})
-                                  </span>
-                                )}
+
+                      {/* Outputs table */}
+                      {interfaceData.outputs && interfaceData.outputs.length > 0 && (
+                        <div>
+                          <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Outputs</h4>
+                          <div className="overflow-x-auto">
+                            <table className="w-full text-sm">
+                              <thead>
+                                <tr className="text-xs text-slate-500 border-b border-slate-700/50">
+                                  <th className="text-left py-2 pr-4">Name</th>
+                                  <th className="text-left py-2 pr-4">Description</th>
+                                  <th className="text-left py-2">Sensitive</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {interfaceData.outputs.map((out) => (
+                                  <tr key={out.name} className="border-b border-slate-700/30">
+                                    <td className="py-2 pr-4 font-mono text-xs text-slate-200">{out.name}</td>
+                                    <td className="py-2 pr-4 text-slate-300">{out.description}</td>
+                                    <td className="py-2">
+                                      {out.sensitive && (
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-900/50 text-red-300">sensitive</span>
+                                      )}
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                      )}
+
+                      {interfaceData.inputs?.length === 0 && interfaceData.outputs?.length === 0 && (
+                        <p className="text-sm text-slate-500">This module version declares no inputs or outputs.</p>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Versions */}
+            <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <button
+                onClick={() => setVersionsExpanded(!versionsExpanded)}
+                className="w-full flex items-center justify-between px-5 py-4 text-left"
+              >
+                <div className="flex items-center gap-3">
+                  <h3 className="text-sm font-semibold text-slate-200">Versions</h3>
+                  <span className="text-xs text-slate-500">
+                    {(module.attributes['version-statuses'] || []).length} version(s)
+                  </span>
+                </div>
+                <svg
+                  className={`w-4 h-4 text-slate-400 transition-transform ${versionsExpanded ? 'rotate-180' : ''}`}
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+
+              {versionsExpanded && (
+                <div className="border-t border-slate-700/50">
+                  {(module.attributes['version-statuses'] || []).length === 0 ? (
+                    <div className="p-5">
+                      <EmptyState message={
+                        isVcsSource
+                          ? `No versions yet. Push a semver tag matching "${module.attributes['vcs-tag-pattern'] || 'v*'}" to the connected repository to publish a version.`
+                          : 'No versions yet. Upload a module or connect VCS to get started.'
+                      } />
+                    </div>
+                  ) : (
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-slate-700/50">
+                          <th className="text-left px-4 py-3 text-slate-400 font-medium">Version</th>
+                          <th className="text-left px-4 py-3 text-slate-400 font-medium">Status</th>
+                          {isVcsSource && (
+                            <th className="text-left px-4 py-3 text-slate-400 font-medium">Source</th>
+                          )}
+                          <th className="text-right px-4 py-3 text-slate-400 font-medium">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {module.attributes['version-statuses'].map((v) => (
+                          <tr key={v.version} className="border-b border-slate-700/30 last:border-0">
+                            <td className="px-4 py-3 text-slate-200 font-mono">{v.version}</td>
+                            <td className="px-4 py-3">
+                              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                                v.status === 'uploaded'
+                                  ? 'bg-green-900/50 text-green-300'
+                                  : 'bg-amber-900/50 text-amber-300'
+                              }`}>
+                                {v.status}
                               </span>
-                            ) : (
-                              <span className="text-slate-500 text-xs">manual upload</span>
+                            </td>
+                            {isVcsSource && (
+                              <td className="px-4 py-3">
+                                {v['vcs-tag'] ? (
+                                  <span className="text-slate-300 text-xs">
+                                    <span className="font-mono">{v['vcs-tag']}</span>
+                                    {v['vcs-commit-sha'] && (
+                                      <span className="text-slate-500 ml-1.5" title={v['vcs-commit-sha']}>
+                                        ({v['vcs-commit-sha'].slice(0, 7)})
+                                      </span>
+                                    )}
+                                  </span>
+                                ) : (
+                                  <span className="text-slate-500 text-xs">manual upload</span>
+                                )}
+                              </td>
                             )}
-                          </td>
-                        )}
-                        {modPerms['can-destroy'] && (
-                          <td className="px-4 py-3 text-right">
-                            <button
-                              onClick={() => setDeleteTarget(v.version)}
-                              className="text-xs text-red-400 hover:text-red-300 transition-colors"
-                            >
-                              Delete
-                            </button>
-                          </td>
-                        )}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
+                            {modPerms['can-destroy'] && (
+                              <td className="px-4 py-3 text-right">
+                                <button
+                                  onClick={() => setDeleteTarget(v.version)}
+                                  className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                                >
+                                  Delete
+                                </button>
+                              </td>
+                            )}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              )}
+            </div>
           </>
         ) : null}
 

--- a/web/src/app/registry/modules/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[name]/[provider]/page.tsx
@@ -167,7 +167,7 @@ export default function ModuleDetailPage() {
 
   // Module interface (inputs/outputs)
   const [interfaceData, setInterfaceData] = useState<{
-    inputs: { name: string; type: string; description: string; default: string | null; required: boolean; sensitive: boolean }[] | null
+    inputs: { name: string; type: string; type_raw: unknown; description: string; default: string | null; required: boolean; sensitive: boolean }[] | null
     outputs: { name: string; description: string; sensitive: boolean }[] | null
   } | null>(null)
   const [interfaceLoading, setInterfaceLoading] = useState(false)


### PR DESCRIPTION
Extract Terraform variable/output declarations from module tarballs
at publish time using python-hcl2. Show them in a collapsible card
on the module detail page. Versions section also now collapsible.