### PR TITLE
fix(helm): int64 cast on ai_summary numeric fields to defeat YAML 5e+06

### DIFF
--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -259,11 +259,14 @@ data:
       {{- if .Values.api.config.ai_summary.api_base }}
       api_base: {{ .Values.api.config.ai_summary.api_base | quote }}
       {{- end }}
-      max_output_tokens: {{ .Values.api.config.ai_summary.max_output_tokens | default 1024 }}
-      request_timeout_seconds: {{ .Values.api.config.ai_summary.request_timeout_seconds | default 60 }}
-      daily_token_budget: {{ .Values.api.config.ai_summary.daily_token_budget | default 0 }}
-      plan_json_max_bytes: {{ .Values.api.config.ai_summary.plan_json_max_bytes | default 500000 }}
-      code_context_max_bytes: {{ .Values.api.config.ai_summary.code_context_max_bytes | default 200000 }}
+      max_output_tokens: {{ .Values.api.config.ai_summary.max_output_tokens | default 1024 | int64 }}
+      request_timeout_seconds: {{ .Values.api.config.ai_summary.request_timeout_seconds | default 60 | int64 }}
+      # int64 cast prevents Helm's default float formatter from emitting
+      # YAML scientific notation (e.g. `5e+06`) for values above ~1M,
+      # which Pydantic on the API side refuses to parse as an int.
+      daily_token_budget: {{ .Values.api.config.ai_summary.daily_token_budget | default 0 | int64 }}
+      plan_json_max_bytes: {{ .Values.api.config.ai_summary.plan_json_max_bytes | default 500000 | int64 }}
+      code_context_max_bytes: {{ .Values.api.config.ai_summary.code_context_max_bytes | default 200000 | int64 }}
       {{- with .Values.api.config.ai_summary.auth }}
       auth:
         # api_key is injected via env var (TERRAPOD_AI_SUMMARY__AUTH__API_KEY)


### PR DESCRIPTION
## Summary

API pod crash-loops after v0.30.0 rollout when a deployment sets `ai_summary.daily_token_budget` to a value above roughly 1,000,000 (e.g. the typical operator setting of `5000000` for 5M tokens/day). Helm's default Go template formatter emits YAML scientific notation (\`5e+06\`) and Pydantic refuses to coerce that string back to an integer:

\`\`\`
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
ai_summary.daily_token_budget
  Input should be a valid integer, unable to parse string as an integer
  [type=int_parsing, input_value='5e+06', input_type=str]
\`\`\`

## Fix

Pipe every numeric integer field in the rendered \`ai_summary\` ConfigMap block through \`| int64\` so Helm emits the value as an integer rather than a Go float. Same pattern is now applied to \`max_output_tokens\` and \`request_timeout_seconds\` for safety even though those values don't trigger the bug today.

No values.yaml or schema change. Existing deployments with small values keep working; this unblocks realistic million-token budgets.

## Test plan

- [x] Repro: \`helm template ./helm/terrapod --set api.config.ai_summary.daily_token_budget=5000000 ...\` emits \`daily_token_budget: 5e+06\` on main, \`daily_token_budget: 5000000\` after the fix
- [x] \`helm template\` clean against both \`values.yaml\` and \`values-local.yaml\`
- [x] No Python / Go / frontend code changes — pure template fix

Hotfix to v0.30.0 — tag as v0.30.1 after merge.