### PR TITLE
fix(vcs): serialise per-PR comment create with a Redis mutex

### DIFF
--- a/services/terrapod/services/vcs_status_dispatcher.py
+++ b/services/terrapod/services/vcs_status_dispatcher.py
@@ -5,6 +5,7 @@ Receives {run_id, workspace_id, target_status} payloads and posts
 commit statuses and PR/MR comments back to the VCS provider.
 """
 
+import asyncio
 import uuid
 from datetime import UTC, datetime
 
@@ -17,6 +18,45 @@ from terrapod.logging_config import get_logger
 from terrapod.services import github_service, gitlab_service
 
 logger = get_logger(__name__)
+
+# Redis lua script for atomic lock release: only delete if we still own
+# it. Token comparison guards against deleting another worker's lock if
+# our TTL had already expired and they re-acquired in the gap.
+_LOCK_RELEASE_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then "
+    "return redis.call('del', KEYS[1]) else return 0 end"
+)
+_COMMENT_LOCK_PREFIX = "tp:vcs_comment_lock:"
+_COMMENT_LOCK_TTL = 10  # seconds — generous bound on a single create/update round-trip
+_COMMENT_LOCK_MAX_ATTEMPTS = 20  # × 0.1s = ~2s total wait
+_COMMENT_LOCK_INTERVAL = 0.1
+
+
+async def _acquire_comment_lock(redis, key: str) -> str | None:
+    """Bounded-retry SETNX lock. Returns the lock token on success, or
+    None if we couldn't acquire within the deadline.
+
+    The lock is keyed on (workspace_id, pr_number) — NOT on (run_id,
+    target_status). Two distinct triggers for the same PR (e.g. a
+    queued → planning flip producing two dedup-distinct enqueues)
+    contend on the same lock, so the find-or-create flow serialises
+    and only one comment is created on the first ever status post.
+    """
+    token = uuid.uuid4().hex
+    for _ in range(_COMMENT_LOCK_MAX_ATTEMPTS):
+        if await redis.set(key, token, nx=True, ex=_COMMENT_LOCK_TTL):
+            return token
+        await asyncio.sleep(_COMMENT_LOCK_INTERVAL)
+    return None
+
+
+async def _release_comment_lock(redis, key: str, token: str) -> None:
+    """Atomic release — only delete if the lock still carries our token."""
+    try:
+        await redis.eval(_LOCK_RELEASE_LUA, 1, key, token)
+    except Exception as e:
+        logger.debug("Failed to release PR comment lock", error=str(e))
+
 
 # Run status → (github_state, gitlab_state, description)
 _STATUS_MAP: dict[str, tuple[str, str, str]] = {
@@ -178,6 +218,15 @@ async def _find_or_create_comment(
     """Find an existing comment by marker, update it, or create a new one.
 
     Uses Redis cache for comment ID, falls back to listing comments.
