### PR TITLE
fix(ai-summary): plan cleaning + CODE_DIFF + prompt hardening + regenerate button + helm default

### DIFF
--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -259,7 +259,7 @@ data:
       {{- if .Values.api.config.ai_summary.api_base }}
       api_base: {{ .Values.api.config.ai_summary.api_base | quote }}
       {{- end }}
-      max_output_tokens: {{ .Values.api.config.ai_summary.max_output_tokens | default 1024 | int64 }}
+      max_output_tokens: {{ .Values.api.config.ai_summary.max_output_tokens | default 16384 | int64 }}
       request_timeout_seconds: {{ .Values.api.config.ai_summary.request_timeout_seconds | default 60 | int64 }}
       # int64 cast prevents Helm's default float formatter from emitting
       # YAML scientific notation (e.g. `5e+06`) for values above ~1M,
@@ -267,6 +267,7 @@ data:
       daily_token_budget: {{ .Values.api.config.ai_summary.daily_token_budget | default 0 | int64 }}
       plan_json_max_bytes: {{ .Values.api.config.ai_summary.plan_json_max_bytes | default 500000 | int64 }}
       code_context_max_bytes: {{ .Values.api.config.ai_summary.code_context_max_bytes | default 200000 | int64 }}
+      code_diff_max_bytes: {{ .Values.api.config.ai_summary.code_diff_max_bytes | default 100000 | int64 }}
       {{- with .Values.api.config.ai_summary.auth }}
       auth:
         # api_key is injected via env var (TERRAPOD_AI_SUMMARY__AUTH__API_KEY)

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -89,11 +89,13 @@ api:
       # invocation of newer Anthropic models, not the bare
       # foundation-model ID. `us.` = US cross-region profile.
       model: "bedrock/us.anthropic.claude-opus-4-8"
-      max_output_tokens: 1024
+      # Use the upstream default (16384); 1024 caused real-plan truncation.
+      # Override here only if you have a reason.
       request_timeout_seconds: 90
       daily_token_budget: 0  # no cap in local dev
       plan_json_max_bytes: 500000
       code_context_max_bytes: 200000
+      code_diff_max_bytes: 100000
       auth:
         aws_region: us-east-1
         # aws_role_arn intentionally unset — use the pod's env-var

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -657,6 +657,7 @@
             "daily_token_budget": { "type": "integer", "minimum": 0 },
             "plan_json_max_bytes": { "type": "integer", "minimum": 0 },
             "code_context_max_bytes": { "type": "integer", "minimum": 0 },
