### PR TITLE
chore(ci): pre-create Release + parallelise provider/migrate + goreleaser parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,20 +733,60 @@ jobs:
             "$REGISTRY/${{ matrix.image }}:sha-${sha_short}-arm64"
 
   # ── Release ────────────────────────────────────────────
-  # The release stage used to be a single 10–15 min serial job. It's
-  # now split into three parallel branches that join in `release-finalize`:
+  # The release stage is five jobs — a tiny pre-create that owns the
+  # Release object and four branches that all upload into it in
+  # parallel:
   #
-  #   release-images   — image retag (5 images) + Helm chart push + SBOMs.
-  #                      Pushes the chart to GHCR directly; saves SBOMs +
-  #                      chart + checksums as a workflow artifact for
-  #                      release-finalize to upload to the GitHub Release.
-  #   release-provider — GoReleaser provider builds (8 platforms, signed).
-  #                      CREATES the GitHub Release for this tag.
-  #   release-migrate  — GoReleaser migrate builds. APPENDS to the Release
-  #                      created by release-provider; needs that job.
-  #   release-finalize — joins all three. Generates release notes from
-  #                      conventional-commit titles, edits the Release's
-  #                      title/notes, and uploads chart + SBOMs + checksums.
+  #   release-create   — pre-creates an empty GitHub Release for the tag
+  #                      with a placeholder title. Owning Release
+  #                      creation here means provider AND migrate can
+  #                      both run in append mode at the same time
+  #                      instead of provider gating migrate (#435 had
+  #                      provider create the Release → migrate append).
+  #   release-images   — image retag + Helm push + SBOM generation.
+  #                      Saves chart + SBOMs + checksums as a workflow
+  #                      artifact for release-finalize to upload.
+  #   release-provider — GoReleaser provider, append mode.
+  #   release-migrate  — GoReleaser migrate, append mode.
+  #   release-finalize — joins all four; sets real title + release notes
+  #                      and uploads the workflow artifact from
+  #                      release-images.
+  #
+  # Both goreleaser configs are also run with `parallelism: 8` so each
+  # process saturates the runner's cores when crunching its own
+  # platform matrix.
+
+  release-create:
+    name: Release — Create empty GitHub Release
+    needs: [prepare, create-manifests]
+    if: |
+      always()
+      && needs.prepare.outputs.is_tag == 'true'
+      && needs.prepare.result == 'success'
+      && (needs.create-manifests.result == 'success' || needs.create-manifests.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create empty Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${{ needs.prepare.outputs.version }}"
+
+          # Idempotent: if the Release already exists (e.g. this job
+          # is being re-run), skip. release-finalize will set the
+          # real title/notes; we just need the Release object so the
+          # append-mode goreleaser runs have somewhere to upload to.
+          if gh release view "$version" >/dev/null 2>&1; then
+            echo "Release $version already exists; skipping create"
+            exit 0
+          fi
+          gh release create "$version" \
+            --title "$version (in progress)" \
+            --notes "Release in progress — assets are being attached by parallel CI jobs."
 
   release-images:
     name: Release — Images, Helm, SBOMs
@@ -825,12 +865,14 @@ jobs:
 
   release-provider:
     name: Release — Provider (GoReleaser)
-    needs: [prepare, create-manifests]
+    # Both goreleaser jobs depend only on release-create — they no
+    # longer gate on each other. provider/.goreleaser.yml is
+    # release.mode=append.
+    needs: [prepare, release-create]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
-      && needs.prepare.result == 'success'
-      && (needs.create-manifests.result == 'success' || needs.create-manifests.result == 'skipped')
+      && needs.release-create.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -864,14 +906,13 @@ jobs:
 
   release-migrate:
     name: Release — Migrate tool (GoReleaser)
-    # Needs release-provider because migrate/.goreleaser.yml is
-    # release.mode=append — the GitHub Release must already exist
-    # (created by release-provider) for the append upload to land.
-    needs: [prepare, release-provider]
+    # Parallel with release-provider — both append to the Release that
+    # release-create made.
+    needs: [prepare, release-create]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
-      && needs.release-provider.result == 'success'
+      && needs.release-create.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -908,10 +949,11 @@ jobs:
 
   release-finalize:
     name: Release — Finalize (notes + chart + SBOMs)
-    needs: [prepare, release-images, release-provider, release-migrate]
+    needs: [prepare, release-create, release-images, release-provider, release-migrate]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
+      && needs.release-create.result == 'success'
       && needs.release-images.result == 'success'
       && needs.release-provider.result == 'success'
       && needs.release-migrate.result == 'success'
@@ -999,11 +1041,11 @@ jobs:
   # ── Cleanup Tag on Failure ─────────────────────────────
   cleanup-tag:
     name: Cleanup Tag
-    needs: [prepare, build-images, scan-images, create-manifests, release-images, release-provider, release-migrate, release-finalize]
+    needs: [prepare, build-images, scan-images, create-manifests, release-create, release-images, release-provider, release-migrate, release-finalize]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
-      && (needs.build-images.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release-images.result == 'failure' || needs.release-provider.result == 'failure' || needs.release-migrate.result == 'failure' || needs.release-finalize.result == 'failure')
+      && (needs.build-images.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release-create.result == 'failure' || needs.release-images.result == 'failure' || needs.release-provider.result == 'failure' || needs.release-migrate.result == 'failure' || needs.release-finalize.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1046,6 +1088,7 @@ jobs:
       - scan-images
       - e2e-test
       - create-manifests
+      - release-create
       - release-images
       - release-provider
       - release-migrate
@@ -1076,6 +1119,7 @@ jobs:
             "${{ needs.scan-images.result }}"
             "${{ needs.e2e-test.result }}"
             "${{ needs.create-manifests.result }}"
+            "${{ needs.release-create.result }}"
             "${{ needs.release-images.result }}"
             "${{ needs.release-provider.result }}"
             "${{ needs.release-migrate.result }}"

--- a/migrate/.goreleaser.yml
+++ b/migrate/.goreleaser.yml
@@ -20,6 +20,10 @@ version: 2
 
 project_name: terrapod-migrate
 
+# Same parallelism setting as provider/.goreleaser.yml — saturates
+# the runner's cores when crunching the platform matrix.
+parallelism: 6
+
 builds:
   - main: ./cmd/terrapod-migrate
     env:

--- a/provider/.goreleaser.yml
+++ b/provider/.goreleaser.yml
@@ -2,6 +2,11 @@ version: 2
 
 project_name: terraform-provider-terrapod
 
+# Saturate the runner's cores when crunching the 8-platform matrix.
+# ubuntu-latest has 4 vCPUs; 6 oversubscribes slightly because part
+# of each build is I/O (go module download, GPG signing).
+parallelism: 6
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -39,7 +44,12 @@ signs:
       - "${artifact}"
 
 release:
-  disable: false
+  # The GitHub Release for this tag is pre-created by the
+  # `release-create` CI job so that provider and migrate goreleaser
+  # runs can both upload to it in parallel. append-mode tells
+  # goreleaser to upload to the existing Release instead of trying
+  # to create a fresh one.
+  mode: append
   extra_files:
     - glob: signing-key.asc
 


### PR DESCRIPTION
Follow-up to #435. Two further wall-clock wins on the release stage.

## What was still serial after #435

\`release-migrate\` depended on \`release-provider\` because provider's goreleaser was creating the GitHub Release object and migrate's was appending to it. That kept the two slowest CI jobs stacked back-to-back on the critical path.

## What this PR does

1. **New \`release-create\` job** — tiny step that pre-creates an empty GitHub Release for the tag with a placeholder title. Idempotent on re-run (skips if Release already exists).
2. **\`provider/.goreleaser.yml\` → \`release.mode: append\`** — it stops trying to create the Release itself; just uploads.
3. **\`release-provider\` and \`release-migrate\` both depend on \`release-create\`** instead of each other → they run **in parallel**, each appending its artefacts to the same Release.
4. **\`release-finalize\`** waits on all four upstream branches and overwrites the placeholder title/notes with the real release notes after every upload has landed.
5. **\`parallelism: 6\` on both goreleaser configs** — ubuntu-latest runners have 4 vCPUs; 6 oversubscribes slightly because a chunk of each per-target build is I/O (go module download, GPG signing).

## Topology

\`\`\`
prepare ─► create-manifests ─┬─► release-create ─┬─► release-provider ─┐
                              │                  ├─► release-migrate  ─┤
                              │                  └─► (release-create   │
                              │                       only gates the   │
                              │                       two goreleasers) │
                              ├─► release-images ────────────────────────►
                                                                       │
                                                                       ▼
                                                                release-finalize
\`\`\`

## Notes / caveats

- \`cleanup-tag.needs\` and \`ci-pass.needs\` updated to include \`release-create\`. Cleanup-tag still fires if any release-* job fails — partial Release gets deleted with the tag, same recovery story as before.
- \`release-create\` is idempotent. If for whatever reason it runs twice (e.g. a manual re-run of the job), the second invocation no-ops because the Release object already exists. Goreleaser is fine with already-uploaded artefacts in append mode (it just adds new ones).
- First real test is the next release tag — same can't-be-exercised-on-a-branch caveat as #435.

## Test plan

- [x] \`python3 -c 'import yaml; yaml.safe_load(...)'\` parses all three changed files
- [ ] Next release tag is the smoke test. If anything goes wrong cleanup-tag deletes the tag + the placeholder Release so the recovery procedure is unchanged.