### PR TITLE
fix(semgrep): scope sync-in-coroutine rules to async def bodies

### DIFF
--- a/pentest/semgrep/.semgrep.yml
+++ b/pentest/semgrep/.semgrep.yml
@@ -86,8 +86,22 @@ rules:
   # blocking I/O inside an `async def` freezes the whole replica — including
   # /health and /ready probes — until it yields. See issue #231.
 
+  # All five rules below restrict matches to call sites INSIDE an `async def`
+  # body (via `pattern-inside`) AND NOT inside a nested sync `def` (via
+  # `pattern-not-inside`). Without these guards the rule fires on every
+  # tarfile/subprocess/etc. call anywhere in `services/terrapod/`, including
+  # sync helpers that are correctly invoked via `asyncio.to_thread(...)` —
+  # producing noise (and false-positive code-scanning alerts) for code that
+  # already follows the rule. Issue #231 is specifically about blocking the
+  # event loop, which can only happen when the call runs directly on it.
   - id: terrapod-no-sync-tarfile-in-coroutine
     patterns:
+      - pattern-inside: |
+          async def $F(...):
+            ...
+      - pattern-not-inside: |
+          def $G(...):
+            ...
       - pattern-either:
           - pattern: tarfile.open(...)
           - pattern: zipfile.ZipFile(...)
@@ -106,6 +120,12 @@ rules:
 
   - id: terrapod-no-sync-pgpy-in-coroutine
     patterns:
+      - pattern-inside: |
+          async def $F(...):
+            ...
+      - pattern-not-inside: |
+          def $G(...):
+            ...
       - pattern-either:
           - pattern: pgpy.PGPKey.new(...)
           - pattern: pgpy.PGPKey.from_blob(...)
@@ -126,6 +146,12 @@ rules:
 
   - id: terrapod-no-sync-pbkdf2-in-coroutine
     patterns:
+      - pattern-inside: |
+          async def $F(...):
+            ...
+      - pattern-not-inside: |
+          def $G(...):
+            ...
       - pattern: hashlib.pbkdf2_hmac(...)
     paths:
       include:
@@ -142,6 +168,12 @@ rules:
 
   - id: terrapod-no-sync-sleep-in-coroutine
     patterns:
+      - pattern-inside: |
+          async def $F(...):
+            ...
+      - pattern-not-inside: |
+          def $G(...):
+            ...
       - pattern: time.sleep(...)
     paths:
       include:
@@ -157,6 +189,12 @@ rules:
 
   - id: terrapod-no-sync-subprocess-in-coroutine
     patterns:
+      - pattern-inside: |
+          async def $F(...):
+            ...
+      - pattern-not-inside: |
+          def $G(...):
+            ...
       - pattern-either:
           - pattern: subprocess.run(...)
           - pattern: subprocess.Popen(...)

--- a/services/tests/services/test_vcs_status_dispatcher.py
+++ b/services/tests/services/test_vcs_status_dispatcher.py
@@ -228,10 +228,10 @@ class TestSupersededRunComment:
         session.get.side_effect = _get
 
         class _Ctx:
-            async def __aenter__(self_inner):
+            async def __aenter__(self):
                 return session
 
-            async def __aexit__(self_inner, *a):
+            async def __aexit__(self, *a):
                 return False
 
         with (
@@ -325,10 +325,10 @@ class TestSupersededRunComment:
         session.get.side_effect = _get
 
         class _Ctx:
-            async def __aenter__(self_inner):
+            async def __aenter__(self):
                 return session
 
-            async def __aexit__(self_inner, *a):
+            async def __aexit__(self, *a):
                 return False
 
         # _find_or_create_comment uses Redis; stub it out wholesale rather


### PR DESCRIPTION
Resolves the open security/code-scanning alerts on
https://github.com/mattrobinsonsre/terrapod/security/code-scanning.

## Code-scanning errors (5 — false positives, fixed by tightening the rule)

The five \`*-in-coroutine\` Semgrep rules in \`pentest/semgrep/.semgrep.yml\`
(tarfile, pgpy, pbkdf2, sleep, subprocess) were over-broad: they fired on
every call site of the gated function anywhere under
\`services/terrapod/\`, regardless of whether the enclosing def was
\`async def\` or a plain \`def\`. Sync helpers correctly invoked via
\`asyncio.to_thread(...)\` were flagged even though they cannot block
the event loop.

The five flagged sites — all sync \`def\` helpers, all called from async
via \`to_thread\`:

| Alert | Loc | Function | Called via |
|---|---|---|---|
| #163 | \`policy_vcs_poller.py:68\` | \`_extract_rego_files\` | \`to_thread\` at L171 |
| #164 | \`module_hcl_parser.py:44\` | \`_read_root_tf_files\` | \`to_thread\` |
| #166 | \`summariser.py:114\` | \`_extract_tf_sources\` | \`to_thread\` at L381 |
| #168 | \`summariser.py:207\` | \`_extract_tf_files_to_dir\` | \`to_thread\` chain |
| #169 | \`summariser.py:262\` | \`_build_code_diff\` (subprocess.run inside) | \`to_thread\` at L399 |

The bug those rules exist to catch (#231 — sync I/O on the event loop)
cannot exist in any of those files.

**Fix**: add \`pattern-inside: async def $F(...): ...\` and a
\`pattern-not-inside: def $G(...): ...\` guard to all five rules, so a
match must be inside an \`async def\` body AND not inside a nested sync
\`def\`. The rules continue to catch the real bug class without flagging
the \`to_thread\`-wrapped pattern.

## Code-scanning notes (4 — cosmetic)

Renames \`self_inner\` → \`self\` in two nested \`_Ctx\` async context
managers in \`test_vcs_status_dispatcher.py\` to silence
\`py/not-named-self\` notes (#170–173). The nested-scope shadowing that
motivated \`self_inner\` is harmless in Python; matching PEP-8 is
cheaper than carrying the warning.

## Dependabot (2 — won't-fix, dismissing in UI)

Both open Dependabot alerts are already-documented won't-fix cases:

- **litellm CVE-2026-40217** (#14, high): proxy-mode sandbox escape.
  Terrapod uses litellm as a library via \`acompletion()\` and never
  starts the proxy. Patched versions pin Python <3.14; the API image
  is on 3.14, so we can't bump the lower bound until upstream
  restores 3.14 compatibility.
- **python-dotenv CVE-2026-28684** (#13, medium): symlink follow in
  \`set_key()\` / \`unset_key()\`. Terrapod and its direct deps never
  call those write APIs — we only \`load_dotenv()\` / read
  \`os.environ\`.

Both already carry rationale comments and \`--ignore-vuln\` entries in
\`.github/workflows/ci.yml\` (lines 256–276). Dismissing the
Dependabot UI alerts separately after this merges (admin action,
not codeable).

## Verification

\`make test\` — 1716 passed, identical baseline. \`self_inner\` →
\`self\` is inert; Semgrep rule change is a tightening (rules can
only match fewer sites now, never more).