### PR TITLE
fix(runner): extend lock file with both linux archs before upload

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -856,6 +856,30 @@ if [ "$TP_CONFIGURED_BACKEND" != "local" ]; then
 fi
 log "[entrypoint] Backend verified: local"
 
+# --- Plan phase: extend .terraform.lock.hcl with the other Linux arch ---
+# `init` only records `h1:` checksums for the arch it just ran on. If
+# the apply phase ends up on a different arch (mixed-arch nodepool,
+# spot reschedule across phases, multi-day wait between plan and
+# apply) the reused single-arch lock fails the apply-side `init`
+# with "doesn't match any of the checksums previously recorded in
+# the dependency lock file" after ~16 seconds. `providers lock`
+# downloads the other-arch archives and appends their checksums to
+# the existing entries — exactly the canonical "extend my lock with
+# another platform's hashes" tool terraform/tofu give us. Bounded
+# by amd64 + arm64 because that's what runner Jobs ever land on.
+#
+# Best-effort: a provider that doesn't publish both archs (rare —
+# `local`, `archive`, niche third-party) will fail this and the
+# warning surfaces it. We carry on with whatever did succeed.
+if [ "$TP_PHASE" = "plan" ] && [ -f .terraform.lock.hcl ]; then
+    log "[entrypoint] Extending .terraform.lock.hcl with linux/amd64 + linux/arm64 checksums..."
+    if ! "$TP_BIN" providers lock \
+            -platform=linux_amd64 \
+            -platform=linux_arm64 2>&1 | sed 's/^/[providers-lock] /'; then
+        log "[entrypoint] Warning: providers lock failed; an apply on a different arch may fail tofu init"
+    fi
+fi
+
 # --- Plan phase: upload the lock file produced (or augmented) by init ---
 # Apply phase will download this so its init resolves to the same
 # provider versions. Best-effort — a failure here just means the


### PR DESCRIPTION
## Problem

\`init\` only records \`h1:\` checksums for the arch it just ran on. When the apply phase ends up on a different arch from the plan phase (mixed-arch nodepool, spot reschedule across phases, multi-day wait between plan and manual confirm) the reused single-arch lock file fails the apply-side \`init\` with:

\`\`\`
Error: Failed to install provider

Error while installing hashicorp/<X> <ver>: the current package for
registry.opentofu.org/hashicorp/<X> <ver> doesn't match any of the
checksums previously recorded in the dependency lock file
\`\`\`

…and the runner exits 1 in ~16 seconds.

Caught in the wild on the [\`aks-prod-us2\` workspace](https://terrapod.markupai.ts.net/workspaces/ws-019e8dc7-a3be-7493-a23d-572f5bc4a350/runs/run-019e9248-6f87-7ba9-a805-a8481fda8ed6) — plan ran on linux/amd64 on 2026-06-04, apply landed on linux/arm64 on 2026-06-05, init refused to verify the providers against the amd64-only lock.

## Fix

After \`init\`, in the plan phase only, run:

\`\`\`
$TP_BIN providers lock -platform=linux_amd64 -platform=linux_arm64
\`\`\`

This extends the existing lock file with the other arch's \`h1:\` checksums before we upload it for apply-phase reuse. The apply-side init then has a valid hash for whichever arch the runner Job lands on.

\`providers lock\` is the canonical "extend my lock with another platform's hashes" tool — terraform/tofu refuse to do this from \`init\` itself because (a) silently adding any archive's hash would be a security regression, (b) the only other path (\`init -upgrade\`) re-resolves versions and would break plan-apply consistency.

## Best-effort

The vast majority of providers publish both linux archs. A handful (\`local\`, \`archive\`, niche third-party) might not — \`providers lock\` will fail for those. We log a warning with the \`[providers-lock]\` prefix and continue. Apply-side init still succeeds on the plan's own arch; mixed-arch protection just degrades for the missing provider.

For belt-and-braces in environments that don't want any single-arch dependency, pinning the agent pool to a single arch via \`runners.nodeSelector\` is still recommended (see e.g. markup.ai's [argocd-internal-apps !1681](https://gitlab.com/acrolinx/cloud-ops/argocd-internal-apps/-/merge_requests/1681)).

## Cost

~5–30 sec added to plan-phase wall clock, depending on provider count and how warm the configured provider-installation mirror's cache is for the other arch. The current arch's providers are already on disk after \`init\`; the other arch is fetched from the mirror.

## Test plan

- [x] \`bash -n docker/runner-entrypoint.sh\` parses
- [ ] First post-merge run on any agent-mode workspace will exercise the new code path; lock-file size grows ~2x (two h1: per provider). aks-prod-us2's next run reproduces the original failure scenario without the fix.