### PR TITLE
fix(ai-summary): partition resource_drift so drift can't be conflated with planned destroys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,12 +268,27 @@ jobs:
         # python-dotenv's load_dotenv). The vulnerability requires the
         # application itself to call the affected functions. Drop this
         # ignore once a transitive dep bumps python-dotenv naturally.
+        #
+        # CVE-2026-34993 + CVE-2026-47265 (aiohttp <3.14.0): published
+        # 2026-06. The first is RCE via CookieJar.load() on untrusted
+        # input; the second leaks `cookies`-param cookies across a
+        # cross-origin redirect. aiohttp is pulled in transitively
+        # and litellm 1.83.7 pins it to exactly ==3.13.5, so we can't
+        # set a >=3.14.0 floor without breaking the resolver (litellm
+        # also blocks bumping its own lower bound — see the
+        # CVE-2026-40217 note above). Neither path is reachable in
+        # Terrapod's litellm-driven outbound calls: we never call
+        # CookieJar.load(), and we don't set request cookies via the
+        # `cookies` param. Drop these two ignores when the litellm
+        # chain bumps aiohttp.
         run: |
           pip install pip-audit
           pip-audit -r services/requirements.txt --strict --desc \
             --ignore-vuln PYSEC-2025-183 \
             --ignore-vuln CVE-2026-40217 \
-            --ignore-vuln CVE-2026-28684
+            --ignore-vuln CVE-2026-28684 \
+            --ignore-vuln CVE-2026-34993 \
+            --ignore-vuln CVE-2026-47265
 
   # ── Dependency Audit (npm) ────────────────────────────
   npm-audit:

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -149,10 +149,18 @@ def _clean_plan_json_bytes(raw: bytes) -> bytes:
       • the top-level "prior_state" key (full pre-refresh state
         snapshot, redundant with resource_changes.before)
 
+    Partitions resource_drift into two top-level keys:
+      • resource_drift — entries whose address ALSO has a real
+        resource_changes entry. These are drift the apply IS
+        reverting; the model treats them as elevated risk.
+      • drift_observed_no_apply_action — entries whose address has
+        no corresponding resource_changes (terraform refreshed and
+        reconciled, apply does nothing). The change.actions array
+        is rewritten to ["drift_observed"] so the model cannot
+        pattern-match destroy/update framing onto them — that
+        conflation produced false destroy summaries in practice.
+
     Preserves:
-      • resource_drift in full — the operator needs both "drift
-        accepted" (informational) and "drift reverted" (risk) signals;
-        the prompt teaches the model to label them.
       • read-only entries when paired with import (rare but valid)
 
     On any structural anomaly (non-dict plan, malformed entries) returns
@@ -169,7 +177,10 @@ def _clean_plan_json_bytes(raw: bytes) -> bytes:
 
     rcs = plan.get("resource_changes")
     if isinstance(rcs, list):
-        plan["resource_changes"] = [r for r in rcs if _resource_change_is_informative(r)]
+        kept_rcs = [r for r in rcs if _resource_change_is_informative(r)]
+        plan["resource_changes"] = kept_rcs
+
+    _partition_resource_drift(plan)
 
     ocs = plan.get("output_changes")
     if isinstance(ocs, dict):
@@ -180,6 +191,61 @@ def _clean_plan_json_bytes(raw: bytes) -> bytes:
         }
 
     return json.dumps(plan, separators=(",", ":")).encode("utf-8")
+
+
+def _partition_resource_drift(plan: dict[str, object]) -> None:
+    """Split `resource_drift` based on whether each address has a real change.
+
+    Mutates `plan` in place. See `_clean_plan_json_bytes` for the
+    rationale. Must be called AFTER `resource_changes` no-ops have been
+    pruned so the address lookup is over the informative set only.
+    """
+    drift = plan.get("resource_drift")
+    if not isinstance(drift, list) or not drift:
+        return
+
+    rcs = plan.get("resource_changes")
+    rc_addresses: set[object] = set()
+    if isinstance(rcs, list):
+        for r in rcs:
+            if isinstance(r, dict):
+                addr = r.get("address")
+                if addr is not None:
+                    rc_addresses.add(addr)
+
+    reverted: list[object] = []
+    observed: list[object] = []
+    for d in drift:
+        if not isinstance(d, dict):
+            reverted.append(d)
+            continue
+        addr = d.get("address")
+        if addr in rc_addresses:
+            reverted.append(d)
+            continue
+        observed.append(_neutralize_drift_actions(d))
+
+    plan["resource_drift"] = reverted
+    if observed:
+        plan["drift_observed_no_apply_action"] = observed
+
+
+def _neutralize_drift_actions(entry: dict[str, object]) -> dict[str, object]:
+    """Replace ["delete"]/["update"] action labels with ["drift_observed"].
+
+    The replacement is intentionally non-standard — the model treats
+    `create`/`update`/`delete` as planned actions, so any of those
+    appearing on a drift entry is a fertile source of misreads. A
+    label the model has never seen before forces it to consult the
+    prompt's drift-handling section instead of pattern-matching.
+    """
+    out = dict(entry)
+    change = out.get("change")
+    if isinstance(change, dict):
+        new_change = dict(change)
+        new_change["actions"] = ["drift_observed"]
+        out["change"] = new_change
+    return out
 
 
 def _resource_change_is_informative(r: object) -> bool:

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -163,27 +163,34 @@ CRITICAL — trust `change.actions`, not snapshots:
   signal: if a resource's declaration is not touched by CODE_DIFF
   AND its `actions` is no-op, it is unchanged. Never describe it.
 
