### PR TITLE
fix(runner): only lock the OTHER arch (init already covers current)

### DIFF
--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -856,26 +856,39 @@ if [ "$TP_CONFIGURED_BACKEND" != "local" ]; then
 fi
 log "[entrypoint] Backend verified: local"
 
-# --- Plan phase: extend .terraform.lock.hcl with the other Linux arch ---
+# --- Plan phase: extend .terraform.lock.hcl with the OTHER Linux arch ---
 # `init` only records `h1:` checksums for the arch it just ran on. If
 # the apply phase ends up on a different arch (mixed-arch nodepool,
 # spot reschedule across phases, multi-day wait between plan and
 # apply) the reused single-arch lock fails the apply-side `init`
 # with "doesn't match any of the checksums previously recorded in
 # the dependency lock file" after ~16 seconds. `providers lock`
-# downloads the other-arch archives and appends their checksums to
-# the existing entries — exactly the canonical "extend my lock with
-# another platform's hashes" tool terraform/tofu give us. Bounded
-# by amd64 + arm64 because that's what runner Jobs ever land on.
+# downloads the requested-arch archives and appends their checksums
+# to the existing entries — exactly the canonical "extend my lock
+# with another platform's hashes" tool terraform/tofu give us.
 #
-# Best-effort: a provider that doesn't publish both archs (rare —
+# Bounded by amd64 + arm64 because that's what runner Jobs ever land
+# on. Importantly we only run it for the OTHER arch — `init` above
+# already downloaded the current arch and updated the lock with its
+# `h1:`, and `providers lock` would re-download regardless of whether
+# the archive is already on disk (h1 is computed over the unzipped
+# contents, sourced from the network mirror not the local cache). So
+# duplicating the current arch here doubles the lock-extension
+# download volume per plan for no functional gain.
+#
+# Best-effort: a provider that doesn't publish the other arch (rare —
 # `local`, `archive`, niche third-party) will fail this and the
 # warning surfaces it. We carry on with whatever did succeed.
-if [ "$TP_PHASE" = "plan" ] && [ -f .terraform.lock.hcl ]; then
-    log "[entrypoint] Extending .terraform.lock.hcl with linux/amd64 + linux/arm64 checksums..."
+case "$(uname -m)" in
+    aarch64) OTHER_PLATFORM="linux_amd64" ;;
+    x86_64)  OTHER_PLATFORM="linux_arm64" ;;
+    *)       OTHER_PLATFORM="" ;;
+esac
+
+if [ "$TP_PHASE" = "plan" ] && [ -f .terraform.lock.hcl ] && [ -n "$OTHER_PLATFORM" ]; then
+    log "[entrypoint] Extending .terraform.lock.hcl with $OTHER_PLATFORM checksums (current arch already locked by init)..."
     if ! "$TP_BIN" providers lock \
-            -platform=linux_amd64 \
-            -platform=linux_arm64 2>&1 | sed 's/^/[providers-lock] /'; then
+            -platform="$OTHER_PLATFORM" 2>&1 | sed 's/^/[providers-lock] /'; then
         log "[entrypoint] Warning: providers lock failed; an apply on a different arch may fail tofu init"
     fi
 fi


### PR DESCRIPTION
## Summary

#438 ran \`tofu providers lock -platform=linux_amd64 -platform=linux_arm64\` on every plan. Empirically (confirmed against tofu 1.12), that command downloads every requested platform's archive in full to compute the \`h1:\` hash — even when init had just downloaded one of them moments ago. \`h1:\` is sha256 over the unzipped archive contents and tofu sources it from the network mirror, not the on-disk provider cache.

For a typical AWS-heavy workspace with 5–10 providers, the redundant current-arch download dragged 500 MB–1.5 GB through the provider mirror on every plan. That's the load the OP flagged.

## Fix

Detect the runner's arch via \`uname -m\` and only ask \`providers lock\` for the OTHER platform:

| Runner arch | Locked here |
|-------------|-------------|
| \`aarch64\` | \`linux_amd64\` |
| \`x86_64\`  | \`linux_arm64\` |
| anything else | skip (restores pre-#438 behaviour) |

Init handles the current arch (downloads it + updates the lock with its \`h1:\`), so we keep #438's cross-arch safety property at half the cost.

## Test plan

- [x] Empirical confirmation: \`tofu init && tofu providers lock -platform=<current-arch>\` re-downloads the archive even though init just put it on disk.
- [x] \`bash -n docker/runner-entrypoint.sh\` clean.
- [ ] CI green.
- [ ] Tilt smoke once merged + tagged: one plan on the local arm64 runner; verify only \`linux_amd64\` is fetched during the providers-lock step.

## Follow-up

(Not in this PR.) Even one extra-arch download per plan is wasteful when the mirror already knows the hash. The network-mirror protocol's \`{version}.json\` response includes \`archives[platform].hashes\` — a future PR can merge the OTHER-arch hash directly from the mirror's JSON and skip \`tofu providers lock\` entirely. That's bigger code; this is the easy 50% win.