### PR TITLE
fix(runner): retry transient download failures in tp_curl_download

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -160,6 +160,47 @@ trap on_exit EXIT
 # untouched; same-server hostname rewrites (filesystem backend) are
 # normalised back to TP_API_URL.
 tp_curl_download() {
+    # Retry wrapper around `_tp_curl_download_once`. Re-tries up to
+    # `TP_DOWNLOAD_RETRIES` (default 3) attempts with `TP_DOWNLOAD_RETRY_DELAY`
+    # (default 5s) between, ONLY for failures we can plausibly recover
+    # from on a redo:
+    #
+    #   - curl couldn't establish a connection (network / TLS / DNS) →
+    #     TP_LAST_HTTP empty
+    #   - presigned-URL storage returned `000` (curl couldn't determine
+    #     a status code, usually mid-transfer connection drop)
+    #   - server returned 5xx or 408 (request timeout)
+    #
+    # 4xx (other than 408) are deterministic auth/permission/shape errors;
+    # retrying just wastes the runner's grace budget on a guaranteed
+    # repeat-failure.
+    _out="$1"
+    _retries="${TP_DOWNLOAD_RETRIES:-3}"
+    _delay="${TP_DOWNLOAD_RETRY_DELAY:-5}"
+    _attempt=1
+    while : ; do
+        if _tp_curl_download_once "$@"; then
+            return 0
+        fi
+        case "${TP_LAST_HTTP:-}" in
+            "" | "000" | 408 | 5*)
+                if [ "$_attempt" -lt "$_retries" ]; then
+                    echo "[entrypoint] download: transient failure (HTTP ${TP_LAST_HTTP:-network}) — retry $_attempt/$_retries in ${_delay}s" >&2
+                    sleep "$_delay"
+                    _attempt=$((_attempt + 1))
+                    rm -f "$_out"
+                    continue
+                fi
+                echo "[entrypoint] download: transient failure persisted across $_retries attempts (last HTTP ${TP_LAST_HTTP:-network})" >&2
+                ;;
+        esac
+        return 1
+    done
+}
+
+# Single-shot core: one attempt of the redirect-aware download. Callers
+# should go via the `tp_curl_download` wrapper above for retries.
+_tp_curl_download_once() {
     # $1 = output file, remaining args = curl options (URL last)
     _out="$1"; shift
     TP_LAST_HTTP=""


### PR DESCRIPTION
## Problem

A workspace run errored during apply with:

```
[entrypoint] Downloading configuration...
[entrypoint] Configuration archive download failed (HTTP unknown) — see storage error above
[entrypoint] No configuration archive (HTTP none)
...
[entrypoint] ERROR: working directory 'terraform/auth0' not found in config
```

`HTTP unknown` means the initial `curl` returned non-zero before any HTTP status could be observed (TP_LAST_HTTP empty — network/TLS/DNS hiccup). The runner gave up on the single attempt and the apply failed, despite plan having succeeded moments earlier in a separate pod.

Plan + apply run in separate Jobs, each does its own config download, so transient network blips during the second download are an entire wasted plan.

## Fix

`tp_curl_download` is the single chokepoint for every blob the runner fetches — binary cache, config archive, current state, lock file, plan file. Wrap its existing body (renamed `_tp_curl_download_once`) in a retry loop. Configurable via:

- `TP_DOWNLOAD_RETRIES` (default `3`)
- `TP_DOWNLOAD_RETRY_DELAY` (default `5`s)

Retry classification — only on transient cases:

| `TP_LAST_HTTP` | Behaviour | Reason |
|---|---|---|
| empty (network/TLS/DNS) | retry | exact failure that bit us |
| `000` | retry | curl couldn't determine status, usually mid-transfer drop |
| `408` Request Timeout | retry | server-side transient |
| `5xx` | retry | server-side transient |
| `4xx` (other than 408) | **no retry** | deterministic auth/permission/shape errors; retrying burns the runner's SIGTERM grace budget on a guaranteed repeat-failure |

## Test plan

- [x] `bash -n` clean on the modified shell
- [x] Local unit test of the retry classifier (8/8 assertions pass):
  - transient → success after 2 retries
  - 4xx → no retry, exits 1 after 1 attempt
  - 5xx → retries exhausted, exits 1 after 3 attempts
  - 408 → retries
  - `000` → retries
  - immediate success → no spurious retries
- [ ] In-cluster smoke would require triggering a transient network failure mid-download. The classifier is unit-tested; the in-cluster path is mechanically the same one all existing callers already use, just wrapped.