### PR TITLE
fix(vcs): only the latest PR run may write the shared per-PR comment

### DIFF
--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -373,8 +373,39 @@ async def handle_vcs_commit_status(payload: dict) -> None:
                 error=str(e),
             )
 
-        # Post/update PR comment (only for PR runs)
+        # Post/update PR comment (only for PR runs).
+        #
+        # The comment is shared across every run for this (workspace, PR)
+        # tuple — keyed by `<!-- terrapod:ws:{ws.id} -->` and updated in
+        # place by `_find_or_create_comment`. That means a stale run's
+        # transition (typically the supersede-cancel that fires when a
+        # force-push creates a fresh run for the new HEAD SHA) can land
+        # AFTER the fresh run's writes and clobber the comment with the
+        # old run's status. The per-SHA commit status check is unaffected
+        # (GitHub only surfaces the head SHA's checks), but the comment
+        # is the only shared surface, so only the latest run for this PR
+        # may write to it.
         if run.vcs_pull_request_number:
+            latest_run_id = (
+                await db.execute(
+                    select(Run.id)
+                    .where(
+                        Run.workspace_id == ws.id,
+                        Run.vcs_pull_request_number == run.vcs_pull_request_number,
+                    )
+                    .order_by(Run.created_at.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if latest_run_id is not None and latest_run_id != run.id:
+                logger.debug(
+                    "Skipping PR comment write for superseded run",
+                    run_id=run_id_str,
+                    latest_run_id=str(latest_run_id),
+                    pr=run.vcs_pull_request_number,
+                )
+                return
+
             run_url = target_url or f"run-{run.id}"
             # AI plan summary (#401) — included in the comment body when
             # a ready row exists for this run. The summariser re-enqueues

--- a/services/tests/services/test_vcs_status_dispatcher.py
+++ b/services/tests/services/test_vcs_status_dispatcher.py
@@ -159,3 +159,206 @@ class TestEnqueueVcsStatus:
             await _enqueue_vcs_status(run, "planned")
 
         mock_enq.assert_not_awaited()
+
+
+class TestSupersededRunComment:
+    """The shared per-PR comment must only be written by the latest run for
+    that (workspace, PR) tuple. Otherwise a stale run's transition (typically
+    the supersede-cancel that fires when a force-push creates a fresh run)
+    can clobber the fresh run's comment with old status."""
+
+    @staticmethod
+    def _build_session(latest_run_id):
+        """Mock async DB session for handle_vcs_commit_status.
+
+        `latest_run_id` is whatever the "latest run for this (ws, PR)" query
+        should return.
+        """
+        session = MagicMock()
+        session.get = AsyncMock()
+        session.execute = AsyncMock()
+
+        # session.execute() result for the latest-run query — .scalar_one_or_none()
+        latest_result = MagicMock()
+        latest_result.scalar_one_or_none = MagicMock(return_value=latest_run_id)
+        session.execute.return_value = latest_result
+        return session
+
+    @pytest.mark.asyncio
+    async def test_superseded_run_skips_comment_but_posts_status(self):
+        """Old run (not the latest for this PR) → commit status fires, comment is skipped."""
+        from terrapod.services.vcs_status_dispatcher import handle_vcs_commit_status
+
+        old_run_id = uuid.uuid4()
+        new_run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        conn_id = uuid.uuid4()
+
+        old_run = MagicMock()
+        old_run.id = old_run_id
+        old_run.workspace_id = ws_id
+        old_run.vcs_commit_sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        old_run.vcs_pull_request_number = 26
+        old_run.plan_only = True
+        old_run.has_changes = None
+
+        ws = MagicMock()
+        ws.id = ws_id
+        ws.name = "terrapod-config"
+        ws.vcs_connection_id = conn_id
+        ws.vcs_repo_url = "https://github.com/markupai/terrapod-config"
+
+        conn = MagicMock()
+        conn.provider = "github"
+        conn.status = "active"
+
+        session = self._build_session(latest_run_id=new_run_id)
+
+        async def _get(model, _id):
+            from terrapod.db.models import Run, VCSConnection, Workspace
+
+            if model is Run:
+                return old_run
+            if model is Workspace:
+                return ws
+            if model is VCSConnection:
+                return conn
+            return None
+
+        session.get.side_effect = _get
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return session
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        with (
+            patch(
+                "terrapod.services.vcs_status_dispatcher.get_db_session",
+                lambda: _Ctx(),
+            ),
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.parse_repo_url",
+                return_value=("markupai", "terrapod-config"),
+            ),
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.create_commit_status",
+                new=AsyncMock(),
+            ) as mock_status,
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.create_pr_comment",
+                new=AsyncMock(),
+            ) as mock_create_comment,
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.update_pr_comment",
+                new=AsyncMock(),
+            ) as mock_update_comment,
+        ):
+            await handle_vcs_commit_status(
+                {
+                    "run_id": str(old_run_id),
+                    "workspace_id": str(ws_id),
+                    "target_status": "canceled",
+                    "has_changes": None,
+                }
+            )
+
+        # Per-SHA commit status must still fire — GitHub only surfaces the
+        # head SHA's checks, so a stale-SHA status is harmless and useful.
+        mock_status.assert_awaited_once()
+        # …but the shared PR comment must NOT be touched for a superseded run.
+        mock_create_comment.assert_not_awaited()
+        mock_update_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_latest_run_writes_comment_normally(self):
+        """Sanity: when the dispatched run IS the latest for the PR, the
+        comment write proceeds (the new guard only short-circuits stale runs)."""
+        from terrapod.services.vcs_status_dispatcher import handle_vcs_commit_status
+
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        conn_id = uuid.uuid4()
+
+        run = MagicMock()
+        run.id = run_id
+        run.workspace_id = ws_id
+        run.vcs_commit_sha = "cafebabecafebabecafebabecafebabecafebabe"
+        run.vcs_pull_request_number = 26
+        run.plan_only = True
+        run.has_changes = True
+
+        ws = MagicMock()
+        ws.id = ws_id
+        ws.name = "terrapod-config"
+        ws.vcs_connection_id = conn_id
+        ws.vcs_repo_url = "https://github.com/markupai/terrapod-config"
+
+        conn = MagicMock()
+        conn.provider = "github"
+        conn.status = "active"
+
+        session = self._build_session(latest_run_id=run_id)  # itself is latest
+
+        # The handler also runs the PlanSummary lookup via session.execute().
+        # Reuse a side_effect so the FIRST execute() returns the latest-run
+        # result and the SECOND returns "no ready summary".
+        latest_result = MagicMock()
+        latest_result.scalar_one_or_none = MagicMock(return_value=run_id)
+        summary_result = MagicMock()
+        summary_result.scalar_one_or_none = MagicMock(return_value=None)
+        session.execute.side_effect = [latest_result, summary_result]
+
+        async def _get(model, _id):
+            from terrapod.db.models import Run, VCSConnection, Workspace
+
+            if model is Run:
+                return run
+            if model is Workspace:
+                return ws
+            if model is VCSConnection:
+                return conn
+            return None
+
+        session.get.side_effect = _get
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return session
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+        # _find_or_create_comment uses Redis; stub it out wholesale rather
+        # than mock-Redis here — the unit under test is the
+        # superseded-skip guard, not the comment-cache plumbing.
+        with (
+            patch(
+                "terrapod.services.vcs_status_dispatcher.get_db_session",
+                lambda: _Ctx(),
+            ),
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.parse_repo_url",
+                return_value=("markupai", "terrapod-config"),
+            ),
+            patch(
+                "terrapod.services.vcs_status_dispatcher.github_service.create_commit_status",
+                new=AsyncMock(),
+            ),
+            patch(
+                "terrapod.services.vcs_status_dispatcher._find_or_create_comment",
+                new=AsyncMock(),
+            ) as mock_comment,
+        ):
+            await handle_vcs_commit_status(
+                {
+                    "run_id": str(run_id),
+                    "workspace_id": str(ws_id),
+                    "target_status": "planned",
+                    "has_changes": True,
+                }
+            )
+
+        mock_comment.assert_awaited_once()


