### PR TITLE
fix(runner): plan-phase eviction retry + Job-conditions exit-code fallback

### DIFF
--- a/services/terrapod/runner/job_manager.py
+++ b/services/terrapod/runner/job_manager.py
@@ -5,6 +5,7 @@ Uses the kubernetes Python client to interact with the K8s API.
 
 import asyncio
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor
 
 from kubernetes import client, config
@@ -297,6 +298,64 @@ async def get_pod_terminated_info(
                 "exit_code": int(term.exit_code) if term.exit_code is not None else -1,
                 "reason": term.reason or "",
             }
+
+    return None
+
+
+async def get_job_failure_info(job_name: str, namespace: str = "") -> dict[str, int | str] | None:
+    """Fallback to `get_pod_terminated_info` when the pod has been GC'd.
+
+    When the listener observes Job=failed but the pod is already gone
+    (eviction by taint-eviction-controller, TTL controller, manual
+    cleanup, etc.), pod-level terminated state is unreadable.
+
+    The Job itself still records the failure cause in
+    `status.conditions[?].reason == "PodFailurePolicy"`. The condition's
+    `message` field contains the exit code that triggered the
+    FailJob rule, e.g.:
+
+        Container runner for pod terrapod/tprun-...-lx72v failed
+        with exit code 137 matching FailJob rule at index 0
+
+    Parse the exit code out and return it so the listener can still
+    typify the failure (`runner_exit_status = "killed"` for exit 137
+    without OOMKilled reason) rather than leaving an empty status that
+    the reconciler renders as a generic "Job failed".
+
+    Returns the same shape as get_pod_terminated_info:
+        { "exit_code": <int>, "reason": <str> }
+    Reason is left empty because the Job-controller event doesn't
+    carry the K8s container terminated.reason — only the exit code.
+    The API's typed-bucket mapping handles `reason=""` + `exit_code=137`
+    correctly (→ "killed").
+
+    Returns None if no PodFailurePolicy condition is present or the
+    message can't be parsed. Never raises.
+    """
+    if not namespace:
+        namespace = _default_namespace()
+
+    batch_api = _get_batch_api()
+
+    try:
+        loop = asyncio.get_event_loop()
+        job = await loop.run_in_executor(
+            None,
+            lambda: batch_api.read_namespaced_job(name=job_name, namespace=namespace),
+        )
+    except ApiException:
+        return None
+
+    conditions = getattr(getattr(job, "status", None), "conditions", None) or []
+    for cond in conditions:
+        if getattr(cond, "reason", None) != "PodFailurePolicy":
+            continue
+        msg = getattr(cond, "message", "") or ""
+        # Format: "... failed with exit code <N> matching FailJob rule ..."
+        m = re.search(r"exit code (\d+)", msg)
+        if not m:
+            continue
+        return {"exit_code": int(m.group(1)), "reason": ""}
 
     return None
 

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -204,19 +204,52 @@ def build_job_spec(
         },
         "spec": {
             "backoffLimit": 3,
+            # PodFailurePolicy differs by phase:
+            #   plan  — K8s-native retry on disruption (eviction, preemption,
+            #           node drain). Plan never mutates Terrapod state or
+            #           live AWS infra, so partial execution is safe to
+            #           retry.
+            #   apply — never retry on disruption. Once the container ran,
+            #           terraform may have mutated state. K8s PodFailurePolicy
+            #           can't reliably distinguish "container started" from
+            #           "container never ran" — kubelet behaviour differs
+            #           across cluster versions/distributions for pre-start
+            #           disruption — so apply is conservatively never-retry.
+            #           Operator decides whether to re-run from the Run UI.
+            #
+            # Order matters: PodFailurePolicy evaluates rules in order, first
+            # match wins. The Ignore rule for plan MUST precede the FailJob
+            # rule so that eviction (which produces exit 137 via SIGKILL on
+            # an already-running container) is ignored before the FailJob
+            # rule catches it.
             "podFailurePolicy": {
-                "rules": [
+                "rules": (
+                    [
+                        {
+                            # Plan-only: ignore disruption-triggered failures
+                            # so K8s retries via backoffLimit.
+                            "action": "Ignore",
+                            "onPodConditions": [
+                                {"type": "DisruptionTarget", "status": "True"},
+                            ],
+                        },
+                    ]
+                    if phase == "plan"
+                    else []
+                )
+                + [
                     {
+                        # Any non-zero exit fails the Job (applies to both
+                        # plan and apply). For plan, a disruption-driven
+                        # SIGKILL would have matched the Ignore rule above
+                        # and skipped this; what remains here is a real
+                        # tofu error code (or other non-disruption kill).
                         "action": "FailJob",
                         "onExitCodes": {
                             "containerName": "runner",
                             "operator": "NotIn",
                             "values": [0],
                         },
-                    },
-                    {
-                        "action": "Count",
-                        "onPodConditions": [{"type": "DisruptionTarget", "status": "True"}],
                     },
                 ],
             },

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -722,7 +722,11 @@ class RunnerListener:
 
     async def _handle_check_job_status(self, data: dict) -> None:
         """Query K8s for Job status and POST the result back to the API."""
-        from terrapod.runner.job_manager import get_job_status, get_pod_terminated_info
+        from terrapod.runner.job_manager import (
+            get_job_failure_info,
+            get_job_status,
+            get_pod_terminated_info,
+        )
 
         job_name = data.get("job_name", "")
         job_namespace = data.get("job_namespace", "")
@@ -743,19 +747,32 @@ class RunnerListener:
         # For Failed Jobs, also collect the container terminated info — exit
         # code + K8s termination reason (OOMKilled / Error / Completed).
         # The API maps `reason` to the typed runner_exit_status bucket (#430).
-        # Best-effort: if the pod has been GC'd or the call errors, we leave
-        # exit_code/reason unset and the reconciler falls back to generic
-        # "Job failed" handling.
+        #
+        # Two-tier lookup:
+        #   1. Pod-side: list the Job's pods and read the runner container's
+        #      terminated state. This is the authoritative source — both
+        #      exit_code AND reason (which carries "OOMKilled" when relevant).
+        #   2. Job-side fallback: when the pod has been GC'd before we
+        #      observed it (taint-eviction, TTL controller, manual cleanup),
+        #      the Job itself carries the failure cause in
+        #      status.conditions[?].reason="PodFailurePolicy". Parse the
+        #      exit code out so we can still typify the run as `killed`
+        #      or `error` instead of an empty status. Reason stays empty
+        #      because the Job-controller event doesn't carry the K8s
+        #      container terminated.reason — the API's typed-bucket
+        #      mapping handles `reason=""` + `exit_code=137` correctly.
         body: dict = {"status": status, "phase": phase}
         if status == "failed":
             try:
                 info = await get_pod_terminated_info(job_name, namespace=job_namespace)
+                if info is None:
+                    info = await get_job_failure_info(job_name, namespace=job_namespace)
                 if info is not None:
                     body["exit_code"] = info["exit_code"]
                     body["reason"] = info["reason"]
             except Exception as e:
                 logger.debug(
-                    "Failed to get pod terminated info",
+                    "Failed to get pod/job terminated info",
                     job=job_name,
                     run_id=run_id,
                     error=str(e),

--- a/services/tests/runner/test_job_manager.py
+++ b/services/tests/runner/test_job_manager.py
@@ -1,0 +1,110 @@
+"""Tests for runner.job_manager — specifically the get_job_failure_info
+fallback used when the pod has been GC'd before the listener could read
+its terminated state."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from kubernetes.client.rest import ApiException
+
+
+def _job_with_conditions(conditions):
+    return SimpleNamespace(status=SimpleNamespace(conditions=conditions))
+
+
+class TestGetJobFailureInfo:
+    """Fallback from #430 — when the pod is gone, recover the exit code
+    from Job.status.conditions[?].reason == "PodFailurePolicy"."""
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_extracts_exit_code_137_from_taint_eviction_message(self, _ns, mock_batch):
+        """The K8s Job-controller writes a condition like:
+            reason=PodFailurePolicy
+            message="Container runner for pod terrapod/tprun-xxx-lx72v
+                     failed with exit code 137 matching FailJob rule at index 0"
+        We need to parse the 137 out."""
+        from terrapod.runner.job_manager import get_job_failure_info
+
+        mock_batch.return_value.read_namespaced_job.return_value = _job_with_conditions(
+            [
+                SimpleNamespace(reason="Other", message="unrelated"),
+                SimpleNamespace(
+                    reason="PodFailurePolicy",
+                    message=(
+                        "Container runner for pod terrapod/tprun-abc-lx72v "
+                        "failed with exit code 137 matching FailJob rule at index 0"
+                    ),
+                ),
+            ]
+        )
+
+        info = await get_job_failure_info("tprun-abc-plan", namespace="terrapod")
+        assert info == {"exit_code": 137, "reason": ""}
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_extracts_exit_code_1_for_normal_tofu_error(self, _ns, mock_batch):
+        """Same fallback used when tofu exits 1 and the pod is somehow GC'd.
+        Reason is NOT OOMKilled in that case, so the API maps exit_code=1
+        + reason='' to runner_exit_status='error'."""
+        from terrapod.runner.job_manager import get_job_failure_info
+
+        mock_batch.return_value.read_namespaced_job.return_value = _job_with_conditions(
+            [
+                SimpleNamespace(
+                    reason="PodFailurePolicy",
+                    message="Container runner ... failed with exit code 1 matching ...",
+                ),
+            ]
+        )
+
+        info = await get_job_failure_info("tprun-abc-plan", namespace="terrapod")
+        assert info == {"exit_code": 1, "reason": ""}
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_returns_none_when_no_podfailurepolicy_condition(self, _ns, mock_batch):
+        """If the Job failed for some other reason (e.g. DeadlineExceeded)
+        we have no exit code to extract — return None so the API leaves
+        runner_exit_status empty and the reconciler renders the generic
+        message. That's strictly no worse than the pre-fix behaviour."""
+        from terrapod.runner.job_manager import get_job_failure_info
+
+        mock_batch.return_value.read_namespaced_job.return_value = _job_with_conditions(
+            [
+                SimpleNamespace(reason="DeadlineExceeded", message="..."),
+            ]
+        )
+
+        assert await get_job_failure_info("tprun-abc-plan", namespace="terrapod") is None
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_returns_none_on_unparseable_message(self, _ns, mock_batch):
+        """If the message format changes upstream and our regex doesn't match,
+        return None rather than guessing."""
+        from terrapod.runner.job_manager import get_job_failure_info
+
+        mock_batch.return_value.read_namespaced_job.return_value = _job_with_conditions(
+            [
+                SimpleNamespace(
+                    reason="PodFailurePolicy",
+                    message="Some new wording that doesn't say 'exit code N'.",
+                ),
+            ]
+        )
+
+        assert await get_job_failure_info("tprun-abc-plan", namespace="terrapod") is None
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_swallows_apiexception(self, _ns, mock_batch):
+        """Never raise. If the K8s API call fails (Job already deleted, RBAC
+        issue, network hiccup), return None and let the listener fall back
+        to the generic path."""
+        from terrapod.runner.job_manager import get_job_failure_info
+
+        mock_batch.return_value.read_namespaced_job.side_effect = ApiException(404)
+
+        assert await get_job_failure_info("tprun-abc-plan", namespace="terrapod") is None

--- a/services/tests/runner/test_job_template.py
+++ b/services/tests/runner/test_job_template.py
@@ -107,50 +107,70 @@ class TestVarFilesInjection:
 
 
 class TestPodFailurePolicy:
-    """Verify pod failure policy prevents retries after container execution."""
+    """Phase-conditional pod failure policy.
 
-    def _build_default_spec(self):
+    plan jobs: K8s-native retry on disruption (eviction, preemption, drain)
+               because plan is read-only on AWS — partial execution is safe
+               to retry. Rule order matters: Ignore-on-DisruptionTarget MUST
+               come BEFORE FailJob-on-non-zero, otherwise the SIGKILL-derived
+               exit 137 from eviction would fail the Job before the disruption
+               rule could ignore it.
+
+    apply jobs: never retry on disruption. Once the container has run, it may
+                have mutated state (resources created/modified/destroyed);
+                K8s retry would risk double-create or split-brain. Operator
+                decides whether to re-run from the Run UI.
+    """
+
+    def _build(self, phase: str):
         from terrapod.runner.job_template import build_job_spec
 
         return build_job_spec(
             run_id="abc123",
-            phase="plan",
+            phase=phase,
             runner_config=_runner_config(),
             auth_secret_name="tprun-abc12345-auth",
             env_vars=[],
             terraform_vars=[],
         )
 
-    def test_backoff_limit(self):
-        """backoffLimit should be 3 to allow retries for pod disruptions."""
-        spec = self._build_default_spec()
-        assert spec["spec"]["backoffLimit"] == 3
+    def test_backoff_limit_unchanged(self):
+        for phase in ("plan", "apply"):
+            spec = self._build(phase)
+            assert spec["spec"]["backoffLimit"] == 3
 
-    def test_container_exit_fails_job(self):
-        """First rule: any non-zero container exit → FailJob (no retry)."""
-        spec = self._build_default_spec()
-        rules = spec["spec"]["podFailurePolicy"]["rules"]
-        rule = rules[0]
-        assert rule["action"] == "FailJob"
-        assert rule["onExitCodes"]["containerName"] == "runner"
-        assert rule["onExitCodes"]["operator"] == "NotIn"
-        assert rule["onExitCodes"]["values"] == [0]
+    def test_plan_ignores_disruption_first(self):
+        """Plan rule[0] must Ignore on DisruptionTarget=True."""
+        rules = self._build("plan")["spec"]["podFailurePolicy"]["rules"]
+        assert rules[0] == {
+            "action": "Ignore",
+            "onPodConditions": [{"type": "DisruptionTarget", "status": "True"}],
+        }
 
-    def test_disruption_counted(self):
-        """Second rule: DisruptionTarget → Count toward backoffLimit."""
-        spec = self._build_default_spec()
-        rules = spec["spec"]["podFailurePolicy"]["rules"]
-        rule = rules[1]
-        assert rule["action"] == "Count"
-        assert rule["onPodConditions"] == [{"type": "DisruptionTarget", "status": "True"}]
-
-    def test_exit_rule_before_disruption_rule(self):
-        """Exit rule must be evaluated before disruption rule."""
-        spec = self._build_default_spec()
-        rules = spec["spec"]["podFailurePolicy"]["rules"]
+    def test_plan_then_fails_on_nonzero_exit(self):
+        """Plan rule[1] is FailJob on non-zero exit."""
+        rules = self._build("plan")["spec"]["podFailurePolicy"]["rules"]
         assert len(rules) == 2
-        assert "onExitCodes" in rules[0]
-        assert "onPodConditions" in rules[1]
+        assert rules[1]["action"] == "FailJob"
+        assert rules[1]["onExitCodes"] == {
+            "containerName": "runner",
+            "operator": "NotIn",
+            "values": [0],
+        }
+
+    def test_apply_only_fails_on_nonzero_exit(self):
+        """Apply has no Ignore rule — DisruptionTarget falls through to FailJob via exit-137."""
+        rules = self._build("apply")["spec"]["podFailurePolicy"]["rules"]
+        assert len(rules) == 1
+        assert rules[0]["action"] == "FailJob"
+        assert rules[0]["onExitCodes"] == {
+            "containerName": "runner",
+            "operator": "NotIn",
+            "values": [0],
+        }
+        # Critically: NO Ignore-on-DisruptionTarget rule. An eviction's
+        # exit-137 will hit the FailJob rule and the run will error.
+        assert not any(r["action"] == "Ignore" for r in rules)
 
 
 class TestAuthTokenInjection:


### PR DESCRIPTION
## Summary

Two related fixes surfaced by an internal run that hit a node taint just after the scheduler bound the pod:
- kubelet evicted the pod (SIGKILL → exit 137)
- Job's `PodFailurePolicy` fired `FailJob` without retry
- the listener's pod-terminated-state read returned None because the pod was already GCed by the taint-eviction-controller
- `#430`'s typed `runner_exit_status` path left the field empty
- the UI rendered the generic \"Job failed\" with no actionable info, and the AI failure analysis ran on an empty plan log

## Fixes

### 1. PodFailurePolicy is now phase-conditional

| Phase | Rules |
|---|---|
| `plan` | `[0]` Ignore on `DisruptionTarget=True`; `[1]` FailJob on non-zero exit |
| `apply` | `[0]` FailJob on non-zero exit (only) |

Plan is read-only on AWS — partial execution is safe to retry, so disruption (eviction, preemption, node drain) goes through K8s-native backoff up to `backoffLimit=3`. Rule order matters: eviction produces exit 137 via SIGKILL, so the Ignore rule MUST precede the FailJob rule.

Apply has no Ignore rule. K8s PodFailurePolicy can't reliably distinguish \"container started\" from \"container never started\" — kubelet behaviour for pre-start disruption varies across cluster versions/distributions, and we shouldn't build on cluster-specific behaviour. So apply stays conservatively never-retry; operator decides from the Run UI.

### 2. `get_job_failure_info()` fallback (closes a `#430` gap)

When the listener's `get_pod_terminated_info()` returns None (pod GCed), fall back to reading the Job's `status.conditions[?].reason == \"PodFailurePolicy\"` whose message contains the exit code:

> Container runner for pod terrapod/tprun-...-lx72v failed with exit code 137 matching FailJob rule at index 0

Parse it out and POST through `report_job_status` so the typed `runner_exit_status` bucket gets set (`killed` for 137 without OOMKilled reason) instead of staying empty. The UI now shows the proper signal rather than \"Job failed\".

## Test plan

- [x] 9 new pytest cases (5 for `get_job_failure_info`, 4 for the phase-conditional `PodFailurePolicy`)
- [x] All 1744 existing tests still pass
- [x] \`make lint\` green
- [ ] Tilt smoke against local stack (next step before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)