### PR TITLE
fix(runner): stop double-descending into cfg.working_dir

### DIFF
--- a/services/terrapod/runner/phases/configuration.py
+++ b/services/terrapod/runner/phases/configuration.py
@@ -133,14 +133,27 @@ def download_configuration(
     workspace. Matches the bash behaviour at line 524.
     """
     work_dir.mkdir(parents=True, exist_ok=True)
-    strip_dir = work_dir
+    # `override_dir` is where the local-backend override file goes — it
+    # MUST land inside the configured working_dir so tofu/terraform
+    # picks it up at init time. `strip_dir` is what we return to
+    # job_entrypoint, which then passes it to
+    # `working_dir.resolve_and_chdir(strip_dir, cfg.working_dir)`. The
+    # descent into `working_dir` must happen exactly ONCE — here
+    # we'd descend, and `resolve_and_chdir` would descend again on top,
+    # producing `<work_dir>/<wd>/<wd>` (doesn't exist) and a confusing
+    # "working directory '…' not found in config" error. So we keep
+    # the two variables separate: `override_dir` carries the descent
+    # for the override-write side-effect; `strip_dir` stays at the
+    # un-descended `work_dir` and lets `resolve_and_chdir` own the
+    # single canonical descent + chdir + path-traversal guard.
+    override_dir = work_dir
     if cfg.working_dir:
         candidate = work_dir / cfg.working_dir
         if candidate.exists():
-            strip_dir = candidate
+            override_dir = candidate
 
     if not cfg.has_api:
-        return ConfigurationResult(downloaded=False, strip_dir=strip_dir)
+        return ConfigurationResult(downloaded=False, strip_dir=work_dir)
 
     # /tmp matches every other scratch artifact this orchestrator
     # writes (combined.log, plan.log, apply.log, plan.json,
@@ -167,7 +180,7 @@ def download_configuration(
             "configuration archive download failed — see storage error above",
             status=result.status,
         )
-        return ConfigurationResult(downloaded=False, strip_dir=strip_dir)
+        return ConfigurationResult(downloaded=False, strip_dir=work_dir)
 
     try:
         with tarfile.open(tarball, "r:gz") as tar:
@@ -176,20 +189,23 @@ def download_configuration(
         # Match bash: tolerate but log. tofu will fail later if needed.
         logger.warning("tar extract reported a problem", err=str(exc))
 
-    # Resolve strip_dir again in case it appeared during extraction.
+    # Resolve override_dir again in case the configured working_dir
+    # appeared during extraction (this is the common case — the tarball
+    # contains the directory; the pre-extraction candidate.exists()
+    # check is only useful in dev where the operator pre-populates).
     if cfg.working_dir:
         candidate = work_dir / cfg.working_dir
         if candidate.exists():
-            strip_dir = candidate
+            override_dir = candidate
 
-    _warn_on_user_override(strip_dir)
+    _warn_on_user_override(override_dir)
 
-    override_file = strip_dir / "zzzz_terrapod_backend_override.tf"
+    override_file = override_dir / "zzzz_terrapod_backend_override.tf"
     override_file.write_text(_LOCAL_BACKEND_OVERRIDE)
     logger.info("wrote local-backend override", path=str(override_file))
 
     return ConfigurationResult(
         downloaded=True,
-        strip_dir=strip_dir,
+        strip_dir=work_dir,
         override_file=override_file,
     )

--- a/services/tests/runner/test_phase_configuration.py
+++ b/services/tests/runner/test_phase_configuration.py
@@ -58,7 +58,25 @@ class TestDownloadConfiguration:
         override = result.override_file.read_text()
         assert 'backend "local"' in override
 
-    def test_working_directory_selects_subpath(self, tmp_path) -> None:
+    def test_working_directory_writes_override_in_subdir_but_strip_dir_is_root(
+        self, tmp_path
+    ) -> None:
+        """When `working_dir` is set, the override file MUST land
+        inside that subdirectory (so tofu/terraform picks it up via
+        the override-file merge at init time), but the returned
+        `strip_dir` MUST be the un-descended work_dir root.
+
+        Regression for the v0.32.0 Python rewrite of the runner: the
+        configuration phase was returning the descended path as
+        `strip_dir`, and `_run_body` was then calling
+        `working_dir.resolve_and_chdir(strip_dir, cfg.working_dir)`
+        which descended again — producing
+        `<work_dir>/<wd>/<wd>` (doesn't exist) and a confusing
+        "working directory '…' not found in config" error for every
+        workspace with a working_dir set (helios-auth0-local-dev run
+        019eac5e was the report). The descent must happen exactly
+        once and `resolve_and_chdir` is the single canonical site.
+        """
         tar_bytes = _make_tarball(
             {
                 "envs/dev/main.tf": "# nested\n",
@@ -75,10 +93,18 @@ class TestDownloadConfiguration:
         )
 
         assert result.downloaded
-        assert result.strip_dir == work_dir / "envs" / "dev"
-        # The override file goes in strip_dir, not work_dir root.
-        assert result.override_file == result.strip_dir / "zzzz_terrapod_backend_override.tf"
+        # CRITICAL invariant: returned strip_dir is the un-descended
+        # work_dir, so `resolve_and_chdir` owns the single descent +
+        # chdir + path-traversal guard.
+        assert result.strip_dir == work_dir
+        # But the override DOES land in the working subdir so tofu's
+        # override-file merge picks it up.
+        assert result.override_file is not None
+        assert (
+            result.override_file == work_dir / "envs" / "dev" / "zzzz_terrapod_backend_override.tf"
+        )
         assert result.override_file.exists()
+        assert 'backend "local"' in result.override_file.read_text()
 
     def test_missing_api_context_returns_undownloaded(self, tmp_path) -> None:
         result = cfg_phase.download_configuration(


### PR DESCRIPTION
## Why

Every Terrapod workspace with \`working-directory\` set has been failing
plan / apply since the v0.32.0 bash → Python runner rewrite.
Production reproducer: helios-auth0-local-dev run \`019eac5e\`
(\`working_dir = \"terraform/auth0\"\`) errors out with:

\`\`\`
[error] orchestrator crashed
err=\"working directory 'terraform/auth0' not found in config\"
\`\`\`

The log immediately above shows the local-backend override file landing
at \`/workspace/terraform/auth0/zzzz_terrapod_backend_override.tf\` — so
the directory clearly DOES exist. The actual failure is a double
descent.

## Mechanism

\`download_configuration\` mutates a local \`strip_dir\` to be the
descended path (\`work_dir / cfg.working_dir\`) so the override file
write targets the working subdirectory. That mutation leaks into the
return value. \`_run_body\` then unpacks the returned strip_dir and
calls:

\`\`\`python
cwd = working_dir.resolve_and_chdir(strip_dir, cfg.working_dir)
\`\`\`

which descends a SECOND time, computing
\`<work_dir>/<wd>/<wd>\` and raising
\`WorkingDirectoryError\` because that double-descended path doesn't
exist. The descent should happen exactly once and
\`resolve_and_chdir\` is the canonical site (it also owns the
path-traversal guard).

## Fix

Split the two concerns inside \`download_configuration\`:

- \`override_dir\` carries the working-dir descent — the override file
  MUST land inside the configured \`working_dir\` for tofu's
  override-file merge to pick it up at init time.
- \`strip_dir\` stays at the un-descended \`work_dir\` root —
  \`resolve_and_chdir\` is then the single source of descent + chdir +
  path-traversal guard.

## Tests

- Renamed the existing test that was asserting the BUGGY contract
  (\`strip_dir == work_dir / 'envs' / 'dev'\`) into
  \`test_working_directory_writes_override_in_subdir_but_strip_dir_is_root\`
  which pins the corrected invariant.
- \`make test\` green: 1990 tests.

## Release

v0.34.0 alongside the plan-artifacts feature (#472, still open and
unblocked by this).