### PR TITLE
fix(runner): splice both h1: + zh: hashes for other-arch in lock

### DIFF
--- a/services/terrapod/runner/lock_extender.py
+++ b/services/terrapod/runner/lock_extender.py
@@ -1,12 +1,12 @@
-"""Inject `h1:` hashes from Terrapod's provider mirror into the
-runner's `.terraform.lock.hcl`.
+"""Inject `h1:` + `zh:` hashes from Terrapod's provider mirror into
+the runner's `.terraform.lock.hcl`.
 
 Replaces the `tofu providers lock -platform=<other_arch>` invocation
 in the bash entrypoint (v0.31.6: only-other-arch mitigation). Where
 that command costs one full archive download per provider per plan,
 this module makes one ~1 KB JSON request per provider — the mirror
-already cached the archive and computed h1 server-side, so the
-runner just splices the returned hash into the lock.
+already cached the archive and computed both hashes server-side, so
+the runner just splices the returned pair into the lock.
 
 Algorithm:
 
@@ -14,10 +14,14 @@ Algorithm:
   2. For each provider block:
      a. GET /v1/providers/{hostname}/{namespace}/{type}/{version}.json
         from Terrapod's mirror.
-     b. Pull the `h1:` hash for `<other_arch>` from
-        `archives.<platform>.hashes`. (Skip if absent — uncached
-        provider; mirror only knew the upstream zh:.)
-     c. Splice the `h1:` line into the provider's `hashes = [...]`
+     b. Pull EVERY hash entry (`h1:` + `zh:`) for `<other_arch>` from
+        `archives.<platform>.hashes`. Both must be present — splicing
+        only one would still let tofu's apply-init mutate the lock to
+        complete the missing half (it computes the other from the
+        downloaded archive when it sees an asymmetric entry), which
+        then invalidates `tofu apply tfplan` with "Inconsistent
+        dependency lock file".
+     c. Splice the new hash lines into the provider's `hashes = [...]`
         list, preserving existing entries.
   3. Write the file back.
 
@@ -113,7 +117,7 @@ def parse_lock_file(text: str) -> list[ProviderBlock]:
     return blocks
 
 
