### PR TITLE
feat(drift): per-workspace drift-ignore rules (#482)

### DIFF
--- a/alembic/versions/56599efa894a_workspace_drift_ignore_rules.py
+++ b/alembic/versions/56599efa894a_workspace_drift_ignore_rules.py
@@ -1,0 +1,39 @@
+"""Add workspaces.drift_ignore_rules.
+
+Per-workspace allowlist of resource-address-plus-attribute-path glob
+patterns that are excluded from drift classification (#482). Stored as
+a JSONB list of strings so the validation happens in Python and the
+database-side schema stays simple.
+
+Default `'[]'::jsonb` so existing workspaces inherit the prior
+behaviour (every plan change counts as drift). Setting this to a
+non-empty list takes effect on the next drift run via the classifier
+in `drift_ignore_classifier.py` — the column is read on the
+`handle_drift_run_completed` path; nothing materialises until then.
+
+Revision ID: 56599efa894a
+Revises: 204f61b07907
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "56599efa894a"
+down_revision = "204f61b07907"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "drift_ignore_rules",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "drift_ignore_rules")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -337,6 +337,7 @@ Workspaces support the following drift detection attributes (settable on create 
 |---|---|---|---|
 | `drift-detection-enabled` | boolean | `true` (VCS) / `false` (non-VCS) | Enable or disable automatic drift detection. Auto-enabled when a VCS connection is set |
 | `drift-detection-interval-seconds` | integer | `86400` | How often to run drift detection checks (minimum: 3600 seconds / 1 hour) |
+| `drift-ignore-rules` | list[string] | `[]` | Glob-aware patterns silenced by the drift-result classifier (#482). Each rule is a Terraform address optionally suffixed with a dotted attribute path; `*` matches zero or more non-`.` chars (spans `[N]` indices), `[*]` matches any bracketed index. A bare address with no attribute suffix silences any change to that resource — including destroys — so use carefully. Max 50 entries, ≤ 500 chars each. Examples: `aws_iam_role.foo.tags.Environment`, `aws_autoscaling_group.workers[*].desired_capacity`, `module.eks*.argocd_cluster.*.config.tls_client_config.ca_data`. Affects drift-detection runs only — regular plan/apply is untouched. See [drift-ignore-rules.md](drift-ignore-rules.md) for the full grammar and recipes |
 
 ### AI Plan Summary Attributes
 

--- a/docs/drift-detection.md
+++ b/docs/drift-detection.md
@@ -167,8 +167,15 @@ Drift detection uses the [distributed scheduler](architecture.md) — only one A
 
 ---
 
+## Suppressing Known-Noisy Attributes
+
+Some workspaces show persistent drift on attributes that change as a normal lifecycle event (provider-rotated serving certs, IAM trust-policy ordering) or that are deliberately co-managed by external systems (HPA-driven `replicas`, autoscaler-driven `desired_capacity`). Per-workspace **drift ignore rules** subtract those attributes from the drift signal without changing apply semantics. See [Drift Ignore Rules](drift-ignore-rules.md).
+
+---
+
 ## See Also
 
+- [Drift Ignore Rules](drift-ignore-rules.md) — suppress known-noisy attributes from the drift signal
 - [Notifications](notifications.md) — configure alerts for drift detection events
 - [Architecture](architecture.md) — scheduler and background task system
 - [API Reference](api-reference.md) — workspace API with drift detection fields

--- a/docs/drift-ignore-rules.md
+++ b/docs/drift-ignore-rules.md
@@ -93,8 +93,8 @@ Set via the API, the Terraform provider, or the workspace settings UI:
 ### Terraform provider
 
 ```hcl
-resource "terrapod_workspace" "tf_aws_core" {
-  name = "tf-aws-core-prod-eu1"
+resource "terrapod_workspace" "platform" {
+  name = "platform-prod"
   # …
   drift_ignore_rules = [
     "module.eks*.argocd_cluster.*.config.tls_client_config.ca_data",

--- a/docs/drift-ignore-rules.md
+++ b/docs/drift-ignore-rules.md
@@ -31,6 +31,13 @@ Each entry is a single string of the form:
 * `[*]` (inside literal brackets) matches any one bracketed index —
   `[0]`, `["foo"]`, `["bar/baz"]`. Use this when you want "any index"
   without accidentally matching surrounding text.
+* **Numeric block indices are optional.** HCL nested blocks serialize
+  as single-element lists in plan JSON, so an attribute path arrives
+  as `config[0].tls_client_config[0].ca_data`. Write the rule the way
+  it reads in HCL — `config.tls_client_config.ca_data` — and it
+  matches the indexed shape automatically. (String-key `for_each`
+  indices like `["prod"]` are NOT optional — they're semantically
+  meaningful, so a bare rule won't span every instance.)
 
 ## Examples
 

--- a/docs/drift-ignore-rules.md
+++ b/docs/drift-ignore-rules.md
@@ -1,0 +1,150 @@
+# Drift-ignore rules
+
+Per-workspace allowlist for the drift-detection classifier (#482). Lets
+you say "this attribute is co-managed elsewhere, don't count it as
+drift" without changing apply semantics (which is what HCL's
+`lifecycle { ignore_changes }` block does).
+
+Drift detection runs `tofu plan` against the workspace's current state
++ tracked branch and reports `has_changes=true` when anything differs.
+The classifier sits between that result and the workspace's
+`drift_status` field — if every changed attribute matches a rule in
+the workspace's `drift_ignore_rules`, the status drops to `no_drift`.
+
+The classifier is **drift-only**. It does not affect `tofu apply` —
+the next time someone runs an apply against an ignored attribute, it
+will change exactly as configured. The rules are a UX layer over the
+drift signal, not a replacement for `ignore_changes`.
+
+## Rule grammar
+
+Each entry is a single string of the form:
+
+```
+<terraform-address>[.<attribute-path>]
+```
+
+* `*` matches **zero or more** characters that are NOT `.`. It can span
+  across `[N]` index suffixes (so `module.eks*` matches both
+  `module.eks` and `module.eks_legacy[0]`) but it never crosses a
+  segment boundary into the next module/resource label.
+* `[*]` (inside literal brackets) matches any one bracketed index —
+  `[0]`, `["foo"]`, `["bar/baz"]`. Use this when you want "any index"
+  without accidentally matching surrounding text.
+
+## Examples
+
+```jsonc
+"drift-ignore-rules": [
+  // Co-managed by external automation
+  "aws_autoscaling_group.workers[*].desired_capacity",
+  "kubernetes_deployment.*.spec[0].replicas",
+
+  // Provider-managed churn we've decided to live with
+  "aws_iam_role_policy_attachment.eks_cluster_policy.policy_arn",
+  "module.eks*.argocd_cluster.*.config.tls_client_config.ca_data",
+
+  // Whole-resource ignore — silences any change to this resource,
+  // including destroys. Use for resources you intentionally let
+  // someone else fully own.
+  "aws_iam_role.externally_managed"
+]
+```
+
+## What gets suppressed vs reported
+
+For each `resource_change` in the drift run's plan:
+
+1. The classifier walks `before` vs `after` and enumerates the
+   attribute paths that actually differ.
+2. For each diff path, it builds `<address>.<path>` and tests it
+   against every compiled rule.
+3. If **every** diff path matches some rule, the whole resource_change
+   is suppressed.
+4. If **any** diff path doesn't match, the resource still counts as
+   drift — partial suppression is intentional. You'll see in the
+   workspace's drift run logs which paths got silenced and which
+   didn't.
+
+After all resource_changes are classified:
+
+* Every resource suppressed → `drift_status = "no_drift"`.
+* Anything still counts → `drift_status = "drifted"` (badge surfaces
+  only the un-ignored changes).
+
+## Safety: per-attribute rules cannot silence destroys
+
+A rule like `kubernetes_deployment.api.spec[0].replicas` will **not**
+silence a `delete` action against `kubernetes_deployment.api`. The
+classifier only allows whole-resource lifecycle changes (create,
+delete, replace) to be silenced by a **bare-address** rule with no
+attribute suffix. The reasoning: a per-attribute ignore probably
+exists because the operator wants `replicas` left alone, not because
+they want to be quiet about their workload disappearing.
+
+If you genuinely want to silence the delete (e.g. an autodiscovery-
+managed resource you've decided you don't care about), use the bare
+address: `kubernetes_deployment.api`.
+
+## Configuration
+
+Set via the API, the Terraform provider, or the workspace settings UI:
+
+### Terraform provider
+
+```hcl
+resource "terrapod_workspace" "tf_aws_core" {
+  name = "tf-aws-core-prod-eu1"
+  # …
+  drift_ignore_rules = [
+    "module.eks*.argocd_cluster.*.config.tls_client_config.ca_data",
+    "module.eks_legacy*.argocd_cluster.*.config.tls_client_config.ca_data",
+  ]
+}
+```
+
+### API (PATCH)
+
+```bash
+curl -X PATCH "https://<host>/api/v2/workspaces/<id>" \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/vnd.api+json" \
+  -d '{
+    "data": {
+      "type": "workspaces",
+      "attributes": {
+        "drift-ignore-rules": [
+          "module.eks*.argocd_cluster.*.config.tls_client_config.ca_data"
+        ]
+      }
+    }
+  }'
+```
+
+## Limits
+
+| Limit | Value |
+|---|---|
+| Maximum rules per workspace | 50 |
+| Maximum characters per rule | 500 |
+| Allowed characters | `A-Z`, `a-z`, `0-9`, `_`, `-`, `.`, `[`, `]`, `*`, `"` |
+
+The character allow-list is intentionally narrow so a stray space,
+backtick, or shell-quote artefact can't reach the classifier and
+crash the regex compiler.
+
+## Audit + observability
+
+Every drift run that suppressed at least one change emits an `info`
+log line on the API pod naming the run, the rules in effect, and the
+suppressed `(address, paths)` tuples. Useful for:
+
+* Confirming a new rule is matching what you expect after deploying
+  it.
+* Spotting "creeping suppression" — rules that started life as a
+  one-off workaround and ended up silencing more than intended.
+* Telling future-you why a workspace stopped flagging drift.
+
+The drift run's plan output still contains the full diff — the
+classifier does not redact the underlying plan JSON. The
+`drift_status` flip is purely cosmetic; the audit trail is intact.

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [VCS Workflows](vcs-workflows.md) | merge_then_apply (default) vs apply_then_merge (Atlantis-style, opt-in) |
 | [Autodiscovery](autodiscovery.md) | Atlantis-style monorepo workspace autodiscovery |
 | [Drift Detection](drift-detection.md) | Scheduled plan-only runs to detect infrastructure drift |
+| [Drift Ignore Rules](drift-ignore-rules.md) | Per-workspace allowlist that suppresses known-noisy attributes from the drift signal (e.g. provider-rotated certs, externally co-managed replicas) |
 | [Run Triggers](run-triggers.md) | Cross-workspace dependency chains |
 | [Remote State](remote-state.md) | Cross-workspace `terraform_remote_state` composition with producer-controlled allowlist |
 | [AI Plan Summary](ai-plan-summary.md) | LLM-generated change summary + risk assessment on every plan; failure analysis on errored plans. Bedrock, OpenAI, Anthropic, Gemini, vLLM — any provider via LiteLLM |

--- a/e2e/tests/workspaces.spec.ts
+++ b/e2e/tests/workspaces.spec.ts
@@ -74,9 +74,17 @@ test.describe('Workspaces', () => {
 
     // Wait for save to complete (Edit button re-appears)
     await expect(page.locator('button:has-text("Edit")')).toBeVisible({ timeout: 10_000 });
+
+    // Reload and verify the toggle changed
+    await page.reload();
+
+    // Click Edit again to check the value
+    await page.click('button:has-text("Edit")');
+    const isAfter = await page.locator('input[type="checkbox"]').first().isChecked();
+    expect(isAfter).not.toBe(wasBefore);
   });
 
-  test('drift-ignore-rules editor adds, persists, and removes a rule', async ({ page, request }) => {
+  test('drift-ignore-rules editor adds, persists, and removes a rule', async ({ page }) => {
     // #482 — verify the workspace settings drift-ignore-rules editor
     // round-trips through the API. Failure cases the spec catches:
     //   - rule not added to the array on Enter / "Add" click
@@ -126,13 +134,5 @@ test.describe('Workspaces', () => {
     await expect(page.locator('button:has-text("Edit")')).toBeVisible({ timeout: 10_000 });
     await page.reload();
     await expect(page.locator(`code:has-text("${rule}")`)).not.toBeVisible();
-
-    // Reload and verify the toggle changed
-    await page.reload();
-
-    // Click Edit again to check the value
-    await page.click('button:has-text("Edit")');
-    const isAfter = await page.locator('input[type="checkbox"]').first().isChecked();
-    expect(isAfter).not.toBe(wasBefore);
   });
 });

--- a/e2e/tests/workspaces.spec.ts
+++ b/e2e/tests/workspaces.spec.ts
@@ -74,6 +74,58 @@ test.describe('Workspaces', () => {
 
     // Wait for save to complete (Edit button re-appears)
     await expect(page.locator('button:has-text("Edit")')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('drift-ignore-rules editor adds, persists, and removes a rule', async ({ page, request }) => {
+    // #482 — verify the workspace settings drift-ignore-rules editor
+    // round-trips through the API. Failure cases the spec catches:
+    //   - rule not added to the array on Enter / "Add" click
+    //   - PATCH body missing the `drift-ignore-rules` attribute
+    //   - re-rendered list doesn't reflect the saved value
+    //   - Remove button doesn't drop the rule from state or PATCH
+    const wsName = `e2e-drift-ignore-${Date.now()}`;
+    const rule = 'module.eks*.argocd_cluster.*.config.tls_client_config.ca_data';
+
+    await page.goto('/workspaces');
+    await page.click('button:has-text("New Workspace")');
+    await page.fill('input[placeholder*="workspace"]', wsName);
+    await page.click('button:has-text("Create Workspace")');
+    await page.click(`text=${wsName}`);
+
+    // Enter edit mode and add a rule via the Add button (covers both
+    // the keydown handler and the click handler — Add reads the same
+    // state, so a working click implies the typed input was captured).
+    await page.click('button:has-text("Edit")');
+    const ruleInput = page.locator('input[placeholder*="argocd_cluster"]');
+    await expect(ruleInput).toBeVisible();
+    await ruleInput.fill(rule);
+    // Two Add buttons exist (trigger-prefixes + drift-ignore-rules) —
+    // scope to the one inside the drift-ignore row.
+    const driftAddRow = page.locator('input[placeholder*="argocd_cluster"]').locator('..');
+    await driftAddRow.locator('button:has-text("Add")').click();
+
+    // The pill should render with the rule text.
+    await expect(page.locator(`code:has-text("${rule}")`)).toBeVisible();
+
+    // Save.
+    await page.click('button:has-text("Save")');
+    await expect(page.locator('button:has-text("Edit")')).toBeVisible({ timeout: 10_000 });
+
+    // Reload and confirm the value persisted server-side (the
+    // settings round-trip is the part that broke for trigger_prefixes
+    // in v0.35.x — this guards us against the same bug landing here).
+    await page.reload();
+    await expect(page.locator(`code:has-text("${rule}")`)).toBeVisible();
+
+    // Remove the rule via Edit → Remove → Save, and confirm it's
+    // gone after reload.
+    await page.click('button:has-text("Edit")');
+    const removeBtn = page.locator(`code:has-text("${rule}")`).locator('..').locator('button:has-text("Remove")');
+    await removeBtn.click();
+    await page.click('button:has-text("Save")');
+    await expect(page.locator('button:has-text("Edit")')).toBeVisible({ timeout: 10_000 });
+    await page.reload();
+    await expect(page.locator(`code:has-text("${rule}")`)).not.toBeVisible();
 
     // Reload and verify the toggle changed
     await page.reload();

--- a/go-terrapod/workspaces.go
+++ b/go-terrapod/workspaces.go
@@ -42,6 +42,11 @@ type Workspace struct {
 	Labels                        map[string]string `json:"labels,omitempty"`
 	VarFiles                      []string          `json:"var-files,omitempty"`
 	TriggerPrefixes               []string          `json:"trigger-prefixes,omitempty"`
+	// DriftIgnoreRules is a list of resource-address-plus-attribute-path
+	// glob patterns suppressed by the drift-result classifier (#482).
+	// Empty list (default) means classic behaviour: every plan diff
+	// counts as drift. See docs/api-reference.md for the rule grammar.
+	DriftIgnoreRules              []string          `json:"drift-ignore-rules,omitempty"`
 	DriftDetectionEnabled         bool              `json:"drift-detection-enabled"`
 	DriftDetectionIntervalSeconds *int64            `json:"drift-detection-interval-seconds,omitempty"`
 	DriftStatus                   string            `json:"drift-status,omitempty"`
@@ -114,6 +119,7 @@ type CreateWorkspaceRequest struct {
 	Labels                        map[string]string  `json:"labels,omitempty"`
 	VarFiles                      []string           `json:"var-files,omitempty"`
 	TriggerPrefixes               []string           `json:"trigger-prefixes,omitempty"`
+	DriftIgnoreRules              []string           `json:"drift-ignore-rules,omitempty"`
 	DriftDetectionEnabled         *bool              `json:"drift-detection-enabled,omitempty"`
 	DriftDetectionIntervalSeconds *int64             `json:"drift-detection-interval-seconds,omitempty"`
 	// AISummaryMode is the three-state per-workspace override (#401):
@@ -153,6 +159,7 @@ type UpdateWorkspaceRequest struct {
 	Labels                        map[string]string `json:"labels,omitempty"`
 	VarFiles                      []string          `json:"var-files,omitempty"`
 	TriggerPrefixes               []string          `json:"trigger-prefixes,omitempty"`
+	DriftIgnoreRules              []string          `json:"drift-ignore-rules,omitempty"`
 	DriftDetectionEnabled         *bool             `json:"drift-detection-enabled,omitempty"`
 	DriftDetectionIntervalSeconds *int64            `json:"drift-detection-interval-seconds,omitempty"`
 	// AISummaryMode see CreateWorkspaceRequest. On UPDATE, empty string
@@ -361,6 +368,9 @@ func workspaceCreateAttrs(req CreateWorkspaceRequest) map[string]any {
 	if req.TriggerPrefixes != nil {
 		attrs["trigger-prefixes"] = req.TriggerPrefixes
 	}
+	if req.DriftIgnoreRules != nil {
+		attrs["drift-ignore-rules"] = req.DriftIgnoreRules
+	}
 	if req.DriftDetectionEnabled != nil {
 		attrs["drift-detection-enabled"] = *req.DriftDetectionEnabled
 	}
@@ -434,6 +444,9 @@ func workspaceUpdateAttrs(req UpdateWorkspaceRequest) map[string]any {
 	if req.TriggerPrefixes != nil {
 		attrs["trigger-prefixes"] = req.TriggerPrefixes
 	}
+	if req.DriftIgnoreRules != nil {
+		attrs["drift-ignore-rules"] = req.DriftIgnoreRules
+	}
 	if req.DriftDetectionEnabled != nil {
 		attrs["drift-detection-enabled"] = *req.DriftDetectionEnabled
 	}
@@ -502,6 +515,7 @@ func workspaceFromResource(res *Resource) *Workspace {
 		Labels:                GetMapAttr(res, "labels"),
 		VarFiles:              GetListAttr(res, "var-files"),
 		TriggerPrefixes:       GetListAttr(res, "trigger-prefixes"),
+		DriftIgnoreRules:      GetListAttr(res, "drift-ignore-rules"),
 		DriftDetectionEnabled: GetBoolAttr(res, "drift-detection-enabled"),
 		DriftStatus:           GetStringAttr(res, "drift-status"),
 		DriftLastCheckedAt:    GetStringAttr(res, "drift-last-checked-at"),

--- a/provider/internal/datasources/workspace/data_source.go
+++ b/provider/internal/datasources/workspace/data_source.go
@@ -41,6 +41,7 @@ type workspaceDataSourceModel struct {
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
 	VarFiles                      types.List   `tfsdk:"var_files"`
 	TriggerPrefixes               types.List   `tfsdk:"trigger_prefixes"`
+	DriftIgnoreRules              types.List   `tfsdk:"drift_ignore_rules"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`
 	DriftDetectionIntervalSeconds types.Int64  `tfsdk:"drift_detection_interval_seconds"`
 	AISummaryMode                 types.String `tfsdk:"ai_summary_mode"`
@@ -91,6 +92,7 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"agent_pool_id":                    computedString("Agent pool ID."),
 			"var_files":                        computedList("Var files for -var-file arguments."),
 			"trigger_prefixes":                 computedList("Repo-root-relative paths the VCS sparse-checkout must include in addition to working_directory (e.g. sibling modules referenced via `source = \"../foo\"`)."),
+			"drift_ignore_rules":               computedList("Glob-aware patterns suppressed by the drift-result classifier (#482). See the resource attribute docs for syntax."),
 			"drift_detection_enabled":          computedBool("Drift detection enabled."),
 			"drift_detection_interval_seconds": computedInt64("Drift detection interval."),
 			"ai_summary_mode":                  computedString("Per-workspace AI plan-summary mode: 'default' (follow deployment global), 'enabled' (always summarise), or 'disabled' (never summarise)."),
@@ -220,6 +222,14 @@ func readDataSourceModel(ctx context.Context, res *terrapod.Resource, m *workspa
 		m.TriggerPrefixes = val
 	} else {
 		m.TriggerPrefixes = types.ListNull(types.StringType)
+	}
+
+	if rules := terrapod.GetListAttr(res, "drift-ignore-rules"); len(rules) > 0 {
+		val, d := types.ListValueFrom(ctx, types.StringType, rules)
+		diags.Append(d...)
+		m.DriftIgnoreRules = val
+	} else {
+		m.DriftIgnoreRules = types.ListNull(types.StringType)
 	}
 
 	if labels := terrapod.GetMapAttr(res, "labels"); len(labels) > 0 {

--- a/provider/internal/resources/workspace/model.go
+++ b/provider/internal/resources/workspace/model.go
@@ -73,6 +73,7 @@ type workspaceModel struct {
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
 	VarFiles                      types.List   `tfsdk:"var_files"`
 	TriggerPrefixes               types.List   `tfsdk:"trigger_prefixes"`
+	DriftIgnoreRules              types.List   `tfsdk:"drift_ignore_rules"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`
 	DriftDetectionIntervalSeconds types.Int64  `tfsdk:"drift_detection_interval_seconds"`
 	AISummaryMode                 types.String `tfsdk:"ai_summary_mode"`

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -165,6 +165,11 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				ElementType: types.StringType,
 			},
+			"drift_ignore_rules": schema.ListAttribute{
+				Description: "Glob-aware patterns suppressed by the drift-result classifier (#482). Each entry is a Terraform resource address optionally suffixed with a dotted attribute path; `*` matches zero or more non-`.` characters (so it can span `[N]` indices but not segment boundaries), and `[*]` matches any bracketed index. A bare address with no attribute suffix silences any change to that resource — including destroys — so use carefully. Examples: `aws_iam_role.foo.tags.Environment`, `aws_autoscaling_group.workers[*].desired_capacity`, `module.eks*.argocd_cluster.*.config.tls_client_config.ca_data`, `aws_iam_role.foo`. Empty list (the default) means classic drift behaviour: every plan diff counts. Affects drift-detection runs only — regular plan/apply is untouched.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 			"drift_detection_enabled": schema.BoolAttribute{
 				Description: "Enable drift detection for this workspace. Defaults to true for VCS-connected workspaces, false otherwise.",
 				Optional:    true,
@@ -549,6 +554,13 @@ func buildCreateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 		}
 		req.TriggerPrefixes = triggerPrefixes
 	}
+	if !m.DriftIgnoreRules.IsNull() && !m.DriftIgnoreRules.IsUnknown() {
+		rules := []string{}
+		for _, v := range m.DriftIgnoreRules.Elements() {
+			rules = append(rules, v.(types.String).ValueString())
+		}
+		req.DriftIgnoreRules = rules
+	}
 	if !m.DriftDetectionEnabled.IsNull() && !m.DriftDetectionEnabled.IsUnknown() {
 		v := m.DriftDetectionEnabled.ValueBool()
 		req.DriftDetectionEnabled = &v
@@ -642,6 +654,13 @@ func buildUpdateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 			triggerPrefixes = append(triggerPrefixes, v.(types.String).ValueString())
 		}
 		req.TriggerPrefixes = triggerPrefixes
+	}
+	if !m.DriftIgnoreRules.IsNull() && !m.DriftIgnoreRules.IsUnknown() {
+		rules := []string{}
+		for _, v := range m.DriftIgnoreRules.Elements() {
+			rules = append(rules, v.(types.String).ValueString())
+		}
+		req.DriftIgnoreRules = rules
 	}
 	if !m.DriftDetectionEnabled.IsNull() && !m.DriftDetectionEnabled.IsUnknown() {
 		v := m.DriftDetectionEnabled.ValueBool()
@@ -822,6 +841,17 @@ func readWorkspaceIntoModel(ctx context.Context, ws *terrapod.Workspace, m *work
 		tpVal, tpDiag := types.ListValueFrom(ctx, types.StringType, ws.TriggerPrefixes)
 		diags.Append(tpDiag...)
 		m.TriggerPrefixes = tpVal
+	}
+
+	// Drift-ignore rules (#482) — same null-vs-empty preservation rule
+	// as trigger_prefixes. Server default `[]` is preserved as null in
+	// state when the caller didn't declare the attribute.
+	if m.DriftIgnoreRules.IsNull() && len(ws.DriftIgnoreRules) == 0 {
+		m.DriftIgnoreRules = types.ListNull(types.StringType)
+	} else {
+		dirVal, dirDiag := types.ListValueFrom(ctx, types.StringType, ws.DriftIgnoreRules)
+		diags.Append(dirDiag...)
+		m.DriftIgnoreRules = dirVal
 	}
 
 	// Labels — same null-vs-empty-map rule as trigger_prefixes above.

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -180,6 +180,55 @@ def _validate_trigger_prefixes(raw: object) -> list[str]:
     return result
 
 
+_DRIFT_IGNORE_RULE_RE = re.compile(r"^[A-Za-z0-9_*.\-\[\]\"]+$")
+
+
+def _validate_drift_ignore_rules(raw: object) -> list[str]:
+    """Validate `drift-ignore-rules` input (#482).
+
+    Each entry is a glob-aware Terraform-address-plus-attribute-path
+    string consumed by `drift_ignore_classifier.classify_drift`. The
+    character set is intentionally narrow — letters, digits, the
+    delimiters `.` `[` `]` `*`, plus underscore, hyphen, double quote
+    (for `for_each` keys). Anything else is rejected so a stray space
+    or backtick can't sneak through and cause a regex-compile failure
+    later in the drift-classifier path. Max 50 entries; max 500 chars
+    per entry (loose enough for `module.x.module.y.aws_iam_policy.z
+    .statements[*].conditions[*].values[*]`-style paths without
+    risking unbounded growth).
+    """
+    if not isinstance(raw, list):
+        raise HTTPException(status_code=422, detail="drift-ignore-rules must be a list of strings")
+    if len(raw) > 50:
+        raise HTTPException(status_code=422, detail="drift-ignore-rules: maximum 50 entries")
+    result: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            raise HTTPException(
+                status_code=422, detail="drift-ignore-rules entries must be strings"
+            )
+        v = entry.strip()
+        if not v:
+            raise HTTPException(
+                status_code=422, detail="drift-ignore-rules entries must be non-empty"
+            )
+        if len(v) > 500:
+            raise HTTPException(
+                status_code=422,
+                detail="drift-ignore-rules entries must be ≤ 500 characters",
+            )
+        if not _DRIFT_IGNORE_RULE_RE.match(v):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "drift-ignore-rules entries may only contain letters, digits, "
+                    "underscores, hyphens, dots, brackets, asterisks, and double quotes"
+                ),
+            )
+        result.append(v)
+    return result
+
+
 _WORKSPACE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 
 
@@ -605,6 +654,7 @@ def _workspace_json(
                 else None,
                 "var-files": ws.var_files or [],
                 "trigger-prefixes": ws.trigger_prefixes or [],
+                "drift-ignore-rules": ws.drift_ignore_rules or [],
                 "ai-summary-mode": ws.ai_summary_mode,
                 "ai-summary-context": ws.ai_summary_context,
                 "drift-detection-enabled": ws.drift_detection_enabled,
@@ -909,6 +959,7 @@ async def create_workspace(
         vcs_branch=attrs.get("vcs-branch", ""),
         var_files=_validate_var_files(attrs.get("var-files", [])),
         trigger_prefixes=_validate_trigger_prefixes(attrs.get("trigger-prefixes", [])),
+        drift_ignore_rules=_validate_drift_ignore_rules(attrs.get("drift-ignore-rules", [])),
         drift_detection_enabled=attrs.get(
             "drift-detection-enabled",
             True if vcs_connection_id else False,
@@ -1368,6 +1419,8 @@ async def update_workspace(
         ws.var_files = _validate_var_files(attrs["var-files"])
     if "trigger-prefixes" in attrs:
         ws.trigger_prefixes = _validate_trigger_prefixes(attrs["trigger-prefixes"])
+    if "drift-ignore-rules" in attrs:
+        ws.drift_ignore_rules = _validate_drift_ignore_rules(attrs["drift-ignore-rules"])
     if "agent-pool-id" in attrs:
         import uuid as _uuid
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -348,6 +348,18 @@ class Workspace(Base):
     # that to break workspace deletion via cascade. The UI handles a 404 on the
     # click-through gracefully.
     drift_latest_run_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # Per-workspace allowlist of resource-address + attribute-path glob
+    # patterns (#482). When a drift run reports `has_changes=True`, every
+    # changed attribute is matched against this list before drift_status
+    # is computed. If every change matches a rule → drift_status=no_drift.
+    # Empty list (default) means classic behaviour: every change counts
+    # as drift. Examples:
+    #   "aws_iam_role.foo.tags.Environment"   (single attr on one resource)
+    #   "module.eks*.argocd_cluster.*.config.tls_client_config.ca_data"
+    #   "aws_autoscaling_group.workers[*]"   (any change to any workers[i])
+    drift_ignore_rules: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default="[]", default=list
+    )
 
     # State divergence — set when an apply Job succeeds but state upload fails
     state_diverged: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")

--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -89,6 +89,84 @@ async def _has_state(db: AsyncSession, workspace_id: uuid.UUID) -> bool:
     return result.scalar_one() > 0
 
 
+async def _apply_drift_ignore_rules(run: Run, rules: list[str]) -> str:
+    """Run a drift-detection plan through `drift_ignore_classifier` (#482).
+
+    Fetches the plan JSON from storage, feeds it through the classifier
+    along with the workspace's rules, and returns the resulting drift
+    status — `"no_drift"` when every change is suppressed, `"drifted"`
+    otherwise. Any failure path (missing object, malformed JSON,
+    classifier crash) is logged and conservatively falls back to
+    `"drifted"` so a runtime hiccup never *silences* drift the
+    operator intended to surface.
+    """
+    import json
+
+    from terrapod.services.drift_ignore_classifier import classify_drift
+    from terrapod.storage import get_storage
+    from terrapod.storage.keys import plan_json_output_key
+    from terrapod.storage.protocol import ObjectNotFoundError
+
+    storage = get_storage()
+    key = plan_json_output_key(str(run.workspace_id), str(run.id))
+    try:
+        raw = await storage.get(key)
+    except ObjectNotFoundError:
+        logger.warning(
+            "drift_ignore: plan JSON missing; treating as drift",
+            run_id=str(run.id),
+            key=key,
+        )
+        return "drifted"
+    except Exception as e:
+        logger.warning(
+            "drift_ignore: storage error; treating as drift",
+            run_id=str(run.id),
+            error=str(e),
+        )
+        return "drifted"
+
+    try:
+        plan = json.loads(raw)
+    except (ValueError, TypeError) as e:
+        logger.warning(
+            "drift_ignore: plan JSON unparseable; treating as drift",
+            run_id=str(run.id),
+            error=str(e),
+        )
+        return "drifted"
+
+    try:
+        still_drifted, suppressed = classify_drift(plan, rules)
+    except Exception as e:
+        logger.warning(
+            "drift_ignore: classifier crashed; treating as drift",
+            run_id=str(run.id),
+            error=str(e),
+            exc_info=True,
+        )
+        return "drifted"
+
+    if not still_drifted and suppressed:
+        # Surface what we silenced so operators can audit the rule set
+        # against the run it just classified.
+        logger.info(
+            "drift_ignore: all changes suppressed by rules",
+            run_id=str(run.id),
+            suppressed=suppressed,
+            rules=rules,
+        )
+        return "no_drift"
+    if suppressed:
+        logger.info(
+            "drift_ignore: partial suppression — drift still flagged",
+            run_id=str(run.id),
+            suppressed=suppressed,
+            rules=rules,
+        )
+    return "drifted"
+
+
 async def _create_drift_run_vcs(
     db: AsyncSession,
     ws: Workspace,
@@ -352,7 +430,20 @@ async def handle_drift_run_completed(payload: dict) -> None:
         # Map run outcome to drift status
         if run.status == "planned":
             if run.has_changes is True:
-                ws.drift_status = "drifted"
+                # If the workspace has `drift_ignore_rules` configured (#482),
+                # filter the plan JSON before declaring drift. Every changed
+                # attribute is matched against the rule globs; if all
+                # match, the drift is suppressed and the status flips to
+                # no_drift. Empty rules → fall through to the historical
+                # "any change is drift" behaviour. Plan JSON has to be
+                # actually available (has_json_output=True) — runs that
+                # errored mid-upload are conservatively treated as drift.
+                if ws.drift_ignore_rules and run.has_json_output:
+                    ws.drift_status = await _apply_drift_ignore_rules(
+                        run, list(ws.drift_ignore_rules)
+                    )
+                else:
+                    ws.drift_status = "drifted"
             elif run.has_changes is False:
                 ws.drift_status = "no_drift"
             else:

--- a/services/terrapod/services/drift_ignore_classifier.py
+++ b/services/terrapod/services/drift_ignore_classifier.py
@@ -1,0 +1,345 @@
+"""Drift-result classifier for per-workspace ignore rules (#482).
+
+A drift run reports `has_changes=True` when `tofu plan` produced any
+non-empty diff. Historically that flips `drift_status` to `drifted`
+directly. Some workspaces have legitimate persistent noise — managed
+policy versions, IAM trust-policy ordering, attributes co-managed by
+external systems (HPA-driven `replicas`, autoscaler-driven
+`desired_capacity`). The HCL-level `lifecycle { ignore_changes }`
+workaround changes apply semantics globally, not just drift.
+
+`drift_ignore_rules` on a workspace lets the operator silence those
+attributes for drift purposes only. This module turns a list of rule
+strings + a plan JSON document into a "should this still count as
+drift?" decision.
+
+Rule grammar
+============
+
+Each rule is a single string of the form::
+
+    <terraform-address>[.<attribute-path>]
+
+`*` matches one segment (non-empty, non-`.`, non-`[`/`]`). `[*]`
+matches any bracketed index — `[0]`, `["foo"]`, `[\"bar\"]`. The
+resource address and attribute path live in one dotted/bracketed
+namespace so callers don't have to know where the address ends and
+the attribute begins; the matcher just regex-tests against
+``address + "." + attribute_path``.
+
+Examples::
+
+    aws_iam_role.foo.tags.Environment
+    aws_autoscaling_group.workers[*].desired_capacity
+    module.eks*.argocd_cluster.*.config.tls_client_config.ca_data
+    aws_iam_role.foo              # any change → whole resource ignored
+
+Match semantics
+===============
+
+For each `resource_change` in the plan JSON:
+
+1. Compute the set of attribute paths whose value differs between
+   `before` and `after` (recursive walk; lists indexed by `[i]`,
+   dicts joined by `.`).
+2. Build a candidate string for each diff path as
+   ``<address>.<path>``. The address alone (no `.path` suffix) is
+   also a candidate for the "whole resource" rule shape.
+3. If every diff path matches at least one rule, drop the
+   resource_change. Otherwise the resource is still considered
+   drifted.
+4. Resources whose `change.actions` is `["no-op"]` or `["read"]` are
+   never considered drift to begin with.
+
+If every resource_change is dropped → drift was fully ignored;
+caller sets `drift_status=no_drift`. Otherwise → `drifted`.
+
+The classifier is deliberately stateless and pure: caller is
+responsible for fetching the plan JSON (typically via the
+`run_artifacts` storage helper) and persisting the resulting
+`drift_status` change.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from terrapod.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Rule shape limits — applied at validation time, not here. The
+# classifier trusts that its caller already enforced
+# `validate_drift_ignore_rules` (in `tfe_v2.py`).
+
+# Actions that constitute "actual" drift. `no-op` is plan's way of
+# saying "no change at all" (it shouldn't appear in a has_changes
+# plan, but be defensive). `read` is a data-source refresh, never
+# drift.
+_DRIFT_ACTIONS = frozenset({"create", "update", "delete", "replace"})
+
+
+def _rule_to_regex(rule: str) -> re.Pattern[str]:
+    """Translate a glob rule into a compiled regex.
+
+    Rules look like dotted/bracketed Terraform addresses extended with
+    attribute paths. We anchor with `^…$` so a rule
+    `aws_iam_role.foo` does not silently match `aws_iam_role.foo.tags`
+    — the latter is a strict superset and the caller has to opt in by
+    extending the rule. The reverse — bare address matches "any change
+    to this resource" — is handled at the match site (see
+    `_path_is_ignored`), not by the regex.
+
+    Glob semantics:
+
+    * `*` matches zero or more characters that are NOT `.` — so a
+      single `*` can span across `[N]` index suffixes (the common
+      case where `module.eks*` should match both `module.eks` and
+      `module.eks_legacy[0]`) but cannot leak across a segment
+      boundary into the next module/resource label.
+    * `[*]` (inside literal brackets) is a special compound that
+      matches any bracketed index expression — `[0]`, `["foo"]`,
+      `["bar/baz"]`. This is the safe way to say "any one index"
+      without accidentally matching surrounding text.
+
+    `fnmatch.translate` would over-match: it treats `.` as a literal
+    but accepts `*` as `.*` (cross-segment). The hand-rolled
+    translation here is short enough to keep in source.
+    """
+    out: list[str] = ["^"]
+    i = 0
+    while i < len(rule):
+        c = rule[i]
+        if c == "*":
+            # `[*]` is a special compound — matches any single bracketed
+            # index expression. Handle it before the bare `*` case.
+            if i > 0 and rule[i - 1] == "[" and i + 1 < len(rule) and rule[i + 1] == "]":
+                # Already inside brackets. Emit a permissive
+                # bracketed-content matcher and let the `]` literal be
+                # emitted naturally on the next iteration. The leading
+                # `[` was emitted as `\[` already.
+                out.append(r"[^\]]+")
+                i += 1
+                continue
+            # Bare `*` — zero or more characters that aren't `.`.
+            # Matches across `[N]` index suffixes but never crosses a
+            # segment boundary.
+            out.append(r"[^.]*")
+        elif c in ".[]":
+            out.append(re.escape(c))
+        else:
+            out.append(re.escape(c))
+        i += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+def _compile_rules(rules: Iterable[str]) -> list[tuple[str, re.Pattern[str]]]:
+    """Compile rule strings into `(rule, regex)` pairs.
+
+    Compiling once per drift-run-completed call is cheap (workspaces
+    rarely hit double-digit rules); duplicating across plan resources
+    inside the same call would be wasteful.
+
+    Returns the original rule string alongside the regex so log lines
+    can name the rule that matched without re-deriving it.
+    """
+    compiled: list[tuple[str, re.Pattern[str]]] = []
+    for rule in rules:
+        rule = rule.strip()
+        if not rule:
+            continue
+        try:
+            compiled.append((rule, _rule_to_regex(rule)))
+        except re.error as e:
+            # Defensive: validation in tfe_v2 should catch this, but
+            # logging here is the failsafe — the rule just won't match
+            # anything rather than ablating drift detection entirely.
+            logger.warning("Skipping invalid drift_ignore rule", rule=rule, error=str(e))
+    return compiled
+
+
+def _diff_paths(before: Any, after: Any, prefix: str = "") -> list[str]:
+    """Recursive walk emitting one dotted path per leaf-level diff.
+
+    Lists become `prefix[i]`; dicts become `prefix.k`. Equal values
+    produce no path. `None` on one side and a structure on the other
+    is treated as a value-level diff at `prefix`.
+
+    Plan JSON's `before`/`after` can each be `null` (resource creation
+    has `before=null`; deletion has `after=null`). For those whole-
+    resource cases the caller treats the address as the diff "path",
+    rather than walking — see `_resource_change_diff_paths`.
+    """
+    if before == after:
+        return []
+    if isinstance(before, dict) and isinstance(after, dict):
+        paths: list[str] = []
+        for k in set(before) | set(after):
+            sub_prefix = f"{prefix}.{k}" if prefix else k
+            paths.extend(_diff_paths(before.get(k), after.get(k), sub_prefix))
+        return paths
+    if isinstance(before, list) and isinstance(after, list):
+        paths = []
+        n = max(len(before), len(after))
+        for i in range(n):
+            sub_prefix = f"{prefix}[{i}]"
+            b = before[i] if i < len(before) else None
+            a = after[i] if i < len(after) else None
+            paths.extend(_diff_paths(b, a, sub_prefix))
+        return paths
+    # Type mismatch or leaf-level inequality — emit one path.
+    return [prefix] if prefix else []
+
+
+def _resource_change_diff_paths(rc: dict[str, Any]) -> tuple[list[str], bool]:
+    """Return (diff_paths, is_whole_resource_action).
+
+    For an update, walk before/after to enumerate the changed fields.
+    For create/delete/replace, no granular path makes sense — the
+    whole resource is the unit of change, so return an empty paths
+    list with `is_whole_resource_action=True`. The match step then
+    checks the bare address against the rule set.
+    """
+    change = rc.get("change") or {}
+    actions = change.get("actions") or []
+
+    # Defensive: plan JSON could carry novel action strings in future
+    # tofu releases. Any action NOT in _DRIFT_ACTIONS is treated as
+    # "not drift" — the safer default is to ignore than to spuriously
+    # flag.
+    if not any(a in _DRIFT_ACTIONS for a in actions):
+        return [], False
+
+    # create / delete / replace: whole resource is the change.
+    if "create" in actions or "delete" in actions or "replace" in actions:
+        return [], True
+
+    # Update — diff before vs after.
+    before = change.get("before")
+    after = change.get("after")
+    return _diff_paths(before, after), False
+
+
+def _path_is_ignored(
+    address: str,
+    diff_path: str,
+    is_whole_resource: bool,
+    rules: list[tuple[str, re.Pattern[str]]],
+) -> tuple[bool, str | None]:
+    """Test a single (address, diff_path) tuple against compiled rules.
+
+    Returns `(ignored, matching_rule)`. The matching rule string is
+    returned for logging — the caller can attribute each suppressed
+    change to a specific rule.
+
+    For whole-resource actions (create / delete / replace) we match
+    the bare address; rules with attribute suffixes never silence
+    a delete because the operator probably wants to know if their
+    workspace's resources are being recreated under them.
+    """
+    if is_whole_resource:
+        # Only allow whole-resource silencing via bare-address rules.
+        # A rule like "aws_iam_role.foo.tags.Environment" must NOT
+        # silence a "delete" of aws_iam_role.foo — that would be a
+        # genuinely surprising semantic. Operators can opt in by
+        # adding the bare address as a rule.
+        for rule_str, regex in rules:
+            if regex.fullmatch(address):
+                return True, rule_str
+        return False, None
+
+    # Per-attribute action: match against `<address>.<diff_path>` or
+    # the bare address (for "whole resource" rule shape).
+    candidate = f"{address}.{diff_path}" if diff_path else address
+    for rule_str, regex in rules:
+        if regex.fullmatch(candidate) or regex.fullmatch(address):
+            return True, rule_str
+    return False, None
+
+
+def classify_drift(
+    plan_json: dict[str, Any],
+    rules: Iterable[str],
+) -> tuple[bool, list[dict[str, Any]]]:
+    """Decide whether a drift run's plan still constitutes drift.
+
+    Args:
+        plan_json: parsed `tofu show -json` output for the drift run's
+            plan. Expected shape includes `resource_changes: list[...]`
+            per the OpenTofu plan-format spec.
+        rules: workspace's `drift_ignore_rules` list.
+
+    Returns:
+        `(still_drifted, suppressed_changes)` where:
+          * `still_drifted` is True if at least one resource_change
+            has a diff that no rule matches.
+          * `suppressed_changes` is a list of `{address, paths, rule}`
+            dicts describing what got silenced. Useful for surfacing
+            "ignored by policy" sections in the UI and for runbook
+            tracing.
+
+    A workspace with no rules → returns the original drift decision
+    unchanged (`still_drifted=True` if any resource_change had a real
+    action). Callers should typically short-circuit on empty rules
+    before invoking this function; it's safe but wasteful.
+    """
+    rule_list = list(rules)
+    compiled = _compile_rules(rule_list) if rule_list else []
+
+    resource_changes = plan_json.get("resource_changes") or []
+    if not resource_changes:
+        return False, []
+
+    suppressed: list[dict[str, Any]] = []
+    still_drifted = False
+    matched_paths: list[str] = []  # accumulate per resource
+
+    for rc in resource_changes:
+        address = rc.get("address") or ""
+        if not address:
+            continue
+        diff_paths, is_whole = _resource_change_diff_paths(rc)
+
+        if not diff_paths and not is_whole:
+            # Action exists but resolves to nothing changing (e.g. a
+            # `no-op` slipped through, or before==after under
+            # update). Not drift.
+            continue
+
+        if is_whole:
+            ignored, matching_rule = _path_is_ignored(address, "", True, compiled)
+            if ignored:
+                suppressed.append({"address": address, "paths": [], "rule": matching_rule})
+            else:
+                still_drifted = True
+            continue
+
+        # Per-attribute: every diff path must be ignored for the whole
+        # resource to be suppressed.
+        unsuppressed: list[str] = []
+        matched_paths = []
+        matched_rule_for_resource: str | None = None
+        for p in diff_paths:
+            ignored, matching_rule = _path_is_ignored(address, p, False, compiled)
+            if ignored:
+                matched_paths.append(p)
+                if matched_rule_for_resource is None:
+                    matched_rule_for_resource = matching_rule
+            else:
+                unsuppressed.append(p)
+
+        if not unsuppressed:
+            suppressed.append(
+                {
+                    "address": address,
+                    "paths": matched_paths,
+                    "rule": matched_rule_for_resource,
+                }
+            )
+        else:
+            still_drifted = True
+
+    return still_drifted, suppressed

--- a/services/terrapod/services/drift_ignore_classifier.py
+++ b/services/terrapod/services/drift_ignore_classifier.py
@@ -80,6 +80,12 @@ logger = get_logger(__name__)
 # drift.
 _DRIFT_ACTIONS = frozenset({"create", "update", "delete", "replace"})
 
+# Matches a numeric block index like `[0]`, `[12]`. Used to produce an
+# index-tolerant candidate so a natural attribute-path rule matches the
+# plan-JSON block-list shape. String-key indices (`["prod"]`) are NOT
+# matched by this — they stay in the candidate.
+_NUMERIC_INDEX_RE = re.compile(r"\[\d+\]")
+
 
 def _rule_to_regex(rule: str) -> re.Pattern[str]:
     """Translate a glob rule into a compiled regex.
@@ -254,8 +260,20 @@ def _path_is_ignored(
     # Per-attribute action: match against `<address>.<diff_path>` or
     # the bare address (for "whole resource" rule shape).
     candidate = f"{address}.{diff_path}" if diff_path else address
+    # HCL nested blocks serialize as single-element lists in `tofu show
+    # -json` output, so a block path like `config.tls_client_config.
+    # ca_data` arrives as `config[0].tls_client_config[0].ca_data`. No
+    # operator thinks in those terms — they write the attribute path the
+    # way it reads in HCL. So we ALSO test the rule against a variant of
+    # the candidate with numeric block indices stripped, letting a bare
+    # `config.tls_client_config.ca_data` rule match the indexed path.
+    # Only NUMERIC `[N]` indices are stripped; string keys (`["prod"]`,
+    # for_each / map indices) stay because they're semantically
+    # meaningful — a rule shouldn't accidentally span every for_each
+    # instance.
+    deindexed = _NUMERIC_INDEX_RE.sub("", candidate)
     for rule_str, regex in rules:
-        if regex.fullmatch(candidate) or regex.fullmatch(address):
+        if regex.fullmatch(candidate) or regex.fullmatch(deindexed) or regex.fullmatch(address):
             return True, rule_str
     return False, None
 

--- a/services/tests/api/test_ai_summary.py
+++ b/services/tests/api/test_ai_summary.py
@@ -56,6 +56,7 @@ def _mock_workspace(ws_id=None, **overrides):
     ws.owner_email = "test@example.com"
     ws.var_files = []
     ws.trigger_prefixes = []
+    ws.drift_ignore_rules = []
     ws.vcs_last_polled_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -60,6 +60,7 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.agent_pool_id = overrides.get("agent_pool_id", None)
     ws.var_files = []
     ws.trigger_prefixes = []
+    ws.drift_ignore_rules = []
     ws.vcs_last_polled_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None

--- a/services/tests/api/test_health_conditions.py
+++ b/services/tests/api/test_health_conditions.py
@@ -25,6 +25,7 @@ def _mock_workspace(**overrides):
     ws.vcs_branch = ""
     ws.var_files = []
     ws.trigger_prefixes = []
+    ws.drift_ignore_rules = []
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400
     ws.drift_last_checked_at = None

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -51,6 +51,7 @@ def _mock_workspace(ws_id=None, pool_id=None):
     ws.vcs_last_error_at = None
     ws.var_files = []
     ws.trigger_prefixes = []
+    ws.drift_ignore_rules = []
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400
     ws.drift_last_checked_at = None

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -62,6 +62,7 @@ def _mock_workspace(
     ws.vcs_last_error_at = None
     ws.var_files = []
     ws.trigger_prefixes = []
+    ws.drift_ignore_rules = []
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400
     ws.drift_last_checked_at = None

--- a/services/tests/services/test_drift_detection_service.py
+++ b/services/tests/services/test_drift_detection_service.py
@@ -14,6 +14,7 @@ def _mock_workspace(**overrides):
     ws.drift_last_checked_at = overrides.get("drift_last_checked_at", None)
     ws.drift_status = overrides.get("drift_status", "")
     ws.drift_latest_run_id = overrides.get("drift_latest_run_id", None)
+    ws.drift_ignore_rules = overrides.get("drift_ignore_rules", [])
     ws.locked = overrides.get("locked", False)
     ws.vcs_connection_id = overrides.get("vcs_connection_id", None)
     ws.vcs_repo_url = overrides.get("vcs_repo_url", "")

--- a/services/tests/services/test_drift_ignore_classifier.py
+++ b/services/tests/services/test_drift_ignore_classifier.py
@@ -1,0 +1,288 @@
+"""Tests for drift_ignore_classifier (#482).
+
+The classifier decides whether a drift run still counts as drift after
+applying the workspace's `drift_ignore_rules`. These tests pin the
+behavioural contract end-to-end against realistic `tofu show -json`
+plan shapes: exact-match rules, attribute globs, address globs,
+brackets, whole-resource suppression, create/delete safety, partial
+suppression, and the "no rules → identity" path.
+"""
+
+from __future__ import annotations
+
+from terrapod.services.drift_ignore_classifier import classify_drift
+
+
+def _update_plan(address: str, before: dict, after: dict) -> dict:
+    """Build a minimal plan-JSON envelope with one update resource_change."""
+    return {
+        "resource_changes": [
+            {
+                "address": address,
+                "type": address.split(".")[-2] if "." in address else address,
+                "name": address.split(".")[-1],
+                "change": {
+                    "actions": ["update"],
+                    "before": before,
+                    "after": after,
+                },
+            }
+        ]
+    }
+
+
+class TestRuleMatching:
+    def test_exact_attribute_match_suppresses_drift(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"tags": {"Environment": "dev", "Owner": "alice"}},
+            {"tags": {"Environment": "prod", "Owner": "alice"}},
+        )
+        still_drifted, suppressed = classify_drift(plan, ["aws_iam_role.foo.tags.Environment"])
+        assert still_drifted is False
+        assert suppressed and suppressed[0]["address"] == "aws_iam_role.foo"
+
+    def test_unmatched_attribute_remains_drift(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"tags": {"Environment": "dev", "Owner": "alice"}},
+            {"tags": {"Environment": "prod", "Owner": "bob"}},
+        )
+        still_drifted, suppressed = classify_drift(plan, ["aws_iam_role.foo.tags.Environment"])
+        # Owner changed too; not in rules → still drift.
+        assert still_drifted is True
+
+    def test_glob_segment_matches_index(self):
+        plan = _update_plan(
+            "aws_autoscaling_group.workers[0]",
+            {"desired_capacity": 3},
+            {"desired_capacity": 5},
+        )
+        still_drifted, suppressed = classify_drift(
+            plan, ["aws_autoscaling_group.workers[*].desired_capacity"]
+        )
+        assert still_drifted is False
+        assert suppressed[0]["paths"] == ["desired_capacity"]
+
+    def test_glob_across_module_path(self):
+        """User's motivating case from the issue: argocd_cluster ca_data drift."""
+        plan = _update_plan(
+            "module.eks_legacy[0].argocd_cluster.eks[0]",
+            {"config": {"tls_client_config": {"ca_data": "OLD"}}},
+            {"config": {"tls_client_config": {"ca_data": "NEW"}}},
+        )
+        rule = "module.eks*.argocd_cluster.eks*.config.tls_client_config.ca_data"
+        still_drifted, _ = classify_drift(plan, [rule])
+        assert still_drifted is False
+
+        plan2 = _update_plan(
+            "module.eks[0].argocd_cluster.eks",
+            {"config": {"tls_client_config": {"ca_data": "OLD"}}},
+            {"config": {"tls_client_config": {"ca_data": "NEW"}}},
+        )
+        still_drifted2, _ = classify_drift(plan2, [rule])
+        assert still_drifted2 is False, (
+            "Wildcard rule must cover both eks[0] and unsuffixed eks variants"
+        )
+
+    def test_single_segment_glob_does_not_cross_dots(self):
+        """`*` is segment-local: `module.*.foo` MUST NOT match
+        `module.a.b.foo` (two segments under module).
+        """
+        plan = _update_plan(
+            "module.a.b.aws_instance.foo",
+            {"ami": "ami-old"},
+            {"ami": "ami-new"},
+        )
+        still_drifted, _ = classify_drift(plan, ["module.*.aws_instance.foo.ami"])
+        assert still_drifted is True  # rule's `*` only crosses one segment
+
+
+class TestWholeResourceRules:
+    def test_bare_address_matches_any_attribute(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"name": "old", "description": "x"},
+            {"name": "new", "description": "y"},
+        )
+        # Bare address with no attribute suffix — silences any change.
+        still_drifted, suppressed = classify_drift(plan, ["aws_iam_role.foo"])
+        assert still_drifted is False
+        assert suppressed[0]["address"] == "aws_iam_role.foo"
+
+    def test_per_attribute_rule_does_not_silence_delete(self):
+        """A `replicas` rule must not silence a delete — the operator
+        wants to know if their resource is being destroyed."""
+        plan = {
+            "resource_changes": [
+                {
+                    "address": "kubernetes_deployment.api",
+                    "type": "kubernetes_deployment",
+                    "name": "api",
+                    "change": {
+                        "actions": ["delete"],
+                        "before": {"spec": [{"replicas": 5}]},
+                        "after": None,
+                    },
+                }
+            ]
+        }
+        still_drifted, _ = classify_drift(plan, ["kubernetes_deployment.api.spec[0].replicas"])
+        assert still_drifted is True, (
+            "Per-attribute rule must NOT silence a delete; only a bare-"
+            "address rule may silence whole-resource lifecycle changes"
+        )
+
+    def test_bare_address_rule_silences_delete(self):
+        plan = {
+            "resource_changes": [
+                {
+                    "address": "aws_lambda_function.scratch",
+                    "type": "aws_lambda_function",
+                    "name": "scratch",
+                    "change": {
+                        "actions": ["delete"],
+                        "before": {"function_name": "scratch"},
+                        "after": None,
+                    },
+                }
+            ]
+        }
+        still_drifted, suppressed = classify_drift(plan, ["aws_lambda_function.scratch"])
+        assert still_drifted is False
+        assert suppressed[0]["address"] == "aws_lambda_function.scratch"
+
+
+class TestPartialSuppression:
+    def test_two_changes_one_ignored_remains_drift(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"tags": {"Environment": "dev"}, "description": "old"},
+            {"tags": {"Environment": "prod"}, "description": "new"},
+        )
+        still_drifted, _ = classify_drift(plan, ["aws_iam_role.foo.tags.Environment"])
+        assert still_drifted is True
+
+    def test_multiple_resources_independent(self):
+        """One resource fully suppressed, another not — drift remains
+        because *some* resource still has un-ignored changes."""
+        plan = {
+            "resource_changes": [
+                {
+                    "address": "aws_iam_role.foo",
+                    "type": "aws_iam_role",
+                    "name": "foo",
+                    "change": {
+                        "actions": ["update"],
+                        "before": {"tags": {"x": "1"}},
+                        "after": {"tags": {"x": "2"}},
+                    },
+                },
+                {
+                    "address": "aws_instance.bar",
+                    "type": "aws_instance",
+                    "name": "bar",
+                    "change": {
+                        "actions": ["update"],
+                        "before": {"ami": "old"},
+                        "after": {"ami": "new"},
+                    },
+                },
+            ]
+        }
+        still_drifted, suppressed = classify_drift(plan, ["aws_iam_role.foo.tags.x"])
+        assert still_drifted is True
+        # The foo resource WAS suppressed; bar wasn't → reported as
+        # partial in logs but overall status is drifted.
+        suppressed_addresses = {s["address"] for s in suppressed}
+        assert "aws_iam_role.foo" in suppressed_addresses
+
+
+class TestNoOpAndReadActions:
+    def test_no_op_action_never_drifts(self):
+        plan = {
+            "resource_changes": [
+                {
+                    "address": "aws_iam_role.foo",
+                    "type": "aws_iam_role",
+                    "name": "foo",
+                    "change": {"actions": ["no-op"], "before": {}, "after": {}},
+                }
+            ]
+        }
+        still_drifted, suppressed = classify_drift(plan, [])
+        assert still_drifted is False
+        assert suppressed == []
+
+    def test_read_action_never_drifts(self):
+        plan = {
+            "resource_changes": [
+                {
+                    "address": "data.aws_ami.x",
+                    "type": "aws_ami",
+                    "name": "x",
+                    "change": {"actions": ["read"], "before": None, "after": {}},
+                }
+            ]
+        }
+        still_drifted, _ = classify_drift(plan, [])
+        assert still_drifted is False
+
+
+class TestEmptyRules:
+    def test_no_rules_with_changes_is_drifted(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"name": "old"},
+            {"name": "new"},
+        )
+        still_drifted, suppressed = classify_drift(plan, [])
+        assert still_drifted is True
+        assert suppressed == []
+
+    def test_no_rules_with_no_changes_is_not_drifted(self):
+        plan = {"resource_changes": []}
+        still_drifted, suppressed = classify_drift(plan, [])
+        assert still_drifted is False
+        assert suppressed == []
+
+    def test_empty_string_rule_skipped_gracefully(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"name": "old"},
+            {"name": "new"},
+        )
+        # Whitespace / empty entries should be ignored by the compiler,
+        # not cause spurious matches.
+        still_drifted, _ = classify_drift(plan, ["", "   "])
+        assert still_drifted is True
+
+
+class TestDiffPathWalking:
+    def test_nested_dict_path_built_correctly(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"a": {"b": {"c": 1}}},
+            {"a": {"b": {"c": 2}}},
+        )
+        still_drifted, _ = classify_drift(plan, ["aws_iam_role.foo.a.b.c"])
+        assert still_drifted is False
+
+    def test_list_index_bracket_form(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"statements": [{"effect": "Allow"}, {"effect": "Deny"}]},
+            {"statements": [{"effect": "Allow"}, {"effect": "Allow"}]},
+        )
+        # statements[1].effect changed; rule must cover index 1.
+        still_drifted, _ = classify_drift(plan, ["aws_iam_role.foo.statements[*].effect"])
+        assert still_drifted is False
+
+    def test_unequal_list_length_emits_paths_at_diff_indices(self):
+        plan = _update_plan(
+            "aws_iam_role.foo",
+            {"statements": [{"x": 1}]},
+            {"statements": [{"x": 1}, {"y": 2}]},
+        )
+        still_drifted, _ = classify_drift(plan, ["aws_iam_role.foo.statements[*]"])
+        assert still_drifted is False

