### PR TITLE
ci: pytest-xdist on mock-heavy shards + 2-shard E2E + Code↔Tests Contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,15 +243,27 @@ jobs:
       fail-fast: false
       matrix:
         slice:
+          # pytest-xdist `-n auto` is enabled for the two mock-heavy
+          # shards. Local bench (Apple M-series; CI ~50-60% of this):
+          #   unit         90s serial → 13s parallel (1495 → 492 tests)
+          #   services-api 138s serial → 30s parallel
+          # The integration shard stays serial — its
+          # session-scoped Postgres table-creation fixture races
+          # under xdist workers (each worker would try to create
+          # the same tables) and the suite is small enough that
+          # serial is fine.
           - name: unit
             paths: tests/auth tests/runner tests/storage tests/test_logging_config.py
+            pytest_args: -n auto
           - name: services-api
             paths: tests/services tests/api
+            pytest_args: -n auto
           - name: integration
             paths: tests/integration
+            pytest_args: ""
     steps:
       - uses: actions/checkout@v6
-      - run: scripts/test.sh python -- ${{ matrix.slice.paths }}
+      - run: scripts/test.sh python -- ${{ matrix.slice.pytest_args }} ${{ matrix.slice.paths }}
 
   # ── Dependency Audit (Python) ─────────────────────────
   python-audit:
@@ -492,13 +504,12 @@ jobs:
 
   # ── E2E Tests (Playwright) ─────────────────────────────
   e2e-test:
-    # Sharded across 4 GitHub runners using Playwright's built-in
+    # Sharded across 2 GitHub runners using Playwright's built-in
     # --shard=k/N. Each shard boots its own docker-compose stack
-    # (~30s overhead) so they're independent; the suite divides into
-    # roughly equal chunks. As the suite grows past the existing 11
-    # spec files (adding runs.spec.ts + ai-summary.spec.ts here, plus
-    # whatever lands next) the shard count keeps the critical path
-    # roughly flat.
+    # (~30s overhead) so they're independent. We initially tried 4
+    # shards but the per-shard boot cost dominated — 4 shards × 30s
+    # in parallel wasted 90s vs 60s for 2 shards. As the suite grows
+    # past the current 13 spec files, revisit shard count.
     name: E2E Tests (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [prepare, build-images]
     if: |
@@ -509,7 +520,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2]
     # Whole-job upper bound. Default is GitHub's 360 min, which lets a
     # wedged step run for six hours before anyone notices. 15 min covers
     # a cold-runner worst-case (image pull + stack boot + test suite)

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 3 : 2,
+  // CI workers bumped from 3 → 4 to fill the 2-shard runner better
+  // (each shard runs ~half the suite; saturating both vCPUs gives a
+  // larger per-shard wall-clock reduction than adding more shards).
+  workers: process.env.CI ? 4 : 2,
   reporter: process.env.CI
     ? [['html', { open: 'never' }], ['github']]
     : [['html', { open: 'on-failure' }]],

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -74,6 +74,13 @@ litellm = ">=1.87,<2.0"
 pytest = "^9.0.2"
 pytest-asyncio = "^1.3.0"
 pytest-cov = "^7.0.0"
+# Parallel test runner. CI Python Test shards (unit, services-api)
+# use `-n auto` to spread across runner vCPUs; integration shard
+# stays serial because its session-scoped Postgres fixture would
+# race under workers. Local `make test` doesn't enable it by
+# default — `pytest` itself in the test container still runs
+# serial unless `-n` is passed.
+pytest-xdist = "^3.6.0"
 ruff = "^0.15.0"
 mypy = ">=1.14,<3.0"
 

--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -54,6 +54,15 @@ RUNNER_BUSY_STATES = {"planning", "applying"}
 async def _is_runner_busy(db: AsyncSession, workspace_id: uuid.UUID) -> bool:
     """Workspace has a run that's actively executing on a runner.
 
+    NOTE — Code ↔ Tests contract (CLAUDE.md): the precise membership of
+    RUNNER_BUSY_STATES is pinned by
+    `tests/services/test_drift_detection_service.py::TestDriftCheckCycle::
+    test_is_runner_busy_only_counts_planning_or_applying`. Widening this
+    set (e.g. re-adding `planned`) reintroduces the production incident
+    where workspaces with stale `planned` peers froze drift forever.
+    Narrow it deliberately — and update both the source comment AND the
+    regression test together.
+
     True only when terraform is mid-plan or mid-apply for this
     workspace — running a parallel drift check then would produce a
     racy/inconsistent observation. Runs in `planned` (awaiting

--- a/services/tests/conftest.py
+++ b/services/tests/conftest.py
@@ -1,5 +1,24 @@
 """
 Top-level test configuration for Terrapod.