-def fetch_h1_hashes(
+def fetch_archive_hashes(
     cfg_api_url: str,
     auth_token: str,
     block: ProviderBlock,
@@ -121,19 +125,21 @@ def fetch_h1_hashes(
     *,
     client: httpx.Client | None = None,
     timeout_seconds: float = 60.0,
-) -> tuple[dict[str, str], set[str]]:
+) -> tuple[dict[str, list[str]], set[str]]:
     """Query Terrapod's provider mirror for `{version}.json` and pull
-    the `h1:` hash for each requested platform.
+    BOTH the `h1:` and `zh:` hashes for each requested platform.
 
     Returns `(hashes, cached_platforms)`:
-      - `hashes`: `{platform: "h1:..."}` for each platform the mirror
-        had an h1 for.
+      - `hashes`: `{platform: ["h1:...", "zh:..."]}` for each platform
+        the mirror had at least one of the pair for. Order within the
+        list is not significant; callers check via prefix.
       - `cached_platforms`: the set of platforms the mirror is
         configured to eagerly cache (operator's `provider_cache.platforms`
-        setting). Used by the caller to distinguish "h1 missing because
-        compute failed → fall back to `providers lock`" from "h1 missing
-        because this platform isn't in the operator's cache filter →
-        silently skip (no apply will run on this arch anyway)".
+        setting). Used by the caller to distinguish "hashes missing
+        because compute failed → fall back to `providers lock`" from
+        "hashes missing because this platform isn't in the operator's
+        cache filter → silently skip (no apply will run on this arch
+        anyway)".
     """
     if not cfg_api_url:
         return {}, set()
@@ -173,15 +179,18 @@ def fetch_h1_hashes(
 
     archives = payload.get("archives", {})
     cached_platforms = set(payload.get("cached_platforms") or [])
-    out: dict[str, str] = {}
+    out: dict[str, list[str]] = {}
     for plat in platforms:
         entry = archives.get(plat)
         if not entry:
             continue
+        plat_hashes: list[str] = []
         for h in entry.get("hashes", []):
-            if isinstance(h, str) and h.startswith("h1:"):
-                out[plat] = h
-                break
+            if isinstance(h, str) and (h.startswith("h1:") or h.startswith("zh:")):
+                if h not in plat_hashes:
+                    plat_hashes.append(h)
+        if plat_hashes:
+            out[plat] = plat_hashes
     return out, cached_platforms
 
 
@@ -257,33 +266,47 @@ def extend_lock_file(
         # We iterate in REVERSE so splice offsets stay valid as we
         # rewrite the text from end to start.
         for block in reversed(blocks):
-            hashes, cached_platforms = fetch_h1_hashes(
+            hashes, cached_platforms = fetch_archive_hashes(
                 api_url,
                 auth_token,
                 block,
                 [other_arch],
                 client=client,
             )
-            h1 = hashes.get(other_arch)
-            if h1 is None:
-                # Two cases: operator has deliberately not configured
-                # the mirror to cache this arch (silent skip — no apply
-                # will run on it anyway), or the platform IS in the
-                # cache config but the mirror failed to compute h1
-                # (warn + caller falls back to `providers lock`).
+            plat_hashes = hashes.get(other_arch, [])
+            has_h1 = any(h.startswith("h1:") for h in plat_hashes)
+            has_zh = any(h.startswith("zh:") for h in plat_hashes)
+            if not (has_h1 and has_zh):
+                # Need BOTH h1: and zh: for a clean splice. Splicing only
+                # one half leaves an asymmetric lock entry; tofu's
+                # apply-init will detect the gap and add the missing
+                # hash itself, mutating the lock and breaking
+                # `apply tfplan` with "Inconsistent dependency lock
+                # file".
+                #
+                # Two cases when we don't have the pair: operator
+                # didn't configure the mirror to cache this arch
+                # (silent skip — no apply will run on it anyway), or
+                # the platform IS in the cache config but the mirror
+                # failed to compute one or both hashes (warn + caller
+                # falls back to `providers lock` to get a complete
+                # lock entry).
                 if cached_platforms and other_arch not in cached_platforms:
                     not_cached_by_config += 1
                 else:
                     logger.info(
-                        "no h1 from mirror for provider — caller may fall back to providers lock",
+                        "incomplete hash pair from mirror for provider — "
+                        "caller may fall back to providers lock",
                         source=block.source,
                         version=block.version,
                         platform=other_arch,
+                        have_h1=has_h1,
+                        have_zh=has_zh,
                     )
                 continue
-            spliced = splice_hashes_into_block(block.block_text, [h1])
+            spliced = splice_hashes_into_block(block.block_text, plat_hashes)
             if spliced == block.block_text:
-                # Hash already present — already extended on a prior plan.
+                # Hashes already present — already extended on a prior plan.
                 extended += 1
                 continue
             new_text = new_text[: block.block_start] + spliced + new_text[block.block_end :]

--- a/services/tests/runner/test_lock_extender.py
+++ b/services/tests/runner/test_lock_extender.py
@@ -87,7 +87,7 @@ class TestFetchH1Hashes:
             block_end=0,
         )
 
-    def test_returns_h1_for_requested_platform(self) -> None:
+    def test_returns_h1_and_zh_for_requested_platform(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -105,16 +105,18 @@ class TestFetchH1Hashes:
             )
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        out, _ = lock_extender.fetch_h1_hashes(
+        out, _ = lock_extender.fetch_archive_hashes(
             "https://api.example.com",
             "token",
             self._block(),
             ["linux_amd64"],
             client=client,
         )
-        assert out == {"linux_amd64": "h1:abcdefghij="}
+        # Both hash types captured — the splice needs the pair to
+        # produce a lock entry tofu's apply-init won't mutate.
+        assert out == {"linux_amd64": ["zh:486a1c921e", "h1:abcdefghij="]}
 
-    def test_skips_platforms_without_h1_in_response(self) -> None:
+    def test_dedupes_repeated_hashes_in_response(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -122,7 +124,40 @@ class TestFetchH1Hashes:
                     "archives": {
                         "linux_amd64": {
                             "url": "https://example.com/zip",
-                            # No h1 — only zh.
+                            "hashes": [
+                                "h1:abcdefghij=",
+                                "h1:abcdefghij=",  # dup
+                                "zh:486a1c921e",
+                                "zh:486a1c921e",  # dup
+                            ],
+                        }
+                    }
+                },
+            )
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        out, _ = lock_extender.fetch_archive_hashes(
+            "https://api.example.com",
+            "token",
+            self._block(),
+            ["linux_amd64"],
+            client=client,
+        )
+        assert out == {"linux_amd64": ["h1:abcdefghij=", "zh:486a1c921e"]}
+
+    def test_returns_only_zh_when_mirror_lacks_h1(self) -> None:
+        """Mirror cached the archive but didn't compute h1 yet. Returns
+        the zh: alone; the caller (`extend_lock_file`) will reject as
+        incomplete and fall back to `providers lock`.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "archives": {
+                        "linux_amd64": {
+                            "url": "https://example.com/zip",
                             "hashes": ["zh:486a1c921e"],
                         }
                     }
@@ -130,21 +165,21 @@ class TestFetchH1Hashes:
             )
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        out, _ = lock_extender.fetch_h1_hashes(
+        out, _ = lock_extender.fetch_archive_hashes(
             "https://api.example.com",
             "token",
             self._block(),
             ["linux_amd64"],
             client=client,
         )
-        assert out == {}
+        assert out == {"linux_amd64": ["zh:486a1c921e"]}
 
     def test_handles_404_silently(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(404)
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        out, cached = lock_extender.fetch_h1_hashes(
+        out, cached = lock_extender.fetch_archive_hashes(
             "https://api.example.com",
             "token",
             self._block(),
@@ -165,7 +200,7 @@ class TestFetchH1Hashes:
             )
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        _, cached = lock_extender.fetch_h1_hashes(
+        _, cached = lock_extender.fetch_archive_hashes(
             "https://api.example.com",
             "token",
             self._block(),
@@ -204,7 +239,7 @@ class TestSpliceHashesIntoBlock:
 
 
 class TestEndToEndExtend:
-    def test_extends_every_provider_when_mirror_has_h1(self, tmp_path) -> None:
+    def test_extends_every_provider_when_mirror_has_h1_and_zh(self, tmp_path) -> None:
         lock = tmp_path / ".terraform.lock.hcl"
         lock.write_text(_SAMPLE_LOCK)
 
@@ -212,14 +247,14 @@ class TestEndToEndExtend:
 
         def handler(request: httpx.Request) -> httpx.Response:
             seen_paths.append(request.url.path)
-            # Both providers get a synthetic linux_arm64 h1.
+            # Both providers get a synthetic linux_arm64 (h1, zh) pair.
             return httpx.Response(
                 200,
                 json={
                     "archives": {
                         "linux_arm64": {
                             "url": "https://example.com/zip",
-                            "hashes": ["h1:NEW_arm64_h1="],
+                            "hashes": ["h1:NEW_arm64_h1=", "zh:NEW_arm64_zh"],
                         }
                     }
                 },
@@ -237,10 +272,14 @@ class TestEndToEndExtend:
         assert extended == 2
 
         out = lock.read_text()
-        # Both blocks now carry the injected h1.
+        # Both blocks now carry the injected h1: AND zh: for the other
+        # arch — the asymmetric "only h1:" splice is what caused
+        # apply-init lock mutations + tfplan invalidation (regression
+        # discovered on cdn-dev run 019eabad).
         assert "hashicorp/random" in out
         assert "hashicorp/null" in out
         assert out.count("h1:NEW_arm64_h1=") == 2
+        assert out.count("zh:NEW_arm64_zh") == 2
         # Original existing entries preserved.
         assert "h1:/xwPFz7kMERBIEk8i6UJt2fTvgzMFbwKlcyCvRJO8Ok=" in out
         assert "h1:NULLFAKEH1FAKE=" in out
@@ -256,18 +295,19 @@ class TestEndToEndExtend:
             client=httpx.Client(transport=httpx.MockTransport(handler)),
         )
         assert seen2 == 2
-        # `extended` counts "had h1 available" — re-runs still count.
+        # `extended` counts "had pair available" — re-runs still count.
         assert extended2 == 2
         # But the file content didn't change.
         assert lock.read_text().count("h1:NEW_arm64_h1=") == 2
+        assert lock.read_text().count("zh:NEW_arm64_zh") == 2
 
-    def test_falls_through_when_mirror_returns_no_h1(self, tmp_path) -> None:
+    def test_falls_through_when_mirror_returns_no_hashes(self, tmp_path) -> None:
         lock = tmp_path / ".terraform.lock.hcl"
         lock.write_text(_SAMPLE_LOCK)
 
         def handler(request: httpx.Request) -> httpx.Response:
-            # No h1 AND the response advertises the requested arch IS
-            # supposed to be cached — so this is the "compute failed"
+            # No archives AND the response advertises the requested arch
+            # IS supposed to be cached — so this is the "compute failed"
             # case, NOT the deliberate-skip case. Caller should see a
             # real gap and run `providers lock` for it.
             return httpx.Response(
@@ -290,6 +330,45 @@ class TestEndToEndExtend:
         assert extended == 0
         # File unchanged.
         assert lock.read_text() == _SAMPLE_LOCK
+
+    def test_falls_through_when_mirror_returns_only_h1(self, tmp_path) -> None:
+        """Mirror has the archive cached but never computed zh: (or vice
+        versa). Splicing the half-pair would leave an asymmetric lock
+        entry — tofu's apply-init then completes the missing half,
+        mutating the lock and breaking `apply tfplan` (cdn-dev run
+        019eabad reproducer). Caller falls back to `providers lock` to
+        produce a complete entry instead.
+        """
+        lock = tmp_path / ".terraform.lock.hcl"
+        lock.write_text(_SAMPLE_LOCK)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "archives": {
+                        "linux_arm64": {
+                            "url": "https://example.com/zip",
+                            "hashes": ["h1:ONLY_h1="],
+                        }
+                    },
+                    "cached_platforms": ["linux_amd64", "linux_arm64"],
+                },
+            )
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        seen, extended = lock_extender.extend_lock_file(
+            lock,
+            api_url="https://api.example.com",
+            auth_token="tok",
+            other_arch="linux_arm64",
+            client=client,
+        )
+        assert seen == 2
+        assert extended == 0
+        # Lock untouched — better an empty splice than an asymmetric one.
+        assert lock.read_text() == _SAMPLE_LOCK
+        assert "ONLY_h1" not in lock.read_text()
 
     def test_silently_skips_when_arch_not_in_operators_cache_config(self, tmp_path) -> None:
         """Operator has narrowed mirror's `provider_cache.platforms` to


### PR DESCRIPTION
## Why

cdn-dev run 019eabad (a real apply on tf-aws-cdn @ \`f687958c\` against
prod main) failed during apply with:

\`\`\`
Error: Inconsistent dependency lock file
  The given plan file was created with a different set of external
  dependency selections than the current configuration.
\`\`\`

The plan-uploaded \`.terraform.lock.hcl\` had two h1: hashes per provider
(own-arch + spliced other-arch) but only one zh:. Apply-init detected
the asymmetry, added the missing zh: itself to symmetrise the lock,
and the resulting lock no longer matched the saved tfplan.

## Fix

\`lock_extender\` was emitting only \`h1:\` hashes for the spliced
other-arch entries. The mirror's \`{version}.json\` returns BOTH \`h1:\`
and \`zh:\` per platform; the splice now captures the pair.

- \`fetch_h1_hashes\` → \`fetch_archive_hashes\`, returns \`dict[platform, list[str]]\`
  with both hash types (dedup'd, future hash types pass-through).
- \`extend_lock_file\` splices only when BOTH \`h1:\` and \`zh:\` are
  present. If the mirror has only one half (cached archive but
  uncomputed h1, or the other way round), the splice is skipped and
  the caller falls back to \`tofu providers lock\` — splicing a
  partial entry would just re-trigger the apply-init mutation we're
  trying to prevent.

## Tests

- Existing fetch test renamed and asserts both hash types captured.
- New test pins de-dup of repeated hashes from the mirror.
- New test pins that an \`h1:\`-only mirror response is reported as
  no-splice.
- End-to-end tests assert both \`h1:\` and \`zh:\` land in the lock file.
- New end-to-end test pins the fall-through path when the mirror
  has only \`h1:\`, asserting the lock is left untouched (so the
  orchestrator's \`providers lock\` fallback kicks in).

\`make test\` green (1992 tests).

## Risk / target

Runner image change. Needs v0.33.2 to land on real workloads.
Cherry-pick is clean off \`main\`.