### PR TITLE
fix: serve platform terrapod provider from mirror (Tier-0a)

### DIFF
--- a/services/terrapod/services/provider_cache_service.py
+++ b/services/terrapod/services/provider_cache_service.py
@@ -32,6 +32,7 @@ from terrapod.db.models import (
     RegistryProviderVersion,
 )
 from terrapod.logging_config import get_logger
+from terrapod.redis.client import get_redis_client
 from terrapod.services.hashing_stream import HashingStream
 from terrapod.storage.keys import provider_binary_key, provider_cache_key
 from terrapod.storage.protocol import ObjectStore
@@ -138,25 +139,39 @@ async def get_or_fetch_platforms(
         f"{p['os']}_{p['arch']}" for p in settings.registry.provider_cache.platforms
     }
 
-    # --- Tier 0: self-hosted registry (this operator's own providers) ---
-    # The mirror is also the canonical CLI download path for providers
-    # published into Terrapod's own registry (e.g. the platform
-    # `terrapod` provider, or any operator-published provider). When the
-    # request hostname matches our external URL, the registry tables are
-    # authoritative — never fall through to upstream tiers for our own
-    # providers (we ARE the upstream).
+    # --- Tier 0: self-hosted providers (this operator owns the source) ---
+    # Two shapes coexist:
+    #   (a) The platform Terrapod provider (`default/terrapod`) — has NO
+    #       row in registry_provider_versions. It's fetched on demand
+    #       from GitHub Releases by `platform_provider_service` and
+    #       cached at `cache/provider/terrapod/...` storage keys. Special-
+    #       case it; the registry-table lookup would always miss.
+    #   (b) Operator-published providers — live in the registry tables
+    #       (registry_providers / _versions / _platforms) and are stored
+    #       at `registry/providers/...` storage keys via `upload_provider_binary`.
+    #
+    # In both cases the operator is authoritative — never fall through
+    # to upstream tiers for our own hostname.
     self_host = _self_hostname()
     if self_host and hostname.lower() == self_host:
-        registry_resp = await _serve_from_registry(
-            db, storage, namespace, type_, version, configured_platforms
-        )
-        if registry_resp is not None:
-            PROVIDER_CACHE_REQUESTS.labels(result="hit_registry").inc()
-            return registry_resp
-        # Provider/version not in our registry — fall through; the
-        # standard tiers will return empty (we won't proxy to an
+        if namespace == "default" and type_ == "terrapod":
+            platform_resp = await _serve_platform_terrapod(storage, version, configured_platforms)
+            if platform_resp is not None:
+                PROVIDER_CACHE_REQUESTS.labels(result="hit_platform_terrapod").inc()
+                return platform_resp
+        else:
+            registry_resp = await _serve_from_registry(
+                db, storage, namespace, type_, version, configured_platforms
+            )
+            if registry_resp is not None:
+                PROVIDER_CACHE_REQUESTS.labels(result="hit_registry").inc()
+                return registry_resp
+        # Self-hosted but not found / not yet cached. Fall through to the
+        # standard tiers; they'll return empty (we won't proxy to an
         # upstream for our own hostname since it's not in
