### PR TITLE
chore: re-suppress 3 reopened Semgrep findings

### DIFF
--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -1638,7 +1638,8 @@ def _request_base_url(request: Request | None) -> str:
         proto = request.headers.get("x-forwarded-proto") or request.url.scheme
         candidate = xfh.split(",", 1)[0].strip()
         if _is_safe_host(candidate) and _is_safe_scheme(proto):
-            return f"{proto}://{candidate}"
+            # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
+            return f"{proto}://{candidate}"  # both parts validated above
         return fallback
     host = request.headers.get("host")
     if host and "." in host and _is_safe_host(host):
@@ -1647,7 +1648,8 @@ def _request_base_url(request: Request | None) -> str:
         # so the scheme reflects what FastAPI saw on the wire.
         scheme = request.url.scheme
         if _is_safe_scheme(scheme):
-            return f"{scheme}://{host}"
+            # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
+            return f"{scheme}://{host}"  # both parts validated above
     return fallback
 
 

--- a/services/terrapod/runner/phases/setup_script.py
+++ b/services/terrapod/runner/phases/setup_script.py
@@ -37,13 +37,12 @@ def run(script: str, *, env: dict[str, str] | None = None) -> None:
     if not script:
         return
     logger.info("running setup script")
-    # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
     # The setup script body IS shell input by design — the feature exists
     # so operators can run arbitrary shell setup (auth, tool config, env
     # prep) before plan/apply. Source is the workspace's TP_SETUP_SCRIPT
     # field, only writable by users with workspace `admin`; the runner's
     # auth boundary, not subprocess flags, is what gates this.
-    result = subprocess.run(  # noqa: S602
+    result = subprocess.run(  # noqa: S602  # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
         script,
         shell=True,
         check=False,


### PR DESCRIPTION
Inline `# nosemgrep:` annotations on the violation lines themselves (the previous placement was too far above the violation for Semgrep to attach). Comment-only — no behaviour change.

Force-merging per maintainer instruction (no release needed).