### PR TITLE
fix(drift): VCS drift CV goes via VCSArchiveCache, not raw GitHub tarball

### DIFF
--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -25,8 +25,6 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db_session
 from terrapod.logging_config import get_logger
 from terrapod.services import run_service
-from terrapod.storage import get_storage
-from terrapod.storage.keys import config_version_key
 
 logger = get_logger(__name__)
 
@@ -97,14 +95,30 @@ async def _create_drift_run_vcs(
 ) -> Run | None:
     """Create a drift detection run for a VCS-connected workspace.
 
-    Downloads the archive from VCS, creates a ConfigurationVersion,
-    and queues a plan-only drift run.
+    Goes through the same VCSArchiveCache / git_fetch pipeline that the
+    regular VCS-poll path uses (`_stream_cv_upload_from_cache`) — NOT
+    the raw `download_archive` provider API. The raw API returns a
+    tarball wrapped in a top-level `<owner>-<repo>-<sha>/` directory;
+    the runner's `chdir /workspace` after extraction lands one level
+    above the actual repo content, and any `var-files` referenced from
+    the workspace's settings (e.g. `envs/prod-us2.tfvars`) resolve as
+    missing. Pre-v0.35.1 this latent bug was masked because drift
+    detection rarely fired (the `_is_workspace_busy` gate was so wide
+    it skipped almost everything); when v0.35.1 narrowed the gate to
+    `RUNNER_BUSY_STATES`, drift started running on every drift-enabled
+    workspace and tripped on this immediately — every drift run errored
+    with `Given variables file <path> does not exist`.
+
+    Using `VCSArchiveCache.get_or_fetch` produces a clean, root-level
+    tarball identical to what regular VCS-poll runs use, so the runner
+    init step behaves the same as on a normal apply.
     """
+    from terrapod.services.vcs_archive_cache import VCSArchiveCache
     from terrapod.services.vcs_poller import (
-        _download_archive,
         _get_branch_sha,
         _parse_repo_url,
         _resolve_branch,
+        _stream_cv_upload_from_cache,
     )
 
     conn = await db.get(VCSConnection, ws.vcs_connection_id)
@@ -131,10 +145,19 @@ async def _create_drift_run_vcs(
     if not sha:
         return None
 
+    cache = VCSArchiveCache()
     try:
-        archive = await _download_archive(conn, owner, repo, sha)
+        # `paths=None` fetches the whole repo. Drift detection has no
+        # narrowing context (no trigger_prefixes equivalent for the
+        # drift-check-fires-on-its-own path); the full repo matches
+        # what a normal VCS-poll apply would have used. The cache is
+        # keyed by (conn, sha, paths) so other concurrent paths
+        # narrowing the same sha don't share this entry.
+        cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha, paths=None)
     except Exception as e:
-        logger.error("Failed to download archive for drift check", workspace=ws.name, error=str(e))
+        logger.error(
+            "Failed to fetch repo archive for drift check", workspace=ws.name, error=str(e)
+        )
         return None
 
     cv = await run_service.create_configuration_version(
@@ -146,9 +169,15 @@ async def _create_drift_run_vcs(
     )
     await db.flush()
 
-    storage = get_storage()
-    key = config_version_key(str(ws.id), str(cv.id))
-    await storage.put(key, archive, content_type="application/x-tar")
+    try:
+        await _stream_cv_upload_from_cache(cache_storage_key, ws.id, cv.id)
+    except Exception as e:
+        logger.error(
+            "Failed to materialise cached archive for drift CV",
+            workspace=ws.name,
+            error=str(e),
+        )
+        return None
 
     cv = await run_service.mark_configuration_uploaded(db, cv)
 

--- a/services/tests/services/test_drift_detection_service.py
+++ b/services/tests/services/test_drift_detection_service.py
@@ -348,6 +348,125 @@ class TestHandleDriftRunCompleted:
         assert mock_publish.call_count == 3
 
 
+class TestCreateDriftRunVcs:
+    """Drift detection on VCS-connected workspaces must download via the
+    VCSArchiveCache / git_fetch pipeline — same as a normal VCS-poll
+    run — NOT through the raw `download_archive` provider API.
+
+    Production incident: pre-v0.35.1 the raw API path was masked
+    because drift rarely fired (the wide _is_workspace_busy gate
+    skipped almost every workspace). v0.35.1 narrowed the gate, drift
+    started firing on every drift-enabled workspace, and the raw
+    GitHub tarball (wrapped in a top-level `<owner>-<repo>-<sha>/`
+    directory) made the runner's `chdir /workspace` land outside the
+    repo content — every drift run errored with `Given variables file
+    envs/<...>.tfvars does not exist`. The VCSArchiveCache pipeline
+    produces a clean, root-level tarball that matches what regular
+    VCS-poll runs use.
+
+    # Code ↔ Tests contract (CLAUDE.md): regression test pins the
+    # function's archive-acquisition path. Widening _is_runner_busy
+    # without also pinning this would reopen the same incident.
+    """
+
+    @patch(
+        "terrapod.services.drift_detection_service.run_service.queue_run", new_callable=AsyncMock
+    )
+    @patch(
+        "terrapod.services.drift_detection_service.run_service.create_run", new_callable=AsyncMock
+    )
+    @patch(
+        "terrapod.services.drift_detection_service.run_service.mark_configuration_uploaded",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "terrapod.services.drift_detection_service.run_service.create_configuration_version",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.vcs_poller._stream_cv_upload_from_cache", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.vcs_archive_cache.VCSArchiveCache.get_or_fetch", new_callable=AsyncMock
+    )
+    @patch("terrapod.services.vcs_poller._get_branch_sha", new_callable=AsyncMock)
+    @patch("terrapod.services.vcs_poller._resolve_branch", new_callable=AsyncMock)
+    @patch("terrapod.services.vcs_poller._parse_repo_url")
+    async def test_uses_vcs_archive_cache_not_raw_download(
+        self,
+        mock_parse,
+        mock_resolve,
+        mock_sha,
+        mock_fetch,
+        mock_upload,
+        mock_cv,
+        mock_mark,
+        mock_create,
+        mock_queue,
+    ):
+        """`_create_drift_run_vcs` MUST call `VCSArchiveCache.get_or_fetch`
+        and `_stream_cv_upload_from_cache`. It MUST NOT call the raw
+        `download_archive` provider API.
+        """
+        from terrapod.services.drift_detection_service import _create_drift_run_vcs
+
+        ws = _mock_workspace(
+            vcs_connection_id=uuid.uuid4(),
+            vcs_repo_url="https://github.com/example/repo",
+        )
+
+        conn = MagicMock()
+        conn.status = "active"
+
+        cv = MagicMock()
+        cv.id = uuid.uuid4()
+
+        mock_db = AsyncMock()
+        mock_db.get = AsyncMock(return_value=conn)
+        mock_parse.return_value = ("example", "repo")
+        mock_resolve.return_value = "main"
+        mock_sha.return_value = "deadbeef"
+        mock_fetch.return_value = "vcs-cache/example/repo/deadbeef.tar.gz"
+        mock_cv.return_value = cv
+        mock_mark.return_value = cv
+        mock_create.return_value = MagicMock()
+        mock_queue.return_value = MagicMock()
+
+        await _create_drift_run_vcs(mock_db, ws)
+
+        # The contract: the VCSArchiveCache pipeline was used.
+        mock_fetch.assert_awaited_once()
+        # paths=None — drift fetches the whole repo, same as a normal
+        # VCS-poll apply that lacks trigger prefixes.
+        _, fetch_kwargs = mock_fetch.call_args
+        assert fetch_kwargs.get("paths") is None
+        # And the streaming upload helper from vcs_poller was called.
+        mock_upload.assert_awaited_once()
+
+    async def test_raw_download_archive_not_referenced(self):
+        """Belt-and-braces source-introspection: the drift_detection
+        module must not import `_download_archive` from `vcs_poller`.
+        Importing it would re-enable the broken path even if the
+        active code path is correct.
+        """
+        import inspect
+
+        from terrapod.services import drift_detection_service
+
+        src = inspect.getsource(drift_detection_service)
+        # The forbidden import is `from terrapod.services.vcs_poller
+        # import (..., _download_archive, ...)`. The function name
+        # might appear in comments; we only care that it isn't
+        # imported.
+        for line in src.splitlines():
+            line = line.strip()
+            if line.startswith("#"):
+                continue
+            assert "_download_archive" not in line, (
+                f"drift detection must not reference _download_archive "
+                f"(the raw GitHub tarball path with wrapping directory). "
+                f"Offending line: {line!r}"
+            )
+
+
 class TestCreateDriftRunNonVcs:
     """Drift detection on non-VCS workspaces must plan against the CV from
     the workspace's latest successful apply — i.e. the bytes that produced


### PR DESCRIPTION
## What broke

After v0.35.1 deployed on the mgmt deployment, **39 of 42 drift-enabled workspaces** went into `drift_status=errored` within one drift cycle. Every drift run errored with:

```
Given variables file envs/<...>.tfvars does not exist.
```

(Example: `aks-prod-us2` workspace's `envs/prod-us2.tfvars` couldn't be found by `tofu init`.)

## Root cause (latent bug v0.35.1 exposed)

`_create_drift_run_vcs` was using `vcs_poller._download_archive` → `vcs_provider.download_archive` → `github_service.download_repo_archive` — the raw GitHub tarball API. That returns a tarball wrapped in a top-level directory like `markupai-tf-azurerm-aks-abc1234/`. The runner's `chdir /workspace` after extraction lands one level above the actual repo content.

Pre-v0.35.1, drift rarely fired (the wide `_is_workspace_busy` gate skipped any workspace with a stale `planned` peer awaiting confirm). That gate masked the underlying tarball-shape bug. v0.35.1 narrowed the gate (correctly), drift started firing on every drift-enabled workspace, and the latent bug surfaced at scale.

Diagnostic confirmation (from `aks-prod-us2`):
```
2026-06-10T10:19:51.444045Z [info ] running init  argv_tail=['init', '-input=false', '-var-file=envs/prod-us2.tfvars']
2026-06-10T10:19:51.470461Z [error] init failed  rc=1
│ Error: Failed to read variables file
│ Given variables file envs/prod-us2.tfvars does not exist.
```

## Fix

Use the same `VCSArchiveCache.get_or_fetch` / `_stream_cv_upload_from_cache` pipeline that `vcs_poller._create_vcs_run` uses for regular VCS-poll runs. That goes through `git_fetch.py` which produces a clean, root-level tarball — byte-identical to what every successful apply on these workspaces already uses.

## Tests

- `test_uses_vcs_archive_cache_not_raw_download` pins the function's archive-acquisition path. The mock asserts `VCSArchiveCache.get_or_fetch` was called with `paths=None` AND `_stream_cv_upload_from_cache` was called.
- `test_raw_download_archive_not_referenced` — source-introspection guard against accidentally re-importing the broken raw-tarball path.

## Release

v0.35.2 hotfix as soon as CI is green. Wrapper MR follows.
EOF
)