+
+    Serialised across replicas via a (workspace_id, pr_number)-keyed
+    Redis mutex — without it, two triggers for the same PR (queued →
+    planning produces two dedup-distinct enqueues) race through the
+    cache-miss + list-miss + create branches and end up POSTing two
+    distinct comments. Once the first lands, subsequent updates use
+    the cached ID and edit the surviving comment, but the duplicate
+    sticks around forever. The lock confines the TOCTOU window to a
+    single worker on a single PR at a time.
     """
     from terrapod.redis.client import get_redis_client
 
@@ -185,62 +234,79 @@ async def _find_or_create_comment(
     cache_key = f"{_COMMENT_CACHE_PREFIX}{workspace_id}:{pr_number}"
     marker = _comment_marker(workspace_id)
 
-    # Try cached comment ID
-    cached_id = await redis.get(cache_key)
-    if cached_id:
-        comment_id = int(cached_id)
-        try:
-            if conn.provider == "gitlab":
-                await gitlab_service.update_mr_comment(
-                    conn, owner, repo, pr_number, comment_id, body
-                )
-            else:
-                await github_service.update_pr_comment(conn, owner, repo, comment_id, body)
-            await redis.set(cache_key, str(comment_id), ex=_COMMENT_CACHE_TTL)
-            return
-        except Exception:
-            # Cache stale — fall through to search
-            logger.debug("Cached comment ID stale, searching", comment_id=comment_id)
+    lock_key = f"{_COMMENT_LOCK_PREFIX}{workspace_id}:{pr_number}"
+    lock_token = await _acquire_comment_lock(redis, lock_key)
+    if lock_token is None:
+        # Another worker is mid-flight for this PR. The dispatcher is
+        # idempotent at the (workspace_id, pr_number, status) level —
+        # if our status is fresher, the next trigger for this PR will
+        # re-fire when the lock holder releases. Drop this update.
+        logger.warning(
+            "Could not acquire PR-comment lock; another worker is updating",
+            workspace_id=workspace_id,
+            pr_number=pr_number,
+        )
+        return
 
-    # Search for existing comment with marker
-    comment_id = None
     try:
-        if conn.provider == "gitlab":
-            comments = await gitlab_service.list_mr_comments(conn, owner, repo, pr_number)
-        else:
-            comments = await github_service.list_pr_comments(conn, owner, repo, pr_number)
+        # Try cached comment ID
+        cached_id = await redis.get(cache_key)
+        if cached_id:
+            comment_id = int(cached_id)
+            try:
+                if conn.provider == "gitlab":
+                    await gitlab_service.update_mr_comment(
+                        conn, owner, repo, pr_number, comment_id, body
+                    )
+                else:
+                    await github_service.update_pr_comment(conn, owner, repo, comment_id, body)
+                await redis.set(cache_key, str(comment_id), ex=_COMMENT_CACHE_TTL)
+                return
+            except Exception:
+                # Cache stale — fall through to search
+                logger.debug("Cached comment ID stale, searching", comment_id=comment_id)
 
-        for c in comments:
-            c_body = c.get("body", "")
-            if marker in c_body:
-                comment_id = c["id"]
-                break
-    except Exception as e:
-        logger.warning("Failed to list PR comments for marker search", error=str(e))
-
-    if comment_id:
-        # Update existing
+        # Search for existing comment with marker
+        comment_id = None
         try:
             if conn.provider == "gitlab":
-                await gitlab_service.update_mr_comment(
-                    conn, owner, repo, pr_number, comment_id, body
-                )
+                comments = await gitlab_service.list_mr_comments(conn, owner, repo, pr_number)
             else:
-                await github_service.update_pr_comment(conn, owner, repo, comment_id, body)
-            await redis.set(cache_key, str(comment_id), ex=_COMMENT_CACHE_TTL)
-            return
+                comments = await github_service.list_pr_comments(conn, owner, repo, pr_number)
+
+            for c in comments:
+                c_body = c.get("body", "")
+                if marker in c_body:
+                    comment_id = c["id"]
+                    break
         except Exception as e:
-            logger.warning("Failed to update PR comment", error=str(e))
+            logger.warning("Failed to list PR comments for marker search", error=str(e))
 
-    # Create new
-    try:
-        if conn.provider == "gitlab":
-            new_id = await gitlab_service.create_mr_comment(conn, owner, repo, pr_number, body)
-        else:
-            new_id = await github_service.create_pr_comment(conn, owner, repo, pr_number, body)
-        await redis.set(cache_key, str(new_id), ex=_COMMENT_CACHE_TTL)
-    except Exception as e:
-        logger.warning("Failed to create PR comment", error=str(e))
+        if comment_id:
+            # Update existing
+            try:
+                if conn.provider == "gitlab":
+                    await gitlab_service.update_mr_comment(
+                        conn, owner, repo, pr_number, comment_id, body
+                    )
+                else:
+                    await github_service.update_pr_comment(conn, owner, repo, comment_id, body)
+                await redis.set(cache_key, str(comment_id), ex=_COMMENT_CACHE_TTL)
+                return
+            except Exception as e:
+                logger.warning("Failed to update PR comment", error=str(e))
+
+        # Create new
+        try:
+            if conn.provider == "gitlab":
+                new_id = await gitlab_service.create_mr_comment(conn, owner, repo, pr_number, body)
+            else:
+                new_id = await github_service.create_pr_comment(conn, owner, repo, pr_number, body)
+            await redis.set(cache_key, str(new_id), ex=_COMMENT_CACHE_TTL)
+        except Exception as e:
+            logger.warning("Failed to create PR comment", error=str(e))
+    finally:
+        await _release_comment_lock(redis, lock_key, lock_token)
 
 
 async def handle_vcs_commit_status(payload: dict) -> None:

--- a/services/tests/services/test_vcs_status_dispatcher.py
+++ b/services/tests/services/test_vcs_status_dispatcher.py
@@ -1,10 +1,12 @@
 """Tests for VCS commit-status resolution — has-changes descriptions."""
 
+import asyncio
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from terrapod.db.models import VCSConnection
 from terrapod.services.vcs_status_dispatcher import (
     _build_comment_body,
     _resolve_status,
@@ -362,3 +364,123 @@ class TestSupersededRunComment:
             )
 
         mock_comment.assert_awaited_once()
+
+
+# ── _find_or_create_comment — race-on-first-status regression ─────────
+
+
+class _FakeRedis:
+    """Minimal in-memory async Redis stand-in for the comment dispatcher.
+
+    Supports the operations `_find_or_create_comment` exercises:
+      - `set(key, value, nx=bool, ex=int)` with the SETNX semantics the
+        lock relies on (returns False when nx=True and key exists)
+      - `get(key)`
+      - `delete(key)`
+      - `eval(script, numkeys, key, arg)` — the only script in play is
+        the CAS-release; emulate it directly rather than parsing Lua.
+    """
+
+    def __init__(self):
+        self._store: dict[str, str] = {}
+
+    async def set(self, key, value, *, nx=False, ex=None):
+        # Real redis-py awaits a TCP round-trip; yield to model that —
+        # otherwise asyncio.gather runs each coroutine to completion in
+        # one slice and the test can't actually exercise contention.
+        await asyncio.sleep(0)
+        if nx and key in self._store:
+            return False
+        self._store[key] = str(value)
+        return True
+
+    async def get(self, key):
+        await asyncio.sleep(0)
+        return self._store.get(key)
+
+    async def delete(self, key):
+        await asyncio.sleep(0)
+        self._store.pop(key, None)
+        return 1
+
+    async def eval(self, script, numkeys, key, arg):
+        # The only script we ever pass is the lock-release CAS:
+        # `if get(K)==ARG then del(K) else 0`. Emulate that contract;
+        # don't try to actually run the Lua.
+        await asyncio.sleep(0)
+        if self._store.get(key) == arg:
+            self._store.pop(key, None)
+            return 1
+        return 0
+
+
+class TestFindOrCreateCommentRaceFix:
+    """Two concurrent dispatchers for the same PR (e.g. queued → planning
+    flipping fast enough that both `vcs_commit_status` triggers run on
+    different scheduler replicas at the same moment) must produce exactly
+    ONE created comment. The (workspace_id, pr_number) Redis mutex
+    serialises the find-or-create flow so the second caller sees the
+    cached ID and updates, rather than racing through cache-miss +
+    list-miss + create. Regression for the duplicate-comment screenshot
+    on terrapod-config PR #31.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_status_creates_only_one_comment(self):
+        from terrapod.services import vcs_status_dispatcher as dispatcher
+
+        conn = MagicMock(spec=VCSConnection)
+        conn.provider = "github"
+        ws_id = "11111111-1111-1111-1111-111111111111"
+        owner, repo, pr_number = "markupai", "terrapod-config", 31
+
+        fake_redis = _FakeRedis()
+
+        # Empty repo: nothing in cache, no existing comments.
+        list_comments = AsyncMock(return_value=[])
+        # Each create returns a distinct id so we can prove only one fired.
+        create_calls: list[int] = []
+
+        async def _create(*args, **kwargs):
+            new_id = 1000 + len(create_calls)
+            create_calls.append(new_id)
+            return new_id
+
+        update_calls: list[int] = []
+
+        # Signature must match github_service.update_pr_comment exactly —
+        # the dispatcher invokes it as (conn, owner, repo, comment_id, body).
+        # A mismatched signature would raise TypeError, which the existing
+        # cache-stale except catches and silently falls through to the
+        # list+create path — so a wrong mock would mask the lock working.
+        async def _update(conn, owner, repo, comment_id, body):
+            update_calls.append(comment_id)
+
+        with (
+            patch(
+                "terrapod.redis.client.get_redis_client",
+                return_value=fake_redis,
+            ),
+            patch.object(dispatcher.github_service, "list_pr_comments", new=list_comments),
+            patch.object(dispatcher.github_service, "create_pr_comment", new=_create),
+            patch.object(dispatcher.github_service, "update_pr_comment", new=_update),
+        ):
+            # Two distinct status-flip bodies firing concurrently.
+            await asyncio.gather(
+                dispatcher._find_or_create_comment(
+                    conn, owner, repo, pr_number, ws_id, "body for queued"
+                ),
+                dispatcher._find_or_create_comment(
+                    conn, owner, repo, pr_number, ws_id, "body for planning"
+                ),
+            )
+
+        # The whole point: exactly one comment created, the other became an update.
+        assert len(create_calls) == 1, (
+            f"expected exactly 1 create, got {len(create_calls)}: {create_calls}"
+        )
+        assert len(update_calls) == 1, (
+            f"expected exactly 1 update on the cached id, got {update_calls}"
+        )
+        # And the update targeted the freshly-created comment, not a phantom one.
+        assert update_calls[0] == create_calls[0]


