### PR TITLE
fix(ai-summary): detect truncation + better parse diagnostics + bump default max_output_tokens

### DIFF
--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -771,10 +771,17 @@ class AISummaryConfig(BaseModel):
         ),
     )
     max_output_tokens: int = Field(
-        default=1024,
+        default=16384,
         description=(
-            "Max tokens for the model response. Sized for ~600 words "
-            "of human description plus a short structured risk block."
+            "Upper bound on model response tokens. Must accommodate the "
+            "full JSON object: ~600 words of description + a risk-factor "
+            "list whose size scales with the plan. This is a CAP, not a "
+            "target — the model only emits what it needs and stops on a "
+            "natural stop token; only oversized plans approach it. 1024 "
+            "was undersized for medium plans and caused finish_reason="
+            "'length' truncation; 16384 leaves comfortable headroom for "
+            "very large plans (100+ resource changes with detailed risk "
+            "listings) while staying well under Opus's 32K output limit."
         ),
     )
     request_timeout_seconds: int = Field(

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -308,8 +308,33 @@ async def _call_model(
 
     if not resp.choices:
         raise RuntimeError("model response had no choices")
-    text = resp.choices[0].message.content or ""
-    parsed = _parse_model_json(text)
+    choice = resp.choices[0]
+    text = choice.message.content or ""
+    finish_reason = getattr(choice, "finish_reason", None)
+
+    # When the model runs out of output tokens it stops mid-JSON, so both
+    # strict json.loads and the balanced-brace fallback fail with a
+    # misleading "not JSON" — call out the real cause first.
+    if finish_reason == "length":
+        raise RuntimeError(
+            f"model response truncated at max_output_tokens={max_output_tokens} "
+            f"(finish_reason=length); raise ai_summary.max_output_tokens"
+        )
+
+    try:
+        parsed = _parse_model_json(text)
+    except ValueError as e:
+        # Log a head+tail snippet so future failures are diagnosable
+        # without rerunning. Limit size so we don't dump megabytes into
+        # the structured log.
+        snippet = text if len(text) <= 800 else f"{text[:400]}…{text[-400:]}"
+        logger.warning(
+            "Summariser response did not parse as JSON",
+            finish_reason=finish_reason,
+            response_length=len(text),
+            response_snippet=snippet,
+        )
+        raise ValueError(f"{e} (finish_reason={finish_reason}, len={len(text)})") from e
 
     usage = getattr(resp, "usage", None)
     in_tok = int(getattr(usage, "prompt_tokens", 0) or 0) if usage else 0
@@ -320,19 +345,43 @@ async def _call_model(
 def _parse_model_json(text: str) -> dict:
     """Parse the model's textual response as a JSON object.
 
-    Permits incidental wrapping (a leading code fence, a stray sentence)
-    by extracting the first balanced ``{...}`` block. The strict schema
-    in the request body should prevent this, but the fallback is cheap.
+    Permits incidental wrapping (a leading ``"Here's the JSON:"`` line, a
+    ```json fenced block, a stray sentence after the object) by trying:
+
+      1. Strict parse of the whole stripped body.
+      2. Strip a fenced ```json / ``` block if present.
+      3. Extract the first balanced ``{...}`` block.
+
+    The strict schema in the prompt should prevent any of this, but the
+    fallbacks are cheap and reduce flakes from chatty models.
     """
     text = text.strip()
     try:
         return json.loads(text)
     except json.JSONDecodeError:
         pass
+
+    # Strip a ```json ... ``` (or plain ``` ... ```) fence — Opus
+    # occasionally adds one despite the "no fences" instruction.
+    if text.startswith("```"):
+        body = text[3:]
+        if body.lower().startswith("json"):
+            body = body[4:]
+        body = body.lstrip("\n")
+        end = body.rfind("```")
+        if end >= 0:
+            try:
+                return json.loads(body[:end].strip())
+            except json.JSONDecodeError:
+                pass
+
     start = text.find("{")
     end = text.rfind("}")
     if start >= 0 and end > start:
-        return json.loads(text[start : end + 1])
+        try:
+            return json.loads(text[start : end + 1])
+        except json.JSONDecodeError:
+            pass
     raise ValueError("model response was not JSON")
 
 

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -160,6 +160,73 @@ def test_parse_unparseable_raises():
         summariser._parse_model_json("this is not json")
 
 
+def test_parse_fenced_block_with_trailing_prose():
+    """Opus sometimes emits ```json {...} ``` AND adds prose after the
+    fence. The balanced-brace fallback alone would slurp the trailing
+    text into the parse; the fence-aware path returns clean JSON.
+    """
+    text = '```json\n{"description": "ok", "risk_level": "low", "risk_factors": []}\n```\n\nLet me know if you want more detail.'
+    parsed = summariser._parse_model_json(text)
+    assert parsed["risk_level"] == "low"
+
+
+def test_parse_fenced_block_without_json_tag():
+    text = '```\n{"description": "ok", "risk_level": "low", "risk_factors": []}\n```'
+    parsed = summariser._parse_model_json(text)
+    assert parsed["description"] == "ok"
+
+
+# ── truncation handling ─────────────────────────────────────────────────
+
+
+async def test_call_model_raises_on_finish_length():
+    """When Bedrock stops mid-JSON because max_output_tokens ran out we
+    must call that out explicitly — not surface a misleading 'not JSON'.
+    """
+    truncated = '{"description": "this stops mid-way",'  # no closing brace
+    fake_choice = MagicMock()
+    fake_choice.message.content = truncated
+    fake_choice.finish_reason = "length"
+    fake_resp = MagicMock(
+        choices=[fake_choice], usage=MagicMock(prompt_tokens=10, completion_tokens=1024)
+    )
+
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "test-model"),
+        patch(
+            "terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=fake_resp)
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="truncated at max_output_tokens"):
+            await summariser._call_model(
+                system_message="s", user_message="u", max_output_tokens=1024
+            )
+
+
+async def test_call_model_parse_failure_includes_finish_reason():
+    """Non-length parse failures should surface finish_reason + length
+    in the error string so the operator can tell stop-vs-content
+    failures apart in the UI / logs.
+    """
+    fake_choice = MagicMock()
+    fake_choice.message.content = "I cannot summarise this plan."
+    fake_choice.finish_reason = "stop"
+    fake_resp = MagicMock(
+        choices=[fake_choice], usage=MagicMock(prompt_tokens=10, completion_tokens=8)
+    )
+
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "test-model"),
+        patch(
+            "terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=fake_resp)
+        ),
+    ):
+        with pytest.raises(ValueError, match="finish_reason=stop"):
+            await summariser._call_model(
+                system_message="s", user_message="u", max_output_tokens=1024
+            )
+
+
 # ── _build_litellm_kwargs ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Follow-up to v0.30.2. With the race fixed, the next failure surfaced: large plans hit `finish_reason='length'` because the default `max_output_tokens=1024` was too small for any plan with more than a handful of resource changes. The summariser silently reported a misleading "model response was not JSON" because both strict JSON parse and the balanced-brace fallback fail on truncated output.

