### PR TITLE
fix(summariser): require non-empty risk_factors at elevated risk_level

### DIFF
--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -873,6 +873,21 @@ async def handle_ai_plan_summary(payload: dict) -> None:
         if not isinstance(risk_factors, list):
             risk_factors = []
 
+        # Telemetry for the prompt rule "empty risk_factors is acceptable
+        # ONLY when risk_level == low". The schema enforces presence but
+        # not non-emptiness, and constrained decoding can't express the
+        # conditional, so the model occasionally returns an elevated
+        # risk_level with no enumerated factors. Log it so we can see how
+        # often the prompt-level guard fails — no auto-repair yet.
+        if risk_level != "low" and not risk_factors:
+            logger.warning(
+                "summariser.risk_factors_empty_at_elevated_level",
+                run_id=str(run_id),
+                kind=kind,
+                risk_level=risk_level,
+                model=cfg.model,
+            )
+
         await _upsert_summary(
             db,
             run_id=run_id,

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -201,6 +201,12 @@ Other rules:
   • Risk severities are about blast radius and reversibility, not
     novelty. Destroying a Lambda is medium. Destroying a database or
     an IAM trust root is critical. Pure additions are low.
+  • If `risk_level` is `medium`, `high`, or `critical`, `risk_factors`
+    MUST contain at least one entry naming what makes it elevated.
+    An empty `risk_factors` array is permitted ONLY when
+    `risk_level == "low"`. If you cannot name a concrete factor, the
+    correct `risk_level` is `low` — do not return an elevated level
+    with an empty factor list.
 
 Style:
   • Operator-facing, terse, professional. No emojis. No first-person

--- a/services/tests/services/test_summariser_prompt.py
+++ b/services/tests/services/test_summariser_prompt.py
@@ -193,6 +193,23 @@ def test_code_diff_described_in_skill_prompt():
     assert "resource_drift" in system
 
 
+def test_plan_summary_skill_forbids_empty_risk_factors_at_elevated_level():
+    """The prompt MUST state that an empty risk_factors array is
+    permitted only when risk_level == "low". The JSON Schema can't
+    express this conditional, and constrained decoding doesn't enforce
+    it, so the prompt is the only place this rule lives. Violations
+    have been observed in production: a plan with mixed in-place
+    updates returned `risk_level: medium` with `risk_factors: []`.
+    """
+    skill = PLAN_SUMMARY_SKILL_PROMPT
+    # The rule names all three elevated levels explicitly so the model
+    # can't pattern-match on "medium" alone and ignore the others.
+    assert "`medium`, `high`, or `critical`" in skill
+    # And the empty-array carve-out is bound to risk_level == "low".
+    assert "empty `risk_factors` array is permitted ONLY when" in skill
+    assert '`risk_level == "low"`' in skill
+
+
 def test_failure_analysis_skill_also_describes_code_diff():
     """Failure analysis benefits from CODE_DIFF too — the recent change
     is the most likely cause of a new failure.


### PR DESCRIPTION
## Summary

The AI plan-summary's JSON schema enforces that `risk_factors` is *present*, but neither the schema nor constrained tool-call decoding can express *non-empty when `risk_level != "low"`* — that rule lived only as inline guidance in a schema field description, which the model can (and does) ignore.

**Observed in production:** a plan with mixed in-place updates produced `risk_level: "medium"` with `risk_factors: []`. The UI renders the risk pill correctly but no factor list, leaving the operator with the severity rating and no enumerated reasons.

This PR closes the gap in three places:

- **Prompt** — promotes the constraint from schema-field guidance to a hard rule in `PLAN_SUMMARY_SKILL_PROMPT`'s "Other rules" block, names all three elevated levels explicitly, and instructs the model to downgrade to `low` rather than return an elevated level with no factors.
- **Telemetry** — adds a `summariser.risk_factors_empty_at_elevated_level` warning log in `handle_ai_plan_summary` so we can see how often the prompt-level guard fails. No auto-repair yet; if the rate stays high after this change, follow up with a retry-once loop.
- **Test** — asserts the new rule text appears in the prompt, so a future refactor of the prompt body can't silently drop it.

### Why not a JSON Schema `if/then`?

Constrained-decoding support for conditional schemas varies across providers (Bedrock Converse, Anthropic direct, OpenAI, Gemini) — the enforcement would silently no-op on some routes. The prompt change is universally applied.

### Why no auto-retry yet?

Sample size of one. Ship the prompt strengthening + observability, let the new warning log tell us whether the prompt change fixed it, and only add the retry/repair loop if violations remain common.

## Test plan

- [x] `make lint` passes (no new findings).
- [x] `make test` passes (1717 passed).
- [x] New unit test `test_plan_summary_skill_forbids_empty_risk_factors_at_elevated_level` asserts:
  - the prompt names `medium`, `high`, or `critical` explicitly;
  - the empty-array carve-out is bound to `risk_level == "low"`.
- [ ] After release: observe `summariser.risk_factors_empty_at_elevated_level` log rate in production. If it stays >0, follow up with a repair loop.

## Release

Intended as a patch release (`v0.X.Z+1`). Per CLAUDE.md the patch audit is lighter; this change is non-destructive (summariser-only, no infrastructure mutation), so step F (live behavioural smoke) is not required. Step D (internal-reference leak scan) — neither the diff nor commit/PR text references any internal identifiers.