### PR DESCRIPTION
## Symptom

Live screenshot from terrapod-config PR #31: two \`Terrapod — terrapod-config\` comments with identical \`Updated 2026-06-02T16:09:42Z\` timestamps. First says "Waiting for runner", second says "Plan in progress". Distinct comments, both pointing at the same run id. Subsequent status updates only edit one of them (the cached id); the other sticks around forever.

## Root cause

A run flipping fast between statuses (e.g. \`queued\` → \`planning\` within the same scheduler tick) produces **two distinct \`vcs_commit_status\` triggers** — \`_enqueue_vcs_status\` dedups on \`vcs_status:<run_id>:<target_status>\`, and different statuses give different keys (correctly — later status must propagate). The distributed scheduler dispatches them concurrently across replicas.

Inside \`_find_or_create_comment\`, both dispatchers then:

1. Check Redis cache for the comment id — empty on the first ever status post for this PR.
2. List PR comments looking for the marker — no marker yet.
3. Fall through to "Create new" and POST to GitHub/GitLab — **two distinct comments**.
4. Race to cache their respective new ids; last writer wins.

## Fix

Redis SETNX mutex keyed on \`(workspace_id, pr_number)\` wrapped around the entire find-or-create flow. Bounded ~2 s retry; the loser bails out (the next event will refresh). Release uses a CAS Lua script so a slow caller can't accidentally delete a successor's lock after its own TTL has expired.

The mutex scope is deliberately wider than per-trigger dedup — the dedup keys (one per status) are correct; the find-or-create flow itself just isn't safe to interleave.

## Test plan

- [x] \`make lint\` clean.
- [x] \`make test\` passes (1718 passed — up by one from the new test).
- [x] New \`TestFindOrCreateCommentRaceFix.test_concurrent_first_status_creates_only_one_comment\` runs two concurrent \`_find_or_create_comment\` calls against a fake Redis with \`asyncio.sleep(0)\` modelling real I/O yields, asserts exactly **one** \`create\` and one \`update\` on the cached id (rather than two creates).
- [ ] After deploy: open a fresh PR against a Terrapod-watched repo, confirm only one bot comment is created on the first status post.

## Notes

- An earlier version of the test mocked \`update_pr_comment\` with a mismatched signature; the existing \`except\` inside the cache-hit branch caught the resulting \`TypeError\` as "cache stale" and fell through to the create path, making the lock look broken. The mock now matches \`github_service.update_pr_comment\`'s real signature \`(conn, owner, repo, comment_id, body)\` and the test stays honest. Inline comment in the test calls this out so a future copy-paste doesn't reintroduce the silent-failure mode.