### PR TITLE
fix: honor remote-state-consumer allowlist on workspace GETs

### DIFF
--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -800,7 +800,16 @@ async def show_workspace(
 
     perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
     if perm is None:
-        raise HTTPException(status_code=404, detail="Workspace not found")
+        # Runner-token consumers can resolve the producer workspace by name
+        # so the OpenTofu `remote` backend's first hop (workspace lookup) in
+        # `data "terraform_remote_state"` finds it instead of falling through
+        # to its create-if-not-found code path (which then 403s on the
+        # runner's missing org-write permission). Allowlist check mirrors
+        # the state-read endpoints below.
+        if await _runner_state_read_allowed(db, user, ws):
+            perm = "read"
+        else:
+            raise HTTPException(status_code=404, detail="Workspace not found")
 
     # Load latest primary run for this workspace (excludes module-test / speculative PR runs)
     run_result = await db.execute(
@@ -1030,8 +1039,23 @@ async def show_workspace_by_id(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Show a workspace by its ID."""
-    ws, perm = await _require_ws_permission(workspace_id, "read", user, db)
+    """Show a workspace by its ID.
+
+    Mirrors the name-keyed handler's allowlist treatment so runner-token
+    consumers (cross-workspace ``terraform_remote_state``) can resolve
+    the producer workspace through this endpoint as well as the
+    state-read endpoints further down.
+    """
+    ws = await _get_workspace_by_id(workspace_id, db)
+    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    if not has_permission(perm, "read"):
+        if await _runner_state_read_allowed(db, user, ws):
+            perm = "read"
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Requires read permission on workspace",
+            )
 
     # Load latest primary run for this workspace (excludes module-test / speculative PR runs)
     run_result = await db.execute(


### PR DESCRIPTION
## Problem

\`data \"terraform_remote_state\" { backend = \"remote\" }\` from agent-mode runs fails with:

\`\`\`
Error: data.terraform_remote_state.network_prod: Unable to read remote state
error loading the remote state: Error creating workspace network-prod: 403 Forbidden
\`\`\`

…even when the producer's \`remote_state_consumers\` allowlist correctly lists the consumer workspace, and even after [#433](https://github.com/mattrobinsonsre/terrapod/pull/433) fixed the runner-side host{} block.

## Root cause

The OpenTofu \`remote\` backend's flow for \`terraform_remote_state\`:

1. **\`GET /api/v2/organizations/{org}/workspaces/{name}\`** — workspace lookup by name (this is the part that's been broken)
2. \`GET /api/v2/workspaces/{id}/current-state-version\` — already supports the allowlist via \`_runner_state_read_allowed\`
3. \`GET /api/v2/state-versions/{id}/download\` — same

Step 1 (\`show_workspace\`) only checks user/role RBAC. A runner-token principal carries \`everyone\` only and no per-user grant on the producer workspace, so \`resolve_workspace_permission\` returns None → handler raises 404.

The remote backend interprets 404 as \"workspace doesn't exist\" and falls through to its create-if-missing code path. The create POST then 403s on the runner token's missing org-write permission. The user sees a confusing \"Error creating workspace\" message even though the workspace exists and is intentionally allowlisted to the consumer.

## Fix

\`show_workspace\` (keyed by org + name) and \`show_workspace_by_id\` (keyed by id) now fall back to \`_runner_state_read_allowed\` when user/role RBAC returns None. That predicate is the same one already used by \`current_state_version\` and \`download_state\` — so the producer's explicit consumer allowlist now applies uniformly across **every** endpoint the remote backend touches: workspace lookup AND state read.

No schema, contract, or other auth-path changes.

## Repro / verification

A consumer workspace with HCL like:

\`\`\`hcl
data \"terraform_remote_state\" \"shared\" {
  backend = \"remote\"
  config = {
    hostname     = \"terrapod.example.com\"
    organization = \"default\"
    workspaces   = { name = \"shared-producer\" }
  }
}
\`\`\`

…and the producer's \`remote_state_consumers\` listing this workspace, reproduces the failure before this fix and resolves after.

Caught in the wild wiring network-* → core-* remote-state composition on the markup.ai instance.