### PR TITLE
fix(runs): canceling intermediate state — cancel-while-applying must honour reality

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -688,7 +688,9 @@ def _plan_status(run: Run) -> str:
         return "pending"
     if s == "planning":
         return "running"
-    if s in ("planned", "confirmed", "applying", "applied"):
+    if s in ("planned", "confirmed", "applying", "canceling", "applied"):
+        # `canceling` only arises from `applying`, by which point the
+        # plan phase is finished — report it accordingly.
         return "finished"
     if s == "errored":
         # Errored during plan phase (plan never finished)
@@ -707,7 +709,10 @@ def _apply_status(run: Run) -> str:
         return "unreachable"
     if s == "confirmed":
         return "pending"
-    if s == "applying":
+    if s in ("applying", "canceling"):
+        # `canceling` is "apply is in flight and being killed". From the
+        # phase-status view it's still running until the reconciler
+        # resolves it to a terminal.
         return "running"
     if s == "applied":
         return "finished"

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -81,7 +81,16 @@ async def reconcile_runs() -> None:
        this cohort so failures surface in minutes, not hours.
     """
     async with get_db_session() as db:
-        result = await db.execute(select(Run).where(Run.status.in_(["planning", "applying"])))
+        # `canceling` joins planning/applying here: it's the intermediate
+        # state entered when a user cancels an in-flight apply. The
+        # reconciler waits for the listener's Job-status report (the
+        # listener deletes the K8s Job on receiving cancel_job; the next
+        # check_job_status reports "deleted") and then resolves the
+        # canceling run to applied/canceled/errored based on whether a
+        # state-version was actually uploaded.
+        result = await db.execute(
+            select(Run).where(Run.status.in_(["planning", "applying", "canceling"]))
+        )
         runs = list(result.scalars().all())
 
         if not runs:
@@ -104,6 +113,8 @@ async def _reconcile_one(db: AsyncSession, run: Run) -> None:
     """Reconcile a single run."""
     from terrapod.redis.client import get_job_status_from_redis, publish_listener_event
 
+    # `canceling` was entered from `applying`, so the Job that may need
+    # resolution is the apply Job — `phase` follows the same mapping.
     phase = "plan" if run.status == "planning" else "apply"
 
     # If no Job has been launched yet (listener never POSTed job-launched),
@@ -150,6 +161,18 @@ async def _reconcile_one(db: AsyncSession, run: Run) -> None:
 
     if status == "running":
         return  # Still running, no-op
+
+    # `canceling` resolution is keyed on the Job-completion signal AND
+    # whether a state-version was uploaded by this run; both branches
+    # of the normal-path handlers (succeeded → applied, failed →
+    # errored) would skip the StateVersion check and the
+    # state_diverged signalling.
+    if run.status == "canceling":
+        from terrapod.services import run_service
+
+        await _persist_live_log_if_missing(run, phase)
+        await run_service.resolve_canceling_run(db, run, job_status=status)
+        return
 
     if status == "succeeded":
         await _handle_succeeded(db, run)

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -39,11 +39,45 @@ VALID_TRANSITIONS: dict[str, set[str]] = {
     # constraint anyway). The reconciler short-circuits to applied
     # without launching a Job.
     "planned": {"confirmed", "applied", "discarded", "errored", "canceled"},
-    "confirmed": {"applying", "errored", "canceled"},
-    "applying": {"applied", "errored", "canceled"},
+    # `confirmed → canceled` stays valid: the listener hasn't claimed
+    # the run yet (the claim is atomic with `confirmed → applying`),
+    # so there is no Job in flight to wait on. The cancel route picks
+    # `canceled` for this branch.
+    "confirmed": {"applying", "canceling", "canceled", "errored"},
+    # `applying → canceled` is intentionally NOT included. Once an
+    # apply Job is in flight, a cancel goes through `canceling` so the
+    # reconciler can resolve the terminal from observable Job outcome
+    # (state-version present → applied; clean kill → canceled;
+    # otherwise → errored).
+    "applying": {"applied", "canceling", "errored"},
+    # `canceling` is the intermediate status entered when a user cancels
+    # a run that may have already launched (or be in the middle of) an
+    # apply Job. We send the runner a cancel_job event but the Job's
+    # actual terminal outcome decides this run's final status:
+    #
+    #   - state-version uploaded for this run → applied
+    #       (apply landed; we cannot say "canceled" without lying about
+    #       reality. Bookkeeping follows state, never the other way.)
+    #   - Job ended with no state-version → canceled, and the workspace's
+    #       state_diverged flag is set so the operator knows real infra
+    #       may have moved without a state record.
+    #   - Job errored without a state-version → errored.
+    #
+    # Pre-execution cancels (pending/queued/planning/planned/confirmed)
+    # still go straight to `canceled` — no apply Job has run yet, so
+    # there's no possible mid-apply outcome to honour.
+    "canceling": {"canceled", "applied", "errored"},
 }
 
 TERMINAL_STATES = {"applied", "errored", "discarded", "canceled"}
+# Statuses that mean a Job has not yet started any infra mutation.
+# Cancelling from any of these can go straight to `canceled` — the
+# canceling-intermediate state is only required when an apply Job
+# may be mid-mutation. `planning` is a pure read; killing it doesn't
+# affect infra. `confirmed` has been picked up logically but the
+# listener has not yet transitioned it to `applying` and launched
+# the Job (that's atomic in claim_next_run).
+PRE_EXECUTION_STATES = frozenset({"pending", "queued", "planning", "planned", "confirmed"})
 
 
 async def _enqueue_notification(run: Run, target_status: str) -> None:
@@ -838,17 +872,161 @@ async def cancel_run(db: AsyncSession, run: Run, *, force: bool = False) -> Run:
     Pass `force=True` to bypass that check — only for internal callers
     that need to cancel superseded `planned` runs as part of cleanup.
     Terminal states are always rejected.
+
+    Behaviour by source state:
+
+      - `applying` → `canceling`. The Job may already be mid-apply.
+        Workspace stays locked. We publish `cancel_job` so the listener
+        deletes the K8s Job, but we DO NOT prejudge the terminal status
+        — the reconciler resolves canceling → applied / canceled /
+        errored based on whether a state-version was uploaded for this
+        run (see [resolve_canceling_run] in run_reconciler.py). If
+        infra mutated, the truth (applied) wins over the cancel intent.
+
+      - Anything else in CANCELABLE_STATES → `canceled` directly. No
+        apply Job has launched, so there is no possible mid-apply
+        outcome to honour. Workspace is unlocked immediately and a
+        `cancel_job` event is still published (the listener may have a
+        plan-phase Job running; killing it is cheap and correct).
     """
     if run.status in TERMINAL_STATES:
         raise ValueError(f"Cannot cancel run in terminal state '{run.status}'")
     if not force and run.status not in CANCELABLE_STATES:
         raise ValueError(f"Cannot cancel run in state '{run.status}'")
