### PR TITLE
feat: AI plan summary + failure analysis via LiteLLM (#401)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,10 +252,28 @@ jobs:
         # application that uses the library, not by the library. No fix
         # version is published. Suppress until a fix lands or the dispute
         # is resolved upstream.
+        #
+        # CVE-2026-40217 (litellm <1.83.11): proxy-mode sandbox escape
+        # in POST /guardrails/test_custom_code. Terrapod uses litellm as a
+        # library via litellm.acompletion() and never starts the proxy
+        # server, so the vulnerable endpoint is not reachable. Patched
+        # versions pin Python <3.14; the API image is on 3.14, so we can't
+        # bump the lower bound until upstream restores 3.14 compatibility.
+        # Drop this ignore once a 3.14-compatible patched release lands.
+        #
+        # CVE-2026-28684 (python-dotenv <1.2.2): symlink follow in
+        # set_key() / unset_key() when rewriting .env files across
+        # filesystems. Terrapod and its direct deps do not call those
+        # write APIs (we only ever READ env vars via os.environ and
+        # python-dotenv's load_dotenv). The vulnerability requires the
+        # application itself to call the affected functions. Drop this
+        # ignore once a transitive dep bumps python-dotenv naturally.
         run: |
           pip install pip-audit
           pip-audit -r services/requirements.txt --strict --desc \
-            --ignore-vuln PYSEC-2025-183
+            --ignore-vuln PYSEC-2025-183 \
+            --ignore-vuln CVE-2026-40217 \
+            --ignore-vuln CVE-2026-28684
 
   # ── Dependency Audit (npm) ────────────────────────────
   npm-audit:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 
 > **Drop-in replacement for HCP Terraform.** Point your existing `cloud` blocks, `go-tfe` clients, and CI/CD pipelines at Terrapod — zero code changes required.
 
+> **AI-augmented plans.** Every plan can carry an LLM-generated change description, risk assessment, and (on failure) suggested fixes — provider-agnostic via [LiteLLM](https://github.com/BerriAI/litellm). Wire AWS Bedrock (Claude, Nova, gpt-oss) with native IAM auth, or point at OpenAI, Anthropic, Gemini, Azure OpenAI, or any OpenAI-compatible endpoint. See [docs/ai-plan-summary.md](docs/ai-plan-summary.md).
+
 ---
 
 ## Key Features
@@ -35,6 +37,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | SSO (OIDC / SAML) | Implemented | Pluggable identity providers (Auth0, Okta, Azure AD, etc.) |
 | Drift Detection | Implemented | Scheduled plan-only runs to detect out-of-band changes |
 | Run Triggers | Implemented | Cross-workspace dependency chains — source apply triggers downstream runs |
+| **AI Plan Summary** | **Implemented** | **LLM-generated change summary + risk assessment on every plan; failure analysis on errored plans. Provider-agnostic via LiteLLM — AWS Bedrock (Claude, Nova, gpt-oss…), OpenAI, Anthropic direct, Google Gemini, Azure OpenAI, vLLM. IAM-native auth for Bedrock (IRSA + optional cross-account `sts:AssumeRole`).** |
 | Notifications | Implemented | Webhook (HMAC-SHA512), Slack (Block Kit), and email alerts on run events |
 | Run Tasks | Implemented | Pre/post-plan webhook hooks for external validation |
 | Workspace Health | Implemented | Per-workspace health conditions, VCS polling status, drift detection indicators |

--- a/alembic/versions/e25fce3f7b58_add_plan_summaries.py
+++ b/alembic/versions/e25fce3f7b58_add_plan_summaries.py
@@ -1,0 +1,90 @@
+"""Add plan_summaries table and workspace AI-summary opt-in columns (#401).
+
+Revision ID: e25fce3f7b58
+Revises: c7d8e9f0a1b2
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "e25fce3f7b58"
+down_revision = "c7d8e9f0a1b2"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "ai_summary_mode",
+            sa.String(10),
+            nullable=False,
+            server_default="default",
+        ),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "ai_summary_context",
+            sa.Text(),
+            nullable=False,
+            server_default="",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_workspaces_ai_summary_mode",
+        "workspaces",
+        "ai_summary_mode IN ('default', 'enabled', 'disabled')",
+    )
+
+    op.create_table(
+        "plan_summaries",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "run_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(20), nullable=False, server_default="plan_summary"),
+        sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("risk_level", sa.String(20), nullable=False, server_default=""),
+        sa.Column("risk_factors", JSONB, nullable=False, server_default="[]"),
+        sa.Column("model", sa.String(255), nullable=False, server_default=""),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_message", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("run_id", name="uq_plan_summaries_run"),
+    )
+    op.create_check_constraint(
+        "ck_plan_summaries_status",
+        "plan_summaries",
+        "status IN ('pending', 'ready', 'skipped', 'errored')",
+    )
+    op.create_check_constraint(
+        "ck_plan_summaries_kind",
+        "plan_summaries",
+        "kind IN ('plan_summary', 'failure_analysis')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_plan_summaries_kind", "plan_summaries", type_="check")
+    op.drop_constraint("ck_plan_summaries_status", "plan_summaries", type_="check")
+    op.drop_table("plan_summaries")
+    op.drop_constraint("ck_workspaces_ai_summary_mode", "workspaces", type_="check")
+    op.drop_column("workspaces", "ai_summary_context")
+    op.drop_column("workspaces", "ai_summary_mode")

--- a/docs/ai-plan-summary.md
+++ b/docs/ai-plan-summary.md
@@ -1,0 +1,305 @@
+# AI Plan Summary
+
+Terrapod can attach an AI-generated change summary and risk assessment
+to every plan, and an AI-generated failure analysis to every plan that
+errors. The summary lands in the run UI alongside the plan output, can
+be edited into the PR/MR comment for VCS-driven runs, and is queryable
+via the API.
+
+The feature is provider-agnostic. Terrapod uses the
+[LiteLLM](https://github.com/BerriAI/litellm) Python library
+in-process, so a single configuration block reaches every major model
+catalogue: AWS Bedrock (Anthropic Claude, Amazon Nova, Mistral, Meta
+Llama, OpenAI gpt-oss…), OpenAI direct (GPT-5, o-series),
+Anthropic direct (Claude Opus/Sonnet/Haiku), Google AI Studio / Vertex
+(Gemini), Azure OpenAI, vLLM, OpenRouter, and any other OpenAI-compat
+endpoint.
+
+The feature is **off by default**. Enabling it requires both flipping
+`ai_summary.enabled: true` and choosing a model.
+
+## What you get
+
+For a plan that succeeds (`status=planned`):
+
+- A change description (~600 words max, markdown-formatted) referring
+  to resources by their terraform address
+- An overall `risk_level` — one of `low`, `medium`, `high`, `critical`
+- A list of `risk_factors` ordered worst first, each with a severity,
+  title, detail, and (optionally) the affected resource address
+
+For a plan that errors before apply (plan-phase `errored`):
+
+- A description of the root cause in operator terms
+- A severity rating for how blocking the failure is
+- A list of suggested fixes with concrete steps
+
+Both kinds are persisted in the `plan_summaries` table, returned by
+`GET /api/v2/plans/{plan-id}/summary`, and announced over the
+per-workspace SSE channel as a `plan_summary_ready` event so the UI
+re-fetches without polling.
+
+## Quick start
+
+### AWS Bedrock + Anthropic Claude Opus
+
+```yaml
+api:
+  config:
+    ai_summary:
+      enabled: true
+      # Bedrock requires the inference-profile ID (not the bare
+      # foundation-model ID) for on-demand invocation of newer models.
+      model: bedrock/us.anthropic.claude-opus-4-8
+      max_output_tokens: 1024
+      daily_token_budget: 1000000   # cap output tokens per UTC day
+      auth:
+        aws_region: us-east-1
+        # Optional cross-account hop. When set, Terrapod's pod-side
+        # IAM identity (IRSA) calls sts:AssumeRole before invoking
+        # Bedrock. Empty = use the pod's ambient credentials.
+        aws_role_arn: arn:aws:iam::703581221739:role/terrapod
+      context:
+        fleet_context: |
+          Production AWS infrastructure for service-X.
+          Workspaces are sharded by region (us-east-1, eu-west-1).
+          Treat IAM role/policy churn on the `runner-*` set as critical;
+          treat S3 lifecycle adjustments as low-risk unless the bucket
+          name contains `audit`.
+```
+
+IAM policy on the `terrapod` role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "InvokeAnyBedrockModel",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:Converse",
+        "bedrock:ConverseStream"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*:ACCOUNT:inference-profile/*",
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:::foundation-model/*"
+      ]
+    }
+  ]
+}
+```
+
+The third resource (regionless `foundation-model/*`) is required when
+the `global.*` cross-region inference profiles are used — those fan
+out to a foundation model whose ARN has no region.
+
+Trust policy: trust the API pod's IRSA role via the
+`aws:PrincipalArn` ArnEquals condition.
+
+### OpenAI direct
+
+```yaml
+api:
+  config:
+    ai_summary:
+      enabled: true
+      model: openai/gpt-5
+      auth:
+        # Inject via env var rather than committing to values.yaml.
+        # Set TERRAPOD_AI_SUMMARY__AUTH__API_KEY from a K8s Secret.
+        # api_key: ""
+```
+
+K8s Secret + env var:
+
+```yaml
+api:
+  extraEnvFrom:
+    - secretRef:
+        name: terrapod-ai-summary-openai
+```
+
+```sh
+kubectl -n terrapod create secret generic terrapod-ai-summary-openai \
+  --from-literal=TERRAPOD_AI_SUMMARY__AUTH__API_KEY=sk-...
+```
+
+### Anthropic direct
+
+Same shape as OpenAI direct, with `model: anthropic/claude-opus-4-8`.
+The Secret carries the Anthropic API key under the same env var name.
+
+### Google Gemini (AI Studio)
+
+```yaml
+api:
+  config:
+    ai_summary:
+      enabled: true
+      model: gemini/gemini-2.5-pro
+```
+
+Secret carries the Google AI Studio API key under
+`TERRAPOD_AI_SUMMARY__AUTH__API_KEY`.
+
+### Self-hosted vLLM / OpenAI-compat gateway
+
+```yaml
+api:
+  config:
+    ai_summary:
+      enabled: true
+      model: openai/llama-3.3-70b
+      api_base: https://vllm.your-cluster.svc.cluster.local/v1
+      # api_key still required by the SDK; can be a placeholder value
+      # when the upstream doesn't actually check it.
+```
+
+## Provider matrix
+
+| Provider | `model` prefix | Auth source |
+|---|---|---|
+| AWS Bedrock | `bedrock/...` | boto3 chain: IRSA → optional `sts:AssumeRole` (via `aws_role_arn`) |
+| OpenAI | `openai/...` | `auth.api_key` |
+| Anthropic | `anthropic/...` | `auth.api_key` |
+| Google AI Studio | `gemini/...` | `auth.api_key` |
+| Azure OpenAI | `azure/<deployment>` | `auth.api_key` + `api_base` |
+| Vertex AI | `vertex_ai/...` | GCP ADC (workload identity) |
+| vLLM, OpenRouter, Together, Groq, … | `openai/<model>` | `auth.api_key` + `api_base` |
+
+`api_base` is only needed when the upstream isn't the vendor default
+(self-hosted, gateway, pinned Azure resource, etc.).
+
+## Workspace-level controls
+
+Each workspace has two opt-in fields:
+
+- `ai_summary_mode` — one of `default` (follow the deployment-wide
+  switch), `enabled` (always summarise this workspace), or `disabled`
+  (never summarise this workspace, regardless of global setting).
+- `ai_summary_context` — free text up to 4000 characters, appended to
+  the prompt as workspace-specific facts. Use this to surface
+  blast-radius warnings ("destroying the KMS key in this workspace
+  causes a global outage") or domain knowledge.
+
+Set both via the workspace settings UI, the API (`PATCH
+/api/v2/workspaces/{id}`), the `terrapod_workspace` Terraform resource
+attributes (`ai_summary_mode` and `ai_summary_context`), or the bulk
+update endpoint.
+
+## Prompt customisation
+
+The model's system prompt is composed of four layers, top to bottom:
+
+1. **In-code skill prompt** — defines the task, the JSON output
+   schema, and the guardrails. Owned by Terrapod source; operators
+   cannot override (changing it would break the DB schema and the UI
+   contract).
+2. **`ai_summary.context.prompt_prefix`** — free-text prepended before
+   the skill prompt. Use for tone/emphasis tweaks ("be terse", "lead
+   with destroys"). Do NOT use this to change the output contract.
+3. **`ai_summary.context.fleet_context`** — deployment-wide facts
+   about your infrastructure (what runs here, naming conventions,
+   provider/action pairs to flag).
+4. **`ai_summary.context.prompt_suffix`** — same as prefix, appended.
+5. (in the user message, after the system prompt) **Per-workspace
+   `ai_summary_context`** column — additive to fleet context.
+
+Tone/emphasis tweaks are safe in prefix/suffix; output schema changes
+are not. The DB schema and SSE/UI contract assume the skill prompt's
+JSON shape.
+
+## Daily token budget
+
+`ai_summary.daily_token_budget` caps total output tokens spent across
+all summaries per UTC day. Tracked in Redis. Once exhausted, further
+plans are recorded with `status='skipped'` and `error_message='daily
+token budget exhausted'`; the budget resets at the next UTC midnight.
+Set to `0` for unlimited.
+
+The counter is on output tokens only (cheaper to reason about than
+mixed input/output cost). Input-side cost is bounded by
+`plan_json_max_bytes` (default 500 KB) and `code_context_max_bytes`
+(default 200 KB).
+
+## Skipping and overrides
+
+A plan **does NOT** get a summary when:
+
+- The feature is globally disabled (`ai_summary.enabled: false`)
+- The workspace's `ai_summary_mode` is `disabled`
+- The daily token budget has been exhausted
+- The plan has no JSON output (older runs, or runner upload failed)
+
+In every case, run lifecycle is unaffected — the feature is best-effort
+and never blocks plan or apply.
+
+## How it works under the hood
+
+1. A plan reaches a terminal state (`planned` or `errored` while still
+   in the plan phase).
+2. The API enqueues an `ai_plan_summary` trigger via the distributed
+   scheduler (multi-replica safe; deduped per `(run_id, kind)`).
+3. Any API replica picks up the trigger, gathers the inputs (plan JSON
+   or plan log, plus the configuration version's `.tf` source for
+   code context), renders the prompt with the layered context, and
+   calls `litellm.acompletion`.
+4. The structured JSON response is parsed and upserted into the
+   `plan_summaries` table.
+5. A `plan_summary_ready` SSE event is published on the per-workspace
+   channel; the run-detail UI re-fetches.
+6. (For VCS-driven runs, future work) The summary is edited into the
+   PR/MR comment in place per head SHA.
+
+The handler is registered as a distributed task and only runs when
+`ai_summary.enabled` is true. Disabling the feature drops the trigger
+registration on the next API restart.
+
+## Troubleshooting
+
+**`status=errored, error_message=...`** — the model call failed. Common
+causes:
+
+- IAM policy missing required Bedrock actions or model resources
+- Anthropic models invoked on Bedrock's OpenAI-compat surface
+  (`bedrock-mantle`) — Bedrock returns
+  `"does not support the '/v1/chat/completions' API"`. Terrapod's
+  default Bedrock path uses Converse, which **does** support Claude;
+  this only happens if you've manually configured a different
+  endpoint
+- Bedrock's "Invocation of model ID X with on-demand throughput isn't
+  supported" — switch the model to its inference-profile form (e.g.
+  `bedrock/us.anthropic.claude-opus-4-8` instead of
+  `bedrock/anthropic.claude-opus-4-8`)
+- API key invalid or revoked
+- Network: the API pod cannot reach the upstream — check egress
+  policies / private endpoints
+
+**`status=skipped`** — see the `error_message` field on the row; it
+explains whether the workspace opted out or the daily budget was hit.
+
+**No row appears at all (404 from `GET /plans/.../summary`)** — the
+feature is globally disabled or the handler hasn't run yet. Check the
+API logs for `Registered trigger handler` (`ai_plan_summary`).
+
+**Wrong-looking risk assessment** — tune `fleet_context` to flag
+blast-radius concerns specific to your deployment. Add workspace-level
+`ai_summary_context` for the specific workspace.
+
+**Cost runaway** — set `daily_token_budget` to a fixed ceiling.
+Telemetry (input + output tokens per summary) is recorded on every
+row.
+
+## See also
+
+- [Authentication](authentication.md) — how API tokens and runner
+  tokens authenticate to Bedrock IAM / IRSA
+- [Cloud Credentials](cloud-credentials.md) — IRSA, GCP WIF, Azure WI
+  setup for the API pod
+- [Notifications](notifications.md) — webhook/Slack/email delivery is
+  separate; the summary is included in the run detail link in those
+  notifications

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Drift Detection](drift-detection.md) | Scheduled plan-only runs to detect infrastructure drift |
 | [Run Triggers](run-triggers.md) | Cross-workspace dependency chains |
 | [Remote State](remote-state.md) | Cross-workspace `terraform_remote_state` composition with producer-controlled allowlist |
+| [AI Plan Summary](ai-plan-summary.md) | LLM-generated change summary + risk assessment on every plan; failure analysis on errored plans. Bedrock, OpenAI, Anthropic, Gemini, vLLM — any provider via LiteLLM |
 | [Notifications](notifications.md) | Webhook, Slack, and email alerts on run events |
 | [Run Tasks](run-tasks.md) | Pre/post-plan webhook hooks for external validation |
 | [Policy-as-Code](policies.md) | OPA/Rego policy sets, advisory/mandatory enforcement, label scoping |

--- a/go-terrapod/plan_summaries.go
+++ b/go-terrapod/plan_summaries.go
@@ -1,0 +1,117 @@
+package terrapod
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// PlanSummary is the AI-generated description + risk assessment (or
+// failure analysis) attached to a single plan, produced by the
+// optional ai_summary feature (#401).
+//
+// Kind distinguishes the two skills:
+//   - "plan_summary": successful plan → describe proposed changes
+//     and rate their risk
+//   - "failure_analysis": errored plan → explain why the plan
+//     failed and suggest fixes
+//
+// Field reuse across kinds:
+//   - Description: change summary OR failure explanation
+//   - RiskLevel:   change-risk severity OR failure severity
+//   - RiskFactors: discrete risks OR suggested fixes (same shape;
+//     the UI / your consumer decides how to render them)
+type PlanSummary struct {
+	ID          string `json:"id"`
+	RunID       string `json:"-"` // resolved from `run` relationship
+	Kind        string `json:"kind"`
+	Status      string `json:"status"`
+	Description string `json:"description,omitempty"`
+	RiskLevel   string `json:"risk-level,omitempty"`
+	RiskFactors []PlanSummaryRiskFactor `json:"risk-factors,omitempty"`
+
+	// Telemetry / debugging
+	Model        string `json:"model,omitempty"`
+	InputTokens  int    `json:"input-tokens"`
+	OutputTokens int    `json:"output-tokens"`
+	ErrorMessage string `json:"error-message,omitempty"`
+
+	CreatedAt string `json:"created-at,omitempty"`
+	UpdatedAt string `json:"updated-at,omitempty"`
+}
+
+// PlanSummaryRiskFactor is one entry in PlanSummary.RiskFactors.
+// For Kind="plan_summary" entries describe a risk; for
+// Kind="failure_analysis" entries describe a suggested fix.
+type PlanSummaryRiskFactor struct {
+	Severity        string `json:"severity"`
+	Title           string `json:"title"`
+	Detail          string `json:"detail"`
+	ResourceAddress string `json:"resource_address,omitempty"`
+}
+
+// GetPlanSummary fetches the AI summary for one plan.
+//
+// planID accepts either a bare run UUID or the prefixed "plan-<uuid>"
+// form — both resolve to the same plan.
+//
+// Returns *NotFoundError when no summary exists yet (the feature is
+// off for this workspace, the plan hasn't been summarised, or the
+// summariser was skipped). Returns the row as-is for any other status
+// — callers should branch on s.Status:
+//
+//	switch s.Status {
+//	case "ready":    // s.Description, s.RiskLevel, s.RiskFactors are populated
+//	case "pending":  // in flight — retry later or wait on the SSE event
+//	case "skipped":  // workspace opted out or daily budget hit
+//	case "errored":  // s.ErrorMessage holds the failure reason
+//	}
+func (c *Client) GetPlanSummary(ctx context.Context, planID string) (*PlanSummary, error) {
+	if planID == "" {
+		return nil, errors.New("plan id is required")
+	}
+	id := planID
+	if len(id) > 5 && id[:5] != "plan-" {
+		id = "plan-" + id
+	}
+	data, err := c.Get(ctx, "/api/v2/plans/"+url.PathEscape(id)+"/summary")
+	if err != nil {
+		return nil, err
+	}
+	res, err := ParseResource(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse plan summary response: %w", err)
+	}
+	return planSummaryFromResource(res), nil
+}
+
+func planSummaryFromResource(res *Resource) *PlanSummary {
+	s := &PlanSummary{
+		ID:           res.ID,
+		Kind:         GetStringAttr(res, "kind"),
+		Status:       GetStringAttr(res, "status"),
+		Description:  GetStringAttr(res, "description"),
+		RiskLevel:    GetStringAttr(res, "risk-level"),
+		Model:        GetStringAttr(res, "model"),
+		InputTokens:  int(GetIntAttr(res, "input-tokens")),
+		OutputTokens: int(GetIntAttr(res, "output-tokens")),
+		ErrorMessage: GetStringAttr(res, "error-message"),
+		CreatedAt:    GetStringAttr(res, "created-at"),
+		UpdatedAt:    GetStringAttr(res, "updated-at"),
+	}
+	// Run relationship → expose as bare UUID for ergonomic round-tripping
+	// with the rest of the SDK (Run.ID is "run-<uuid>"; we strip the prefix
+	// here so callers can pass either form to GetRun).
+	s.RunID = GetRelationshipID(res, "run")
+
+	if raw, ok := res.Attributes["risk-factors"]; ok {
+		// risk-factors arrives as a JSON array of objects; unmarshal
+		// directly into the slice rather than hand-walking interface
+		// values. The server clamps each field, so we don't bother
+		// re-validating here.
+		_ = json.Unmarshal(raw, &s.RiskFactors)
+	}
+	return s
+}

--- a/go-terrapod/workspaces.go
+++ b/go-terrapod/workspaces.go
@@ -45,8 +45,16 @@ type Workspace struct {
 	DriftDetectionIntervalSeconds *int64            `json:"drift-detection-interval-seconds,omitempty"`
 	DriftStatus                   string            `json:"drift-status,omitempty"`
 	DriftLastCheckedAt            string            `json:"drift-last-checked-at,omitempty"`
-	CreatedAt                     string            `json:"created-at,omitempty"`
-	UpdatedAt                     string            `json:"updated-at,omitempty"`
+	// AISummaryMode is the three-state per-workspace override (#401):
+	//   "default"  → follow the deployment-wide ai_summary.enabled flag
+	//   "enabled"  → always summarise (no-op when global is off)
+	//   "disabled" → never summarise this workspace's plans
+	AISummaryMode string `json:"ai-summary-mode,omitempty"`
+	// AISummaryContext is workspace-specific facts added on top of the
+	// deployment-wide fleet_context when the summariser builds its prompt.
+	AISummaryContext string `json:"ai-summary-context,omitempty"`
+	CreatedAt        string `json:"created-at,omitempty"`
+	UpdatedAt        string `json:"updated-at,omitempty"`
 }
 
 // CreateWorkspaceRequest is the input shape for Client.CreateWorkspace.
@@ -77,6 +85,13 @@ type CreateWorkspaceRequest struct {
 	VarFiles                      []string           `json:"var-files,omitempty"`
 	DriftDetectionEnabled         *bool              `json:"drift-detection-enabled,omitempty"`
 	DriftDetectionIntervalSeconds *int64             `json:"drift-detection-interval-seconds,omitempty"`
+	// AISummaryMode is the three-state per-workspace override (#401):
+	// "default" | "enabled" | "disabled". Empty string omits the field
+	// (server-side default applies — "default").
+	AISummaryMode string `json:"ai-summary-mode,omitempty"`
+	// AISummaryContext is workspace-specific context added to the model
+	// prompt. Capped at 4000 chars server-side.
+	AISummaryContext string `json:"ai-summary-context,omitempty"`
 }
 
 // UpdateWorkspaceRequest is the input shape for Client.UpdateWorkspace.
@@ -108,6 +123,14 @@ type UpdateWorkspaceRequest struct {
 	VarFiles                      []string          `json:"var-files,omitempty"`
 	DriftDetectionEnabled         *bool             `json:"drift-detection-enabled,omitempty"`
 	DriftDetectionIntervalSeconds *int64            `json:"drift-detection-interval-seconds,omitempty"`
+	// AISummaryMode see CreateWorkspaceRequest. On UPDATE, empty string
+	// leaves the existing value untouched — to explicitly set "follow
+	// deployment default", pass "default".
+	AISummaryMode string `json:"ai-summary-mode,omitempty"`
+	// AISummaryContext see CreateWorkspaceRequest. To clear an existing
+	// context, set this to "" — but note empty string also means
+	// "leave alone" (a Terrapod-side limitation; clear via the UI).
+	AISummaryContext *string `json:"ai-summary-context,omitempty"`
 }
 
 // WorkspaceListOptions filters and paginates ListWorkspaces. Zero
@@ -309,6 +332,12 @@ func workspaceCreateAttrs(req CreateWorkspaceRequest) map[string]any {
 	if req.DriftDetectionIntervalSeconds != nil {
 		attrs["drift-detection-interval-seconds"] = *req.DriftDetectionIntervalSeconds
 	}
+	if req.AISummaryMode != "" {
+		attrs["ai-summary-mode"] = req.AISummaryMode
+	}
+	if req.AISummaryContext != "" {
+		attrs["ai-summary-context"] = req.AISummaryContext
+	}
 	return attrs
 }
 
@@ -373,6 +402,13 @@ func workspaceUpdateAttrs(req UpdateWorkspaceRequest) map[string]any {
 	if req.DriftDetectionIntervalSeconds != nil {
 		attrs["drift-detection-interval-seconds"] = *req.DriftDetectionIntervalSeconds
 	}
+	if req.AISummaryMode != "" {
+		attrs["ai-summary-mode"] = req.AISummaryMode
+	}
+	if req.AISummaryContext != nil {
+		// *string so callers can explicitly clear the context with &"".
+		attrs["ai-summary-context"] = *req.AISummaryContext
+	}
 	return attrs
 }
 
@@ -430,6 +466,8 @@ func workspaceFromResource(res *Resource) *Workspace {
 		DriftDetectionEnabled: GetBoolAttr(res, "drift-detection-enabled"),
 		DriftStatus:           GetStringAttr(res, "drift-status"),
 		DriftLastCheckedAt:    GetStringAttr(res, "drift-last-checked-at"),
+		AISummaryMode:         GetStringAttr(res, "ai-summary-mode"),
+		AISummaryContext:      GetStringAttr(res, "ai-summary-context"),
 		CreatedAt:             GetStringAttr(res, "created-at"),
 		UpdatedAt:             GetStringAttr(res, "updated-at"),
 	}

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -250,6 +250,40 @@ data:
       binary_cache_retention_days: {{ .Values.api.config.artifact_retention.binary_cache_retention_days | default 30 }}
       module_overrides_retention_days: {{ .Values.api.config.artifact_retention.module_overrides_retention_days | default 14 }}
     {{- end }}
+    {{- if .Values.api.config.ai_summary }}
+    ai_summary:
+      enabled: {{ .Values.api.config.ai_summary.enabled | default false }}
+      {{- if .Values.api.config.ai_summary.model }}
+      model: {{ .Values.api.config.ai_summary.model | quote }}
+      {{- end }}
+      {{- if .Values.api.config.ai_summary.api_base }}
+      api_base: {{ .Values.api.config.ai_summary.api_base | quote }}
+      {{- end }}
+      max_output_tokens: {{ .Values.api.config.ai_summary.max_output_tokens | default 1024 }}
+      request_timeout_seconds: {{ .Values.api.config.ai_summary.request_timeout_seconds | default 60 }}
+      daily_token_budget: {{ .Values.api.config.ai_summary.daily_token_budget | default 0 }}
+      plan_json_max_bytes: {{ .Values.api.config.ai_summary.plan_json_max_bytes | default 500000 }}
+      code_context_max_bytes: {{ .Values.api.config.ai_summary.code_context_max_bytes | default 200000 }}
+      {{- with .Values.api.config.ai_summary.auth }}
+      auth:
+        # api_key is injected via env var (TERRAPOD_AI_SUMMARY__AUTH__API_KEY)
+        # from a K8s Secret; never rendered into this ConfigMap.
+        aws_region: {{ .aws_region | default "us-east-1" | quote }}
+        {{- if .aws_role_arn }}
+        aws_role_arn: {{ .aws_role_arn | quote }}
+        {{- end }}
+        aws_session_name: {{ .aws_session_name | default "terrapod-ai-summary" | quote }}
+        {{- if .aws_external_id }}
+        aws_external_id: {{ .aws_external_id | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.api.config.ai_summary.context }}
+      context:
+        prompt_prefix: {{ .prompt_prefix | default "" | quote }}
+        prompt_suffix: {{ .prompt_suffix | default "" | quote }}
+        fleet_context: {{ .fleet_context | default "" | quote }}
+      {{- end }}
+    {{- end }}
     default_execution_backend: {{ .Values.api.config.default_execution_backend | default "tofu" | quote }}
     default_terraform_version: {{ .Values.api.config.default_terraform_version | default "1.12" | quote }}
     {{- if .Values.api.config.cors.allow_origins }}

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -7,6 +7,15 @@ api:
   # Hot reload for local dev
   command: ["uvicorn", "terrapod.api.app:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--timeout-graceful-shutdown", "5"]
 
+  # Local-only: inject AWS creds for the in-development AI plan-summary
+  # feature (#401). The k8s Secret is created out-of-band via kubectl;
+  # both the user and the inline policy auto-expire on 2026-06-08T23:59:59Z
+  # so this is safe to leave wired even if the Secret is forgotten.
+  extraEnvFrom:
+    - secretRef:
+        name: terrapod-ai-summary-aws-creds
+        optional: true
+
   autoscaling:
     enabled: false
 
@@ -66,6 +75,36 @@ api:
       local_enabled: true
       callback_base_url: "https://terrapod.local"
       session_ttl_hours: 12
+
+    # AI plan-summary (#401) — Bedrock Converse via LiteLLM. The
+    # terrapod-testing IAM user's static keys (delivered via the
+    # terrapod-ai-summary-aws-creds K8s Secret + extraEnvFrom above)
+    # are picked up by boto3's default credential chain. No AssumeRole
+    # hop in local dev — the user's inline policy grants Bedrock
+    # actions directly and auto-expires on 2026-06-08. Production
+    # deployments set aws_role_arn to chain into the central role.
+    ai_summary:
+      enabled: true
+      # Bedrock requires the inference-profile ID for on-demand
+      # invocation of newer Anthropic models, not the bare
+      # foundation-model ID. `us.` = US cross-region profile.
+      model: "bedrock/us.anthropic.claude-opus-4-8"
+      max_output_tokens: 1024
+      request_timeout_seconds: 90
+      daily_token_budget: 0  # no cap in local dev
+      plan_json_max_bytes: 500000
+      code_context_max_bytes: 200000
+      auth:
+        aws_region: us-east-1
+        # aws_role_arn intentionally unset — use the pod's env-var
+        # creds (terrapod-testing user) directly. Set to
+        # "arn:aws:iam::703581221739:role/terrapod" in production.
+      context:
+        fleet_context: |
+          This is a local Tilt development stack for Terrapod itself.
+          Workspaces here are throw-away test fixtures, not real
+          infrastructure. Bias toward low/medium risk ratings unless
+          the plan actually destroys data stores or IAM trust roots.
 
   serviceAccount:
     create: true

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -645,6 +645,41 @@
           }
         },
 
+        "ai_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "model": { "type": "string" },
+            "api_base": { "type": "string" },
+            "max_output_tokens": { "type": "integer", "minimum": 1 },
+            "request_timeout_seconds": { "type": "integer", "minimum": 1 },
+            "daily_token_budget": { "type": "integer", "minimum": 0 },
+            "plan_json_max_bytes": { "type": "integer", "minimum": 0 },
+            "code_context_max_bytes": { "type": "integer", "minimum": 0 },
+            "auth": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "api_key": { "type": "string" },
+                "aws_region": { "type": "string" },
+                "aws_role_arn": { "type": "string" },
+                "aws_session_name": { "type": "string" },
+                "aws_external_id": { "type": "string" }
+              }
+            },
+            "context": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "prompt_prefix": { "type": "string" },
+                "prompt_suffix": { "type": "string" },
+                "fleet_context": { "type": "string" }
+              }
+            }
+          }
+        },
+
         "drift_detection": {
           "type": "object",
           "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -269,6 +269,72 @@ api:
       default_join_token_max_uses: 2
       default_join_token_ttl_seconds: 3600
 
+    # AI plan-summary (#401). Off by default. When enabled, every
+    # plan-phase terminal transition triggers an asynchronous LLM call
+    # via the LiteLLM library — successful plans get a change-summary +
+    # risk assessment; plan-phase failures get a failure analysis +
+    # suggested fixes. Results are stored in the plan_summaries table,
+    # surfaced in the run UI, and (for VCS-driven runs) edited into the
+    # PR/MR comment.
+    #
+    # The `model` string's prefix selects the provider AND its auth path:
+    #   bedrock/<id>     — AWS Bedrock via boto3 + IAM (IRSA / optional
+    #                      sts:AssumeRole via aws_role_arn below)
+    #   openai/<id>      — OpenAI direct, with auth.api_key
+    #   anthropic/<id>   — Anthropic direct, with auth.api_key
+    #   gemini/<id>      — Google AI Studio, with auth.api_key
+    #   azure/<deployment> — Azure OpenAI, with auth.api_key + api_base
+    #
+    # For self-hosted OpenAI-compat endpoints (vLLM, a deployed
+    # LiteLLM proxy, etc.), use `openai/<model>` with `api_base` set.
+    #
+    # Context layering (top → bottom of model prompt):
+    #   1. In-code skill prompt (owns the JSON output contract)
+    #   2. context.prompt_prefix (operator tone tweak)
+    #   3. context.fleet_context (deployment-wide facts)
+    #   4. context.prompt_suffix (operator tone tweak)
+    #   5. Per-workspace ai_summary_context (additive workspace facts)
+    ai_summary:
+      enabled: false
+      # LiteLLM model string. Examples:
+      #   bedrock/anthropic.claude-opus-4-8
+      #   openai/gpt-5
+      #   anthropic/claude-opus-4-8
+      #   gemini/gemini-2.5-pro
+      model: ""
+      # Optional base URL override (vLLM, LiteLLM proxy, custom Azure).
+      # Leave empty for vendor providers — LiteLLM knows the defaults.
+      api_base: ""
+      max_output_tokens: 1024
+      request_timeout_seconds: 60
+      # Output-token cap per UTC day across all summaries. 0 = unlimited.
+      daily_token_budget: 0
+      # Size caps on the inputs attached to the model request.
+      plan_json_max_bytes: 500000
+      code_context_max_bytes: 200000
+      auth:
+        # Bearer key for non-AWS providers (OpenAI, Anthropic, Gemini,
+        # Azure, vLLM). Inject via TERRAPOD_AI_SUMMARY__AUTH__API_KEY
+        # from a K8s Secret. Ignored when model="bedrock/..." (AWS
+        # credential chain takes over).
+        # api_key: ""
+        # AWS / Bedrock fields. Only used when model="bedrock/...".
+        # aws_role_arn empty → use pod's ambient IAM creds directly
+        # (IRSA via the service account annotation). Set to chain
+        # into a cross-account role via sts:AssumeRole.
+        aws_region: us-east-1
+        aws_role_arn: ""
+        aws_session_name: terrapod-ai-summary
+        aws_external_id: ""
+      context:
+        # Tone/emphasis tweaks around the in-code skill prompt. Do NOT
+        # use these to change the output schema — that breaks the UI.
+        prompt_prefix: ""
+        prompt_suffix: ""
+        # Deployment-wide facts about your infrastructure. Plain text
+        # or markdown. Multiline strings are supported via `|`.
+        fleet_context: ""
+
     # Drift Detection — scheduled plan-only runs to detect infrastructure drift
     drift_detection:
       enabled: true

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -51,3 +51,16 @@ CVE-2026-46680
 # this entry as soon as the upstream base image picks up the patched
 # Debian point release.
 CVE-2026-40356
+
+# CVE-2026-40217 — litellm proxy-mode arbitrary code execution via
+# bytecode-level sandbox escape in POST /guardrails/test_custom_code.
+# Reaching the endpoint requires a proxy-admin credential and the
+# proxy server to be running. Terrapod imports litellm as a library
+# and only calls `litellm.acompletion()` from the API process — the
+# proxy server is never started, the /guardrails/* HTTP routes are
+# never mounted, and no proxy-admin credentials exist in our config.
+# The vulnerable code path is structurally unreachable.
+# Patched in litellm 1.83.11+, but the patched versions pin Python
+# <3.14 and our API image is on 3.14. Drop this ignore once a
+# 3.14-compatible patched release lands upstream.
+CVE-2026-40217

--- a/provider/internal/datasources/workspace/data_source.go
+++ b/provider/internal/datasources/workspace/data_source.go
@@ -42,6 +42,8 @@ type workspaceDataSourceModel struct {
 	VarFiles                      types.List   `tfsdk:"var_files"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`
 	DriftDetectionIntervalSeconds types.Int64  `tfsdk:"drift_detection_interval_seconds"`
+	AISummaryMode                 types.String `tfsdk:"ai_summary_mode"`
+	AISummaryContext              types.String `tfsdk:"ai_summary_context"`
 	OwnerEmail                    types.String `tfsdk:"owner_email"`
 	DriftStatus                   types.String `tfsdk:"drift_status"`
 	DriftLastCheckedAt            types.String `tfsdk:"drift_last_checked_at"`
@@ -82,6 +84,8 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"var_files":                        computedList("Var files for -var-file arguments."),
 			"drift_detection_enabled":          computedBool("Drift detection enabled."),
 			"drift_detection_interval_seconds": computedInt64("Drift detection interval."),
+			"ai_summary_mode":                  computedString("Per-workspace AI plan-summary mode: 'default' (follow deployment global), 'enabled' (always summarise), or 'disabled' (never summarise)."),
+			"ai_summary_context":               computedString("Workspace-specific context appended to the AI summariser prompt."),
 			"owner_email":                      computedString("Owner email."),
 			"drift_status":                     computedString("Drift status."),
 			"drift_last_checked_at":            computedString("Last drift check."),
@@ -150,6 +154,13 @@ func readDataSourceModel(ctx context.Context, res *terrapod.Resource, m *workspa
 	m.CreatedAt = types.StringValue(terrapod.GetStringAttr(res, "created-at"))
 	m.UpdatedAt = types.StringValue(terrapod.GetStringAttr(res, "updated-at"))
 	m.DriftDetectionEnabled = types.BoolValue(terrapod.GetBoolAttr(res, "drift-detection-enabled"))
+	// AI plan summary (#401)
+	mode := terrapod.GetStringAttr(res, "ai-summary-mode")
+	if mode == "" {
+		mode = "default"
+	}
+	m.AISummaryMode = types.StringValue(mode)
+	m.AISummaryContext = types.StringValue(terrapod.GetStringAttr(res, "ai-summary-context"))
 
 	setOptionalString(&m.TerraformVersion, terrapod.GetStringAttr(res, "terraform-version"))
 	setOptionalString(&m.VCSRepoURL, terrapod.GetStringAttr(res, "vcs-repo-url"))

--- a/provider/internal/resources/workspace/model.go
+++ b/provider/internal/resources/workspace/model.go
@@ -73,6 +73,8 @@ type workspaceModel struct {
 	VarFiles                      types.List   `tfsdk:"var_files"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`
 	DriftDetectionIntervalSeconds types.Int64  `tfsdk:"drift_detection_interval_seconds"`
+	AISummaryMode                 types.String `tfsdk:"ai_summary_mode"`
+	AISummaryContext              types.String `tfsdk:"ai_summary_context"`
 
 	// Set of workspace IDs authorized to read this workspace's state
 	// via `terraform_remote_state` (#344). Producer-controlled

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -176,6 +176,22 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
+			"ai_summary_mode": schema.StringAttribute{
+				Description: "Per-workspace AI plan-summary opt-in (#401). One of \"default\" (follow the deployment's global `ai_summary.enabled` setting), \"enabled\" (always summarise this workspace's plans), or \"disabled\" (never summarise — overrides global). Defaults to \"default\".",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"ai_summary_context": schema.StringAttribute{
+				Description: "Workspace-specific facts appended to the AI summariser's prompt (#401). Additive to the deployment-wide fleet context. Use to flag blast-radius concerns or domain knowledge the model should weigh when describing changes for this workspace. Max 4000 characters.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"remote_state_consumers": schema.SetAttribute{
 				Description: "Workspace IDs authorized to read this workspace's state via `terraform_remote_state` (#344). Optional + Computed: leave null to opt out of managing the set here (server side is left intact — useful when consumers are managed via standalone `terrapod_remote_state_consumer` resources elsewhere). Set to `[]` to explicitly remove all consumers. **Do not mix this attribute with standalone `terrapod_remote_state_consumer` resources targeting the same producer** — the two will drift on every plan and fight each other. Mutations require admin/write on this (producer) workspace; a consumer team cannot self-grant.",
 				Optional:    true,
@@ -461,6 +477,12 @@ func buildCreateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 		v := m.DriftDetectionIntervalSeconds.ValueInt64()
 		req.DriftDetectionIntervalSeconds = &v
 	}
+	if !m.AISummaryMode.IsNull() && !m.AISummaryMode.IsUnknown() {
+		req.AISummaryMode = m.AISummaryMode.ValueString()
+	}
+	if !m.AISummaryContext.IsNull() && !m.AISummaryContext.IsUnknown() {
+		req.AISummaryContext = m.AISummaryContext.ValueString()
+	}
 	return req, diags
 }
 
@@ -542,6 +564,13 @@ func buildUpdateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 		v := m.DriftDetectionIntervalSeconds.ValueInt64()
 		req.DriftDetectionIntervalSeconds = &v
 	}
+	if !m.AISummaryMode.IsNull() && !m.AISummaryMode.IsUnknown() {
+		req.AISummaryMode = m.AISummaryMode.ValueString()
+	}
+	if !m.AISummaryContext.IsNull() && !m.AISummaryContext.IsUnknown() {
+		v := m.AISummaryContext.ValueString()
+		req.AISummaryContext = &v
+	}
 	return req, diags
 }
 
@@ -612,6 +641,17 @@ func readWorkspaceIntoModel(ctx context.Context, ws *terrapod.Workspace, m *work
 	} else {
 		m.DriftLastCheckedAt = types.StringNull()
 	}
+
+	// AI plan summary (#401). The server always returns a concrete
+	// value for `ai-summary-mode` (defaulting to "default"); the
+	// context is the empty string for new workspaces. Pin both to
+	// concrete StringValues so Terraform doesn't see "unknown" drift.
+	if ws.AISummaryMode != "" {
+		m.AISummaryMode = types.StringValue(ws.AISummaryMode)
+	} else {
+		m.AISummaryMode = types.StringValue("default")
+	}
+	m.AISummaryContext = types.StringValue(ws.AISummaryContext)
 
 	// Var files
 	if len(ws.VarFiles) > 0 {

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -52,6 +52,12 @@ sse-starlette = "^3.3.2"
 prometheus-client = ">=0.24,<0.26"
 # imghdr removed in Python 3.13; pgpy still imports it
 standard-imghdr = "^3.13"
+# LiteLLM SDK for the AI plan-summary feature (#401). One library, every
+# major provider — Bedrock (native Converse + IAM auth via boto3),
+# OpenAI, Anthropic direct, Gemini, Azure OpenAI, vLLM, etc. Terrapod
+# speaks OpenAI Chat Completions request shape to LiteLLM; LiteLLM
+# handles per-provider request translation and auth in-process.
+litellm = ">=1.78,<2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.2"

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -57,6 +57,14 @@ standard-imghdr = "^3.13"
 # OpenAI, Anthropic direct, Gemini, Azure OpenAI, vLLM, etc. Terrapod
 # speaks OpenAI Chat Completions request shape to LiteLLM; LiteLLM
 # handles per-provider request translation and auth in-process.
+#
+# Upper bound <2.0 is the standard major-version cap. We can't bump
+# the lower bound to clear CVE-2026-40217 (litellm proxy sandbox
+# escape, patched in 1.83.11+) because the patched releases pin
+# Python <3.14 and our API image runs on 3.14. The CVE is in proxy
+# mode only — we use the library directly via acompletion(), never
+# start the proxy server — so it's not exploitable here. Ignored in
+# CI via --ignore-vuln (see .github/workflows/ci.yml).
 litellm = ">=1.78,<2.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -208,6 +208,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             description="Check workspaces for infrastructure drift",
         )
 
+    # AI plan summariser (#401). Always registered when feature is enabled
+    # — runs that don't qualify (workspace disabled, budget exhausted) are
+    # handled inside the handler so the trigger queue is uniform.
+    if settings.ai_summary.enabled:
+        from terrapod.services.summariser import handle_ai_plan_summary
+
+        register_trigger_handler(
+            "ai_plan_summary",
+            handler=handle_ai_plan_summary,
+            description="Summarise plan changes or analyse plan failures via LLM",
+        )
+
     # Run reconciler (drives run state transitions based on Job outcomes)
     from terrapod.services.run_reconciler import reconcile_runs
 

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -43,7 +43,7 @@ from terrapod.api.dependencies import (
     get_current_user,
     get_listener_identity,
 )
-from terrapod.db.models import Run, StateVersion, VCSConnection, Workspace
+from terrapod.db.models import PlanSummary, Run, StateVersion, VCSConnection, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service, run_service
@@ -790,6 +790,10 @@ def _plan_json(run: Run) -> dict:
         attrs["resource-changes"] = run.resource_changes
         attrs["resource-destructions"] = run.resource_destructions
         attrs["resource-imports"] = run.resource_imports
+    # AI plan summary URL — surfaced as a Terrapod-native link on every
+    # plan response so the UI knows where to fetch the structured
+    # summary. 404s gracefully when no summary exists yet.
+    attrs["ai-summary-url"] = f"{base}/api/v2/plans/{run.id}/summary"
     return {
         "data": {
             "id": f"plan-{run.id}",
@@ -816,6 +820,55 @@ async def show_plan_by_id(
     run = await _get_run(plan_id.replace("plan-", "run-"), db)
     await _require_run_ws_permission(run, "read", user, db)
     return JSONResponse(content=_plan_json(run))
+
+
+@router.get("/plans/{plan_id}/summary")
+async def show_plan_summary(
+    plan_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """AI-generated plan summary or failure analysis (#401).
+
+    Returns 404 when no summary exists yet — the UI uses this as the
+    "not summarised" signal (vs a `pending` row which means "in flight").
+    The response shape is the same for both ``kind`` values; the UI
+    branches on the ``kind`` attribute.
+    """
+    run = await _get_run(plan_id.replace("plan-", "run-"), db)
+    await _require_run_ws_permission(run, "read", user, db)
+
+    summary = (
+        await db.execute(select(PlanSummary).where(PlanSummary.run_id == run.id))
+    ).scalar_one_or_none()
+    if summary is None:
+        raise HTTPException(status_code=404, detail="no summary for this plan")
+
+    return JSONResponse(
+        content={
+            "data": {
+                "id": f"plan-summary-{summary.id}",
+                "type": "plan-summaries",
+                "attributes": {
+                    "kind": summary.kind,
+                    "status": summary.status,
+                    "description": summary.description,
+                    "risk-level": summary.risk_level,
+                    "risk-factors": summary.risk_factors,
+                    "model": summary.model,
+                    "input-tokens": summary.input_tokens,
+                    "output-tokens": summary.output_tokens,
+                    "error-message": summary.error_message,
+                    "created-at": _rfc3339(summary.created_at),
+                    "updated-at": _rfc3339(summary.updated_at),
+                },
+                "relationships": {
+                    "plan": {"data": {"id": f"plan-{run.id}", "type": "plans"}},
+                    "run": {"data": {"id": f"run-{run.id}", "type": "runs"}},
+                },
+            }
+        }
+    )
 
 
 @extensions_router.get("/runs/{run_id}/plan")

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -605,6 +605,8 @@ def _workspace_json(
                 else None,
                 "var-files": ws.var_files or [],
                 "trigger-prefixes": ws.trigger_prefixes or [],
+                "ai-summary-mode": ws.ai_summary_mode,
+                "ai-summary-context": ws.ai_summary_context,
                 "drift-detection-enabled": ws.drift_detection_enabled,
                 "drift-detection-interval-seconds": ws.drift_detection_interval_seconds,
                 "drift-last-checked-at": _rfc3339(ws.drift_last_checked_at),
@@ -1377,6 +1379,33 @@ async def update_workspace(
         ws.drift_detection_interval_seconds = _clamp_drift_interval(
             attrs["drift-detection-interval-seconds"]
         )
+
+    # AI plan summary opt-in (#401). The mode is a three-state enum
+    # constrained by a DB CHECK; reject other values up-front rather than
+    # surfacing a less-helpful 500 from the integrity error.
+    if "ai-summary-mode" in attrs:
+        mode = attrs["ai-summary-mode"]
+        if mode not in ("default", "enabled", "disabled"):
+            raise HTTPException(
+                status_code=422,
+                detail="ai-summary-mode must be 'default', 'enabled', or 'disabled'",
+            )
+        ws.ai_summary_mode = mode
+    if "ai-summary-context" in attrs:
+        ctx = attrs["ai-summary-context"]
+        if ctx is None:
+            ctx = ""
+        if not isinstance(ctx, str):
+            raise HTTPException(status_code=422, detail="ai-summary-context must be a string")
+        # Cap at a reasonable size — workspace context is a hint, not a
+        # repo. Anything bigger lives in fleet_context or a doc the user
+        # can paste into their prompt_suffix.
+        if len(ctx) > 4000:
+            raise HTTPException(
+                status_code=422,
+                detail="ai-summary-context max length is 4000 characters",
+            )
+        ws.ai_summary_context = ctx
 
     # VCS connection relationship
     relationships = body.get("data", {}).get("relationships", {})

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -624,6 +624,195 @@ class MetricsConfig(BaseModel):
     )
 
 
+# --- AI Plan Summary Configuration ---
+
+
+class AISummaryAuthConfig(BaseModel):
+    """Auth configuration for the AI summariser.
+
+    LiteLLM picks the right auth path per provider automatically: bearer
+    for OpenAI/Anthropic/Gemini/Azure/vLLM (read from the relevant env
+    var or this config), AWS credential chain for Bedrock (boto3 inherits
+    the pod's IRSA creds and optionally hops through sts:AssumeRole).
+    No mode switch — the model string's prefix (``bedrock/``,
+    ``openai/``, ``anthropic/``, ``gemini/``, etc.) is what selects the
+    underlying auth path.
+    """
+
+    api_key: str = Field(
+        default="",
+        description=(
+            "Bearer API key for non-AWS providers (OpenAI, Anthropic "
+            "direct, Gemini, Azure OpenAI, vLLM gateway, etc.). Inject "
+            "from a K8s Secret via env var (TERRAPOD_AI_SUMMARY__AUTH__API_KEY) "
+            "rather than committing to values.yaml. Ignored when the "
+            "model string targets a provider LiteLLM authenticates "
+            "another way (e.g. ``bedrock/...`` uses the AWS credential "
+            "chain instead)."
+        ),
+    )
+    aws_region: str = Field(
+        default="us-east-1",
+        description=(
+            "AWS region for Bedrock invocation. Used only when the "
+            "model string starts with ``bedrock/``. Passed through to "
+            "LiteLLM as ``aws_region_name``."
+        ),
+    )
+    aws_role_arn: str = Field(
+        default="",
+        description=(
+            "Cross-account IAM role to assume for Bedrock access. Empty "
+            "means use the pod's ambient credentials (IRSA / env-var / "
+            "shared credentials file) directly. When set, LiteLLM calls "
+            "sts:AssumeRole and caches the temporary credentials, "
+            "refreshing them before expiry. Passed to LiteLLM as "
+            "``aws_role_name``."
+        ),
+    )
+    aws_session_name: str = Field(
+        default="terrapod-ai-summary",
+        description=(
+            "STS AssumeRole session name (visible in CloudTrail). Only "
+            "used when ``aws_role_arn`` is set."
+        ),
+    )
+    aws_external_id: str = Field(
+        default="",
+        description=(
+            "Optional ExternalId for the AssumeRole call. Set when the "
+            "destination role's trust policy requires it."
+        ),
+    )
+
+
+class AISummaryContextConfig(BaseModel):
+    """Layered context injected into the model prompt.
+
+    Layers (rendered top-to-bottom in the request):
+      1. In-code skill prompt — owns the JSON output contract, NOT
+         operator-overridable. Lives in `summariser_prompt.py`.
+      2. `prompt_prefix` (this block) — free-text prepended.
+      3. `fleet_context` — facts about this Terrapod deployment.
+      4. `prompt_suffix` — free-text appended.
+      5. Per-workspace `ai_summary_context` column — workspace-specific.
+
+    Layers 2 and 4 are escape hatches for tone/emphasis tweaks; do not
+    use them to change the output schema (it is wired to the DB schema
+    and the SSE/UI contract).
+    """
+
+    prompt_prefix: str = Field(
+        default="",
+        description=(
+            "Free-text prepended before the skill prompt. Use for tone "
+            "or emphasis tweaks ('be terse'). Do not change the output "
+            "schema instructions here — that breaks the UI contract."
+        ),
+    )
+    fleet_context: str = Field(
+        default="",
+        description=(
+            "Static deployment-wide facts about the infrastructure this "
+            "Terrapod instance manages (what runs here, naming "
+            "conventions, provider/action pairs to flag, etc.). Rendered "
+            "below the skill prompt and above the per-workspace context."
+        ),
+    )
+    prompt_suffix: str = Field(
+        default="",
+        description=(
+            "Free-text appended after fleet_context and before the "
+            "per-workspace context. Same caveats as prompt_prefix."
+        ),
+    )
+
+
+class AISummaryConfig(BaseModel):
+    """AI plan-summary configuration (#401).
+
+    When enabled, every successful plan triggers an asynchronous call to
+    an OpenAI-compatible Chat Completions endpoint. The model is given
+    the structured plan JSON plus optional code context and returns a
+    structured summary (human description + risk assessment). The
+    summary is stored in the plan_summaries table, surfaced in the run
+    UI, and (for VCS-driven runs) edited into the PR/MR comment in place.
+
+    All deployments default to disabled — enabling requires both an
+    auth secret AND explicit endpoint + model config.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Master switch. Off by default — no calls made.",
+    )
+    model: str = Field(
+        default="",
+        description=(
+            "LiteLLM model string. The prefix selects the provider and "
+            "auth path; the suffix names the model. Examples: "
+            "``bedrock/anthropic.claude-opus-4-8`` (AWS Bedrock + IAM), "
+            "``openai/gpt-5`` (OpenAI direct + api_key), "
+            "``anthropic/claude-opus-4-8`` (Anthropic direct + api_key), "
+            "``gemini/gemini-2.5-pro`` (Google AI Studio + api_key), "
+            "``azure/<deployment-name>`` (Azure OpenAI). For self-hosted "
+            "OpenAI-compat endpoints (vLLM, LiteLLM proxy), use "
+            "``openai/<model>`` with ``api_base`` set below."
+        ),
+    )
+    api_base: str = Field(
+        default="",
+        description=(
+            "Override the upstream base URL. Only needed for "
+            "self-hosted OpenAI-compat endpoints (vLLM, a deployed "
+            "LiteLLM proxy, etc.) or to pin a specific Azure OpenAI "
+            "instance. Leave empty for vendor providers — LiteLLM "
+            "knows the default URLs."
+        ),
+    )
+    max_output_tokens: int = Field(
+        default=1024,
+        description=(
+            "Max tokens for the model response. Sized for ~600 words "
+            "of human description plus a short structured risk block."
+        ),
+    )
+    request_timeout_seconds: int = Field(
+        default=60,
+        description="HTTP timeout for a single summariser call.",
+    )
+    daily_token_budget: int = Field(
+        default=0,
+        description=(
+            "Cap on output tokens spent per UTC day across all summaries. "
+            "0 = unlimited. Counter is maintained in Redis; calls past "
+            "the cap are skipped (with a log entry, no run failure)."
+        ),
+    )
+    code_context_max_bytes: int = Field(
+        default=200_000,
+        description=(
+            "Max bytes of .tf source attached as context alongside the "
+            "plan JSON. The runner already uploads the config tarball; "
+            "summariser reads it from object storage and concatenates "
+            "the .tf files (truncated to this cap). 0 disables code "
+            "context entirely (plan JSON only — terser, cheaper, less "
+            "accurate)."
+        ),
+    )
+    plan_json_max_bytes: int = Field(
+        default=500_000,
+        description=(
+            "Max bytes of plan JSON attached. The runner-uploaded "
+            "plan JSON is truncated to this cap (keeping resource_changes "
+            "intact via best-effort structural truncation). Defends "
+            "against pathological monorepos producing 50MB plan files."
+        ),
+    )
+    auth: AISummaryAuthConfig = Field(default_factory=AISummaryAuthConfig)
+    context: AISummaryContextConfig = Field(default_factory=AISummaryContextConfig)
+
+
 class DatabaseConfig(BaseModel):
     """SQLAlchemy connection pool settings.
 
@@ -747,6 +936,9 @@ class Settings(BaseSettings):
 
     # Artifact Retention
     artifact_retention: ArtifactRetentionConfig = Field(default_factory=ArtifactRetentionConfig)
+
+    # AI Plan Summary (#401)
+    ai_summary: AISummaryConfig = Field(default_factory=AISummaryConfig)
 
     # Workspace defaults
     default_execution_backend: str = Field(

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -344,6 +344,21 @@ class Workspace(Base):
     # State divergence — set when an apply Job succeeds but state upload fails
     state_diverged: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
+    # AI plan summary (#401). `ai_summary_mode` is a three-state opt-in:
+    # - "default": follow the global ai_summary.enabled toggle
+    # - "enabled": always summarise (no-op if global is disabled — the UI
+    #   does not offer this state when global is off)
+    # - "disabled": never summarise, even when global is enabled
+    # `ai_summary_context` is workspace-specific facts added as the last
+    # layer of context before the plan JSON; it is ADDITIVE to the global
+    # fleet_context rather than replacing it.
+    ai_summary_mode: Mapped[str] = mapped_column(
+        String(10), nullable=False, server_default="default", default="default"
+    )
+    ai_summary_context: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="", default=""
+    )
+
     # Autodiscovery lifecycle (#314). lifecycle_state: active (normal) |
     # pending_deletion (origin dir/PR gone — needs explicit operator
     # action; NEVER auto-destroyed) | archived (soft-deleted after a
@@ -1715,3 +1730,76 @@ class PolicyEvaluation(Base):
         Index("ix_policy_evaluations_run_id", "run_id"),
         Index("ix_policy_evaluations_policy_set_id", "policy_set_id"),
     )
+
+
+class PlanSummary(Base):
+    """LLM-generated summary attached to a plan (#401).
+
+    One-to-one with Run, keyed by (run_id). The summariser fires once
+    when the plan phase reaches a terminal state and stores the result
+    here, then emits a `plan_summary_ready` SSE event. Stored separately
+    from `runs` so the column footprint of a 50-million-row table
+    doesn't grow for a feature only some deployments enable, and so the
+    (potentially large) description text doesn't bloat cold reads.
+
+    `kind` distinguishes two skills the API runs:
+      - "plan_summary": successful plan → describe proposed changes
+        and rate risk. Input: PLAN_JSON + code.
+      - "failure_analysis": errored plan → explain why it failed and
+        suggest fixes. Input: plan log + code.
+
+    Field reuse across kinds:
+      - description: change summary OR failure explanation.
+      - risk_level: change-risk severity OR failure severity.
+      - risk_factors: discrete risks ({severity,title,detail,address})
+        OR suggested fixes (same shape — severity = "how critical to
+        apply this fix"). The UI renders them differently per kind.
+
+    Status values:
+      - "pending": handler started, no result yet (transient)
+      - "ready": model returned a parseable structured response
+      - "skipped": daily budget hit, or workspace mode == "disabled"
+      - "errored": model call failed (HTTP / parse / refusal)
+
+    The handler upserts on (run_id) so retries on the same run are
+    idempotent — a "ready" row is never overwritten by a later errored
+    attempt for the same plan.
+    """
+
+    __tablename__ = "plan_summaries"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=generate_uuid7
+    )
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    kind: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="plan_summary", default="plan_summary"
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+
+    # Model fields — populated when status == "ready"
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    risk_level: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=""
+    )  # "low", "medium", "high", "critical", "" for non-ready
+    risk_factors: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, default=list, nullable=False)
+
+    # Telemetry / debugging
+    model: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    error_message: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=now_utc, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
+    )
+
+    __table_args__ = (sa.UniqueConstraint("run_id", name="uq_plan_summaries_run"),)

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -140,6 +140,29 @@ async def _enqueue_module_test_status(run: Run, target_status: str) -> None:
         logger.warning("Failed to enqueue module test status", error=str(e))
 
 
+async def _enqueue_ai_plan_summary(run: Run, kind: str) -> None:
+    """Enqueue an ai_plan_summary trigger for the summariser handler.
+
+    Fast-path no-op when the feature is globally disabled so we don't
+    charge Redis traffic for runs that will never be summarised.
+    """
+    from terrapod.config import settings
+
+    if not settings.ai_summary.enabled:
+        return
+    from terrapod.services.scheduler import enqueue_trigger
+
+    try:
+        await enqueue_trigger(
+            "ai_plan_summary",
+            {"run_id": str(run.id), "kind": kind},
+            dedup_key=f"aisum:{run.id}:{kind}",
+            dedup_ttl=300,
+        )
+    except Exception as e:
+        logger.debug("Failed to enqueue ai_plan_summary", error=str(e))
+
+
 async def _enqueue_drift_completed(run: Run) -> None:
     """Enqueue a drift_run_completed trigger when a drift run finishes."""
     from terrapod.services.scheduler import enqueue_trigger
@@ -416,6 +439,16 @@ async def transition_run(
     drift_terminal = TERMINAL_STATES | {"planned"}
     if run.is_drift_detection and target_status in drift_terminal:
         await _enqueue_drift_completed(run)
+
+    # AI plan summariser (#401) — fires on plan-phase terminal transitions.
+    # `planned` → summarise the changes. `errored` *during the plan phase*
+    # (apply hasn't started) → analyse the failure cause. Apply-phase
+    # errored runs are skipped — the failure surface is different and
+    # belongs to a future feature.
+    if target_status == "planned":
+        await _enqueue_ai_plan_summary(run, "plan_summary")
+    elif target_status == "errored" and run.apply_started_at is None:
+        await _enqueue_ai_plan_summary(run, "failure_analysis")
 
     return run
 

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -1,0 +1,558 @@
+"""AI plan summariser + plan-failure analyser (#401).
+
+When enabled via ``ai_summary.enabled``, the API triggers an
+asynchronous call after every plan-phase terminal transition:
+  - ``planned`` → ``kind=plan_summary``: describe changes + rate risk.
+  - ``errored`` while still in the plan phase → ``kind=failure_analysis``:
+    explain why the plan failed and suggest fixes.
+
+The model call goes through the LiteLLM Python library
+(``litellm.acompletion``). Terrapod always speaks the OpenAI Chat
+Completions request shape; LiteLLM handles the per-provider request
+translation, auth, and response normalisation in-process. No gateway
+deployment, no second pod.
+
+The model string's prefix selects the provider:
+
+  - ``bedrock/<model-id>`` — AWS Bedrock via boto3. IAM auth via the
+    pod's IRSA service account; optional ``sts:AssumeRole`` hop into a
+    cross-account role when ``auth.aws_role_arn`` is set. Works for
+    Anthropic Claude, Amazon Nova, Mistral, Meta Llama, etc.
+  - ``openai/<model-id>`` — OpenAI direct, with ``auth.api_key``.
+  - ``anthropic/<model-id>`` — Anthropic direct, with ``auth.api_key``.
+  - ``gemini/<model-id>`` — Google AI Studio, with ``auth.api_key``.
+  - ``azure/<deployment-name>`` — Azure OpenAI, with ``api_base`` + key.
+  - Self-hosted OpenAI-compat (vLLM, deployed LiteLLM proxy, etc.) —
+    use ``openai/<model>`` with ``api_base`` pointing at the endpoint.
+
+The model's JSON response is parsed and stored in the
+``plan_summaries`` table; an SSE ``plan_summary_ready`` event is
+emitted on the per-workspace channel so the UI re-fetches.
+
+Daily token budget (``ai_summary.daily_token_budget``) is tracked in a
+Redis counter per UTC day. Once exhausted, further calls are skipped
+(``status='skipped'``) without raising — run lifecycle is never
+affected by this feature.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import io
+import json
+import tarfile
+import uuid
+
+import litellm
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.config import settings
+from terrapod.db.models import PlanSummary, Run, Workspace, now_utc
+from terrapod.db.session import get_db_session
+from terrapod.logging_config import get_logger
+from terrapod.services.summariser_prompt import render_prompt
+from terrapod.storage import get_storage
+from terrapod.storage.keys import (
+    config_version_key,
+    plan_json_output_key,
+    plan_log_key,
+)
+
+logger = get_logger(__name__)
+
+
+# --- Input retrieval ---------------------------------------------------------
+
+
+def _truncate_tail(data: bytes, max_bytes: int) -> str:
+    """Return ``data`` decoded as UTF-8 (best-effort), tail-trimmed.
+
+    Logs are tail-relevant — the failure is at the end. We drop the head
+    when over budget rather than the tail.
+    """
+    if max_bytes <= 0 or len(data) <= max_bytes:
+        return data.decode("utf-8", errors="replace")
+    trimmed = data[-max_bytes:]
+    return f"[... {len(data) - max_bytes} bytes truncated from head ...]\n" + trimmed.decode(
+        "utf-8", errors="replace"
+    )
+
+
+def _truncate_head(data: bytes, max_bytes: int) -> str:
+    """Return ``data`` decoded as UTF-8, truncated from the tail.
+
+    Plan JSON's structural value is at the head — provider config and
+    resource_changes come first.
+    """
+    if max_bytes <= 0 or len(data) <= max_bytes:
+        return data.decode("utf-8", errors="replace")
+    return (
+        data[:max_bytes].decode("utf-8", errors="replace")
+        + f"\n[... {len(data) - max_bytes} bytes truncated from tail ...]"
+    )
+
+
+def _extract_tf_sources(tarball: bytes, max_bytes: int) -> str:
+    """Read .tf files from a config-version tarball, concatenated.
+
+    Files are read in tar order until the byte cap is hit. Each file is
+    prefixed with a header so the model can attribute snippets to paths.
+    Defends against zip-bombs by bailing as soon as the cap is reached.
+    """
+    if max_bytes <= 0:
+        return ""
+
+    buf = io.StringIO()
+    written = 0
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
+            for member in tar:
+                if not member.isfile() or not member.name.endswith(".tf"):
+                    continue
+                if member.size > max_bytes - written:
+                    break
+                fobj = tar.extractfile(member)
+                if fobj is None:
+                    continue
+                content = fobj.read().decode("utf-8", errors="replace")
+                header = f"\n# === {member.name} ===\n"
+                buf.write(header)
+                buf.write(content)
+                written += len(header) + len(content)
+                if written >= max_bytes:
+                    break
+    except tarfile.TarError as e:
+        logger.warning("Failed to read CV tarball for AI context", error=str(e))
+        return ""
+    return buf.getvalue()
+
+
+async def _gather_inputs(run: Run, kind: str) -> tuple[str, str, str, str]:
+    """Return ``(primary_input, primary_label, primary_lang, code_context)``.
+
+    primary_input is the plan JSON (for plan_summary) or the plan log
+    (for failure_analysis). code_context is the concatenated .tf source
+    or "" when the workspace has no config version.
+    """
+    storage = get_storage()
+    cfg = settings.ai_summary
+
+    if kind == "plan_summary":
+        key = plan_json_output_key(str(run.workspace_id), str(run.id))
+        primary_label = "PLAN_JSON"
+        primary_lang = "json"
+        try:
+            raw = await storage.get(key)
+        except Exception as e:
+            logger.warning(
+                "plan JSON not available for summariser", run_id=str(run.id), error=str(e)
+            )
+            return "", primary_label, primary_lang, ""
+        primary = _truncate_head(raw, cfg.plan_json_max_bytes)
+    else:
+        key = plan_log_key(str(run.workspace_id), str(run.id))
+        primary_label = "PLAN_LOG"
+        primary_lang = "text"
+        try:
+            raw = await storage.get(key)
+        except Exception as e:
+            logger.warning(
+                "plan log not available for summariser", run_id=str(run.id), error=str(e)
+            )
+            return "", primary_label, primary_lang, ""
+        primary = _truncate_tail(raw, cfg.plan_json_max_bytes)
+
+    code_context = ""
+    if cfg.code_context_max_bytes > 0 and run.configuration_version_id:
+        cv_key = config_version_key(str(run.workspace_id), str(run.configuration_version_id))
+        try:
+            tarball = await storage.get(cv_key)
+            code_context = await asyncio.to_thread(
+                _extract_tf_sources, tarball, cfg.code_context_max_bytes
+            )
+        except Exception as e:
+            logger.debug("CV tarball not available; running without code context", error=str(e))
+
+    return primary, primary_label, primary_lang, code_context
+
+
+# --- Daily budget ------------------------------------------------------------
+
+
+def _budget_key() -> str:
+    today = dt.datetime.now(dt.UTC).strftime("%Y%m%d")
+    return f"tp:ai_summary:budget:{today}"
+
+
+async def _budget_remaining() -> int | None:
+    """Return remaining output-token budget, or None if unlimited."""
+    cfg = settings.ai_summary
+    if cfg.daily_token_budget <= 0:
+        return None
+    from terrapod.redis.client import get_redis_client
+
+    r = get_redis_client()
+    spent_raw = await r.get(_budget_key())
+    spent = int(spent_raw) if spent_raw else 0
+    return max(0, cfg.daily_token_budget - spent)
+
+
+async def _budget_charge(tokens: int) -> None:
+    cfg = settings.ai_summary
+    if cfg.daily_token_budget <= 0 or tokens <= 0:
+        return
+    from terrapod.redis.client import get_redis_client
+
+    r = get_redis_client()
+    pipe = r.pipeline(transaction=False)
+    pipe.incrby(_budget_key(), tokens)
+    pipe.expire(_budget_key(), 60 * 60 * 36)  # span at least one UTC day
+    await pipe.execute()
+
+
+# --- Workspace mode resolution ----------------------------------------------
+
+
+def _resolve_workspace_mode(ws: Workspace) -> bool:
+    """Resolve the 3-state per-workspace toggle against the global flag.
+
+    Truth table (global × workspace):
+      enabled × default  → ON
+      enabled × enabled  → ON  (UX may not even surface this state)
+      enabled × disabled → OFF
+      disabled × default  → OFF
+      disabled × enabled  → OFF  (global wins; UX hides this state)
+      disabled × disabled → OFF
+    """
+    if not settings.ai_summary.enabled:
+        return False
+    return ws.ai_summary_mode != "disabled"
+
+
+# --- Model call --------------------------------------------------------------
+
+
+def _build_litellm_kwargs(
+    *, system_message: str, user_message: str, max_output_tokens: int
+) -> dict:
+    """Assemble the keyword arguments for ``litellm.acompletion``.
+
+    Provider-specific keys (``api_key``, ``api_base``, ``aws_*``) are
+    passed through unconditionally — LiteLLM ignores the ones that
+    don't apply to the resolved provider, so this keeps the dispatch
+    table flat (no per-provider branching in Terrapod).
+    """
+    cfg = settings.ai_summary
+    auth = cfg.auth
+
+    # We deliberately don't set response_format — Bedrock Converse for
+    # Anthropic models rejects the OpenAI json_schema field with
+    # "output_config.format: Extra inputs are not permitted", and other
+    # providers' translations vary in quality. The skill prompt embeds
+    # the JSON schema in the system message and instructs "Output JSON
+    # only"; _parse_model_json forgives incidental fence wrapping. That
+    # gives us portable behaviour across every LiteLLM backend.
+    kwargs: dict = {
+        "model": cfg.model,
+        "max_tokens": max_output_tokens,
+        "messages": [
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": user_message},
+        ],
+        "timeout": cfg.request_timeout_seconds,
+    }
+
+    if cfg.api_base:
+        kwargs["api_base"] = cfg.api_base
+    if auth.api_key:
+        kwargs["api_key"] = auth.api_key
+
+    # AWS / Bedrock — LiteLLM only honours these when the model is
+    # ``bedrock/...``; safe to send unconditionally.
+    if auth.aws_region:
+        kwargs["aws_region_name"] = auth.aws_region
+    if auth.aws_role_arn:
+        kwargs["aws_role_name"] = auth.aws_role_arn
+        kwargs["aws_session_name"] = auth.aws_session_name
+        if auth.aws_external_id:
+            kwargs["aws_external_id"] = auth.aws_external_id
+
+    return kwargs
+
+
+async def _call_model(
+    *,
+    system_message: str,
+    user_message: str,
+    max_output_tokens: int,
+) -> tuple[dict, int, int]:
+    """Drive a Chat Completions call via the LiteLLM library.
+
+    Returns ``(parsed_json, input_tokens, output_tokens)``. Raises on
+    HTTP errors, missing choices, or JSON parse errors.
+    """
+    cfg = settings.ai_summary
+    if not cfg.model:
+        raise RuntimeError("ai_summary.model must be set")
+
+    resp = await litellm.acompletion(
+        **_build_litellm_kwargs(
+            system_message=system_message,
+            user_message=user_message,
+            max_output_tokens=max_output_tokens,
+        )
+    )
+
+    if not resp.choices:
+        raise RuntimeError("model response had no choices")
+    text = resp.choices[0].message.content or ""
+    parsed = _parse_model_json(text)
+
+    usage = getattr(resp, "usage", None)
+    in_tok = int(getattr(usage, "prompt_tokens", 0) or 0) if usage else 0
+    out_tok = int(getattr(usage, "completion_tokens", 0) or 0) if usage else 0
+    return parsed, in_tok, out_tok
+
+
+def _parse_model_json(text: str) -> dict:
+    """Parse the model's textual response as a JSON object.
+
+    Permits incidental wrapping (a leading code fence, a stray sentence)
+    by extracting the first balanced ``{...}`` block. The strict schema
+    in the request body should prevent this, but the fallback is cheap.
+    """
+    text = text.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    start = text.find("{")
+    end = text.rfind("}")
+    if start >= 0 and end > start:
+        return json.loads(text[start : end + 1])
+    raise ValueError("model response was not JSON")
+
+
+# --- Trigger handler ---------------------------------------------------------
+
+
+async def _emit_ready_event(workspace_id: uuid.UUID, run_id: uuid.UUID) -> None:
+    try:
+        from terrapod.redis.client import RUN_EVENTS_PREFIX, publish_event
+
+        await publish_event(
+            f"{RUN_EVENTS_PREFIX}{workspace_id}",
+            json.dumps(
+                {
+                    "event": "plan_summary_ready",
+                    "run_id": str(run_id),
+                    "workspace_id": str(workspace_id),
+                }
+            ),
+        )
+    except Exception as e:  # SSE is best-effort
+        logger.debug("Failed to publish plan_summary_ready", error=str(e))
+
+
+async def _upsert_summary(
+    db: AsyncSession,
+    *,
+    run_id: uuid.UUID,
+    kind: str,
+    status: str,
+    description: str = "",
+    risk_level: str = "",
+    risk_factors: list[dict] | None = None,
+    model: str = "",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    error_message: str = "",
+) -> None:
+    """Idempotent upsert keyed on (run_id).
+
+    Never downgrades a 'ready' row — a later errored retry for the same
+    run is a no-op so the UI doesn't lose a good summary to a transient
+    network blip.
+    """
+    existing = (
+        await db.execute(select(PlanSummary).where(PlanSummary.run_id == run_id))
+    ).scalar_one_or_none()
+
+    if existing is not None and existing.status == "ready" and status != "ready":
+        return
+
+    values = {
+        "id": uuid.uuid4(),
+        "run_id": run_id,
+        "kind": kind,
+        "status": status,
+        "description": description,
+        "risk_level": risk_level,
+        "risk_factors": risk_factors or [],
+        "model": model,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "error_message": error_message,
+        "updated_at": now_utc(),
+    }
+    stmt = pg_insert(PlanSummary).values(**values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["run_id"],
+        set_={
+            "kind": stmt.excluded.kind,
+            "status": stmt.excluded.status,
+            "description": stmt.excluded.description,
+            "risk_level": stmt.excluded.risk_level,
+            "risk_factors": stmt.excluded.risk_factors,
+            "model": stmt.excluded.model,
+            "input_tokens": stmt.excluded.input_tokens,
+            "output_tokens": stmt.excluded.output_tokens,
+            "error_message": stmt.excluded.error_message,
+            "updated_at": stmt.excluded.updated_at,
+        },
+    )
+    await db.execute(stmt)
+
+
+async def handle_ai_plan_summary(payload: dict) -> None:
+    """Triggered handler: summarise (or analyse the failure of) one plan.
+
+    Payload: ``{"run_id": "<uuid>", "kind": "plan_summary" | "failure_analysis"}``.
+    Enqueued from ``run_service.transition_run`` on plan-phase terminal
+    transitions when the feature is globally enabled.
+    """
+    cfg = settings.ai_summary
+    if not cfg.enabled:
+        return
+
+    try:
+        run_id = uuid.UUID(payload["run_id"])
+    except (KeyError, ValueError):
+        logger.warning("Invalid ai_plan_summary payload", payload=payload)
+        return
+
+    kind = payload.get("kind") or "plan_summary"
+    if kind not in {"plan_summary", "failure_analysis"}:
+        logger.warning("Invalid ai_plan_summary kind", kind=kind)
+        return
+
+    async with get_db_session() as db:
+        run = (await db.execute(select(Run).where(Run.id == run_id))).scalar_one_or_none()
+        if run is None:
+            return
+
+        ws = (
+            await db.execute(select(Workspace).where(Workspace.id == run.workspace_id))
+        ).scalar_one_or_none()
+        if ws is None:
+            return
+
+        if not _resolve_workspace_mode(ws):
+            await _upsert_summary(
+                db,
+                run_id=run_id,
+                kind=kind,
+                status="skipped",
+                error_message="workspace disabled",
+            )
+            await db.commit()
+            return
+
+        remaining = await _budget_remaining()
+        if remaining is not None and remaining <= 0:
+            logger.info("AI summariser daily budget exhausted, skipping", run_id=str(run_id))
+            await _upsert_summary(
+                db,
+                run_id=run_id,
+                kind=kind,
+                status="skipped",
+                error_message="daily token budget exhausted",
+            )
+            await db.commit()
+            await _emit_ready_event(ws.id, run_id)
+            return
+
+        primary, label, lang, code_context = await _gather_inputs(run, kind)
+        if not primary:
+            await _upsert_summary(
+                db,
+                run_id=run_id,
+                kind=kind,
+                status="errored",
+                error_message=f"no {label} available",
+            )
+            await db.commit()
+            return
+
+        system_message, user_message = render_prompt(
+            kind=kind,
+            fleet_context=cfg.context.fleet_context,
+            workspace_context=ws.ai_summary_context,
+            primary_input=primary,
+            primary_input_label=label,
+            primary_input_lang=lang,
+            code_context_truncated=code_context,
+            prompt_prefix=cfg.context.prompt_prefix,
+            prompt_suffix=cfg.context.prompt_suffix,
+        )
+
+        try:
+            parsed, in_tok, out_tok = await _call_model(
+                system_message=system_message,
+                user_message=user_message,
+                max_output_tokens=cfg.max_output_tokens,
+            )
+        except Exception as e:
+            logger.warning(
+                "AI summariser call failed",
+                run_id=str(run_id),
+                kind=kind,
+                error=str(e),
+            )
+            await _upsert_summary(
+                db,
+                run_id=run_id,
+                kind=kind,
+                status="errored",
+                model=cfg.model,
+                error_message=str(e)[:500],
+            )
+            await db.commit()
+            return
+
+        description = str(parsed.get("description", ""))[:50_000]
+        risk_level = str(parsed.get("risk_level", "")).lower()
+        if risk_level not in {"low", "medium", "high", "critical"}:
+            risk_level = "low"
+        risk_factors = parsed.get("risk_factors") or []
+        if not isinstance(risk_factors, list):
+            risk_factors = []
+
+        await _upsert_summary(
+            db,
+            run_id=run_id,
+            kind=kind,
+            status="ready",
+            description=description,
+            risk_level=risk_level,
+            risk_factors=risk_factors,
+            model=cfg.model,
+            input_tokens=in_tok,
+            output_tokens=out_tok,
+        )
+        await db.commit()
+
+    # Out-of-transaction side effects
+    await _budget_charge(out_tok)
+    await _emit_ready_event(ws.id, run_id)
+    logger.info(
+        "AI summary ready",
+        run_id=str(run_id),
+        kind=kind,
+        risk_level=risk_level,
+        in_tok=in_tok,
+        out_tok=out_tok,
+    )

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -548,6 +548,30 @@ async def handle_ai_plan_summary(payload: dict) -> None:
     # Out-of-transaction side effects
     await _budget_charge(out_tok)
     await _emit_ready_event(ws.id, run_id)
+
+    # PR/MR comment refresh — re-enqueue the existing vcs_commit_status
+    # trigger so handle_vcs_commit_status picks up the now-ready
+    # PlanSummary and edits it into the per-workspace comment in place.
+    # The dedup key includes "aisum" so it doesn't collide with the
+    # standard run-state-change enqueues from run_service.
+    if run.vcs_pull_request_number:
+        try:
+            from terrapod.services.scheduler import enqueue_trigger
+
+            await enqueue_trigger(
+                "vcs_commit_status",
+                {
+                    "run_id": str(run_id),
+                    "workspace_id": str(ws.id),
+                    "target_status": run.status,
+                    "has_changes": run.has_changes,
+                },
+                dedup_key=f"vcs_status:aisum:{run_id}",
+                dedup_ttl=60,
+            )
+        except Exception as e:
+            logger.debug("Failed to refresh PR comment after AI summary", error=str(e))
+
     logger.info(
         "AI summary ready",
         run_id=str(run_id),

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -1,0 +1,246 @@
+"""Skill prompt for the AI plan-summary feature (#401).
+
+This module owns the in-code system prompt that defines the model's task,
+the structured output contract, and the safety guardrails. The DB schema,
+SSE event shape, and UI rendering all assume the JSON schema declared
+here — changing the schema means changing all three.
+
+Helm-provided `prompt_prefix` and `prompt_suffix` strings wrap this skill
+prompt; they are intended for tone/emphasis tweaks, NOT for changing the
+output contract. See `AISummaryContextConfig` in `config.py`.
+"""
+
+from __future__ import annotations
+
+# Single source of truth for the schema. The JSON-schema dict is sent in
+# the request `response_format` and the prose schema is also embedded in
+# the user message — Bedrock OpenAI-compat ignores `response_format` for
+# some Anthropic models, so the in-prompt schema is the durable backstop.
+PLAN_SUMMARY_JSON_SCHEMA: dict = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["description", "risk_level", "risk_factors"],
+    "properties": {
+        "description": {
+            "type": "string",
+            "description": (
+                "Plain-language explanation of what this plan will do. "
+                "Up to ~600 words. Describe changes, not the plan format. "
+                "Group related resource changes; do not enumerate every "
+                "no-op refresh. Refer to resources by their terraform "
+                "address. No chain-of-thought, no preamble."
+            ),
+        },
+        "risk_level": {
+            "type": "string",
+            "enum": ["low", "medium", "high", "critical"],
+            "description": (
+                "Overall risk. 'critical' is reserved for irreversible "
+                "destructive changes to production-critical resources "
+                "(data stores, certificate authorities, IAM trust roots). "
+                "'high' is for any unmitigated destroy or replace. "
+                "'medium' for in-place updates with non-trivial blast "
+                "radius. 'low' for pure additions / read-only changes."
+            ),
+        },
+        "risk_factors": {
+            "type": "array",
+            "description": (
+                "Discrete risks identified, ordered worst first. Empty "
+                "array when risk_level == 'low' is acceptable."
+            ),
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["severity", "title", "detail"],
+                "properties": {
+                    "severity": {
+                        "type": "string",
+                        "enum": ["low", "medium", "high", "critical"],
+                    },
+                    "title": {"type": "string", "maxLength": 120},
+                    "detail": {"type": "string", "maxLength": 600},
+                    "resource_address": {
+                        "type": "string",
+                        "description": (
+                            "Terraform address of the resource the risk "
+                            "attaches to, when applicable."
+                        ),
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+PLAN_SUMMARY_SKILL_PROMPT = """\
+You are a Terraform plan reviewer embedded in Terrapod. You receive the
+proposed changes from a terraform/tofu plan and the HCL that produced
+them. Your job is to summarise what the plan changes and rate the risk
+of those changes. Nothing else.
+
+You will receive these inputs in the user message:
+  • PLAN_JSON — `tofu show -json` output for the proposed changes.
+  • CODE_CONTEXT — concatenated .tf source. May be absent.
+  • FLEET_CONTEXT — deployment-wide notes from the operator. May be empty.
+  • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
+
+You return a single JSON object matching this schema, with no
+surrounding text, markdown fences, or commentary:
+
+  {
+    "description": "<plain language summary of what changes, ~600 words max>",
+    "risk_level": "<low | medium | high | critical>",
+    "risk_factors": [
+      {
+        "severity": "<low | medium | high | critical>",
+        "title": "<short label, max 120 chars>",
+        "detail": "<explanation, max 600 chars>",
+        "resource_address": "<terraform address, optional>"
+      }
+    ]
+  }
+
+Rules:
+
+  • Describe the proposed changes. Do not describe the JSON format, the
+    plan run, terrapod, or anything other than the infrastructure
+    changes themselves.
+  • Refer to resources by their terraform address (e.g.
+    `module.vpc.aws_vpc.this`, `aws_iam_role.runner`).
+  • Group related changes. "5 IAM policy attachments rotate" beats five
+    bullets repeating the same fact.
+  • Call out destroys and replacements — these have blast radius. A
+    `replace` means destroy-then-create; the resource gets a new
+    identity even when it looks the same.
+  • Do not invent resources or addresses not in the plan.
+  • Risk severities are about blast radius and reversibility, not
+    novelty. Destroying a Lambda is medium. Destroying a database or
+    an IAM trust root is critical. Pure additions are low.
+
+Style:
+  • Operator-facing, terse, professional. No emojis. No first-person
+    narration ("I will...", "Let me...").
+  • Markdown allowed inside `description` only (lists, backticks for
+    identifiers). Plain strings everywhere else.
+"""
+
+
+FAILURE_ANALYSIS_SKILL_PROMPT = """\
+You are a Terraform run failure analyst embedded in Terrapod. A plan
+failed to execute. You receive the operator's plan log and the source
+HCL that was being processed. Your job is to explain WHY the plan
+failed and suggest concrete fixes. Nothing else.
+
+You will receive these inputs in the user message:
+  • PLAN_LOG — the terraform/tofu stdout+stderr leading up to the
+    failure. May be truncated from the head; the tail (where the error
+    typically appears) is preserved.
+  • CODE_CONTEXT — concatenated .tf source. May be absent.
+  • FLEET_CONTEXT — deployment-wide notes. May be empty.
+  • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
+
+You return a single JSON object matching this schema, with no
+surrounding text, markdown fences, or commentary:
+
+  {
+    "description": "<plain language explanation of what went wrong, ~600 words max>",
+    "risk_level": "<low | medium | high | critical>",
+    "risk_factors": [
+      {
+        "severity": "<low | medium | high | critical>",
+        "title": "<short fix label, max 120 chars>",
+        "detail": "<concrete steps or change to make, max 600 chars>",
+        "resource_address": "<terraform address, optional>"
+      }
+    ]
+  }
+
+For failure analysis, the fields carry these meanings:
+  • description: what failed and why — the root cause in operator
+    language, not a paraphrase of the stack trace.
+  • risk_level: how blocking the failure is. 'critical' for state
+    corruption / data loss risk. 'high' for blocking but recoverable.
+    'medium' for transient or retryable failures. 'low' for advisory.
+  • risk_factors: candidate fixes, ordered most-likely-to-resolve
+    first. Each `severity` rates how important that fix is to apply
+    (not the severity of the underlying error).
+
+Rules:
+
+  • Identify the actual error, not just the last log line. Terraform
+    errors often appear several lines before the final non-zero exit.
+  • Quote the relevant error text in `description` (use backticks for
+    short fragments). Do not invent error text.
+  • If multiple errors fired in sequence, treat the first concrete
+    error as primary — later ones are usually consequences.
+  • Suggest fixes in operator terms ("set `vpc_id` to the actual VPC
+    output", "ensure the `aws` provider has `region` configured")
+    rather than generic ("check your config").
+  • If the cause is unclear from the log alone, say so plainly in
+    `description` and leave `risk_factors` empty rather than guessing.
+
+Style:
+  • Operator-facing, terse, professional. No emojis. No first-person.
+  • Markdown allowed inside `description` only.
+"""
+
+
+def render_prompt(
+    *,
+    kind: str,
+    fleet_context: str,
+    workspace_context: str,
+    primary_input: str,
+    primary_input_label: str,
+    primary_input_lang: str,
+    code_context_truncated: str,
+    prompt_prefix: str = "",
+    prompt_suffix: str = "",
+) -> tuple[str, str]:
+    """Render the system + user messages for the Chat Completions request.
+
+    Returns ``(system_message, user_message)``. The system message owns
+    the contract (skill prompt + operator's prefix/suffix); the user
+    message carries the deployment-specific context plus the primary
+    input (PLAN_JSON or PLAN_LOG) and the code.
+
+    Args:
+        kind: "plan_summary" or "failure_analysis" — selects the skill.
+        primary_input: the truncated plan JSON or plan log.
+        primary_input_label: header label ("PLAN_JSON" or "PLAN_LOG").
+        primary_input_lang: fenced-code language ("json" or "text").
+    """
+    if kind == "plan_summary":
+        skill = PLAN_SUMMARY_SKILL_PROMPT
+    elif kind == "failure_analysis":
+        skill = FAILURE_ANALYSIS_SKILL_PROMPT
+    else:
+        raise ValueError(f"unknown summariser kind: {kind!r}")
+
+    parts: list[str] = []
+    if prompt_prefix.strip():
+        parts.append(prompt_prefix.strip())
+    parts.append(skill)
+    if prompt_suffix.strip():
+        parts.append(prompt_suffix.strip())
+    system_message = "\n\n".join(parts)
+
+    user_parts: list[str] = []
+    if fleet_context.strip():
+        user_parts.append(f"FLEET_CONTEXT:\n{fleet_context.strip()}")
+    if workspace_context.strip():
+        user_parts.append(f"WORKSPACE_CONTEXT:\n{workspace_context.strip()}")
+
+    user_parts.append(f"{primary_input_label}:\n```{primary_input_lang}\n{primary_input}\n```")
+    if code_context_truncated.strip():
+        user_parts.append(f"CODE_CONTEXT:\n```hcl\n{code_context_truncated}\n```")
+
+    user_parts.append(
+        "Now produce the JSON object per the schema in the system prompt. "
+        "Output JSON only — no surrounding text or code fences."
+    )
+
+    user_message = "\n\n".join(user_parts)
+    return system_message, user_message

--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -8,8 +8,10 @@ commit statuses and PR/MR comments back to the VCS provider.
 import uuid
 from datetime import UTC, datetime
 
+from sqlalchemy import select
+
 from terrapod.config import settings
-from terrapod.db.models import Run, VCSConnection, Workspace
+from terrapod.db.models import PlanSummary, Run, VCSConnection, Workspace
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service
@@ -82,29 +84,83 @@ def _build_comment_body(
     plan_only: bool,
     has_changes: bool | None,
     run_url: str,
+    ai_summary: "PlanSummary | None" = None,
 ) -> str:
     """Build the markdown body for a PR/MR comment.
 
     `has_changes` is consumed by ``_resolve_status`` to form the status
     description ("Has changes" / "No changes"); we don't append a second
     has-changes line, which used to be redundant with the description.
+
+    When ``ai_summary`` is provided and its status is "ready", a
+    collapsible ``<details>`` block is appended with the LLM-generated
+    description + risk pill + risk-factor list (#401). Other statuses
+    (pending / skipped / errored) are skipped — the comment shouldn't
+    advertise empty or error rows to PR readers.
     """
     github_state, _, description = _resolve_status(run_status, plan_only, has_changes)
     emoji = _STATUS_EMOJI.get(run_status, ":grey_question:")
 
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    return "\n".join(
-        [
-            f"<!-- terrapod:ws:{workspace_id} -->",
-            f"### Terrapod — {workspace_name}",
-            "",
-            f"**Status:** {emoji} {description}",
-            f"**Run:** [{run_id}]({run_url})",
-            "",
-            f"*Updated {now}*",
-        ]
-    )
+    parts = [
+        f"<!-- terrapod:ws:{workspace_id} -->",
+        f"### Terrapod — {workspace_name}",
+        "",
+        f"**Status:** {emoji} {description}",
+        f"**Run:** [{run_id}]({run_url})",
+    ]
+    if ai_summary is not None and ai_summary.status == "ready":
+        parts.append("")
+        parts.append(_render_ai_summary_section(ai_summary))
+    parts.append("")
+    parts.append(f"*Updated {now}*")
+    return "\n".join(parts)
+
+
+def _render_ai_summary_section(s: "PlanSummary") -> str:
+    """Render one PlanSummary as a collapsible PR-comment section (#401).
+
+    Both GitHub and GitLab support raw HTML inside Markdown comments;
+    `<details>` keeps verbose summaries out of the default view so PRs
+    spanning many workspaces stay scannable. The summary header carries
+    the risk pill so a reviewer can triage without expanding.
+    """
+    kind_label = "Failure analysis" if s.kind == "failure_analysis" else "AI summary"
+    risk_emoji = {
+        "low": "🟢",
+        "medium": "🟡",
+        "high": "🟠",
+        "critical": "🔴",
+    }.get(s.risk_level, "⚪")
+    lines = [
+        f"<details><summary>🤖 {kind_label} &mdash; "
+        f"{risk_emoji} risk: <strong>{s.risk_level or 'unknown'}</strong></summary>",
+        "",
+        s.description.strip(),
+    ]
+    if s.risk_factors:
+        rf_heading = "**Suggested fixes:**" if s.kind == "failure_analysis" else "**Risk factors:**"
+        lines.extend(["", rf_heading, ""])
+        for rf in s.risk_factors:
+            sev = (rf.get("severity") or "").lower() if isinstance(rf, dict) else ""
+            sev_emoji = {
+                "low": "🟢",
+                "medium": "🟡",
+                "high": "🟠",
+                "critical": "🔴",
+            }.get(sev, "⚪")
+            title = rf.get("title", "") if isinstance(rf, dict) else ""
+            detail = (rf.get("detail", "") or "").strip() if isinstance(rf, dict) else ""
+            addr = rf.get("resource_address", "") if isinstance(rf, dict) else ""
+            head = f"- {sev_emoji} **{title}**"
+            if addr:
+                head += f" — `{addr}`"
+            lines.append(head)
+            if detail:
+                lines.append(f"  {detail}")
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
 
 
 def _comment_marker(workspace_id: str) -> str:
@@ -320,6 +376,19 @@ async def handle_vcs_commit_status(payload: dict) -> None:
         # Post/update PR comment (only for PR runs)
         if run.vcs_pull_request_number:
             run_url = target_url or f"run-{run.id}"
+            # AI plan summary (#401) — included in the comment body when
+            # a ready row exists for this run. The summariser re-enqueues
+            # this same trigger after a ready row lands so the comment
+            # picks up the LLM content as soon as it's available, not on
+            # the next status change.
+            ai_summary = (
+                await db.execute(
+                    select(PlanSummary).where(
+                        PlanSummary.run_id == run.id,
+                        PlanSummary.status == "ready",
+                    )
+                )
+            ).scalar_one_or_none()
             body = _build_comment_body(
                 workspace_name=ws.name,
                 workspace_id=str(ws.id),
@@ -328,6 +397,7 @@ async def handle_vcs_commit_status(payload: dict) -> None:
                 plan_only=run.plan_only,
                 has_changes=has_changes,
                 run_url=run_url,
+                ai_summary=ai_summary,
             )
             await _find_or_create_comment(
                 conn, owner, repo, run.vcs_pull_request_number, str(ws.id), body

--- a/services/tests/api/test_ai_summary.py
+++ b/services/tests/api/test_ai_summary.py
@@ -1,0 +1,324 @@
+"""Tests for the AI plan summary API surface (#401).
+
+Covers:
+  - GET /api/v2/plans/{plan_id}/summary 404 / 200 / auth-required paths
+  - PATCH workspace ai-summary-mode validation
+  - PATCH workspace ai-summary-context length cap
+  - Workspace GET includes the new ai-summary-* attributes
+  - /plans/{plan_id} response advertises the ai-summary-url link
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+def _user(email="test@example.com", roles=None):
+    return AuthenticatedUser(
+        email=email,
+        display_name="Test",
+        roles=roles or ["everyone"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _mock_workspace(ws_id=None, **overrides):
+    ws = MagicMock()
+    ws.id = ws_id or uuid.uuid4()
+    ws.name = overrides.get("name", "test-ws")
+    ws.auto_apply = False
+    ws.execution_mode = "agent"
+    ws.execution_backend = "tofu"
+    ws.terraform_version = "1.12"
+    ws.working_directory = ""
+    ws.locked = False
+    ws.lock_id = None
+    ws.resource_cpu = "1"
+    ws.resource_memory = "2Gi"
+    ws.vcs_repo_url = ""
+    ws.vcs_branch = ""
+    ws.vcs_connection_id = None
+    ws.vcs_connection = None
+    ws.agent_pool_id = None
+    ws.agent_pool = None
+    ws.labels = {}
+    ws.owner_email = "test@example.com"
+    ws.var_files = []
+    ws.trigger_prefixes = []
+    ws.vcs_last_polled_at = None
+    ws.vcs_last_error = None
+    ws.vcs_last_error_at = None
+    ws.vcs_workflow = "merge_then_apply"
+    ws.auto_merge = False
+    ws.auto_merge_strategy = "merge"
+    ws.lifecycle_state = "active"
+    ws.lifecycle_reason = ""
+    ws.autodiscovery_pr_number = None
+    ws.drift_detection_enabled = False
+    ws.drift_detection_interval_seconds = 86400
+    ws.drift_last_checked_at = None
+    ws.drift_status = ""
+    ws.state_diverged = False
+    ws.ai_summary_mode = overrides.get("ai_summary_mode", "default")
+    ws.ai_summary_context = overrides.get("ai_summary_context", "")
+    ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return ws
+
+
+def _mock_run(ws_id=None, run_id=None, status="planned"):
+    run = MagicMock()
+    run.id = run_id or uuid.uuid4()
+    run.workspace_id = ws_id or uuid.uuid4()
+    run.status = status
+    run.has_json_output = False
+    run.resource_additions = None
+    run.resource_changes = None
+    run.resource_destructions = None
+    run.resource_imports = None
+    run.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    run.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return run
+
+
+def _mock_summary(run_id, **overrides):
+    s = MagicMock()
+    s.id = uuid.uuid4()
+    s.run_id = run_id
+    s.kind = overrides.get("kind", "plan_summary")
+    s.status = overrides.get("status", "ready")
+    s.description = overrides.get("description", "All good.")
+    s.risk_level = overrides.get("risk_level", "low")
+    s.risk_factors = overrides.get("risk_factors", [])
+    s.model = overrides.get("model", "test-model")
+    s.input_tokens = overrides.get("input_tokens", 100)
+    s.output_tokens = overrides.get("output_tokens", 50)
+    s.error_message = overrides.get("error_message", "")
+    s.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    s.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return s
+
+
+def _make_app(user, mock_db=None):
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app, mock_db
+
+
+# ── GET /plans/{id}/summary ─────────────────────────────────────────────────
+
+
+class TestGetPlanSummary:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    async def test_returns_summary_when_present(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "read"
+        run = _mock_run()
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        summary = _mock_summary(run.id, risk_level="high")
+
+        app, mock_db = _make_app(_user())
+        # _get_run → execute(select Run) → run
+        # _require_run_ws_permission → db.get(Workspace, …) → ws
+        # summary lookup → execute(select PlanSummary) → summary
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+                MagicMock(scalar_one_or_none=MagicMock(return_value=summary)),
+            ]
+        )
+        mock_db.get = AsyncMock(return_value=ws)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{run.id}/summary", headers=_AUTH)
+
+        assert resp.status_code == 200
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["kind"] == "plan_summary"
+        assert attrs["status"] == "ready"
+        assert attrs["risk-level"] == "high"
+        assert attrs["description"] == "All good."
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    async def test_returns_404_when_no_summary(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "read"
+        run = _mock_run()
+        ws = _mock_workspace(ws_id=run.workspace_id)
+
+        app, mock_db = _make_app(_user())
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+                MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+            ]
+        )
+        mock_db.get = AsyncMock(return_value=ws)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{run.id}/summary", headers=_AUTH)
+
+        assert resp.status_code == 404
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    async def test_plan_response_includes_ai_summary_url(self, mock_resolve, *mocks):
+        """GET /plans/{id} advertises the ai-summary-url even when no row exists yet."""
+        mock_resolve.return_value = "read"
+        run = _mock_run()
+        ws = _mock_workspace(ws_id=run.workspace_id)
+
+        app, mock_db = _make_app(_user())
+        mock_db.execute = AsyncMock(
+            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+        )
+        mock_db.get = AsyncMock(return_value=ws)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/plans/plan-{run.id}", headers=_AUTH)
+
+        assert resp.status_code == 200
+        attrs = resp.json()["data"]["attributes"]
+        assert "ai-summary-url" in attrs
+        assert str(run.id) in attrs["ai-summary-url"]
+
+
+# ── Workspace PATCH ─────────────────────────────────────────────────────────
+
+
+class TestWorkspaceAISummaryFields:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_get_includes_ai_summary_fields(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "read"
+        ws = _mock_workspace(ai_summary_mode="enabled", ai_summary_context="vault prod")
+
+        app, mock_db = _make_app(_user())
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run = MagicMock()
+        no_run.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+
+        assert resp.status_code == 200
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["ai-summary-mode"] == "enabled"
+        assert attrs["ai-summary-context"] == "vault prod"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_patch_accepts_valid_mode(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()
+
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "ai-summary-mode": "disabled",
+                            "ai-summary-context": "hands off",
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert ws.ai_summary_mode == "disabled"
+        assert ws.ai_summary_context == "hands off"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_patch_rejects_invalid_mode(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()
+
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"ai-summary-mode": "yes_please"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_patch_rejects_oversize_context(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()
+
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"ai-summary-context": "x" * 5000}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    async def test_patch_rejects_non_string_context(self, mock_resolve, *mocks):
+        mock_resolve.return_value = "admin"
+        ws = _mock_workspace()
+
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"ai-summary-context": 42}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -53,6 +53,8 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.lifecycle_state = overrides.get("lifecycle_state", "active")
     ws.lifecycle_reason = overrides.get("lifecycle_reason", "")
     ws.autodiscovery_pr_number = overrides.get("autodiscovery_pr_number", None)
+    ws.ai_summary_mode = overrides.get("ai_summary_mode", "default")
+    ws.ai_summary_context = overrides.get("ai_summary_context", "")
     ws.execution_backend = overrides.get("execution_backend", "tofu")
     ws.agent_pool = None
     ws.agent_pool_id = overrides.get("agent_pool_id", None)

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -62,6 +62,8 @@ def _mock_workspace(ws_id=None, pool_id=None):
     ws.lifecycle_state = "active"
     ws.lifecycle_reason = ""
     ws.autodiscovery_pr_number = None
+    ws.ai_summary_mode = "default"
+    ws.ai_summary_context = ""
     ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return ws

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -73,6 +73,8 @@ def _mock_workspace(
     ws.lifecycle_state = "active"
     ws.lifecycle_reason = ""
     ws.autodiscovery_pr_number = None
+    ws.ai_summary_mode = "default"
+    ws.ai_summary_context = ""
     ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     ws.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return ws

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from terrapod.services.run_service import (
     TERMINAL_STATES,
     VALID_TRANSITIONS,
+    _enqueue_ai_plan_summary,
     _publish_run_available,
     _publish_run_event,
     can_transition,
@@ -637,3 +638,52 @@ class TestCompleteApply:
         run = _mock_run(status="applying", apply_started_at=datetime.now(UTC))
         result = await complete_apply(_mock_db, run)
         assert result.status == "applied"
+
+
+# ── AI plan-summary trigger (#401) ─────────────────────────────────────
+
+
+class TestEnqueueAIPlanSummary:
+    async def test_no_op_when_globally_disabled(self):
+        run = _mock_run()
+        with (
+            patch("terrapod.config.settings") as mock_settings,
+            patch(
+                "terrapod.services.scheduler.enqueue_trigger",
+                new_callable=AsyncMock,
+            ) as mock_enq,
+        ):
+            mock_settings.ai_summary.enabled = False
+            await _enqueue_ai_plan_summary(run, "plan_summary")
+            mock_enq.assert_not_called()
+
+    async def test_enqueues_trigger_when_enabled(self):
+        run = _mock_run()
+        with (
+            patch("terrapod.config.settings") as mock_settings,
+            patch(
+                "terrapod.services.scheduler.enqueue_trigger",
+                new_callable=AsyncMock,
+            ) as mock_enq,
+        ):
+            mock_settings.ai_summary.enabled = True
+            await _enqueue_ai_plan_summary(run, "plan_summary")
+            mock_enq.assert_awaited_once()
+            args, kwargs = mock_enq.call_args
+            assert args[0] == "ai_plan_summary"
+            assert args[1] == {"run_id": str(run.id), "kind": "plan_summary"}
+            assert kwargs.get("dedup_key") == f"aisum:{run.id}:plan_summary"
+
+    async def test_handles_enqueue_failure_silently(self):
+        run = _mock_run()
+        with (
+            patch("terrapod.config.settings") as mock_settings,
+            patch(
+                "terrapod.services.scheduler.enqueue_trigger",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("redis down"),
+            ),
+        ):
+            mock_settings.ai_summary.enabled = True
+            # Must not raise — feature is best-effort, never breaks runs
+            await _enqueue_ai_plan_summary(run, "plan_summary")

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -1,0 +1,445 @@
+"""Unit tests for the AI plan summariser (#401)."""
+
+import io
+import tarfile
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.services import summariser
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _mock_workspace(*, mode="default", ctx="", ws_id=None):
+    ws = MagicMock()
+    ws.id = ws_id or uuid.uuid4()
+    ws.ai_summary_mode = mode
+    ws.ai_summary_context = ctx
+    return ws
+
+
+def _mock_run(*, ws_id=None, cv_id=None):
+    run = MagicMock()
+    run.id = uuid.uuid4()
+    run.workspace_id = ws_id or uuid.uuid4()
+    run.configuration_version_id = cv_id
+    return run
+
+
+# ── _resolve_workspace_mode truth table ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "global_enabled,mode,expected",
+    [
+        (True, "default", True),
+        (True, "enabled", True),
+        (True, "disabled", False),
+        (False, "default", False),
+        (False, "enabled", False),  # global wins
+        (False, "disabled", False),
+    ],
+)
+def test_resolve_workspace_mode_truth_table(global_enabled, mode, expected):
+    ws = _mock_workspace(mode=mode)
+    with patch.object(summariser.settings.ai_summary, "enabled", global_enabled):
+        assert summariser._resolve_workspace_mode(ws) is expected
+
+
+# ── Truncation ───────────────────────────────────────────────────────────
+
+
+def test_truncate_head_preserves_head():
+    data = b"a" * 100 + b"TAIL"
+    out = summariser._truncate_head(data, 50)
+    assert out.startswith("a" * 50)
+    assert "TAIL" not in out
+    assert "truncated from tail" in out
+
+
+def test_truncate_head_no_op_when_under_cap():
+    data = b"small"
+    assert summariser._truncate_head(data, 100) == "small"
+
+
+def test_truncate_tail_preserves_tail():
+    data = b"HEAD" + b"a" * 100
+    out = summariser._truncate_tail(data, 50)
+    assert out.endswith("a" * 50)
+    assert "HEAD" not in out
+    assert "truncated from head" in out
+
+
+def test_truncate_tail_no_op_when_under_cap():
+    assert summariser._truncate_tail(b"small", 100) == "small"
+
+
+def test_truncate_zero_cap_returns_full_string():
+    # 0 means "unlimited" in this helper — _gather_inputs uses the
+    # config value directly. Code-context max=0 disables code entirely,
+    # but the truncation primitives themselves are no-ops at 0.
+    assert summariser._truncate_head(b"abc", 0) == "abc"
+
+
+# ── _extract_tf_sources ──────────────────────────────────────────────────
+
+
+def _build_tarball(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def test_extract_tf_sources_includes_tf_files():
+    tarball = _build_tarball(
+        {
+            "main.tf": b'resource "aws_vpc" "this" {}',
+            "vars.tf": b'variable "name" {}',
+            "README.md": b"not tf",  # must be skipped
+        }
+    )
+    out = summariser._extract_tf_sources(tarball, 100_000)
+    assert "main.tf" in out
+    assert "vars.tf" in out
+    assert "aws_vpc" in out
+    assert "not tf" not in out
+
+
+def test_extract_tf_sources_zero_cap_returns_empty():
+    tarball = _build_tarball({"main.tf": b'resource "aws_vpc" "this" {}'})
+    assert summariser._extract_tf_sources(tarball, 0) == ""
+
+
+def test_extract_tf_sources_respects_byte_cap():
+    tarball = _build_tarball(
+        {
+            "a.tf": b"x" * 500,
+            "b.tf": b"y" * 500,
+            "c.tf": b"z" * 500,
+        }
+    )
+    out = summariser._extract_tf_sources(tarball, 600)
+    # cap is hit after first file plus header (or after second small one)
+    assert len(out) <= 1200  # generous bound including headers
+    assert "x" in out
+
+
+def test_extract_tf_sources_returns_empty_on_corrupt_tarball():
+    assert summariser._extract_tf_sources(b"not a tarball", 100) == ""
+
+
+# ── JSON parsing ─────────────────────────────────────────────────────────
+
+
+def test_parse_clean_json():
+    text = '{"description": "ok", "risk_level": "low", "risk_factors": []}'
+    parsed = summariser._parse_model_json(text)
+    assert parsed["risk_level"] == "low"
+
+
+def test_parse_json_wrapped_in_code_fence():
+    text = '```json\n{"description": "ok", "risk_level": "low", "risk_factors": []}\n```'
+    parsed = summariser._parse_model_json(text)
+    assert parsed["description"] == "ok"
+
+
+def test_parse_json_with_leading_prose():
+    text = 'Here is the summary:\n{"description": "x", "risk_level": "medium", "risk_factors": []}'
+    parsed = summariser._parse_model_json(text)
+    assert parsed["risk_level"] == "medium"
+
+
+def test_parse_unparseable_raises():
+    with pytest.raises(ValueError):
+        summariser._parse_model_json("this is not json")
+
+
+# ── _build_litellm_kwargs ───────────────────────────────────────────────
+
+
+def test_build_litellm_kwargs_includes_aws_role_when_set():
+    """aws_role_arn populates LiteLLM's aws_role_name + session + external_id."""
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "bedrock/anthropic.claude-opus-4-8"),
+        patch.object(summariser.settings.ai_summary, "api_base", ""),
+        patch.object(summariser.settings.ai_summary.auth, "api_key", ""),
+        patch.object(summariser.settings.ai_summary.auth, "aws_region", "us-east-1"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_role_arn", "arn:aws:iam::1:role/r"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_session_name", "tp-sess"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_external_id", "ext-id-123"),
+    ):
+        kw = summariser._build_litellm_kwargs(
+            system_message="sys", user_message="usr", max_output_tokens=100
+        )
+        assert kw["model"] == "bedrock/anthropic.claude-opus-4-8"
+        assert kw["aws_region_name"] == "us-east-1"
+        assert kw["aws_role_name"] == "arn:aws:iam::1:role/r"
+        assert kw["aws_session_name"] == "tp-sess"
+        assert kw["aws_external_id"] == "ext-id-123"
+
+
+def test_build_litellm_kwargs_omits_role_when_unset():
+    """aws_role_arn empty → no aws_role_name kwarg (pod's ambient creds used directly)."""
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "bedrock/anthropic.claude-opus-4-8"),
+        patch.object(summariser.settings.ai_summary, "api_base", ""),
+        patch.object(summariser.settings.ai_summary.auth, "api_key", ""),
+        patch.object(summariser.settings.ai_summary.auth, "aws_region", "us-east-1"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_role_arn", ""),
+        patch.object(summariser.settings.ai_summary.auth, "aws_session_name", "x"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_external_id", ""),
+    ):
+        kw = summariser._build_litellm_kwargs(
+            system_message="sys", user_message="usr", max_output_tokens=100
+        )
+        assert "aws_role_name" not in kw
+        assert "aws_external_id" not in kw
+
+
+def test_build_litellm_kwargs_passes_api_key_and_base():
+    """Bearer providers get api_key + api_base; AWS kwargs harmless when ignored."""
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "openai/gpt-5"),
+        patch.object(summariser.settings.ai_summary, "api_base", "https://vllm.local/v1"),
+        patch.object(summariser.settings.ai_summary.auth, "api_key", "sk-abc"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_region", "us-east-1"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_role_arn", ""),
+        patch.object(summariser.settings.ai_summary.auth, "aws_session_name", "x"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_external_id", ""),
+    ):
+        kw = summariser._build_litellm_kwargs(
+            system_message="sys", user_message="usr", max_output_tokens=100
+        )
+        assert kw["api_key"] == "sk-abc"
+        assert kw["api_base"] == "https://vllm.local/v1"
+
+
+# ── handle_ai_plan_summary integration ──────────────────────────────────
+
+
+async def test_handler_no_op_when_globally_disabled():
+    with patch.object(summariser.settings.ai_summary, "enabled", False):
+        # No DB session should be opened — the handler short-circuits
+        with patch("terrapod.services.summariser.get_db_session") as mock_session:
+            await summariser.handle_ai_plan_summary({"run_id": str(uuid.uuid4())})
+            mock_session.assert_not_called()
+
+
+async def test_handler_skips_when_workspace_disabled():
+    run = _mock_run()
+    ws = _mock_workspace(mode="disabled", ws_id=run.workspace_id)
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=ws)),
+        ]
+    )
+    mock_db.commit = AsyncMock()
+
+    upsert = AsyncMock()
+    with (
+        patch.object(summariser.settings.ai_summary, "enabled", True),
+        patch("terrapod.services.summariser.get_db_session") as mock_session,
+        patch("terrapod.services.summariser._upsert_summary", upsert),
+        patch("terrapod.services.summariser._call_model") as call_model,
+    ):
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await summariser.handle_ai_plan_summary({"run_id": str(run.id), "kind": "plan_summary"})
+
+        call_model.assert_not_called()
+        upsert.assert_awaited_once()
+        kwargs = upsert.await_args.kwargs
+        assert kwargs["status"] == "skipped"
+        assert "workspace disabled" in kwargs["error_message"]
+
+
+async def test_handler_rejects_bad_payload():
+    with patch.object(summariser.settings.ai_summary, "enabled", True):
+        # Missing run_id, malformed uuid — must not raise
+        await summariser.handle_ai_plan_summary({})
+        await summariser.handle_ai_plan_summary({"run_id": "not-a-uuid"})
+
+
+async def test_handler_rejects_unknown_kind():
+    with patch.object(summariser.settings.ai_summary, "enabled", True):
+        await summariser.handle_ai_plan_summary({"run_id": str(uuid.uuid4()), "kind": "bogus"})
+
+
+async def test_handler_success_path_writes_ready_row():
+    run = _mock_run()
+    ws = _mock_workspace(mode="default", ctx="vault prod", ws_id=run.workspace_id)
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=ws)),
+        ]
+    )
+    mock_db.commit = AsyncMock()
+
+    upsert = AsyncMock()
+    call_model = AsyncMock(
+        return_value=(
+            {
+                "description": "Changes the VPC.",
+                "risk_level": "medium",
+                "risk_factors": [{"severity": "medium", "title": "T", "detail": "D"}],
+            },
+            120,
+            55,
+        )
+    )
+
+    with (
+        patch.object(summariser.settings.ai_summary, "enabled", True),
+        patch.object(summariser.settings.ai_summary, "model", "test-model"),
+        patch.object(summariser.settings.ai_summary, "daily_token_budget", 0),
+        patch("terrapod.services.summariser.get_db_session") as mock_session,
+        patch("terrapod.services.summariser._upsert_summary", upsert),
+        patch("terrapod.services.summariser._call_model", call_model),
+        patch(
+            "terrapod.services.summariser._gather_inputs",
+            AsyncMock(return_value=('{"resource_changes": []}', "PLAN_JSON", "json", "")),
+        ),
+        patch("terrapod.services.summariser._emit_ready_event", AsyncMock()),
+    ):
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await summariser.handle_ai_plan_summary({"run_id": str(run.id), "kind": "plan_summary"})
+
+        call_model.assert_awaited_once()
+        upsert.assert_awaited_once()
+        kwargs = upsert.await_args.kwargs
+        assert kwargs["status"] == "ready"
+        assert kwargs["risk_level"] == "medium"
+        assert kwargs["output_tokens"] == 55
+
+
+async def test_handler_call_failure_writes_errored_row():
+    run = _mock_run()
+    ws = _mock_workspace(mode="default", ws_id=run.workspace_id)
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=ws)),
+        ]
+    )
+    mock_db.commit = AsyncMock()
+
+    upsert = AsyncMock()
+    with (
+        patch.object(summariser.settings.ai_summary, "enabled", True),
+        patch.object(summariser.settings.ai_summary, "daily_token_budget", 0),
+        patch("terrapod.services.summariser.get_db_session") as mock_session,
+        patch("terrapod.services.summariser._upsert_summary", upsert),
+        patch(
+            "terrapod.services.summariser._gather_inputs",
+            AsyncMock(return_value=("plan_json", "PLAN_JSON", "json", "")),
+        ),
+        patch(
+            "terrapod.services.summariser._call_model",
+            AsyncMock(side_effect=RuntimeError("upstream 500")),
+        ),
+    ):
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await summariser.handle_ai_plan_summary({"run_id": str(run.id), "kind": "plan_summary"})
+
+        upsert.assert_awaited_once()
+        kwargs = upsert.await_args.kwargs
+        assert kwargs["status"] == "errored"
+        assert "upstream 500" in kwargs["error_message"]
+
+
+async def test_handler_missing_primary_input_writes_errored_row():
+    run = _mock_run()
+    ws = _mock_workspace(mode="default", ws_id=run.workspace_id)
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=ws)),
+        ]
+    )
+    mock_db.commit = AsyncMock()
+
+    upsert = AsyncMock()
+    with (
+        patch.object(summariser.settings.ai_summary, "enabled", True),
+        patch.object(summariser.settings.ai_summary, "daily_token_budget", 0),
+        patch("terrapod.services.summariser.get_db_session") as mock_session,
+        patch("terrapod.services.summariser._upsert_summary", upsert),
+        patch(
+            "terrapod.services.summariser._gather_inputs",
+            AsyncMock(return_value=("", "PLAN_JSON", "json", "")),
+        ),
+        patch("terrapod.services.summariser._call_model") as call_model,
+    ):
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await summariser.handle_ai_plan_summary({"run_id": str(run.id), "kind": "plan_summary"})
+
+        call_model.assert_not_called()
+        upsert.assert_awaited_once()
+        assert upsert.await_args.kwargs["status"] == "errored"
+
+
+async def test_handler_normalises_invalid_risk_level():
+    """Model returns an out-of-enum risk_level — handler clamps to 'low'."""
+    run = _mock_run()
+    ws = _mock_workspace(mode="default", ws_id=run.workspace_id)
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=ws)),
+        ]
+    )
+    mock_db.commit = AsyncMock()
+
+    upsert = AsyncMock()
+    with (
+        patch.object(summariser.settings.ai_summary, "enabled", True),
+        patch.object(summariser.settings.ai_summary, "daily_token_budget", 0),
+        patch("terrapod.services.summariser.get_db_session") as mock_session,
+        patch("terrapod.services.summariser._upsert_summary", upsert),
+        patch(
+            "terrapod.services.summariser._gather_inputs",
+            AsyncMock(return_value=("{}", "PLAN_JSON", "json", "")),
+        ),
+        patch(
+            "terrapod.services.summariser._call_model",
+            AsyncMock(
+                return_value=(
+                    {"description": "x", "risk_level": "CATASTROPHIC", "risk_factors": []},
+                    10,
+                    5,
+                )
+            ),
+        ),
+        patch("terrapod.services.summariser._emit_ready_event", AsyncMock()),
+    ):
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await summariser.handle_ai_plan_summary({"run_id": str(run.id), "kind": "plan_summary"})
+
+        assert upsert.await_args.kwargs["risk_level"] == "low"

