### PR TITLE
fix(ci): move goreleaser parallelism from yaml to CLI flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,7 +752,7 @@ jobs:
   #                      and uploads the workflow artifact from
   #                      release-images.
   #
-  # Both goreleaser configs are also run with `parallelism: 8` so each
+  # Both goreleaser invocations also pass `--parallelism 6` so each
   # process saturates the runner's cores when crunching its own
   # platform matrix.
 
@@ -898,7 +898,10 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          # --parallelism saturates the runner's 4 vCPUs across the
+          # 8-platform build matrix (slightly oversubscribed because
+          # part of each build is I/O — module download, GPG signing).
+          args: release --clean --parallelism 6
           workdir: provider
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -941,7 +944,8 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          # See note on release-provider — same parallelism rationale.
+          args: release --clean --parallelism 6
           workdir: migrate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/migrate/.goreleaser.yml
+++ b/migrate/.goreleaser.yml
@@ -20,9 +20,9 @@ version: 2
 
 project_name: terrapod-migrate
 
-# Same parallelism setting as provider/.goreleaser.yml — saturates
-# the runner's cores when crunching the platform matrix.
-parallelism: 6
+# Build parallelism is set via the `--parallelism` CLI flag in
+# .github/workflows/ci.yml (goreleaser v2 has no project-level
+# `parallelism` field in the schema).
 
 builds:
   - main: ./cmd/terrapod-migrate

--- a/provider/.goreleaser.yml
+++ b/provider/.goreleaser.yml
@@ -2,10 +2,11 @@ version: 2
 
 project_name: terraform-provider-terrapod
 
-# Saturate the runner's cores when crunching the 8-platform matrix.
-# ubuntu-latest has 4 vCPUs; 6 oversubscribes slightly because part
-# of each build is I/O (go module download, GPG signing).
-parallelism: 6
+# Build parallelism is set via the `--parallelism` CLI flag in
+# .github/workflows/ci.yml (goreleaser v2 has no project-level
+# `parallelism` field in the schema). ubuntu-latest has 4 vCPUs;
+# 6 oversubscribes slightly because part of each build is I/O
+# (go module download, GPG signing).
 
 builds:
   - env:


### PR DESCRIPTION
## Summary

GoReleaser v2's project-level schema has no \`parallelism\` field, so the project-level \`parallelism: 6\` added by #437 caused every release tag pipeline to fail with:

\`\`\`
yaml: unmarshal errors:
  line N: field parallelism not found in type config.Project
\`\`\`

The bug was latent on main (no goreleaser run on push) and surfaced on the first release tag after #437 — v0.31.5, which Cleanup Tag then deleted. Same end result: each goreleaser invocation builds its platform matrix with \`--parallelism 6\`, just passed through the action's \`args:\` instead of the YAML.

## Test plan

- [ ] PR CI green
- [ ] Re-tag v0.31.5 after merge; release pipeline completes through release-finalize