### PR TITLE
docs+chore(security): v0.33.0 pre-release audit fixes

### DIFF
--- a/docs/ai-plan-summary.md
+++ b/docs/ai-plan-summary.md
@@ -28,11 +28,20 @@ For a plan that succeeds (`status=planned`):
 - A list of `risk_factors` ordered worst first, each with a severity,
   title, detail, and (optionally) the affected resource address
 
-For a plan that errors before apply (plan-phase `errored`):
+For a run that errored during EITHER plan or apply (`errored`):
 
-- A description of the root cause in operator terms
-- A severity rating for how blocking the failure is
-- A list of suggested fixes with concrete steps
+- A description of the root cause in operator terms. For apply-phase
+  failures the description also identifies the specific resource
+  whose Create/Modify/Destroy failed, calls out which resources had
+  already completed before the failure (the infrastructure is in a
+  partial state), and flags the state gap when the workspace is
+  marked `state_diverged` (the runner couldn't upload the post-apply
+  state).
+- A severity rating for how blocking the failure is.
+- A list of suggested fixes with concrete steps. For apply-phase
+  failures these are ranked by recovery type: re-run safe vs.
+  needs `terraform refresh` vs. needs manual cleanup vs. needs a
+  targeted re-apply (`-target=...`).
 
 Both kinds are persisted in the `plan_summaries` table, returned by
 `GET /api/v2/plans/{plan-id}/summary`, and announced over the
@@ -240,14 +249,23 @@ and never blocks plan or apply.
 
 ## How it works under the hood
 
-1. A plan reaches a terminal state (`planned` or `errored` while still
-   in the plan phase).
+1. A run reaches a terminal state (`planned` → `plan_summary` kind,
+   or `errored` at any point → `failure_analysis` kind, plan-phase or
+   apply-phase).
 2. The API enqueues an `ai_plan_summary` trigger via the distributed
    scheduler (multi-replica safe; deduped per `(run_id, kind)`).
-3. Any API replica picks up the trigger, gathers the inputs (plan JSON
-   or plan log, plus the configuration version's `.tf` source for
-   code context), renders the prompt with the layered context, and
-   calls `litellm.acompletion`.
+3. Any API replica picks up the trigger, gathers the inputs:
+   - `plan_summary` reads the structured plan JSON.
+   - `failure_analysis` reads the **apply log** when
+     `apply_started_at` is set, otherwise the **plan log**. When the
+     workspace's `state_diverged` flag is true, a `STATE_DIVERGED`
+     block is included in the prompt so the model flags the
+     state-vs-reality gap explicitly.
+   - Both kinds also include the configuration version's `.tf` source
+     for code context and a unified diff against the previously-
+     applied configuration when one is available.
+   Renders the prompt with the layered context and calls
+   `litellm.acompletion`.
 4. The structured JSON response is parsed and upserted into the
    `plan_summaries` table.
 5. A `plan_summary_ready` SSE event is published on the per-workspace

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ This document describes the internal architecture of Terrapod, covering system c
 | **Next.js Web** | Single ingress entry point; serves UI pages and proxies API calls | Next.js 15, React 19, Tailwind CSS, Radix UI |
 | **FastAPI API** | All business logic, TFE V2 API, auth, registry, VCS polling | Python 3.13+, FastAPI, SQLAlchemy async, Pydantic |
 | **Runner Listener** | Receives run events via SSE, creates K8s Jobs, reports status, streams logs | Same Python codebase as API, different entrypoint |
-| **Runner Jobs** | Ephemeral containers that execute `terraform` or `tofu` | Minimal Alpine image with curl/tar/jq |
+| **Runner Jobs** | Ephemeral containers that execute `terraform` or `tofu` | Slim Debian image (`python:3.13-slim`) with git/openssh-client/opa; pure-Python orchestrator |
 | **PostgreSQL** | Relational data: users, workspaces, state metadata, runs, registry | PostgreSQL 14+ |
 | **Redis** | Sessions, auth state, listener heartbeats, SSE event channels, Job status cache, API token role cache | Redis 7+ |
 | **Object Storage** | State files, config tarballs, plan outputs, logs, registry artifacts, cache | S3, Azure Blob, GCS, or filesystem |