--- a/services/tests/services/test_summariser_prompt.py
+++ b/services/tests/services/test_summariser_prompt.py
@@ -1,0 +1,132 @@
+"""Unit tests for the AI plan-summary skill prompts (#401)."""
+
+import json
+
+import pytest
+
+from terrapod.services.summariser_prompt import (
+    FAILURE_ANALYSIS_SKILL_PROMPT,
+    PLAN_SUMMARY_JSON_SCHEMA,
+    PLAN_SUMMARY_SKILL_PROMPT,
+    render_prompt,
+)
+
+
+def test_json_schema_is_valid_json_serialisable():
+    # The schema dict travels in an HTTP request body — must round-trip.
+    encoded = json.dumps(PLAN_SUMMARY_JSON_SCHEMA)
+    assert json.loads(encoded) == PLAN_SUMMARY_JSON_SCHEMA
+
+
+def test_json_schema_required_fields():
+    required = set(PLAN_SUMMARY_JSON_SCHEMA["required"])
+    assert required == {"description", "risk_level", "risk_factors"}
+
+
+def test_render_plan_summary_returns_skill_in_system():
+    system, user = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input="{}",
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated="",
+    )
+    assert PLAN_SUMMARY_SKILL_PROMPT.strip() in system
+    assert FAILURE_ANALYSIS_SKILL_PROMPT.strip() not in system
+    assert "PLAN_JSON" in user
+
+
+def test_render_failure_analysis_uses_failure_skill():
+    system, user = render_prompt(
+        kind="failure_analysis",
+        fleet_context="",
+        workspace_context="",
+        primary_input="Error: missing provider",
+        primary_input_label="PLAN_LOG",
+        primary_input_lang="text",
+        code_context_truncated="",
+    )
+    assert FAILURE_ANALYSIS_SKILL_PROMPT.strip() in system
+    assert PLAN_SUMMARY_SKILL_PROMPT.strip() not in system
+    assert "PLAN_LOG" in user
+
+
+def test_render_unknown_kind_raises():
+    with pytest.raises(ValueError):
+        render_prompt(
+            kind="bogus",
+            fleet_context="",
+            workspace_context="",
+            primary_input="",
+            primary_input_label="X",
+            primary_input_lang="text",
+            code_context_truncated="",
+        )
+
+
+def test_prefix_and_suffix_wrap_skill_prompt():
+    system, _ = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input="{}",
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated="",
+        prompt_prefix="BE TERSE.",
+        prompt_suffix="TRAILING NOTE.",
+    )
+    p_idx = system.index("BE TERSE.")
+    skill_idx = system.index(PLAN_SUMMARY_SKILL_PROMPT.strip())
+    s_idx = system.index("TRAILING NOTE.")
+    assert p_idx < skill_idx < s_idx
+
+
+def test_empty_prefix_suffix_omitted_from_system():
+    system, _ = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input="{}",
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated="",
+        prompt_prefix="   ",  # whitespace-only must be stripped
+        prompt_suffix="",
+    )
+    # No leading/trailing blank sections from empty layers
+    assert not system.startswith("\n\n")
+    assert not system.endswith("\n\n\n")
+
+
+def test_context_layers_render_in_user_message():
+    _, user = render_prompt(
+        kind="plan_summary",
+        fleet_context="FLEET: we run AWS only.",
+        workspace_context="WS: vault production.",
+        primary_input='{"resource_changes":[]}',
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated='resource "aws_vpc" "this" {}',
+    )
+    # Fleet then workspace then primary then code, in that order
+    f_idx = user.index("FLEET_CONTEXT")
+    w_idx = user.index("WORKSPACE_CONTEXT")
+    p_idx = user.index("PLAN_JSON")
+    c_idx = user.index("CODE_CONTEXT")
+    assert f_idx < w_idx < p_idx < c_idx
+
+
+def test_code_context_omitted_when_empty():
+    _, user = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input="{}",
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated="",
+    )
+    assert "CODE_CONTEXT" not in user

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,6 +23,8 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-hot-toast": "^2.6.0",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -2197,6 +2199,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -2256,12 +2324,38 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2275,6 +2369,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2291,7 +2400,6 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2306,6 +2414,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.57.2",
@@ -2356,6 +2470,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -2954,6 +3074,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3117,6 +3247,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3132,6 +3272,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/class-variance-authority": {
@@ -3180,6 +3360,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3281,7 +3471,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3293,6 +3482,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -3338,6 +3540,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3353,6 +3564,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -4344,6 +4568,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4353,6 +4587,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4816,6 +5056,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4831,6 +5111,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -4870,6 +5160,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4883,6 +5179,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5030,6 +5350,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5089,6 +5419,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5140,6 +5480,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -5740,6 +6092,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5782,6 +6144,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5790,6 +6162,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge2": {
@@ -5801,6 +6455,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5830,7 +7047,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6167,6 +7383,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6286,6 +7527,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6361,6 +7612,33 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -6473,6 +7751,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -6827,6 +8171,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -6961,6 +8315,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -6982,6 +8350,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {
@@ -7132,6 +8518,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7297,6 +8703,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -7414,6 +8907,34 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/which": {
@@ -7572,6 +9093,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,8 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-hot-toast": "^2.6.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -53,6 +53,8 @@ interface WorkspaceAttrs {
   'vcs-workflow': 'merge_then_apply' | 'apply_then_merge'
   'auto-merge': boolean
   'auto-merge-strategy': 'merge' | 'squash' | 'rebase'
+  'ai-summary-mode': 'default' | 'enabled' | 'disabled'
+  'ai-summary-context': string
   'drift-detection-enabled': boolean
   'drift-detection-interval-seconds': number
   'drift-last-checked-at': string
@@ -337,6 +339,12 @@ function WorkspaceDetailContent() {
   const [savingDrift, setSavingDrift] = useState(false)
   const [checkingDrift, setCheckingDrift] = useState(false)
   const [dismissingDrift, setDismissingDrift] = useState(false)
+
+  // AI plan summary (#401). Local draft for the context textarea so we
+  // can autosave on blur rather than every keystroke; mode is saved on
+  // dropdown change directly.
+  const [savingAiSummary, setSavingAiSummary] = useState(false)
+  const [aiSummaryContextDraft, setAiSummaryContextDraft] = useState<string | null>(null)
 
   // Delete confirmation
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -933,6 +941,30 @@ function WorkspaceDetailContent() {
       await loadWorkspace()
     } catch (err) {
       setError(err instanceof Error ? err.message : `Failed to ${action} workspace`)
+    }
+  }
+
+  // AI plan summary (#401)
+  async function handleAiSummaryAttrUpdate(patch: { 'ai-summary-mode'?: string; 'ai-summary-context'?: string }) {
+    if (!workspace) return
+    setSavingAiSummary(true)
+    try {
+      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: JSON.stringify({ data: { type: 'workspaces', attributes: patch } }),
+      })
+      if (!res.ok) {
+        const body = await res.text()
+        throw new Error(body || 'Failed to update AI summary settings')
+      }
+      const data = await res.json()
+      setWorkspace(data.data)
+      setAiSummaryContextDraft(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update AI summary settings')
+    } finally {
+      setSavingAiSummary(false)
     }
   }
 
@@ -1984,6 +2016,83 @@ function WorkspaceDetailContent() {
                     </button>
                   </div>
                 )}