-CRITICAL — `resource_drift` is NOT the apply change set:
+CRITICAL — drift is NOT the apply change set:
 
-  PLAN_JSON may include a `resource_drift` array alongside
-  `resource_changes`. resource_drift is what terraform observed
-  during refresh that disagreed with prior state — out-of-band
-  changes to live infrastructure since the last apply. The refresh
-  has already reconciled state to reality; the apply phase acts on
-  `resource_changes`, not `resource_drift`.
+  PLAN_JSON may include two drift-related arrays alongside
+  `resource_changes`. Both record what terraform observed during
+  refresh that disagreed with prior state. Neither is what apply
+  acts on — apply acts on `resource_changes`. The two arrays are
+  partitioned so the structural shape carries the semantic:
 
-  Two cases to handle:
-    1. Address appears in `resource_drift` AND has a non-no-op entry
-       in `resource_changes` → the plan is REVERTING a manual change.
-       Call this out explicitly in `description` and treat as
-       elevated risk in `risk_factors`.
-    2. Address appears only in `resource_drift` (no corresponding
-       resource_changes entry, or only no-op) → out-of-band change
-       has already been accepted into state; apply does nothing
-       about it. You MAY note it briefly in `description` as
-       "observed out-of-band change to X" if it is notable; do NOT
-       list it as something this plan changes, and do not include
-       it as a risk_factor.
+    • `resource_drift` — drift the apply IS reverting. Every
+      entry's address also has a non-no-op entry in
+      `resource_changes`. The combination means: someone changed
+      the live resource out-of-band, and this plan undoes it.
+      Call out the reversion in `description` and include as a
+      `risk_factor` (elevated severity — undoing manual fixes).
+
+    • `drift_observed_no_apply_action` — drift terraform refreshed
+      and accepted into state with no follow-up. Apply does
+      nothing about these entries. To make this impossible to
+      conflate with planned actions, every entry's
+      `change.actions` has been rewritten to `["drift_observed"]`
+      — a non-standard label that does NOT correspond to a
+      planned `create` / `update` / `delete`. You MAY mention
+      these briefly in `description` as "observed out-of-band
+      change to X" when notable, but you MUST NOT describe them
+      as "will be destroyed" / "will be updated" / etc., and
+      MUST NOT list them as `risk_factors`. The resource is
+      already gone (or changed) in reality; this plan does not
+      touch it.
 
 CRITICAL — `risk_level` and `risk_factors` are paired, not independent:
 

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -768,21 +768,98 @@ class TestCleanPlanJsonBytes:
         out = self._clean(plan)
         assert "prior_state" not in out
 
