### PR TITLE
fix(run-triggers): attach latest uploaded CV + add UX (#439)

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -659,13 +659,43 @@ async def retry_run(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
+    # Defensive: if the source run has no CV (e.g. it was queued by an
+    # older fire_run_triggers before #439, or by some other path that
+    # forgot to attach one), pick the workspace's latest uploaded CV
+    # rather than faithfully copying the null forward. A retry with no
+    # CV would just re-hit the runner's "no configuration archive (HTTP
+    # 404)" exit — preserving the bug instead of clearing it. Existing
+    # null-CV runs already in the DB become retry-able after this.
+    cv_id_for_retry = run.configuration_version_id
+    if cv_id_for_retry is None:
+        from terrapod.db.models import ConfigurationVersion
+
+        cv_result = await db.execute(
+            select(ConfigurationVersion.id)
+            .where(
+                ConfigurationVersion.workspace_id == ws.id,
+                ConfigurationVersion.status == "uploaded",
+            )
+            .order_by(ConfigurationVersion.created_at.desc())
+            .limit(1)
+        )
+        cv_id_for_retry = cv_result.scalar_one_or_none()
+        if cv_id_for_retry is None:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Source run has no configuration version and the workspace has "
+                    "never had one uploaded; nothing to retry against."
+                ),
+            )
+
     new_run = await run_service.create_run(
         db,
         workspace=ws,
         message=f"Retry of run-{run.id}",
         source=run.source,
         plan_only=run.plan_only,
-        configuration_version_id=run.configuration_version_id,
+        configuration_version_id=cv_id_for_retry,
         created_by=user.email,
         target_addrs=run.target_addrs,
         replace_addrs=run.replace_addrs,

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -709,9 +709,23 @@ async def fire_run_triggers(
     """Fire run triggers for downstream workspaces after a successful apply.
 
     Queries all RunTrigger rows where this workspace is the source,
-    then creates and queues a new run for each destination workspace.
+    then creates and queues a new run on each destination workspace
+    against its latest successfully-uploaded configuration version.
+
+    Without a CV attached, the runner has no code to plan against:
+    its first action is `GET /api/terrapod/v1/runs/{id}/artifacts/config`,
+    which the API answers with 404 when `run.configuration_version_id`
+    is null. The runner then exits 1 in ~8 seconds and the run shows
+    as errored — exactly the failure that #439 fixed (this code path
+    used to call `create_run` with no CV reference at all).
+
+    If the destination has never had a CV uploaded, the trigger is
+    skipped with a warning: there is nothing the runner could
+    sensibly do, and queueing a doomed run is just noise.
     """
     from sqlalchemy.orm import selectinload
+
+    from terrapod.db.models import ConfigurationVersion
 
     result = await db.execute(
         select(RunTrigger)
@@ -732,6 +746,27 @@ async def fire_run_triggers(
         if dest_ws is None:
             continue
 
+        # Latest uploaded CV for the destination — required so the
+        # runner has code to plan against.
+        cv_result = await db.execute(
+            select(ConfigurationVersion.id)
+            .where(
+                ConfigurationVersion.workspace_id == dest_ws.id,
+                ConfigurationVersion.status == "uploaded",
+            )
+            .order_by(ConfigurationVersion.created_at.desc())
+            .limit(1)
+        )
+        latest_cv_id = cv_result.scalar_one_or_none()
+
+        if latest_cv_id is None:
+            logger.warning(
+                "Run trigger skipped: destination workspace has no uploaded CV",
+                source_workspace=source_name,
+                destination_workspace=dest_ws.name,
+            )
+            continue
+
         run = await create_run(
             db,
             workspace=dest_ws,
@@ -739,6 +774,7 @@ async def fire_run_triggers(
             auto_apply=dest_ws.auto_apply,
             plan_only=False,
             source="tfe-api",
+            configuration_version_id=latest_cv_id,
         )
         await queue_run(db, run)
 
@@ -747,6 +783,7 @@ async def fire_run_triggers(
             source_workspace=source_name,
             destination_workspace=dest_ws.name,
             run_id=str(run.id),
+            configuration_version_id=str(latest_cv_id),
         )
 
 

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -468,3 +468,62 @@ class TestFireRunTriggers:
         await transition_run(mock_db, run, "applied")
 
         mock_fire.assert_called_once_with(mock_db, run.workspace_id)
+
+    @patch("terrapod.services.run_service.queue_run")
+    @patch("terrapod.services.run_service.create_run")
+    async def test_fire_triggers_attaches_latest_cv(self, mock_create, mock_queue):
+        """#439: triggered runs must carry the destination's latest uploaded CV."""
+        from terrapod.services.run_service import fire_run_triggers
+
+        source_ws_id = uuid.uuid4()
+        dest_ws = _mock_workspace(name="downstream")
+        trigger = MagicMock()
+        trigger.workspace = dest_ws
+
+        source_ws = _mock_workspace(ws_id=source_ws_id, name="upstream")
+        latest_cv_id = uuid.uuid4()
+
+        triggers_result = MagicMock()
+        triggers_result.scalars.return_value.all.return_value = [trigger]
+        cv_result = MagicMock()
+        cv_result.scalar_one_or_none.return_value = latest_cv_id
+
+        mock_db = AsyncMock()
+        mock_db.execute.side_effect = [triggers_result, cv_result]
+        mock_db.get.return_value = source_ws
+
+        downstream_run = MagicMock()
+        mock_create.return_value = downstream_run
+
+        await fire_run_triggers(mock_db, source_ws_id)
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["configuration_version_id"] == latest_cv_id
+        mock_queue.assert_called_once_with(mock_db, downstream_run)
+
+    @patch("terrapod.services.run_service.queue_run")
+    @patch("terrapod.services.run_service.create_run")
+    async def test_fire_triggers_skips_destination_with_no_cv(self, mock_create, mock_queue):
+        """#439: destination with no uploaded CV is skipped (no doomed run)."""
+        from terrapod.services.run_service import fire_run_triggers
+
+        source_ws_id = uuid.uuid4()
+        dest_ws = _mock_workspace(name="downstream")
+        trigger = MagicMock()
+        trigger.workspace = dest_ws
+
+        source_ws = _mock_workspace(ws_id=source_ws_id, name="upstream")
+
+        triggers_result = MagicMock()
+        triggers_result.scalars.return_value.all.return_value = [trigger]
+        cv_result = MagicMock()
+        cv_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute.side_effect = [triggers_result, cv_result]
+        mock_db.get.return_value = source_ws
+
+        await fire_run_triggers(mock_db, source_ws_id)
+
+        mock_create.assert_not_called()
+        mock_queue.assert_not_called()

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -1069,3 +1069,79 @@ class TestPlanJsonAttribute:
 
         attrs = resp.json()["data"]["attributes"]
         assert "json-output" not in attrs
+
+
+class TestRetryRun:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.queue_run")
+    @patch("terrapod.api.routers.runs.run_service.create_run")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    async def test_retry_attaches_latest_cv_when_source_has_none(
+        self, mock_resolve, mock_get_run, mock_create_run, mock_queue, *mocks
+    ):
+        """#439: retrying a run whose CV is null falls back to the workspace's
+        latest uploaded CV rather than faithfully copying the null forward."""
+        mock_resolve.return_value = "plan"
+
+        original = _mock_run(status="errored")
+        original.configuration_version_id = None  # The bug
+        mock_get_run.return_value = original
+
+        ws = _mock_workspace(ws_id=original.workspace_id)
+        new_run = _mock_run(status="pending", ws_id=ws.id)
+        mock_create_run.return_value = new_run
+        mock_queue.return_value = new_run
+
+        latest_cv_id = uuid.uuid4()
+        cv_result = MagicMock()
+        cv_result.scalar_one_or_none.return_value = latest_cv_id
+
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+        mock_db.execute.return_value = cv_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/terrapod/v1/runs/run-{original.id}/actions/retry",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 201
+        assert mock_create_run.await_args.kwargs["configuration_version_id"] == latest_cv_id
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.create_run")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    async def test_retry_rejects_when_workspace_has_no_cv(
+        self, mock_resolve, mock_get_run, mock_create_run, *mocks
+    ):
+        """If the source run has no CV AND the workspace has never had one
+        uploaded, the retry is rejected with 422 (nothing the runner could do)."""
+        mock_resolve.return_value = "plan"
+
+        original = _mock_run(status="errored")
+        original.configuration_version_id = None
+        mock_get_run.return_value = original
+
+        ws = _mock_workspace(ws_id=original.workspace_id)
+        cv_result = MagicMock()
+        cv_result.scalar_one_or_none.return_value = None
+
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+        mock_db.execute.return_value = cv_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/terrapod/v1/runs/run-{original.id}/actions/retry",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 422
+        mock_create_run.assert_not_called()

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -205,9 +205,9 @@ const ALL_TRIGGERS = [
 const ALL_STAGES = ['pre_plan', 'post_plan', 'pre_apply'] as const
 const ALL_ENFORCEMENT_LEVELS = ['mandatory', 'advisory'] as const
 
-type Tab = 'overview' | 'variables' | 'runs' | 'state' | 'configurations' | 'notifications' | 'run-tasks' | 'sharing'
+type Tab = 'overview' | 'variables' | 'runs' | 'state' | 'configurations' | 'notifications' | 'run-tasks' | 'run-triggers' | 'sharing'
 
-const VALID_TABS: Set<string> = new Set(['overview', 'variables', 'runs', 'state', 'configurations', 'notifications', 'run-tasks', 'sharing'])
+const VALID_TABS: Set<string> = new Set(['overview', 'variables', 'runs', 'state', 'configurations', 'notifications', 'run-tasks', 'run-triggers', 'sharing'])
 
 export default function WorkspaceDetailPage() {
   return (
@@ -369,6 +369,21 @@ function WorkspaceDetailContent() {
   const [rscAddName, setRscAddName] = useState('')
   const [rscAdding, setRscAdding] = useState(false)
 
+  // Run Triggers — cross-workspace apply-fires-plan dependency edges
+  interface RunTriggerEdge {
+    id: string
+    workspaceId: string
+    workspaceName: string
+    sourceableId: string
+    sourceableName: string
+    createdAt: string
+  }
+  const [trgInbound, setTrgInbound] = useState<RunTriggerEdge[]>([])
+  const [trgOutbound, setTrgOutbound] = useState<RunTriggerEdge[]>([])
+  const [trgLoading, setTrgLoading] = useState(false)
+  const [trgAddName, setTrgAddName] = useState('')
+  const [trgAdding, setTrgAdding] = useState(false)
+
   // Notifications
   const [notifications, setNotifications] = useState<NotificationConfig[]>([])
   const [notifLoading, setNotifLoading] = useState(false)
@@ -499,6 +514,7 @@ function WorkspaceDetailContent() {
     if (activeTab === 'configurations') loadConfigurations()
     if (activeTab === 'notifications') loadNotifications()
     if (activeTab === 'run-tasks') loadRunTasks()
+    if (activeTab === 'run-triggers') loadRunTriggers()
   }, [activeTab, workspace, loadRuns])
 
   // Load VCS refs when plan options panel opens on a VCS-connected workspace
@@ -741,6 +757,87 @@ function WorkspaceDetailContent() {
       await loadRemoteStateConsumers()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to revoke consumer')
+    }
+  }
+
+  function _trgFromRow(row: { id: string; relationships?: { workspace?: { data?: { id: string } }; sourceable?: { data?: { id: string } } }; attributes: { 'workspace-name'?: string; 'sourceable-name'?: string; 'created-at'?: string } }): RunTriggerEdge {
+    return {
+      id: row.id,
+      workspaceId: row.relationships?.workspace?.data?.id || '',
+      workspaceName: row.attributes['workspace-name'] || '',
+      sourceableId: row.relationships?.sourceable?.data?.id || '',
+      sourceableName: row.attributes['sourceable-name'] || '',
+      createdAt: row.attributes['created-at'] || '',
+    }
+  }
+
+  async function loadRunTriggers() {
+    setTrgLoading(true)
+    try {
+      const base = `/api/terrapod/v1/workspaces/${workspaceId}/run-triggers`
+      const [inRes, outRes] = await Promise.all([
+        apiFetch(`${base}?filter[run-trigger][type]=inbound`),
+        apiFetch(`${base}?filter[run-trigger][type]=outbound`),
+      ])
+      if (!inRes.ok) throw new Error('Failed to load inbound run triggers')
+      if (!outRes.ok) throw new Error('Failed to load outbound run triggers')
+      const inData = await inRes.json()
+      const outData = await outRes.json()
+      setTrgInbound((inData.data || []).map(_trgFromRow))
+      setTrgOutbound((outData.data || []).map(_trgFromRow))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load run triggers')
+    } finally {
+      setTrgLoading(false)
+    }
+  }
+
+  async function addRunTrigger() {
+    const name = trgAddName.trim()
+    if (!name) return
+    setTrgAdding(true)
+    try {
+      const lookup = await apiFetch(`/api/v2/organizations/default/workspaces/${encodeURIComponent(name)}`)
+      if (!lookup.ok) {
+        throw new Error(lookup.status === 404 ? `Workspace "${name}" not found` : 'Failed to resolve source workspace')
+      }
+      const wsBody = await lookup.json()
+      const sourceId = wsBody.data?.id
+      if (!sourceId) throw new Error('Workspace lookup returned no id')
+
+      const res = await apiFetch(
+        `/api/terrapod/v1/workspaces/${workspaceId}/run-triggers`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/vnd.api+json' },
+          body: JSON.stringify({
+            data: { relationships: { sourceable: { data: { id: sourceId, type: 'workspaces' } } } },
+          }),
+        },
+      )
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: 'Failed to add run trigger' }))
+        throw new Error(err.detail || 'Failed to add run trigger')
+      }
+      setTrgAddName('')
+      await loadRunTriggers()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add run trigger')
+    } finally {
+      setTrgAdding(false)
+    }
+  }
+
+  async function removeRunTrigger(triggerId: string) {
+    try {
+      const res = await apiFetch(`/api/terrapod/v1/run-triggers/${triggerId}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: 'Failed to remove run trigger' }))
+        throw new Error(err.detail || 'Failed to remove run trigger')
+      }
+      await loadRunTriggers()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove run trigger')
     }
   }
 
@@ -1367,6 +1464,7 @@ function WorkspaceDetailContent() {
     { key: 'configurations', label: 'Configurations' },
     { key: 'notifications', label: 'Notifications' },
     { key: 'run-tasks', label: 'Run Tasks' },
+    { key: 'run-triggers', label: 'Run Triggers' },
     { key: 'sharing', label: 'Sharing' },
   ]
 
@@ -3134,6 +3232,90 @@ function WorkspaceDetailContent() {
                 })}
               </div>
             )}
+          </div>
+        )}
+
+        {/* Run Triggers Tab — cross-workspace apply-fires-plan edges */}
+        {activeTab === 'run-triggers' && (
+          <div>
+            <div className="flex items-baseline justify-between mb-1">
+              <h3 className="text-lg font-semibold text-slate-200">Run Triggers</h3>
+              {trgLoading && <span className="text-xs text-slate-500">loading…</span>}
+            </div>
+            <p className="text-xs text-slate-500 mb-6">
+              When a source workspace completes an apply, downstream workspaces get a new run queued automatically. Up to 20 source workspaces per destination.
+            </p>
+
+            {/* Inbound — source workspaces that trigger runs HERE */}
+            <div className="mb-8">
+              <h4 className="text-sm font-medium text-slate-300 mb-2">Source workspaces that trigger runs here</h4>
+              {trgInbound.length === 0 ? (
+                <p className="text-sm text-slate-500 italic">No source workspaces trigger runs on this workspace.</p>
+              ) : (
+                <ul className="space-y-1">
+                  {trgInbound.map((t) => (
+                    <li key={t.id} className="flex items-center justify-between gap-3 rounded bg-slate-800/40 px-3 py-2 text-sm">
+                      <div>
+                        <a href={`/workspaces/${t.sourceableId}`} className="text-brand-400 hover:text-brand-300 font-medium">
+                          {t.sourceableName || t.sourceableId}
+                        </a>
+                      </div>
+                      {perms['can-update'] && (
+                        <button
+                          type="button"
+                          onClick={() => removeRunTrigger(t.id)}
+                          className="rounded px-2 py-1 text-xs font-medium bg-red-900/40 text-red-200 hover:bg-red-900/60"
+                        >
+                          Remove
+                        </button>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {perms['can-update'] && (
+                <form
+                  onSubmit={(e) => { e.preventDefault(); addRunTrigger() }}
+                  className="mt-3 flex items-center gap-2"
+                >
+                  <input
+                    type="text"
+                    value={trgAddName}
+                    onChange={(e) => setTrgAddName(e.target.value)}
+                    placeholder="Add source workspace by name"
+                    className="flex-1 rounded border border-slate-700 bg-slate-900 px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500"
+                    disabled={trgAdding}
+                  />
+                  <button
+                    type="submit"
+                    disabled={trgAdding || !trgAddName.trim()}
+                    className="rounded bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {trgAdding ? 'Adding…' : 'Add'}
+                  </button>
+                </form>
+              )}
+            </div>
+
+            {/* Outbound — destination workspaces this one triggers */}
+            <div>
+              <h4 className="text-sm font-medium text-slate-300 mb-2">Destination workspaces this workspace triggers</h4>
+              {trgOutbound.length === 0 ? (
+                <p className="text-sm text-slate-500 italic">This workspace does not trigger runs on any other workspace.</p>
+              ) : (
+                <ul className="space-y-1">
+                  {trgOutbound.map((t) => (
+                    <li key={t.id} className="rounded bg-slate-800/40 px-3 py-2 text-sm">
+                      <a href={`/workspaces/${t.workspaceId}`} className="text-brand-400 hover:text-brand-300 font-medium">
+                        {t.workspaceName || t.workspaceId}
+                      </a>
+                      <span className="ml-2 text-xs text-slate-500">(destination; remove from there)</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

When a source workspace completed an apply, `fire_run_triggers` created downstream runs with no `configuration_version_id`. The runner's first action is `GET /runs/{id}/artifacts/config`; with no CV attached the API 404s, the runner exits 1 in ~8s, and the run shows as errored. Manual "retry" on the errored run faithfully copied the null CV forward, so retries hit the same path. This had been happening silently on every trigger-fired downstream run.

## Server fix

- `fire_run_triggers` now selects the destination workspace's latest uploaded CV and attaches it. If the destination has never had a CV uploaded, the trigger is skipped with a warning rather than queueing a doomed run.
- `retry_run` defensively does the same: if the source run has no CV, fall back to the workspace's latest uploaded CV. If neither has one, return 422 ("nothing to retry against") instead of producing a run the runner cannot service.

## UX

New **Run Triggers** tab on the workspace detail page, modelled on the existing remote-state Sharing tab:

- **Inbound** — source workspaces that trigger runs here. Add (textbox + button; admin on this workspace required) and Remove controls.
- **Outbound** — destination workspaces this one triggers. View-only with a hint "(destination; remove from there)" since admin lives on the destination per the API contract.

## Test plan

- [x] Unit tests added for `fire_run_triggers` (attaches CV, skips when destination has no CV) and `retry_run` (uses latest CV when source has none, 422 when nothing available).
- [x] Full pytest run (`make test`) — 1748 passed.
- [x] Lint clean (`make lint`).
- [x] API smoke against Tilt: create/list/remove via curl on `/api/terrapod/v1/workspaces/{id}/run-triggers` and `/api/terrapod/v1/run-triggers/{id}`.
- [x] UI smoke via Playwright on the new tab: inbound add + remove round-trip; outbound view shows destination with hint and no Remove button.