+              </dl>
+            </div>
+
+            {/* AI Plan Summary (#401) */}
+            <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-6">
+              <div className="flex items-center justify-between mb-4">
+                <div>
+                  <h3 className="text-sm font-medium text-slate-300">AI Plan Summary</h3>
+                  <p className="text-xs text-slate-500 mt-1">
+                    Automatic LLM-generated change summary, risk assessment, and failure
+                    analysis on every plan-phase outcome for this workspace.
+                  </p>
+                </div>
+              </div>
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <dt className="text-xs text-slate-500">Mode</dt>
+                  <dd className="mt-1">
+                    {perms['can-update'] ? (
+                      <select
+                        value={attrs['ai-summary-mode'] || 'default'}
+                        onChange={(e) => handleAiSummaryAttrUpdate({ 'ai-summary-mode': e.target.value })}
+                        disabled={savingAiSummary}
+                        className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                      >
+                        <option value="default">Follow deployment default</option>
+                        <option value="enabled">Always summarise</option>
+                        <option value="disabled">Never summarise</option>
+                      </select>
+                    ) : (
+                      <span className="text-sm text-slate-200">
+                        {attrs['ai-summary-mode'] === 'enabled'
+                          ? 'Always summarise'
+                          : attrs['ai-summary-mode'] === 'disabled'
+                            ? 'Never summarise'
+                            : 'Follow deployment default'}
+                      </span>
+                    )}
+                  </dd>
+                </div>
+                <div className="sm:col-span-2">
+                  <dt className="text-xs text-slate-500">
+                    Workspace context
+                    <span className="ml-2 text-slate-600">(optional, additive)</span>
+                  </dt>
+                  <dd className="mt-1">
+                    {perms['can-update'] ? (
+                      <textarea
+                        value={aiSummaryContextDraft ?? attrs['ai-summary-context'] ?? ''}
+                        onChange={(e) => setAiSummaryContextDraft(e.target.value)}
+                        onBlur={() => {
+                          if (
+                            aiSummaryContextDraft !== null &&
+                            aiSummaryContextDraft !== (attrs['ai-summary-context'] ?? '')
+                          ) {
+                            handleAiSummaryAttrUpdate({ 'ai-summary-context': aiSummaryContextDraft })
+                          } else {
+                            setAiSummaryContextDraft(null)
+                          }
+                        }}
+                        placeholder="Facts the AI should know about this workspace specifically. e.g. 'Fronts the vault for service X — destroying the KMS key causes a global outage.'"
+                        rows={3}
+                        maxLength={4000}
+                        disabled={savingAiSummary}
+                        className="w-full px-3 py-2 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-1 focus:ring-brand-500 font-mono"
+                      />
+                    ) : attrs['ai-summary-context'] ? (
+                      <p className="text-sm text-slate-200 whitespace-pre-wrap">{attrs['ai-summary-context']}</p>
+                    ) : (
+                      <p className="text-sm text-slate-500 italic">No workspace context set.</p>
+                    )}
+                    <p className="text-xs text-slate-500 mt-1">
+                      Added on top of deployment-wide context. Max 4000 characters.
+                      {savingAiSummary && <span className="ml-2 text-brand-400">Saving…</span>}
+                    </p>
+                  </dd>
+                </div>
               </dl>
             </div>
 

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from '@/components/page-header'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { PlanSummaryBadges } from '@/components/plan-summary-badges'
+import { PlanAiSummary } from '@/components/plan-ai-summary'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useRunEvents } from '@/lib/use-run-events'
@@ -316,6 +317,10 @@ export default function RunDetailPage() {
   const [applyHtml, setApplyHtml] = useState('')
   const [planLogLoading, setPlanLogLoading] = useState(false)
   const [applyLogLoading, setApplyLogLoading] = useState(false)
+  // Bumped when the SSE `plan_summary_ready` event arrives so the
+  // PlanAiSummary component refetches without forcing the whole run to
+  // reload.
+  const [aiSummaryRefresh, setAiSummaryRefresh] = useState(0)
 
   // Offset tracking for incremental log fetching (byte position in raw log data)
   const planLogOffset = useRef(0)
@@ -367,6 +372,9 @@ export default function RunDetailPage() {
     if (event.event === 'log_updated' && event.run_id === bareId) {
       if (event.phase === 'plan') loadPlanLog()
       else if (event.phase === 'apply') loadApplyLog()
+    }
+    if (event.event === 'plan_summary_ready' && event.run_id === bareId) {
+      setAiSummaryRefresh((n) => n + 1)
     }
   }, [runId, loadRun]))
 
