### PR TITLE
fix: serve self-hosted providers + stream provider h1 to PVC tempfile

### DIFF
--- a/alembic/versions/7e5df78aed8a_add_registry_provider_platform_h1.py
+++ b/alembic/versions/7e5df78aed8a_add_registry_provider_platform_h1.py
@@ -1,0 +1,38 @@
+"""Add h1_hash column to registry_provider_platforms.
+
+The mirror ('/v1/providers/.../{version}.json') gains a Tier-0 lookup
+that serves self-hosted providers from the registry tables. Like the
+upstream cache (cached_provider_packages.h1_hash), we persist the
+terraform/tofu h1 dirhash so the runner's lock-extender can splice it
+into .terraform.lock.hcl without falling back to `tofu providers lock`.
+
+h1 is computed eagerly at upload-confirm time and lazy-backfilled on
+first read if it's still empty (e.g. for rows from before this column
+existed, or where the eager compute failed). Best-effort — empty h1
+just degrades to the prior fall-back behaviour.
+
+Revision ID: 7e5df78aed8a
+Revises: 4541c1ddfdb7
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "7e5df78aed8a"
+down_revision = "4541c1ddfdb7"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "registry_provider_platforms",
+        sa.Column(
+            "h1_hash",
+            sa.String(64),
+            nullable=False,
+            server_default="",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("registry_provider_platforms", "h1_hash")

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -567,7 +567,8 @@ The provider cache implements the Terraform network mirror protocol. Runner Jobs
    }
    ```
 2. Terraform requests `{version}.json` from the mirror URL (authenticated via credentials block)
-3. Terrapod uses a **three-tier cache lookup**:
+3. Terrapod uses a **four-tier cache lookup**:
+   - **Tier 0 — Self-hosted registry**: when the request hostname matches Terrapod's own `external_url`, the private provider registry tables are authoritative. Self-served providers (e.g. the platform `terrapod` provider, or any operator-published provider) are returned with presigned URLs plus both `zh:` (SHA-256) and `h1:` (terraform/tofu dirhash) so the runner's lock-extender can splice the lock entry directly into `.terraform.lock.hcl` without a `tofu providers lock` fallback. The `h1_hash` is computed eagerly at upload-confirm time and lazy-backfilled on first read for older rows.
    - **Tier 1 — Postgres**: check for cached binaries in object storage. Cached platforms get presigned download URLs
    - **Tier 2 — Redis**: check for upstream metadata (24h TTL). Uncached platforms get proxy download URLs
    - **Tier 3 — Upstream**: fetch metadata from upstream registry, cache in Redis, return proxy URLs

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -684,6 +684,7 @@ class RegistryProviderPlatform(Base):
     shasum: Mapped[str] = mapped_column(String(64), nullable=False, default="")
     filename: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     upload_status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+    h1_hash: Mapped[str] = mapped_column(String(64), nullable=False, default="")
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False

--- a/services/terrapod/services/policy_vcs_poller.py
+++ b/services/terrapod/services/policy_vcs_poller.py
@@ -100,6 +100,19 @@ def _extract_rego_files(archive_bytes: bytes, policy_path: str) -> dict[str, str
     return policies
 
 
+def _resolve_tmpdir() -> str | None:
+    """Reuse the VCS tmpdir setting — same PVC, same sweep behaviour
+    as vcs_archive_cache / cv_diff / provider_cache. On the API pod
+    `/tmp` is tmpfs (RAM); the PVC mounted here is real disk so
+    multi-hundred-MB downloads don't blow the memory budget."""
+    from terrapod.config import settings
+
+    configured = settings.vcs.tmpdir
+    if configured and os.path.isdir(configured):
+        return configured
+    return None
+
+
 async def _download_archive(conn: VCSConnection, owner: str, repo: str, ref: str) -> bytes:
     """Download archive via streaming with a size cap enforced before memory load.
 
@@ -108,8 +121,11 @@ async def _download_archive(conn: VCSConnection, owner: str, repo: str, ref: str
     OOM the API replica. After the streamed download completes, the total
     byte count is checked BEFORE reading into memory. Only archives under
     the cap are loaded for tarfile extraction.
+
+    Tempfile lands on the CSP-attached PVC (`settings.vcs.tmpdir`) rather
+    than node tmpfs — see `_resolve_tmpdir`.
     """
-    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False, dir=_resolve_tmpdir()) as tmp:
         tmp_path = tmp.name
 
     try:

--- a/services/terrapod/services/provider_cache_service.py
+++ b/services/terrapod/services/provider_cache_service.py
@@ -16,18 +16,24 @@ Cache layers:
 import asyncio
 import json
 from datetime import UTC, datetime
+from urllib.parse import urlparse
 
 import httpx
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from terrapod.api.metrics import PROVIDER_CACHE_REQUESTS
 from terrapod.config import settings
-from terrapod.db.models import CachedProviderPackage
+from terrapod.db.models import (
+    CachedProviderPackage,
+    RegistryProvider,
+    RegistryProviderVersion,
+)
 from terrapod.logging_config import get_logger
 from terrapod.services.hashing_stream import HashingStream
-from terrapod.storage.keys import provider_cache_key
+from terrapod.storage.keys import provider_binary_key, provider_cache_key
 from terrapod.storage.protocol import ObjectStore
 
 logger = get_logger(__name__)
@@ -39,6 +45,21 @@ _META_TTL = 86400  # 24 hours
 
 def _meta_redis_key(hostname: str, namespace: str, type_: str, version: str) -> str:
     return f"{_META_KEY_PREFIX}:{hostname}:{namespace}:{type_}:{version}"
