### PR TITLE
ci: make image build/scan/e2e work on fork PRs (no GHCR push on PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,10 +438,36 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/${{ matrix.arch }}
-          push: true
+          # On PRs we do NOT push to GHCR. Fork PRs get a read-only
+          # GITHUB_TOKEN (no package:write), so a push fails outright — and
+          # even same-repo PRs gain nothing from a registry round-trip. The
+          # built image is loaded into the local Docker daemon and handed to
+          # the scan/e2e jobs as a workflow artifact instead. Pushes happen
+          # only on branch/tag builds, which run from the main repo and have
+          # the write token. `is_pr` (not fork-status) is the discriminator,
+          # so fork and same-repo PRs take the identical artifact path.
+          push: ${{ needs.prepare.outputs.is_pr != 'true' }}
+          load: ${{ needs.prepare.outputs.is_pr == 'true' && matrix.arch == 'amd64' }}
           tags: ${{ env.REGISTRY }}/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-${{ matrix.arch }}
           cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}
+
+      # PR builds: persist the loaded image as an artifact for scan/e2e.
+      # amd64 only — that's the arch those jobs consume; the arm64 PR build
+      # is a "does it still build on arm" check and needs no artifact.
+      - name: Export image artifact
+        if: needs.prepare.outputs.is_pr == 'true' && matrix.arch == 'amd64'
+        run: |
+          docker save "$REGISTRY/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-amd64" \
+            | gzip > "/tmp/${{ matrix.image }}-amd64.tar.gz"
+
+      - name: Upload image artifact
+        if: needs.prepare.outputs.is_pr == 'true' && matrix.arch == 'amd64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: image-${{ matrix.image }}-amd64
+          path: /tmp/${{ matrix.image }}-amd64.tar.gz
+          retention-days: 1
 
   # ── E2E Tests (Playwright) ─────────────────────────────
   e2e-test:
@@ -463,17 +489,39 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Branch/tag builds pull the images from GHCR; PR builds load them
+      # from the build-images artifacts (no registry push on PRs). Either
+      # way the stack runs off the `<image>:local` tags.
       - name: Log in to GHCR
+        if: needs.prepare.outputs.is_pr != 'true'
         uses: ./.github/actions/ghcr-login
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
 
-      - name: Pull images
+      - name: Pull images (branch/tag)
+        if: needs.prepare.outputs.is_pr != 'true'
         run: |
           sha_short="${{ needs.prepare.outputs.sha_short }}"
           for image in terrapod-api terrapod-web terrapod-migrations; do
             docker pull "$REGISTRY/$image:sha-${sha_short}-amd64"
+            docker tag "$REGISTRY/$image:sha-${sha_short}-amd64" "$image:local"
+          done
+
+      - name: Download image artifacts (PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          pattern: image-*-amd64
+          path: /tmp/images
+          merge-multiple: true
+
+      - name: Load images (PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        run: |
+          sha_short="${{ needs.prepare.outputs.sha_short }}"
+          for image in terrapod-api terrapod-web terrapod-migrations; do
+            gunzip -c "/tmp/images/$image-amd64.tar.gz" | docker load
             docker tag "$REGISTRY/$image:sha-${sha_short}-amd64" "$image:local"
           done
 
@@ -555,11 +603,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # On branch/tag builds the image lives in GHCR — log in and let Trivy
+      # pull it. On PRs nothing was pushed; the image arrives as an artifact
+      # from build-images and is loaded into the local daemon below, where
+      # Trivy finds it by the same tag without any registry access.
       - name: Log in to GHCR
+        if: needs.prepare.outputs.is_pr != 'true'
         uses: ./.github/actions/ghcr-login
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
+
+      - name: Download image artifact (PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          name: image-${{ matrix.image }}-amd64
+          path: /tmp
+
+      - name: Load image (PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        run: gunzip -c "/tmp/${{ matrix.image }}-amd64.tar.gz" | docker load
 
       # Human-readable findings step. Always prints the table of CVEs
       # Trivy would gate on to the action log — so a failure in the


### PR DESCRIPTION
## Problem

External contributors' PRs (forks) can never go green. The `build-images` job pushes every image to GHCR unconditionally:

```yaml
push: true
```

Fork PRs run with a **read-only** `GITHUB_TOKEN` (no `packages: write`), so the push fails immediately (`installation not allowed to Write organization package`). That cascades: `scan-images` and `e2e-test` both pull the image back from GHCR by ref, so with nothing pushed they fail too, and the `CI` gate goes red. The only way fork PRs (e.g. #383–#385, #388–#391) have ever merged is owner override — which means the Trivy scan and Playwright e2e never actually ran on the contributed code before merge.

## Fix

Stop pushing to GHCR on PRs. The discriminator is `is_pr` (already emitted by `prepare`), so **fork and same-repo PRs take the identical path** — nothing fork-specific.

- **build-images** — `push` only on branch/tag builds; on PRs build with `load: true` (amd64) and upload the image as a 1-day-retention workflow artifact. arm64 PR builds stay a compile-only check (no load, no artifact).
- **scan-images** — on PRs, `download-artifact` + `docker load` instead of GHCR login + pull. The loaded image keeps the same tag, so Trivy's `image-ref` resolves it from the local daemon; the scan itself is unchanged.
- **e2e-test** — on PRs, load the api/web/migrations artifacts and tag `:local` instead of pulling from GHCR. Stack + Playwright steps unchanged.

Branch/tag builds are **untouched**: they still push to GHCR, and the release path (`create-manifests`, `release`) is gated on `is_pr != 'true'` / `is_tag` exactly as before.

## Result

Full PR validation — build + Trivy + Playwright e2e — now runs on fork PRs with **zero registry writes**. Contributor PRs can go green on their own merit instead of being override-merged blind.

## Test plan

This branch is non-fork but still `is_pr=true`, so its own CI run exercises the **exact artifact path** a fork PR will take (build→load→artifact→scan/e2e download→load). A green run here validates the fork-relevant path directly. The push-to-GHCR path (branch/tag) is the unchanged branch and runs post-merge.

- [ ] This PR's CI goes green via the artifact path (build/scan/e2e all pass without a GHCR push)