### PR TITLE
fix(drift): clickable Drifted badge + always-whole-repo CV + planning cap

### DIFF
--- a/alembic/versions/204f61b07907_workspaces_drift_latest_run_id.py
+++ b/alembic/versions/204f61b07907_workspaces_drift_latest_run_id.py
@@ -1,0 +1,39 @@
+"""Add workspaces.drift_latest_run_id.
+
+Records the run that produced the workspace's current drift_status —
+lets the workspace-list UI link the "Drifted" / "Errored" status
+badge directly to the drift detection run that produced it (so
+operators can click through and see the plan output instead of
+hunting through the runs list).
+
+Set by `drift_detection_service.handle_drift_run_completed` on every
+non-cancelled drift run completion (planned/no_drift, planned/drifted,
+errored). Null when drift detection has never run (or was dismissed
+via the dismiss-drift endpoint).
+
+Plain nullable UUID — no FK. Drift runs may be GC'd by the run-
+artifact retention sweep eventually, but we don't want a stale
+drift_latest_run_id to break workspace deletion via FK cascade. The
+UI handles 404 on click-through gracefully.
+
+Revision ID: 204f61b07907
+Revises: d8fe7d2eb1e0
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "204f61b07907"
+down_revision = "d8fe7d2eb1e0"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column("drift_latest_run_id", UUID(as_uuid=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "drift_latest_run_id")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -358,6 +358,7 @@ The following read-only attributes are included in workspace responses when drif
 |---|---|---|
 | `drift-last-checked-at` | string (RFC3339) or null | Timestamp of the last completed drift detection check |
 | `drift-status` | string | Current drift status: `""` (never checked), `"no_drift"`, `"drifted"`, or `"errored"` |
+| `drift-latest-run-id` | string (run-…) or null | ID of the drift run that produced the current `drift-status`. Lets the workspace-list UI link the badge straight to the run that explains the status. Cleared on a successful (non-drift) apply because the previous drift run is no longer the canonical link. Null when drift detection has never run or when the column predates v0.35.3 |
 
 ### Lifecycle Attributes (Autodiscovery)
 

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -78,6 +78,35 @@ A run is marked "stale" by the reconciler when it has been in `planning` or `app
 
 ---
 
+## Drift Run Exceeded Max Duration
+
+A drift detection run was errored by the reconciler because it spent longer than `runners.driftMaxDurationSeconds` (default: 30 min) in `planning`. Distinct from the generic stale timeout — the listener and runner pod were both healthy; the underlying `tofu plan` was simply taking too long for a background plan-only check.
+
+### Symptoms
+
+- Workspace's Drifted/Errored badge in the workspace list shows `drift-status: errored`
+- The linked drift run's `error_message` reads `Drift run exceeded max duration (1800s)`
+- Listener and runner pods for the drift run were healthy at the time of failure (no `stale` or `launch-timeout` message)
+
+### Diagnosis
+
+The typical underlying cause is a refresh path that talks to a rate-limited upstream — e.g. the `integrations/github` provider refreshing dozens of `github_repository` / `github_branch_protection` resources, or a Vault provider reading a long secret list. Confirm by looking at the run's plan log: if the last activity is a `Refreshing state...` line and no `Plan: ...` summary, the plan was wedged in refresh, not the drift cap itself misbehaving.
+
+### Resolution
+
+Two reasonable options depending on whether the slow refresh is expected:
+
+1. **Slow plan is expected** — raise the cap. `runners.driftMaxDurationSeconds: 3600` (or higher) in Helm values, then `helm upgrade`. Set to `0` to disable the cap entirely.
+2. **Slow plan is not expected** — investigate the refresh path itself. Common fixes: shrink the workspace by splitting it; configure a stricter provider page-size; add a provider-level cache (e.g. github_repository data sources reading the same repo from multiple resources).
+
+### Verification
+
+- A new drift cycle completes within the cap
+- `drift-status` returns to `no_drift` (or `drifted` if there's real drift to report)
+- The Errored badge clears on the workspace list
+
+---
+
 ## Runner OOM-Killed (#430)
 
 A runner Job was killed by Kubernetes because its container exceeded its memory limit (`2 × workspace.resource_memory`). This usually shows up after a provider schema grows or a workspace acquires a lot more managed resources than it had when `resource_memory` was first set.

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -160,6 +160,7 @@ All runner Jobs inherit the following settings from `runners.*` in Helm values:
 | `runners.tokenTTLSeconds` | `3600` | Runner token TTL (1 hour) |
 | `runners.maxTokenTTLSeconds` | `7200` | Maximum runner token TTL (2 hours) |
 | `runners.staleTimeoutSeconds` | `3600` | Mark run as errored if no Job status after this long |
+| `runners.driftMaxDurationSeconds` | `1800` | Max time a drift run may spend in `planning` before the reconciler errors it. Independent of `staleTimeoutSeconds` (which fires on dead listeners) — this one fires on terraform legitimately running too long for a background plan-only check. Set to `0` to disable |
 
 ### Per-Workspace Resources
 

--- a/helm/terrapod/templates/configmap-runner.yaml
+++ b/helm/terrapod/templates/configmap-runner.yaml
@@ -20,6 +20,7 @@ data:
     token_ttl_seconds: {{ .Values.runners.tokenTTLSeconds }}
     max_token_ttl_seconds: {{ .Values.runners.maxTokenTTLSeconds }}
     stale_timeout_seconds: {{ .Values.runners.staleTimeoutSeconds }}
+    drift_max_duration_seconds: {{ .Values.runners.driftMaxDurationSeconds | default 1800 }}
     {{- with .Values.runners.imagePullSecrets }}
     image_pull_secrets:
       {{- toYaml . | nindent 6 }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -126,6 +126,7 @@
         "tokenTTLSeconds": { "type": "integer", "minimum": 1 },
         "maxTokenTTLSeconds": { "type": "integer", "minimum": 1 },
         "staleTimeoutSeconds": { "type": "integer", "minimum": 60 },
+        "driftMaxDurationSeconds": { "type": "integer", "minimum": 0 },
         "planArtifactsMaxBytes": { "type": "integer", "minimum": 10240 },
         "serviceAccount": { "$ref": "#/$defs/serviceAccountSpec" },
         "azureWorkloadIdentity": { "type": "boolean" }

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -716,6 +716,15 @@ runners:
   tokenTTLSeconds: 3600         # Runner token TTL (default 1 hour)
   maxTokenTTLSeconds: 7200      # Runner token max TTL (default 2 hours)
   staleTimeoutSeconds: 3600     # Seconds before a run with no Job status is marked errored
+  # Maximum wall-clock seconds a drift-detection run may spend in `planning`
+  # before the reconciler errors it out. Independent of staleTimeoutSeconds:
+  # that one fires on listeners going dark; this one fires on terraform
+  # legitimately running too long for a background drift check (e.g. a
+  # github-provider state refresh that takes hours on a workspace with
+  # hundreds of rate-limited reads). Drift runs are plan-only and
+  # background-priority — a 30-minute cap is a generous SLO for "tell me
+  # if there's drift". Set to 0 to disable the cap.
+  driftMaxDurationSeconds: 1800
 
   # Maximum size in bytes of the plan-phase workspace-diff tarball that
   # the runner uploads at end of plan and downloads at start of apply.

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -335,20 +335,18 @@ async def _fetch_vcs_config(
     # is fine here — the in-process single-flight only matters when multiple
     # workspaces poll the same SHA concurrently.
     #
-    # Path narrowing: pass this workspace's own `working_directory ∪
-    # trigger_prefixes`. Cross-workspace coalescing isn't useful here
-    # (one request, one workspace), so we don't bother computing a wider
-    # union. If another caller fetched the same SHA with a different path
-    # set, that's a different cache entry — content-addressed by paths_hash.
-    fetch_paths: list[str] = []
-    if ws.working_directory:
-        fetch_paths.append(ws.working_directory.strip("/ "))
-    if ws.trigger_prefixes:
-        fetch_paths.extend(p.strip("/ ") for p in ws.trigger_prefixes if p)
-    fetch_paths = [p for p in fetch_paths if p]
-
+    # No path narrowing — always fetch the whole repo. Sparse-checkout cone
+    # mode includes parent dirs of the cone but NOT siblings, so narrowing by
+    # `working_directory` silently drops sibling directories the terraform
+    # code references via relative module sources (`module "auth0" {
+    # source = "../auth0" }`). The narrowing saved a marginal amount of
+    # bandwidth on one-shot UI-triggered fetches and broke correctness on any
+    # multi-directory layout (#477 — sls-local errored every drift run with
+    # `Unable to evaluate directory symlink: lstat ../auth0`). The VCS-poll
+    # path keeps its narrowing because it shares the cached tarball across
+    # the cycle's workspaces; one-shot fetches don't benefit from that.
     cache = VCSArchiveCache()
-    cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha, paths=fetch_paths or None)
+    cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha, paths=None)
 
     cv = await run_service.create_configuration_version(
         db, workspace_id=ws.id, source="vcs", auto_queue_runs=False

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -611,6 +611,9 @@ def _workspace_json(
                 "drift-detection-interval-seconds": ws.drift_detection_interval_seconds,
                 "drift-last-checked-at": _rfc3339(ws.drift_last_checked_at),
                 "drift-status": ws.drift_status,
+                "drift-latest-run-id": (
+                    f"run-{ws.drift_latest_run_id}" if ws.drift_latest_run_id else None
+                ),
                 "state-diverged": ws.state_diverged,
                 "lifecycle-state": ws.lifecycle_state,
                 "lifecycle-reason": ws.lifecycle_reason,

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -85,6 +85,22 @@ class RunnerConfig(BaseModel):
             "failure signal, whereas a long-running Job with no status is not."
         ),
     )
+    drift_max_duration_seconds: int = Field(
+        default=1800,
+        description=(
+            "Maximum wall-clock seconds a drift-detection run may spend in "
+            "`planning` before the reconciler errors it out and frees the "
+            "workspace for the next drift cycle. Distinct from stale_timeout: "
+            "stale_timeout protects against listeners that stop reporting; "
+            "this protects against terraform legitimately running for hours "
+            "(e.g. a github provider refresh on a workspace with hundreds of "
+            "rate-limited reads) and blocking drift indefinitely for that "
+            "workspace. Drift runs are background-priority and plan-only — "
+            "a 30 min cap is a generous SLO for 'just tell me if there's "
+            "drift'. Set higher for deployments with genuinely large plans "
+            "you still want drift on; set to 0 to disable the cap."
+        ),
+    )
 
 
 def load_runner_config(path: str = "/etc/terrapod/runners.yaml") -> RunnerConfig:

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -341,6 +341,13 @@ class Workspace(Base):
     drift_status: Mapped[str] = mapped_column(
         String(20), nullable=False, default=""
     )  # "", "no_drift", "drifted", "errored"
+    # The run that produced the current `drift_status`. Lets the workspace-list
+    # UI link the Drifted / Errored badge straight to the run, instead of the
+    # operator hunting through the runs list. Plain nullable UUID, no FK — a
+    # later artifact-retention sweep may delete the run row, and we don't want
+    # that to break workspace deletion via cascade. The UI handles a 404 on the
+    # click-through gracefully.
+    drift_latest_run_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
 
     # State divergence — set when an apply Job succeeds but state upload fails
     state_diverged: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")

--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -366,6 +366,12 @@ async def handle_drift_run_completed(payload: dict) -> None:
         else:
             return
 
+        # Pin the run that produced this status so the workspace-list UI can
+        # link the badge to it. Updated for every status the badge can show
+        # (drifted / no_drift / errored) — that way the Errored badge also
+        # links to the drift run that produced the error, not to whichever
+        # earlier drift run set drift_latest_run_id last.
+        ws.drift_latest_run_id = run.id
         ws.drift_last_checked_at = now_utc()
         await db.commit()
 

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -283,6 +283,32 @@ async def _check_stale(db: AsyncSession, run: Run) -> None:
         return
 
     cfg = load_runner_config()
+    now = datetime.now(UTC)
+
+    # Drift-detection runs get a separate, tighter cap regardless of whether
+    # they're actively reporting status. Background-priority + plan-only +
+    # auto-scheduled = an upper bound that says "if drift hasn't decided in
+    # 30 min, we want the slot back". Without it, a single workspace with
+    # a multi-hour github-provider refresh (terrapod-config: ~30 rate-limited
+    # API reads) blocks drift on that workspace indefinitely and the operator
+    # never sees a clear "this drift run timed out" signal. Set to 0 to
+    # disable. Checked BEFORE the generic stale/launch timeouts so a
+    # drift run that's stale AND over-cap is reported as "drift cap exceeded"
+    # (the more actionable failure mode).
+    if run.is_drift_detection and run.status == "planning" and cfg.drift_max_duration_seconds > 0:
+        cap = timedelta(seconds=cfg.drift_max_duration_seconds)
+        if now - phase_start > cap:
+            await _handle_failed(
+                db, run, f"Drift run exceeded max duration ({cfg.drift_max_duration_seconds}s)"
+            )
+            logger.warning(
+                "Drift run errored: max duration exceeded",
+                run_id=str(run.id),
+                duration_seconds=int((now - phase_start).total_seconds()),
+                cap_seconds=cfg.drift_max_duration_seconds,
+            )
+            return
+
     if run.job_name is None:
         timeout = timedelta(seconds=cfg.launch_timeout_seconds)
         message_prefix = "Run stuck pre-launch"
@@ -290,7 +316,6 @@ async def _check_stale(db: AsyncSession, run: Run) -> None:
         timeout = timedelta(seconds=cfg.stale_timeout_seconds)
         message_prefix = "Run stale"
 
-    now = datetime.now(UTC)
     if now - phase_start > timeout:
         await _handle_failed(db, run, f"{message_prefix} — no progress for >{timeout}")
         if run.job_name is None:

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -459,6 +459,11 @@ async def transition_run(
         if ws is not None and ws.drift_detection_enabled:
             ws.drift_status = "no_drift"
             ws.drift_last_checked_at = now_utc()
+            # Apply just reconciled state to the desired config — the previous
+            # drift run is no longer the canonical "explain the current
+            # status" link. Clear it so the workspace-list badge falls back
+            # to the no-link state until the next drift run completes.
+            ws.drift_latest_run_id = None
 
     # #314: a successful opt-in autodiscovery destroy archives the
     # workspace (soft-delete; retained for audit). Literal source

--- a/services/tests/services/test_drift_detection_service.py
+++ b/services/tests/services/test_drift_detection_service.py
@@ -13,6 +13,7 @@ def _mock_workspace(**overrides):
     ws.drift_detection_interval_seconds = overrides.get("drift_detection_interval_seconds", 86400)
     ws.drift_last_checked_at = overrides.get("drift_last_checked_at", None)
     ws.drift_status = overrides.get("drift_status", "")
+    ws.drift_latest_run_id = overrides.get("drift_latest_run_id", None)
     ws.locked = overrides.get("locked", False)
     ws.vcs_connection_id = overrides.get("vcs_connection_id", None)
     ws.vcs_repo_url = overrides.get("vcs_repo_url", "")
@@ -202,6 +203,8 @@ class TestHandleDriftRunCompleted:
         )
 
         assert ws.drift_status == "drifted"
+        # Links the workspace-list badge to the run that produced this status.
+        assert ws.drift_latest_run_id == run.id
         mock_notif.assert_called_once()
 
     @patch("terrapod.services.drift_detection_service._enqueue_drift_notification")
@@ -230,6 +233,7 @@ class TestHandleDriftRunCompleted:
         )
 
         assert ws.drift_status == "no_drift"
+        assert ws.drift_latest_run_id == run.id
         mock_notif.assert_not_called()
 
     @patch("terrapod.services.drift_detection_service._enqueue_drift_notification")
@@ -256,6 +260,9 @@ class TestHandleDriftRunCompleted:
         )
 
         assert ws.drift_status == "errored"
+        # Errored badge must link to the drift run that produced the error
+        # so the operator can click straight to the plan log.
+        assert ws.drift_latest_run_id == run.id
         mock_notif.assert_not_called()
 
     @patch("terrapod.services.drift_detection_service._enqueue_drift_notification")
@@ -283,6 +290,9 @@ class TestHandleDriftRunCompleted:
         )
 
         assert ws.drift_status == original_status
+        # Canceled drift runs MUST NOT overwrite drift_latest_run_id —
+        # the previous run is still what "explains" the current badge.
+        assert ws.drift_latest_run_id is None
 
     @patch("terrapod.services.drift_detection_service._enqueue_drift_notification")
     @patch("terrapod.services.drift_detection_service.get_db_session")

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -500,6 +500,113 @@ class TestCheckStale:
         assert "stale" in mock_handle.call_args.args[2].lower()
 
 
+# ── drift-detection max-duration cap ─────────────────────────────────
+
+
+class TestDriftMaxDuration:
+    """Independent cap for drift runs.
+
+    Distinct from the generic stale_timeout (which only fires when a
+    listener stops reporting): this cap fires on a drift run that's
+    legitimately running too long for a background plan-only check.
+    The motivating incident: a github-provider state refresh ran past
+    50 min on terrapod-config and silently blocked drift on that
+    workspace; the listener was still reporting and the runner pod was
+    healthy, so neither stale_timeout nor launch_timeout caught it.
+    """
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_drift_planning_over_cap_gets_errored(self, mock_handle, mock_config):
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS,
+            launch_timeout_seconds=300,
+            drift_max_duration_seconds=1800,
+        )
+        db = AsyncMock()
+        # 35 min in — over the 30-min default drift cap
+        run = _mock_run(
+            status="planning",
+            is_drift_detection=True,
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=35),
+        )
+
+        await _check_stale(db, run)
+
+        mock_handle.assert_called_once()
+        assert "drift" in mock_handle.call_args.args[2].lower()
+        assert "max duration" in mock_handle.call_args.args[2].lower()
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_drift_under_cap_is_not_errored(self, mock_handle, mock_config):
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS,
+            launch_timeout_seconds=300,
+            drift_max_duration_seconds=1800,
+        )
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            is_drift_detection=True,
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=10),
+        )
+
+        await _check_stale(db, run)
+
+        mock_handle.assert_not_called()
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_drift_cap_disabled_falls_through_to_stale(self, mock_handle, mock_config):
+        """drift_max_duration_seconds=0 disables the cap.
+
+        The run can still be errored by the generic stale_timeout, but
+        not by the drift-specific cap. With a 1h stale timeout and a
+        35-min-old run, neither fires.
+        """
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS,
+            launch_timeout_seconds=300,
+            drift_max_duration_seconds=0,
+        )
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            is_drift_detection=True,
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=35),
+        )
+
+        await _check_stale(db, run)
+
+        mock_handle.assert_not_called()
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_non_drift_run_ignores_cap(self, mock_handle, mock_config):
+        """Regular (non-drift) runs MUST NOT be subject to the drift cap.
+
+        A real interactive plan/apply can legitimately exceed 30 min;
+        only the drift cohort is constrained by it.
+        """
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS,
+            launch_timeout_seconds=300,
+            drift_max_duration_seconds=1800,
+        )
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            is_drift_detection=False,
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=35),
+        )
+
+        await _check_stale(db, run)
+
+        # Below the 1h stale timeout, drift cap doesn't apply → no error
+        mock_handle.assert_not_called()
+
+
 # ── launch_timeout (no job_name) cohort ──────────────────────────────
 
 

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -52,6 +52,7 @@ interface Workspace {
     'agent-pool-name': string | null
     'drift-detection-enabled': boolean
     'drift-status': string
+    'drift-latest-run-id': string | null
     'state-diverged': boolean
     'vcs-last-error': string | null
     'health-conditions': HealthCondition[]

--- a/web/src/lib/workspace-status.ts
+++ b/web/src/lib/workspace-status.ts
@@ -59,6 +59,7 @@ interface ResolveInput {
     'state-diverged': boolean
     'vcs-last-error': string | null
     'drift-status': string
+    'drift-latest-run-id'?: string | null
     'latest-run': {
       id: string
       status: string
@@ -99,7 +100,13 @@ export function resolveStatus(ws: ResolveInput): ResolvedStatus {
   }
   if (a['state-diverged']) return { def: STATUS_BY_FILTER.get('state-diverged') ?? null, runId: null }
   if (a['vcs-last-error']) return { def: STATUS_BY_FILTER.get('vcs-error') ?? null, runId: null }
-  if (a['drift-status'] === 'drifted') return { def: STATUS_BY_FILTER.get('drifted') ?? null, runId: null }
+  if (a['drift-status'] === 'drifted') {
+    // Drift status links to the drift run that produced it when one exists,
+    // so clicking the badge takes the operator straight to the plan output
+    // instead of forcing them to hunt through the runs list. Falls back to
+    // null (no link) for legacy rows where the column was never populated.
+    return { def: STATUS_BY_FILTER.get('drifted') ?? null, runId: a['drift-latest-run-id'] ?? null }
+  }
   if (!run) return { def: null, runId: null }
   // plan-only `planned` is a successful read of the world, not an
   // awaiting-confirm signal.


### PR DESCRIPTION
Three related fixes that fell out of investigating drift runs going stuck or errored after v0.35.2 across the mgmt fleet.

## Summary

### A. Clickable Drifted badge
- New `workspaces.drift_latest_run_id` column populated by `handle_drift_run_completed` for every drift outcome that updates `drift_status` (drifted / no_drift / errored)
- Workspace JSON surfaces `drift-latest-run-id`; workspace-list UI links the badge to that run
- Cleared on a successful non-drift apply (the previous drift run is no longer the canonical "explain the current state" link)
- Operator clicks the badge → straight to the drift run's plan output, no more hunting through the runs list

### B. `_fetch_vcs_config` always whole-repo
- Sparse-checkout cone mode includes parent dirs of the cone but NOT siblings — narrowing by a workspace's own `working_directory` silently dropped sibling directories the terraform code referenced via relative module sources (`module \"auth0\" { source = \"../auth0\" }`)
- Runner errored: `Unable to evaluate directory symlink: lstat ../auth0: no such file or directory`
- One-shot UI/manual fetches don't benefit from the cross-workspace coalescing the narrowing existed for
- VCS-poll path keeps its narrowing — it does share the cached tarball across the cycle's workspaces

### C. Drift-run planning cap
- New `drift_max_duration_seconds` (default `1800`, runner config)
- Reconciler errors any drift run that sits in `planning` past the cap, even when the listener is healthy
- Distinct from `stale_timeout`: stale protects against listeners going dark; this protects against terraform legitimately running too long for a background plan-only check
- Motivating incident: a github-provider state refresh ran 50+ min on terrapod-config and silently blocked drift on that workspace; the runner pod was healthy and the listener was reporting, so neither stale_timeout nor launch_timeout caught it
- Set to `0` to disable

## Tests

- Updated `TestHandleDriftRunCompleted` to assert `drift_latest_run_id` is set on every status-updating outcome and NOT set on cancel/discard
- New `TestDriftMaxDuration` reconciler test class: covers over-cap → errored, under-cap → unchanged, `cap=0` → falls through to stale logic, non-drift runs → unaffected
- All 2050 existing tests still green

## Helm

- New `runners.driftMaxDurationSeconds` value + schema entry
- `helm lint` + `helm template` clean on both `values.yaml` and `values-local.yaml`

## Test plan

- [ ] CI green
- [ ] Tilt local smoke: drift enables on a workspace, drift run completes, badge links to that run
- [ ] Tilt local smoke: drift run that artificially exceeds the cap gets errored (set `driftMaxDurationSeconds: 60` in values-local)
- [ ] Verify on mgmt: trigger fresh drift on `platform-prod-us1` post-deploy; v0.35.2 + B should now produce a clean root-level tarball and a green drift run