@@ -208,7 +208,7 @@ Terrapod's execution layer follows the Actions Runner Controller (ARC) pattern: 
    - Returns short-lived HMAC-signed token scoped to run_id
         |
 5. Listener creates K8s Job in runner namespace
-   - Image: terrapod-runner (minimal Alpine)
+   - Image: terrapod-runner (slim Debian + python + git + opa)
    - Resources: from workspace config (cpu/memory requests + 2x limits)
    - Env vars: workspace variables + Terraform vars
    - TP_AUTH_TOKEN via secretKeyRef (token never in Job spec)
@@ -242,20 +242,20 @@ Terrapod's execution layer follows the Actions Runner Controller (ARC) pattern: 
 
 ### Signal Forwarding and Graceful Termination
 
-Runner Jobs use a configurable `terminationGracePeriodSeconds` (default 120, set via `runners.terminationGracePeriodSeconds` in Helm). The entrypoint (`docker/runner-entrypoint.sh`) implements time-budgeted graceful shutdown with a SIGKILL watchdog:
+Runner Jobs use a configurable `terminationGracePeriodSeconds` (default 120, set via `runners.terminationGracePeriodSeconds` in Helm). The Python orchestrator (`services/terrapod/runner/job_entrypoint.py`) implements time-budgeted graceful shutdown with a SIGKILL watchdog:
 
 ```
-T=0: K8s sends SIGTERM to PID 1
+T=0: K8s sends SIGTERM to PID 1 (python -m terrapod.runner.job_entrypoint)
     |
     v
-runner-entrypoint.sh (traps SIGTERM/SIGQUIT)
+exec_subprocess.run signal handler (registered per terraform/tofu invocation)
     |
     v
 Forwards SIGINT to terraform/tofu child process
 (SIGINT is HashiCorp's recommended signal for containers)
     |                                          |
     v                                          v
-Terraform graceful shutdown            Background watchdog starts
+Terraform graceful shutdown            Background watchdog thread starts
 (finishes API call, writes state,      (sleeps CHILD_GRACE seconds,
  releases lock, exits)                  then sends SIGKILL if still running)
     |
@@ -263,9 +263,13 @@ Terraform graceful shutdown            Background watchdog starts
 T=0→T=95s: Wait for terraform to exit (or be killed by watchdog)
     |
     v
-T=95s→T=115s: Upload artifacts with --max-time bounds
-    - Apply/plan log upload (best-effort)
-    - State upload (FATAL — failure flags workspace as state-diverged)
+T=95s→T=115s: try/finally block in job_entrypoint.main runs the
+              EXIT-trap equivalent:
+    - Roll per-phase logs (init.log, plan.log, apply.log) into the
+      combined log via LogCapture.append_file
+    - upload_combined_log → /artifacts/{phase}-log
+    - resource_profile.post_profile → /resource-profile (cgroup peak
+      memory + cumulative CPU, plus the run's exit code)
     |
     v
 T=120s: K8s SIGKILL deadline
@@ -274,10 +278,10 @@ T=120s: K8s SIGKILL deadline
 **Key design decisions:**
 - **SIGINT, not SIGTERM**: HashiCorp recommends SIGINT for container graceful shutdown. A second signal (INT or TERM) causes ungraceful abort that may skip state writing entirely
 - **SIGKILL watchdog**: Only one signal is ever sent. If terraform hangs, the watchdog escalates to SIGKILL after `CHILD_GRACE` seconds
-- **State upload is fatal**: If state upload fails after a successful apply, the entrypoint calls `POST /api/terrapod/v1/runs/{run_id}/state-diverged` to flag the workspace and exits with code 1
+- **State upload is fatal**: If state upload fails after a successful apply, the apply phase calls `POST /api/terrapod/v1/runs/{run_id}/state-diverged` to flag the workspace and the orchestrator exits non-zero
 - **Time budget**: `TP_TERMINATION_GRACE` env var (from Helm `runners.terminationGracePeriodSeconds`) partitions the K8s grace period between terraform shutdown and artifact uploads (25s reserved for uploads)
 
-The entrypoint script is at `docker/runner-entrypoint.sh`.
+The orchestrator is `services/terrapod/runner/job_entrypoint.py`; each phase is its own module under `services/terrapod/runner/phases/`.
 
 ### Agent Pools and Listeners
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -606,13 +606,18 @@ GET /v1/providers/{hostname}/{namespace}/{type}/{version}.json
 
 Returns platform-specific download info with `zh:` (zip hash) checksums. Cached platforms get presigned storage URLs; uncached platforms get proxy download URLs. Cached platforms additionally carry the precomputed `h1:` directory hash in their `hashes` array (see "Cross-arch lock-file extension" below).
 
+The response also includes a top-level `cached_platforms` field — the list of `{os}_{arch}` strings the operator has configured under `registry.provider_cache.platforms`. The runner's lock-extender uses this to distinguish "no h1 because the operator deliberately doesn't cache this arch" (silent skip, no fallback) from "no h1 because compute failed" (warn + fallback). Single-arch deployments stop logging spurious "no h1 from mirror" warnings.
+
 ### Cross-arch lock-file extension
 
 When a runner Job's plan phase runs on `linux/arm64` but the matching apply lands on `linux/amd64` (or vice-versa) — common on mixed-arch nodepools or after a spot reschedule — `tofu init` at the apply pod will reject the workspace's `.terraform.lock.hcl` because its `h1:` hashes only cover the plan-arch's archive contents.
 
 Terrapod extends the lock file at plan time so the OTHER architecture's `h1:` is present when the apply runs. The cheap path: the mirror has already cached the archive, so it returns the precomputed `h1:` in `{version}.json`'s `hashes` array; the runner's lock-extender splices the hash directly into `.terraform.lock.hcl` — one ~1 KB JSON request per provider, **no archive downloads**.
 
-The fallback path: if the mirror returns no `h1:` for a provider (uncached, or upstream-only), the runner falls through to `tofu providers lock -platform=<other_arch>`, which downloads the archive itself to compute the hash. This costs what v0.31.6's mitigation cost — one archive download per uncached provider. Each download then primes the mirror's cache, so subsequent plans take the cheap path.
+Behaviour when `h1:` is absent from the mirror response depends on the operator's `provider_cache.platforms` config:
+
+- **Other-arch is in `cached_platforms`** but the mirror returned no `h1:` for it (compute failed at ingest, or the cached row predates h1 tracking): the runner backfills h1 lazily on the next request from the cached archive bytes, then serves it. If backfill also fails, the runner falls through to `tofu providers lock -platform=<other_arch>` which downloads the archive itself. Each download primes the mirror's cache; subsequent plans take the cheap path.
+- **Other-arch is NOT in `cached_platforms`**: the operator has deliberately scoped the mirror to a subset of arches — for example a single-arch cluster that will never run apply on the other arch. The lock-extender treats this as a silent skip: no warning, no archive download, no `providers lock` fallback.
 
 Operators don't need to configure anything for this — the lock-extender runs automatically during the plan phase whenever `.terraform.lock.hcl` exists and the runner detects a supported arch (`linux_amd64` or `linux_arm64`). Look for `runner.lock_extender` log lines in plan output to see hit/miss per provider.
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -1,6 +1,6 @@
 # Runners
 
-Runners are ephemeral Kubernetes Jobs that execute `terraform` or `tofu` plan and apply operations. The default runner image is a minimal Alpine container with `curl`, `tar`, `jq`, `unzip`, and `git` -- no terraform/tofu binary baked in. The correct version is downloaded at runtime from the [binary cache](registry.md).
+Runners are ephemeral Kubernetes Jobs that execute `terraform` or `tofu` plan and apply operations. The default runner image is a slim Debian (`python:3.13-slim`) container with `git`, `openssh-client`, `ca-certificates`, and a pinned `opa` binary -- no terraform/tofu binary baked in. The correct version is downloaded at runtime from the [binary cache](registry.md). The whole runner orchestrator is Python; nothing from the bash era survives.
 
 ---
 
@@ -10,36 +10,48 @@ The default image covers most use cases, but you may need additional tools -- cl
 
 ### Building a Custom Image
 
-Base your image on the default runner and add what you need:
+Base your image on the default runner and add what you need. The base is Debian, so use `apt-get` (not `apk`):
 
 ```dockerfile
 FROM ghcr.io/mattrobinsonsre/terrapod-runner:latest
 
 USER root
 
