### PR TITLE
docs: api-reference + runbooks for AI plan-summary (v0.30.0 audit fix)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -338,6 +338,20 @@ Workspaces support the following drift detection attributes (settable on create 
 | `drift-detection-enabled` | boolean | `true` (VCS) / `false` (non-VCS) | Enable or disable automatic drift detection. Auto-enabled when a VCS connection is set |
 | `drift-detection-interval-seconds` | integer | `86400` | How often to run drift detection checks (minimum: 3600 seconds / 1 hour) |
 
+### AI Plan Summary Attributes
+
+Workspaces carry two attributes that govern the optional AI plan-summary feature (settable on create and update). When the feature is globally disabled at the deployment level (`api.config.ai_summary.enabled: false`), these fields are stored but inert — no calls are made. See [docs/ai-plan-summary.md](ai-plan-summary.md) for the full operator guide.
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `ai-summary-mode` | string | `"default"` | Per-workspace override. One of `"default"` (follow the global toggle), `"enabled"` (always summarise this workspace's plans), or `"disabled"` (never summarise this workspace — overrides global). |
+| `ai-summary-context` | string | `""` | Free text up to 4000 characters appended to the model's prompt as workspace-specific facts (e.g. "Fronts the vault for service X — destroying the KMS key causes a global outage."). Additive to the deployment-wide `fleet_context`. |
+
+422 errors:
+- `ai-summary-mode` outside the enum
+- `ai-summary-context` longer than 4000 characters
+- `ai-summary-context` not a string
+
 The following read-only attributes are included in workspace responses when drift detection is enabled:
 
 | Attribute | Type | Description |
@@ -700,6 +714,72 @@ GET /api/v2/plans/{plan_id}/json-output
 Returns the structured JSON representation of the plan, as produced by `terraform show -json tfplan`. Useful for downstream tooling that wants to consume the resource changes without parsing the human-readable log. Responds **302** to a presigned object-storage URL.
 
 The endpoint is mounted at `/api/v2/` because `go-tfe` and Terraform's `cloud` block expect it there. Returns **404** if the runner never uploaded the JSON output (older runs, runs that errored before the plan completed).
+
+### Plan Summary
+
+```
+GET /api/v2/plans/{plan_id}/summary
+```
+
+Returns the AI-generated plan summary (or failure analysis on errored plans) when the optional `ai_summary` feature is enabled and a summary has been produced for the run. See [docs/ai-plan-summary.md](ai-plan-summary.md) for the operator-side setup.
+
+**Required permission:** `read` on the workspace.
+
+`plan_id` accepts either `plan-{uuid}` (the canonical form, matching what's returned in the `plans` relationship of a Run) or a bare run UUID.
+
+**Responses:**
+- **200 OK** — the workspace has a summary row for this run. See response shape below.
+- **404 Not Found** — no summary row exists. Either the feature is globally disabled, the workspace opted out (`ai-summary-mode: disabled`), or the summariser hasn't run yet. The UI treats 404 as "no AI surface" and renders nothing.
+
+**Response shape:**
+
+```json
+{
+  "data": {
+    "id": "plan-summary-<uuid>",
+    "type": "plan-summaries",
+    "attributes": {
+      "kind": "plan_summary",
+      "status": "ready",
+      "description": "Adds a single root-level output named `marker` ...",
+      "risk-level": "low",
+      "risk-factors": [
+        {
+          "severity": "low",
+          "title": "Output-only addition",
+          "detail": "The plan only introduces the `marker` output ...",
+          "resource_address": "output.marker"
+        }
+      ],
+      "model": "bedrock/us.anthropic.claude-opus-4-8",
+      "input-tokens": 1335,
+      "output-tokens": 171,
+      "error-message": "",
+      "created-at": "2026-06-01T12:00:00Z",
+      "updated-at": "2026-06-01T12:00:30Z"
+    },
+    "relationships": {
+      "plan": { "data": { "id": "plan-<uuid>", "type": "plans" } },
+      "run":  { "data": { "id": "run-<uuid>",  "type": "runs"  } }
+    }
+  }
+}
+```
+
+**Attribute reference:**
+
+| Attribute | Type | Description |
+|---|---|---|
+| `kind` | string | `"plan_summary"` (successful plan → change description + risk assessment) or `"failure_analysis"` (plan-phase errored → root-cause + suggested fixes). |
+| `status` | string | `"pending"` (handler running), `"ready"` (model returned a parseable response), `"skipped"` (workspace disabled or daily budget hit — see `error-message`), or `"errored"` (model call failed — see `error-message`). |
+| `description` | string | Markdown body. For `kind=plan_summary`, ~600 words describing the proposed changes. For `kind=failure_analysis`, root-cause explanation. |
+| `risk-level` | string | One of `"low"`, `"medium"`, `"high"`, `"critical"`. Reflects blast radius + reversibility, not novelty. |
+| `risk-factors` | array of object | Each item carries `severity` (same enum as `risk-level`), `title` (max 120 chars), `detail` (max 600 chars), and optional `resource_address` (terraform address). For `kind=failure_analysis` these are suggested fixes ordered most-likely-to-resolve first. |
+| `model` | string | LiteLLM model string used for this summary (e.g. `bedrock/us.anthropic.claude-opus-4-8`). |
+| `input-tokens` / `output-tokens` | integer | Telemetry counts reported by the upstream provider. |
+| `error-message` | string | Populated only for `status=errored` or `status=skipped`. Empty for `ready`. |
+
+**Real-time updates:** when a summary lands, the per-workspace SSE channel (`GET /api/terrapod/v1/workspaces/{id}/runs/events`) emits a `plan_summary_ready` event with `{run_id, workspace_id}`. The UI re-fetches the summary on receipt. For VCS-driven runs, the per-workspace PR/MR status comment is also edited in place to include the summary content.
 
 ### Apply Details
 

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -752,3 +752,107 @@ service=terrapod-api logger=terrapod.services.vcs_status_dispatcher
 
 - Run logs after the rotation show `level=info logger=terrapod.services.gitlab_service msg="GitLab commit status posted"` (or the equivalent for GitHub).
 - The PR check on the next pushed commit lands within ~30 seconds of the run completing.
+
+---
+
+## AI plan-summary daily token budget exhausted
+
+**Symptom**: AI plan summary panels on run detail pages start showing "Summary skipped for this run" (italic grey muted text) instead of the LLM description. New `plan_summaries` rows arrive with `status='skipped'` and `error_message='daily token budget exhausted'`. The run lifecycle itself is unaffected (plan / apply / lock state machine continues normally) — only the summary surface is muted.
+
+**Why**: `api.config.ai_summary.daily_token_budget` caps the total *output* tokens spent across all summaries per UTC day. A Redis counter at `tp:ai_summary:budget:YYYYMMDD` (key TTL ~36h) accumulates `usage.completion_tokens` from every successful summariser call. When the next call would push past the cap, the handler short-circuits before invoking LiteLLM, writes a `status='skipped'` row, and emits the `plan_summary_ready` SSE event. The counter rolls over at the next UTC midnight automatically — no operator action is required for normal recovery.
+
+### Diagnosis
+
+1. **Confirm the budget actually exhausted** rather than a provider outage:
+   ```bash
+   kubectl exec -n <ns> <redis-pod> -- redis-cli GET "tp:ai_summary:budget:$(date -u +%Y%m%d)"
+   # Compare against the configured cap:
+   kubectl get configmap <release>-api-config -n <ns> -o jsonpath='{.data.config\.yaml}' \
+     | grep -A1 ai_summary | grep daily_token_budget
+   ```
+   If the Redis value is at or above the cap, the budget is the cause. If well below, look at `plan_summaries.error_message` for the actual reason.
+
+2. **Quantify the runaway** — query the last 24h of summaries:
+   ```sql
+   SELECT kind, status, count(*), sum(output_tokens) AS out_tokens
+   FROM plan_summaries
+   WHERE created_at > now() - interval '24 hours'
+   GROUP BY kind, status ORDER BY out_tokens DESC;
+   ```
+   Look for a workspace or kind disproportionately consuming tokens (e.g. a flapping VCS workspace re-summarising the same plan many times).
+
+### Resolution
+
+- **Wait for UTC midnight reset.** If the spend is in line with normal usage and you just hit the cap because of a busy day, do nothing — the next plan after 00:00 UTC summarises again.
+- **Bump the cap and `helm upgrade`** if the cap is too tight for legitimate steady-state use:
+  ```yaml
+  api:
+    config:
+      ai_summary:
+        daily_token_budget: 10000000  # was 5000000
+  ```
+- **Set `daily_token_budget: 0`** for unlimited. Do this only if you have a separate cost guardrail upstream (provider-side spend limit, gateway quota, etc.).
+- **Force-reset the counter** as an emergency measure (e.g. a runaway workspace already fixed):
+  ```bash
+  kubectl exec -n <ns> <redis-pod> -- redis-cli DEL "tp:ai_summary:budget:$(date -u +%Y%m%d)"
+  ```
+  The counter rebuilds from the next successful summary. Reset doesn't replay missed summaries — they stay `status='skipped'` for the historical runs.
+
+### Verification
+
+- Redis `tp:ai_summary:budget:<date>` is below the configured cap.
+- New plans land with `plan_summaries.status='ready'` rather than `skipped`.
+- The run-detail UI panel re-renders with markdown content within ~30 seconds of the plan reaching `planned`.
+
+---
+
+## AI plan-summary provider outage / credential failure
+
+**Symptom**: AI summary panels show "Summariser failed" with an upstream error (HTTP 401 / 403 / 5xx, timeout, or model-not-found). The `plan_summaries` table accumulates rows with `status='errored'` and `error_message` carrying the LiteLLM exception. The run lifecycle is unaffected.
+
+**Why**: the summariser's failure path is best-effort by design — every exception from `litellm.acompletion()` is caught, logged, and recorded as an `errored` row. The trigger handler never raises into the scheduler, so a sustained provider outage does NOT block plans, applies, VCS comments, or any other run state. Only the summary surface goes red.
+
+### Diagnosis
+
+1. **Inspect the most recent failure messages** to identify the upstream issue:
+   ```sql
+   SELECT kind, error_message, count(*)
+   FROM plan_summaries
+   WHERE status = 'errored' AND created_at > now() - interval '1 hour'
+   GROUP BY kind, error_message ORDER BY count DESC;
+   ```
+   The error text comes straight from LiteLLM — Bedrock IAM, OpenAI 429, Anthropic 401, etc. each present distinctively.
+
+2. **Confirm the provider isn't degraded** (Bedrock service health dashboard, OpenAI status, Anthropic status). Provider-side incidents auto-clear once upstream stabilises; no operator action is needed.
+
+3. **For Bedrock IAM failures** specifically — verify the API pod's IRSA identity is still admitted by the cross-account trust policy on the `ai_summary.auth.aws_role_arn`:
+   ```bash
+   kubectl exec -n <ns> <api-pod> -- aws sts get-caller-identity
+   kubectl exec -n <ns> <api-pod> -- aws sts assume-role \
+     --role-arn "$(grep aws_role_arn /etc/terrapod/config.yaml | awk '{print $2}' | tr -d '"')" \
+     --role-session-name diag
+   ```
+
+### Resolution
+
+- **Provider outage**: no action; summaries auto-recover when upstream stabilises. The run-detail UI shows the latest errored row's message so reviewers see what's failing.
+- **Credential / scope issue** (API key revoked, IRSA trust policy edited, cross-account role deleted): fix at the source. If using the bearer path, rotate the secret value:
+  ```bash
+  kubectl edit secret terrapod-ai-summary-credentials -n <ns>
+  # update TERRAPOD_AI_SUMMARY__AUTH__API_KEY, save
+  kubectl rollout restart deployment/<release>-api -n <ns>
+  ```
+- **Emergency disable** if the provider is down for an extended period and the red panels are visible to many reviewers, flip the global toggle off without restart-required code changes:
+  ```yaml
+  api:
+    config:
+      ai_summary:
+        enabled: false
+  ```
+  followed by `helm upgrade ...`. The API pod re-reads its config on rollout and the trigger handler stops registering. All subsequent plans go through without ever attempting to summarise — no `plan_summaries` row is written at all (the handler short-circuits before the DB write). Re-enable when the upstream is healthy.
+
+### Verification
+
+- Errored rows stop accumulating: `SELECT count(*) FROM plan_summaries WHERE status='errored' AND created_at > now() - interval '15 minutes';` returns 0.
+- The run-detail UI panel renders summaries with `status='ready'` (after re-enable + a new plan).
+- If you emergency-disabled, no `plan_summaries` row appears for new runs and the UI panel doesn't render at all.


### PR DESCRIPTION
Closes the docs gaps flagged by the v0.30.0 pre-release audit (post-#402 / pre-tag).

## Summary

- **`docs/api-reference.md`**: new "Plan Summary" endpoint section (GET /api/v2/plans/{id}/summary — request, response shape, attribute reference, SSE event); new "AI Plan Summary Attributes" subsection under Workspaces (`ai-summary-mode` + `ai-summary-context` with 422 validation rules).
- **`docs/runbooks.md`**: two new operator entries — "AI plan-summary daily token budget exhausted" (detection via Redis counter, quantification SQL, reset / bump / emergency-clear options) and "AI plan-summary provider outage / credential failure" (diagnosis steps for IAM and bearer credential failures, recommended emergency-disable via `ai_summary.enabled: false` flip, verification queries).

## Audit step G result

The new ignored-vulnerability review step from CLAUDE.md was also run as part of the audit. CVE-2026-40217 (litellm proxy sandbox) ignore is still required: the latest litellm release on PyPI (1.88.0rc1) still pins `Python <3.14` and the API image is on 3.14, so the bump-to-patched path remains unavailable upstream. Rationale comment in `pentest/trivy/.trivyignore` and `.github/workflows/ci.yml` is accurate.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] Frontend `tsc --noEmit` clean
- [x] No source code or schema changes — pure docs

After merge: tag `v0.30.0` and watch the release pipeline.