### PR TITLE
fix(alembic): linearize module_interface and policy_set_vcs heads

### DIFF
--- a/alembic/versions/c7d8e9f0a1b2_add_policy_set_vcs_fields.py
+++ b/alembic/versions/c7d8e9f0a1b2_add_policy_set_vcs_fields.py
@@ -1,16 +1,15 @@
 """Add VCS fields to policy_sets.
 
 Revision ID: c7d8e9f0a1b2
-Revises: 5a173d4b4e20
+Revises: 6e2f3a8b9c10
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
-
 revision = "c7d8e9f0a1b2"
-down_revision = "5a173d4b4e20"
+down_revision = "6e2f3a8b9c10"
 
 
 def upgrade() -> None:
@@ -18,9 +17,7 @@ def upgrade() -> None:
         "policy_sets",
         sa.Column("source", sa.String(20), nullable=False, server_default="inline"),
     )
-    op.add_column(
-        "policy_sets", sa.Column("vcs_connection_id", UUID(as_uuid=True), nullable=True)
-    )
+    op.add_column("policy_sets", sa.Column("vcs_connection_id", UUID(as_uuid=True), nullable=True))
     op.add_column(
         "policy_sets",
         sa.Column("vcs_repo_url", sa.String(500), nullable=False, server_default=""),
@@ -35,17 +32,13 @@ def upgrade() -> None:
     )
     op.add_column(
         "policy_sets",
-        sa.Column(
-            "vcs_last_commit_sha", sa.String(40), nullable=False, server_default=""
-        ),
+        sa.Column("vcs_last_commit_sha", sa.String(40), nullable=False, server_default=""),
     )
     op.add_column(
         "policy_sets",
         sa.Column("vcs_last_synced_at", sa.DateTime(timezone=True), nullable=True),
     )
-    op.add_column(
-        "policy_sets", sa.Column("vcs_last_error", sa.String(500), nullable=True)
-    )
+    op.add_column("policy_sets", sa.Column("vcs_last_error", sa.String(500), nullable=True))
     op.create_foreign_key(
         "fk_policy_sets_vcs_connection",
         "policy_sets",
@@ -63,9 +56,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_constraint("ck_policy_sets_source", "policy_sets", type_="check")
-    op.drop_constraint(
-        "fk_policy_sets_vcs_connection", "policy_sets", type_="foreignkey"
-    )
+    op.drop_constraint("fk_policy_sets_vcs_connection", "policy_sets", type_="foreignkey")
     op.drop_column("policy_sets", "vcs_last_error")
     op.drop_column("policy_sets", "vcs_last_synced_at")
     op.drop_column("policy_sets", "vcs_last_commit_sha")


### PR DESCRIPTION
## Summary
#391 (add_module_interface, `6e2f3a8b9c10`) and #372 (add_policy_set_vcs_fields, `c7d8e9f0a1b2`) both landed on main with `down_revision = 5a173d4b4e20`, leaving two alembic heads. `alembic upgrade head` errors with `Multiple head revisions are present` and the migrations Job crashes — blocking v0.29.0.

Neither migration has been applied anywhere outside local Tilt stacks (confirmed against prod state — DB schema doesn't have either set of columns yet), so the cleanest fix is to re-point #372's `down_revision` at #391 and **linearize** them, rather than landing a no-op merge migration on top.

## Change
- `c7d8e9f0a1b2_add_policy_set_vcs_fields.py`: `down_revision = "5a173d4b4e20"` → `"6e2f3a8b9c10"`
- Drive-by `ruff format` + import-sort pass on the same file (pre-commit hook caught it; the file was merged with slightly different formatting in #372).

## Verified locally
- `alembic heads` returns a single head (`c7d8e9f0a1b2`).
- Migrations Job in Tilt runs to completion (previously failing with multi-head error).
- DB shows both feature migrations' columns + the policy_sets check constraint applied correctly.

## Required before tagging v0.29.0.