### PR TITLE
fix(ai-summary): enqueue plan_summary after JSON upload (v0.30.2)

### DIFF
--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -31,6 +31,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_runner_for_run
+from terrapod.config import settings
 from terrapod.db.models import Run, StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -253,6 +254,30 @@ async def upload_plan_json_output(
             body_bytes=len(body),
         )
     await db.commit()
+
+    # AI plan summariser (#401) — enqueue the `plan_summary` kind now
+    # that the JSON is actually in storage. Previously this fired from
+    # run_service.transition_run on the planned transition, which
+    # raced the runner: transition_run runs on the plan-result POST,
+    # which the runner sends BEFORE uploading plan-json-output. The
+    # summariser would then hit "Object not found" half the time and
+    # write status='errored'. Firing here closes the race — by the
+    # time the trigger is enqueued the storage put + db commit have
+    # both succeeded. Failure-analysis kind still fires from
+    # transition_run on errored runs (no JSON involved).
+    if settings.ai_summary.enabled:
+        try:
+            from terrapod.services.scheduler import enqueue_trigger
+
+            await enqueue_trigger(
+                "ai_plan_summary",
+                {"run_id": str(run.id), "kind": "plan_summary"},
+                dedup_key=f"aisum:{run.id}:plan_summary",
+                dedup_ttl=300,
+            )
+        except Exception as e:
+            logger.debug("Failed to enqueue ai_plan_summary after upload", error=str(e))
+
     return Response(status_code=204)
 
 

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -440,14 +440,16 @@ async def transition_run(
     if run.is_drift_detection and target_status in drift_terminal:
         await _enqueue_drift_completed(run)
 
-    # AI plan summariser (#401) — fires on plan-phase terminal transitions.
-    # `planned` → summarise the changes. `errored` *during the plan phase*
-    # (apply hasn't started) → analyse the failure cause. Apply-phase
-    # errored runs are skipped — the failure surface is different and
-    # belongs to a future feature.
-    if target_status == "planned":
-        await _enqueue_ai_plan_summary(run, "plan_summary")
-    elif target_status == "errored" and run.apply_started_at is None:
+    # AI plan summariser (#401) — failure-analysis kind only.
+    # The `plan_summary` kind is enqueued from
+    # routers/run_artifacts.upload_plan_json_output AFTER the runner has
+    # uploaded the structured plan JSON. Firing it here on the `planned`
+    # transition raced the runner: transition_run runs on the
+    # plan-result POST, but plan-json-output upload happens a few
+    # operations later in the runner entrypoint, so the summariser
+    # would hit `Object not found` half the time. Errored plans never
+    # upload JSON, so failure-analysis still belongs here.
+    if target_status == "errored" and run.apply_started_at is None:
         await _enqueue_ai_plan_summary(run, "failure_analysis")
 
     return run

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -293,6 +293,68 @@ class TestUploadPlanJsonOutput:
         assert run.resource_additions is None
         assert run.resource_changes is None
 
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    @patch("terrapod.api.routers.run_artifacts.settings")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_enqueues_ai_plan_summary_after_upload(
+        self, mock_enq, mock_settings, mock_get_storage, *_mocks
+    ):
+        """The plan_summary trigger must fire only after the JSON has
+        landed in storage — otherwise the summariser races the runner
+        and hits "Object not found" (v0.30.2 fix).
+        """
+        mock_settings.ai_summary.enabled = True
+        run_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-json-output",
+                content=b'{"resource_changes":[]}',
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 204
+        mock_enq.assert_awaited_once()
+        args, kwargs = mock_enq.call_args
+        assert args[0] == "ai_plan_summary"
+        assert args[1] == {"run_id": str(run_id), "kind": "plan_summary"}
+        assert kwargs.get("dedup_key") == f"aisum:{run_id}:plan_summary"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    @patch("terrapod.api.routers.run_artifacts.settings")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_skips_ai_plan_summary_when_disabled(
+        self, mock_enq, mock_settings, mock_get_storage, *_mocks
+    ):
+        mock_settings.ai_summary.enabled = False
+        run_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-json-output",
+                content=b'{"resource_changes":[]}',
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 204
+        mock_enq.assert_not_called()
+
 
 # ── lock-file (#306) ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fix a race between the AI summariser trigger and the runner's plan-json-output upload.

`run_service.transition_run` runs on the runner's `POST .../plan-result` (the runner-driven `planning → planned` transition). At that point the runner has **not yet** uploaded the structured plan JSON — that PUT happens a few operations later in `docker/runner-entrypoint.sh`. Firing the `plan_summary` enqueue from `transition_run` therefore raced the upload, and the summariser's `_load_plan_json` hit `Object not found` half the time and wrote `status='errored'` with `error_reason='no PLAN_JSON available'`.

## Fix

- Move the `plan_summary` enqueue out of `run_service.transition_run` and into `routers/run_artifacts.upload_plan_json_output`, after the storage `put()` + `db.commit()`. By the time the trigger is enqueued the JSON is definitely in storage.
- Keep `failure_analysis` enqueue in `transition_run` — errored plans never produce JSON, so there's nothing to race.
- Same dedup key (`aisum:{run_id}:plan_summary`) so retried uploads don't double-fire.
- Best-effort: any `enqueue_trigger` failure is logged at debug and swallowed; AI features never break run lifecycle.

## Test plan

- [x] `make test` — 1673 passed
- [x] `make lint` — passes
- [x] Added two new tests in `test_run_artifacts.py`:
  - `test_enqueues_ai_plan_summary_after_upload` — asserts the trigger fires with the right args when `ai_summary.enabled` is true
  - `test_skips_ai_plan_summary_when_disabled` — asserts the gate works
- [x] Existing `TestEnqueueAIPlanSummary` (in `test_run_service.py`) still passes — the helper still exists for the `failure_analysis` path