### PR TITLE
chore(ci): reap all five images in GHCR cleanup, not just three

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,7 +16,11 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [terrapod-api, terrapod-web, terrapod-runner]
+        # All five published images. Omitting any (previously listener +
+        # migrations were missing) leaves its sha-tagged versions to
+        # accumulate in GHCR forever, since main pushes all five on every
+        # commit but only the listed ones get reaped.
+        image: [terrapod-api, terrapod-web, terrapod-runner, terrapod-listener, terrapod-migrations]
     steps:
       - name: Delete old SHA-tagged versions
         env:


### PR DESCRIPTION
## Problem

`.github/workflows/cleanup.yml` runs weekly and deletes sha-tagged + untagged GHCR versions older than 30 days, keeping semver tags indefinitely. Its matrix only listed three images:

```yaml
matrix:
  image: [terrapod-api, terrapod-web, terrapod-runner]
```

But every push to `main` publishes **five** images (api, web, runner, **listener**, **migrations**). The two missing ones — `terrapod-listener` and `terrapod-migrations` — never get reaped, so their sha-tagged versions accumulate in GHCR forever.

## Fix

Add `terrapod-listener` and `terrapod-migrations` to the matrix. Same retention rule (30-day, keep semver) applies uniformly.

## After merge

Worth a one-off `workflow_dispatch` to sweep the backlog on the two omitted images. The weekly schedule then takes over.

## Test plan
- [ ] YAML parses (verified locally)
- [ ] After merge, dispatch the cleanup workflow once and confirm listener/migrations sha-* versions older than 30 days disappear, semver versions stay