### PR TITLE
fix(runner): set HOME=/home/runner in runner Job pods

### DIFF
--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -41,9 +41,19 @@ RUN ARCH="${TARGETARCH:-$(apk --print-arch | sed 's/aarch64/arm64/;s/x86_64/amd6
 COPY docker/runner-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-RUN mkdir -p /workspace /tmp/bin && chown -R 1000:1000 /workspace /tmp/bin
+# /home/runner is the writable HOME for UID 1000 — without it, tools
+# that consult $HOME (helm's repository/index cache, kubectl's
+# ~/.kube/cache, git's ~/.gitconfig, AWS CLI's ~/.aws) fall back to
+# os.UserHomeDir() lookups that resolve to "/" for a UID with no
+# /etc/passwd entry, then write to /.cache/… which isn't writable
+# and triggers misleading "cannot be reached" errors from helm
+# specifically. Keeping HOME off /workspace so terraform's .terraform/
+# and the user's HCL stay separate from tool caches.
+RUN mkdir -p /workspace /tmp/bin /home/runner \
+    && chown -R 1000:1000 /workspace /tmp/bin /home/runner
 
 USER 1000:1000
+ENV HOME=/home/runner
 WORKDIR /workspace
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -85,6 +85,18 @@ def build_job_spec(
     # Build container env vars
     api_url = os.environ.get("TERRAPOD_API_URL", "http://terrapod-api:8000")
     container_env = [
+        # HOME defends against tools that consult $HOME without a
+        # passwd entry (helm's repository/index cache,
+        # kubectl's ~/.kube/cache, AWS CLI's ~/.aws, git's
+        # ~/.gitconfig). Without it, Go's os.UserHomeDir() returns
+        # "" and downstream code writes to /.cache/… which isn't
+        # writable for UID 1000 and surfaces as misleading
+        # "cannot be reached" errors from helm specifically.
+        # The default Terrapod runner image ships /home/runner
+        # owned by 1000 (see Dockerfile.runner); setting it here
+        # too means custom runner images that miss the ENV line
+        # still get the right behaviour.
+        {"name": "HOME", "value": "/home/runner"},
         {"name": "TP_RUN_ID", "value": run_id},
         {"name": "TP_PHASE", "value": phase},
         {"name": "TP_API_URL", "value": api_url},

--- a/services/tests/runner/test_job_template.py
+++ b/services/tests/runner/test_job_template.py
@@ -173,6 +173,28 @@ class TestAuthTokenInjection:
         assert auth_env["valueFrom"]["secretKeyRef"]["name"] == "tprun-abc12345-auth"
         assert auth_env["valueFrom"]["secretKeyRef"]["key"] == "token"
 
+    def test_home_env_set_to_home_runner(self):
+        """HOME must be present in the Job's env so tools that consult
+        $HOME (helm's cache, kubectl's cache, AWS CLI, git) don't fall
+        back to "/" — the misleading "looks like X is not a valid chart
+        repository" error from terraform-provider-helm traces back to
+        an unset HOME and Helm writing to /.cache/...
+        """
+        from terrapod.runner.job_template import build_job_spec
+
+        spec = build_job_spec(
+            run_id="abc123",
+            phase="apply",
+            runner_config=_runner_config(),
+            auth_secret_name="tprun-abc12345-auth",
+            env_vars=[],
+            terraform_vars=[],
+        )
+        container = spec["spec"]["template"]["spec"]["containers"][0]
+        home_env = next((e for e in container["env"] if e["name"] == "HOME"), None)
+        assert home_env is not None, "HOME env var missing from runner Job spec"
+        assert home_env["value"] == "/home/runner"
+
 
 class TestPublicApiUrl:
     """Split-networking: TP_PUBLIC_API_URL only emitted when distinct from TP_API_URL."""


### PR DESCRIPTION
Real production apply failed with:

> looks like \"https://aws.github.io/secrets-store-csi-driver-provider-aws\" is not a valid chart repository or cannot be reached: open /.cache/helm/repository/...-index.yaml: no such file or directory

The leading-slash path (no user prefix) gave it away: \`\$HOME\` was unset inside the runner Pod, so terraform-provider-helm's Go \`os.UserHomeDir()\` returned \`\"\"\` (no \`/etc/passwd\` entry for UID 1000), helm then wrote to \`/.cache/...\` which isn't writable, and the subsequent index read surfaced as a misleading \"cannot be reached\". Affects every helm_release resource using a remote chart repo.

Two-layer fix:
- **Dockerfile.runner**: mkdir \`/home/runner\`, chown to 1000, \`ENV HOME=/home/runner\`. Default image works out of the box.
- **job_template.py**: also set \`HOME=/home/runner\` in the Job Pod env. Belt-and-braces so custom runner images that miss the \`ENV\` line still work — Pod env is authoritative cross-image.

Affects every tool that consults \$HOME: helm cache, kubectl cache, AWS CLI, git. All now land in \`/home/runner\`, ephemeral with the Pod.

Test plan:
- [x] \`make test\` — 1714 passed (+1 for HOME assertion)
- [x] \`make lint\` — clean
- [ ] Live verification post-deploy: re-run the failed apply, helm_release should now Modify successfully

Part of v0.30.6 bundle (after tool-calling #417, before apply-failure-analysis).