### PR TITLE
fix(runs): publish log_updated SSE on final artifact upload

### DIFF
--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -59,6 +59,38 @@ async def _get_run(run_id: str, db: AsyncSession) -> Run:
     return run
 
 
+async def _publish_log_updated(workspace_id: str, run_id: str, phase: str) -> None:
+    """Notify the UI that a fresh log artifact landed in storage.
+
+    The runner's EXIT trap uploads the authoritative final log to storage
+    AFTER it POSTs plan-result / apply-result and the run has already
+    transitioned to a terminal state. Without this notification the UI
+    sits on the last Redis-snapshot it fetched mid-flight: `_serve_log`
+    correctly omits ETX on the Redis path so polling stays open, but the
+    UI only triggers a re-fetch when a `log_updated` event arrives. The
+    mid-flight listener `upload_log_stream` emits one per chunk; without
+    a corresponding emit here, the trailing bytes from the EXIT trap are
+    invisible until the user hits Refresh.
+    """
+    try:
+        from terrapod.redis.client import RUN_EVENTS_PREFIX, publish_event
+
+        payload = json.dumps(
+            {
+                "event": "log_updated",
+                "run_id": run_id,
+                "workspace_id": workspace_id,
+                "phase": phase,
+            }
+        )
+        await publish_event(f"{RUN_EVENTS_PREFIX}{workspace_id}", payload)
+    except Exception:
+        # Match upload_log_stream: SSE publishing failures must never break
+        # an in-flight artifact upload. Worst case we fall back to the old
+        # behaviour (UI waits until next event or manual refresh).
+        logger.debug("Failed to publish log_updated after artifact upload")
+
+
 # ── Downloads (302 redirect to presigned GET URL) ────────────────────────
 
 
@@ -167,6 +199,7 @@ async def upload_plan_log(
     storage = get_storage()
     key = plan_log_key(str(run.workspace_id), str(run.id))
     await storage.put(key, body)
+    await _publish_log_updated(str(run.workspace_id), str(run.id), "plan")
     return Response(status_code=204)
 
 
@@ -296,6 +329,7 @@ async def upload_apply_log(
     storage = get_storage()
     key = apply_log_key(str(run.workspace_id), str(run.id))
     await storage.put(key, body)
+    await _publish_log_updated(str(run.workspace_id), str(run.id), "apply")
     return Response(status_code=204)
 
 

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -444,3 +444,115 @@ class TestLockFile:
         mock_storage.presigned_get_url.assert_awaited_once_with(
             f"plans/{ws_id}/{run_id}.terraform.lock.hcl"
         )
+
+
+# ── upload_plan_log / upload_apply_log — log_updated SSE publish ──────
+
+
+class TestLogUploadPublishesEvent:
+    """Final log uploads from the runner's EXIT trap MUST publish a
+    `log_updated` SSE event. Otherwise the UI — which only re-fetches
+    on `log_updated` — sits on its last Redis-snapshot polled
+    mid-flight and never picks up the trailing bytes that storage now
+    holds (PR #424's symptom: `[entrypoint] PLAN_HAS_CHANGES=true` and
+    post-plan OPA lines missing until refresh).
+
+    The companion server-side fix (PR #423) already keeps the stream
+    open by withholding ETX on the Redis path; this event is the
+    matching nudge that makes the UI come back for the tail.
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.redis.client.publish_event", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_plan_log_upload_publishes_log_updated(
+        self, mock_get_storage, mock_publish, *_mocks
+    ):
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-log",
+                content=b"final plan log bytes",
+                headers={**_AUTH, "Content-Type": "text/plain"},
+            )
+
+        assert resp.status_code == 204
+        mock_publish.assert_awaited_once()
+        channel, payload = mock_publish.await_args.args
+        assert channel == f"tp:run_events:{ws_id}"
+        body = json.loads(payload)
+        assert body == {
+            "event": "log_updated",
+            "run_id": str(run_id),
+            "workspace_id": str(ws_id),
+            "phase": "plan",
+        }
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.redis.client.publish_event", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_apply_log_upload_publishes_log_updated(
+        self, mock_get_storage, mock_publish, *_mocks
+    ):
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/apply-log",
+                content=b"final apply log bytes",
+                headers={**_AUTH, "Content-Type": "text/plain"},
+            )
+
+        assert resp.status_code == 204
+        mock_publish.assert_awaited_once()
+        _, payload = mock_publish.await_args.args
+        body = json.loads(payload)
+        assert body["event"] == "log_updated"
+        assert body["phase"] == "apply"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.redis.client.publish_event", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_publish_failure_does_not_break_upload(
+        self, mock_get_storage, mock_publish, *_mocks
+    ):
+        """A Redis publish error must NOT fail the artifact upload —
+        the log file has already landed in storage; the worst case is
+        the UI falls back to its pre-fix behaviour (refresh-required).
+        Matches the same try/except guarantee in `upload_log_stream`.
+        """
+        run_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+        mock_publish.side_effect = RuntimeError("redis is angry")
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-log",
+                content=b"x",
+                headers={**_AUTH, "Content-Type": "text/plain"},
+            )
+
+        assert resp.status_code == 204


### PR DESCRIPTION
## Summary

PR #423 stopped the UI from terminating the log poll prematurely (the Redis path no longer appends ETX), but the symptom — "plan output truncates at \`PLAN_HAS_CHANGES=...\` until I refresh" — still surfaces in production. Root cause is one layer up:

The runner's EXIT trap uploads the authoritative final log to object storage **after** it POSTs \`plan-result\` and the run has already transitioned. \`upload_plan_log\` / \`upload_apply_log\` write the file and return 204 — **without publishing any SSE event**. The UI's log-fetcher only re-polls when a \`log_updated\` event arrives (\`run/[runId]/page.tsx:372-375\`). The listener's mid-flight \`upload_log_stream\` emits one per chunk (\`runs.py:1426-1437\`); the final-log upload does not. Result: the UI sits on the last Redis-snapshot it fetched and never picks up the bytes that storage now holds.

## Fix

Extract the same publish pattern into \`_publish_log_updated\` and call it from both \`upload_plan_log\` and \`upload_apply_log\` after the \`storage.put\`. The publish is wrapped in try/except — matches the \`upload_log_stream\` guarantee that SSE plumbing failures never break an in-flight artifact upload.

## Test plan

- [x] \`make lint\` clean.
- [x] \`make test\` passes (1720 passed).
- [x] New \`TestLogUploadPublishesEvent\` class verifies:
  - plan-log upload publishes \`log_updated\` with the right channel + payload;
  - apply-log upload publishes with \`phase: apply\`;
  - a Redis publish exception does NOT fail the upload (204 still returned).
- [ ] After deploy: open a run with a long plan, wait for storage upload, confirm the trailing lines (\`PLAN_HAS_CHANGES=...\` etc.) appear in the UI without manual refresh.