-        # upstream_registries anyway).
+        # upstream_registries anyway). For the platform Terrapod provider
+        # specifically, the runner's next CLI download request will hit
+        # platform_provider_service and warm the cache.
 
     # --- Tier 1: check Postgres for cached binaries ---
     result = await db.execute(
@@ -330,6 +345,128 @@ async def get_or_fetch_platforms(
             }
 
     return _resp()
+
+
+# Redis cache for the platform Terrapod provider's h1 hashes.
+# Archive contents are immutable per (version, os, arch) — a published
+# tag's binary never changes — so we can cache the computed h1 forever.
+# 30-day TTL is a defence-in-depth window against accidental rebuild +
+# overwrite (which shouldn't happen but we don't want a stale h1 to
+# linger across an unlikely incident).
+_PLATFORM_TERRAPOD_H1_KEY = "tp:platform_provider_h1"
+_PLATFORM_TERRAPOD_H1_TTL = 86400 * 30  # 30 days
+
+
+def _platform_terrapod_h1_redis_key(version: str, os_: str, arch: str) -> str:
+    return f"{_PLATFORM_TERRAPOD_H1_KEY}:{version}:{os_}:{arch}"
+
+
+async def _serve_platform_terrapod(
+    storage: ObjectStore,
+    version: str,
+    configured_platforms: set[str],
+) -> dict | None:
+    """Tier-0a: serve the platform Terrapod provider from its on-disk cache.
+
+    The platform Terrapod provider has NO row in `registry_provider_versions`.
+    It's fetched on demand from GitHub Releases by `platform_provider_service`
+    and cached at `platform_provider_binary_key` paths. This helper mirrors
+    that storage layout, returns presigned URLs + `zh:`/`h1:` hashes for any
+    platforms that are already cached, and skips platforms that aren't (the
+    runner's next CLI download request will warm them via
+    `platform_provider_service`).
+
+    h1 is computed lazily on first request per (version, os, arch) and cached
+    in Redis with a long TTL (archives are immutable). Computed via the same
+    constant-memory streaming path as the Tier-1 backfill — never loads the
+    archive into RAM.
+
+    Returns None when no platforms are cached (caller falls through to the
+    standard tiers, which will also return empty for this hostname).
+    """
+    # Late imports — platform_provider_service depends on terrapod.config
+    # being importable, which is fine in production but the tests patch
+    # `settings` at module scope here.
+    from terrapod.services.platform_provider_service import _get_shasum_for_file
+    from terrapod.storage.keys import (
+        platform_provider_binary_key,
+        platform_provider_shasums_key,
+    )
+
+    archives: dict = {}
+    shasums_key = platform_provider_shasums_key(version)
+    shasums_cached: bool | None = None  # lazy: don't hit storage if no platforms exist
+    redis = get_redis_client()
+
+    for platform_key in sorted(configured_platforms):
+        os_, arch = platform_key.split("_", 1)
+        binary_key = platform_provider_binary_key(version, os_, arch)
+
+        if not await storage.exists(binary_key):
+            continue
+
+        # Resolve shasum from the cached SHA256SUMS file (one storage read
+        # per request when any platforms are present). The file is tiny
+        # (a few hundred bytes) so the bytes-load is fine.
+        if shasums_cached is None:
+            shasums_cached = await storage.exists(shasums_key)
+        shasum = ""
+        if shasums_cached:
+            filename = f"terraform-provider-terrapod_{version}_{os_}_{arch}.zip"
+            shasum = await _get_shasum_for_file(storage, shasums_key, filename)
+
+        presigned = await storage.presigned_get_url(binary_key)
+        archive: dict = {
+            "url": presigned.url,
+            "hashes": [f"zh:{shasum}"] if shasum else [],
+        }
+
+        # Lazy h1 backfill via Redis cache. No DB column needed — the
+        # platform Terrapod provider isn't in the registry tables.
+        redis_key = _platform_terrapod_h1_redis_key(version, os_, arch)
+        h1_cached = await redis.get(redis_key)
+        if h1_cached:
+            h1 = h1_cached.decode("utf-8") if isinstance(h1_cached, bytes) else h1_cached
+            archive["hashes"].append(f"h1:{h1}")
+        else:
+            tmp_path: str | None = None
+            try:
+                tmp_path = await _stream_storage_to_tempfile(storage, binary_key)
+                h1_full = await asyncio.to_thread(_compute_h1_from_zip_path, tmp_path)
+                h1 = h1_full.removeprefix("h1:")
+                await redis.set(redis_key, h1, ex=_PLATFORM_TERRAPOD_H1_TTL)
+                archive["hashes"].append(f"h1:{h1}")
+                logger.info(
+                    "backfilled h1 for platform terrapod provider",
+                    version=version,
+                    platform=platform_key,
+                )
+            except Exception:
+                logger.warning(
+                    "h1 backfill failed for platform terrapod provider; "
+                    "runner falls back to providers lock",
+                    version=version,
+                    platform=platform_key,
+                    exc_info=True,
+                )
+            finally:
+                if tmp_path is not None:
+                    import os as _os
+
+                    try:
+                        _os.unlink(tmp_path)
+                    except OSError:
+                        pass
+
+        archives[platform_key] = archive
+
+    if not archives:
+        return None
+
+    return {
+        "archives": archives,
+        "cached_platforms": sorted(configured_platforms),
+    }
 
 
 async def _serve_from_registry(

--- a/services/tests/services/test_provider_cache_service.py
+++ b/services/tests/services/test_provider_cache_service.py
@@ -212,11 +212,11 @@ class TestH1Backfill:
 
 
 class TestSelfHostedRegistryTier:
-    """Tier-0: a self-hostname request for a registered provider is served
-    from the registry tables (not the cache tables, not upstream). This
-    is what makes `terrapod.example.com/default/terrapod` resolvable via
-    the mirror so the runner's lock-extender can splice h1 into
-    .terraform.lock.hcl without a `tofu providers lock` fallback.
+    """Tier-0: a self-hostname request for a registered (operator-published)
+    provider is served from the registry tables. Uses an `op-addon` name
+    rather than `terrapod` to avoid the platform-Terrapod-provider
+    short-circuit (see TestPlatformTerrapodTier for that path) — the
+    platform provider has no registry-table rows.
     """
 
     def _make_provider_zip(self) -> bytes:
@@ -266,7 +266,7 @@ class TestSelfHostedRegistryTier:
         storage.get_stream = MagicMock()  # likewise
 
         out = await get_or_fetch_platforms(
-            db, storage, "terrapod.example.com", "default", "terrapod", "0.33.0"
+            db, storage, "terrapod.example.com", "default", "op-addon", "0.33.0"
         )
 
         # Tier-0 served: zh + h1 hashes, preexisting h1 not recomputed.
@@ -313,7 +313,7 @@ class TestSelfHostedRegistryTier:
         storage.get = AsyncMock()  # should NOT be called — backfill streams
 
         out = await get_or_fetch_platforms(
-            db, storage, "terrapod.example.com", "default", "terrapod", "0.33.0"
+            db, storage, "terrapod.example.com", "default", "op-addon", "0.33.0"
         )
 
         # h1 was computed and persisted on the row.
@@ -401,4 +401,171 @@ class TestSelfHostedRegistryTier:
 
         # Both Tier-0 and Tier-1 queries fired.
         assert db.execute.await_count == 2
+        assert out["archives"] == {}
+
+
+class TestPlatformTerrapodTier:
+    """Tier-0a: the platform Terrapod provider is fetched on demand from
+    GitHub Releases by `platform_provider_service` and cached at
+    `platform_provider_binary_key` paths — it has NO row in
+    `registry_provider_versions`. The mirror's self-hostname branch
+    short-circuits to `_serve_platform_terrapod` for
+    `(namespace=default, type=terrapod)` rather than the registry-tables
+    lookup, which would always miss.
+    """
+
+    def _make_provider_zip(self) -> bytes:
+        import io
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("terraform-provider-terrapod_v0.33.1", b"binary contents")
+        return buf.getvalue()
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.provider_cache_service.get_redis_client")
+    @patch("terrapod.services.provider_cache_service.settings")
+    async def test_serves_cached_platforms_with_h1_from_redis(
+        self,
+        mock_settings: MagicMock,
+        mock_get_redis: MagicMock,
+    ) -> None:
+        """Cached binary + cached h1 in Redis → served from Tier-0a
+        with zh + h1 hashes, no archive read, no h1 compute, no DB
+        query."""
+        from terrapod.services.provider_cache_service import get_or_fetch_platforms
+
+        mock_settings.external_url = "https://terrapod.example.com"
+        mock_settings.registry.provider_cache.platforms = [
+            {"os": "linux", "arch": "amd64"},
+        ]
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+
+        storage = MagicMock()
+        storage.exists = AsyncMock(return_value=True)
+        storage.presigned_get_url = AsyncMock(return_value=MagicMock(url="https://example/p.zip"))
+        shasums_body = (
+            b"deadbeefcafef00d0123456789abcdef0123456789abcdef0123456789abcdef"
+            b"  terraform-provider-terrapod_0.33.1_linux_amd64.zip\n"
+        )
+        storage.get = AsyncMock(return_value=shasums_body)
+        storage.get_stream = MagicMock()  # should NOT be called
+
+        redis = MagicMock()
+        redis.get = AsyncMock(return_value=b"preexisting-h1-from-redis")
+        redis.set = AsyncMock()
+        mock_get_redis.return_value = redis
+
+        out = await get_or_fetch_platforms(
+            db, storage, "terrapod.example.com", "default", "terrapod", "0.33.1"
+        )
+
+        archive = out["archives"]["linux_amd64"]
+        zh_entries = [h for h in archive["hashes"] if h.startswith("zh:")]
+        h1_entries = [h for h in archive["hashes"] if h.startswith("h1:")]
+        assert zh_entries == ["zh:deadbeefcafef00d0123456789abcdef0123456789abcdef0123456789abcdef"]
+        assert "h1:preexisting-h1-from-redis" in h1_entries
+        # No archive streaming (h1 came from Redis).
+        storage.get_stream.assert_not_called()
+        redis.set.assert_not_awaited()
+        # Tier-1 never reached.
+        db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.provider_cache_service.get_redis_client")
+    @patch("terrapod.services.provider_cache_service.settings")
+    async def test_lazy_h1_backfill_via_redis(
+        self,
+        mock_settings: MagicMock,
+        mock_get_redis: MagicMock,
+    ) -> None:
+        """Cached binary but no Redis h1 → compute via streaming, cache
+        in Redis with the 30-day TTL, return with zh + h1."""
+        from terrapod.services.provider_cache_service import get_or_fetch_platforms
+
+        mock_settings.external_url = "https://terrapod.example.com"
+        mock_settings.registry.provider_cache.platforms = [
+            {"os": "linux", "arch": "amd64"},
+        ]
+
+        archive_bytes = self._make_provider_zip()
+        db = MagicMock()
+        db.execute = AsyncMock()
+
+        storage = MagicMock()
+        storage.exists = AsyncMock(return_value=True)
+        storage.presigned_get_url = AsyncMock(return_value=MagicMock(url="https://example/p.zip"))
+        storage.get = AsyncMock(
+            return_value=(b"abc123  terraform-provider-terrapod_0.33.1_linux_amd64.zip\n")
+        )
+        storage.get_stream = MagicMock(return_value=_stream_mock(archive_bytes))
+
+        redis = MagicMock()
+        redis.get = AsyncMock(return_value=None)
+        redis.set = AsyncMock()
+        mock_get_redis.return_value = redis
+
+        out = await get_or_fetch_platforms(
+            db, storage, "terrapod.example.com", "default", "terrapod", "0.33.1"
+        )
+
+        archive = out["archives"]["linux_amd64"]
+        h1_entries = [h for h in archive["hashes"] if h.startswith("h1:")]
+        assert h1_entries, f"expected h1 in hashes, got {archive['hashes']}"
+        zh_entries = [h for h in archive["hashes"] if h.startswith("zh:")]
+        assert zh_entries == ["zh:abc123"]
+
+        # Redis was populated with the computed h1 (30-day TTL).
+        redis.set.assert_awaited_once()
+        call_args = redis.set.await_args
+        assert call_args.args[0] == "tp:platform_provider_h1:0.33.1:linux:amd64"
+        assert call_args.kwargs.get("ex") == 86400 * 30
+        # Tier-1 never reached.
+        db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.provider_cache_service.get_redis_client")
+    @patch("terrapod.services.provider_cache_service._get_cached_metadata", new_callable=AsyncMock)
+    @patch("terrapod.services.provider_cache_service.settings")
+    async def test_no_cached_platforms_returns_none_falls_through(
+        self,
+        mock_settings: MagicMock,
+        mock_get_cached_metadata: AsyncMock,
+        mock_get_redis: MagicMock,
+    ) -> None:
+        """Cold cache: no platforms exist on disk → Tier-0a returns
+        None and the standard tiers run. Tier-1 also finds nothing
+        (self-hostname isn't in upstream_registries) so we end with an
+        empty archives response. This is the runner's first-ever lookup
+        before any CLI download has warmed the cache."""
+        from terrapod.services.provider_cache_service import get_or_fetch_platforms
+
+        mock_settings.external_url = "https://terrapod.example.com"
+        mock_settings.registry.provider_cache.platforms = [
+            {"os": "linux", "arch": "amd64"},
+        ]
+        mock_settings.registry.provider_cache.warm_on_first_request = False
+        mock_settings.registry.provider_cache.upstream_registries = []
+
+        db = MagicMock()
+        tier1_result = MagicMock()
+        tier1_result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(return_value=tier1_result)
+
+        storage = MagicMock()
+        storage.exists = AsyncMock(return_value=False)  # no cached binary
+
+        redis = MagicMock()
+        mock_get_redis.return_value = redis
+        mock_get_cached_metadata.return_value = None
+
+        out = await get_or_fetch_platforms(
+            db, storage, "terrapod.example.com", "default", "terrapod", "0.33.1"
+        )
+
+        # Tier-0a returned None → Tier-1 select fired.
+        assert db.execute.await_count == 1
         assert out["archives"] == {}


### PR DESCRIPTION
Follow-up to v0.33.1. The Tier-0 self-hosted lookup added in #467 queries the registry tables — but the platform Terrapod provider itself is NOT in those tables. It's fetched from GitHub Releases by `platform_provider_service` and cached at `cache/provider/terrapod/...` (separate from `registry/providers/...`). So Tier-0 always missed and the runner's lock-extender kept logging `no h1 from mirror for provider terrapod.../default/terrapod`.

Adds a Tier-0a branch ahead of the registry-tables lookup for `(namespace=default, type=terrapod)`:

- Per configured platform, `storage.exists` check + presigned URL.
- Shasum read from the cached `SHA256SUMS` file.
- Lazy h1 backfill via the same constant-memory streaming path used by the other backfills; result cached in Redis at `tp:platform_provider_h1:{version}:{os}:{arch}` with 30-day TTL (archive contents are immutable per release).
- No DB column needed — the platform provider has no registry rows.

Side cleanups:
- `get_redis_client` hoisted to module-level imports so the new tests can patch it.
- The v0.33.1 `TestSelfHostedRegistryTier` tests now use a non-`terrapod` provider name so they continue to exercise the registry-tables path; the `terrapod` name is reserved for the new Tier-0a tests.

Ships as v0.33.2.