@@ -683,6 +691,10 @@ export default function RunDetailPage() {
             )}
           </div>
         )}
+
+        {/* AI plan summary / failure analysis (#401) — renders nothing
+            when the feature is off or no row exists for this plan. */}
+        <PlanAiSummary runId={runId.replace(/^run-/, '')} refreshKey={aiSummaryRefresh} />
 
         {/* Run metadata */}
         <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-6 mb-6">

--- a/web/src/components/plan-ai-summary.tsx
+++ b/web/src/components/plan-ai-summary.tsx
@@ -1,0 +1,257 @@
+'use client'
+
+/**
+ * AI-generated plan summary panel (#401).
+ *
+ * Renders one of:
+ *   - "ready"    → description (markdown) + risk pill + risk factor list
+ *   - "pending"  → spinner + "Summarising plan..."
+ *   - "skipped"  → grey muted line ("Workspace opted out" / "Daily budget exhausted")
+ *   - "errored"  → red banner with the error text
+ *   - 404         → nothing renders (caller decides whether feature is on)
+ *
+ * Refetches on the `plan_summary_ready` SSE event — the caller is
+ * responsible for hooking up `useRunEvents` and bumping the refresh
+ * counter passed in via `refreshKey`.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Sparkles, AlertTriangle, Info, ShieldAlert, ShieldX } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+import { LoadingSpinner } from '@/components/loading-spinner'
+
+type Severity = 'low' | 'medium' | 'high' | 'critical' | ''
+
+interface RiskFactor {
+  severity: Severity
+  title: string
+  detail: string
+  resource_address?: string
+}
+
+interface PlanSummary {
+  id: string
+  type: string
+  attributes: {
+    kind: 'plan_summary' | 'failure_analysis'
+    status: 'pending' | 'ready' | 'skipped' | 'errored'
+    description: string
+    'risk-level': Severity
+    'risk-factors': RiskFactor[]
+    model: string
+    'input-tokens': number
+    'output-tokens': number
+    'error-message': string
+    'created-at': string
+    'updated-at': string
+  }
+}
+
+interface Props {
+  /** Bare run UUID, no `run-` prefix. */
+  runId: string
+  /** Bump to force refetch (typically from SSE plan_summary_ready). */
+  refreshKey?: number
+}
+
+const RISK_STYLES: Record<Severity, { pill: string; icon: typeof AlertTriangle }> = {
+  '': { pill: 'bg-slate-700 text-slate-300', icon: Info },
+  low: { pill: 'bg-emerald-900/40 text-emerald-300 border border-emerald-800/50', icon: Info },
+  medium: { pill: 'bg-amber-900/40 text-amber-300 border border-amber-800/50', icon: AlertTriangle },
+  high: { pill: 'bg-orange-900/40 text-orange-300 border border-orange-800/50', icon: ShieldAlert },
+  critical: { pill: 'bg-red-900/40 text-red-300 border border-red-800/50', icon: ShieldX },
+}
+
+export function PlanAiSummary({ runId, refreshKey = 0 }: Props) {
+  const [summary, setSummary] = useState<PlanSummary | null>(null)
+  const [missing, setMissing] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [transportError, setTransportError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiFetch(`/api/v2/plans/plan-${runId}/summary`)
+      if (res.status === 404) {
+        setMissing(true)
+        setSummary(null)
+        return
+      }
+      if (!res.ok) {
+        setTransportError(`HTTP ${res.status}`)
+        return
+      }
+      const data = await res.json()
+      setSummary(data.data as PlanSummary)
+      setMissing(false)
+      setTransportError(null)
+    } catch (e) {
+      setTransportError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [runId])
+
+  useEffect(() => {
+    load()
+  }, [load, refreshKey])
+
+  // When the feature is globally disabled (no row will ever appear) we
+  // render nothing — operators on a non-AI deployment don't see this
+  // panel at all.
+  if (missing) return null
+  if (loading && !summary) return null
+  if (transportError) return null
+
+  const attrs = summary?.attributes
+  const kind = attrs?.kind ?? 'plan_summary'
+  const heading = kind === 'failure_analysis' ? 'Failure analysis' : 'Plan summary'
+
+  return (
+    <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-6 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-brand-400" aria-hidden="true" />
+          <h3 className="text-sm font-medium text-slate-300">{heading}</h3>
+          <span className="text-xs text-slate-500">AI generated</span>
+        </div>
+        {attrs && attrs.status === 'ready' && attrs['risk-level'] && (
+          <RiskPill level={attrs['risk-level']} />
+        )}
+      </div>
+
+      {attrs?.status === 'pending' && (
+        <div className="flex items-center gap-3 text-sm text-slate-400">
+          <LoadingSpinner />
+          <span>
+            {kind === 'failure_analysis' ? 'Analysing failure…' : 'Summarising plan…'}
+          </span>
+        </div>
+      )}
+
+      {attrs?.status === 'skipped' && (
+        <p className="text-sm text-slate-500 italic">
+          {attrs['error-message'] || 'Summary skipped for this run.'}
+        </p>
+      )}
+
+      {attrs?.status === 'errored' && (
+        <div className="text-sm text-red-300 bg-red-900/20 border border-red-800/50 rounded p-3">
+          <div className="font-medium mb-1">Summariser failed</div>
+          <div className="text-red-400/80 text-xs font-mono whitespace-pre-wrap break-all">
+            {attrs['error-message']}
+          </div>
+        </div>
+      )}
+
+      {attrs?.status === 'ready' && (
+        <>
+          <div className="prose prose-sm prose-invert max-w-none text-slate-200">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                // Tighten markdown defaults to match our dark surface
+                code: ({ children, ...props }) => (
+                  <code
+                    {...props}
+                    className="px-1 py-0.5 rounded bg-slate-900 text-brand-300 font-mono text-xs"
+                  >
+                    {children}
+                  </code>
+                ),
+                a: ({ children, ...props }) => (
+                  <a {...props} className="text-brand-400 hover:text-brand-300 underline">
+                    {children}
+                  </a>
+                ),
+                ul: ({ children, ...props }) => (
+                  <ul {...props} className="list-disc list-inside space-y-1 my-2 text-slate-200">
+                    {children}
+                  </ul>
+                ),
+                ol: ({ children, ...props }) => (
+                  <ol {...props} className="list-decimal list-inside space-y-1 my-2 text-slate-200">
+                    {children}
+                  </ol>
+                ),
+                p: ({ children, ...props }) => (
+                  <p {...props} className="my-2 leading-relaxed">
+                    {children}
+                  </p>
+                ),
+              }}
+            >
+              {attrs.description}
+            </ReactMarkdown>
+          </div>
+
+          {attrs['risk-factors'].length > 0 && (
+            <div className="mt-5 pt-4 border-t border-slate-700/50">
+              <h4 className="text-xs font-medium text-slate-400 mb-3">
+                {kind === 'failure_analysis' ? 'Suggested fixes' : 'Risk factors'}
+              </h4>
+              <ul className="space-y-3">
+                {attrs['risk-factors'].map((rf, idx) => (
+                  <RiskFactorRow key={idx} factor={rf} />
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {attrs.model && (
+            <div className="mt-4 pt-3 border-t border-slate-700/50 flex items-center justify-between text-xs text-slate-500">
+              <span className="font-mono">{attrs.model}</span>
+              <span>
+                {attrs['input-tokens']} in / {attrs['output-tokens']} out tokens
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function RiskPill({ level }: { level: Severity }) {
+  const style = RISK_STYLES[level] ?? RISK_STYLES['']
+  const Icon = style.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium uppercase tracking-wide ${style.pill}`}
+    >
+      <Icon className="w-3 h-3" aria-hidden="true" />
+      {level || 'unknown'}
+    </span>
+  )
+}
+
+function RiskFactorRow({ factor }: { factor: RiskFactor }) {
+  const style = RISK_STYLES[factor.severity] ?? RISK_STYLES['']
+  const Icon = style.icon
+  return (
+    <li className="flex gap-3">
+      <Icon
+        className={`w-4 h-4 mt-0.5 flex-shrink-0 ${
+          factor.severity === 'critical'
+            ? 'text-red-400'
+            : factor.severity === 'high'
+              ? 'text-orange-400'
+              : factor.severity === 'medium'
+                ? 'text-amber-400'
+                : 'text-emerald-400'
+        }`}
+        aria-hidden="true"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <span className="text-sm text-slate-200 font-medium">{factor.title}</span>
+          {factor.resource_address && (
+            <span className="font-mono text-xs text-brand-300">{factor.resource_address}</span>
+          )}
+        </div>
+        <p className="text-xs text-slate-400 mt-1 leading-relaxed">{factor.detail}</p>
+      </div>
+    </li>
+  )
+}


### PR DESCRIPTION
Closes #401.

## Summary

Adds optional LLM-generated change description, risk assessment, and failure analysis to every plan-phase terminal transition. Off by default; provider-agnostic via [LiteLLM](https://github.com/BerriAI/litellm) — Bedrock (Claude, Nova, gpt-oss), OpenAI, Anthropic direct, Gemini, Azure OpenAI, vLLM all reachable through one config block. AWS Bedrock auth is IAM-native (IRSA + optional cross-account `sts:AssumeRole`); no static bearer tokens required.

When enabled, every plan-phase terminal transition triggers a background summariser call:

- `planned` → describes the proposed changes + overall risk (`low|medium|high|critical`) + risk factors keyed by terraform address.
- `errored` while in the plan phase → root-cause description + suggested fixes ranked most-likely-to-resolve first.

Results land in:

- The run detail UI (markdown description + risk pill + risk-factor list + model/token telemetry) with SSE-driven live update.
- The per-workspace PR/MR comment, edited in place — collapsible `<details>` block beneath the run status line. The summariser re-enqueues the existing `vcs_commit_status` trigger after a ready summary lands, so the comment refreshes within seconds of the LLM responding, not at the next state change.

Workspace owners override the global toggle with a three-state per-workspace mode (`default | enabled | disabled`) and can pin workspace-specific context appended to the model prompt.

See `docs/ai-plan-summary.md` for the operator guide (provider matrix, IAM policy, Bedrock + OpenAI + Anthropic + Gemini config examples, prompt layering, troubleshooting).

## Surfaces touched

- **Backend**: `AISummaryConfig` block, `PlanSummary` table + Alembic migration, `summariser.py` with `litellm.acompletion` + daily Redis token budget, two skill prompts (plan_summary / failure_analysis) with layered context, trigger handler, `GET /api/v2/plans/{id}/summary`, workspace PATCH for the new fields.
- **VCS PR/MR comments**: `vcs_status_dispatcher._build_comment_body` extended to render a collapsible AI summary section; summariser handler re-enqueues `vcs_commit_status` after a ready summary lands so the comment is refreshed immediately.
- **Helm**: `api.config.ai_summary` block (off by default) + `values.schema.json` validation + `values-local.yaml` wired against Bedrock Opus 4.8 for dev smoke.
- **Web UI**: `PlanAiSummary` component renders all four statuses (ready/pending/skipped/errored); workspace Settings tab gains a three-state mode + 4000-char context textarea; `react-markdown` + `remark-gfm` added.
- **go-terrapod**: `Workspace` + `Create/UpdateWorkspaceRequest` gain `AISummaryMode` + `AISummaryContext` (update uses `*string` for explicit clear); new `PlanSummary` type + `GetPlanSummary`.
- **Provider**: `terrapod_workspace` resource + data source gain `ai_summary_mode` + `ai_summary_context` attributes (Optional+Computed).
- **Migration tool**: inherits via go-terrapod; no source-side equivalent in TFE/Atlantis, so server defaults apply.
- **Docs**: `docs/ai-plan-summary.md` operator guide, `docs/index.md` row, README callout + Key Features bold entry.
- **CI**: pip-audit `--ignore-vuln CVE-2026-40217 CVE-2026-28684` with rationale (proxy-mode sandbox escape we don't expose + symlink-follow in write APIs we don't call; patched litellm pins Python <3.14, our image is on 3.14).

## Test plan

- [x] Backend unit tests pass (1671 — added `test_summariser_prompt.py`, `test_summariser.py`, `test_ai_summary.py`, expanded `test_run_service.py`)
- [x] `ruff check` + `ruff format --check` clean
- [x] Frontend `tsc --noEmit` clean
- [x] `helm template` clean against both production and local values
- [x] `go build ./...` + `go test ./...` clean for go-terrapod
- [x] `go build ./...` clean for provider + migrate
- [x] Live local stack smoke: real planned run summarised end-to-end via Bedrock Opus 4.8 (`bedrock/us.anthropic.claude-opus-4-8`) → `status=ready`, `risk_level=low`, structured response stored, SSE event fired
- [x] Playwright UI smoke: run detail panel renders with description + risk pill + risk-factor row + model/token footer; workspace settings shows three-state mode dropdown + textarea

## Provider matrix

| Provider | `ai_summary.model` | Auth |
|---|---|---|
| AWS Bedrock | `bedrock/us.anthropic.claude-opus-4-8`, `bedrock/anthropic.nova-pro-v1:0`, `bedrock/openai.gpt-oss-120b`, etc. | boto3 chain: IRSA → optional `sts:AssumeRole` via `auth.aws_role_arn` |
| OpenAI | `openai/gpt-5`, `openai/o4-mini` | `auth.api_key` (env var) |
| Anthropic direct | `anthropic/claude-opus-4-8` | `auth.api_key` |
| Google Gemini | `gemini/gemini-2.5-pro` | `auth.api_key` |
| Azure OpenAI | `azure/<deployment-name>` | `auth.api_key` + `api_base` |
| Self-hosted (vLLM, gateway, …) | `openai/<model>` | `auth.api_key` + `api_base` |

## Out of scope (follow-up PRs)

- Per-workspace / per-team token quotas (global daily budget in place; finer-grained budgeting is a future enhancement).
- `/api/terrapod/v1/features` endpoint exposing whether AI summary is globally enabled (UI currently shows all three workspace-mode options regardless; backend no-ops when global is off — acceptable for v1).