Live evidence: a 25-resource-change plan on \`core-cp-mgmt-eu1\` produced ~3000 output tokens of JSON; LiteLLM/Bedrock stopped at 1024 mid-object.

## Changes

- **Detect truncation explicitly.** Capture \`finish_reason\` from the LiteLLM response. When \"length\", raise a specific \`RuntimeError\` naming the cap so the operator knows what to raise. The message lands in \`PlanSummary.error_message\` and shows on the run page.
- **Diagnostic snippet on parse failure.** Log finish_reason + length + a head-and-tail snippet of the actual response (capped 800 chars) when JSON parsing fails. Future failures are diagnosable without rerunning.
- **Fence-aware parser.** \`_parse_model_json\` now strips \`\`\`json ... \`\`\` fences explicitly; the previous balanced-brace fallback slurped trailing prose when Opus emitted \`\`\`json ... \`\`\` plus chatter.
- **Bump default \`max_output_tokens\` 1024 → 16384.** The cap is an upper bound, not a target — the model emits only what it needs. 16384 covers very large plans (100+ resource changes with detailed risk listings) while staying under Opus's 32K output limit.

## Test plan

- [x] Added \`test_call_model_raises_on_finish_length\` — asserts truncation produces a clear error string
- [x] Added \`test_call_model_parse_failure_includes_finish_reason\` — non-length parse failure surfaces finish_reason
- [x] Added \`test_parse_fenced_block_with_trailing_prose\` — fenced JSON followed by chatter parses cleanly
- [x] Added \`test_parse_fenced_block_without_json_tag\` — plain \`\`\` fence works
- [x] \`make test\` — 1677 passed
- [x] \`make lint\` — passes