### PR DESCRIPTION
## Symptom

A force-push on an open PR can leave Terrapod's PR comment showing the
**old, cancelled run's status** ("🛑 Run canceled") even though the new
run for the new HEAD SHA has already planned successfully and posted a
green commit-status check. The AI summary section in the comment
reflects the new run's plan, but the status header points at the
superseded run, which is confusing and looks broken.

Real-world example (terrapod-config PR #26 after a rebase): comment
header pointed at \`run-019e87e6\` (canceled), commit-status check
pointed at \`run-019e87e7\` (planned, success).

## Root cause

The PR comment is shared across every run for a \`(workspace, PR)\`
tuple — keyed by \`<!-- terrapod:ws:{ws.id} -->\` and updated in place
by \`_find_or_create_comment\`. Every run transition for a VCS-sourced
run enqueues a \`vcs_commit_status\` trigger; the dispatcher
unconditionally re-renders + overwrites the shared comment from
**whichever run** the trigger carried.

The supersede-cancel that fires when a force-push creates a fresh run
for the new HEAD SHA lands AFTER the fresh run's writes, and clobbers
the comment with the old run's \`canceled\` status. Per-SHA commit
status checks are unaffected — GitHub only surfaces the head SHA's
checks — but the shared comment has no per-SHA partitioning, so the
stale-run write wins.

## Fix

Before writing the shared comment, look up the latest run for this
\`(workspace, PR)\` tuple. If the dispatched run isn't it, short-circuit
the comment write and \`return\`. The per-SHA commit-status check still
fires above this gate (it's harmless on stale SHAs and stays useful for
audit / history).

~25 lines of code in \`vcs_status_dispatcher.handle_vcs_commit_status\`,
two new tests:

- \`test_superseded_run_skips_comment_but_posts_status\` — when the
  dispatched run isn't the latest for the PR, commit status fires but
  no comment-write occurs.
- \`test_latest_run_writes_comment_normally\` — the new guard
  short-circuits only stale runs; the latest run writes the comment as
  before.

## Verification

\`make test\` — 1716 passed (1714 prior + the 2 added here).