### PR TITLE
fix(contract): revert Fix B + reconcile workspace API↔SDK↔provider

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -44,6 +44,13 @@ RUN poetry config virtualenvs.create false \
 COPY services/terrapod ./terrapod
 COPY services/tests ./tests
 
+# Source for the API↔SDK↔provider contract test (tests/test_api_sdk_contract.py).
+# The test reads these files as raw text — no Go build is performed in the
+# Python image. Kept narrow (.go files only) so the image stays slim.
+COPY go-terrapod/*.go ./go-terrapod/
+COPY provider/internal/resources/workspace/*.go ./provider/internal/resources/workspace/
+COPY provider/internal/datasources/workspace/*.go ./provider/internal/datasources/workspace/
+
 # Storage data directory for tests
 RUN mkdir -p /var/lib/terrapod/storage
 

--- a/go-terrapod/workspaces.go
+++ b/go-terrapod/workspaces.go
@@ -41,10 +41,40 @@ type Workspace struct {
 	Locked                        bool              `json:"locked"`
 	Labels                        map[string]string `json:"labels,omitempty"`
 	VarFiles                      []string          `json:"var-files,omitempty"`
+	TriggerPrefixes               []string          `json:"trigger-prefixes,omitempty"`
 	DriftDetectionEnabled         bool              `json:"drift-detection-enabled"`
 	DriftDetectionIntervalSeconds *int64            `json:"drift-detection-interval-seconds,omitempty"`
 	DriftStatus                   string            `json:"drift-status,omitempty"`
 	DriftLastCheckedAt            string            `json:"drift-last-checked-at,omitempty"`
+	// DriftLatestRunID is the ID (prefixed `run-…`) of the drift run that
+	// produced the current DriftStatus, or "" when drift has never run or
+	// was just cleared by a successful apply. Lets consumers link the
+	// status badge to the actual run.
+	DriftLatestRunID string `json:"drift-latest-run-id,omitempty"`
+	// StateDiverged is set when an apply Job succeeded but uploading the
+	// resulting state to Terrapod failed — the workspace's recorded state
+	// is now out of sync with reality.
+	StateDiverged bool `json:"state-diverged"`
+	// LifecycleState tracks autodiscovery-managed workspaces:
+	// "active" | "pending_deletion" | "archived".
+	LifecycleState string `json:"lifecycle-state,omitempty"`
+	// LifecycleReason is a human-readable explanation of LifecycleState
+	// (e.g. "directory 'accounts/x' removed on 'main'"). Empty for active.
+	LifecycleReason string `json:"lifecycle-reason,omitempty"`
+	// VCSLastPolledAt is the timestamp of the most recent successful VCS
+	// poll cycle for this workspace.
+	VCSLastPolledAt string `json:"vcs-last-polled-at,omitempty"`
+	// VCSLastError is the last error from a VCS poll attempt (auth
+	// failure, repo gone, etc.). Empty when the last poll succeeded.
+	VCSLastError string `json:"vcs-last-error,omitempty"`
+	// VCSLastErrorAt is the timestamp of VCSLastError.
+	VCSLastErrorAt string `json:"vcs-last-error-at,omitempty"`
+	// AgentPoolName is the human-readable name of the assigned agent
+	// pool, server-derived from AgentPoolID. Empty when no pool is set.
+	AgentPoolName string `json:"agent-pool-name,omitempty"`
+	// VCSConnectionName is the human-readable name of the assigned VCS
+	// connection, server-derived from VCSConnectionID. Empty when none.
+	VCSConnectionName string `json:"vcs-connection-name,omitempty"`
 	// AISummaryMode is the three-state per-workspace override (#401):
 	//   "default"  → follow the deployment-wide ai_summary.enabled flag
 	//   "enabled"  → always summarise (no-op when global is off)
@@ -83,6 +113,7 @@ type CreateWorkspaceRequest struct {
 	OwnerEmail                    string             `json:"owner-email,omitempty"`
 	Labels                        map[string]string  `json:"labels,omitempty"`
 	VarFiles                      []string           `json:"var-files,omitempty"`
+	TriggerPrefixes               []string           `json:"trigger-prefixes,omitempty"`
 	DriftDetectionEnabled         *bool              `json:"drift-detection-enabled,omitempty"`
 	DriftDetectionIntervalSeconds *int64             `json:"drift-detection-interval-seconds,omitempty"`
 	// AISummaryMode is the three-state per-workspace override (#401):
@@ -121,6 +152,7 @@ type UpdateWorkspaceRequest struct {
 	AutoMergeStrategy             string            `json:"auto-merge-strategy,omitempty"`
 	Labels                        map[string]string `json:"labels,omitempty"`
 	VarFiles                      []string          `json:"var-files,omitempty"`
+	TriggerPrefixes               []string          `json:"trigger-prefixes,omitempty"`
 	DriftDetectionEnabled         *bool             `json:"drift-detection-enabled,omitempty"`
 	DriftDetectionIntervalSeconds *int64            `json:"drift-detection-interval-seconds,omitempty"`
 	// AISummaryMode see CreateWorkspaceRequest. On UPDATE, empty string
@@ -326,6 +358,9 @@ func workspaceCreateAttrs(req CreateWorkspaceRequest) map[string]any {
 	if req.VarFiles != nil {
 		attrs["var-files"] = req.VarFiles
 	}
+	if req.TriggerPrefixes != nil {
+		attrs["trigger-prefixes"] = req.TriggerPrefixes
+	}
 	if req.DriftDetectionEnabled != nil {
 		attrs["drift-detection-enabled"] = *req.DriftDetectionEnabled
 	}
@@ -396,6 +431,9 @@ func workspaceUpdateAttrs(req UpdateWorkspaceRequest) map[string]any {
 	if req.VarFiles != nil {
 		attrs["var-files"] = req.VarFiles
 	}
+	if req.TriggerPrefixes != nil {
+		attrs["trigger-prefixes"] = req.TriggerPrefixes
+	}
 	if req.DriftDetectionEnabled != nil {
 		attrs["drift-detection-enabled"] = *req.DriftDetectionEnabled
 	}
@@ -463,9 +501,19 @@ func workspaceFromResource(res *Resource) *Workspace {
 		Locked:                GetBoolAttr(res, "locked"),
 		Labels:                GetMapAttr(res, "labels"),
 		VarFiles:              GetListAttr(res, "var-files"),
+		TriggerPrefixes:       GetListAttr(res, "trigger-prefixes"),
 		DriftDetectionEnabled: GetBoolAttr(res, "drift-detection-enabled"),
 		DriftStatus:           GetStringAttr(res, "drift-status"),
 		DriftLastCheckedAt:    GetStringAttr(res, "drift-last-checked-at"),
+		DriftLatestRunID:      GetStringAttr(res, "drift-latest-run-id"),
+		StateDiverged:         GetBoolAttr(res, "state-diverged"),
+		LifecycleState:        GetStringAttr(res, "lifecycle-state"),
+		LifecycleReason:       GetStringAttr(res, "lifecycle-reason"),
+		VCSLastPolledAt:       GetStringAttr(res, "vcs-last-polled-at"),
+		VCSLastError:          GetStringAttr(res, "vcs-last-error"),
+		VCSLastErrorAt:        GetStringAttr(res, "vcs-last-error-at"),
+		AgentPoolName:         GetStringAttr(res, "agent-pool-name"),
+		VCSConnectionName:     GetStringAttr(res, "vcs-connection-name"),
 		AISummaryMode:         GetStringAttr(res, "ai-summary-mode"),
 		AISummaryContext:      GetStringAttr(res, "ai-summary-context"),
 		CreatedAt:             GetStringAttr(res, "created-at"),

--- a/go-terrapod/workspaces_test.go
+++ b/go-terrapod/workspaces_test.go
@@ -368,6 +368,85 @@ func TestWorkspaceFromResource_DriftFields(t *testing.T) {
 	}
 }
 
+// TestWorkspaceFromResource_ContractParity pins the read-side of the
+// API↔SDK contract for workspace attributes that were silently missing
+// before #480. Adding a new server attribute → extending the SDK
+// `Workspace` struct + this fixture is the path that keeps the
+// contract enforceable: if the server attribute is later renamed and
+// the SDK isn't updated to match, this test goes red.
+func TestWorkspaceFromResource_ContractParity(t *testing.T) {
+	body := `{"data": {
+	  "id": "ws-aaa",
+	  "type": "workspaces",
+	  "attributes": {
+	    "name": "api",
+	    "trigger-prefixes": ["terraform/auth0", "terraform/shared"],
+	    "drift-latest-run-id": "run-019eb151-4faf-71a9-9f1a-9841e8c993aa",
+	    "state-diverged": true,
+	    "lifecycle-state": "pending_deletion",
+	    "lifecycle-reason": "directory 'accounts/x' removed on 'main'",
+	    "vcs-last-polled-at": "2026-06-10T11:50:00Z",
+	    "vcs-last-error": "github app token expired",
+	    "vcs-last-error-at": "2026-06-10T11:45:00Z",
+	    "agent-pool-name": "mai-dev-us1",
+	    "vcs-connection-name": "markupai-github"
+	  }
+	}}`
+	ws, err := parseWorkspace([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ws.TriggerPrefixes) != 2 || ws.TriggerPrefixes[0] != "terraform/auth0" {
+		t.Errorf("TriggerPrefixes = %v", ws.TriggerPrefixes)
+	}
+	if ws.DriftLatestRunID != "run-019eb151-4faf-71a9-9f1a-9841e8c993aa" {
+		t.Errorf("DriftLatestRunID = %q", ws.DriftLatestRunID)
+	}
+	if !ws.StateDiverged {
+		t.Error("StateDiverged should be true")
+	}
+	if ws.LifecycleState != "pending_deletion" || ws.LifecycleReason == "" {
+		t.Errorf("lifecycle fields: state=%q reason=%q", ws.LifecycleState, ws.LifecycleReason)
+	}
+	if ws.VCSLastPolledAt == "" || ws.VCSLastError == "" || ws.VCSLastErrorAt == "" {
+		t.Errorf("vcs-poll status fields: polled=%q err=%q errAt=%q",
+			ws.VCSLastPolledAt, ws.VCSLastError, ws.VCSLastErrorAt)
+	}
+	if ws.AgentPoolName != "mai-dev-us1" || ws.VCSConnectionName != "markupai-github" {
+		t.Errorf("derived names: pool=%q conn=%q", ws.AgentPoolName, ws.VCSConnectionName)
+	}
+}
+
+// TestWorkspaceCreate_TriggerPrefixes_Wire pins the write-side: when a
+// caller supplies TriggerPrefixes on CreateWorkspaceRequest, the SDK
+// MUST marshal it into the JSON:API attributes block as
+// `trigger-prefixes`. Was silently dropped before #480.
+func TestWorkspaceCreate_TriggerPrefixes_Wire(t *testing.T) {
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"id":"ws-new","type":"workspaces","attributes":{"name":"x","trigger-prefixes":["a","b"]}}}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.CreateWorkspace(context.Background(), CreateWorkspaceRequest{
+		Name:            "x",
+		ExecutionMode:   "agent",
+		TriggerPrefixes: []string{"a", "b"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(receivedBody), `"trigger-prefixes":["a","b"]`) {
+		t.Errorf("trigger-prefixes missing from request body: %s", receivedBody)
+	}
+}
+
 func TestWorkspaceFromResource_VCSConnectionRelationship(t *testing.T) {
 	body := `{"data": {
 	  "id": "ws-aaa",

--- a/provider/internal/datasources/workspace/data_source.go
+++ b/provider/internal/datasources/workspace/data_source.go
@@ -40,6 +40,7 @@ type workspaceDataSourceModel struct {
 	VCSConnectionID               types.String `tfsdk:"vcs_connection_id"`
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
 	VarFiles                      types.List   `tfsdk:"var_files"`
+	TriggerPrefixes               types.List   `tfsdk:"trigger_prefixes"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`
 	DriftDetectionIntervalSeconds types.Int64  `tfsdk:"drift_detection_interval_seconds"`
 	AISummaryMode                 types.String `tfsdk:"ai_summary_mode"`
@@ -47,8 +48,15 @@ type workspaceDataSourceModel struct {
 	OwnerEmail                    types.String `tfsdk:"owner_email"`
 	DriftStatus                   types.String `tfsdk:"drift_status"`
 	DriftLastCheckedAt            types.String `tfsdk:"drift_last_checked_at"`
+	DriftLatestRunID              types.String `tfsdk:"drift_latest_run_id"`
+	StateDiverged                 types.Bool   `tfsdk:"state_diverged"`
 	LifecycleState                types.String `tfsdk:"lifecycle_state"`
 	LifecycleReason               types.String `tfsdk:"lifecycle_reason"`
+	VCSLastPolledAt               types.String `tfsdk:"vcs_last_polled_at"`
+	VCSLastError                  types.String `tfsdk:"vcs_last_error"`
+	VCSLastErrorAt                types.String `tfsdk:"vcs_last_error_at"`
+	AgentPoolName                 types.String `tfsdk:"agent_pool_name"`
+	VCSConnectionName             types.String `tfsdk:"vcs_connection_name"`
 	Locked                        types.Bool   `tfsdk:"locked"`
 	CreatedAt                     types.String `tfsdk:"created_at"`
 	UpdatedAt                     types.String `tfsdk:"updated_at"`
@@ -82,6 +90,7 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"vcs_connection_id":                computedString("VCS connection ID."),
 			"agent_pool_id":                    computedString("Agent pool ID."),
 			"var_files":                        computedList("Var files for -var-file arguments."),
+			"trigger_prefixes":                 computedList("Repo-root-relative paths the VCS sparse-checkout must include in addition to working_directory (e.g. sibling modules referenced via `source = \"../foo\"`)."),
 			"drift_detection_enabled":          computedBool("Drift detection enabled."),
 			"drift_detection_interval_seconds": computedInt64("Drift detection interval."),
 			"ai_summary_mode":                  computedString("Per-workspace AI plan-summary mode: 'default' (follow deployment global), 'enabled' (always summarise), or 'disabled' (never summarise)."),
@@ -89,8 +98,15 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"owner_email":                      computedString("Owner email."),
 			"drift_status":                     computedString("Drift status."),
 			"drift_last_checked_at":            computedString("Last drift check."),
+			"drift_latest_run_id":              computedString("ID of the drift run that produced the current `drift_status`, prefixed `run-…`. Empty when drift has never run or was just cleared by a successful apply."),
+			"state_diverged":                   computedBool("True when an apply Job succeeded but uploading the resulting state to Terrapod failed; the recorded state is out of sync with reality."),
 			"lifecycle_state":                  computedString("Workspace lifecycle state (e.g. active, or flagged/destroying when its autodiscovery source directory was deleted)."),
 			"lifecycle_reason":                 computedString("Human-readable reason for the current lifecycle state."),
+			"vcs_last_polled_at":               computedString("Timestamp of the most recent successful VCS poll cycle."),
+			"vcs_last_error":                   computedString("Most recent VCS poll error message. Empty when the last poll succeeded."),
+			"vcs_last_error_at":                computedString("Timestamp of `vcs_last_error`."),
+			"agent_pool_name":                  computedString("Human-readable name of the assigned agent pool, server-derived from `agent_pool_id`."),
+			"vcs_connection_name":              computedString("Human-readable name of the assigned VCS connection, server-derived from `vcs_connection_id`."),
 			"locked":                           computedBool("Lock status."),
 			"created_at":                       computedString("Creation timestamp."),
 			"updated_at":                       computedString("Update timestamp."),
@@ -168,8 +184,15 @@ func readDataSourceModel(ctx context.Context, res *terrapod.Resource, m *workspa
 	setOptionalString(&m.AgentPoolID, terrapod.GetStringAttr(res, "agent-pool-id"))
 	setOptionalString(&m.DriftStatus, terrapod.GetStringAttr(res, "drift-status"))
 	setOptionalString(&m.DriftLastCheckedAt, terrapod.GetStringAttr(res, "drift-last-checked-at"))
+	setOptionalString(&m.DriftLatestRunID, terrapod.GetStringAttr(res, "drift-latest-run-id"))
 	setOptionalString(&m.LifecycleState, terrapod.GetStringAttr(res, "lifecycle-state"))
 	setOptionalString(&m.LifecycleReason, terrapod.GetStringAttr(res, "lifecycle-reason"))
+	setOptionalString(&m.VCSLastPolledAt, terrapod.GetStringAttr(res, "vcs-last-polled-at"))
+	setOptionalString(&m.VCSLastError, terrapod.GetStringAttr(res, "vcs-last-error"))
+	setOptionalString(&m.VCSLastErrorAt, terrapod.GetStringAttr(res, "vcs-last-error-at"))
+	setOptionalString(&m.AgentPoolName, terrapod.GetStringAttr(res, "agent-pool-name"))
+	setOptionalString(&m.VCSConnectionName, terrapod.GetStringAttr(res, "vcs-connection-name"))
+	m.StateDiverged = types.BoolValue(terrapod.GetBoolAttr(res, "state-diverged"))
 
 	if v := terrapod.GetRelationshipID(res, "vcs-connection"); v != "" {
 		m.VCSConnectionID = types.StringValue(v)
@@ -189,6 +212,14 @@ func readDataSourceModel(ctx context.Context, res *terrapod.Resource, m *workspa
 		m.VarFiles = val
 	} else {
 		m.VarFiles = types.ListNull(types.StringType)
+	}
+
+	if tp := terrapod.GetListAttr(res, "trigger-prefixes"); len(tp) > 0 {
+		val, d := types.ListValueFrom(ctx, types.StringType, tp)
+		diags.Append(d...)
+		m.TriggerPrefixes = val
+	} else {
+		m.TriggerPrefixes = types.ListNull(types.StringType)
 	}
 
 	if labels := terrapod.GetMapAttr(res, "labels"); len(labels) > 0 {

--- a/provider/internal/resources/workspace/model.go
+++ b/provider/internal/resources/workspace/model.go
@@ -26,6 +26,7 @@
 //	"vcs-branch"                        → vcs_branch          (string, optional)
 //	"agent-pool-id"                     → agent_pool_id       (string, optional)
 //	"var-files"                         → var_files           (list,   optional)
+//	"trigger-prefixes"                  → trigger_prefixes    (list,   optional)
 //	"drift-detection-enabled"           → drift_detection_enabled (bool, optional)
 //	"drift-detection-interval-seconds"  → drift_detection_interval_seconds (int, optional)
 //
@@ -71,6 +72,7 @@ type workspaceModel struct {
 	AutoMergeStrategy             types.String `tfsdk:"auto_merge_strategy"`
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
 	VarFiles                      types.List   `tfsdk:"var_files"`
+	TriggerPrefixes               types.List   `tfsdk:"trigger_prefixes"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`
 	DriftDetectionIntervalSeconds types.Int64  `tfsdk:"drift_detection_interval_seconds"`
 	AISummaryMode                 types.String `tfsdk:"ai_summary_mode"`
@@ -88,6 +90,15 @@ type workspaceModel struct {
 	OwnerEmail         types.String `tfsdk:"owner_email"`
 	DriftStatus        types.String `tfsdk:"drift_status"`
 	DriftLastCheckedAt types.String `tfsdk:"drift_last_checked_at"`
+	DriftLatestRunID   types.String `tfsdk:"drift_latest_run_id"`
+	StateDiverged      types.Bool   `tfsdk:"state_diverged"`
+	LifecycleState     types.String `tfsdk:"lifecycle_state"`
+	LifecycleReason    types.String `tfsdk:"lifecycle_reason"`
+	VCSLastPolledAt    types.String `tfsdk:"vcs_last_polled_at"`
+	VCSLastError       types.String `tfsdk:"vcs_last_error"`
+	VCSLastErrorAt     types.String `tfsdk:"vcs_last_error_at"`
+	AgentPoolName      types.String `tfsdk:"agent_pool_name"`
+	VCSConnectionName  types.String `tfsdk:"vcs_connection_name"`
 	Locked             types.Bool   `tfsdk:"locked"`
 	CreatedAt          types.String `tfsdk:"created_at"`
 	UpdatedAt          types.String `tfsdk:"updated_at"`

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -160,6 +160,11 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				ElementType: types.StringType,
 			},
+			"trigger_prefixes": schema.ListAttribute{
+				Description: "Repo-root-relative directories to include in the sparse VCS fetch in addition to `working_directory`. Required when the workspace's terraform crosses directory boundaries via relative module sources (`module \"foo\" { source = \"../foo\" }`) — sparse-checkout cone mode includes parents of the listed directories but NOT siblings, so the referenced sibling must be declared here or the runner will error with `Unable to evaluate directory symlink`.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 			"drift_detection_enabled": schema.BoolAttribute{
 				Description: "Enable drift detection for this workspace. Defaults to true for VCS-connected workspaces, false otherwise.",
 				Optional:    true,
@@ -211,11 +216,47 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"drift_status": schema.StringAttribute{
-				Description: "Current drift status.",
+				Description: "Current drift status: \"\" (never checked), \"no_drift\", \"drifted\", or \"errored\".",
 				Computed:    true,
 			},
 			"drift_last_checked_at": schema.StringAttribute{
 				Description: "Timestamp of the last drift check.",
+				Computed:    true,
+			},
+			"drift_latest_run_id": schema.StringAttribute{
+				Description: "ID of the drift run that produced the current `drift_status`, prefixed `run-…`. Empty when drift has never run or when cleared by a successful apply.",
+				Computed:    true,
+			},
+			"state_diverged": schema.BoolAttribute{
+				Description: "True when an apply Job succeeded but uploading the resulting state to Terrapod failed; the recorded state is out of sync with reality.",
+				Computed:    true,
+			},
+			"lifecycle_state": schema.StringAttribute{
+				Description: "Autodiscovery lifecycle state for managed workspaces: \"active\", \"pending_deletion\", or \"archived\".",
+				Computed:    true,
+			},
+			"lifecycle_reason": schema.StringAttribute{
+				Description: "Human-readable explanation of `lifecycle_state`. Empty for active workspaces.",
+				Computed:    true,
+			},
+			"vcs_last_polled_at": schema.StringAttribute{
+				Description: "Timestamp of the most recent successful VCS poll cycle.",
+				Computed:    true,
+			},
+			"vcs_last_error": schema.StringAttribute{
+				Description: "Most recent VCS poll error message. Empty when the last poll succeeded.",
+				Computed:    true,
+			},
+			"vcs_last_error_at": schema.StringAttribute{
+				Description: "Timestamp of `vcs_last_error`.",
+				Computed:    true,
+			},
+			"agent_pool_name": schema.StringAttribute{
+				Description: "Human-readable name of the assigned agent pool, server-derived from `agent_pool_id`.",
+				Computed:    true,
+			},
+			"vcs_connection_name": schema.StringAttribute{
+				Description: "Human-readable name of the assigned VCS connection, server-derived from `vcs_connection_id`.",
 				Computed:    true,
 			},
 			"locked": schema.BoolAttribute{
@@ -469,6 +510,13 @@ func buildCreateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 		}
 		req.VarFiles = varFiles
 	}
+	if !m.TriggerPrefixes.IsNull() && !m.TriggerPrefixes.IsUnknown() {
+		triggerPrefixes := []string{}
+		for _, v := range m.TriggerPrefixes.Elements() {
+			triggerPrefixes = append(triggerPrefixes, v.(types.String).ValueString())
+		}
+		req.TriggerPrefixes = triggerPrefixes
+	}
 	if !m.DriftDetectionEnabled.IsNull() && !m.DriftDetectionEnabled.IsUnknown() {
 		v := m.DriftDetectionEnabled.ValueBool()
 		req.DriftDetectionEnabled = &v
@@ -556,6 +604,13 @@ func buildUpdateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 		}
 		req.VarFiles = varFiles
 	}
+	if !m.TriggerPrefixes.IsNull() && !m.TriggerPrefixes.IsUnknown() {
+		triggerPrefixes := []string{}
+		for _, v := range m.TriggerPrefixes.Elements() {
+			triggerPrefixes = append(triggerPrefixes, v.(types.String).ValueString())
+		}
+		req.TriggerPrefixes = triggerPrefixes
+	}
 	if !m.DriftDetectionEnabled.IsNull() && !m.DriftDetectionEnabled.IsUnknown() {
 		v := m.DriftDetectionEnabled.ValueBool()
 		req.DriftDetectionEnabled = &v
@@ -641,6 +696,52 @@ func readWorkspaceIntoModel(ctx context.Context, ws *terrapod.Workspace, m *work
 	} else {
 		m.DriftLastCheckedAt = types.StringNull()
 	}
+	if ws.DriftLatestRunID != "" {
+		m.DriftLatestRunID = types.StringValue(ws.DriftLatestRunID)
+	} else {
+		m.DriftLatestRunID = types.StringNull()
+	}
+
+	// State + lifecycle + VCS poll status — read-only fields the server
+	// surfaces for diagnostics and operator UX. Empty-string from the
+	// SDK becomes Terraform null so a fresh workspace doesn't show
+	// "empty string" values in the state diff.
+	m.StateDiverged = types.BoolValue(ws.StateDiverged)
+	if ws.LifecycleState != "" {
+		m.LifecycleState = types.StringValue(ws.LifecycleState)
+	} else {
+		m.LifecycleState = types.StringNull()
+	}
+	if ws.LifecycleReason != "" {
+		m.LifecycleReason = types.StringValue(ws.LifecycleReason)
+	} else {
+		m.LifecycleReason = types.StringNull()
+	}
+	if ws.VCSLastPolledAt != "" {
+		m.VCSLastPolledAt = types.StringValue(ws.VCSLastPolledAt)
+	} else {
+		m.VCSLastPolledAt = types.StringNull()
+	}
+	if ws.VCSLastError != "" {
+		m.VCSLastError = types.StringValue(ws.VCSLastError)
+	} else {
+		m.VCSLastError = types.StringNull()
+	}
+	if ws.VCSLastErrorAt != "" {
+		m.VCSLastErrorAt = types.StringValue(ws.VCSLastErrorAt)
+	} else {
+		m.VCSLastErrorAt = types.StringNull()
+	}
+	if ws.AgentPoolName != "" {
+		m.AgentPoolName = types.StringValue(ws.AgentPoolName)
+	} else {
+		m.AgentPoolName = types.StringNull()
+	}
+	if ws.VCSConnectionName != "" {
+		m.VCSConnectionName = types.StringValue(ws.VCSConnectionName)
+	} else {
+		m.VCSConnectionName = types.StringNull()
+	}
 
 	// AI plan summary (#401). The server always returns a concrete
 	// value for `ai-summary-mode` (defaulting to "default"); the
@@ -660,6 +761,18 @@ func readWorkspaceIntoModel(ctx context.Context, ws *terrapod.Workspace, m *work
 		m.VarFiles = val
 	} else {
 		m.VarFiles = types.ListNull(types.StringType)
+	}
+
+	// Trigger prefixes — repo paths beyond `working_directory` that must
+	// land in the sparse-checkout fetch (typically because the workspace's
+	// terraform references siblings via `module ... { source = "../foo" }`
+	// — sparse cone mode includes parents but not siblings).
+	if len(ws.TriggerPrefixes) > 0 {
+		val, d := types.ListValueFrom(ctx, types.StringType, ws.TriggerPrefixes)
+		diags.Append(d...)
+		m.TriggerPrefixes = val
+	} else {
+		m.TriggerPrefixes = types.ListNull(types.StringType)
 	}
 
 	// Labels

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -335,18 +335,31 @@ async def _fetch_vcs_config(
     # is fine here — the in-process single-flight only matters when multiple
     # workspaces poll the same SHA concurrently.
     #
-    # No path narrowing — always fetch the whole repo. Sparse-checkout cone
-    # mode includes parent dirs of the cone but NOT siblings, so narrowing by
-    # `working_directory` silently drops sibling directories the terraform
-    # code references via relative module sources (`module "auth0" {
-    # source = "../auth0" }`). The narrowing saved a marginal amount of
-    # bandwidth on one-shot UI-triggered fetches and broke correctness on any
-    # multi-directory layout (#477 — sls-local errored every drift run with
-    # `Unable to evaluate directory symlink: lstat ../auth0`). The VCS-poll
-    # path keeps its narrowing because it shares the cached tarball across
-    # the cycle's workspaces; one-shot fetches don't benefit from that.
+    # Path narrowing: pass this workspace's own `working_directory ∪
+    # trigger_prefixes`. Cross-workspace coalescing isn't useful here
+    # (one request, one workspace), so we don't bother computing a wider
+    # union. If another caller fetched the same SHA with a different path
+    # set, that's a different cache entry — content-addressed by paths_hash.
+    #
+    # If the workspace's terraform crosses directory boundaries via relative
+    # module sources (`module "auth0" { source = "../auth0" }`), the operator
+    # MUST declare the referenced paths in `trigger_prefixes` — sparse-checkout
+    # cone mode includes parent directories but not siblings, so without an
+    # explicit prefix the runner would `lstat ../foo: no such file`. This
+    # contract is consistent with the VCS-poll path's `_compute_paths_unions`,
+    # so a workspace that works under VCS poll also works here. See #478 /
+    # #480 for the history (v0.35.3 briefly forced whole-repo here as a
+    # blanket fix; v0.35.4 reverted that and put the responsibility back on
+    # the workspace declaration).
+    fetch_paths: list[str] = []
+    if ws.working_directory:
+        fetch_paths.append(ws.working_directory.strip("/ "))
+    if ws.trigger_prefixes:
+        fetch_paths.extend(p.strip("/ ") for p in ws.trigger_prefixes if p)
+    fetch_paths = [p for p in fetch_paths if p]
+
     cache = VCSArchiveCache()
-    cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha, paths=None)
+    cache_storage_key = await cache.get_or_fetch(conn, owner, repo, sha, paths=fetch_paths or None)
 
     cv = await run_service.create_configuration_version(
         db, workspace_id=ws.id, source="vcs", auto_queue_runs=False

--- a/services/tests/test_api_sdk_contract.py
+++ b/services/tests/test_api_sdk_contract.py
@@ -1,0 +1,255 @@
+"""Source-introspection enforcement for the API ↔ SDK ↔ provider contract.
+
+The "Adding a new attribute → add to go-terrapod + provider in the same PR"
+rule in CLAUDE.md was historically guidance, not enforced. Twice in 24h we
+shipped server attributes that were never wired through (`trigger-prefixes`
+since PR #152, `drift-latest-run-id` in v0.35.3). #480 reconciles the
+workspace contract; this test exists so the next drift fails CI loudly the
+moment it's introduced rather than years later when an operator hits a
+missing field.
+
+The test is **source-introspection**, not behavioural: it reads
+`tfe_v2.py` to extract the API attribute keys emitted by
+`_workspace_json`, then reads `go-terrapod/workspaces.go` and the
+provider's workspace resource + datasource to extract their attribute
+sets, and asserts equivalence. No process is started; no HTTP is
+involved. The cost is a `Path.read_text()` per file and a regex pass.
+
+When this test fails, the message names the missing attribute(s) and
+points at the file the contributor needs to edit. The right fix is
+nearly always "extend the SDK/provider to surface the attribute", not
+"add the attribute to the allowlist below". The allowlist is reserved
+for attributes that are intentionally API-side-only (computed flags
+emitted for cloud-block compatibility, per-request permission blocks,
+nested relationships, UI-only health rollups).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Locate the API + SDK + provider source trees. The repo lays them out
+# under `services/`, `go-terrapod/`, `provider/`, but the Docker test
+# image flattens to `/app/terrapod`, `/app/go-terrapod`,
+# `/app/provider`. This helper tries each candidate path until it
+# finds a file that exists.
+_TESTS_DIR = Path(__file__).resolve().parent
+
+_API_TFE_V2 = next(
+    p
+    for p in (
+        _TESTS_DIR.parent.parent / "services/terrapod/api/routers/tfe_v2.py",  # local
+        _TESTS_DIR.parent / "terrapod/api/routers/tfe_v2.py",  # docker
+    )
+    if p.exists()
+)
+_SDK_WORKSPACES = next(
+    p
+    for p in (
+        _TESTS_DIR.parent.parent / "go-terrapod/workspaces.go",  # local
+        _TESTS_DIR.parent / "go-terrapod/workspaces.go",  # docker
+    )
+    if p.exists()
+)
+_PROVIDER_WS_MODEL = next(
+    p
+    for p in (
+        _TESTS_DIR.parent.parent / "provider/internal/resources/workspace/model.go",
+        _TESTS_DIR.parent / "provider/internal/resources/workspace/model.go",
+    )
+    if p.exists()
+)
+_PROVIDER_WS_DATASOURCE = next(
+    p
+    for p in (
+        _TESTS_DIR.parent.parent / "provider/internal/datasources/workspace/data_source.go",
+        _TESTS_DIR.parent / "provider/internal/datasources/workspace/data_source.go",
+    )
+    if p.exists()
+)
+
+# Attributes that appear in the API workspace serializer but are
+# intentionally NOT mirrored in the SDK Workspace struct or the
+# provider's workspace resource. Each entry should be documented so
+# future contributors don't need to re-discover why.
+WORKSPACE_API_ONLY: frozenset[str] = frozenset(
+    {
+        # Derived from `execution_mode` ("agent" → True). Cosmetic flag
+        # for the TFE cloud-backend handshake. Recomputable by clients.
+        "operations",
+        # Cloud-block tag compat — generated from `labels` to satisfy
+        # OpenTofu's `cloud { workspaces { tags = [...] } }` block. Not
+        # a user-settable attribute; the SDK gets it via `Labels`.
+        "tag-names",
+        # JSON object — per-request permission rollup computed from the
+        # caller's effective role on the workspace. Out of scope for a
+        # storage-shaped SDK struct.
+        "permissions",
+        # Per-request action gating; same rationale as `permissions`.
+        "actions",
+        # Per-request health rollup the UI consumes — derived from
+        # state-diverged / vcs-last-error / drift-status, all of which
+        # ARE in the SDK individually.
+        "health-conditions",
+        # Nested relationship-y object describing the most recent run;
+        # the SDK exposes runs as a separate concept rather than
+        # embedding them on Workspace.
+        "latest-run",
+    }
+)
+
+
+def _extract_workspace_api_attrs() -> set[str]:
+    """Return the set of attribute keys emitted by `_workspace_json`.
+
+    Parses `tfe_v2.py` source as text rather than importing it
+    (the importable module's `_workspace_json` builds a runtime dict,
+    not a static one — and source parsing is exactly the level of
+    coupling we want: this test fails when the literal source changes).
+    """
+    src = _API_TFE_V2.read_text()
+    # Locate `def _workspace_json(` and consume until the next top-level def.
+    m = re.search(r"^def _workspace_json\(.*?(?=^\ndef |^\nasync def )", src, re.M | re.S)
+    if m is None:
+        raise AssertionError("Could not locate `_workspace_json` in tfe_v2.py")
+    body = m.group(0)
+    # Pull the `"attributes": { ... }` block out so we don't pick up
+    # `relationships` keys or unrelated dict literals defined later in
+    # the function.
+    attrs_match = re.search(r'"attributes":\s*\{(.*?)\n\s+\}\s*,\s*"relationships"', body, re.S)
+    if attrs_match is None:
+        raise AssertionError("Could not locate attributes block inside _workspace_json")
+    attrs_block = attrs_match.group(1)
+    # Only top-level keys. The attributes block is indented 12 spaces
+    # (inside `"data": { ... "attributes": { ... } }`), so each direct
+    # key sits at 16 spaces. Nested dicts (permissions, actions) push
+    # their keys to 20 spaces and must be excluded — the contract test
+    # is about top-level attribute names, not per-permission sub-keys.
+    return set(re.findall(r'^ {16}"([a-z][a-z0-9-]+)":', attrs_block, re.M))
+
+
+def _extract_sdk_workspace_tags() -> set[str]:
+    """Return the set of `json:"..."` tags on the SDK's Workspace struct."""
+    src = _SDK_WORKSPACES.read_text()
+    # Slice out the Workspace struct body.
+    m = re.search(r"type Workspace struct \{(.*?)^\}", src, re.M | re.S)
+    if m is None:
+        raise AssertionError("Could not locate `type Workspace struct` in workspaces.go")
+    body = m.group(1)
+    # `json:"<key>,omitempty"` or just `json:"<key>"` — strip trailing
+    # ",omitempty" or whitespace.
+    return {tag.split(",", 1)[0] for tag in re.findall(r'json:"([a-z][a-z0-9-]+)', body)}
+
+
+def _extract_provider_workspace_tfsdk_tags(source_path: Path, type_name: str) -> set[str]:
+    """Return `tfsdk:"..."` tags from a provider Go struct."""
+    src = source_path.read_text()
+    m = re.search(rf"type {type_name} struct \{{(.*?)^\}}", src, re.M | re.S)
+    if m is None:
+        raise AssertionError(f"Could not locate `type {type_name} struct` in {source_path}")
+    body = m.group(1)
+    return set(re.findall(r'tfsdk:"([a-z][a-z0-9_]+)"', body))
+
+
+# Maps the provider's Terraform attribute names (underscored) to the
+# corresponding API attribute names (hyphenated). For drift detection
+# only — when the API has an attribute, both the SDK (json tag) AND
+# the provider's resource/datasource (tfsdk tag, with `_`→`-`) need to
+# expose it.
+def _provider_to_api(tfsdk_tag: str) -> str:
+    return tfsdk_tag.replace("_", "-")
+
+
+def _provider_attrs_as_api(tfsdk_tags: set[str]) -> set[str]:
+    return {_provider_to_api(t) for t in tfsdk_tags}
+
+
+class TestWorkspaceContract:
+    """Pin the Workspace attribute contract end-to-end."""
+
+    def test_api_attrs_present_in_sdk(self):
+        """Every API attribute must be in the SDK Workspace struct.
+
+        Failure means the API serializer emits an attribute the Go SDK
+        silently drops on read — exactly the failure mode that left
+        `trigger-prefixes` invisible to terraform-provider-terrapod for
+        years. To fix: add the field + json tag to `Workspace` struct
+        and the matching `GetXxxAttr(res, "<api-key>")` call in
+        `workspaceFromResource` in go-terrapod/workspaces.go.
+        """
+        api = _extract_workspace_api_attrs()
+        sdk = _extract_sdk_workspace_tags()
+        missing = api - sdk - WORKSPACE_API_ONLY
+        assert not missing, (
+            f"Workspace API attributes missing from go-terrapod SDK: {sorted(missing)}. "
+            "Either add them to `Workspace` + `workspaceFromResource` in "
+            "go-terrapod/workspaces.go, or — if intentional — extend "
+            "WORKSPACE_API_ONLY in this test with a comment explaining why."
+        )
+
+    def test_sdk_tags_present_in_api(self):
+        """Reverse direction: an SDK field with no API attribute is dead weight.
+
+        Allowlist is intentionally limited to internal-only fields like
+        ID (relationship type) and synthetic helper fields the SDK adds.
+        """
+        api = _extract_workspace_api_attrs()
+        sdk = _extract_sdk_workspace_tags()
+        sdk_only_ok = frozenset({"id"})  # `id` is the resource identifier, not an attribute
+        missing = sdk - api - sdk_only_ok
+        assert not missing, (
+            f"SDK Workspace fields with no matching API attribute: {sorted(missing)}. "
+            "Either the API stopped emitting them (delete from the SDK) or "
+            "they were never API attributes (review and add to the allowlist)."
+        )
+
+    def test_api_attrs_present_in_provider_resource(self):
+        """API attributes must be surfaced on terrapod_workspace resource."""
+        api = _extract_workspace_api_attrs()
+        provider_tfsdk = _extract_provider_workspace_tfsdk_tags(
+            _PROVIDER_WS_MODEL, "workspaceModel"
+        )
+        provider_api_form = _provider_attrs_as_api(provider_tfsdk)
+        # The provider resource doesn't surface tag-names / health
+        # conditions / permissions etc., same allowlist applies.
+        # `remote_state_consumers` is a provider-specific concept managed
+        # via a separate API endpoint, not part of the workspace body.
+        provider_only_ok = frozenset({"remote-state-consumers"})
+        missing = api - provider_api_form - WORKSPACE_API_ONLY
+        assert not missing - provider_only_ok, (
+            f"Workspace API attributes missing from terrapod_workspace resource: "
+            f"{sorted(missing - provider_only_ok)}. Add them to workspaceModel "
+            "+ schema.Attributes + readWorkspaceIntoModel in "
+            "provider/internal/resources/workspace/."
+        )
+
+    def test_api_attrs_present_in_provider_datasource(self):
+        """Same parity check for the data source — it should expose everything
+        the resource does so users can read state without managing it."""
+        api = _extract_workspace_api_attrs()
+        provider_tfsdk = _extract_provider_workspace_tfsdk_tags(
+            _PROVIDER_WS_DATASOURCE, "workspaceDataSourceModel"
+        )
+        provider_api_form = _provider_attrs_as_api(provider_tfsdk)
+        # Datasource intentionally omits a few writable-only / nested
+        # fields: `auto_merge_strategy` is paired with auto-merge but
+        # rarely consulted on read; ai-summary-mode/context are
+        # writable knobs documented in the resource.
+        ds_only_ok = frozenset(
+            {
+                "auto-merge",
+                "auto-merge-strategy",
+                "vcs-workflow",
+                "ai-summary-mode",
+                "ai-summary-context",
+                "resource-cpu",
+                "resource-memory",
+            }
+        )
+        missing = api - provider_api_form - WORKSPACE_API_ONLY - ds_only_ok
+        assert not missing, (
+            f"Workspace API attributes missing from terrapod_workspace data source: "
+            f"{sorted(missing)}. Add to workspaceDataSourceModel + Schema + "
+            "readDataSourceModel in provider/internal/datasources/workspace/."
+        )


### PR DESCRIPTION
## Why

v0.35.3's Fix B forced `_fetch_vcs_config` to always fetch the whole repo. You were right to push back: that trade burns bandwidth + CV storage + runner download time on every UI/manual fetch, and the existing `trigger_prefixes` knob is the proper per-workspace lever. Reverted, with an explicit contract comment in the code.

Reverting B exposed a deeper drift: `trigger_prefixes` has been a writable API attribute since #152 (PR 3a707aa) but was **never** exposed through go-terrapod or the Terraform provider. Same for `drift-latest-run-id` which I added in v0.35.3 yesterday. The API↔Consumer Contract in CLAUDE.md was guidance — not enforcement.

## What changed

### Code
- **`_fetch_vcs_config` reverted to narrowed paths.** Comment documents the contract: workspaces with `module \"foo\" { source = \"../foo\" }` MUST declare the target paths in `trigger_prefixes`.
- **go-terrapod `Workspace` struct** gains: `TriggerPrefixes` (writable), `DriftLatestRunID`, `StateDiverged`, `LifecycleState`, `LifecycleReason`, `VCSLastPolledAt`, `VCSLastError`, `VCSLastErrorAt`, `AgentPoolName`, `VCSConnectionName`. Create/Update payloads carry `TriggerPrefixes`; `workspaceFromResource` reads all the new fields.
- **Terraform provider `terrapod_workspace` resource**: `trigger_prefixes` (optional list), plus 9 read-only computed attributes mirroring the SDK additions.
- **Terraform provider `terrapod_workspace` data source**: same attributes as the resource so users can read state without managing.

### Forcing function

`services/tests/test_api_sdk_contract.py` is a **source-introspection test** that diffs:
1. API attribute keys emitted by `_workspace_json` in `tfe_v2.py`
2. `json:\"\"` tags on `Workspace` in `go-terrapod/workspaces.go`
3. `tfsdk:\"\"` tags on `workspaceModel` and `workspaceDataSourceModel`

If they drift, CI goes red with a message naming the missing attribute and the file to fix. Allowlist documents the intentionally-API-only fields (`operations`, `tag-names`, `permissions`, `actions`, `health-conditions`, `latest-run`).

`Dockerfile.test` now copies the go-terrapod + provider workspace source so the contract check runs in CI without a Go toolchain.

go-terrapod also gets two new tests:
- `TestWorkspaceFromResource_ContractParity` pins the read side.
- `TestWorkspaceCreate_TriggerPrefixes_Wire` pins the write side.

## Test plan

- [x] make test: 2054 pass (1997 unit/services-api + 57 integration)
- [x] go-terrapod tests pass including the new contract tests
- [x] provider build + go vet clean
- [x] ruff lint/format clean
- [ ] Local Tilt smoke after merge: queue a fresh run on a workspace with `trigger_prefixes` set, confirm sparse-checkout includes the declared sibling
- [ ] Wait for v0.35.4 mgmt rollout, then merge markupai/terrapod-config#38 (sls-local `trigger_prefixes = [\"terraform/auth0\"]`)

## Out of scope

The same audit is needed for Run, AgentPool, VCSConnection, Variable. Run is the biggest gap (~15 fields), but go-terrapod has no `Run` struct and the provider has no `terrapod_run` resource/data source — so it's a feature gap, not active drift. Queued for a follow-up if/when consumers need it.