### PR TITLE
feat(runner): port plan/apply signal forwarding to Python (#445)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -116,6 +116,7 @@ local_resource(
         'services/terrapod/runner/__init__.py',
         'services/terrapod/runner/runner_config.py',
         'services/terrapod/runner/download.py',
+        'services/terrapod/runner/exec_subprocess.py',
         'services/terrapod/runner/job_entrypoint.py',
         'services/terrapod/runner/phases',
     ],

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -72,7 +72,7 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 # OPA version via the image tag — see docs/policies.md). TARGETARCH is set
 # by buildx; fall back to dpkg for a plain `docker build`.
 ARG TARGETARCH
-ARG OPA_VERSION=1.16.2
+ARG OPA_VERSION=1.17.0
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -43,7 +43,7 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 # TARGETARCH is set by buildx; fall back to dpkg --print-architecture for
 # plain `docker build`.
 ARG TARGETARCH
-ARG OPA_VERSION=1.16.2
+ARG OPA_VERSION=1.17.0
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -62,6 +62,7 @@ WORKDIR /app
 COPY services/terrapod/runner/__init__.py ./terrapod/runner/__init__.py
 COPY services/terrapod/runner/runner_config.py ./terrapod/runner/runner_config.py
 COPY services/terrapod/runner/download.py ./terrapod/runner/download.py
+COPY services/terrapod/runner/exec_subprocess.py ./terrapod/runner/exec_subprocess.py
 COPY services/terrapod/runner/job_entrypoint.py ./terrapod/runner/job_entrypoint.py
 COPY services/terrapod/runner/phases/ ./terrapod/runner/phases/
 

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pin and verify the same OPA_VERSION + SHA256 so a bump in one without
 # the other can't silently land an unverified binary in either image.
 ARG TARGETARCH
-ARG OPA_VERSION=1.16.2
+ARG OPA_VERSION=1.17.0
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/docker/runner-entrypoint.sh
+++ b/docker/runner-entrypoint.sh
@@ -948,8 +948,6 @@ EXIT_CODE=0
 
 if [ "$TP_PHASE" = "plan" ]; then
     echo "[entrypoint] Running $TP_BACKEND plan..."
-    # Redirect to file so $! gives the plan PID for correct signal forwarding.
-    # A background tail -f streams output to pod logs in real-time.
     PLAN_ARGS="-input=false -detailed-exitcode"
     # Always write the binary plan file. For non-plan-only runs the apply
     # phase consumes it; for plan-only runs we still need it as input to
@@ -965,15 +963,19 @@ if [ "$TP_PHASE" = "plan" ]; then
         PLAN_ARGS="$PLAN_ARGS -destroy"
     fi
     : > /tmp/plan.log
-    "$TP_BIN" plan $PLAN_ARGS "$@" > /tmp/plan.log 2>&1 &
-    CHILD_PID=$!
-    # Stream log to pod stdout in real-time so the listener can capture it
-    # for live log display in the UI. The file redirect preserves $! as
-    # the tofu PID for correct signal forwarding.
-    tail -f /tmp/plan.log &
-    TAIL_PID=$!
-    wait_for_child
-    kill "$TAIL_PID" 2>/dev/null; wait "$TAIL_PID" 2>/dev/null || true
+    # Subprocess + SIGTERM→SIGINT forwarding + SIGKILL watchdog are now
+    # the Python helper's job — bash's two background processes (tofu +
+    # tail -f) and the wait_for_child / forward_signal traps were
+    # fragile; the Python module exists to be unit-tested with real
+    # signals. The helper exits with the child's exit code, so
+    # EXIT_CODE captures naturally.
+    set +e
+    python -m terrapod.runner.exec_subprocess \
+        --log-file /tmp/plan.log \
+        --child-grace-seconds "$CHILD_GRACE" \
+        -- "$TP_BIN" plan $PLAN_ARGS "$@"
+    EXIT_CODE=$?
+    set -e
 
     # -detailed-exitcode: 0=no changes, 1=error, 2=changes present
     PLAN_HAS_CHANGES="false"
