### PR TITLE
fix(runner): add tfe.v2 services to host{} redirect

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -707,6 +707,18 @@ host "$TP_PUBLIC_HOST" {
   services = {
     "modules.v1"   = "${TP_API_URL}/api/v2/registry/modules/"
     "providers.v1" = "${TP_API_URL}/api/v2/registry/providers/"
+    # tfe.v2 + tfe.v2.1 + tfe.v2.2 are required so that
+    # `data "terraform_remote_state" { backend = "remote" }` resolves
+    # the API base URL through this redirect instead of giving up
+    # with "Host <X> does not provide a tfe service". The cloud-block
+    # state path doesn't go through service discovery so the cloud
+    # block keeps working without these, but every other consumer of
+    # the discovery doc (terraform_remote_state, future TFE V2 RPCs)
+    # does and needs them. All three minor versions point at the same
+    # /api/v2/ base — matches what the public discovery doc serves.
+    "tfe.v2"       = "${TP_API_URL}/api/v2/"
+    "tfe.v2.1"     = "${TP_API_URL}/api/v2/"
+    "tfe.v2.2"     = "${TP_API_URL}/api/v2/"
   }
 }
 TFEOF


### PR DESCRIPTION
## Problem

\`data \"terraform_remote_state\" { backend = \"remote\" }\` fails in agent-mode runs with:

\`\`\`
Error: Host terrapod.example.com does not provide a tfe service
\`\`\`

…even when the public Terrapod \`/.well-known/terraform.json\` correctly advertises \`tfe.v2\` at \`/api/v2/\`.

## Root cause

The runner entrypoint writes a terraform CLI \`host{}\` block redirecting the public Terrapod hostname to the internal in-cluster API URL (for module + provider downloads). Terraform's \`host{}\` block **overrides** automatic service discovery for that hostname — when only some services are declared, terraform never falls back to public discovery.

The block currently declares \`modules.v1\` + \`providers.v1\` only. The remote backend looks for \`tfe.v2\`, doesn't find it in the override, and bails out.

The cloud block keeps working because its state path doesn't go through service discovery — it calls \`/api/v2/\` directly off the configured hostname.

## Fix

Add \`tfe.v2\` + \`tfe.v2.1\` + \`tfe.v2.2\` to the services map, all three pointing at \`\${TP_API_URL}/api/v2/\` — matches what the public discovery doc serves.

## Repro / verification

A consumer workspace using:

\`\`\`hcl
data \"terraform_remote_state\" \"network\" {
  backend = \"remote\"
  config = {
    hostname     = \"terrapod.markupai.ts.net\"
    organization = \"default\"
    workspaces   = { name = \"network-prod\" }
  }
}
\`\`\`

…on a deployment where \`TERRAPOD_PUBLIC_API_URL\` differs from \`TERRAPOD_API_URL\` (i.e. internal-ingress is on) reproduces the failure. After this fix, it resolves.

Found while wiring [tf-aws-network → tf-aws-core remote-state composition](https://github.com/markupai/tf-aws-core/pull/12).