### PR TITLE
fix(ui): only append log-stream ETX when serving from storage

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1617,12 +1617,24 @@ async def _serve_log(
     1. Object storage (authoritative — final log uploaded by Job on completion)
     2. Redis live stream (live-streamed data from listener during execution)
     3. Empty response (no data available yet — client retries)
+
+    ETX (end-of-log sentinel that tells the UI to stop polling) is appended
+    ONLY when the data came from object storage. The Redis live-stream
+    snapshot is inherently incomplete — the runner uploads the
+    authoritative log to storage from its EXIT trap, which fires AFTER it
+    POSTs plan-result and the run transitions to terminal. If we appended
+    ETX on the Redis path the moment `phase_done` flipped true, the UI
+    would stop polling before the EXIT trap landed the trailing bytes
+    (typically the entrypoint's `PLAN_HAS_CHANGES=...` line and post-plan
+    OPA output). The user then has to refresh to see the tail.
     """
     storage = get_storage()
     phase_done = run.status in phase_complete_states
+    from_storage = False
 
     try:
         data = await storage.get(log_key)
+        from_storage = True
     except ObjectNotFoundError:
         # Try live-streamed data from Redis (available for both in-progress
         # and recently-completed runs where the Job didn't upload final logs)
@@ -1636,7 +1648,8 @@ async def _serve_log(
                     live_data = live_data.encode()
                 data = live_data
             elif phase_done:
-                # Phase finished, no log in storage or Redis — empty stream
+                # Phase finished and neither storage nor Redis has anything —
+                # nothing more is ever coming. Send ETX so the UI gives up.
                 return Response(content=_STX + _ETX, media_type="text/plain")
             else:
                 # Still running, no log yet — return empty (client retries)
@@ -1657,7 +1670,10 @@ async def _serve_log(
     if offset == 0:
         result += _STX
     result += chunk
-    # Append ETX if phase is done and this is the last chunk
-    if phase_done and (limit == 0 or offset + limit >= len(data)):
+    # Append ETX only when serving from storage (authoritative final log)
+    # AND the client has consumed everything. Redis-served data can be a
+    # mid-flight snapshot even when phase_done is true; closing the stream
+    # there truncates the visible log.
+    if from_storage and phase_done and (limit == 0 or offset + limit >= len(data)):
         result += _ETX
     return Response(content=result, media_type="text/plain")


### PR DESCRIPTION
## Symptom

Plan Output panel (and any other consumer of \`/plans/{id}/log\` /
\`/applies/{id}/log\`) intermittently truncates the tail of the log —
typically the entrypoint's \`[entrypoint] PLAN_HAS_CHANGES=...\` line
and any post-plan OPA output — until the user hits **Refresh**.

Example: Plan completed at 14:31:46, screenshot taken at 14:35, log
truncated at \`PLAN_HAS_CHANGES=true\`. Hard refresh shows the full
trailing content.

## Root cause

\`_serve_log\` falls back from object storage to the Redis live-stream
snapshot when storage misses. Both paths fell through to the same
ETX-append: ETX (the end-of-log sentinel that tells the UI to stop
polling) was appended whenever \`phase_done\` was true, regardless of
where the data came from.

But the Redis snapshot is inherently mid-flight — the runner uploads
the authoritative final log to storage from its EXIT trap, which
fires **after** it POSTs \`plan-result\` and the run transitions to
terminal. Sequence:

1. Runner emits \`[entrypoint] PLAN_HAS_CHANGES=true\` to stdout.
2. Listener's last \`stream_logs\` cycle may or may not have captured
   that line into Redis.
3. Runner POSTs \`plan-result\` → API transitions run to phase-complete.
4. UI polls. Storage miss (EXIT trap hasn't fired yet) → falls
   through to Redis → returns whatever's in Redis **plus ETX**.
5. UI sees ETX, stops polling.
6. EXIT trap fires, uploads the complete log to storage — UI never
   sees it because it stopped.

## Fix

Track whether the response data came from object storage. Append ETX
only on the storage path. The Redis path keeps the stream open so
the UI continues polling until storage lands. The pre-existing
\"storage miss + Redis miss + phase_done\" branch still sends ETX
(correct — nothing more is ever coming for that case).

Net change: 5 lines (track \`from_storage\`, gate the ETX append on
it). Docstring expanded to record the reasoning.

## Verification

\`make test\` — 1716 passed. The path-difference is small enough that
the existing test suite covers the regression surface; no new tests
added.