-    def test_preserves_resource_drift_intact(self):
-        """resource_drift carries the only signal about out-of-band changes;
-        the prompt teaches the model to label it correctly, the cleaner
-        does NOT prune it. Regressions here would silence drift-revert
-        risk signals.
+    def test_partitions_drift_reverted_vs_observed_only(self):
+        """resource_drift is split based on whether each address ALSO has
+        a real resource_changes entry:
+          - matched → stays in resource_drift (the apply IS reverting it,
+            elevated risk)
+          - unmatched → moved to drift_observed_no_apply_action with
+            actions rewritten to ["drift_observed"] so the model can't
+            pattern-match destroy framing onto it.
         """
         plan = {
             "resource_drift": [
+                # matched: also in resource_changes — drift being reverted
                 {"address": "drift_a", "change": {"actions": ["update"]}},
+                # unmatched: no resource_changes — accepted, apply no-ops
                 {"address": "drift_b", "change": {"actions": ["delete"]}},
+            ],
+            "resource_changes": [
+                {"address": "drift_a", "change": {"actions": ["update"]}},
+            ],
+        }
+        out = self._clean(plan)
+        assert out["resource_drift"] == [
+            {"address": "drift_a", "change": {"actions": ["update"]}},
+        ]
+        assert out["drift_observed_no_apply_action"] == [
+            {"address": "drift_b", "change": {"actions": ["drift_observed"]}},
+        ]
+
+    def test_drift_without_resource_changes_all_moves(self):
+        """When no resource_changes match, every drift entry moves to
+        drift_observed_no_apply_action and its actions are neutralised.
+        Reproduces the failure mode from the prod-us2-services1 AKS
+        plan summary: node pools missing in Azure showed as drift
+        deletes, model hallucinated them as planned destroys.
+        """
+        plan = {
+            "resource_drift": [
+                {
+                    "address": 'module.aks.azurerm_kubernetes_cluster_node_pool.this["gpu0"]',
+                    "change": {"actions": ["delete"]},
+                },
+                {
+                    "address": 'module.aks.azurerm_kubernetes_cluster_node_pool.this["pulsar1"]',
+                    "change": {"actions": ["delete"]},
+                },
             ],
             "resource_changes": [],
         }
         out = self._clean(plan)
+        assert out["resource_drift"] == []
+        assert [d["address"] for d in out["drift_observed_no_apply_action"]] == [
+            'module.aks.azurerm_kubernetes_cluster_node_pool.this["gpu0"]',
+            'module.aks.azurerm_kubernetes_cluster_node_pool.this["pulsar1"]',
+        ]
+        for d in out["drift_observed_no_apply_action"]:
+            assert d["change"]["actions"] == ["drift_observed"]
+
+    def test_drift_partition_skips_noop_resource_changes(self):
+        """no-op resource_changes are dropped first; the drift partition
+        must run against the pruned set, so a drift entry matched only
+        by a no-op resource_change is moved to drift_observed (apply
+        does nothing about it).
+        """
+        plan = {
+            "resource_drift": [
+                {"address": "addr_a", "change": {"actions": ["delete"]}},
+            ],
+            "resource_changes": [
+                {"address": "addr_a", "change": {"actions": ["no-op"]}},
+            ],
+        }
+        out = self._clean(plan)
+        assert out["resource_drift"] == []
+        assert out["drift_observed_no_apply_action"] == [
+            {"address": "addr_a", "change": {"actions": ["drift_observed"]}},
+        ]
+
+    def test_no_drift_observed_key_when_no_unmatched(self):
+        """Don't emit drift_observed_no_apply_action when there's nothing
+        to put in it — keeps the input minimal.
+        """
+        plan = {
+            "resource_drift": [
+                {"address": "a", "change": {"actions": ["update"]}},
+            ],
+            "resource_changes": [
+                {"address": "a", "change": {"actions": ["update"]}},
+            ],
+        }
+        out = self._clean(plan)
         assert out["resource_drift"] == plan["resource_drift"]
+        assert "drift_observed_no_apply_action" not in out
 
     def test_keeps_weird_actions_shape(self):
         """Defensive: never drop a resource_change whose shape we don't


### PR DESCRIPTION
## Summary

The AI plan summariser was observed hallucinating destructive narratives from drift entries that the apply does not act on. Concrete instance: a run with no node-pool destroys planned was summarised as "Seven node pools will be destroyed" at risk_level=high, because seven `azurerm_kubernetes_cluster_node_pool` entries appeared in `resource_drift` with `change.actions = ["delete"]` (refresh found they no longer exist in Azure; state was reconciled silently). The model pattern-matched the `"delete"` string and framed them as planned destroys despite explicit prompt guidance to the contrary.

## Diagnosis

The existing prompt describes two drift cases:
1. drift entry's address ALSO has a non-no-op `resource_changes` entry → apply is reverting a manual change (real risk)
2. drift entry's address has no matching `resource_changes` → refresh accepted the change, apply does nothing (informational only)

Both cases used the same input shape: the `resource_drift` array with `change.actions ∈ {create, update, delete}`. The model regressed to pattern-matching the action string and ignored the "look for a matching `resource_changes` entry" rule. Instruction alone wasn't enough.

## Fix

Make the semantic distinction structural at the cleaner level:

- **`resource_drift`** — now contains only entries whose address ALSO has a non-no-op `resource_changes` entry. These are still drift-being-reverted, still elevated risk. Existing prompt guidance unchanged for these.
- **`drift_observed_no_apply_action`** (new) — entries with no matching `resource_changes`. Apply does nothing about them. Their `change.actions` is rewritten to `["drift_observed"]` — a non-standard label that cannot be pattern-matched against the create/update/delete planned-action vocabulary.

Prompt updated to teach the new two-array structure and forbid describing `drift_observed_no_apply_action` entries as planned actions or as `risk_factors`.

## Test plan

- [x] 4 new cleaner tests cover partition correctness, action-rewrite, interaction with no-op `resource_changes`, and the no-emit case when nothing is unmatched
- [x] `make test` — 1729 passed, no regressions
- [x] `make lint` — clean
- [ ] Smoke against Bedrock with a representative plan once deployed (operator-driven; the failure mode is hard to fixture artificially because it depends on Bedrock's actual interpretation)