### PR TITLE
fix(runner): apply-phase init must run -lockfile=readonly

### DIFF
--- a/services/terrapod/runner/job_entrypoint.py
+++ b/services/terrapod/runner/job_entrypoint.py
@@ -392,7 +392,12 @@ def _run_body(cfg: RunnerConfig, work_dir: Path) -> int:
     # 8. Build var-file / target / replace argv pieces.
     var_file_argv = tf_args.var_file_args(cfg.var_files)
 
-    # 9. Init.
+    # 9. Init. Apply-phase init runs with -lockfile=readonly so it
+    # doesn't drop the other-arch hashes the plan phase's lock_extender
+    # spliced in (tofu's network_mirror code path only records hashes
+    # for the target platform — see init_phase.run_init docstring).
+    # Plan phase runs init normally so the splice has a complete
+    # base lock to extend.
     child_grace = _child_grace_seconds(cfg)
     _flush_stdio()
     try:
@@ -401,6 +406,7 @@ def _run_body(cfg: RunnerConfig, work_dir: Path) -> int:
             var_file_args=var_file_argv,
             log_file=str(_INIT_LOG),
             child_grace_seconds=child_grace,
+            lockfile_readonly=(cfg.phase == "apply"),
         )
     except init_phase.InitError as exc:
         log.error("init failed", rc=exc.exit_code)

--- a/services/terrapod/runner/phases/init_phase.py
+++ b/services/terrapod/runner/phases/init_phase.py
@@ -34,9 +34,24 @@ def run_init(
     var_file_args: list[str],
     log_file: str,
     child_grace_seconds: float = 25.0,
+    lockfile_readonly: bool = False,
 ) -> None:
     """Run `<binary> init -input=false [var_file_args...]` via
     exec_subprocess, redirecting combined stdout/stderr to log_file.
+
+    `lockfile_readonly=True` appends `-lockfile=readonly`, which tells
+    terraform/tofu to verify the existing `.terraform.lock.hcl` against
+    what install would produce but NOT to rewrite it. Required on
+    apply-phase init when the lock has been carried over from the plan
+    phase (with other-arch hashes spliced in by `lock_extender`):
+    without readonly, tofu's network_mirror code path silently drops
+    the spliced other-arch hashes (it only records hashes for the
+    target platform — `internal/getproviders/http_mirror_source.go:223`),
+    the lock falls out of sync with the snapshot recorded in tfplan,
+    and `tofu apply tfplan` then refuses with "Inconsistent dependency
+    lock file" (#470, follow-up). Provider source + version are the
+    same across plan and apply, so readonly passes with a warning
+    rather than erroring.
 
     Raises InitError on non-zero exit so the orchestrator can short-
     circuit (skip plan/apply, still flush the log)."""
@@ -51,6 +66,8 @@ def run_init(
                 "variables in backend/required_providers/module-source will fail.",
                 binary=binary,
             )