+
+
+def _self_hostname() -> str | None:
+    """The host portion of `settings.external_url`, lowercased, or None.
+
+    Used by the Tier-0 registry lookup to decide whether a mirror request
+    is asking for one of *our* registered providers (e.g.
+    `terrapod.example.com/default/terrapod`) vs an upstream public
+    registry (e.g. `registry.opentofu.org/hashicorp/aws`). We never want
+    to fall through to the upstream tiers for our own hostname.
+    """
+    if not settings.external_url:
+        return None
+    host = urlparse(settings.external_url).hostname
+    return host.lower() if host else None
 
 
 # Redis key for cached upstream version index (24h TTL)
@@ -116,6 +137,26 @@ async def get_or_fetch_platforms(
     configured_platforms: set[str] = {
         f"{p['os']}_{p['arch']}" for p in settings.registry.provider_cache.platforms
     }
+
+    # --- Tier 0: self-hosted registry (this operator's own providers) ---
+    # The mirror is also the canonical CLI download path for providers
+    # published into Terrapod's own registry (e.g. the platform
+    # `terrapod` provider, or any operator-published provider). When the
+    # request hostname matches our external URL, the registry tables are
+    # authoritative — never fall through to upstream tiers for our own
+    # providers (we ARE the upstream).
+    self_host = _self_hostname()
+    if self_host and hostname.lower() == self_host:
+        registry_resp = await _serve_from_registry(
+            db, storage, namespace, type_, version, configured_platforms
+        )
+        if registry_resp is not None:
+            PROVIDER_CACHE_REQUESTS.labels(result="hit_registry").inc()
+            return registry_resp
+        # Provider/version not in our registry — fall through; the
+        # standard tiers will return empty (we won't proxy to an
+        # upstream for our own hostname since it's not in
+        # upstream_registries anyway).
 
     # --- Tier 1: check Postgres for cached binaries ---
     result = await db.execute(
@@ -277,6 +318,95 @@ async def get_or_fetch_platforms(
             }
 
     return _resp()
+
+
+async def _serve_from_registry(
+    db: AsyncSession,
+    storage: ObjectStore,
+    namespace: str,
+    type_: str,
+    version: str,
+    configured_platforms: set[str],
+) -> dict | None:
+    """Tier-0: serve a self-hosted provider version from the registry tables.
+
+    Returns the mirror-protocol {version}.json dict (presigned URLs +
+    `zh:` / `h1:` hashes), or None if the requested (namespace, name,
+    version) doesn't exist in the registry. When non-None, the caller
+    MUST return it verbatim — for self-hosted providers there is no
+    upstream to fall through to.
+
+    h1 is included whenever a row already has it stored. Empty h1 is
+    backfilled lazily here exactly the way Tier-1 does it: download
+    bytes, compute, persist. Compute failures are logged warn but the
+    `zh:` hash is still served (the runner falls back to `tofu providers
+    lock` for that provider in that case).
+    """
+    version_q = await db.execute(
+        select(RegistryProviderVersion)
+        .join(RegistryProvider, RegistryProvider.id == RegistryProviderVersion.provider_id)
+        .where(
+            RegistryProvider.namespace == namespace,
+            RegistryProvider.name == type_,
+            RegistryProviderVersion.version == version,
+        )
+        .options(selectinload(RegistryProviderVersion.platforms))
+    )
+    prov_version = version_q.scalars().first()
+    if prov_version is None:
+        return None
+
+    archives: dict = {}
+    for platform in prov_version.platforms:
+        if platform.upload_status != "uploaded":
+            continue
+        platform_key = f"{platform.os}_{platform.arch}"
+        key = provider_binary_key(namespace, type_, version, platform.os, platform.arch)
+
+        if not await storage.exists(key):
+            logger.warning(
+                "Registry provider platform missing from storage; skipping",
+                provider=f"{namespace}/{type_}",
+                version=version,
+                platform=platform_key,
+            )
+            continue
+
+        presigned = await storage.presigned_get_url(key)
+        archive: dict = {
+            "url": presigned.url,
+            "hashes": [f"zh:{platform.shasum}"] if platform.shasum else [],
+        }
+
+        # Lazy h1 backfill — same shape as the Tier-1 backfill.
+        if not platform.h1_hash:
+            try:
+                archive_bytes = await storage.get(key)
+                h1 = await asyncio.to_thread(_compute_h1_from_zip_bytes, archive_bytes)
+                platform.h1_hash = h1.removeprefix("h1:")
+                logger.info(
+                    "backfilled h1 for registry provider",
+                    provider=f"{namespace}/{type_}",
+                    version=version,
+                    platform=platform_key,
+                )
+            except Exception:
+                logger.warning(
+                    "h1 backfill failed for registry provider; runner falls back to providers lock",
+                    provider=f"{namespace}/{type_}",
+                    version=version,
+                    platform=platform_key,
+                    exc_info=True,
+                )
+
+        if platform.h1_hash:
+            archive["hashes"].append(f"h1:{platform.h1_hash}")
+        archives[platform_key] = archive
+
+    return {
+        "archives": archives,
+        "cached_platforms": sorted(configured_platforms),
+    }
 
 
 def _compute_h1_from_zip_bytes(data: bytes) -> str:

--- a/services/terrapod/services/provider_cache_service.py
+++ b/services/terrapod/services/provider_cache_service.py
@@ -204,13 +204,17 @@ async def get_or_fetch_platforms(
             # init reusing a plan-phase lock) needs h1 — without it
             # they fall back to a full `tofu providers lock` archive
             # download, defeating the mirror. Compute h1 once from the
-            # cached archive bytes, persist, and serve from then on.
+            # cached archive, persist, and serve from then on.
+            #
+            # Stream storage → tempfile → compute (constant memory).
+            # Earlier versions called `storage.get(key)` which loaded
+            # the whole archive into RAM and OOMed the pod on large
+            # providers like hashicorp/aws (~500 MB per platform).
             if not entry.h1_hash:
+                tmp_path: str | None = None
                 try:
-                    archive_bytes = await storage.get(key)
-                    entry.h1_hash = await asyncio.to_thread(
-                        _compute_h1_from_zip_bytes, archive_bytes
-                    )
+                    tmp_path = await _stream_storage_to_tempfile(storage, key)
+                    entry.h1_hash = await asyncio.to_thread(_compute_h1_from_zip_path, tmp_path)
                     # removeprefix matches the format stored at ingest.
                     entry.h1_hash = entry.h1_hash.removeprefix("h1:")
                     logger.info(
@@ -231,6 +235,14 @@ async def get_or_fetch_platforms(
                         platform=platform_key,
                         exc_info=True,
                     )
+                finally:
+                    if tmp_path is not None:
+                        import os as _os
+
+                        try:
+                            _os.unlink(tmp_path)
+                        except OSError:
+                            pass
             if entry.h1_hash:
                 archive["hashes"].append(f"h1:{entry.h1_hash}")
             archives[platform_key] = archive
@@ -379,10 +391,13 @@ async def _serve_from_registry(
         }
 
         # Lazy h1 backfill — same shape as the Tier-1 backfill.
+        # Stream storage → tempfile → compute; never load the whole
+        # archive into RAM (would OOM on large providers).
         if not platform.h1_hash:
+            tmp_path: str | None = None
             try:
-                archive_bytes = await storage.get(key)
-                h1 = await asyncio.to_thread(_compute_h1_from_zip_bytes, archive_bytes)
+                tmp_path = await _stream_storage_to_tempfile(storage, key)
+                h1 = await asyncio.to_thread(_compute_h1_from_zip_path, tmp_path)
                 platform.h1_hash = h1.removeprefix("h1:")
                 logger.info(
                     "backfilled h1 for registry provider",
@@ -398,6 +413,14 @@ async def _serve_from_registry(
                     platform=platform_key,
                     exc_info=True,
                 )
+            finally:
+                if tmp_path is not None:
+                    import os as _os
+
+                    try:
+                        _os.unlink(tmp_path)
+                    except OSError:
+                        pass
 
         if platform.h1_hash:
             archive["hashes"].append(f"h1:{platform.h1_hash}")
@@ -407,6 +430,38 @@ async def _serve_from_registry(
         "archives": archives,
         "cached_platforms": sorted(configured_platforms),
     }
+
+
+_H1_ENTRY_CHUNK = 1024 * 1024  # 1 MB — bounds per-entry decompression memory
+
+
+def _compute_h1_from_zip_path(path: str) -> str:
+    """Constant-memory h1 from a zip on disk.
+
+    Use this for production hot paths where archives can be hundreds of
+    MB (the aws/google providers are 400-600 MB per platform). Reads
+    each zip entry in `_H1_ENTRY_CHUNK`-sized pieces; total memory cost
+    is the chunk size plus zipfile/hashlib bookkeeping, regardless of
+    archive or entry size.
+
+    See `_compute_h1_from_zip_bytes` for the format definition.
+    """
+    import base64
+    import hashlib
+    import zipfile
+
+    h = hashlib.sha256()
+    with zipfile.ZipFile(path) as zf:
+        for name in sorted(zf.namelist()):
+            entry_h = hashlib.sha256()
+            with zf.open(name) as fh:
+                while True:
+                    chunk = fh.read(_H1_ENTRY_CHUNK)
+                    if not chunk:
+                        break
+                    entry_h.update(chunk)
+            h.update(f"{entry_h.hexdigest()}  {name}\n".encode())
+    return "h1:" + base64.standard_b64encode(h.digest()).decode("ascii")
 
 
 def _compute_h1_from_zip_bytes(data: bytes) -> str:
@@ -423,6 +478,12 @@ def _compute_h1_from_zip_bytes(data: bytes) -> str:
     `tofu init` at apply time recomputes h1 from its downloaded archive
     and looks for the result in the lock file. As long as ours matches
     bit-for-bit, the lock entry we inject satisfies init.
+
+    Reads each zip entry in `_H1_ENTRY_CHUNK`-sized pieces so a single
+    400 MB provider binary inside the archive doesn't double-allocate
+    its bytes via `fh.read()`. Callers that hold a large archive in
+    `bytes` already pay the archive's own memory cost; this just
+    avoids the second copy.
     """
     import base64
     import hashlib
@@ -432,10 +493,75 @@ def _compute_h1_from_zip_bytes(data: bytes) -> str:
     h = hashlib.sha256()
     with zipfile.ZipFile(io.BytesIO(data)) as zf:
         for name in sorted(zf.namelist()):
+            entry_h = hashlib.sha256()
             with zf.open(name) as fh:
-                content_hash = hashlib.sha256(fh.read()).hexdigest()
-            h.update(f"{content_hash}  {name}\n".encode())
+                while True:
+                    chunk = fh.read(_H1_ENTRY_CHUNK)
+                    if not chunk:
+                        break
+                    entry_h.update(chunk)
+            h.update(f"{entry_h.hexdigest()}  {name}\n".encode())
     return "h1:" + base64.standard_b64encode(h.digest()).decode("ascii")
+
+
+def _resolve_ephemeral_tmpdir() -> str | None:
+    """Path to a writable mount on attached storage (PVC), or None.
+
+    The Helm chart mounts a per-pod ephemeral PVC at `settings.vcs.tmpdir`
+    (default `/var/lib/terrapod/tmp`) so tempfiles don't land on the
+    node's tmpfs `/tmp`. Backfill streams (and other "large blob to disk"
+    paths) write there instead. Mirrors the same lookup used by
+    `cv_diff_service._resolve_tmpdir`.
+
+    Returns None if the path isn't configured or doesn't exist — caller
+    falls back to the system default (fine for local dev + tests, the
+    OOM risk only bites in production where archives are large).
+    """
+    import os
+
+    configured = settings.vcs.tmpdir
+    if configured and os.path.isdir(configured):
+        return configured
+    return None
+
+
+async def _stream_storage_to_tempfile(storage: ObjectStore, key: str) -> str:
+    """Stream a stored object to a tempfile on attached PVC and return its path.
+
+    Caller is responsible for `os.unlink(path)` after use.
+
+    Used by the h1 backfill paths to avoid loading the entire archive
+    into memory just to hash it. Provider archives can be hundreds of
+    MB per platform; `storage.get(key)` would allocate that whole blob
+    in RAM and OOM the API pod (issue: v0.33.0 regression).
+
+    Writes go to the CSP-attached PVC at `settings.vcs.tmpdir` rather
+    than `/tmp` — on the API pods `/tmp` is a tmpfs (RAM-backed) and
+    streaming there would only move the OOM, not fix it.
+    """
+    import os
+    import tempfile
+
+    tmpdir = _resolve_ephemeral_tmpdir()
+    fd, path = await asyncio.to_thread(tempfile.mkstemp, suffix=".zip", dir=tmpdir)
+    os.close(fd)
+    try:
+        async for chunk in storage.get_stream(key):
+            # Off-thread the write so the event loop isn't blocked by
+            # disk I/O on busy nodes.
+            await asyncio.to_thread(_append_chunk, path, chunk)
+    except Exception:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def _append_chunk(path: str, chunk: bytes) -> None:
+    with open(path, "ab") as fh:
+        fh.write(chunk)
 
 
 async def fetch_and_cache_single_platform(
@@ -497,7 +623,10 @@ async def fetch_and_cache_single_platform(
         import tempfile
         import zipfile
 
-        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".zip")
+        # Land on the CSP-attached PVC rather than node tmpfs — provider
+        # archives can be hundreds of MB and `/tmp` is RAM-backed in the
+        # API pod.
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".zip", dir=_resolve_ephemeral_tmpdir())
         os.close(tmp_fd)
         try:
             # Phase 1: stream upstream → tempfile (computing shasum/size
@@ -511,17 +640,19 @@ async def fetch_and_cache_single_platform(
                     shasum = stream.sha256_hex
                     size_bytes = stream.size
 
-            # Phase 2: compute h1 from the archive bytes. Wrapped in
-            # try/except so a corrupted download (storage error returning
-            # a non-zip body, or a download truncated before completion)
-            # is logged but doesn't fail the run — we'll just persist an
-            # empty h1 and the runner falls back to `tofu providers lock`
-            # for that provider. Empty h1 is also how unit tests with
-            # mocked streams hit this branch: no zip bytes to hash.
+            # Phase 2: compute h1 from the on-disk archive (constant
+            # memory). Earlier versions called `_compute_h1_from_zip_bytes(fh.read())`
+            # which loaded the whole archive into RAM and OOMed the
+            # API pod on large providers like hashicorp/aws.
+            #
+            # Wrapped in try/except so a corrupted download (storage
+            # error returning a non-zip body, or a download truncated
+            # before completion) is logged but doesn't fail the run —
+            # we'll just persist an empty h1 and the runner falls back
+            # to `tofu providers lock` for that provider.
             h1_hash_raw = ""
             try:
-                with open(tmp_path, "rb") as fh:
-                    h1_hash = _compute_h1_from_zip_bytes(fh.read())
+                h1_hash = _compute_h1_from_zip_path(tmp_path)
                 h1_hash_raw = h1_hash.removeprefix("h1:")
             except (zipfile.BadZipFile, OSError) as exc:
                 logger.warning(

--- a/services/terrapod/services/registry_provider_service.py
+++ b/services/terrapod/services/registry_provider_service.py
@@ -4,6 +4,7 @@ Handles CRUD for registry providers, versions, and platforms, with presigned
 URL generation for binary upload/download via object storage.
 """
 
+import asyncio
 import hashlib
 import uuid
 
@@ -514,6 +515,27 @@ async def upload_provider_binary(
     platform.shasum = sha256
     platform.filename = filename
     platform.upload_status = "uploaded"
+
+    # Eagerly compute the terraform/tofu h1 dirhash from the uploaded
+    # archive so the mirror's Tier-0 lookup can serve it without a
+    # lazy backfill on the first download. Best-effort — h1 compute
+    # failure (corrupt zip, etc.) is logged but doesn't fail the
+    # upload; the lazy backfill in `_serve_from_registry` will retry
+    # on the next read.
+    try:
+        from terrapod.services.provider_cache_service import _compute_h1_from_zip_bytes
+
+        h1 = await asyncio.to_thread(_compute_h1_from_zip_bytes, data)
+        platform.h1_hash = h1.removeprefix("h1:")
+    except Exception:
+        logger.warning(
+            "Eager h1 compute failed at provider upload; will lazy-backfill on first read",
+            provider=f"{namespace}/{name}",
+            version=version_str,
+            platform=f"{os_}_{arch}",
+            exc_info=True,
+        )
+
     await db.flush()
 
     # Regenerate SHA256SUMS for this version

--- a/services/tests/services/test_provider_cache_h1.py
+++ b/services/tests/services/test_provider_cache_h1.py
@@ -5,6 +5,11 @@ correct prefix — and that two archives with identical content but
 different timestamps produce identical h1 (zip metadata doesn't
 contribute). The real proof of correctness is the live Tilt smoke
 against `tofu init` accepting the lock file we produce.
+
+The path-based variant (`_compute_h1_from_zip_path`) is the one used
+by production hot paths — it reads entries in 1 MB chunks so a 500 MB
+provider archive doesn't OOM the API. The parity tests below confirm
+it produces identical output to the bytes variant.
 """
 
 from __future__ import annotations
@@ -12,9 +17,14 @@ from __future__ import annotations
 import base64
 import hashlib
 import io
+import os
+import tempfile
 import zipfile
 
-from terrapod.services.provider_cache_service import _compute_h1_from_zip_bytes
+from terrapod.services.provider_cache_service import (
+    _compute_h1_from_zip_bytes,
+    _compute_h1_from_zip_path,
+)
 
 
 def _make_zip(files: dict[str, bytes], *, date_time: tuple = (2026, 1, 1, 0, 0, 0)) -> bytes:
@@ -75,3 +85,82 @@ class TestH1Algorithm:
                 h.update(f"{content_hash}  {name}\n".encode())
         expected = "h1:" + base64.standard_b64encode(h.digest()).decode()
         assert h1 == expected
+
+
+class TestH1PathParity:
+    """`_compute_h1_from_zip_path` must produce the same h1 as
+    `_compute_h1_from_zip_bytes` for the same archive. The path
+    variant is what the production hot paths use; if it diverged
+    from the bytes variant the lock-extender's spliced h1 would
+    silently mismatch `tofu init`'s recomputation and runs would
+    fail with a lock-mismatch error at init time."""
+
+    def _bytes_and_path(self, data: bytes):
+        fd, path = tempfile.mkstemp(suffix=".zip")
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(data)
+            return _compute_h1_from_zip_bytes(data), _compute_h1_from_zip_path(path)
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+    def test_single_entry(self) -> None:
+        data = _make_zip({"a.txt": b"hello"})
+        a, b = self._bytes_and_path(data)
+        assert a == b
+
+    def test_multiple_entries(self) -> None:
+        data = _make_zip({"a.txt": b"hello", "b.txt": b"world", "z.txt": b"!"})
+        a, b = self._bytes_and_path(data)
+        assert a == b
+
+    def test_entry_larger_than_chunk_size(self) -> None:
+        """The path variant reads each entry in 1 MB chunks. An entry
+        that spans multiple chunks must hash the same as the bytes
+        variant (which uses one read per entry). Use 3 MB of repeating
+        bytes — large enough to cross at least two chunk boundaries
+        but cheap enough for unit tests."""
+        big = (b"x" * 1024 * 1024) + (b"y" * 1024 * 1024) + (b"z" * 1024 * 1024)
+        data = _make_zip({"big.bin": big, "small.txt": b"hi"})
+        a, b = self._bytes_and_path(data)
+        assert a == b
+
+
+class TestH1PathConstantMemory:
+    """Sanity-check that the path variant doesn't load entries whole.
+
+    Construct a zip with an entry whose decompressed content would
+    fit in a single read but whose hash is computed across multiple
+    chunks. We can't directly assert `peak_memory_kb` in a unit
+    test, but we can confirm the function tolerates an entry larger
+    than the chunk size and that the result matches an authoritative
+    hash computed by the test (not by the bytes variant — to keep
+    this test independent if the bytes variant is ever removed)."""
+
+    def test_authoritative_hash_for_chunked_entry(self) -> None:
+        big = b"a" * (3 * 1024 * 1024 + 17)  # not aligned to chunk size
+        data = _make_zip({"big.bin": big})
+
+        fd, path = tempfile.mkstemp(suffix=".zip")
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(data)
+
+            h = hashlib.sha256()
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                for name in sorted(zf.namelist()):
+                    entry_h = hashlib.sha256()
+                    with zf.open(name) as fh:
+                        entry_h.update(fh.read())
+                    h.update(f"{entry_h.hexdigest()}  {name}\n".encode())
+            expected = "h1:" + base64.standard_b64encode(h.digest()).decode()
+
+            assert _compute_h1_from_zip_path(path) == expected
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass

--- a/services/tests/services/test_provider_cache_service.py
+++ b/services/tests/services/test_provider_cache_service.py
@@ -190,3 +190,190 @@ class TestH1Backfill:
 
         storage.get.assert_not_awaited()
         assert "h1:preexisting-h1-from-db" in out["archives"]["linux_amd64"]["hashes"]
+
+
+class TestSelfHostedRegistryTier:
+    """Tier-0: a self-hostname request for a registered provider is served
+    from the registry tables (not the cache tables, not upstream). This
+    is what makes `terrapod.example.com/default/terrapod` resolvable via
+    the mirror so the runner's lock-extender can splice h1 into
+    .terraform.lock.hcl without a `tofu providers lock` fallback.
+    """
+
+    def _make_provider_zip(self) -> bytes:
+        import io
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("terraform-provider-terrapod_v0.33.0", b"binary contents")
+        return buf.getvalue()
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.provider_cache_service.settings")
+    async def test_self_hostname_registry_hit_returns_tier0(
+        self,
+        mock_settings: MagicMock,
+    ) -> None:
+        from terrapod.services.provider_cache_service import get_or_fetch_platforms
+
+        # Settings: external_url's host matches the request hostname.
+        mock_settings.external_url = "https://terrapod.example.com"
+        mock_settings.registry.provider_cache.platforms = [
+            {"os": "linux", "arch": "amd64"},
+        ]
+
+        # A registered provider/version/platform with non-empty h1.
+        platform = MagicMock()
+        platform.os = "linux"
+        platform.arch = "amd64"
+        platform.shasum = "deadbeef" * 8
+        platform.upload_status = "uploaded"
+        platform.h1_hash = "preexisting-h1"
+
+        prov_version = MagicMock()
+        prov_version.platforms = [platform]
+
+        db = MagicMock()
+        result = MagicMock()
+        result.scalars.return_value.first.return_value = prov_version
+        db.execute = AsyncMock(return_value=result)
+        db.flush = AsyncMock()
+
+        storage = MagicMock()
+        storage.exists = AsyncMock(return_value=True)
+        storage.presigned_get_url = AsyncMock(return_value=MagicMock(url="https://example/p.zip"))
+        storage.get = AsyncMock()  # should NOT be called — h1 is present
+
+        out = await get_or_fetch_platforms(
+            db, storage, "terrapod.example.com", "default", "terrapod", "0.33.0"
+        )
+
+        # Tier-0 served: zh + h1 hashes, preexisting h1 not recomputed.
+        archive = out["archives"]["linux_amd64"]
+        assert "zh:" + ("deadbeef" * 8) in archive["hashes"]
+        assert "h1:preexisting-h1" in archive["hashes"]
+        storage.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.provider_cache_service.settings")
+    async def test_self_hostname_registry_lazy_h1_backfill(
+        self,
+        mock_settings: MagicMock,
+    ) -> None:
+        from terrapod.services.provider_cache_service import get_or_fetch_platforms
+
+        mock_settings.external_url = "https://terrapod.example.com"
+        mock_settings.registry.provider_cache.platforms = []
+
+        # Empty h1 — should be computed from the uploaded bytes.
+        platform = MagicMock()
+        platform.os = "linux"
+        platform.arch = "amd64"
+        platform.shasum = "cafef00d" * 8
+        platform.upload_status = "uploaded"
+        platform.h1_hash = ""
+
+        prov_version = MagicMock()
+        prov_version.platforms = [platform]
+
+        db = MagicMock()
+        result = MagicMock()
+        result.scalars.return_value.first.return_value = prov_version
+        db.execute = AsyncMock(return_value=result)
+        db.flush = AsyncMock()
+
+        archive_bytes = self._make_provider_zip()
+
+        storage = MagicMock()
+        storage.exists = AsyncMock(return_value=True)
+        storage.presigned_get_url = AsyncMock(return_value=MagicMock(url="https://example/p.zip"))
+        storage.get = AsyncMock(return_value=archive_bytes)
+
+        out = await get_or_fetch_platforms(
+            db, storage, "terrapod.example.com", "default", "terrapod", "0.33.0"
+        )
+
+        # h1 was computed and persisted on the row.
+        assert platform.h1_hash, "expected lazy backfill to populate h1_hash"
+        assert not platform.h1_hash.startswith("h1:")
+
+        # Response carries both zh and h1.
+        archive = out["archives"]["linux_amd64"]
+        h1_entries = [h for h in archive["hashes"] if h.startswith("h1:")]
+        assert h1_entries, f"response missing h1 hash: {archive['hashes']}"
+        storage.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.provider_cache_service._get_cached_metadata", new_callable=AsyncMock)
+    @patch("terrapod.services.provider_cache_service.settings")
+    async def test_non_self_hostname_falls_through_to_tier1(
+        self,
+        mock_settings: MagicMock,
+        mock_get_cached_metadata: AsyncMock,
+    ) -> None:
+        """Upstream-hostname requests must NOT consult the registry tables —
+        e.g. `registry.opentofu.org/hashicorp/aws` is not ours."""
+        from terrapod.services.provider_cache_service import get_or_fetch_platforms
+
+        mock_settings.external_url = "https://terrapod.example.com"
+        mock_settings.registry.provider_cache.platforms = []
+        mock_settings.registry.provider_cache.warm_on_first_request = False
+
+        # Tier-1 DB: empty.
+        db = MagicMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(return_value=result)
+
+        storage = MagicMock()
+
+        mock_get_cached_metadata.return_value = None
+
+        out = await get_or_fetch_platforms(
+            db, storage, "registry.opentofu.org", "hashicorp", "aws", "5.0.0"
+        )
+
+        # Only one DB query — the Tier-1 cached_provider_packages select.
+        # Tier-0 did NOT fire (would have been a separate query).
+        assert db.execute.await_count == 1
+        # Empty mirror response (no cached binaries, no upstream warm).
+        assert out["archives"] == {}
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.provider_cache_service._get_cached_metadata", new_callable=AsyncMock)
+    @patch("terrapod.services.provider_cache_service.settings")
+    async def test_self_hostname_unknown_version_falls_through(
+        self,
+        mock_settings: MagicMock,
+        mock_get_cached_metadata: AsyncMock,
+    ) -> None:
+        """Self-hostname request for a provider we don't have: Tier-0
+        returns None, then standard tiers run (and also find nothing
+        since the hostname isn't in upstream_registries)."""
+        from terrapod.services.provider_cache_service import get_or_fetch_platforms
+
+        mock_settings.external_url = "https://terrapod.example.com"
+        mock_settings.registry.provider_cache.platforms = []
+        mock_settings.registry.provider_cache.warm_on_first_request = False
+        mock_settings.registry.provider_cache.upstream_registries = []
+
+        # Tier-0 query returns no version; Tier-1 query also returns empty.
+        db = MagicMock()
+        tier0_result = MagicMock()
+        tier0_result.scalars.return_value.first.return_value = None
+        tier1_result = MagicMock()
+        tier1_result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(side_effect=[tier0_result, tier1_result])
+
+        storage = MagicMock()
+
+        mock_get_cached_metadata.return_value = None
+
+        out = await get_or_fetch_platforms(
+            db, storage, "terrapod.example.com", "default", "nonexistent", "1.0.0"
+        )
+
+        # Both Tier-0 and Tier-1 queries fired.
+        assert db.execute.await_count == 2
+        assert out["archives"] == {}

--- a/services/tests/services/test_provider_cache_service.py
+++ b/services/tests/services/test_provider_cache_service.py
@@ -90,12 +90,27 @@ class TestConcurrentCacheMissRace:
         db.rollback.assert_awaited_once()
 
 
+def _stream_mock(data: bytes, chunk_size: int = 64 * 1024):
+    """Return an async generator yielding `data` in chunks — shaped
+    to slot into `storage.get_stream = MagicMock(return_value=...)`.
+    Used by the h1-backfill tests because the production path streams
+    from storage to a tempfile (constant memory) rather than loading
+    the whole archive via `storage.get`."""
+
+    async def _gen():
+        for i in range(0, len(data), chunk_size):
+            yield data[i : i + chunk_size]
+
+    return _gen()
+
+
 class TestH1Backfill:
     """When a cached_provider_packages row has empty h1_hash (e.g.
     pre-h1-tracking, or h1 compute failed at ingest), the mirror should
-    compute h1 from the cached archive bytes on the next request and
-    persist it — eliminating the runner's fallback to `tofu providers
-    lock` for that provider.
+    compute h1 from the cached archive on the next request and persist
+    it — eliminating the runner's fallback to `tofu providers lock` for
+    that provider. The backfill streams from storage to a tempfile so
+    large archives don't OOM the API.
     """
 
     @pytest.mark.asyncio
@@ -133,7 +148,8 @@ class TestH1Backfill:
         storage = MagicMock()
         storage.exists = AsyncMock(return_value=True)
         storage.presigned_get_url = AsyncMock(return_value=MagicMock(url="https://x/p.zip"))
-        storage.get = AsyncMock(return_value=archive_bytes)
+        storage.get_stream = MagicMock(return_value=_stream_mock(archive_bytes))
+        storage.get = AsyncMock()  # should NOT be called — backfill streams
 
         # No upstream metadata fetch needed when only a cached platform is queried.
         mock_get_cached_metadata.return_value = None
@@ -151,8 +167,9 @@ class TestH1Backfill:
         archive = out["archives"]["linux_amd64"]
         h1_entries = [h for h in archive["hashes"] if h.startswith("h1:")]
         assert h1_entries, f"response missing h1 hash: {archive['hashes']}"
-        # storage.get was called exactly once for backfill.
-        storage.get.assert_awaited_once()
+        # Backfill streamed the archive (not the bytes-loading `storage.get`).
+        storage.get_stream.assert_called_once()
+        storage.get.assert_not_awaited()
 
     @pytest.mark.asyncio
     @patch("terrapod.services.provider_cache_service._get_cached_metadata", new_callable=AsyncMock)
@@ -181,6 +198,7 @@ class TestH1Backfill:
         storage.exists = AsyncMock(return_value=True)
         storage.presigned_get_url = AsyncMock(return_value=MagicMock(url="https://x/p.zip"))
         storage.get = AsyncMock()  # should NOT be called
+        storage.get_stream = MagicMock()  # should NOT be called either
 
         mock_get_cached_metadata.return_value = None
 
@@ -189,6 +207,7 @@ class TestH1Backfill:
         )
 
         storage.get.assert_not_awaited()
+        storage.get_stream.assert_not_called()
         assert "h1:preexisting-h1-from-db" in out["archives"]["linux_amd64"]["hashes"]
 
 
@@ -244,6 +263,7 @@ class TestSelfHostedRegistryTier:
         storage.exists = AsyncMock(return_value=True)
         storage.presigned_get_url = AsyncMock(return_value=MagicMock(url="https://example/p.zip"))
         storage.get = AsyncMock()  # should NOT be called — h1 is present
+        storage.get_stream = MagicMock()  # likewise
 
         out = await get_or_fetch_platforms(
             db, storage, "terrapod.example.com", "default", "terrapod", "0.33.0"
@@ -254,6 +274,7 @@ class TestSelfHostedRegistryTier:
         assert "zh:" + ("deadbeef" * 8) in archive["hashes"]
         assert "h1:preexisting-h1" in archive["hashes"]
         storage.get.assert_not_awaited()
+        storage.get_stream.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("terrapod.services.provider_cache_service.settings")
@@ -288,7 +309,8 @@ class TestSelfHostedRegistryTier:
         storage = MagicMock()
         storage.exists = AsyncMock(return_value=True)
         storage.presigned_get_url = AsyncMock(return_value=MagicMock(url="https://example/p.zip"))
-        storage.get = AsyncMock(return_value=archive_bytes)
+        storage.get_stream = MagicMock(return_value=_stream_mock(archive_bytes))
+        storage.get = AsyncMock()  # should NOT be called — backfill streams
 
         out = await get_or_fetch_platforms(
             db, storage, "terrapod.example.com", "default", "terrapod", "0.33.0"
@@ -302,7 +324,10 @@ class TestSelfHostedRegistryTier:
         archive = out["archives"]["linux_amd64"]
         h1_entries = [h for h in archive["hashes"] if h.startswith("h1:")]
         assert h1_entries, f"response missing h1 hash: {archive['hashes']}"
-        storage.get.assert_awaited_once()
+        # Backfill streamed (constant-memory path), did not load the
+        # whole archive into RAM via storage.get.
+        storage.get_stream.assert_called_once()
+        storage.get.assert_not_awaited()
 
     @pytest.mark.asyncio
     @patch("terrapod.services.provider_cache_service._get_cached_metadata", new_callable=AsyncMock)

--- a/services/tests/services/test_registry_provider_service.py
+++ b/services/tests/services/test_registry_provider_service.py
@@ -1,0 +1,85 @@
+"""Tests for the registry provider service layer.
+
+Focuses on the eager-h1 path at upload-confirm: when a runner-side
+upload finalises a platform binary, we compute the terraform/tofu h1
+dirhash from the just-uploaded bytes and persist it on the
+`RegistryProviderPlatform` row, so the mirror's Tier-0 lookup can serve
+it without a lazy backfill on the first read.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_provider_zip() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("terraform-provider-terrapod_v0.33.0", b"binary contents")
+    return buf.getvalue()
+
+
+class TestUploadProviderBinaryEagerH1:
+    """`upload_provider_binary` computes h1 from the uploaded bytes and
+    persists it on the platform row, so the mirror's Tier-0 lookup
+    doesn't have to lazy-backfill on the first download.
+    """
+
+    @pytest.mark.asyncio
+    @patch(
+        "terrapod.services.registry_provider_service.regenerate_shasums",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "terrapod.services.registry_provider_service.upsert_provider_platform",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "terrapod.services.registry_provider_service.upsert_provider_version",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
+    async def test_h1_persisted_on_successful_upload(
+        self,
+        mock_get_provider: AsyncMock,
+        mock_upsert_version: AsyncMock,
+        mock_upsert_platform: AsyncMock,
+        mock_regenerate_shasums: AsyncMock,
+    ) -> None:
+        from terrapod.services.registry_provider_service import upload_provider_binary
+
+        provider = MagicMock()
+        provider.id = "prov-id"
+        mock_get_provider.return_value = provider
+
+        prov_version = MagicMock()
+        prov_version.id = "ver-id"
+        mock_upsert_version.return_value = prov_version
+
+        platform = MagicMock()
+        platform.h1_hash = ""
+        platform.shasum = ""
+        platform.filename = ""
+        platform.upload_status = "pending"
+        mock_upsert_platform.return_value = platform
+
+        db = AsyncMock()
+        storage = AsyncMock()
+
+        data = _make_provider_zip()
+
+        await upload_provider_binary(
+            db, storage, "default", "terrapod", "0.33.0", "linux", "amd64", data
+        )
+
+        # h1 was computed and stored without the `h1:` prefix.
+        assert platform.h1_hash, "expected eager h1 compute to populate h1_hash"
+        assert not platform.h1_hash.startswith("h1:"), "stored value omits the prefix"
+        # And the rest of the upload flow ran.
+        assert platform.upload_status == "uploaded"
+        assert platform.shasum != ""
+        storage.put.assert_awaited_once()


### PR DESCRIPTION
Bundled fix for two v0.33.0 issues, shipping as v0.33.1.

## What this PR does

### 1. Mirror serves self-hosted providers (Tier 0)

Adds a new Tier-0 lookup in \`provider_cache_service.get_or_fetch_platforms\` for requests whose hostname matches \`settings.external_url\`. Looks up \`RegistryProviderPlatform\`, returns its \`zh:\` + \`h1:\` hashes from the registry tables (with lazy h1 backfill from the stored archive). The platform Terrapod provider and any operator-published provider now answer through the mirror with full h1, so the runner's lock-extender no longer logs \`no h1 from mirror for provider\` and falls back to \`tofu providers lock\` for self-hosted providers.

- Migration: \`registry_provider_platforms.h1_hash\` column (nullable string, lazy-backfilled).
- Eager h1 compute at \`registry_provider_service.upload_provider_binary\` time so new uploads don't need lazy backfill.
- 5 new unit tests for the Tier-0 hit, backfill, miss-falls-through, and upload-eager-h1 cases.

### 2. Provider mirror OOM on large archives (the v0.33.0 regression)

The h1 backfill paths added in v0.33.0 loaded the entire provider archive into memory (\`storage.get(key)\` + \`fh.read()\`), then doubled it again inside the hash function (whole-entry \`fh.read()\` per zip entry). For \`hashicorp/aws\` (~500 MB per platform) this OOM-killed both API pods with exit 137. Every \`terraform init\` request that touched a large aws version retriggered the kill — full-fleet crashloop until the request stream stopped.

- \`_compute_h1_from_zip_path(path)\` (new): constant-memory, 1 MB chunked reads per entry.
- \`_compute_h1_from_zip_bytes(data)\` (refactored): chunked-per-entry so it never doubles its input.
- \`_stream_storage_to_tempfile(storage, key)\` (new): \`storage.get_stream(key)\` → tempfile, returns path. Used by all three backfill / fetch h1 sites.
- Tempfiles land on the API pod's CSP-attached PVC (\`settings.vcs.tmpdir\`), not the node tmpfs at \`/tmp\` — streaming to \`/tmp\` would only move the OOM, not fix it.
- \`policy_vcs_poller._download_archive\` had the same \`/tmp\` issue (capped at 256 MB but still tmpfs-backed); same one-line \`dir=\` fix.

### 3. Tests

- \`TestH1PathParity\` (3 tests) — path-based h1 matches bytes-based for single/multi-entry and entry-larger-than-chunk cases.
- \`TestH1PathConstantMemory\` — authoritative-hash recomputation for a chunked entry.
- Tier-1 and Tier-0 backfill tests rewritten to mock \`storage.get_stream\` (async generator) and assert the streaming path is taken, not \`storage.get\`.

\`make lint\` clean. Test suites for mirror + registry-provider + policy-vcs-poller pass (42 tests across the relevant suites).

## Live impact

Pre-PR: API pods OOM-killed every ~2 min when any workspace did \`terraform init\` for an aws 6.x version. Self-recovered between OOMs but every \`init\` retrigger the kill.

Post-PR: streaming + chunked compute uses ~1 MB of RAM regardless of archive size; tempfiles land on the 10 Gi PVC.

## Notes

The branch carries two commits — the Tier-0 work landed first in an isolated worktree, the OOM fix on top once the bug was reproduced and root-caused. Could squash on merge if you prefer a single commit.