### PR TITLE
docs+chore(security): v0.32.0 pre-release audit fixes

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -604,7 +604,17 @@ Returns a version list for the provider.
 GET /v1/providers/{hostname}/{namespace}/{type}/{version}.json
 ```
 
-Returns platform-specific download info with `zh:` (zip hash) checksums. Cached platforms get presigned storage URLs; uncached platforms get proxy download URLs.
+Returns platform-specific download info with `zh:` (zip hash) checksums. Cached platforms get presigned storage URLs; uncached platforms get proxy download URLs. Cached platforms additionally carry the precomputed `h1:` directory hash in their `hashes` array (see "Cross-arch lock-file extension" below).
+
+### Cross-arch lock-file extension
+
+When a runner Job's plan phase runs on `linux/arm64` but the matching apply lands on `linux/amd64` (or vice-versa) — common on mixed-arch nodepools or after a spot reschedule — `tofu init` at the apply pod will reject the workspace's `.terraform.lock.hcl` because its `h1:` hashes only cover the plan-arch's archive contents.
+
+Terrapod extends the lock file at plan time so the OTHER architecture's `h1:` is present when the apply runs. The cheap path: the mirror has already cached the archive, so it returns the precomputed `h1:` in `{version}.json`'s `hashes` array; the runner's lock-extender splices the hash directly into `.terraform.lock.hcl` — one ~1 KB JSON request per provider, **no archive downloads**.
+
+The fallback path: if the mirror returns no `h1:` for a provider (uncached, or upstream-only), the runner falls through to `tofu providers lock -platform=<other_arch>`, which downloads the archive itself to compute the hash. This costs what v0.31.6's mitigation cost — one archive download per uncached provider. Each download then primes the mirror's cache, so subsequent plans take the cheap path.
+
+Operators don't need to configure anything for this — the lock-extender runs automatically during the plan phase whenever `.terraform.lock.hcl` exists and the runner detects a supported arch (`linux_amd64` or `linux_arm64`). Look for `runner.lock_extender` log lines in plan output to see hit/miss per provider.
 
 ```
 GET /v1/providers/{hostname}/{namespace}/{type}/{version}/download/{os}/{arch}

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -39,7 +39,7 @@ USER 1000:1000
 
 Important:
 - Switch back to `USER 1000:1000` -- runner Jobs run as non-root
-- The entrypoint (`/entrypoint.sh`) must remain unchanged -- it handles signal forwarding and graceful shutdown
+- The canonical entrypoint is `python -m terrapod.runner.job_entrypoint` -- it drives signal forwarding, graceful shutdown, phase orchestration, and artifact uploads. Custom images should not override `ENTRYPOINT`; layer additional tooling on top via `RUN` and let the inherited entrypoint stand. (A transitional `/entrypoint.sh` bash script still exists in the image for unported phases — it's invoked by the Python entrypoint, not by the kubelet.)
 - The working directory is `/workspace` and `/tmp` is writable (both are emptyDir volumes)
 
 ### Using a Custom Image

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -19,7 +19,7 @@ CVE-2025-69720
 # (Kubernetes manages process lifecycle). The library code is loaded
 # but the IPC entrypoints aren't reachable without a running systemd
 # instance, which our images never have. Re-evaluate when Debian
-# backports the fix or when the python:3.14-slim base drops systemd.
+# backports the fix or when the python:3.13-slim base drops systemd.
 CVE-2026-29111
 
 # CVE-2026-46680 — containerd user ID handling bypass that allows a
@@ -33,18 +33,11 @@ CVE-2026-29111
 # when OPA upstream bumps containerd in a patch release.
 CVE-2026-46680
 
-# CVE-2026-40217 — litellm proxy-mode arbitrary code execution via
-# bytecode-level sandbox escape in POST /guardrails/test_custom_code.
-# Reaching the endpoint requires a proxy-admin credential and the
-# proxy server to be running. Terrapod imports litellm as a library
-# and only calls `litellm.acompletion()` from the API process — the
-# proxy server is never started, the /guardrails/* HTTP routes are
-# never mounted, and no proxy-admin credentials exist in our config.
-# The vulnerable code path is structurally unreachable.
-# Patched in litellm 1.83.11+, but the patched versions pin Python
-# <3.14 and our API image is on 3.14. Drop this ignore once a
-# 3.14-compatible patched release lands upstream.
-CVE-2026-40217
+# CVE-2026-40217 — was litellm proxy-mode arbitrary code execution.
+# Dropped: v0.32.0 (PR #442) bumped litellm to >=1.87 on Python 3.13,
+# which includes the patched code path. No longer in the dependency
+# graph; the ignore would just shadow regressions if litellm's hot
+# patch is rolled back. Re-add only if the floor drops below 1.83.11.
 
 # CVE-2026-42504 — Go stdlib mime/multipart `Reader.NextPart` allows
 # an attacker who can supply a maliciously crafted MIME header (many


### PR DESCRIPTION
## Summary

Two minor fixups surfaced by the v0.32.0 pre-release audit. No behavioural change; folds into a single PR per the existing pattern (#324, #337) so the audit-clean main is ready to tag.

## Docs

- \`docs/registry.md\` — new **Cross-arch lock-file extension** subsection covering the cheap mirror-fed \`h1:\` path (PR #447's headline feature) and the \`tofu providers lock\` fallback for uncached providers. Notes \`h1:\` hashes are now added to \`{version}.json\`'s \`hashes\` array for cached platforms — surface change from #447 not previously documented.
- \`docs/runners.md\` — custom-image builder note updated to reflect that the canonical entrypoint is \`python -m terrapod.runner.job_entrypoint\` (post #443). The bash script still exists in the image but is no longer the kubelet entrypoint.

## Security

\`pentest/trivy/.trivyignore\`:
- **CVE-2026-29111** — comment was pointing at \`python:3.14-slim\`; project sat on 3.13 since #442. Updated to 3.13.
- **CVE-2026-40217** — dropped entirely. The proxy-mode CVE was patched in litellm 1.83.11+; #442 bumped to \`>=1.87\` which carries the fix. Keeping the ignore would just shadow regressions if the floor ever dropped below 1.83.11.

## Release

Last PR before v0.32.0 tag.