### PR TITLE
fix(docker): keep Poetry's transitive deps out of the API runtime image

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -17,19 +17,32 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     libxmlsec1-openssl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Poetry
-RUN pip install --no-cache-dir poetry==1.8.4
+# Install Poetry into its own isolated venv so neither Poetry nor its
+# transitive dependencies (dulwich, cleo, cachecontrol, build, …) land in
+# the system site-packages that the runtime stage COPYs wholesale. A plain
+# `pip install poetry` + `pip uninstall -y poetry` leaves those transitive
+# deps orphaned in site-packages, where they drag Poetry-only CVEs into the
+# shipped image (e.g. dulwich CVE-2026-42305, Poetry CVE-2026-34591) even
+# though the application never imports them.
+ENV POETRY_HOME=/opt/poetry
+RUN python -m venv "$POETRY_HOME" \
+    && "$POETRY_HOME"/bin/pip install --no-cache-dir poetry==1.8.4
 
 WORKDIR /app
 
 # Copy dependency files
 COPY services/pyproject.toml services/poetry.lock* ./
 
-# Install dependencies into system Python (no virtualenv), then remove Poetry
-# from site-packages so it doesn't end up in the runtime image (CVE-2026-34591).
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --only main --no-root \
-    && pip uninstall -y poetry
+# Resolve the project's `main` dependency closure with Poetry (running from
+# its isolated venv) and export it to a requirements file, then install ONLY
+# that closure into the system Python with pip. Poetry + its own deps stay in
+# /opt/poetry, which is never copied into the runtime image. The repo carries
+# no committed lock, so we resolve one at build time — same fresh resolution
+# the previous `poetry install` performed.
+RUN "$POETRY_HOME"/bin/poetry lock --no-interaction --no-ansi \
+    && "$POETRY_HOME"/bin/poetry export \
+        --only main --without-hashes -f requirements.txt -o /tmp/requirements.txt \
+    && pip install --no-cache-dir -r /tmp/requirements.txt
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 FROM python:3.14-slim


### PR DESCRIPTION
## Problem

The Trivy gate is failing on **every open PR** (#392, #388–#390, …) on the `terrapod-api` image:

```
dulwich (METADATA)  CVE-2026-42305  HIGH  fixed  0.21.7 → 1.2.5
  Dulwich has an arbitrary file write via NTFS-hostile tree
```

`dulwich` is not an application dependency. It is a **transitive dependency of Poetry**. The API Dockerfile installed Poetry into system Python, ran `poetry install`, then `pip uninstall -y poetry` — but pip's uninstall does **not** cascade to a package's dependencies. So Poetry's transitive deps (`dulwich`, `cleo`, `crashtest`, `cachecontrol`, `build`, `distlib`, …) stayed orphaned in `site-packages`, which the runtime stage `COPY`s wholesale. They are dead weight the app never imports — but they still carry Poetry-only CVEs into the shipped image, and Trivy (correctly) flags them.

This is pre-existing image hygiene, surfaced now because CVE-2026-42305 was published recently. It is **unrelated to any of the open feature/fix PRs** — it fails their scans purely because each PR rebuilds and re-scans the api image.

## Fix

Install Poetry into its own isolated venv (`/opt/poetry`). Poetry resolves and exports the project's `main` dependency closure to a requirements file; pip then installs **only that closure** into system Python. Poetry and its own deps live in `/opt/poetry`, which is never copied into the runtime stage — so no Poetry-internal package can reach the shipped image. This is robust against future Poetry-dependency CVEs, not just this one.

The repo carries no committed lock, so a lock is resolved at build time — the same fresh resolution the previous `poetry install` already performed.

## Verification

Rebuilt the api image locally with the change:

- `dulwich`, `cleo`, `crashtest`, `cachecontrol`, `poetry`, `build`, `distlib`, `trove-classifiers` — **all absent** from site-packages
- All application deps (`fastapi`, `sqlalchemy`, `pydantic`, `uvicorn`, `asyncpg`, `authlib`, `pyjwt`, …) present
- `python -c "import terrapod.api.app"` succeeds

Listener and migrations images are unaffected — they install via `pip install .` and never carried Poetry.

## Test plan
- [x] Local build clean + app imports
- [ ] Trivy gate passes on this PR's api scan (the real proof)