+            "code_diff_max_bytes": { "type": "integer", "minimum": 0 },
             "auth": {
               "type": "object",
               "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -305,13 +305,24 @@ api:
       # Optional base URL override (vLLM, LiteLLM proxy, custom Azure).
       # Leave empty for vendor providers — LiteLLM knows the defaults.
       api_base: ""
-      max_output_tokens: 1024
+      # Upper bound on model response tokens. Cap, not a target: the
+      # model emits what it needs and stops on a natural stop token.
+      # 16384 leaves comfortable headroom for very large plans (100+
+      # resource changes with detailed risk listings) while staying
+      # under Opus's 32K output ceiling.
+      max_output_tokens: 16384
       request_timeout_seconds: 60
       # Output-token cap per UTC day across all summaries. 0 = unlimited.
       daily_token_budget: 0
       # Size caps on the inputs attached to the model request.
       plan_json_max_bytes: 500000
       code_context_max_bytes: 200000
+      # Size cap on the CODE_DIFF input (unified diff of *.tf / *.tfvars
+      # between this run's config version and the previously-applied
+      # config version). 0 disables CODE_DIFF entirely. Diffs are
+      # usually tiny; this cap is a safety net for monorepo-scale
+      # refactors.
+      code_diff_max_bytes: 100000
       auth:
         # Bearer key for non-AWS providers (OpenAI, Anthropic, Gemini,
         # Azure, vLLM). Inject via TERRAPOD_AI_SUMMARY__AUTH__API_KEY

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -34,6 +34,7 @@ from typing import Literal
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response, status
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
@@ -43,7 +44,7 @@ from terrapod.api.dependencies import (
     get_current_user,
     get_listener_identity,
 )
-from terrapod.db.models import PlanSummary, Run, StateVersion, VCSConnection, Workspace
+from terrapod.db.models import PlanSummary, Run, StateVersion, VCSConnection, Workspace, now_utc
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service, run_service
@@ -793,7 +794,7 @@ def _plan_json(run: Run) -> dict:
     # AI plan summary URL — surfaced as a Terrapod-native link on every
     # plan response so the UI knows where to fetch the structured
     # summary. 404s gracefully when no summary exists yet.
-    attrs["ai-summary-url"] = f"{base}/api/v2/plans/{run.id}/summary"
+    attrs["ai-summary-url"] = f"{base}/api/terrapod/v1/runs/{run.id}/plan-summary"
     return {
         "data": {
             "id": f"plan-{run.id}",
@@ -822,20 +823,23 @@ async def show_plan_by_id(
     return JSONResponse(content=_plan_json(run))
 
 
-@router.get("/plans/{plan_id}/summary")
+@extensions_router.get("/runs/{run_id}/plan-summary")
 async def show_plan_summary(
-    plan_id: str = Path(...),
+    run_id: str = Path(...),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """AI-generated plan summary or failure analysis (#401).
+
+    Terrapod-native — not part of the TFE CLI surface. Lives under
+    ``/api/terrapod/v1/`` alongside the other run extensions.
 
     Returns 404 when no summary exists yet — the UI uses this as the
     "not summarised" signal (vs a `pending` row which means "in flight").
     The response shape is the same for both ``kind`` values; the UI
     branches on the ``kind`` attribute.
     """
-    run = await _get_run(plan_id.replace("plan-", "run-"), db)
+    run = await _get_run(run_id, db)
     await _require_run_ws_permission(run, "read", user, db)
 
     summary = (
@@ -868,6 +872,138 @@ async def show_plan_summary(
                 },
             }
         }
+    )
+
+
+def _summary_kind_for_run(run: Run) -> str | None:
+    """Pick the right summariser kind for a run's current state.
+
+    Returns "plan_summary" for runs that produced a plan (any state past
+    `planning` except plan-phase errored), "failure_analysis" for runs
+    that failed during the plan phase, and None when no summary kind
+    applies (still in `pending`/`queued`/`planning`, or apply-phase
+    errored — apply failures aren't part of #401).
+    """
+    if run.status == "errored" and run.plan_started_at and run.apply_started_at is None:
+        return "failure_analysis"
+    if run.status in {"planned", "confirmed", "applying", "applied", "discarded"}:
+        return "plan_summary"
+    return None
+
+
+@extensions_router.post("/runs/{run_id}/plan-summary/regenerate")
+async def regenerate_plan_summary(
+    run_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Re-fire the AI summary for an existing run (#401 follow-up).
+
+    Anyone with workspace `read` can regenerate; the call doesn't mutate
+    infrastructure. Cost is centrally gated by `ai_summary.daily_token_budget`.
+
+    The endpoint:
+      • picks `kind` from current run state (plan_summary vs failure_analysis)
+      • upserts the PlanSummary row to status='pending' synchronously
+        so the UI immediately reflects the regenerate
+      • enqueues the same `ai_plan_summary` trigger as the auto-fire path,
+        BYPASSING the 5-min dedup (the user explicitly asked)
+      • returns 202 with the now-pending row
+
+    Returns 409 if the run has no summarisable state (still planning, or
+    apply-phase errored). Returns 503 if AI summary is globally disabled.
+    """
+    from terrapod.config import settings as _settings
+    from terrapod.services.scheduler import enqueue_trigger
+
+    if not _settings.ai_summary.enabled:
+        raise HTTPException(status_code=503, detail="AI summary is disabled globally")
+
+    run = await _get_run(run_id, db)
+    await _require_run_ws_permission(run, "read", user, db)
+
+    kind = _summary_kind_for_run(run)
+    if kind is None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"run is in state '{run.status}' — no summary kind applies "
+                "(plan_summary needs a post-plan state; failure_analysis "
+                "needs plan-phase errored)"
+            ),
+        )
+
+    # Upsert to pending so the UI shows feedback immediately. Reuses the
+    # same model field so the operator sees which model is being called.
+    pending_values = {
+        "run_id": run.id,
+        "kind": kind,
+        "status": "pending",
+        "model": _settings.ai_summary.model,
+        "description": "",
+        "risk_level": "",
+        "risk_factors": [],
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "error_message": "",
+    }
+    stmt = pg_insert(PlanSummary).values(**pending_values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["run_id"],
+        set_={
+            "kind": stmt.excluded.kind,
+            "status": stmt.excluded.status,
+            "model": stmt.excluded.model,
+            "description": stmt.excluded.description,
+            "risk_level": stmt.excluded.risk_level,
+            "risk_factors": stmt.excluded.risk_factors,
+            "input_tokens": stmt.excluded.input_tokens,
+            "output_tokens": stmt.excluded.output_tokens,
+            "error_message": stmt.excluded.error_message,
+            "updated_at": now_utc(),
+        },
+    )
+    await db.execute(stmt)
+    await db.commit()
+
+    # Re-read so we return the fresh row (gives us the id + timestamps).
+    summary = (
+        await db.execute(select(PlanSummary).where(PlanSummary.run_id == run.id))
+    ).scalar_one_or_none()
+
+    # No dedup_key → bypass the 5-min auto-dedup. Operator clicks should
+    # always go through, even when an automatic enqueue happened seconds
+    # ago. Budget gating still applies on the handler side.
+    await enqueue_trigger(
+        "ai_plan_summary",
+        {"run_id": str(run.id), "kind": kind},
+    )
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            "data": {
+                "id": f"plan-summary-{summary.id}",
+                "type": "plan-summaries",
+                "attributes": {
+                    "kind": summary.kind,
+                    "status": summary.status,
+                    "description": summary.description,
+                    "risk-level": summary.risk_level,
+                    "risk-factors": summary.risk_factors,
+                    "model": summary.model,
+                    "input-tokens": summary.input_tokens,
+                    "output-tokens": summary.output_tokens,
+                    "error-message": summary.error_message,
+                    "created-at": _rfc3339(summary.created_at),
+                    "updated-at": _rfc3339(summary.updated_at),
+                },
+                "relationships": {
+                    "plan": {"data": {"id": f"plan-{run.id}", "type": "plans"}},
+                    "run": {"data": {"id": f"run-{run.id}", "type": "runs"}},
+                },
+            }
+        },
     )
 
 

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -816,6 +816,17 @@ class AISummaryConfig(BaseModel):
             "against pathological monorepos producing 50MB plan files."
         ),
     )
+    code_diff_max_bytes: int = Field(
+        default=100_000,
+        description=(
+            "Max bytes of CODE_DIFF (unified diff of *.tf / *.tfvars "
+            "between this run's config version and the previously-applied "
+            "config version) attached to the request. The diff is computed "
+            "via `git diff --no-index` between the two tarballs. 0 disables "
+            "CODE_DIFF entirely. Diffs are usually tiny; this cap is a "
+            "safety net for monorepo-scale refactors."
+        ),
+    )
     auth: AISummaryAuthConfig = Field(default_factory=AISummaryAuthConfig)
     context: AISummaryContextConfig = Field(default_factory=AISummaryContextConfig)
 

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -41,7 +41,10 @@ import asyncio
 import datetime as dt
 import io
 import json
+import pathlib
+import subprocess
 import tarfile
+import tempfile
 import uuid
 
 import litellm
@@ -130,12 +133,206 @@ def _extract_tf_sources(tarball: bytes, max_bytes: int) -> str:
     return buf.getvalue()
 
 
-async def _gather_inputs(run: Run, kind: str) -> tuple[str, str, str, str]:
-    """Return ``(primary_input, primary_label, primary_lang, code_context)``.
+def _clean_plan_json_bytes(raw: bytes) -> bytes:
+    """Strip definitionally-uninformative noise from terraform plan JSON.
 
-    primary_input is the plan JSON (for plan_summary) or the plan log
-    (for failure_analysis). code_context is the concatenated .tf source
-    or "" when the workspace has no config version.
+    The model was observed confabulating "upgrade" narratives from
+    `before` / `after` snapshot fields on no-op resources. The fix is
+    twofold: prompt the model to trust `change.actions` (done in the
+    skill prompt), and remove the snapshot noise so it physically
+    cannot be hallucinated.
+
+    Drops:
+      • resource_changes entries where every action is in
+        {no-op, read} AND change.importing is unset
+      • output_changes entries with actions == ["no-op"]
+      • the top-level "prior_state" key (full pre-refresh state
+        snapshot, redundant with resource_changes.before)
+
+    Preserves:
+      • resource_drift in full — the operator needs both "drift
+        accepted" (informational) and "drift reverted" (risk) signals;
+        the prompt teaches the model to label them.
+      • read-only entries when paired with import (rare but valid)
+
+    On any structural anomaly (non-dict plan, malformed entries) returns
+    the input unchanged. Cleaner is best-effort: never fail the call.
+    """
+    try:
+        plan = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    if not isinstance(plan, dict):
+        return raw
+
+    plan.pop("prior_state", None)
+
+    rcs = plan.get("resource_changes")
+    if isinstance(rcs, list):
+        plan["resource_changes"] = [r for r in rcs if _resource_change_is_informative(r)]
+
+    ocs = plan.get("output_changes")
+    if isinstance(ocs, dict):
+        plan["output_changes"] = {
+            k: v
+            for k, v in ocs.items()
+            if not (isinstance(v, dict) and v.get("actions") == ["no-op"])
+        }
+
+    return json.dumps(plan, separators=(",", ":")).encode("utf-8")
+
+
+def _resource_change_is_informative(r: object) -> bool:
+    """Return True when this resource_change should reach the model."""
+    if not isinstance(r, dict):
+        return True
+    change = r.get("change")
+    if not isinstance(change, dict):
+        return True
+    if change.get("importing") is not None:
+        return True
+    actions = change.get("actions")
+    if not isinstance(actions, list) or not actions:
+        return True
+    return any(a not in ("no-op", "read") for a in actions)
+
+
+def _extract_tf_files_to_dir(tarball: bytes, target: pathlib.Path) -> int:
+    """Extract *.tf / *.tfvars files from a config-version tarball.
+
+    Returns the number of files written. Defends against zip-slip via
+    member-name normalisation; skips entries whose path escapes target.
+    """
+    written = 0
+    with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
+        for member in tar:
+            if not member.isfile():
+                continue
+            if not (member.name.endswith(".tf") or member.name.endswith(".tfvars")):
+                continue
+            safe = pathlib.PurePosixPath(member.name).as_posix()
+            if safe.startswith("/") or ".." in safe.split("/"):
+                continue
+            fobj = tar.extractfile(member)
+            if fobj is None:
+                continue
+            dest = target / safe
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(fobj.read())
+            written += 1
+    return written
+
+
+def _build_code_diff(prev_tarball: bytes | None, cur_tarball: bytes, max_bytes: int) -> str:
+    """Return a unified diff of *.tf / *.tfvars between two CV tarballs.
+
+    Returns "" when:
+      • max_bytes is 0 (feature disabled)
+      • prev_tarball is None (first run for this workspace, or the
+        previous CV's tarball has been GC'd by artifact retention)
+      • either tarball is unreadable
+      • the two trees contain no .tf / .tfvars files
+      • the trees are identical (empty diff)
+      • git is missing or times out
+
+    Uses `git diff --no-index` against two temp directories. Falls back
+    silently on any failure: CODE_DIFF is best-effort context, never
+    blocks the summariser.
+    """
+    if max_bytes <= 0 or prev_tarball is None:
+        return ""
+
+    with tempfile.TemporaryDirectory(prefix="tp-aisum-diff-") as tmp:
+        tmp_root = pathlib.Path(tmp)
+        prev_dir = tmp_root / "previous"
+        cur_dir = tmp_root / "current"
+        prev_dir.mkdir()
+        cur_dir.mkdir()
+        try:
+            prev_n = _extract_tf_files_to_dir(prev_tarball, prev_dir)
+            cur_n = _extract_tf_files_to_dir(cur_tarball, cur_dir)
+        except tarfile.TarError as e:
+            logger.debug("CODE_DIFF: tarball extract failed", error=str(e))
+            return ""
+
+        if prev_n == 0 and cur_n == 0:
+            return ""
+
+        try:
+            proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+                [
+                    "git",
+                    "diff",
+                    "--no-index",
+                    "--unified=3",
+                    "--no-color",
+                    "--",
+                    "previous",
+                    "current",
+                ],
+                cwd=tmp_root,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+            logger.debug("CODE_DIFF: git diff failed", error=str(e))
+            return ""
+
+        # git diff --no-index exits 1 when there's a diff, 0 when there
+        # isn't — both are success for us. Anything else (e.g. 128 from
+        # git missing) is a real failure.
+        if proc.returncode not in (0, 1):
+            logger.debug(
+                "CODE_DIFF: git diff returned unexpected exit code",
+                returncode=proc.returncode,
+                stderr=proc.stderr[:200],
+            )
+            return ""
+
+        diff = proc.stdout
+        if not diff.strip():
+            return ""
+
+        if len(diff) > max_bytes:
+            diff = (
+                diff[:max_bytes] + f"\n[... {len(diff) - max_bytes} bytes truncated from tail ...]"
+            )
+        return diff
+
+
+async def _find_previously_applied_cv_id(
+    db: AsyncSession, workspace_id: uuid.UUID, current_run_id: uuid.UUID
+) -> uuid.UUID | None:
+    """Return the configuration_version_id of the most recently *applied*
+    Run on the workspace, excluding ``current_run_id``.
+
+    None when no prior applied run exists (first run, or all prior
+    runs were plan-only / errored / discarded). The summariser falls
+    back to no CODE_DIFF in that case.
+    """
+    stmt = (
+        select(Run.configuration_version_id)
+        .where(
+            Run.workspace_id == workspace_id,
+            Run.status == "applied",
+            Run.id != current_run_id,
+            Run.configuration_version_id.is_not(None),
+        )
+        .order_by(Run.updated_at.desc())
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def _gather_inputs(db: AsyncSession, run: Run, kind: str) -> tuple[str, str, str, str, str]:
+    """Return ``(primary_input, primary_label, primary_lang, code_context, code_diff)``.
+
+    primary_input is the (cleaned) plan JSON for ``plan_summary`` or
+    the plan log for ``failure_analysis``. code_context is the
+    concatenated current .tf source. code_diff is a unified diff of
+    *.tf / *.tfvars between this run's CV and the previously-applied
+    CV (when both tarballs are available).
     """
     storage = get_storage()
     cfg = settings.ai_summary
@@ -150,8 +347,11 @@ async def _gather_inputs(run: Run, kind: str) -> tuple[str, str, str, str]:
             logger.warning(
                 "plan JSON not available for summariser", run_id=str(run.id), error=str(e)
             )
-            return "", primary_label, primary_lang, ""
-        primary = _truncate_head(raw, cfg.plan_json_max_bytes)
+            return "", primary_label, primary_lang, "", ""
+        # Clean BEFORE truncation so the head-truncate budget is spent
+        # on actual changes, not no-op snapshot noise.
+        cleaned = await asyncio.to_thread(_clean_plan_json_bytes, raw)
+        primary = _truncate_head(cleaned, cfg.plan_json_max_bytes)
     else:
         key = plan_log_key(str(run.workspace_id), str(run.id))
         primary_label = "PLAN_LOG"
@@ -162,21 +362,47 @@ async def _gather_inputs(run: Run, kind: str) -> tuple[str, str, str, str]:
             logger.warning(
                 "plan log not available for summariser", run_id=str(run.id), error=str(e)
             )
-            return "", primary_label, primary_lang, ""
+            return "", primary_label, primary_lang, "", ""
         primary = _truncate_tail(raw, cfg.plan_json_max_bytes)
 
+    cur_tarball: bytes | None = None
     code_context = ""
-    if cfg.code_context_max_bytes > 0 and run.configuration_version_id:
+    if (
+        cfg.code_context_max_bytes > 0 or cfg.code_diff_max_bytes > 0
+    ) and run.configuration_version_id:
         cv_key = config_version_key(str(run.workspace_id), str(run.configuration_version_id))
         try:
-            tarball = await storage.get(cv_key)
-            code_context = await asyncio.to_thread(
-                _extract_tf_sources, tarball, cfg.code_context_max_bytes
-            )
+            cur_tarball = await storage.get(cv_key)
         except Exception as e:
-            logger.debug("CV tarball not available; running without code context", error=str(e))
+            logger.debug("Current CV tarball not available", error=str(e))
+            cur_tarball = None
+        if cur_tarball is not None and cfg.code_context_max_bytes > 0:
+            try:
+                code_context = await asyncio.to_thread(
+                    _extract_tf_sources, cur_tarball, cfg.code_context_max_bytes
+                )
+            except Exception as e:
+                logger.debug("Failed to extract code_context", error=str(e))
 
-    return primary, primary_label, primary_lang, code_context
+    code_diff = ""
+    if cfg.code_diff_max_bytes > 0 and cur_tarball is not None:
+        prev_cv_id = await _find_previously_applied_cv_id(db, run.workspace_id, run.id)
+        if prev_cv_id is not None:
+            prev_key = config_version_key(str(run.workspace_id), str(prev_cv_id))
+            try:
+                prev_tarball = await storage.get(prev_key)
+            except Exception as e:
+                logger.debug("Previous CV tarball not available (likely GC'd)", error=str(e))
+                prev_tarball = None
+            if prev_tarball is not None:
+                try:
+                    code_diff = await asyncio.to_thread(
+                        _build_code_diff, prev_tarball, cur_tarball, cfg.code_diff_max_bytes
+                    )
+                except Exception as e:
+                    logger.debug("Failed to build code_diff", error=str(e))
+
+    return primary, primary_label, primary_lang, code_context, code_diff
 
 
 # --- Daily budget ------------------------------------------------------------
@@ -524,7 +750,7 @@ async def handle_ai_plan_summary(payload: dict) -> None:
             await _emit_ready_event(ws.id, run_id)
             return
 
-        primary, label, lang, code_context = await _gather_inputs(run, kind)
+        primary, label, lang, code_context, code_diff = await _gather_inputs(db, run, kind)
         if not primary:
             await _upsert_summary(
                 db,
@@ -544,6 +770,7 @@ async def handle_ai_plan_summary(payload: dict) -> None:
             primary_input_label=label,
             primary_input_lang=lang,
             code_context_truncated=code_context,
+            code_diff=code_diff,
             prompt_prefix=cfg.context.prompt_prefix,
             prompt_suffix=cfg.context.prompt_suffix,
         )

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -82,7 +82,16 @@ of those changes. Nothing else.
 
 You will receive these inputs in the user message:
   • PLAN_JSON — `tofu show -json` output for the proposed changes.
-  • CODE_CONTEXT — concatenated .tf source. May be absent.
+    No-op resource_changes and prior_state have been stripped before
+    you see this; everything in `resource_changes` is a real change.
+  • CODE_DIFF — unified diff of *.tf / *.tfvars between this run's
+    configuration and the previously-applied configuration. May be
+    absent (first run on this workspace, or the prior CV has been
+    GC'd). When present, this is the authoritative record of what
+    changed in source.
+  • CODE_CONTEXT — concatenated *.tf source for THIS run's
+    configuration. Use it to look up declarations referenced by
+    resource_changes or CODE_DIFF. May be absent.
   • FLEET_CONTEXT — deployment-wide notes from the operator. May be empty.
   • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
 
@@ -102,7 +111,40 @@ surrounding text, markdown fences, or commentary:
     ]
   }
 
-Rules:
+CRITICAL — trust `change.actions`, not snapshots:
+
+  The only source of truth for what changes is the `change.actions`
+  array on each resource_change. Describe a resource ONLY when its
+  actions array contains `create`, `update`, or `delete` (in any
+  combination), OR `change.importing` is set. Do not infer changes
+  from `before` / `after` field contents — those carry state context,
+  not the diff. CODE_DIFF (when present) is a second authoritative
+  signal: if a resource's declaration is not touched by CODE_DIFF
+  AND its `actions` is no-op, it is unchanged. Never describe it.
+
+CRITICAL — `resource_drift` is NOT the apply change set:
+
+  PLAN_JSON may include a `resource_drift` array alongside
+  `resource_changes`. resource_drift is what terraform observed
+  during refresh that disagreed with prior state — out-of-band
+  changes to live infrastructure since the last apply. The refresh
+  has already reconciled state to reality; the apply phase acts on
+  `resource_changes`, not `resource_drift`.
+
+  Two cases to handle:
+    1. Address appears in `resource_drift` AND has a non-no-op entry
+       in `resource_changes` → the plan is REVERTING a manual change.
+       Call this out explicitly in `description` and treat as
+       elevated risk in `risk_factors`.
+    2. Address appears only in `resource_drift` (no corresponding
+       resource_changes entry, or only no-op) → out-of-band change
+       has already been accepted into state; apply does nothing
+       about it. You MAY note it briefly in `description` as
+       "observed out-of-band change to X" if it is notable; do NOT
+       list it as something this plan changes, and do not include
+       it as a risk_factor.
+
+Other rules:
 
   • Describe the proposed changes. Do not describe the JSON format, the
     plan run, terrapod, or anything other than the infrastructure
@@ -114,7 +156,7 @@ Rules:
   • Call out destroys and replacements — these have blast radius. A
     `replace` means destroy-then-create; the resource gets a new
     identity even when it looks the same.
-  • Do not invent resources or addresses not in the plan.
+  • Do not invent resources or addresses not in the plan or CODE_DIFF.
   • Risk severities are about blast radius and reversibility, not
     novelty. Destroying a Lambda is medium. Destroying a database or
     an IAM trust root is critical. Pure additions are low.
@@ -122,8 +164,19 @@ Rules:
 Style:
   • Operator-facing, terse, professional. No emojis. No first-person
     narration ("I will...", "Let me...").
-  • Markdown allowed inside `description` only (lists, backticks for
-    identifiers). Plain strings everywhere else.
+  • CONSISTENT TONE across `description` and `risk_factors[].detail`.
+    Both are prose paragraphs at the same register — terse engineering
+    write-up, not a hierarchy of headings.
+  • `description` is one to three short paragraphs separated by blank
+    lines. NO bold section headers (no `**Section:**`), NO bullet
+    lists, NO heading levels. Group related changes inside a paragraph
+    with prose connectives ("Alongside that, …", "Separately, …").
+  • Backticks (\\`) for terraform addresses, attribute names, and
+    short identifiers are allowed and encouraged in BOTH `description`
+    and `risk_factors[].detail`. Use them the same way in both.
+  • `risk_factors[].title` is a short label, plain text, no
+    backticks. `risk_factors[].detail` is one or two sentences of
+    prose at the same tone as `description`.
 """
 
 
@@ -137,6 +190,10 @@ You will receive these inputs in the user message:
   • PLAN_LOG — the terraform/tofu stdout+stderr leading up to the
     failure. May be truncated from the head; the tail (where the error
     typically appears) is preserved.
+  • CODE_DIFF — unified diff of *.tf / *.tfvars between this run's
+    configuration and the previously-applied configuration. May be
+    absent. When present, suspect it as a potential cause — recent
+    HCL changes are the most likely culprit for new failures.
   • CODE_CONTEXT — concatenated .tf source. May be absent.
   • FLEET_CONTEXT — deployment-wide notes. May be empty.
   • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
@@ -183,7 +240,12 @@ Rules:
 
 Style:
   • Operator-facing, terse, professional. No emojis. No first-person.
-  • Markdown allowed inside `description` only.
+  • CONSISTENT TONE across `description` and `risk_factors[].detail`.
+    Both are prose paragraphs at the same register. NO bold section
+    headers, NO bullet lists in `description` — one to three short
+    paragraphs separated by blank lines.
+  • Backticks for identifiers, attribute names, and quoted error
+    fragments are allowed and encouraged in BOTH fields.
 """
 
 
@@ -196,6 +258,7 @@ def render_prompt(
     primary_input_label: str,
     primary_input_lang: str,
     code_context_truncated: str,
+    code_diff: str = "",
     prompt_prefix: str = "",
     prompt_suffix: str = "",
 ) -> tuple[str, str]:
@@ -204,13 +267,16 @@ def render_prompt(
     Returns ``(system_message, user_message)``. The system message owns
     the contract (skill prompt + operator's prefix/suffix); the user
     message carries the deployment-specific context plus the primary
-    input (PLAN_JSON or PLAN_LOG) and the code.
+    input (PLAN_JSON or PLAN_LOG), the code diff, and the current code.
 
     Args:
         kind: "plan_summary" or "failure_analysis" — selects the skill.
-        primary_input: the truncated plan JSON or plan log.
+        primary_input: the (cleaned, truncated) plan JSON or plan log.
         primary_input_label: header label ("PLAN_JSON" or "PLAN_LOG").
         primary_input_lang: fenced-code language ("json" or "text").
+        code_diff: unified diff of *.tf / *.tfvars between this run's
+            config and the previously-applied config. Empty when no
+            prior CV is available (first run, or GC'd).
     """
     if kind == "plan_summary":
         skill = PLAN_SUMMARY_SKILL_PROMPT
@@ -234,6 +300,8 @@ def render_prompt(
         user_parts.append(f"WORKSPACE_CONTEXT:\n{workspace_context.strip()}")
 
     user_parts.append(f"{primary_input_label}:\n```{primary_input_lang}\n{primary_input}\n```")
+    if code_diff.strip():
+        user_parts.append(f"CODE_DIFF:\n```diff\n{code_diff}\n```")
     if code_context_truncated.strip():
         user_parts.append(f"CODE_CONTEXT:\n```hcl\n{code_context_truncated}\n```")
 

--- a/services/tests/api/test_ai_summary.py
+++ b/services/tests/api/test_ai_summary.py
@@ -1,11 +1,12 @@
 """Tests for the AI plan summary API surface (#401).
 
 Covers:
-  - GET /api/v2/plans/{plan_id}/summary 404 / 200 / auth-required paths
+  - GET /api/terrapod/v1/runs/{run_id}/plan-summary 404 / 200 / auth-required paths
   - PATCH workspace ai-summary-mode validation
   - PATCH workspace ai-summary-context length cap
   - Workspace GET includes the new ai-summary-* attributes
   - /plans/{plan_id} response advertises the ai-summary-url link
+  - POST /api/terrapod/v1/runs/{run_id}/plan-summary/regenerate (v0.30.4)
 """
 
 import uuid
@@ -145,7 +146,7 @@ class TestGetPlanSummary:
         mock_db.get = AsyncMock(return_value=ws)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get(f"/api/v2/plans/plan-{run.id}/summary", headers=_AUTH)
+            resp = await c.get(f"/api/terrapod/v1/runs/run-{run.id}/plan-summary", headers=_AUTH)
 
         assert resp.status_code == 200
         attrs = resp.json()["data"]["attributes"]
@@ -173,7 +174,7 @@ class TestGetPlanSummary:
         mock_db.get = AsyncMock(return_value=ws)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
-            resp = await c.get(f"/api/v2/plans/plan-{run.id}/summary", headers=_AUTH)
+            resp = await c.get(f"/api/terrapod/v1/runs/run-{run.id}/plan-summary", headers=_AUTH)
 
         assert resp.status_code == 404
 
@@ -322,3 +323,188 @@ class TestWorkspaceAISummaryFields:
                 headers=_AUTH,
             )
         assert resp.status_code == 422
+
+
+# ── POST /runs/{id}/plan-summary/regenerate (v0.30.4) ───────────────────────
+
+
+class TestRegeneratePlanSummary:
+    """Manual regenerate endpoint. Anyone with workspace read can trigger,
+    cost is gated by ai_summary.daily_token_budget on the handler side,
+    dedup is bypassed so a click always goes through.
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_regenerate_planned_run_returns_202_and_enqueues(
+        self, mock_enq, mock_resolve, *_mocks
+    ):
+        mock_resolve.return_value = "read"
+        run = _mock_run(status="planned")
+        run.plan_started_at = datetime(2026, 1, 1, tzinfo=UTC)
+        run.apply_started_at = None
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        summary = _mock_summary(run.id, status="pending")
+
+        app, mock_db = _make_app(_user())
+        # _get_run select → run; _require_run_ws_permission → ws (db.get);
+        # the upsert SQL execute returns nothing useful (None mock fine);
+        # the re-read select PlanSummary → pending summary.
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+                MagicMock(),  # upsert
+                MagicMock(scalar_one_or_none=MagicMock(return_value=summary)),
+            ]
+        )
+        mock_db.get = AsyncMock(return_value=ws)
+        mock_db.commit = AsyncMock()
+
+        with patch("terrapod.config.settings") as mock_settings:
+            mock_settings.ai_summary.enabled = True
+            mock_settings.ai_summary.model = "bedrock/test"
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+                resp = await c.post(
+                    f"/api/terrapod/v1/runs/run-{run.id}/plan-summary/regenerate",
+                    headers=_AUTH,
+                )
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["data"]["attributes"]["status"] == "pending"
+
+        # Trigger enqueued with the right kind, and WITHOUT a dedup_key
+        # (manual clicks must bypass the 5-min auto-dedup).
+        mock_enq.assert_awaited_once()
+        args, kwargs = mock_enq.call_args
+        assert args[0] == "ai_plan_summary"
+        assert args[1] == {"run_id": str(run.id), "kind": "plan_summary"}
+        assert "dedup_key" not in kwargs
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_regenerate_plan_phase_errored_picks_failure_analysis(
+        self, mock_enq, mock_resolve, *_mocks
+    ):
+        mock_resolve.return_value = "read"
+        run = _mock_run(status="errored")
+        run.plan_started_at = datetime(2026, 1, 1, tzinfo=UTC)
+        run.apply_started_at = None  # errored during plan, not apply
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        summary = _mock_summary(run.id, status="pending", kind="failure_analysis")
+
+        app, mock_db = _make_app(_user())
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+                MagicMock(),
+                MagicMock(scalar_one_or_none=MagicMock(return_value=summary)),
+            ]
+        )
+        mock_db.get = AsyncMock(return_value=ws)
+        mock_db.commit = AsyncMock()
+
+        with patch("terrapod.config.settings") as mock_settings:
+            mock_settings.ai_summary.enabled = True
+            mock_settings.ai_summary.model = "bedrock/test"
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+                resp = await c.post(
+                    f"/api/terrapod/v1/runs/run-{run.id}/plan-summary/regenerate",
+                    headers=_AUTH,
+                )
+
+        assert resp.status_code == 202
+        mock_enq.assert_awaited_once()
+        assert mock_enq.call_args.args[1]["kind"] == "failure_analysis"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_regenerate_409_when_no_summary_kind_applies(
+        self, mock_enq, mock_resolve, *_mocks
+    ):
+        """A run still in `pending` / `queued` / `planning` has nothing
+        to summarise; apply-phase errored runs are also out of scope.
+        """
+        mock_resolve.return_value = "read"
+        run = _mock_run(status="queued")
+        run.plan_started_at = None
+        run.apply_started_at = None
+        ws = _mock_workspace(ws_id=run.workspace_id)
+
+        app, mock_db = _make_app(_user())
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+            ]
+        )
+        mock_db.get = AsyncMock(return_value=ws)
+        mock_db.commit = AsyncMock()
+
+        with patch("terrapod.config.settings") as mock_settings:
+            mock_settings.ai_summary.enabled = True
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+                resp = await c.post(
+                    f"/api/terrapod/v1/runs/run-{run.id}/plan-summary/regenerate",
+                    headers=_AUTH,
+                )
+        assert resp.status_code == 409
+        mock_enq.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_regenerate_503_when_ai_summary_globally_disabled(self, mock_enq, *_mocks):
+        run = _mock_run(status="planned")
+
+        app, mock_db = _make_app(_user())
+        mock_db.execute = AsyncMock()  # not reached past the gate
+        mock_db.commit = AsyncMock()
+
+        with patch("terrapod.config.settings") as mock_settings:
+            mock_settings.ai_summary.enabled = False
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+                resp = await c.post(
+                    f"/api/terrapod/v1/runs/run-{run.id}/plan-summary/regenerate",
+                    headers=_AUTH,
+                )
+        assert resp.status_code == 503
+        mock_enq.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_regenerate_403_when_no_workspace_read(self, mock_enq, mock_resolve, *_mocks):
+        """No workspace read → 403 (the permission helper raises)."""
+        mock_resolve.return_value = None  # no permission
+        run = _mock_run(status="planned")
+        ws = _mock_workspace(ws_id=run.workspace_id)
+
+        app, mock_db = _make_app(_user())
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+            ]
+        )
+        mock_db.get = AsyncMock(return_value=ws)
+
+        with patch("terrapod.config.settings") as mock_settings:
+            mock_settings.ai_summary.enabled = True
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+                resp = await c.post(
+                    f"/api/terrapod/v1/runs/run-{run.id}/plan-summary/regenerate",
+                    headers=_AUTH,
+                )
+        assert resp.status_code in (401, 403)
+        mock_enq.assert_not_called()

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -377,7 +377,7 @@ async def test_handler_success_path_writes_ready_row():
         patch("terrapod.services.summariser._call_model", call_model),
         patch(
             "terrapod.services.summariser._gather_inputs",
-            AsyncMock(return_value=('{"resource_changes": []}', "PLAN_JSON", "json", "")),
+            AsyncMock(return_value=('{"resource_changes": []}', "PLAN_JSON", "json", "", "")),
         ),
         patch("terrapod.services.summariser._emit_ready_event", AsyncMock()),
     ):
@@ -415,7 +415,7 @@ async def test_handler_call_failure_writes_errored_row():
         patch("terrapod.services.summariser._upsert_summary", upsert),
         patch(
             "terrapod.services.summariser._gather_inputs",
-            AsyncMock(return_value=("plan_json", "PLAN_JSON", "json", "")),
+            AsyncMock(return_value=("plan_json", "PLAN_JSON", "json", "", "")),
         ),
         patch(
             "terrapod.services.summariser._call_model",
@@ -454,7 +454,7 @@ async def test_handler_missing_primary_input_writes_errored_row():
         patch("terrapod.services.summariser._upsert_summary", upsert),
         patch(
             "terrapod.services.summariser._gather_inputs",
-            AsyncMock(return_value=("", "PLAN_JSON", "json", "")),
+            AsyncMock(return_value=("", "PLAN_JSON", "json", "", "")),
         ),
         patch("terrapod.services.summariser._call_model") as call_model,
     ):
@@ -490,7 +490,7 @@ async def test_handler_normalises_invalid_risk_level():
         patch("terrapod.services.summariser._upsert_summary", upsert),
         patch(
             "terrapod.services.summariser._gather_inputs",
-            AsyncMock(return_value=("{}", "PLAN_JSON", "json", "")),
+            AsyncMock(return_value=("{}", "PLAN_JSON", "json", "", "")),
         ),
         patch(
             "terrapod.services.summariser._call_model",
@@ -510,3 +510,296 @@ async def test_handler_normalises_invalid_risk_level():
         await summariser.handle_ai_plan_summary({"run_id": str(run.id), "kind": "plan_summary"})
 
         assert upsert.await_args.kwargs["risk_level"] == "low"
+
+
+# ── _clean_plan_json_bytes (#406 / v0.30.4) ───────────────────────────────
+
+
+class TestCleanPlanJsonBytes:
+    """The cleaner physically removes definitionally-uninformative noise so
+    no-op snapshots cannot be hallucinated as changes.
+
+    Rules under test:
+      • drop resource_changes with actions ⊆ {no-op, read} AND no
+        `importing`
+      • keep import-via-no-op
+      • drop output_changes with actions == ["no-op"]
+      • drop top-level `prior_state`
+      • preserve `resource_drift` untouched
+      • degrade gracefully on malformed input
+    """
+
+    def _clean(self, plan: dict) -> dict:
+        import json as _json
+
+        out = summariser._clean_plan_json_bytes(_json.dumps(plan).encode())
+        return _json.loads(out)
+
+    def test_drops_pure_noop_resource_change(self):
+        plan = {
+            "resource_changes": [
+                {"address": "x", "change": {"actions": ["no-op"]}},
+                {"address": "y", "change": {"actions": ["update"]}},
+            ]
+        }
+        out = self._clean(plan)
+        addrs = [r["address"] for r in out["resource_changes"]]
+        assert addrs == ["y"]
+
+    def test_drops_pure_read_resource_change(self):
+        plan = {
+            "resource_changes": [
+                {"address": "ds", "change": {"actions": ["read"]}},
+                {"address": "y", "change": {"actions": ["delete"]}},
+            ]
+        }
+        out = self._clean(plan)
+        addrs = [r["address"] for r in out["resource_changes"]]
+        assert addrs == ["y"]
+
+    def test_keeps_noop_with_import(self):
+        """State-only adoption shows as actions=["no-op"] + importing set."""
+        plan = {
+            "resource_changes": [
+                {
+                    "address": "vault.ns",
+                    "change": {
+                        "actions": ["no-op"],
+                        "importing": {"id": "vault"},
+                    },
+                },
+            ]
+        }
+        out = self._clean(plan)
+        assert len(out["resource_changes"]) == 1
+        assert out["resource_changes"][0]["address"] == "vault.ns"
+
+    def test_keeps_create_update_delete_and_replace(self):
+        plan = {
+            "resource_changes": [
+                {"address": "c", "change": {"actions": ["create"]}},
+                {"address": "u", "change": {"actions": ["update"]}},
+                {"address": "d", "change": {"actions": ["delete"]}},
+                {"address": "r", "change": {"actions": ["create", "delete"]}},
+                {"address": "noop", "change": {"actions": ["no-op"]}},
+            ]
+        }
+        out = self._clean(plan)
+        addrs = sorted(r["address"] for r in out["resource_changes"])
+        assert addrs == ["c", "d", "r", "u"]
+
+    def test_drops_noop_output_changes(self):
+        plan = {
+            "output_changes": {
+                "stable": {"actions": ["no-op"]},
+                "changed": {"actions": ["update"]},
+            }
+        }
+        out = self._clean(plan)
+        assert "stable" not in out["output_changes"]
+        assert "changed" in out["output_changes"]
+
+    def test_drops_prior_state(self):
+        plan = {"prior_state": {"big": "snapshot"}, "resource_changes": []}
+        out = self._clean(plan)
+        assert "prior_state" not in out
+
+    def test_preserves_resource_drift_intact(self):
+        """resource_drift carries the only signal about out-of-band changes;
+        the prompt teaches the model to label it correctly, the cleaner
+        does NOT prune it. Regressions here would silence drift-revert
+        risk signals.
+        """
+        plan = {
+            "resource_drift": [
+                {"address": "drift_a", "change": {"actions": ["update"]}},
+                {"address": "drift_b", "change": {"actions": ["delete"]}},
+            ],
+            "resource_changes": [],
+        }
+        out = self._clean(plan)
+        assert out["resource_drift"] == plan["resource_drift"]
+
+    def test_keeps_weird_actions_shape(self):
+        """Defensive: never drop a resource_change whose shape we don't
+        recognise. Better to over-include than silently lose data.
+        """
+        plan = {
+            "resource_changes": [
+                {"address": "weird1", "change": {"actions": None}},
+                {"address": "weird2", "change": {}},
+                {"address": "weird3", "change": "not a dict"},
+                {"address": "weird4"},  # no change key
+            ]
+        }
+        out = self._clean(plan)
+        addrs = sorted(r["address"] for r in out["resource_changes"])
+        assert addrs == ["weird1", "weird2", "weird3", "weird4"]
+
+    def test_malformed_json_returns_unchanged(self):
+        raw = b"not json at all"
+        assert summariser._clean_plan_json_bytes(raw) == raw
+
+    def test_non_dict_top_level_returns_unchanged(self):
+        raw = b"[1, 2, 3]"
+        assert summariser._clean_plan_json_bytes(raw) == raw
+
+    def test_drops_in_real_world_shape(self):
+        """End-to-end: cluster + node-group + log-group all no-ops with
+        the snapshot fields that previously confused the model.
+        """
+        plan = {
+            "format_version": "1.2",
+            "resource_changes": [
+                {
+                    "address": "module.eks.aws_eks_cluster.this[0]",
+                    "type": "aws_eks_cluster",
+                    "change": {
+                        "actions": ["no-op"],
+                        "before": {"version": "1.35"},
+                        "after": {"version": "1.35"},
+                    },
+                },
+                {
+                    "address": "module.eks.aws_eks_node_group.ng1",
+                    "type": "aws_eks_node_group",
+                    "change": {
+                        "actions": ["no-op"],
+                        "before": {"version": "1.35"},
+                        "after": {"version": "1.35"},
+                    },
+                },
+                {
+                    "address": "module.vpc.aws_subnet.private[3]",
+                    "type": "aws_subnet",
+                    "change": {
+                        "actions": ["update"],
+                        "before": {"map_public_ip_on_launch": True},
+                        "after": {"map_public_ip_on_launch": False},
+                    },
+                },
+            ],
+        }
+        out = self._clean(plan)
+        addrs = [r["address"] for r in out["resource_changes"]]
+        assert addrs == ["module.vpc.aws_subnet.private[3]"]
+        # The cluster's "version: 1.35" snapshot — the exact field that
+        # confabulated the v0.30.3 hallucination — is GONE from the
+        # bytes the model will see. Hard guarantee, not prompt-based.
+        import json as _json
+
+        out_str = _json.dumps(out)
+        assert "aws_eks_cluster" not in out_str
+        assert "aws_eks_node_group" not in out_str
+
+
+# ── _build_code_diff (#406 / v0.30.4) ────────────────────────────────────
+
+
+class TestBuildCodeDiff:
+    """CODE_DIFF is best-effort context. The contract is:
+    • return "" on every plausible failure
+    • return a unified diff (with `+`/`-` lines) when both tarballs
+      exist and differ on *.tf / *.tfvars files
+    • only diff .tf / .tfvars — README.md, .terraform/, etc. don't count
+    • respect the byte cap
+    """
+
+    def test_returns_empty_when_prev_tarball_none(self):
+        cur = _build_tarball({"main.tf": b'resource "x" "y" {}'})
+        assert summariser._build_code_diff(None, cur, 100_000) == ""
+
+    def test_returns_empty_when_max_bytes_zero(self):
+        cur = _build_tarball({"main.tf": b'resource "x" "y" {}'})
+        prev = _build_tarball({"main.tf": b"# different"})
+        assert summariser._build_code_diff(prev, cur, 0) == ""
+
+    def test_returns_empty_when_tarballs_identical(self):
+        same = _build_tarball({"main.tf": b'resource "x" "y" {}'})
+        # Use literal-identical bytes for both sides → diff must be empty.
+        out = summariser._build_code_diff(same, same, 100_000)
+        assert out == ""
+
+    def test_returns_diff_when_tf_changed(self):
+        prev = _build_tarball(
+            {"main.tf": b'resource "aws_vpc" "this" {\n  cidr_block = "10.0.0.0/16"\n}\n'}
+        )
+        cur = _build_tarball(
+            {"main.tf": b'resource "aws_vpc" "this" {\n  cidr_block = "10.1.0.0/16"\n}\n'}
+        )
+        out = summariser._build_code_diff(prev, cur, 100_000)
+        assert out != ""
+        # Both sides of the change appear in the unified diff
+        assert "10.0.0.0/16" in out
+        assert "10.1.0.0/16" in out
+        # Standard unified-diff markers
+        assert "---" in out
+        assert "+++" in out
+
+    def test_ignores_non_tf_files(self):
+        prev = _build_tarball(
+            {
+                "main.tf": b'resource "x" "y" {}',
+                "README.md": b"old readme",
+            }
+        )
+        cur = _build_tarball(
+            {
+                "main.tf": b'resource "x" "y" {}',
+                "README.md": b"WILDLY DIFFERENT README CONTENT",
+            }
+        )
+        # Only README.md changed; *.tf is identical. Should be empty.
+        out = summariser._build_code_diff(prev, cur, 100_000)
+        assert out == ""
+
+    def test_includes_tfvars(self):
+        prev = _build_tarball({"terraform.tfvars": b'env = "dev"\n'})
+        cur = _build_tarball({"terraform.tfvars": b'env = "prod"\n'})
+        out = summariser._build_code_diff(prev, cur, 100_000)
+        assert "dev" in out
+        assert "prod" in out
+
+    def test_corrupt_prev_tarball_returns_empty(self):
+        cur = _build_tarball({"main.tf": b'resource "x" "y" {}'})
+        out = summariser._build_code_diff(b"not a tarball", cur, 100_000)
+        assert out == ""
+
+    def test_corrupt_cur_tarball_returns_empty(self):
+        prev = _build_tarball({"main.tf": b'resource "x" "y" {}'})
+        out = summariser._build_code_diff(prev, b"not a tarball", 100_000)
+        assert out == ""
+
+    def test_path_traversal_member_skipped(self):
+        """A tarball containing `../../etc/passwd` must not write outside
+        the temp dir. The malicious member is silently skipped.
+        """
+        prev = _build_tarball({"main.tf": b"# v1"})
+        # Build a tarball that includes a traversal entry alongside a
+        # legitimate .tf file. The legitimate .tf is what should be
+        # used for the diff; the traversal entry must be dropped.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for name, content in [
+                ("../escape.tf", b"# escape attempt"),
+                ("main.tf", b"# v2"),
+            ]:
+                info = tarfile.TarInfo(name=name)
+                info.size = len(content)
+                tar.addfile(info, io.BytesIO(content))
+        cur = buf.getvalue()
+        out = summariser._build_code_diff(prev, cur, 100_000)
+        assert out != ""
+        assert "# v1" in out
+        assert "# v2" in out
+        assert "escape attempt" not in out  # never extracted
+
+    def test_diff_truncated_at_max_bytes(self):
+        # Construct a large diff by changing a single line many times
+        prev_content = ("a\n" * 5000).encode()
+        cur_content = ("b\n" * 5000).encode()
+        prev = _build_tarball({"main.tf": prev_content})
+        cur = _build_tarball({"main.tf": cur_content})
+        out = summariser._build_code_diff(prev, cur, 1000)
+        assert len(out) <= 1000 + 100  # 1000 cap + truncation marker
+        assert "truncated from tail" in out

--- a/services/tests/services/test_summariser_prompt.py
+++ b/services/tests/services/test_summariser_prompt.py
@@ -130,3 +130,80 @@ def test_code_context_omitted_when_empty():
         code_context_truncated="",
     )
     assert "CODE_CONTEXT" not in user
+
+
+# ── code_diff (#406 / v0.30.4) ───────────────────────────────────────────
+
+
+def test_code_diff_renders_between_primary_and_code_context():
+    _, user = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input="{}",
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated='resource "aws_vpc" "this" {}',
+        code_diff="--- a/main.tf\n+++ b/main.tf\n@@ -1 +1 @@\n-old\n+new\n",
+    )
+    p_idx = user.index("PLAN_JSON")
+    d_idx = user.index("CODE_DIFF")
+    c_idx = user.index("CODE_CONTEXT")
+    # Diff sits between primary input and the full-source context — the
+    # model reads the change FIRST, then can look up declarations.
+    assert p_idx < d_idx < c_idx
+    # Rendered as a diff-fenced block
+    assert "```diff" in user
+
+
+def test_code_diff_omitted_when_empty():
+    _, user = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input="{}",
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated="",
+        code_diff="",
+    )
+    assert "CODE_DIFF" not in user
+
+
+def test_code_diff_described_in_skill_prompt():
+    """The skill prompt must teach the model what CODE_DIFF is — without
+    that doc the new field is just noise. Keeps prompt-input contract
+    in sync with the renderer.
+    """
+    system, _ = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input="{}",
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated="",
+        code_diff="",
+    )
+    assert "CODE_DIFF" in system
+    # And the model must be told about the actions rule (the v0.30.3
+    # hallucination fix moves into the upstream prompt itself).
+    assert "change.actions" in system
+    # And resource_drift must be described as NOT the apply change set.
+    assert "resource_drift" in system
+
+
+def test_failure_analysis_skill_also_describes_code_diff():
+    """Failure analysis benefits from CODE_DIFF too — the recent change
+    is the most likely cause of a new failure.
+    """
+    system, _ = render_prompt(
+        kind="failure_analysis",
+        fleet_context="",
+        workspace_context="",
+        primary_input="ERROR: ...",
+        primary_input_label="PLAN_LOG",
+        primary_input_lang="text",
+        code_context_truncated="",
+    )
+    assert "CODE_DIFF" in system

--- a/web/src/components/plan-ai-summary.tsx
+++ b/web/src/components/plan-ai-summary.tsx
@@ -18,7 +18,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { Sparkles, AlertTriangle, Info, ShieldAlert, ShieldX } from 'lucide-react'
+import { Sparkles, AlertTriangle, Info, ShieldAlert, ShieldX, RefreshCw } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { LoadingSpinner } from '@/components/loading-spinner'
 
@@ -69,10 +69,12 @@ export function PlanAiSummary({ runId, refreshKey = 0 }: Props) {
   const [missing, setMissing] = useState(false)
   const [loading, setLoading] = useState(true)
   const [transportError, setTransportError] = useState<string | null>(null)
+  const [regenerating, setRegenerating] = useState(false)
+  const [regenerateError, setRegenerateError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     try {
-      const res = await apiFetch(`/api/v2/plans/plan-${runId}/summary`)
+      const res = await apiFetch(`/api/terrapod/v1/runs/run-${runId}/plan-summary`)
       if (res.status === 404) {
         setMissing(true)
         setSummary(null)
@@ -97,6 +99,43 @@ export function PlanAiSummary({ runId, refreshKey = 0 }: Props) {
     load()
   }, [load, refreshKey])
 
+  const regenerate = useCallback(async () => {
+    // Skip confirmation modal: errored/skipped clicks are clearly an
+    // operator asking for a retry; ready→regen is also unambiguous —
+    // they're saying "this one wasn't good enough".
+    setRegenerating(true)
+    setRegenerateError(null)
+    try {
+      const res = await apiFetch(
+        `/api/terrapod/v1/runs/run-${runId}/plan-summary/regenerate`,
+        { method: 'POST' },
+      )
+      if (!res.ok) {
+        // Surface the API's structured detail when available.
+        let detail = `HTTP ${res.status}`
+        try {
+          const body = await res.json()
+          if (body?.detail) detail = body.detail
+        } catch {
+          /* fall through to status code */
+        }
+        setRegenerateError(detail)
+        return
+      }
+      // 202: server upserted a pending row + enqueued. Refetch
+      // immediately so the UI shows the pending state; the SSE
+      // `plan_summary_ready` event drives the next refresh when the
+      // handler finishes.
+      const data = await res.json()
+      setSummary(data.data as PlanSummary)
+      setMissing(false)
+    } catch (e) {
+      setRegenerateError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setRegenerating(false)
+    }
+  }, [runId])
+
   // When the feature is globally disabled (no row will ever appear) we
   // render nothing — operators on a non-AI deployment don't see this
   // panel at all.
@@ -116,10 +155,33 @@ export function PlanAiSummary({ runId, refreshKey = 0 }: Props) {
           <h3 className="text-sm font-medium text-slate-300">{heading}</h3>
           <span className="text-xs text-slate-500">AI generated</span>
         </div>
-        {attrs && attrs.status === 'ready' && attrs['risk-level'] && (
-          <RiskPill level={attrs['risk-level']} />
-        )}
+        <div className="flex items-center gap-3">
+          {attrs && attrs.status === 'ready' && attrs['risk-level'] && (
+            <RiskPill level={attrs['risk-level']} />
+          )}
+          {/* Regenerate is gated on the summary existing — once we know
+              the feature is enabled. While in `pending` we lock the
+              button so concurrent clicks can't double-enqueue. */}
+          {attrs && attrs.status !== 'pending' && (
+            <button
+              type="button"
+              onClick={regenerate}
+              disabled={regenerating}
+              className="inline-flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-200 disabled:opacity-50 disabled:cursor-not-allowed px-2 py-1 rounded border border-slate-700/50 hover:border-slate-600"
+              title="Re-run the AI summary against the same plan inputs"
+            >
+              <RefreshCw className={`w-3 h-3 ${regenerating ? 'animate-spin' : ''}`} />
+              {regenerating ? 'Queueing…' : 'Regenerate'}
+            </button>
+          )}
+        </div>
       </div>
+
+      {regenerateError && (
+        <div className="mb-3 text-xs text-red-300 bg-red-900/20 border border-red-800/50 rounded p-2">
+          Could not regenerate: <span className="font-mono">{regenerateError}</span>
+        </div>
+      )}
 
       {attrs?.status === 'pending' && (
         <div className="flex items-center gap-3 text-sm text-slate-400">


### PR DESCRIPTION
## Summary

Bundle of five AI-summary improvements that together kill the production hallucinations observed on v0.30.3 and add an iteration loop for prompt / config tuning.

### 1. PLAN_JSON cleaning (`_clean_plan_json_bytes`)
Server-side filter applied before the head-truncate. High-confidence drops only:
- \`resource_changes\` where \`actions ⊆ {no-op, read}\` AND no \`importing\`
- \`output_changes\` with \`actions == [\"no-op\"]\`
- top-level \`prior_state\` snapshot

**Preserves** \`resource_drift\` in full — false negatives from pruning are more dangerous than false positives. The prompt handles drift labelling.

### 2. CODE_DIFF input (`_build_code_diff`)
New optional model input: unified diff of \`*.tf\` / \`*.tfvars\` between this run's CV tarball and the previously-applied CV tarball. Lookup uses the workspace's most-recent applied run; falls back to absent on first runs or GC'd prior CVs. Zip-slip guarded. Best-effort: never blocks the summariser.

### 3. Prompt hardening
\`PLAN_SUMMARY_SKILL_PROMPT\` now bakes in two CRITICAL rules (previously deployed as wrapper \`prompt_suffix\`):
- trust \`change.actions\`, never infer changes from before/after snapshots
- \`resource_drift\` is NOT the apply change set — distinguish \"drift accepted\" (informational) from \"drift reverted\" (elevated risk)

Plus CODE_DIFF documentation in both skill prompts, and style rules aligned across \`description\` and \`risk_factors[].detail\` so the rendered summary doesn't whiplash between bold-sectioned description and plain-prose risk details.

### 4. Regenerate button + endpoint move
The AI summary endpoints weren't CLI surface, so they're moved to \`/api/terrapod/v1/\`:
- GET  \`/api/terrapod/v1/runs/{run_id}/plan-summary\` (was \`/api/v2/plans/{id}/summary\`)
- POST \`/api/terrapod/v1/runs/{run_id}/plan-summary/regenerate\` (new)

Operators can now re-fire the AI summary on any post-plan run via a button in the summary card. Workspace \`read\` is required; cost is gated by \`ai_summary.daily_token_budget\`; manual clicks bypass the 5-min auto-dedup. Frontend shows a pending spinner and refreshes on the existing \`plan_summary_ready\` SSE event.

### 5. Helm template default
\`configmap-api.yaml\` hardcoded \`| default 1024\` for \`max_output_tokens\` independently of the v0.30.3 Pydantic-side bump to 16384. Aligned to 16384. Also adds \`code_diff_max_bytes\` (default 100_000). Audited every other \`| default\` in configmap-api.yaml against config.py — no other drift.

## Tests

+30 new unit tests covering plan cleaning, CODE_DIFF generation, prompt rendering, and regenerate endpoint behaviour. \`make test\` → 1707 passed (was 1677, +30). \`make lint\` passes. \`helm template\` clean.

## Follow-up (separate)

Wrapper MR will bump the subchart 0.30.3 → 0.30.4 and drop the temporary \`prompt_suffix\` + \`max_output_tokens\` overrides we shipped while iterating — both now live upstream.