+
+The test suite is organised by tier — directory layout maps 1:1 to the
+CI Python Test matrix (see "Code ↔ Tests Contract" in CLAUDE.md):
+
+  tests/auth/           ─┐
+  tests/runner/          │  shard: unit          (pytest-xdist -n auto)
+  tests/storage/         │  fast, pure / mocked, no DB
+  tests/test_logging…   ─┘
+
+  tests/services/       ─┐  shard: services-api  (pytest-xdist -n auto)
+  tests/api/            ─┘  bulk of tests; AsyncMock-driven
+
+  tests/integration/    ──  shard: integration   (serial — real Postgres)
+
+When adding a test, put it under the directory whose tier it belongs
+to, NOT whichever directory feels closest by file name. The CI matrix
+expects the split. The integration shard stays serial because its
+session-scoped Postgres table-creation fixture races under xdist
+workers.
 """
 
 import os

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -1070,6 +1070,11 @@ class TestNoStateLeakage:
     Same invariant applies to the upcoming follow-up chat path (#463) —
     the assertions inspect the whole `summariser` module so any new
     code path that pulls state in will fail here.
+
+    # Code ↔ Tests contract: "hard invariant" tier.
+    # See CLAUDE.md → "Code ↔ Tests Contract" → Contract Rules.
+    # Lives in services-api shard (`tests/services/`); runs serial-safe
+    # under pytest-xdist via the `_source()` reflection (no side effects).
     """
 
     @staticmethod


### PR DESCRIPTION
Follow-up to PR #475 (CI shard) — the directory-shard split alone delivered 28% Python / 14% E2E on the critical path. Going deeper:

## Python Test — pytest-xdist `-n auto`

Added \`pytest-xdist ^3.6.0\` as a dev dep. Enabled on the two mock-heavy shards via the matrix:

| Shard | Bench (local, parallel) | Bench (local, serial) |
|---|---|---|
| unit | 13s (-n auto, 492 tests) | ~90s |
| services-api | 30s (-n auto, 1495 tests) | ~138s |
| integration | 43s (serial, 57 tests) | — |

Integration shard stays **serial** — its session-scoped Postgres table-creation fixture races under workers (asyncpg refuses concurrent ops on the same connection).

CI 2-vCPU runners are slower in absolute terms but the ratio holds. Services-api 223s should drop to ~140s; new Python critical path becomes **integration at ~148s**.

## E2E Tests — 2 shards (was 4) + workers=4 (was 3)

4 shards × 30s docker-compose stack boot in parallel = 90s wasted on boot. 2 shards × 30s = 60s. Each shard runs Playwright with \`workers: 4\` to saturate both vCPUs.

Suite is currently 13 spec files — 2 shards is the sweet spot. Will revisit if the suite grows past 25 specs.

## Expected combined wall-clock

| | Baseline (v0.35.0) | After PR #475 | After this PR |
|---|---|---|---|
| Python Test (critical path) | 310s | 223s | ~148s (52% of baseline) |
| E2E Tests (critical path) | 136s | 117s | ~80s (59% of baseline) |

\`make test\` green: 2044 tests, 180s wall (was 222s on v0.35.0; was 126s mid-feature with my Apple Silicon optimised). The local wall-clock fluctuates with the Docker daemon's cgroup share — CI will land between the two.

## Code ↔ Tests Contract (CLAUDE.md + code-comment pointers)

Documented the project-wide test contract that has been implicit until now:

- **CLAUDE.md** (gitignored project-instruction file) — new top-level section after "API ↔ Consumer Contract" defining test tiers (unit / services-api / integration / E2E / live Tilt smoke), what tier each kind of code change requires, what NOT to do, and how the contract maps to the CI matrix.
- **services/tests/conftest.py** — directory layout → CI shard mapping, made explicit at the top of the file.
- **services/terrapod/services/drift_detection_service.py** — \`_is_runner_busy\` notes the contract relationship: the precise membership of \`RUNNER_BUSY_STATES\` is pinned by a regression test; widening this set without updating the test is the way the original production incident happens again.
- **services/tests/services/test_summariser.py::TestNoStateLeakage** — pointer to the hard-invariant tier (source-introspection tests fail CI loudly when a future change violates the no-state-to-AI invariant).

The contract becomes the gate for new code: PR review can now reference a specific rule rather than relitigating "should this have a test?" each time.