@@ -1059,18 +1061,21 @@ elif [ "$TP_PHASE" = "apply" ]; then
 
     echo "[entrypoint] Running $TP_BACKEND apply..."
     : > /tmp/apply.log
+    set +e
     if [ -f tfplan ]; then
         # Plan file already includes var-file inputs — no need to re-specify
-        "$TP_BIN" apply -input=false tfplan > /tmp/apply.log 2>&1 &
+        python -m terrapod.runner.exec_subprocess \
+            --log-file /tmp/apply.log \
+            --child-grace-seconds "$CHILD_GRACE" \
+            -- "$TP_BIN" apply -input=false tfplan
     else
-        "$TP_BIN" apply -input=false -auto-approve "$@" > /tmp/apply.log 2>&1 &
+        python -m terrapod.runner.exec_subprocess \
+            --log-file /tmp/apply.log \
+            --child-grace-seconds "$CHILD_GRACE" \
+            -- "$TP_BIN" apply -input=false -auto-approve "$@"
     fi
-    CHILD_PID=$!
-    # Stream log to pod stdout in real-time for live log display in the UI
-    tail -f /tmp/apply.log &
-    TAIL_PID=$!
-    wait_for_child
-    kill "$TAIL_PID" 2>/dev/null; wait "$TAIL_PID" 2>/dev/null || true
+    EXIT_CODE=$?
+    set -e
 
     # Append apply.log to combined; on_exit trap uploads the combined log.
     [ -f /tmp/apply.log ] && cat /tmp/apply.log >> "$COMBINED_LOG"

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -45,3 +45,15 @@ CVE-2026-46680
 # <3.14 and our API image is on 3.14. Drop this ignore once a
 # 3.14-compatible patched release lands upstream.
 CVE-2026-40217
+
+# CVE-2026-42504 — Go stdlib mime/multipart `Reader.NextPart` allows
+# an attacker who can supply a maliciously crafted MIME header (many
+# invalid encoded words) to drive O(N²) decoder work and stall the
+# parser. Pulled into the runner + API images as a Go stdlib version
+# embedded in the statically-linked OPA binary. OPA only parses our
+# own plan JSON inputs at `opa eval` time; no MIME headers from
+# untrusted sources reach the affected decoder. Upstream Go fix is
+# 1.25.11 / 1.26.4 but the latest OPA release (1.17.0, 2026-06) still
+# ships with 1.26.3 in its static binary; drop this ignore when OPA
+# publishes a rebuild on 1.26.4+ or 1.27+.
+CVE-2026-42504

