### PR TITLE
fix(summariser): make risk_level/risk_factors invariant more emphatic

### DIFF
--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -185,6 +185,38 @@ CRITICAL — `resource_drift` is NOT the apply change set:
        list it as something this plan changes, and do not include
        it as a risk_factor.
 
+CRITICAL — `risk_level` and `risk_factors` are paired, not independent:
+
+  Before you submit, check this invariant:
+
+      risk_level in {"medium", "high", "critical"}  ⇔  len(risk_factors) ≥ 1
+
+  In words: an elevated `risk_level` REQUIRES at least one entry in
+  `risk_factors`. An empty `risk_factors` array is permitted ONLY when
+  `risk_level == "low"`. Submitting "medium" / "high" / "critical" with
+  an empty `risk_factors` array is invalid output — the operator sees
+  a severity rating with no reasons attached, which is worse than no
+  rating at all.
+
+  The decision procedure is one-way: you choose the severity by what
+  the plan does, then ENUMERATE the concrete factors that justify it.
+  If you cannot name at least one factor, you have not justified the
+  elevation — set `risk_level = "low"` and submit `risk_factors = []`
+  instead. Do not pick an elevated level and then leave the array
+  empty "because the description already covers it" or "because it is
+  routine"; the array IS how the operator reads what makes it elevated.
+
+  A concrete factor names a thing in the plan and why it matters, e.g.:
+    {"severity": "medium", "title": "RDS engine_version 16.11 → 16.13",
+     "detail": "Aurora minor-version upgrade applies immediately on
+     apply (apply_immediately=true); expect a brief connection drop
+     while the writer restarts.",
+     "resource_address": "module.helios_rds[0].aws_rds_cluster.this[0]"}
+
+  Order `risk_factors` worst-first. Severities on each factor match
+  the schema enum; the overall `risk_level` should equal the highest
+  factor severity.
+
 Other rules:
 
   • Describe the proposed changes. Do not describe the JSON format, the
@@ -201,12 +233,6 @@ Other rules:
   • Risk severities are about blast radius and reversibility, not
     novelty. Destroying a Lambda is medium. Destroying a database or
     an IAM trust root is critical. Pure additions are low.
-  • If `risk_level` is `medium`, `high`, or `critical`, `risk_factors`
-    MUST contain at least one entry naming what makes it elevated.
-    An empty `risk_factors` array is permitted ONLY when
-    `risk_level == "low"`. If you cannot name a concrete factor, the
-    correct `risk_level` is `low` — do not return an elevated level
-    with an empty factor list.
 
 Style:
   • Operator-facing, terse, professional. No emojis. No first-person

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -211,7 +211,7 @@ CRITICAL — `risk_level` and `risk_factors` are paired, not independent:
      "detail": "Aurora minor-version upgrade applies immediately on
      apply (apply_immediately=true); expect a brief connection drop
      while the writer restarts.",
-     "resource_address": "module.helios_rds[0].aws_rds_cluster.this[0]"}
+     "resource_address": "module.app_rds[0].aws_rds_cluster.this[0]"}
 
   Order `risk_factors` worst-first. Severities on each factor match
   the schema enum; the overall `risk_level` should equal the highest

--- a/services/tests/services/test_summariser_prompt.py
+++ b/services/tests/services/test_summariser_prompt.py
@@ -200,14 +200,26 @@ def test_plan_summary_skill_forbids_empty_risk_factors_at_elevated_level():
     it, so the prompt is the only place this rule lives. Violations
     have been observed in production: a plan with mixed in-place
     updates returned `risk_level: medium` with `risk_factors: []`.
+
+    The rule lives in a dedicated CRITICAL block (not buried in a
+    bulleted list) and names all three elevated levels explicitly so
+    the model can't pattern-match on "medium" alone and ignore the
+    others.
     """
     skill = PLAN_SUMMARY_SKILL_PROMPT
-    # The rule names all three elevated levels explicitly so the model
-    # can't pattern-match on "medium" alone and ignore the others.
-    assert "`medium`, `high`, or `critical`" in skill
-    # And the empty-array carve-out is bound to risk_level == "low".
+    # Dedicated CRITICAL block, not a single bullet.
+    assert "CRITICAL — `risk_level` and `risk_factors` are paired" in skill
+    # The biconditional names all three elevated levels.
+    assert 'risk_level in {"medium", "high", "critical"}  ⇔  len(risk_factors) ≥ 1' in skill
+    # The empty-array carve-out is bound to risk_level == "low".
     assert "empty `risk_factors` array is permitted ONLY when" in skill
     assert '`risk_level == "low"`' in skill
+    # Submitting elevated + empty is called out as invalid output, not
+    # just "discouraged".
+    assert "is invalid output" in skill
+    # And the prompt instructs the fallback: downgrade to low rather
+    # than return an elevated level with no factors.
+    assert 'set `risk_level = "low"`' in skill
 
 
 def test_failure_analysis_skill_also_describes_code_diff():


### PR DESCRIPTION
## Summary

The rule that an elevated `risk_level` (medium/high/critical) MUST be paired with at least one `risk_factors` entry was already in the prompt — but as the last bullet in 'Other rules'. The model still violates it: a recent plan returned `risk_level: "medium"` with `risk_factors: []`. Loki shows 4 hits of `summariser.risk_factors_empty_at_elevated_level` in a 15-minute window on a single workspace, all bedrock/claude-opus-4-8.

The schema can't express the conditional (no `if/then` support across all decoders), so the prompt is the only place this rule lives. Promoting it from a buried bullet into a dedicated CRITICAL block, with stronger framing and a worked example, should pull it out of the noise.

## What changed

- Move the invariant into its own `CRITICAL — risk_level and risk_factors are paired` block, above 'Other rules'.
- State it as a check the model can run before submitting:
  `risk_level in {"medium", "high", "critical"} <=> len(risk_factors) >= 1`.
- "Submitting elevated + empty is invalid output" framing instead of "permitted only when low".
- One-way decision procedure: pick severity by what the plan does, then enumerate concrete factors; if you cannot name one, the elevation is unjustified — drop to low.
- A concrete factor example (Aurora minor-version upgrade) showing severity/title/detail/resource_address together.
- Existing prompt test updated to anchor on the new structural markers (the CRITICAL heading, the biconditional, "is invalid output", "set risk_level = low") so a future refactor can't silently drop the rule.

## Test plan

- [x] `make test` (full suite passes; 1726 tests)
- [ ] Watch new plan-summary runs for `summariser.risk_factors_empty_at_elevated_level` warnings after deploy; expect rate to drop. If it doesn't, next step is a retry-once loop (second tool call asking the model to add factors or downgrade) — kept out of this PR.