+    if lockfile_readonly:
+        argv.append("-lockfile=readonly")
 
     logger.info("running init", binary=binary, argv_tail=argv[1:])
     result = exec_subprocess.run(

--- a/services/tests/runner/test_phase_init.py
+++ b/services/tests/runner/test_phase_init.py
@@ -83,3 +83,66 @@ class TestRunInit:
             init_phase.run_init(binary="tofu", var_file_args=[], log_file="/tmp/x")
             probe.assert_not_called()
         assert captured["argv"] == ["tofu", "init", "-input=false"]
+
+    def test_lockfile_readonly_appends_flag(self) -> None:
+        """Apply-phase init must run with -lockfile=readonly so it
+        doesn't drop the other-arch hashes the plan phase's
+        lock_extender spliced in. Without readonly, tofu's
+        network_mirror code path silently records only the
+        target-platform hashes, the lock falls out of sync with the
+        snapshot recorded in tfplan, and `tofu apply tfplan` then
+        refuses with "Inconsistent dependency lock file" (#470).
+        """
+        captured: dict[str, object] = {}
+
+        def fake_run(argv, log_file, child_grace_seconds, tee_to_stdout):
+            captured["argv"] = argv
+            return _Result(0)
+
+        with (
+            patch("terrapod.runner.exec_subprocess.run", side_effect=fake_run),
+            patch(
+                "terrapod.runner.phases.init_phase.init_supports_var_file",
+                return_value=True,
+            ),
+        ):
+            init_phase.run_init(
+                binary="tofu",
+                var_file_args=["-var-file=prod.tfvars"],
+                log_file="/tmp/init.log",
+                lockfile_readonly=True,
+            )
+        # Order: binary, init, -input=false, var-files..., -lockfile=readonly
+        assert captured["argv"] == [
+            "tofu",
+            "init",
+            "-input=false",
+            "-var-file=prod.tfvars",
+            "-lockfile=readonly",
+        ]
+
+    def test_lockfile_readonly_default_false(self) -> None:
+        """Plan-phase init runs WITHOUT readonly so the lock_extender
+        and its providers-lock fallback have a writable base lock to
+        extend. The default must be False so we don't accidentally lock
+        plan-phase init out of rewriting on first run.
+        """
+        captured: dict[str, object] = {}
+
+        def fake_run(argv, log_file, child_grace_seconds, tee_to_stdout):
+            captured["argv"] = argv
+            return _Result(0)
+
+        with (
+            patch("terrapod.runner.exec_subprocess.run", side_effect=fake_run),
+            patch(
+                "terrapod.runner.phases.init_phase.init_supports_var_file",
+                return_value=True,
+            ),
+        ):
+            init_phase.run_init(
+                binary="tofu",
+                var_file_args=[],
+                log_file="/tmp/init.log",
+            )
+        assert "-lockfile=readonly" not in captured["argv"]


### PR DESCRIPTION
## Why

v0.33.3 (#470) fixed the lock-extender to splice both \`h1:\` and \`zh:\`
for the other arch, but real apply runs **still failed** with
\`Inconsistent dependency lock file\`. Investigation against the live
prod failure (cdn-dev run 019eabff) found the lock-extender splice is
**structurally worthless** under tofu's network_mirror code path.

From OpenTofu \`internal/getproviders/http_mirror_source.go:223\`:

\`\`\`go
for platform, meta := range bodyContent.Archives {
    if s.locationConfig.TrustAllHashes || platform == target.String() {
        // record hashes for this platform
    }
}
\`\`\`

\`TrustAllHashes\` defaults to **false**. So when apply-phase init runs
against the same mirror that plan-phase init used, tofu records hashes
only for the target platform — silently dropping every other-arch
hash the splice injected. The lock falls from 4 hashes back to 2,
init writes the smaller lock, and \`tofu apply tfplan\` then refuses
because the lock the tfplan recorded at plan time (4 hashes) doesn't
match what's now on disk (2 hashes).

## Fix

Pass \`-lockfile=readonly\` to apply-phase init. From OpenTofu
\`internal/command/init.go:944\`:

\`\`\`go
if !newLocks.Equal(previousLocks) {
    if flagLockfile == "readonly" {
        if !newLocks.EqualProviderAddress(previousLocks) {
            // ERROR only if provider source/version changed
        }
        // warning, no rewrite — return
    }
    ...
    view.LockFileChanged()  // (only without readonly)
}
\`\`\`

In our case provider source + version are identical across plan and
apply (same mirror, same lock), so \`EqualProviderAddress\` is true
and readonly just emits a \"Provider lock file not updated\" warning.
The runtime lock then equals the plan-recorded lock and
\`apply tfplan\` succeeds.

Plan-phase init still runs without readonly so the lock_extender
(and its \`tofu providers lock\` fallback) has a writable base lock
to extend.

## Live experiment

Reproduced production scenario locally: 4-hash lock against the same
prod mgmt mirror.

| | Lock SHA before | Lock SHA after | Diff |
|---|---|---|---|
| \`tofu init\` (no readonly) | \`01deff11…\` | \`b78a5547…\` | reordered/dropped |
| \`tofu init -lockfile=readonly\` | \`01deff11…\` | \`01deff11…\` | **byte-identical** |

Init succeeded in both runs; readonly just emits the expected warning.

## Tests

- New test asserts \`-lockfile=readonly\` is appended to apply-init argv
  when \`lockfile_readonly=True\`.
- New test asserts the flag is NOT in plan-init argv by default
  (defaults to False so plan-phase init keeps its writable behaviour).
- Existing test_phase_init tests continue to pass with the new
  optional kwarg.
- \`make test\` green: 1992 tests.

## Risk / target

Runner image change. Needs a release (v0.33.4) to land on real
workloads. Hotfix branch is off latest \`main\`.