+# `curl` and `unzip` aren't in the base image; install them just for
+# the duration of this layer and remove afterwards.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
 # Example: AWS CLI v2
-RUN apk add --no-cache gcompat \
-    && curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip \
+RUN curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-$(dpkg --print-architecture).zip" -o /tmp/awscliv2.zip \
     && unzip -q /tmp/awscliv2.zip -d /tmp \
     && /tmp/aws/install \
     && rm -rf /tmp/awscliv2.zip /tmp/aws
 
-# Example: Azure CLI
-RUN apk add --no-cache py3-pip \
-    && pip3 install --break-system-packages azure-cli
+# Example: Azure CLI (via apt repo)
+RUN curl -sSL https://packages.microsoft.com/keys/microsoft.asc \
+    | gpg --dearmor -o /usr/share/keyrings/microsoft.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(. /etc/os-release && echo $VERSION_CODENAME) main" \
+       > /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends azure-cli \
+    && rm -rf /var/lib/apt/lists/*
 
 # Example: gcloud CLI
-RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz \
+RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-$(uname -m).tar.gz \
     | tar -xz -C /opt \
     && /opt/google-cloud-sdk/install.sh --quiet \
     && ln -s /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
+
+# Drop the install-time tools so they don't sit in the final image.
+RUN apt-get purge -y curl unzip && apt-get autoremove -y
 
 USER 1000:1000
 ```
 
 Important:
 - Switch back to `USER 1000:1000` -- runner Jobs run as non-root
-- The canonical entrypoint is `python -m terrapod.runner.job_entrypoint` -- it drives signal forwarding, graceful shutdown, phase orchestration, and artifact uploads. Custom images should not override `ENTRYPOINT`; layer additional tooling on top via `RUN` and let the inherited entrypoint stand. (A transitional `/entrypoint.sh` bash script still exists in the image for unported phases — it's invoked by the Python entrypoint, not by the kubelet.)
+- The canonical entrypoint is `python -m terrapod.runner.job_entrypoint` -- it drives signal forwarding, graceful shutdown, phase orchestration, and artifact uploads. Custom images should not override `ENTRYPOINT`; layer additional tooling on top via `RUN` and let the inherited entrypoint stand.
 - The working directory is `/workspace` and `/tmp` is writable (both are emptyDir volumes)
 
 ### Using a Custom Image
@@ -245,12 +257,12 @@ Terraform and OpenTofu merge any file matching `*_override.tf` over the main con
 
 Policy-as-code evaluation runs **on the runner**, between the plan phase and posting plan-result. The plan JSON is already on disk (just produced by `tofu show -json tfplan`), so the runner can evaluate OPA policies against it without a round-trip to storage and without any server-side concurrent-eval load. See [`docs/policies.md`](policies.md) for the authoring contract.
 
-Sequence inside `runner-entrypoint.sh`, after `tofu plan` completes successfully:
+Sequence inside the Python runner orchestrator (`services/terrapod/runner/job_entrypoint.py`), after `tofu plan` completes successfully:
 
-1. `tofu show -json tfplan > /tmp/plan.json` — produces the JSON form used by both OPA and the `plan-json-output` artifact.
-2. `tp_evaluate_policies` (the shell function in the entrypoint):
+1. `plan_apply.run_plan_show_json` runs `tofu show -json tfplan` and writes `/tmp/plan.json` — the JSON form used by both OPA and the `plan-json-output` artifact.
+2. `phases.opa.evaluate_policies`:
    - `GET /api/terrapod/v1/runs/{id}/policy-bundle` — fetches the policy sets in scope for this workspace, plus the run/workspace context. Bounded retries (3 attempts, 3s backoff); a persistent fetch failure is **fatal** to the run, never silently skipped.
-   - For each applicable set, for each policy: `opa eval --format json --stdin-input --data <rego> --data <context> 'data.terrapod' < /tmp/plan.json`. Parses `deny` / `warn` from the OPA output. One eval per policy preserves per-policy attribution in the UI.
+   - For each applicable set, for each policy: `opa eval --format json --stdin-input --data <rego> --data <context> 'data.terrapod' < /tmp/plan.json`. Parses `deny` / `warn` from the OPA output with defensive coercion (a misauthored `deny := "msg"` scalar is not allowed to silently pass). One eval per policy preserves per-policy attribution in the UI.
    - `POST /api/terrapod/v1/runs/{id}/policy-results` — uploads the aggregated results. Persisted via Postgres `ON CONFLICT DO NOTHING` on `(run_id, policy_set_id)` so retries are idempotent.
 3. The runner posts `plan-result`. The API's post-plan gate is now a pure DB query — by this point the policy_evaluation rows already exist (or there were no applicable sets, which is the right answer too).
 

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -1,10 +1,15 @@
-"""AI plan summariser + plan-failure analyser (#401).
+"""AI plan summariser + run-failure analyser (#401, #419).
 
 When enabled via ``ai_summary.enabled``, the API triggers an
-asynchronous call after every plan-phase terminal transition:
+asynchronous call after every terminal run transition:
   - ``planned`` → ``kind=plan_summary``: describe changes + rate risk.
-  - ``errored`` while still in the plan phase → ``kind=failure_analysis``:
-    explain why the plan failed and suggest fixes.
+  - ``errored`` at any point → ``kind=failure_analysis``: explain why
+    the run failed and suggest fixes. Plan-phase errors read the
+    plan log; apply-phase errors read the apply log and the prompt
+    grows apply-specific guidance (identify the failed resource,
+    identify resources that completed before the failure, call out
+    partial-state, rank fixes by recovery type). Workspaces flagged
+    ``state_diverged`` also surface that in a dedicated prompt block.
 
 The model call goes through the LiteLLM Python library
 (``litellm.acompletion``). Terrapod always speaks the OpenAI Chat

--- a/services/tests/api/test_request_base_url.py
+++ b/services/tests/api/test_request_base_url.py
@@ -1,0 +1,181 @@
+"""Tests for tfe_v2._request_base_url host/scheme validation (Semgrep
+#174/#175).
+
+The function takes operator-controlled headers (X-Forwarded-Host,
+Host, X-Forwarded-Proto) and splices them into URL prefixes that go
+into JSON:API response bodies (and downstream into redirect
+Location: headers). A malicious upstream proxy injecting CRLF or
+other separators into those headers could end up in user-visible
+URLs without the strict validation.
+
+We test the validators themselves directly — that's the security-
+relevant surface — plus a couple of integration-shape cases through
+the full function.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from terrapod.api.routers.tfe_v2 import (
+    _is_safe_host,
+    _is_safe_scheme,
+    _request_base_url,
+)
+
+
+class TestIsSafeHost:
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "terrapod.local",
+            "terrapod.example.com",
+            "api.terrapod.example.com",
+            "host-with-dashes.example.com",
+            "h1.h2.h3.h4.h5.example.com",
+            "terrapod.local:8443",
+            "host.example.com:443",
+            "10-0-0-1.example.com",  # numeric segments are fine in DNS
+            "x.y",  # minimum sensible host
+        ],
+    )
+    def test_accepts_safe_hosts(self, host: str) -> None:
+        assert _is_safe_host(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            # CRLF injection — the attack the validation is here for.
+            "evil.com\r\nLocation: https://attacker/",
+            "evil.com\rfoo",
+            "evil.com\nfoo",
+            # Other separator characters that could split headers or URLs.
+            "evil.com\tfoo",
+            "evil.com foo",
+            "evil.com/path",  # slashes never legal in a Host header
+            "evil.com?q=1",
+            "evil.com#frag",
+            "evil.com@attacker.com",  # userinfo smuggling
+            # Empty / falsy.
+            "",
+            # Just-port no host.
+            ":8443",
+            # Port that doesn't fit \d{1,5}.
+            "host.example.com:123456",
+            "host.example.com:abc",
+            # Length explosion — RFC 1123 caps at 253; we cap host portion
+            # at 253 chars (port may follow).
+            "a" * 254,
+            # IPv6 literal (brackets aren't in our whitelist; if we ever
+            # need IPv6 callback hosts that's an explicit addition, not
+            # a regression to allow [] through).
+            "[::1]",
+            "[2001:db8::1]:8443",
+        ],
+    )
+    def test_rejects_unsafe_hosts(self, host: str) -> None:
+        assert _is_safe_host(host) is False
+
+
+class TestIsSafeScheme:
+    def test_accepts_http_and_https(self) -> None:
+        assert _is_safe_scheme("http") is True
+        assert _is_safe_scheme("https") is True
+
+    @pytest.mark.parametrize(
+        "scheme", ["", "HTTP", "HTTPS", "javascript", "data", "file", "https:"]
+    )
+    def test_rejects_anything_else(self, scheme: str) -> None:
+        assert _is_safe_scheme(scheme) is False
+
+
+def _request_with(headers: dict[str, str], url_scheme: str = "https") -> MagicMock:
+    """Build a minimal Request-shaped mock with the headers and scheme
+    `_request_base_url` actually reads."""
+    req = MagicMock()
+    req.headers = headers
+    req.url = MagicMock()
+    req.url.scheme = url_scheme
+    return req
+
+
+class TestRequestBaseUrl:
+    """Integration shape: full _request_base_url through the validator
+    branches. callback_base_url is mocked to a known sentinel so we
+    can prove the fallback fires when a header is rejected."""
+
+    _FALLBACK = "https://callback.example.com"
+
+    def _patched_settings(self):
+        mock_settings = MagicMock()
+        mock_settings.auth.callback_base_url = self._FALLBACK
+        return patch("terrapod.config.settings", mock_settings)
+
+    def test_none_request_returns_callback(self) -> None:
+        with self._patched_settings():
+            assert _request_base_url(None) == self._FALLBACK
+
+    def test_clean_xfh_returns_constructed_url(self) -> None:
+        req = _request_with(
+            {"x-forwarded-host": "terrapod.example.com", "x-forwarded-proto": "https"}
+        )
+        with self._patched_settings():
+            assert _request_base_url(req) == "https://terrapod.example.com"
+
+    def test_xfh_with_port_accepted(self) -> None:
+        req = _request_with(
+            {"x-forwarded-host": "terrapod.example.com:8443", "x-forwarded-proto": "https"}
+        )
+        with self._patched_settings():
+            assert _request_base_url(req) == "https://terrapod.example.com:8443"
+
+    def test_xfh_with_comma_takes_first_entry(self) -> None:
+        # Standard XFH chain (multi-proxy). We take the leftmost (client-
+        # nearest) value and validate it.
+        req = _request_with(
+            {
+                "x-forwarded-host": "terrapod.example.com, internal-proxy.example.com",
+                "x-forwarded-proto": "https",
+            }
+        )
+        with self._patched_settings():
+            assert _request_base_url(req) == "https://terrapod.example.com"
+
+    def test_crlf_in_xfh_falls_back(self) -> None:
+        """The attack case. A CRLF-injected XFH must NOT make it into
+        the returned URL — fall back to the configured callback."""
+        req = _request_with(
+            {
+                "x-forwarded-host": "evil.com\r\nLocation: https://attacker/",
+                "x-forwarded-proto": "https",
+            }
+        )
+        with self._patched_settings():
+            assert _request_base_url(req) == self._FALLBACK
+
+    def test_unsafe_scheme_falls_back(self) -> None:
+        req = _request_with(
+            {"x-forwarded-host": "terrapod.example.com", "x-forwarded-proto": "javascript"}
+        )
+        with self._patched_settings():
+            assert _request_base_url(req) == self._FALLBACK
+
+    def test_host_header_with_dot_used_when_xfh_missing(self) -> None:
+        req = _request_with({"host": "terrapod.example.com"})
+        with self._patched_settings():
+            assert _request_base_url(req) == "https://terrapod.example.com"
+
+    def test_service_dns_host_skipped(self) -> None:
+        """Service-DNS hostnames like `terrapod-api:8000` have no `.`
+        and are skipped — emitting them would publish a URL only the
+        API pod itself can resolve."""
+        req = _request_with({"host": "terrapod-api:8000"})
+        with self._patched_settings():
+            assert _request_base_url(req) == self._FALLBACK
+
+    def test_crlf_in_host_falls_back(self) -> None:
+        req = _request_with({"host": "evil.com\r\nfoo: bar"})
+        with self._patched_settings():
+            assert _request_base_url(req) == self._FALLBACK


### PR DESCRIPTION
## Summary

Pre-release audit (A–E + G per CLAUDE.md) for v0.33.0. All P0 + P1 findings addressed.

| Dim | Finding | Fix |
|---|---|---|
| A1–A5 | \`docs/runners.md\` + \`docs/architecture.md\` describe an Alpine image and the bash entrypoint that no longer exist | Rewrote runner image description (\`python:3.13-slim\`), Docker custom-image example (\`apt-get\` not \`apk\`), graceful-termination + signal-handling + OPA-evaluation sequences to reflect the Python orchestrator |
| A6 | \`docs/ai-plan-summary.md\` only covers plan-phase \`failure_analysis\` | Updated for #419: apply-phase coverage, apply-log path, STATE_DIVERGED guidance |
| A7 + A10 | \`docs/registry.md\` lock-extender section is pre-\`cached_platforms\` | Documents the new field + the silent-skip vs. fallback distinction |
| A8 | \`CLAUDE.md\` still references the deleted bash entrypoint | Updated graceful-termination section + project-structure tree |
| A9 | \`summariser.py\` module docstring scope is pre-#419 | "run-failure analyser" + apply-phase scope |
| C1 | New \`_request_base_url\` host/scheme validators (Semgrep #174/#175) have no unit tests | New \`test_request_base_url.py\`: 42 tests covering CRLF injection, scheme allow-list, service-DNS skip, multi-proxy XFH chains |

## Clean dimensions

- **B (helm)**: no values.yaml/schema diff in this range
- **D (internal-reference leak)**: zero hits across commit messages, source diff, all docs
- **E (version strings)**: no stale \`v0.32\` / \`0.32\` references
- **F (live smoke)**: done on Tilt before the audit — plan-only, apply-phase \`failure_analysis\`, streaming-log fix, config-aware h1 skip all verified
- **G (ignored-vulnerability review)**: 5 active ignores (4 Trivy + 1 pip-audit) all re-checked; none droppable this cycle; rationales remain accurate

## Verification

- \`make lint\` green
- \`make test\` green: **1974 pass** (was 1932; +42 for the host-validation tests)
- Pre-flight for v0.33.0 tag