### PR TITLE
fix(drift): classify drift after plan JSON lands, not on transition (v0.36.1)

### DIFF
--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -316,6 +316,32 @@ async def upload_plan_json_output(
         except Exception as e:
             logger.debug("Failed to enqueue ai_plan_summary after upload", error=str(e))
 
+    # Drift-ignore classifier (#482) — same race as the AI summariser.
+    # `handle_drift_run_completed` fires from run_service.transition_run
+    # on the `planned` transition, which the runner POSTs BEFORE
+    # uploading plan-json-output. So when a workspace has
+    # `drift_ignore_rules` configured, that first pass finds
+    # `has_json_output == False`, can't fetch the plan to classify, and
+    # conservatively leaves drift_status = "drifted". Re-enqueue the
+    # completion handler now that the JSON is committed; it re-runs with
+    # `has_json_output == True` and the classifier flips drift_status to
+    # "no_drift" when every change matches a rule. Distinct dedup key so
+    # this re-trigger isn't swallowed by the transition-time enqueue's
+    # `drift:{run_id}` dedup window. Only drift runs need this; normal
+    # runs don't touch drift_status.
+    if run.is_drift_detection:
+        try:
+            from terrapod.services.scheduler import enqueue_trigger
+
+            await enqueue_trigger(
+                "drift_run_completed",
+                {"run_id": str(run.id), "workspace_id": str(run.workspace_id)},
+                dedup_key=f"drift_postjson:{run.id}",
+                dedup_ttl=300,
+            )
+        except Exception as e:
+            logger.debug("Failed to re-enqueue drift completion after upload", error=str(e))
+
     return Response(status_code=204)
 
 

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -26,11 +26,14 @@ def _runner_user(run_id: uuid.UUID) -> AuthenticatedUser:
     )
 
 
-def _mock_run(run_id=None, ws_id=None):
+def _mock_run(run_id=None, ws_id=None, is_drift_detection=False):
     run = MagicMock()
     run.id = run_id or uuid.uuid4()
     run.workspace_id = ws_id or uuid.uuid4()
     run.created_by = "matt@example.com"
+    # Default False so the AI-summary tests see exactly one enqueue; the
+    # drift-reclassify path (#482) is opt-in per test via True.
+    run.is_drift_detection = is_drift_detection
     return run
 
 
@@ -340,6 +343,76 @@ class TestUploadPlanJsonOutput:
         mock_settings.ai_summary.enabled = False
         run_id = uuid.uuid4()
         run = _mock_run(run_id=run_id)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-json-output",
+                content=b'{"resource_changes":[]}',
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 204
+        mock_enq.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    @patch("terrapod.api.routers.run_artifacts.settings")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_reenqueues_drift_completion_for_drift_run(
+        self, mock_enq, mock_settings, mock_get_storage, *_mocks
+    ):
+        """A drift-detection run must re-fire drift_run_completed AFTER the
+        plan JSON lands (#482). handle_drift_run_completed first runs on
+        the planned transition — before this upload — when has_json_output
+        is still False, so the ignore-rule classifier can't read the plan
+        and conservatively leaves drift_status='drifted'. Re-enqueuing here
+        lets it re-run with the JSON available and flip to no_drift. Was
+        the v0.36.1 fix.
+        """
+        mock_settings.ai_summary.enabled = False  # isolate the drift enqueue
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id, is_drift_detection=True)
+        mock_db = AsyncMock()
+        mock_db.get.return_value = run
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/plan-json-output",
+                content=b'{"resource_changes":[]}',
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 204
+        mock_enq.assert_awaited_once()
+        args, kwargs = mock_enq.call_args
+        assert args[0] == "drift_run_completed"
+        assert args[1] == {"run_id": str(run_id), "workspace_id": str(ws_id)}
+        # Distinct dedup key from the transition-time enqueue (drift:{id})
+        # so this re-trigger isn't swallowed by the 60s dedup window.
+        assert kwargs.get("dedup_key") == f"drift_postjson:{run_id}"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    @patch("terrapod.api.routers.run_artifacts.settings")
+    @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
+    async def test_no_drift_reenqueue_for_normal_run(
+        self, mock_enq, mock_settings, mock_get_storage, *_mocks
+    ):
+        """A normal (non-drift) run must NOT re-enqueue drift_run_completed."""
+        mock_settings.ai_summary.enabled = False
+        run_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, is_drift_detection=False)
         mock_db = AsyncMock()
         mock_db.get.return_value = run
         mock_get_storage.return_value = AsyncMock()


### PR DESCRIPTION
## The bug

v0.36.0's drift-ignore classifier **never ran in production**. Same race the AI summariser hit in v0.30.2:

`handle_drift_run_completed` fires from `run_service.transition_run` on the `planned` transition, which the runner POSTs **before** uploading plan-json-output. So the first (and only) pass saw `run.has_json_output == False`, couldn't fetch the plan to classify, and conservatively left `drift_status='drifted'` — even when every change matched an ignore rule.

Confirmed live on a real drift run (core-dev-eu1, only `ca_data` changed, rule present):
```
16:49:43.698  drift handler ran → set 'drifted'   (has_json_output=False)
16:49:43.923  plan JSON uploaded                   (225ms too late)
```

## The fix

Mirror the AI-summary fix exactly: re-enqueue `drift_run_completed` from `upload_plan_json_output` **after** `has_json_output` is committed, with a distinct dedup key (`drift_postjson:{id}`) so it isn't swallowed by the transition-time enqueue's 60s dedup window. The handler re-runs with the JSON available; the classifier flips `drift_status` to `no_drift` when every change is covered.

## Tests

- New: re-enqueue fires for drift runs with the right payload + dedup key
- New: does NOT fire for normal (non-drift) runs
- Existing AI-summary upload tests still see exactly one enqueue (fixture defaults `is_drift_detection=False`)
- 2021 fast + 57 integration green

## Test plan
- [ ] CI green
- [ ] After deploy: re-run drift on core-dev-eu1 → classifier flips it to no_drift
