### PR TITLE
fix(ui): prevent status pill labels wrapping to two lines

### DIFF
--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -881,22 +881,22 @@ function WorkspacesPageInner() {
                         ) : runId ? (
                           <Link
                             href={`/workspaces/${ws.id}/runs/${runId}`}
-                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium hover:opacity-80 transition-opacity ${badgeColors[def.color]}`}
+                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap hover:opacity-80 transition-opacity ${badgeColors[def.color]}`}
                           >
                             {def.label}
                           </Link>
                         ) : (
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors[def.color]}`}>
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${badgeColors[def.color]}`}>
                             {def.label}
                           </span>
                         )}
                         {ws.attributes['lifecycle-state'] === 'pending_deletion' && (
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors.amber}`}>
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${badgeColors.amber}`}>
                             Pending deletion
                           </span>
                         )}
                         {ws.attributes['lifecycle-state'] === 'archived' && (
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${badgeColors.slate}`}>
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${badgeColors.slate}`}>
                             Archived
                           </span>
                         )}


### PR DESCRIPTION
## Problem

On the workspace list, the **Needs Confirm** status pill wraps onto two lines inside the chip at the `lg` breakpoint, because the pill's class string has no `whitespace-nowrap`. \"Applied\" fits because it's shorter; longer labels break ugly.

## Fix

Add `whitespace-nowrap` to all four pill variants in `workspaces/page.tsx` (run link, no-run status, pending-deletion banner, archived banner). The pill expands horizontally as needed instead of breaking the label.

## Test plan
- [x] Local Tilt browser — \"Needs Confirm\", \"Pending deletion\", and \"Archived\" pills all render on one line
- [x] Tailwind class only — no behaviour change