-    # Unlock workspace
-    workspace = await db.get(Workspace, run.workspace_id)
-    if workspace and workspace.locked:
-        workspace.locked = False
-        workspace.lock_id = None
-    return await transition_run(db, run, "canceled")
+
+    # Choose the target status. `applying` is the only state where a
+    # Job may already be mutating real infrastructure; everything else
+    # is safe to mark terminal-canceled immediately.
+    if run.status == "applying":
+        target = "canceling"
+    else:
+        target = "canceled"
+
+    # Workspace lock only releases on terminal transition. Holding it
+    # through `canceling` prevents a fresh run from racing the still-
+    # running apply Job and stomping its state upload.
+    if target == "canceled":
+        workspace = await db.get(Workspace, run.workspace_id)
+        if workspace and workspace.locked:
+            workspace.locked = False
+            workspace.lock_id = None
+
+    # Tell the listener to delete the K8s Job, best-effort. Publish
+    # before transitioning so a same-tick run_status_change observer
+    # sees the cancel intent reflected when it polls. The publish path
+    # is wrapped — SSE plumbing failures must never break the cancel.
+    await _publish_cancel_job(run)
+
+    return await transition_run(db, run, target)
+
+
+async def resolve_canceling_run(db: AsyncSession, run: Run, *, job_status: str) -> Run:
+    """Pick the terminal status for a `canceling` run from observable reality.
+
+    Called by the reconciler when a Job-completion signal (`succeeded`,
+    `failed`, or `deleted`) lands for a run that the user previously
+    asked to cancel mid-`applying`.
+
+    Ground truth for "did the apply land?" is whether a StateVersion was
+    uploaded for this run_id — state-version creation is the runner's
+    last act after a successful (or partially successful) apply, and
+    Terrapod **never** rejects a state upload based on tracking status
+    (see the cancel-zombie design note: tracking must follow reality,
+    not the other way around). Outcomes:
+
+      - State exists → `applied`. Apply landed before the kill, or
+        completed naturally before the cancel arrived. We can't claim
+        the run was canceled when real infra changed and we recorded
+        the change.
+      - `job_status == "deleted"` (listener killed the Job) and no
+        state → `canceled`. Workspace `state_diverged` is set: in the
+        worst case, tofu apply was already mid-mutation when SIGKILL
+        landed, so real resources may have changed without a state
+        record. The flag is the existing operator-visible drift
+        signal; it's how the runner entrypoint reports failed state
+        uploads, and it interacts correctly with retention sweeps.
+      - Anything else (Job `failed` with no state, or any unrecognised
+        terminal) → `errored`. Workspace `state_diverged` set for the
+        same drift-warning reason.
+    """
+    if run.status != "canceling":
+        return run
+
+    from terrapod.db.models import StateVersion
+
+    sv_result = await db.execute(select(StateVersion).where(StateVersion.run_id == run.id).limit(1))
+    state_uploaded = sv_result.scalar_one_or_none() is not None
+
+    if state_uploaded:
+        run = await transition_run(db, run, "applied")
+        target = "applied"
+    elif job_status == "deleted":
+        run = await transition_run(db, run, "canceled")
+        target = "canceled"
+    else:
+        run = await transition_run(
+            db,
+            run,
+            "errored",
+            error_message=(
+                f"Run canceled mid-apply; Job ended with status "
+                f"{job_status!r} and no state-version was uploaded."
+            ),
+        )
+        target = "errored"
+
+    # Workspace lock + drift bookkeeping. Lock releases on any terminal
+    # exit from `canceling`. state_diverged is set on the non-applied
+    # exits because we can't tell from here whether tofu apply ran any
+    # of its planned mutations before the kill signal landed.
+    ws = await db.get(Workspace, run.workspace_id)
+    if ws:
+        if ws.locked:
+            ws.locked = False
+            ws.lock_id = None
+        if target != "applied":
+            ws.state_diverged = True
+
+    logger.info(
+        "Canceling run resolved",
+        run_id=str(run.id),
+        terminal=target,
+        state_uploaded=state_uploaded,
+        job_status=job_status,
+    )
+    return run
+
+
+async def _publish_cancel_job(run: Run) -> None:
+    """Send a `cancel_job` SSE event to the pool's listeners.
+
+    The reconciler's check_job_status / stream_logs events publish on
+    `tp:listener_events:<pool_id>`; the listener consumes them via its
+    SSE loop. `cancel_job` follows the same channel so the same
+    listener that claimed the run (or any listener in the pool — they
+    can all answer cancellation, since the K8s Job is named on the
+    run row and the listener has cluster-wide CRUD on Jobs in the
+    runner namespace) deletes the Job promptly.
+
+    No-op when there's no Job (`run.job_name` empty / null) or no pool
+    (`run.pool_id` null) — that means the cancel landed before claim
+    + Job-launch, and there's nothing for a listener to do.
+    """
+    if not run.pool_id or not getattr(run, "job_name", None):
+        return
+    try:
+        from terrapod.redis.client import LISTENER_EVENTS_PREFIX, publish_event
+
+        payload = json.dumps(
+            {
+                "event": "cancel_job",
+                "run_id": str(run.id),
+                "job_name": run.job_name,
+            }
+        )
+        await publish_event(f"{LISTENER_EVENTS_PREFIX}{run.pool_id}", payload)
+    except Exception as e:
+        logger.warning("Failed to publish cancel_job event", error=str(e), run_id=str(run.id))
 
 
 async def get_run(db: AsyncSession, run_id: uuid.UUID) -> Run | None:

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -86,8 +86,17 @@ class TestCanTransition:
         assert can_transition("applying", "applied") is True
 
     def test_any_non_terminal_to_canceled(self):