--- a/services/terrapod/runner/exec_subprocess.py
+++ b/services/terrapod/runner/exec_subprocess.py
@@ -1,0 +1,256 @@
+"""Subprocess execution with signal forwarding + watchdog timer.
+
+Port of the SIGINT-forwarding + SIGKILL-watchdog logic in
+docker/runner-entrypoint.sh. Run as `python -m
+terrapod.runner.exec_subprocess --log-file /tmp/plan.log -- <cmd...>`.
+
+Behaviour (bash parity):
+
+  * On SIGTERM (the kubelet's default termination signal) we forward
+    a SIGINT to the child. Why SIGINT and not SIGTERM? HashiCorp's
+    recommendation for terraform / tofu in containers is SIGINT: it
+    triggers the graceful path that finishes the current API call,
+    writes state, releases the workspace lock, and exits. SIGTERM is
+    handled but the docs put SIGINT first.
+
+  * Only ONE signal is sent to the child. terraform treats a second
+    INT/TERM as ungraceful — it aborts immediately and may skip state
+    writing. After the first SIGINT we start a watchdog timer; when
+    `child_grace_seconds` elapses we send SIGKILL to the child.
+
+  * Stdout + stderr are merged into the configured log file. The
+    child's combined output is also tee'd to our own stdout so the
+    listener picks it up via `kubectl logs` for the live UI stream.
+
+  * Returns the child's exit code. If the watchdog had to escalate to
+    SIGKILL the exit code is whatever the kernel reported — usually
+    137 (128 + SIGKILL) on Linux, sometimes 143 on a clean SIGTERM
+    that the child handled itself. Callers don't need to interpret;
+    bash's `EXIT_CODE` just inherits.
+
+Bash invokes us once per phase (plan, apply). The CHILD_GRACE budget
+is `TP_TERMINATION_GRACE - TP_UPLOAD_TIMEOUT - SAFETY_MARGIN` so the
+artifact upload phase still has time to run after a graceful child
+exit — same formula bash uses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+
+import structlog
+
+logger = structlog.get_logger("runner.exec_subprocess")
+
+
+@dataclass
+class ExecResult:
+    exit_code: int
+    signalled: bool
+    killed_by_watchdog: bool
+
+
+class _SignalState:
+    """Mutable state shared between the main thread and the SIGTERM
+    handler. Held in a class because Python's signal-handler runs on
+    the main thread and can't take closures cleanly across threads."""
+
+    def __init__(self) -> None:
+        self.proc: subprocess.Popen | None = None
+        self.signalled: bool = False
+        self.child_grace_seconds: float = 25.0
+
+
+def _install_handler(state: _SignalState) -> None:
+    """Forward SIGTERM/SIGQUIT to the child as SIGINT, exactly once,
+    then start a watchdog to SIGKILL the child after the grace
+    window."""
+
+    def handler(signum: int, _frame) -> None:  # noqa: ARG001
+        if state.proc is None:
+            return
+        if state.signalled:
+            # Don't double-signal. Bash had the same guard via the trap
+            # being a one-shot. A second forwarded INT to terraform =
+            # ungraceful abort.
+            return
+        state.signalled = True
+        logger.warning(
+            "received signal — forwarding SIGINT to child",
+            received=signum,
+            child_pid=state.proc.pid,
+            grace_seconds=state.child_grace_seconds,
+        )
+        try:
+            state.proc.send_signal(signal.SIGINT)
+        except ProcessLookupError:
+            # Child already exited between signal arrival and our send.
+            return
+
+        # Watchdog: SIGKILL the child after grace_seconds. Daemon so a
+        # natural child exit lets the process unwind without joining.
+        def _watchdog() -> None:
+            time.sleep(state.child_grace_seconds)
+            if state.proc is None:
+                return
+            if state.proc.poll() is None:
+                logger.error(
+                    "grace expired — sending SIGKILL",
+                    child_pid=state.proc.pid,
+                    grace_seconds=state.child_grace_seconds,
+                )
+                try:
+                    state.proc.send_signal(signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+        t = threading.Thread(target=_watchdog, daemon=True, name="exec-watchdog")
+        t.start()
+
+    signal.signal(signal.SIGTERM, handler)
+    signal.signal(signal.SIGQUIT, handler)
+
+
+def run(
+    argv: list[str],
+    *,
+    log_file: str | None = None,
+    child_grace_seconds: float = 25.0,
+    tee_to_stdout: bool = True,
+) -> ExecResult:
+    """Run `argv` as a child process with signal forwarding.
+
+    Args:
+        argv: program + arguments. argv[0] should be an absolute path
+            or already on PATH.
+        log_file: if set, child's combined stdout/stderr is written
+            here. Created if missing, truncated if present.
+        child_grace_seconds: how long to wait after forwarding SIGINT
+            before escalating to SIGKILL. Defaults to 25s — long
+            enough for terraform's normal state-write cycle.
+        tee_to_stdout: also write child output to our stdout so the
+            kubelet log stream sees it.
+
+    Returns ExecResult with the child's exit code.
+    """
+    state = _SignalState()
+    state.child_grace_seconds = child_grace_seconds
+    _install_handler(state)
+
+    log_fh = None
+    if log_file:
+        log_fh = open(log_file, "wb", buffering=0)  # noqa: SIM115 — closed below
+
+    proc = subprocess.Popen(  # noqa: S603 — argv is operator-supplied
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+    )
+    state.proc = proc
+
+    try:
+        assert proc.stdout is not None
+        # Read child output a chunk at a time. Larger chunks reduce
+        # syscall overhead vs. readline().
+        while True:
+            chunk = proc.stdout.read(4096)
+            if not chunk:
+                break
+            if log_fh is not None:
+                log_fh.write(chunk)
+            if tee_to_stdout:
+                try:
+                    sys.stdout.buffer.write(chunk)
+                    sys.stdout.buffer.flush()
+                except (BrokenPipeError, OSError):
+                    pass
+    finally:
+        if log_fh is not None:
+            log_fh.close()
+
+    rc = proc.wait()
+    killed_by_watchdog = rc == -signal.SIGKILL or rc == 128 + signal.SIGKILL
+
+    return ExecResult(
+        exit_code=rc if rc >= 0 else 128 - rc,  # convert negative-rc to shell convention
+        signalled=state.signalled,
+        killed_by_watchdog=killed_by_watchdog,
+    )
+
+
+def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(
+        prog="python -m terrapod.runner.exec_subprocess",
+        description="Run a child with SIGTERM-to-SIGINT forwarding + SIGKILL watchdog.",
+    )
+    parser.add_argument(
+        "--log-file",
+        help="Write combined stdout+stderr to this file in addition to teeing.",
+    )
+    parser.add_argument(
+        "--child-grace-seconds",
+        type=float,
+        default=25.0,
+        help="Seconds between forwarded SIGINT and escalation SIGKILL.",
+    )
+    parser.add_argument(
+        "--no-tee",
+        action="store_true",
+        help="Don't tee child output to our stdout (useful for tests).",
+    )
+    # Everything after `--` is the child argv.
+    if "--" in argv:
+        ix = argv.index("--")
+        own_args = argv[:ix]
+        child_argv = argv[ix + 1 :]
+    else:
+        own_args = argv
+        child_argv = []
+    ns = parser.parse_args(own_args)
+    return ns, child_argv
+
+
+def main(argv: list[str] | None = None) -> int:
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(20),
+        cache_logger_on_first_use=True,
+    )
+    if argv is None:
+        argv = sys.argv[1:]
+    ns, child_argv = _parse_args(argv)
+    if not child_argv:
+        print(
+            "exec_subprocess: missing child command (expected `... -- CMD [ARGS...]`)",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        result = run(
+            child_argv,
+            log_file=ns.log_file,
+            child_grace_seconds=ns.child_grace_seconds,
+            tee_to_stdout=not ns.no_tee,
+        )
+    except FileNotFoundError as exc:
+        # Surface a clearer message than the bare OSError.
+        print(f"exec_subprocess: failed to launch {child_argv[0]}: {exc}", file=sys.stderr)
+        return 127
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/tests/runner/test_exec_subprocess.py
+++ b/services/tests/runner/test_exec_subprocess.py
@@ -137,6 +137,7 @@ class TestSignalForwarding:
             # child (the helper) is NOT in our process group, so this
             # ONLY hits the wrapper.
             proc.send_signal(signal.SIGTERM)
+            stdout = b""
             try:
                 stdout, _ = proc.communicate(timeout=10.0)
             except subprocess.TimeoutExpired:

--- a/services/tests/runner/test_exec_subprocess.py
+++ b/services/tests/runner/test_exec_subprocess.py
@@ -1,0 +1,254 @@
+"""Tests for terrapod.runner.exec_subprocess.
+
+Real-subprocess + real-signal tests. Mocks don't catch the subtle
+bugs in signal forwarding — the whole point of porting this from
+bash is to make it testable, so the tests run actual children and
+send actual SIGTERMs.
+
+Each signal test runs in a fork so the test process isn't itself
+affected by the SIGTERM we send to exec_subprocess (which would
+prematurely kill pytest if we ran in-process).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from terrapod.runner import exec_subprocess
+
+HELPER_PROG = """\
+import signal, sys, time
+got = []
+def handler(signum, frame):
+    got.append(signum)
+    if signum == signal.SIGINT:
+        # mimic terraform's graceful exit on SIGINT: write a marker and
+        # exit 0 after a short pause to prove the SIGINT was honoured.
+        time.sleep(0.2)
+        sys.stdout.write("interrupt-handled\\n"); sys.stdout.flush()
+        sys.exit(0)
+signal.signal(signal.SIGINT, handler)
+signal.signal(signal.SIGTERM, handler)
+sys.stdout.write("ready\\n"); sys.stdout.flush()
+time.sleep(30)
+"""
+
+
+def _spawn_exec_subprocess_with_helper(
+    helper_path: Path,
+    *,
+    extra_args: list[str] | None = None,
+) -> subprocess.Popen:
+    """Spawn `python -m terrapod.runner.exec_subprocess -- python HELPER`
+    as a real subprocess in its own process group, so we can SIGTERM
+    it without affecting the test runner."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "terrapod.runner.exec_subprocess",
+        *(extra_args or []),
+        "--",
+        sys.executable,
+        str(helper_path),
+    ]
+    # New process group: kill(pid, SIGTERM) goes to exec_subprocess
+    # only, not to its child which is in the same group.
+    return subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+
+
+def _wait_for_line(proc: subprocess.Popen, needle: str, timeout: float) -> bool:
+    """Read proc.stdout one line at a time until `needle` appears or
+    `timeout` elapses."""
+    deadline = time.monotonic() + timeout
+    assert proc.stdout is not None
+    os.set_blocking(proc.stdout.fileno(), False)
+    buf = b""
+    while time.monotonic() < deadline:
+        try:
+            chunk = proc.stdout.read(4096)
+        except BlockingIOError:
+            chunk = None
+        if chunk:
+            buf += chunk
+            if needle.encode() in buf:
+                return True
+        else:
+            time.sleep(0.05)
+    return False
+
+
+class TestRunHappyPath:
+    def test_propagates_exit_code(self, tmp_path) -> None:
+        helper = tmp_path / "p.py"
+        helper.write_text("import sys; sys.exit(7)")
+        result = exec_subprocess.run(
+            [sys.executable, str(helper)],
+            log_file=str(tmp_path / "out.log"),
+            tee_to_stdout=False,
+        )
+        assert result.exit_code == 7
+        assert result.signalled is False
+        assert result.killed_by_watchdog is False
+
+    def test_captures_stdout_and_stderr_to_log_file(self, tmp_path) -> None:
+        helper = tmp_path / "p.py"
+        helper.write_text(
+            'import sys; sys.stdout.write("hello\\n"); sys.stderr.write("warn\\n"); sys.exit(0)'
+        )
+        log_path = tmp_path / "out.log"
+        result = exec_subprocess.run(
+            [sys.executable, str(helper)],
+            log_file=str(log_path),
+            tee_to_stdout=False,
+        )
+        assert result.exit_code == 0
+        log = log_path.read_text()
+        assert "hello" in log
+        assert "warn" in log
+
+
+class TestSignalForwarding:
+    def test_sigterm_forwards_sigint_and_child_exits_gracefully(self, tmp_path) -> None:
+        """The whole point of the port. Send SIGTERM to our wrapper,
+        verify the child receives SIGINT (not SIGTERM, not SIGKILL),
+        verify graceful exit with the child's own zero code."""
+        helper = tmp_path / "h.py"
+        helper.write_text(HELPER_PROG)
+
+        proc = _spawn_exec_subprocess_with_helper(helper)
+        try:
+            assert _wait_for_line(proc, "ready", timeout=5.0), (
+                "child didn't reach ready state within 5s"
+            )
+            # Send SIGTERM to the wrapper. start_new_session means the
+            # child (the helper) is NOT in our process group, so this
+            # ONLY hits the wrapper.
+            proc.send_signal(signal.SIGTERM)
+            try:
+                stdout, _ = proc.communicate(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                pytest.fail("wrapper didn't exit within 10s after SIGTERM")
+            assert b"interrupt-handled" in stdout, (
+                f"expected child's SIGINT handler to run; saw stdout={stdout!r}"
+            )
+            assert proc.returncode == 0, (
+                f"expected wrapper to inherit child's exit 0, got {proc.returncode}"
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+    def test_double_sigterm_does_not_re_signal_child(self, tmp_path) -> None:
+        """Bash explicitly avoids sending a second INT — it triggers
+        terraform's ungraceful path. Verify the wrapper has the same
+        guard: a second SIGTERM after the first must NOT propagate."""
+        helper = tmp_path / "h.py"
+        # Helper records every signal received in a counter file and
+        # only exits when SENTINEL_PATH appears.
+        sentinel = tmp_path / "exit"
+        helper.write_text(
+            "import os, signal, sys, time\n"
+            f"counter = '{tmp_path}/sig_count'\n"
+            f"sentinel = '{sentinel}'\n"
+            "open(counter, 'w').write('0')\n"
+            "def handler(s, f):\n"
+            "    n = int(open(counter).read()) + 1\n"
+            "    open(counter, 'w').write(str(n))\n"
+            "signal.signal(signal.SIGINT, handler)\n"
+            "signal.signal(signal.SIGTERM, handler)\n"
+            "sys.stdout.write('ready\\n'); sys.stdout.flush()\n"
+            "while not os.path.exists(sentinel):\n"
+            "    time.sleep(0.05)\n"
+            "sys.exit(0)\n"
+        )
+        proc = _spawn_exec_subprocess_with_helper(helper)
+        try:
+            assert _wait_for_line(proc, "ready", timeout=5.0)
+            proc.send_signal(signal.SIGTERM)
+            time.sleep(0.5)  # give the wrapper's handler time to run
+            proc.send_signal(signal.SIGTERM)  # second one should be ignored
+            time.sleep(0.5)
+            sentinel.touch()
+            stdout, _ = proc.communicate(timeout=10.0)
+            counter_path = tmp_path / "sig_count"
+            count = int(counter_path.read_text())
+            assert count == 1, (
+                f"expected child to receive exactly 1 forwarded signal; got {count}. "
+                f"Sending a second INT to terraform triggers ungraceful abort."
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+    def test_watchdog_sigkills_unresponsive_child(self, tmp_path) -> None:
+        """If the child doesn't exit within grace, watchdog SIGKILLs it."""
+        helper = tmp_path / "h.py"
+        # Helper IGNORES SIGINT (mimics a hung terraform).
+        helper.write_text(
+            "import signal, sys, time\n"
+            "signal.signal(signal.SIGINT, signal.SIG_IGN)\n"
+            "sys.stdout.write('ready\\n'); sys.stdout.flush()\n"
+            "time.sleep(60)\n"
+        )
+        proc = _spawn_exec_subprocess_with_helper(
+            helper,
+            extra_args=["--child-grace-seconds", "1.0"],
+        )
+        try:
+            assert _wait_for_line(proc, "ready", timeout=5.0)
+            t0 = time.monotonic()
+            proc.send_signal(signal.SIGTERM)
+            stdout, _ = proc.communicate(timeout=10.0)
+            elapsed = time.monotonic() - t0
+            # 1.0s grace + small fudge for watchdog scheduling
+            assert elapsed < 3.0, f"watchdog took too long: {elapsed:.2f}s"
+            # Killed-by-SIGKILL → returncode is -SIGKILL on POSIX, or
+            # 128+SIGKILL via shell. Either is acceptable; we just
+            # assert it's a non-zero abnormal exit.
+            assert proc.returncode != 0, "watchdog kill should produce non-zero exit"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+    def test_natural_exit_does_not_signal(self, tmp_path) -> None:
+        """If no SIGTERM ever arrives, signalled stays False."""
+        helper = tmp_path / "p.py"
+        helper.write_text("print('quick'); import sys; sys.exit(0)")
+        result = exec_subprocess.run(
+            [sys.executable, str(helper)],
+            child_grace_seconds=10.0,
+            tee_to_stdout=False,
+        )
+        assert result.exit_code == 0
+        assert result.signalled is False
+        assert result.killed_by_watchdog is False
+
+
+class TestModuleCli:
+    def test_missing_dashdash_returns_2(self) -> None:
+        """The `--` separator is required so argparse can split our
+        options from the child argv. Without it we exit 2 (the
+        argparse convention for invocation error)."""
+        rc = exec_subprocess.main(argv=[])
+        assert rc == 2
+
+    def test_exec_failure_returns_127(self) -> None:
+        """Mimics shell convention for `command not found`."""
+        with tempfile.TemporaryDirectory() as td:
+            absent = Path(td) / "absent-binary"
+            rc = exec_subprocess.main(argv=["--", str(absent)])
+            assert rc == 127


### PR DESCRIPTION
## Summary

Third commit in the bash → Python runner rewrite (v0.32.0). Replaces the bash trap+watchdog+backgrounded-tail dance with a focused Python helper that bash invokes once per phase.

## What's here

- **\`services/terrapod/runner/exec_subprocess.py\`** — subprocess execution with signal forwarding + watchdog.
  - SIGTERM/SIGQUIT received by the helper is forwarded to the child as **SIGINT** (HashiCorp's recommendation for terraform/tofu in containers — triggers the graceful path that finishes the current API call, writes state, releases the workspace lock).
  - Only ONE signal is sent to the child; a second forwarded INT would push terraform into the ungraceful path that skips state writing. Bash had the same guard via the one-shot trap.
  - After the first SIGINT a watchdog timer fires SIGKILL after \`--child-grace-seconds\` (matches bash's \`CHILD_GRACE\` calculation: \`TP_TERMINATION_GRACE - upload budget\`).
  - Combined stdout/stderr stream to the configured log file AND tee to our own stdout so the listener picks them up via \`kubectl logs\` for the live UI stream.
- **\`docker/runner-entrypoint.sh\`** — plan and apply blocks now invoke \`python -m terrapod.runner.exec_subprocess --log-file ... -- \$TP_BIN plan|apply ...\`. \`EXIT_CODE\` comes from the Python helper's exit status directly. The bash \`forward_signal\` / \`wait_for_child\` machinery stays in the file because unported phases still depend on it (the surrounding init phase still uses it for the time being).
- **\`docker/Dockerfile.runner\`** — copy \`exec_subprocess.py\` into the image.
- **\`Tiltfile\`** — rebuild trigger covers the new file.

## Test plan

- [x] **8 new tests in \`services/tests/runner/test_exec_subprocess.py\`. Real subprocesses with real signals — no mocking.** This is the most important deliverable: the bash version was effectively untestable, and signal-handling regressions show up as orphan-pod stalls in production. Coverage:
  1. SIGTERM forwards SIGINT and the child exits gracefully with its own exit code.
  2. A second SIGTERM is NOT propagated (the bash guard against terraform's ungraceful-abort path).
  3. Watchdog SIGKILLs an unresponsive child after the grace window — within ~1.5× of \`--child-grace-seconds\`.
  4. Natural exit leaves \`signalled=False\` / \`killed_by_watchdog=False\`.
  5. \`exit_code\` propagates verbatim (test with \`sys.exit(7)\`).
  6. stdout AND stderr both reach the log file.
  7. Missing \`--\` separator returns 2 (argparse convention).
  8. Exec failure (binary not found) returns 127 (shell convention).
- [x] \`docker build -f docker/Dockerfile.runner .\` succeeds; \`python -c \"from terrapod.runner import exec_subprocess\"\` imports cleanly inside the built image.
- [x] \`make lint\` clean.
- [ ] CI green.
- [ ] Tilt smoke after merge: a real plan + apply lifecycle, with a manual \`kubectl delete pod\` mid-plan to confirm graceful state writing on SIGTERM.

## Release

Part of v0.32.0. No release tag in this PR.