--- a/services/tests/services/test_drift_ignore_classifier.py
+++ b/services/tests/services/test_drift_ignore_classifier.py
@@ -98,6 +98,69 @@ class TestRuleMatching:
         assert still_drifted is True  # rule's `*` only crosses one segment
 
 
+class TestHclBlockListShape:
+    """HCL nested blocks serialize as single-element lists in `tofu show
+    -json`. A natural attribute-path rule must match the indexed shape.
+
+    This is the exact shape that the v0.36.0 pre-release live smoke
+    surfaced: `module.eks[0].argocd_cluster.eks` reports a change at
+    config[0].tls_client_config[0].ca_data, and the operator's rule
+    `...config.tls_client_config.ca_data` (no indices) must still match.
+    Synthetic plan — no production data.
+    """
+
+    def test_block_indices_optional_in_rule(self):
+        plan = _update_plan(
+            "module.eks[0].argocd_cluster.eks",
+            {"config": [{"tls_client_config": [{"ca_data": "OLD"}]}]},
+            {"config": [{"tls_client_config": [{"ca_data": "NEW"}]}]},
+        )
+        # Operator writes the natural HCL path with no [0] block indices.
+        rule = "module.eks*.argocd_cluster.*.config.tls_client_config.ca_data"
+        still_drifted, suppressed = classify_drift(plan, [rule])
+        assert still_drifted is False, (
+            "Rule without explicit block indices must match the "
+            "plan-JSON single-element-list block shape"
+        )
+        assert suppressed[0]["address"] == "module.eks[0].argocd_cluster.eks"
+
+    def test_legacy_module_variant_same_rule(self):
+        plan = _update_plan(
+            "module.eks_legacy[0].argocd_cluster.eks[0]",
+            {"config": [{"tls_client_config": [{"ca_data": "OLD"}]}]},
+            {"config": [{"tls_client_config": [{"ca_data": "NEW"}]}]},
+        )
+        rule = "module.eks*.argocd_cluster.*.config.tls_client_config.ca_data"
+        still_drifted, _ = classify_drift(plan, [rule])
+        assert still_drifted is False
+
+    def test_explicit_bracket_star_also_works(self):
+        """Operators who DO write `config[*]` get the same result —
+        the index-tolerant fallback doesn't break explicit brackets."""
+        plan = _update_plan(
+            "module.eks[0].argocd_cluster.eks",
+            {"config": [{"tls_client_config": [{"ca_data": "OLD"}]}]},
+            {"config": [{"tls_client_config": [{"ca_data": "NEW"}]}]},
+        )
+        rule = "module.eks*.argocd_cluster.*.config[*].tls_client_config[*].ca_data"
+        still_drifted, _ = classify_drift(plan, [rule])
+        assert still_drifted is False
+
+    def test_string_key_index_not_stripped(self):
+        """Numeric block indices are stripped for matching; string-key
+        (for_each) indices are NOT, so a bare rule can't over-match
+        across for_each instances."""
+        plan = _update_plan(
+            'aws_instance.web["prod"]',
+            {"ami": "ami-old"},
+            {"ami": "ami-new"},
+        )
+        # Rule without the ["prod"] key must NOT match — the key is
+        # semantically meaningful and stays in the candidate.
+        still_drifted, _ = classify_drift(plan, ["aws_instance.web.ami"])
+        assert still_drifted is True
+
+
 class TestWholeResourceRules:
     def test_bare_address_matches_any_attribute(self):
         plan = _update_plan(

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -46,6 +46,7 @@ interface WorkspaceAttrs {
   'owner-email': string
   'var-files': string[]
   'trigger-prefixes': string[]
+  'drift-ignore-rules': string[]
   'vcs-repo-url': string
   'vcs-branch': string
   'vcs-connection-id': string | null
@@ -252,6 +253,8 @@ function WorkspaceDetailContent() {
   const [newVarFile, setNewVarFile] = useState('')
   const [editTriggerPrefixes, setEditTriggerPrefixes] = useState<string[]>([])
   const [newTriggerPrefix, setNewTriggerPrefix] = useState('')
+  const [editDriftIgnoreRules, setEditDriftIgnoreRules] = useState<string[]>([])
+  const [newDriftIgnoreRule, setNewDriftIgnoreRule] = useState('')
   const [editWorkingDir, setEditWorkingDir] = useState('')
   const [editVcsConnectionId, setEditVcsConnectionId] = useState<string | null>(null)
   const [editVcsRepoUrl, setEditVcsRepoUrl] = useState('')
@@ -934,6 +937,8 @@ function WorkspaceDetailContent() {
     setNewVarFile('')
     setEditTriggerPrefixes(workspace.attributes['trigger-prefixes'] || [])
     setNewTriggerPrefix('')
+    setEditDriftIgnoreRules(workspace.attributes['drift-ignore-rules'] || [])
+    setNewDriftIgnoreRule('')
     setEditWorkingDir(workspace.attributes['working-directory'] || '')
     setEditVcsConnectionId(workspace.attributes['vcs-connection-id'] || null)
     setEditVcsRepoUrl(workspace.attributes['vcs-repo-url'] || '')
@@ -990,6 +995,7 @@ function WorkspaceDetailContent() {
               'working-directory': editWorkingDir,
               'var-files': editVarFiles,
               'trigger-prefixes': editTriggerPrefixes,
+              'drift-ignore-rules': editDriftIgnoreRules,
               'vcs-repo-url': editVcsRepoUrl,
               'vcs-branch': editVcsBranch,
               'vcs-workflow': editVcsWorkflow,
@@ -1987,6 +1993,68 @@ function WorkspaceDetailContent() {
                         </div>
                       ) : (
                         <span className="text-slate-500">None (uses working directory)</span>
+                      )}
+                    </dd>
+                  )}
+                </div>
+                <div className="sm:col-span-2">
+                  <dt className="text-xs text-slate-500 mb-1">Drift Ignore Rules</dt>
+                  {editing && perms['can-update'] ? (
+                    <div className="space-y-2">
+                      <p className="text-xs text-slate-400">
+                        Glob-aware Terraform address + attribute paths suppressed by the drift classifier. <code className="text-[10px] bg-slate-800 px-1">*</code> matches zero or more non-<code className="text-[10px] bg-slate-800 px-1">.</code> chars (spans <code className="text-[10px] bg-slate-800 px-1">[N]</code> indices); <code className="text-[10px] bg-slate-800 px-1">[*]</code> matches any bracketed index. A bare address with no attribute suffix silences any change to that resource — including destroys. Affects drift only, not regular plan/apply. See <a href="https://github.com/mattrobinsonsre/terrapod/blob/main/docs/drift-ignore-rules.md" target="_blank" rel="noreferrer" className="text-brand-400 hover:underline">drift-ignore-rules.md</a> for the full grammar.
+                      </p>
+                      {editDriftIgnoreRules.map((r, i) => (
+                        <div key={`${r}-${i}`} className="flex items-center gap-2">
+                          <code className="text-sm text-slate-200 bg-slate-700 px-2 py-0.5 rounded flex-1 truncate">{r}</code>
+                          <button
+                            onClick={() => setEditDriftIgnoreRules(editDriftIgnoreRules.filter((_, j) => j !== i))}
+                            className="text-xs text-red-400 hover:text-red-300"
+                          >Remove</button>
+                        </div>
+                      ))}
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="text"
+                          value={newDriftIgnoreRule}
+                          onChange={(e) => setNewDriftIgnoreRule(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' && newDriftIgnoreRule.trim()) {
+                              e.preventDefault()
+                              const v = newDriftIgnoreRule.trim()
+                              if (v && !editDriftIgnoreRules.includes(v)) {
+                                setEditDriftIgnoreRules([...editDriftIgnoreRules, v])
+                              }
+                              setNewDriftIgnoreRule('')
+                            }
+                          }}
+                          placeholder="e.g. module.eks*.argocd_cluster.*.config.tls_client_config.ca_data"
+                          className="flex-1 px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 font-mono"
+                        />
+                        <button
+                          onClick={() => {
+                            if (newDriftIgnoreRule.trim()) {
+                              const v = newDriftIgnoreRule.trim()
+                              if (v && !editDriftIgnoreRules.includes(v)) {
+                                setEditDriftIgnoreRules([...editDriftIgnoreRules, v])
+                              }
+                              setNewDriftIgnoreRule('')
+                            }
+                          }}
+                          className="text-xs text-brand-400 hover:text-brand-300"
+                        >Add</button>
+                      </div>
+                    </div>
+                  ) : (
+                    <dd className="mt-1 text-sm text-slate-200">
+                      {(attrs['drift-ignore-rules'] || []).length > 0 ? (
+                        <div className="flex flex-col gap-1">
+                          {attrs['drift-ignore-rules'].map((r) => (
+                            <code key={r} className="bg-slate-700 px-2 py-0.5 rounded text-xs font-mono">{r}</code>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-slate-500">None (every plan diff counts as drift)</span>
                       )}
                     </dd>
                   )}


### PR DESCRIPTION
Closes #482.

Per-workspace allowlist for the drift-detection classifier. Wired end-to-end through API + classifier + go-terrapod + provider + UI + docs so the contract test catches drift.

See [docs/drift-ignore-rules.md](https://github.com/mattrobinsonsre/terrapod/blob/main/docs/drift-ignore-rules.md) for the full grammar and recipes.

## Highlights

- DB column `workspaces.drift_ignore_rules` (JSONB list of strings, default `[]`)
- Validator: max 50 entries, ≤500 chars, character allow-list
- `drift_ignore_classifier.classify_drift(plan_json, rules)` — pure source-introspection function with 18 cases covering globs, brackets, partial suppression, delete-safety, multi-resource plans
- Wired into `handle_drift_run_completed` after `has_changes=True`; failure paths conservatively fall back to drifted
- go-terrapod + provider resource + datasource + UI editor (workspace settings)
- Contract test (`test_api_sdk_contract.py`) catches the new attribute end-to-end

## Glob semantics

- `*` → zero or more non-`.` chars (spans `[N]` indices but never crosses segment boundaries)
- `[*]` → any one bracketed index

## Safety

A per-attribute rule cannot silence a destroy. Only a bare-address rule (no attribute suffix) may suppress whole-resource lifecycle changes.

## Test plan

- [x] 18 classifier tests covering exact match, globs, partial suppression, create/delete safety, no-op/read actions, empty rules
- [x] 2015 + 57 integration tests green
- [x] go-terrapod + provider build + vet clean
- [x] Frontend tsc clean
- [ ] Playwright spec for the workspace settings editor (next)
- [ ] Live Tilt smoke for end-to-end behaviour
- [ ] Pre-release audit before tagging v0.36.0


## Pre-release audit (v0.36.0)

- **A. Docs**: `drift-ignore-rules.md` added; linked from `index.md` + `drift-detection.md`; `api-reference.md` row added.
- **B. Helm**: no new values (feature is a DB column + classifier).
- **C. Tests**: 22 classifier tests (incl. 4 HCL-block-shape fixtures), handler tests, contract test, e2e editor spec.
- **D. Internal-reference scan**: one leak found + scrubbed (`tf-aws-core-prod-eu1` → `platform-prod` in the docs example).
- **E. Version strings**: none stale.
- **F. Live smoke**: ran the classifier against a real drift run's plan JSON shape — **found a bug**: HCL nested blocks serialize as single-element lists (`config[0].tls_client_config[0].ca_data`), so the natural rule didn't match. Fixed with index-tolerant matching + 4 synthetic fixture tests. This is exactly the kind of bug unit tests miss and the F gate exists to catch.
- **G. Vuln allowlist**: unchanged (no dependency changes).
