### PR TITLE
deps: Python 3.14 → 3.13 + litellm 1.87 + aiohttp 3.14 (clears 4 CVEs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: python:3.14-slim
+    container: python:3.13-slim
     steps:
       - uses: actions/checkout@v6
       - name: Install Poetry and export plugin
@@ -252,41 +252,10 @@ jobs:
         # application that uses the library, not by the library. No fix
         # version is published. Suppress until a fix lands or the dispute
         # is resolved upstream.
-        #
-        # The remaining four ignores are all transitively gated by
-        # litellm 1.83.x. Patched releases (1.83.11+) pin Python
-        # <3.14 and our API image is on 3.14. Re-checked 2026-06-04:
-        # latest 1.87.0 still requires_python = <3.14. Until litellm
-        # restores 3.14 compatibility, ALL FOUR of the below have to
-        # stay.  See services/pyproject.toml for the matching
-        # dependency-side comment.
-        #
-        # CVE-2026-40217 (litellm <1.83.11): proxy-mode sandbox
-        # escape in POST /guardrails/test_custom_code. Terrapod uses
-        # litellm as a library via acompletion(), never starts the
-        # proxy server — endpoint unreachable.
-        #
-        # CVE-2026-28684 (python-dotenv <1.2.2): symlink follow in
-        # set_key()/unset_key(). Terrapod only READS env vars
-        # (load_dotenv / os.environ); never calls the affected write
-        # APIs. Cannot bump independently — litellm 1.83.7+ pins
-        # python-dotenv==1.0.1 exactly, so forcing >=1.2.2 here
-        # pushes the resolver back to litellm 1.83.0 (strictly worse
-        # — three more proxy CVEs).
-        #
-        # CVE-2026-34993 + CVE-2026-47265 (aiohttp <3.14.0): RCE via
-        # CookieJar.load() on untrusted input; cross-origin leak of
-        # cookies set via the `cookies` request param. litellm
-        # 1.83.x pins aiohttp==3.13.5; not reachable from how we
-        # call litellm.
         run: |
           pip install pip-audit
           pip-audit -r services/requirements.txt --strict --desc \
-            --ignore-vuln PYSEC-2025-183 \
-            --ignore-vuln CVE-2026-40217 \
-            --ignore-vuln CVE-2026-28684 \
-            --ignore-vuln CVE-2026-34993 \
-            --ignore-vuln CVE-2026-47265
+            --ignore-vuln PYSEC-2025-183
 
   # ── Dependency Audit (npm) ────────────────────────────
   npm-audit:

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -4,7 +4,7 @@
 # Multi-stage: builder has gcc for compiling C extensions (asyncpg),
 # runtime image is slim with only runtime libraries.
 
-FROM python:3.14-slim AS builder
+FROM python:3.13-slim AS builder
 
 # Install build + runtime dependencies
 # apt-get upgrade picks up security patches for base OS packages
@@ -45,7 +45,7 @@ RUN "$POETRY_HOME"/bin/poetry lock --no-interaction --no-ansi \
     && pip install --no-cache-dir -r /tmp/requirements.txt
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM python:3.14-slim
+FROM python:3.13-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # Runtime-only system libraries (no gcc, no -dev headers)

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -85,7 +85,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
 WORKDIR /app
 
 # Copy installed Python packages from builder
-COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Copy application code

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -3,7 +3,7 @@
 # Only includes httpx, kubernetes, prometheus-client, structlog, pydantic.
 # No cloud SDKs, no SQLAlchemy, no authlib, no SAML.
 
-FROM python:3.14-slim AS builder
+FROM python:3.13-slim AS builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     pkg-config \
@@ -16,7 +16,7 @@ COPY services/pyproject-listener.toml pyproject.toml
 RUN pip install --no-cache-dir .
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM python:3.14-slim
+FROM python:3.13-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # Bump APT_REFRESH to bust the cached apt layer and re-pull Debian

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -30,7 +30,7 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 WORKDIR /app
 
 # Copy installed Python packages from builder
-COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Only the modules the listener imports: config, logging_config, runner/

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -2,7 +2,7 @@
 # Minimal image for Alembic database migrations.
 # Only includes SQLAlchemy, asyncpg, and alembic.
 
-FROM python:3.14-slim AS builder
+FROM python:3.13-slim AS builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     pkg-config \
@@ -15,7 +15,7 @@ COPY services/pyproject-migrations.toml pyproject.toml
 RUN pip install --no-cache-dir .
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM python:3.14-slim
+FROM python:3.13-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # Pick up post-publish Debian security patches. Bump APT_REFRESH to

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -28,7 +28,7 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 WORKDIR /app
 
 # Copy installed Python packages from builder
-COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Only the modules needed for migrations: db models + alembic config

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,7 +1,7 @@
 # Terrapod API test runner
 # Includes all dev dependencies (pytest, ruff, mypy)
 
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-or-later"
 packages = [{include = "terrapod"}]
 
 [tool.poetry.dependencies]
-python = "^3.13"
+python = ">=3.13,<3.14"
 fastapi = ">=0.135.2,!=0.136.3,<0.137.0"
 uvicorn = {extras = ["standard"], version = ">=0.42,<0.49"}
 pydantic = "^2.10.0"
@@ -65,18 +65,14 @@ standard-imghdr = "^3.13"
 # proxy never started), but tightening the floor keeps the resolver
 # off the older line.
 #
-# We can't push the floor past 1.83.x to clear CVE-2026-40217 (also
-# proxy-mode, patched in 1.83.11+): every release from 1.83.11 onwards
-# pins Python <3.14, and our API image is on 3.14. Re-checked
-# 2026-06-04: latest 1.87.0 still requires_python = <3.14.
-#
-# We also can't directly bump python-dotenv past 1.0.1 to clear
-# CVE-2026-28684: litellm 1.83.7+ pins python-dotenv==1.0.1 exactly,
-# so a >=1.2.2 floor on dotenv would force the resolver back to
-# litellm 1.83.0 (which has CVEs 42203/42208/42271 unpatched —
-# strictly worse). Tracked together with CVE-2026-40217 — both
-# clear when litellm restores 3.14 compatibility.
-litellm = ">=1.83.7,<2.0"
+# Bumped floor to 1.87 (the latest as of 2026-06-05): clears
+# CVE-2026-40217 (proxy-mode, patched in 1.83.11+) and relaxes the
+# aiohttp pin from `==3.13.5` to `<4.0,>=3.10`, which lets us pull in
+# aiohttp 3.14+ for GHSA-hg6j-4rv6-33pg + GHSA-jg22-mg44-37j8. This is
+# only reachable now that we sit on Python 3.13 — every litellm
+# release from 1.83.11 onwards requires_python = <3.14. The 3.13
+# floor stays until litellm restores 3.14 compatibility.
+litellm = ">=1.87,<2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.2"

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -58,20 +58,16 @@ standard-imghdr = "^3.13"
 # speaks OpenAI Chat Completions request shape to LiteLLM; LiteLLM
 # handles per-provider request translation and auth in-process.
 #
-# Upper bound <2.0 is the standard major-version cap. The lower bound
-# is 1.83.7, which patches three proxy-mode CVEs (CVE-2026-42203,
-# CVE-2026-42208, CVE-2026-42271) — all proxy-only and not reachable
-# from how Terrapod uses litellm (library-only via acompletion(),
-# proxy never started), but tightening the floor keeps the resolver
-# off the older line.
-#
-# Bumped floor to 1.87 (the latest as of 2026-06-05): clears
-# CVE-2026-40217 (proxy-mode, patched in 1.83.11+) and relaxes the
-# aiohttp pin from `==3.13.5` to `<4.0,>=3.10`, which lets us pull in
-# aiohttp 3.14+ for GHSA-hg6j-4rv6-33pg + GHSA-jg22-mg44-37j8. This is
-# only reachable now that we sit on Python 3.13 — every litellm
-# release from 1.83.11 onwards requires_python = <3.14. The 3.13
-# floor stays until litellm restores 3.14 compatibility.
+# Upper bound <2.0 is the standard major-version cap. Lower bound
+# 1.87 patches the proxy-mode CVEs (CVE-2026-40217, CVE-2026-42203,
+# CVE-2026-42208, CVE-2026-42271) — all proxy-only, not reachable from
+# how Terrapod uses litellm (library-only via acompletion(), proxy
+# never started) — and relaxes the aiohttp pin from ==3.13.5 to
+# <4.0,>=3.10, which lets aiohttp resolve to 3.14+ and clears
+# GHSA-hg6j-4rv6-33pg + GHSA-jg22-mg44-37j8 + CVE-2026-34993 +
+# CVE-2026-47265. Reachable only on Python 3.13 — litellm 1.83.11+
+# requires_python = <3.14. The 3.13 floor stays until litellm
+# restores 3.14 compatibility.
 litellm = ">=1.87,<2.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary

Closes four CVEs that were blocked behind the same root cause — litellm 1.83.7's hard-pin on aiohttp 3.13.5, combined with newer litellm requiring \`requires_python <3.14\` while our Docker images sat on 3.14.

| CVE / GHSA | Package | Severity | Closed by |
|---|---|---|---|
| GHSA-hg6j-4rv6-33pg | aiohttp <3.14.0 | medium | aiohttp 3.14.0 |
| GHSA-jg22-mg44-37j8 | aiohttp <3.14.0 | medium | aiohttp 3.14.0 |
| CVE-2026-40217 | litellm proxy | medium | litellm 1.87.1 |
| CVE-2026-28684 | python-dotenv | low | side-effect of litellm 1.87 |

## Why downgrade Python

Python 3.14 was introduced 2026-03-05 by a routine dependabot bump (\`bb1980e\`), not a deliberate feature jump. No code uses 3.14-only syntax; mypy + ruff were already pinned to \`py313\`. Most upstream packages (not just litellm) haven't published wheels for 3.14 yet — staying on 3.13 cuts churn until the ecosystem catches up.

Tightening \`python = "^3.13"\` → \`python = ">=3.13,<3.14"\` is what actually unblocks the litellm bump (the resolver was choosing 1.83.7 because newer ones rejected 3.14).

## Test plan

- [ ] CI: full build + Python tests + Helm template + provider/migrate tests.
- [ ] Tilt smoke: rebuild API + listener + migrations images on python:3.13-slim, verify all pods come up green.
- [ ] Confirm aiohttp resolves to 3.14.0+ inside the built image (\`docker exec ... pip show aiohttp\`).
- [ ] Live behavioural smoke for v0.32.0 minor-release audit (separate checklist).

## Release

This is **v0.32.0** (minor — base-image bump is wider blast radius than a patch). Pre-release audit will run before tagging.