### PR TITLE
fix(ai-summary): use LiteLLM tool-calling for guaranteed structured output

### DIFF
--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -56,7 +56,7 @@ from terrapod.config import settings
 from terrapod.db.models import PlanSummary, Run, Workspace, now_utc
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
-from terrapod.services.summariser_prompt import render_prompt
+from terrapod.services.summariser_prompt import render_prompt, tool_for_kind
 from terrapod.storage import get_storage
 from terrapod.storage.keys import (
     config_version_key,
@@ -462,9 +462,15 @@ def _resolve_workspace_mode(ws: Workspace) -> bool:
 
 
 def _build_litellm_kwargs(
-    *, system_message: str, user_message: str, max_output_tokens: int
+    *, kind: str, system_message: str, user_message: str, max_output_tokens: int
 ) -> dict:
     """Assemble the keyword arguments for ``litellm.acompletion``.
+
+    Includes the ``tools`` definition and a forcing ``tool_choice`` so
+    the provider returns structured output via its native tool-calling
+    surface (Bedrock Converse toolConfig, OpenAI function calling,
+    Anthropic direct, etc.). LiteLLM translates per provider; we always
+    write OpenAI-shape on the way in.
 
     Provider-specific keys (``api_key``, ``api_base``, ``aws_*``) are
     passed through unconditionally — LiteLLM ignores the ones that
@@ -473,14 +479,9 @@ def _build_litellm_kwargs(
     """
     cfg = settings.ai_summary
     auth = cfg.auth
+    tool = tool_for_kind(kind)
+    tool_name = tool["function"]["name"]
 
-    # We deliberately don't set response_format — Bedrock Converse for
-    # Anthropic models rejects the OpenAI json_schema field with
-    # "output_config.format: Extra inputs are not permitted", and other
-    # providers' translations vary in quality. The skill prompt embeds
-    # the JSON schema in the system message and instructs "Output JSON
-    # only"; _parse_model_json forgives incidental fence wrapping. That
-    # gives us portable behaviour across every LiteLLM backend.
     kwargs: dict = {
         "model": cfg.model,
         "max_tokens": max_output_tokens,
@@ -488,6 +489,10 @@ def _build_litellm_kwargs(
             {"role": "system", "content": system_message},
             {"role": "user", "content": user_message},
         ],
+        "tools": [tool],
+        # Force the named tool — without this, models can choose to
+        # respond in plain prose and we lose the schema guarantee.
+        "tool_choice": {"type": "function", "function": {"name": tool_name}},
         "timeout": cfg.request_timeout_seconds,
     }
 
@@ -511,14 +516,23 @@ def _build_litellm_kwargs(
 
 async def _call_model(
     *,
+    kind: str,
     system_message: str,
     user_message: str,
     max_output_tokens: int,
 ) -> tuple[dict, int, int]:
-    """Drive a Chat Completions call via the LiteLLM library.
+    """Drive a tool-calling completion via the LiteLLM library.
 
-    Returns ``(parsed_json, input_tokens, output_tokens)``. Raises on
-    HTTP errors, missing choices, or JSON parse errors.
+    The model is forced (via ``tool_choice``) to call the
+    kind-specific submission tool with arguments matching
+    ``PLAN_SUMMARY_JSON_SCHEMA``. Provider-side constrained decoding
+    (Bedrock Converse, OpenAI function calling, etc.) guarantees the
+    arguments are valid JSON — no more mid-string escape bugs.
+
+    Returns ``(parsed_args, input_tokens, output_tokens)``. Raises on
+    HTTP errors, missing choices, truncation, or — defensively — if a
+    model ignores ``tool_choice`` and returns prose, in which case we
+    fall back to parsing the response body as JSON.
     """
     cfg = settings.ai_summary
     if not cfg.model:
@@ -526,6 +540,7 @@ async def _call_model(
 
     resp = await litellm.acompletion(
         **_build_litellm_kwargs(
+            kind=kind,
             system_message=system_message,
             user_message=user_message,
             max_output_tokens=max_output_tokens,
@@ -535,37 +550,87 @@ async def _call_model(
     if not resp.choices:
         raise RuntimeError("model response had no choices")
     choice = resp.choices[0]
-    text = choice.message.content or ""
     finish_reason = getattr(choice, "finish_reason", None)
 
-    # When the model runs out of output tokens it stops mid-JSON, so both
-    # strict json.loads and the balanced-brace fallback fail with a
-    # misleading "not JSON" — call out the real cause first.
+    # Truncation diagnostic stays — applies to both tool args and
+    # plain text. `tool_calls` is the finish_reason for a successful
+    # tool call on most providers; `stop` is also valid (Bedrock
+    # Converse normalises everything to `stop` after a clean tool call
+    # in LiteLLM's translation). `length` always means trouble.
     if finish_reason == "length":
         raise RuntimeError(
             f"model response truncated at max_output_tokens={max_output_tokens} "
             f"(finish_reason=length); raise ai_summary.max_output_tokens"
         )
 
-    try:
-        parsed = _parse_model_json(text)
-    except ValueError as e:
-        # Log a head+tail snippet so future failures are diagnosable
-        # without rerunning. Limit size so we don't dump megabytes into
-        # the structured log.
-        snippet = text if len(text) <= 800 else f"{text[:400]}…{text[-400:]}"
+    tool_calls = getattr(choice.message, "tool_calls", None) or []
+    if tool_calls:
+        parsed = _parse_tool_call_arguments(tool_calls[0])
+    else:
+        # Defensive fallback: model ignored tool_choice and replied in
+        # prose. Shouldn't happen with constrained-decoding providers
+        # but keeps us working against self-hosted endpoints that don't
+        # support tool calling.
+        text = choice.message.content or ""
         logger.warning(
-            "Summariser response did not parse as JSON",
+            "Model returned no tool_calls despite tool_choice; "
+            "falling back to body-content JSON parse",
             finish_reason=finish_reason,
             response_length=len(text),
-            response_snippet=snippet,
         )
-        raise ValueError(f"{e} (finish_reason={finish_reason}, len={len(text)})") from e
+        try:
+            parsed = _parse_model_json(text)
+        except ValueError as e:
+            snippet = text if len(text) <= 800 else f"{text[:400]}…{text[-400:]}"
+            logger.warning(
+                "Summariser body content did not parse as JSON either",
+                finish_reason=finish_reason,
+                response_length=len(text),
+                response_snippet=snippet,
+            )
+            raise ValueError(f"{e} (finish_reason={finish_reason}, len={len(text)})") from e
 
     usage = getattr(resp, "usage", None)
     in_tok = int(getattr(usage, "prompt_tokens", 0) or 0) if usage else 0
     out_tok = int(getattr(usage, "completion_tokens", 0) or 0) if usage else 0
     return parsed, in_tok, out_tok
+
+
+def _parse_tool_call_arguments(tool_call: object) -> dict:
+    """Extract the parsed arguments dict from a LiteLLM tool_call object.
+
+    LiteLLM normalises to OpenAI shape: ``tool_call.function.arguments``
+    is the canonical location, and it can come back as either a JSON
+    string (most providers) or an already-parsed dict (some translations).
+    Handles both, plus the failure modes (missing function attr,
+    malformed JSON despite the constrained-decode promise).
+    """
+    fn = getattr(tool_call, "function", None)
+    if fn is None and isinstance(tool_call, dict):
+        fn = tool_call.get("function")
+    if fn is None:
+        raise ValueError("tool_call had no `function` attribute")
+
+    args = getattr(fn, "arguments", None)
+    if args is None and isinstance(fn, dict):
+        args = fn.get("arguments")
+    if args is None:
+        raise ValueError("tool_call.function had no `arguments`")
+
+    if isinstance(args, dict):
+        return args
+    if isinstance(args, str):
+        try:
+            return json.loads(args)
+        except json.JSONDecodeError as e:
+            snippet = args if len(args) <= 800 else f"{args[:400]}…{args[-400:]}"
+            logger.warning(
+                "Tool-call arguments were not valid JSON despite tool_choice",
+                response_length=len(args),
+                response_snippet=snippet,
+            )
+            raise ValueError(f"tool-call arguments invalid JSON: {e}") from e
+    raise ValueError(f"tool_call.function.arguments had unexpected type: {type(args).__name__}")
 
 
 def _parse_model_json(text: str) -> dict:
@@ -777,6 +842,7 @@ async def handle_ai_plan_summary(payload: dict) -> None:
 
         try:
             parsed, in_tok, out_tok = await _call_model(
+                kind=kind,
                 system_message=system_message,
                 user_message=user_message,
                 max_output_tokens=cfg.max_output_tokens,

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -8,14 +8,23 @@ here — changing the schema means changing all three.
 Helm-provided `prompt_prefix` and `prompt_suffix` strings wrap this skill
 prompt; they are intended for tone/emphasis tweaks, NOT for changing the
 output contract. See `AISummaryContextConfig` in `config.py`.
+
+Structured output is delivered via LiteLLM tool-calling: the model is
+forced (``tool_choice``) to call ``submit_plan_summary`` /
+``submit_failure_analysis`` with arguments matching
+``PLAN_SUMMARY_JSON_SCHEMA``. Providers that support constrained
+decoding (Bedrock Converse for Anthropic, OpenAI function calling,
+etc.) guarantee the arguments are valid JSON. The legacy "ask for
+JSON in the response body" path remains in the summariser as a
+defensive fallback for providers / models that ignore tools.
 """
 
 from __future__ import annotations
 
-# Single source of truth for the schema. The JSON-schema dict is sent in
-# the request `response_format` and the prose schema is also embedded in
-# the user message — Bedrock OpenAI-compat ignores `response_format` for
-# some Anthropic models, so the in-prompt schema is the durable backstop.
+# Single source of truth for the schema. Used both as the tool's
+# `parameters` JSON Schema (the canonical structured-output path) and
+# previously also embedded in the user message as prose — the in-prompt
+# schema is the durable backstop if a model ignores the tool definition.
 PLAN_SUMMARY_JSON_SCHEMA: dict = {
     "type": "object",
     "additionalProperties": False,
@@ -74,6 +83,48 @@ PLAN_SUMMARY_JSON_SCHEMA: dict = {
 }
 
 
+# Tool / function-call definitions. The model is forced (via
+# ``tool_choice``) to call the appropriate one with arguments matching
+# the schema. Providers with constrained decoding (Bedrock Converse for
+# Anthropic, OpenAI function calling, Anthropic direct, Gemini, etc.)
+# guarantee the arguments are valid JSON — no more "model response was
+# not JSON" parse failures from mid-string escaping bugs.
+PLAN_SUMMARY_TOOL: dict = {
+    "type": "function",
+    "function": {
+        "name": "submit_plan_summary",
+        "description": (
+            "Submit the structured plan summary. Call this tool exactly once "
+            "with the description, overall risk_level, and discrete risk_factors."
+        ),
+        "parameters": PLAN_SUMMARY_JSON_SCHEMA,
+    },
+}
+
+FAILURE_ANALYSIS_TOOL: dict = {
+    "type": "function",
+    "function": {
+        "name": "submit_failure_analysis",
+        "description": (
+            "Submit the structured failure analysis. Call this tool exactly "
+            "once. `description` is the root-cause explanation; `risk_factors` "
+            "are candidate fixes ordered most-likely-to-resolve first; "
+            "`risk_level` is how blocking the failure is."
+        ),
+        "parameters": PLAN_SUMMARY_JSON_SCHEMA,
+    },
+}
+
+
+def tool_for_kind(kind: str) -> dict:
+    """Return the LiteLLM tool definition matching this summariser kind."""
+    if kind == "plan_summary":
+        return PLAN_SUMMARY_TOOL
+    if kind == "failure_analysis":
+        return FAILURE_ANALYSIS_TOOL
+    raise ValueError(f"unknown summariser kind: {kind!r}")
+
+
 PLAN_SUMMARY_SKILL_PROMPT = """\
 You are a Terraform plan reviewer embedded in Terrapod. You receive the
 proposed changes from a terraform/tofu plan and the HCL that produced
@@ -95,21 +146,11 @@ You will receive these inputs in the user message:
   • FLEET_CONTEXT — deployment-wide notes from the operator. May be empty.
   • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
 
-You return a single JSON object matching this schema, with no
-surrounding text, markdown fences, or commentary:
-
-  {
-    "description": "<plain language summary of what changes, ~600 words max>",
-    "risk_level": "<low | medium | high | critical>",
-    "risk_factors": [
-      {
-        "severity": "<low | medium | high | critical>",
-        "title": "<short label, max 120 chars>",
-        "detail": "<explanation, max 600 chars>",
-        "resource_address": "<terraform address, optional>"
-      }
-    ]
-  }
+You submit your answer by calling the `submit_plan_summary` tool
+exactly once. The tool's parameters carry the schema; the provider
+guarantees your arguments are well-formed JSON. Do not respond with
+prose, do not paraphrase the JSON in your message body — just call
+the tool.
 
 CRITICAL — trust `change.actions`, not snapshots:
 
@@ -198,21 +239,11 @@ You will receive these inputs in the user message:
   • FLEET_CONTEXT — deployment-wide notes. May be empty.
   • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
 
-You return a single JSON object matching this schema, with no
-surrounding text, markdown fences, or commentary:
-
-  {
-    "description": "<plain language explanation of what went wrong, ~600 words max>",
-    "risk_level": "<low | medium | high | critical>",
-    "risk_factors": [
-      {
-        "severity": "<low | medium | high | critical>",
-        "title": "<short fix label, max 120 chars>",
-        "detail": "<concrete steps or change to make, max 600 chars>",
-        "resource_address": "<terraform address, optional>"
-      }
-    ]
-  }
+You submit your answer by calling the `submit_failure_analysis` tool
+exactly once. The tool's parameters carry the schema; the provider
+guarantees your arguments are well-formed JSON. Do not respond with
+prose, do not paraphrase the JSON in your message body — just call
+the tool.
 
 For failure analysis, the fields carry these meanings:
   • description: what failed and why — the root cause in operator
@@ -305,10 +336,8 @@ def render_prompt(
     if code_context_truncated.strip():
         user_parts.append(f"CODE_CONTEXT:\n```hcl\n{code_context_truncated}\n```")
 
-    user_parts.append(
-        "Now produce the JSON object per the schema in the system prompt. "
-        "Output JSON only — no surrounding text or code fences."
-    )
+    tool_name = "submit_plan_summary" if kind == "plan_summary" else "submit_failure_analysis"
+    user_parts.append(f"Now call the `{tool_name}` tool exactly once with your structured answer.")
 
     user_message = "\n\n".join(user_parts)
     return system_message, user_message

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -179,51 +179,149 @@ def test_parse_fenced_block_without_json_tag():
 # ── truncation handling ─────────────────────────────────────────────────
 
 
-async def test_call_model_raises_on_finish_length():
-    """When Bedrock stops mid-JSON because max_output_tokens ran out we
-    must call that out explicitly — not surface a misleading 'not JSON'.
-    """
-    truncated = '{"description": "this stops mid-way",'  # no closing brace
-    fake_choice = MagicMock()
-    fake_choice.message.content = truncated
-    fake_choice.finish_reason = "length"
-    fake_resp = MagicMock(
-        choices=[fake_choice], usage=MagicMock(prompt_tokens=10, completion_tokens=1024)
+def _fake_tool_call(arguments):
+    """Build a MagicMock shaped like LiteLLM's tool_call entry."""
+    tc = MagicMock()
+    tc.function.arguments = arguments
+    return tc
+
+
+def _fake_response(*, tool_calls=None, content="", finish_reason="stop", in_tok=10, out_tok=20):
+    """Build a MagicMock shaped like LiteLLM's `ModelResponse.choices[0]`."""
+    choice = MagicMock()
+    choice.message.tool_calls = tool_calls
+    choice.message.content = content
+    choice.finish_reason = finish_reason
+    return MagicMock(
+        choices=[choice],
+        usage=MagicMock(prompt_tokens=in_tok, completion_tokens=out_tok),
     )
 
+
+async def test_call_model_raises_on_finish_length():
+    """Truncation must surface as a specific error, regardless of whether
+    we got a partial tool-call or partial body content.
+    """
+    resp = _fake_response(content='{"partial"', finish_reason="length")
     with (
         patch.object(summariser.settings.ai_summary, "model", "test-model"),
-        patch(
-            "terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=fake_resp)
-        ),
+        patch("terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=resp)),
     ):
         with pytest.raises(RuntimeError, match="truncated at max_output_tokens"):
             await summariser._call_model(
-                system_message="s", user_message="u", max_output_tokens=1024
+                kind="plan_summary",
+                system_message="s",
+                user_message="u",
+                max_output_tokens=1024,
             )
 
 
-async def test_call_model_parse_failure_includes_finish_reason():
-    """Non-length parse failures should surface finish_reason + length
-    in the error string so the operator can tell stop-vs-content
-    failures apart in the UI / logs.
+async def test_call_model_parses_tool_call_arguments_string():
+    """Happy path: provider returns the tool call with arguments as a
+    JSON string (OpenAI native shape, also what Bedrock Converse for
+    Anthropic produces via LiteLLM's translation).
     """
-    fake_choice = MagicMock()
-    fake_choice.message.content = "I cannot summarise this plan."
-    fake_choice.finish_reason = "stop"
-    fake_resp = MagicMock(
-        choices=[fake_choice], usage=MagicMock(prompt_tokens=10, completion_tokens=8)
-    )
-
+    args_str = '{"description":"adds a VPC","risk_level":"low","risk_factors":[]}'
+    resp = _fake_response(tool_calls=[_fake_tool_call(args_str)])
     with (
         patch.object(summariser.settings.ai_summary, "model", "test-model"),
-        patch(
-            "terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=fake_resp)
-        ),
+        patch("terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=resp)),
+    ):
+        parsed, in_tok, out_tok = await summariser._call_model(
+            kind="plan_summary",
+            system_message="s",
+            user_message="u",
+            max_output_tokens=1024,
+        )
+    assert parsed["description"] == "adds a VPC"
+    assert parsed["risk_level"] == "low"
+    assert in_tok == 10
+    assert out_tok == 20
+
+
+async def test_call_model_parses_tool_call_arguments_dict():
+    """Some LiteLLM provider translations return `arguments` as a dict
+    rather than a JSON string. Both shapes must work.
+    """
+    args_dict = {
+        "description": "deletes a Lambda",
+        "risk_level": "medium",
+        "risk_factors": [],
+    }
+    resp = _fake_response(tool_calls=[_fake_tool_call(args_dict)])
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "test-model"),
+        patch("terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=resp)),
+    ):
+        parsed, *_ = await summariser._call_model(
+            kind="plan_summary",
+            system_message="s",
+            user_message="u",
+            max_output_tokens=1024,
+        )
+    assert parsed == args_dict
+
+
+async def test_call_model_falls_back_to_body_when_no_tool_calls():
+    """If a provider ignores tool_choice and replies in prose, we fall
+    back to the legacy `_parse_model_json` path. Defensive — shouldn't
+    happen with constrained-decode providers but keeps self-hosted
+    backends working.
+    """
+    body = '{"description":"fallback path","risk_level":"low","risk_factors":[]}'
+    resp = _fake_response(tool_calls=None, content=body)
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "test-model"),
+        patch("terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=resp)),
+    ):
+        parsed, *_ = await summariser._call_model(
+            kind="plan_summary",
+            system_message="s",
+            user_message="u",
+            max_output_tokens=1024,
+        )
+    assert parsed["description"] == "fallback path"
+
+
+async def test_call_model_surfaces_malformed_tool_arguments():
+    """If the provider somehow returns a malformed-JSON string for the
+    tool arguments (shouldn't happen, but defensive), surface as an
+    actionable ValueError that mentions the JSON cause.
+    """
+    bad = '{"description":"truncated mid'  # unterminated string + obj
+    resp = _fake_response(tool_calls=[_fake_tool_call(bad)])
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "test-model"),
+        patch("terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=resp)),
+    ):
+        with pytest.raises(ValueError, match="tool-call arguments invalid JSON"):
+            await summariser._call_model(
+                kind="plan_summary",
+                system_message="s",
+                user_message="u",
+                max_output_tokens=1024,
+            )
+
+
+async def test_call_model_fallback_parse_failure_includes_finish_reason():
+    """When the body-fallback path itself fails to parse, surface
+    finish_reason + length so the operator can tell from the run UI
+    whether they got a refusal, a truncation, or a malformed JSON
+    blob from a provider that ignored tools.
+    """
+    resp = _fake_response(
+        tool_calls=None, content="I cannot summarise this plan.", finish_reason="stop"
+    )
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "test-model"),
+        patch("terrapod.services.summariser.litellm.acompletion", AsyncMock(return_value=resp)),
     ):
         with pytest.raises(ValueError, match="finish_reason=stop"):
             await summariser._call_model(
-                system_message="s", user_message="u", max_output_tokens=1024
+                kind="plan_summary",
+                system_message="s",
+                user_message="u",
+                max_output_tokens=1024,
             )
 
 
@@ -242,7 +340,10 @@ def test_build_litellm_kwargs_includes_aws_role_when_set():
         patch.object(summariser.settings.ai_summary.auth, "aws_external_id", "ext-id-123"),
     ):
         kw = summariser._build_litellm_kwargs(
-            system_message="sys", user_message="usr", max_output_tokens=100
+            kind="plan_summary",
+            system_message="sys",
+            user_message="usr",
+            max_output_tokens=100,
         )
         assert kw["model"] == "bedrock/anthropic.claude-opus-4-8"
         assert kw["aws_region_name"] == "us-east-1"
@@ -263,10 +364,70 @@ def test_build_litellm_kwargs_omits_role_when_unset():
         patch.object(summariser.settings.ai_summary.auth, "aws_external_id", ""),
     ):
         kw = summariser._build_litellm_kwargs(
-            system_message="sys", user_message="usr", max_output_tokens=100
+            kind="plan_summary",
+            system_message="sys",
+            user_message="usr",
+            max_output_tokens=100,
         )
         assert "aws_role_name" not in kw
         assert "aws_external_id" not in kw
+
+
+def test_build_litellm_kwargs_includes_tool_choice_for_plan_summary():
+    """Tool-calling is the canonical structured-output path. The kwargs
+    must include the submit_plan_summary tool AND force it via
+    tool_choice — without the force, models can opt to reply in prose.
+    """
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "bedrock/anthropic.claude-opus-4-8"),
+        patch.object(summariser.settings.ai_summary, "api_base", ""),
+        patch.object(summariser.settings.ai_summary.auth, "api_key", ""),
+        patch.object(summariser.settings.ai_summary.auth, "aws_region", "us-east-1"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_role_arn", ""),
+        patch.object(summariser.settings.ai_summary.auth, "aws_session_name", "x"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_external_id", ""),
+    ):
+        kw = summariser._build_litellm_kwargs(
+            kind="plan_summary",
+            system_message="sys",
+            user_message="usr",
+            max_output_tokens=100,
+        )
+        assert isinstance(kw["tools"], list) and len(kw["tools"]) == 1
+        tool = kw["tools"][0]
+        assert tool["type"] == "function"
+        assert tool["function"]["name"] == "submit_plan_summary"
+        # Schema lands on the tool, not in the user message.
+        assert "description" in tool["function"]["parameters"]["properties"]
+        assert "risk_level" in tool["function"]["parameters"]["properties"]
+        assert kw["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "submit_plan_summary"},
+        }
+
+
+def test_build_litellm_kwargs_uses_failure_analysis_tool_for_failure_kind():
+    """failure_analysis kind selects the submit_failure_analysis tool
+    (same JSON schema, different name + description). The wrong tool
+    would confuse the model about whether it's summarising or analysing.
+    """
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "openai/gpt-5"),
+        patch.object(summariser.settings.ai_summary, "api_base", ""),
+        patch.object(summariser.settings.ai_summary.auth, "api_key", "sk-x"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_region", "us-east-1"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_role_arn", ""),
+        patch.object(summariser.settings.ai_summary.auth, "aws_session_name", "x"),
+        patch.object(summariser.settings.ai_summary.auth, "aws_external_id", ""),
+    ):
+        kw = summariser._build_litellm_kwargs(
+            kind="failure_analysis",
+            system_message="sys",
+            user_message="usr",
+            max_output_tokens=100,
+        )
+        assert kw["tools"][0]["function"]["name"] == "submit_failure_analysis"
+        assert kw["tool_choice"]["function"]["name"] == "submit_failure_analysis"
 
 
 def test_build_litellm_kwargs_passes_api_key_and_base():
@@ -281,7 +442,10 @@ def test_build_litellm_kwargs_passes_api_key_and_base():
         patch.object(summariser.settings.ai_summary.auth, "aws_external_id", ""),
     ):
         kw = summariser._build_litellm_kwargs(
-            system_message="sys", user_message="usr", max_output_tokens=100
+            kind="plan_summary",
+            system_message="sys",
+            user_message="usr",
+            max_output_tokens=100,
         )
         assert kw["api_key"] == "sk-abc"
         assert kw["api_base"] == "https://vllm.local/v1"


### PR DESCRIPTION
The v0.30.5 production summariser failed on a real plan with `"model response was not JSON (finish_reason=stop, len=3125)"` — Opus stopped naturally but returned JSON with malformed escaping somewhere in the middle of a 3.1KB response. Prompt-driven JSON has a long tail of these failures that no prompt instruction fully eliminates.

The fix is to stop asking the model to produce JSON-as-text and constrain the output via the provider's native tool-calling surface. LiteLLM translates `tools` + `tool_choice` per provider (Bedrock Converse `toolConfig`, OpenAI function calling, Anthropic direct, Gemini, etc.); providers with constrained decoding then guarantee well-formed arguments matching the JSON Schema.

`_call_model` reads from `tool_calls[0].function.arguments` (handling both string and dict shapes). A defensive fallback to the existing `_parse_model_json` body path stays, with a warning log, for providers that ignore tools. Truncation diagnostic preserved.

Skill prompts drop the embedded JSON schema and the "Output JSON only" instruction; both are now redundant. 1713 tests pass.

Test plan:
- [x] `make test` — 1713 passed
- [x] `make lint` — clean
- [ ] Live verification post-release on a real plan