-        for state in ["pending", "queued", "planning", "planned", "confirmed", "applying"]:
+        # `applying` is intentionally excluded: cancel-while-applying
+        # routes through `canceling` and the reconciler picks the
+        # terminal from observable Job outcome (state-version present
+        # → applied; clean kill → canceled; otherwise → errored). The
+        # direct `applying → canceled` path is closed because it would
+        # silently mark a run "canceled" while real infra may have
+        # changed.
+        for state in ["pending", "queued", "planning", "planned", "confirmed"]:
             assert can_transition(state, "canceled") is True
+        assert can_transition("applying", "canceling") is True
+        assert can_transition("applying", "canceled") is False
 
     def test_any_non_terminal_to_errored(self):
         for state in ["pending", "queued", "planning", "planned", "confirmed", "applying"]:
@@ -687,3 +696,200 @@ class TestEnqueueAIPlanSummary:
             mock_settings.ai_summary.enabled = True
             # Must not raise — feature is best-effort, never breaks runs
             await _enqueue_ai_plan_summary(run, "plan_summary")
+
+
+# ── Cancel-while-applying: canceling intermediate + reality-wins resolution ──
+
+
+class TestCancelWhileApplying:
+    """`applying` → `canceling` (not direct → `canceled`).
+
+    The cancel route sends `cancel_job` to the listener so the K8s Job
+    is deleted, but the run's terminal status is decided by what the
+    apply actually did — never by the cancel intent alone. Otherwise
+    we risk marking a run "canceled" while real infrastructure
+    changed (the worst possible outcome for an IaC platform).
+    """
+
+    @pytest.mark.asyncio
+    async def test_applying_cancel_transitions_to_canceling_not_canceled(self):
+        from terrapod.services import run_service
+
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.workspace_id = uuid.uuid4()
+        run.pool_id = uuid.uuid4()
+        run.job_name = "tpjob-abc"
+        run.status = "applying"
+
+        db = AsyncMock()
+        ws = MagicMock()
+        ws.locked = True
+        db.get.return_value = ws
+
+        async def _transition(_db, _run, target, **_):
+            _run.status = target
+            return _run
+
+        with (
+            patch.object(run_service, "transition_run", new=AsyncMock(side_effect=_transition)),
+            patch.object(run_service, "_publish_cancel_job", new=AsyncMock()) as mock_publish,
+        ):
+            result = await run_service.cancel_run(db, run)
+
+        # Reality check: status went to canceling, NOT canceled. Workspace
+        # stays locked (the apply Job is still alive until reconciler
+        # confirms otherwise).
+        assert result.status == "canceling"
+        assert ws.locked is True
+        # The cancel_job event MUST have been published — without it the
+        # listener doesn't know to delete the Job and we have a true
+        # zombie apply.
+        mock_publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_confirmed_cancel_goes_direct_to_canceled(self):
+        """confirmed has no Job yet (claim is atomic with confirmed→applying)
+        so the canceling intermediate isn't needed — straight to canceled
+        and unlock the workspace."""
+        from terrapod.services import run_service
+
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.workspace_id = uuid.uuid4()
+        run.pool_id = None
+        run.job_name = None
+        run.status = "confirmed"
+
+        db = AsyncMock()
+        ws = MagicMock()
+        ws.locked = True
+        ws.lock_id = "lock-1"
+        db.get.return_value = ws
+
+        async def _transition(_db, _run, target, **_):
+            _run.status = target
+            return _run
+
+        with (
+            patch.object(run_service, "transition_run", new=AsyncMock(side_effect=_transition)),
+            patch.object(run_service, "_publish_cancel_job", new=AsyncMock()),
+        ):
+            result = await run_service.cancel_run(db, run)
+
+        assert result.status == "canceled"
+        assert ws.locked is False
+        assert ws.lock_id is None
+
+
+class TestResolveCancelingRun:
+    """The reconciler resolves a `canceling` run to a terminal status
+    based on observable Job outcome and whether a state-version was
+    actually uploaded. State-version presence is the ground truth: if
+    state landed, real infra changed, and the run is `applied`
+    regardless of the cancel intent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_state_uploaded_resolves_to_applied(self):
+        """Apply landed before the kill (or completed naturally) — state
+        is recorded, so the terminal MUST be applied. We never claim
+        "canceled" while a state-version exists for this run."""
+        from terrapod.services import run_service
+
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.workspace_id = uuid.uuid4()
+        run.status = "canceling"
+
+        db = AsyncMock()
+        # One StateVersion row → state was uploaded.
+        sv_result = MagicMock()
+        sv_result.scalar_one_or_none = MagicMock(return_value=MagicMock())
+        db.execute.return_value = sv_result
+
+        ws = MagicMock()
+        ws.locked = True
+        ws.state_diverged = False
+        db.get.return_value = ws
+
+        async def _transition(_db, _run, target, **_):
+            _run.status = target
+            return _run
+
+        with patch.object(run_service, "transition_run", new=AsyncMock(side_effect=_transition)):
+            result = await run_service.resolve_canceling_run(db, run, job_status="deleted")
+
+        assert result.status == "applied"
+        # Workspace lock released; state_diverged NOT set (state is fine).
+        assert ws.locked is False
+        assert ws.state_diverged is False
+
+    @pytest.mark.asyncio
+    async def test_clean_kill_no_state_resolves_to_canceled_with_drift_flag(self):
+        """Job was killed before state was uploaded — best case the cancel
+        arrived before any mutation, worst case it killed mid-mutation.
+        Without a runner-side "nothing applied" report we can't tell,
+        so we set state_diverged as the operator-visible drift signal.
+        """
+        from terrapod.services import run_service
+
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.workspace_id = uuid.uuid4()
+        run.status = "canceling"
+
+        db = AsyncMock()
+        sv_result = MagicMock()
+        sv_result.scalar_one_or_none = MagicMock(return_value=None)
+        db.execute.return_value = sv_result
+
+        ws = MagicMock()
+        ws.locked = True
+        ws.state_diverged = False
+        db.get.return_value = ws
+
+        async def _transition(_db, _run, target, **_):
+            _run.status = target
+            return _run
+
+        with patch.object(run_service, "transition_run", new=AsyncMock(side_effect=_transition)):
+            result = await run_service.resolve_canceling_run(db, run, job_status="deleted")
+
+        assert result.status == "canceled"
+        assert ws.locked is False
+        # The whole point: signal the operator that real infra may have
+        # moved without a state record. Without this flag the
+        # "canceled" outcome would silently hide possible drift.
+        assert ws.state_diverged is True
+
+    @pytest.mark.asyncio
+    async def test_failed_no_state_resolves_to_errored_with_drift_flag(self):
+        from terrapod.services import run_service
+
+        run = MagicMock()
+        run.id = uuid.uuid4()
+        run.workspace_id = uuid.uuid4()
+        run.status = "canceling"
+
+        db = AsyncMock()
+        sv_result = MagicMock()
+        sv_result.scalar_one_or_none = MagicMock(return_value=None)
+        db.execute.return_value = sv_result
+
+        ws = MagicMock()
+        ws.locked = True
+        ws.state_diverged = False
+        db.get.return_value = ws
+
+        async def _transition(_db, _run, target, error_message=""):
+            _run.status = target
+            _run.error_message = error_message
+            return _run
+
+        with patch.object(run_service, "transition_run", new=AsyncMock(side_effect=_transition)):
+            result = await run_service.resolve_canceling_run(db, run, job_status="failed")
+
+        assert result.status == "errored"
+        assert "no state-version" in result.error_message
+        assert ws.state_diverged is True

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1374,7 +1374,7 @@ function WorkspaceDetailContent() {
     switch (status) {
       case 'applied': return 'bg-green-900/50 text-green-300'
       case 'planned': return 'bg-blue-900/50 text-blue-300'
-      case 'planning': case 'applying': return 'bg-yellow-900/50 text-yellow-300'
+      case 'planning': case 'applying': case 'canceling': return 'bg-yellow-900/50 text-yellow-300'
       case 'errored': return 'bg-red-900/50 text-red-300'
       case 'canceled': case 'discarded': return 'bg-slate-700 text-slate-400'
       default: return 'bg-slate-700 text-slate-400'

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -381,11 +381,11 @@ export default function RunDetailPage() {
   useEffect(() => {
     if (!run) return
     const status = run.attributes.status
-    if (['planning', 'planned', 'confirmed', 'applying', 'applied', 'errored', 'canceled', 'discarded'].includes(status)) {
+    if (['planning', 'planned', 'confirmed', 'applying', 'canceling', 'applied', 'errored', 'canceled', 'discarded'].includes(status)) {
       setPlanLogLoading(prev => planLog === null ? true : prev)
       loadPlanLog(true).finally(() => setPlanLogLoading(false))
     }
-    if (['applying', 'applied', 'errored'].includes(status) && !run.attributes['plan-only']) {
+    if (['applying', 'canceling', 'applied', 'errored'].includes(status) && !run.attributes['plan-only']) {
       setApplyLogLoading(prev => applyLog === null ? true : prev)
       loadApplyLog(true).finally(() => setApplyLogLoading(false))
     }
@@ -522,7 +522,7 @@ export default function RunDetailPage() {
     switch (status) {
       case 'applied': return 'bg-green-900/50 text-green-300'
       case 'planned': case 'confirmed': return 'bg-blue-900/50 text-blue-300'
-      case 'planning': case 'applying': case 'queued': return 'bg-yellow-900/50 text-yellow-300'
+      case 'planning': case 'applying': case 'canceling': case 'queued': return 'bg-yellow-900/50 text-yellow-300'
       case 'errored': return 'bg-red-900/50 text-red-300'
       case 'canceled': case 'discarded': return 'bg-slate-700 text-slate-400'
       case 'pending': return 'bg-slate-700 text-slate-300'

--- a/web/src/lib/workspace-status.ts
+++ b/web/src/lib/workspace-status.ts
@@ -40,6 +40,7 @@ export const WORKSPACE_STATUSES: ReadonlyArray<WorkspaceStatusDef> = [
   { filter: 'needs-confirm', label: 'Needs Confirm', color: 'amber', dot: 'bg-amber-400', priority: 3 },
   { filter: 'planning', label: 'Planning', color: 'blue', dot: 'bg-blue-400', priority: 4 },
   { filter: 'applying', label: 'Applying', color: 'blue', dot: 'bg-blue-400', priority: 4 },
+  { filter: 'canceling', label: 'Canceling', color: 'amber', dot: 'bg-amber-400', priority: 4 },
   { filter: 'confirmed', label: 'Confirmed', color: 'blue', dot: 'bg-blue-400', priority: 4 },
   { filter: 'queued', label: 'Queued', color: 'blue', dot: 'bg-blue-400', priority: 4 },
   { filter: 'pending', label: 'Pending', color: 'slate', dot: 'bg-slate-500', priority: 5 },


### PR DESCRIPTION
## Symptom

Reported in production: hitting **Confirm + Apply** then **Cancel** immediately leaves the listener running the apply phase as a zombie. Two failures stack:

1. The K8s Job runs to completion regardless of the cancel — real infrastructure changes.
2. The post-apply state-version upload may then fail (or partly land) for a run the system already considers terminal.

## Why the naive fix was wrong

My first instinct was a guard on \`upload_state\` rejecting uploads from \`canceled\` runs. **Wrong direction.** That would leave real infrastructure changed with no state record — the worst possible outcome for an IaC platform. Tracking must follow reality, not constrain it. Matt called this out directly:

> the worst thing you can do is let an apply job apply changes and then not save them to state.

## Fix shape

A \`canceling\` intermediate state plus a reality-wins resolver:

- **\`cancel_run\` route** — \`applying\` → \`canceling\` (NOT \`canceled\`), publish a \`cancel_job\` SSE event so the listener deletes the K8s Job, leave the workspace locked. All other CANCELABLE_STATES (\`pending\`/\`queued\`/\`planning\`/\`planned\`/\`confirmed\`) still transition straight to \`canceled\` and unlock — no Job in flight.
- **Reconciler picks up \`canceling\`** alongside \`planning\`/\`applying\`. When the listener reports a terminal Job status (\`deleted\`/\`failed\`/\`succeeded\`), \`resolve_canceling_run\` picks the run's terminal from ground truth:

  | state-version uploaded? | Job status | Terminal | Workspace |
  |---|---|---|---|
  | yes | any | \`applied\` | unlock, state_diverged stays false |
  | no | \`deleted\` (clean kill) | \`canceled\` | unlock, **state_diverged = true** |
  | no | \`failed\` | \`errored\` | unlock, **state_diverged = true** |

- **Artifact upload endpoints are unchanged.** They never reject based on tracking status — by design.

## Workspace.state_diverged

The non-applied resolutions set the existing \`Workspace.state_diverged\` flag — same drift-warning signal the runner uses when its own state upload fails. Best-case the cancel arrived before tofu apply mutated anything; worst-case it killed mid-apply, and we can't tell from here, so we flag it for the operator.

## UI

Status colour maps in the run-page and workspace-page handle \`canceling\` (amber/in-flight). \`workspace-status.ts\` adds a \"Canceling\" filter chip at priority 4 alongside \"Applying\". The log-fetch effect on the run page now triggers on \`canceling\` so the trailing apply log streams while the cancel resolves.

## Test plan

- [x] \`make lint\` clean.
- [x] \`make test\` passes — 1725 passed (+6 from this PR's new tests).
- [x] \`npm run build\` passes (frontend status-colour and log-fetch changes).
- [x] New \`TestCancelWhileApplying\` and \`TestResolveCancelingRun\` cover:
  - \`applying → canceling\` with \`cancel_job\` published and workspace lock retained;
  - \`confirmed → canceled\` direct path (no Job in flight);
  - state-version present forcing \`applied\` even when the listener reports \`deleted\`;
  - clean-kill-no-state → \`canceled\` with \`state_diverged = true\`;
  - failed-no-state → \`errored\` with \`state_diverged = true\`.
- [ ] Live smoke (post-deploy): Confirm + Apply + Cancel on a slow apply, verify run lands as \`canceled\` with \`state_diverged\` set if no state landed, or \`applied\` if state landed.

## State-machine diff

\`\`\`
confirmed: {applying, errored, canceled}
        → {applying, canceling, canceled, errored}
applying:  {applied, errored, canceled}
        → {applied, canceling, errored}      # canceled removed!
canceling: NEW → {canceled, applied, errored}
\`\`\`

\`applying → canceled\` is intentionally removed — that's exactly the path that produced the zombie behaviour.