### PR TITLE
fix(runner): don't flag state-diverged on a serial-neutral no-op apply

### DIFF
--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -393,31 +393,49 @@ async def upload_state(
     # Hash off the event loop — runner state uploads can be multi-MB
     md5 = await asyncio.to_thread(lambda: hashlib.md5(body).hexdigest())  # noqa: S324  # nosemgrep: insecure-hash-algorithm-md5
 
-    # Reject duplicate-serial uploads with 409 Conflict instead of letting
-    # the unique constraint surface as a 500. tofu doesn't bump the state
-    # serial on a no-op apply, so a runner re-uploading the same state would
-    # otherwise blow up with `IntegrityError on uq_state_versions`. The
-    # reconciler short-circuits planned→applied for has_changes=False so
-    # this path shouldn't be reached in steady state, but explicit 409 is
-    # correct semantics regardless: a stale serial is a client-visible
-    # conflict, not a server error.
+    # tofu/terraform does NOT bump the state serial when an apply leaves the
+    # persisted state byte-identical to the prior state. This happens whenever a
+    # resource carries a *perpetual phantom diff* — write-only attributes that are
+    # re-sent on every apply (e.g. auth0 client secrets), values the provider
+    # normalises, etc. The plan reports "1 changed", the apply calls the provider's
+    # Update, but the resulting state equals the prior state, so the serial is
+    # unchanged. That is NOT a divergence: the API's state already matches the
+    # state the runner holds. Treat an identical (same serial + same md5) upload as
+    # an idempotent no-op success rather than flagging state-diverged.
     #
-    # Two-layer check: (1) pre-INSERT lookup gives the common case a clean
-    # 409 with a helpful message; (2) IntegrityError catch on the INSERT
-    # closes the race window where a concurrent upload inserts between our
-    # SELECT and INSERT — the unique constraint is the source of truth.
+    # Only a *different* state body at an already-recorded serial is a genuine
+    # conflict (two distinct states claiming the same serial → real divergence) →
+    # 409. The IntegrityError catch on the INSERT below closes the race window
+    # where a concurrent upload inserts between our SELECT and INSERT.
     _existing_serial_msg = (
-        f"State serial {serial} already exists for this workspace. "
-        "tofu apply did not bump the serial — likely a no-op apply that "
-        "should not have produced a state upload."
+        f"State serial {serial} already exists for this workspace with different "
+        "content. The runner's post-apply state diverged from the recorded state "
+        "at this serial."
     )
-    existing = await db.execute(
-        select(StateVersion).where(
-            StateVersion.workspace_id == run.workspace_id,
-            StateVersion.serial == serial,
+    existing = (
+        await db.execute(
+            select(StateVersion).where(
+                StateVersion.workspace_id == run.workspace_id,
+                StateVersion.serial == serial,
+            )
         )
-    )
-    if existing.scalar_one_or_none() is not None:
+    ).scalar_one_or_none()
+    if existing is not None:
+        if existing.md5 == md5:
+            # Serial-neutral no-op apply: state is provably identical. Clear any
+            # stale divergence flag and return success so the runner does NOT
+            # signal state-diverged and the run transitions to applied.
+            ws = await db.get(Workspace, run.workspace_id)
+            if ws and ws.state_diverged:
+                ws.state_diverged = False
+                await db.commit()
+            logger.info(
+                "state_upload_noop_serial_unchanged",
+                run_id=run_id,
+                workspace_id=str(run.workspace_id),
+                serial=serial,
+            )
+            return Response(status_code=200)
         raise HTTPException(status_code=409, detail=_existing_serial_msg)
 
     # Create StateVersion record

--- a/services/terrapod/runner/job_entrypoint.py
+++ b/services/terrapod/runner/job_entrypoint.py
@@ -30,6 +30,7 @@ code; the K8s Job phase tracking maps any non-zero to "failed".
 
 from __future__ import annotations
 
+import hashlib
 import os
 import signal
 import sys
@@ -311,6 +312,23 @@ def _run_plan_phase(
     return 0
 
 
+def _state_digest(state_path: Path) -> str | None:
+    """SHA-256 of the state file, or None if it doesn't exist. Used to
+    detect a serial-neutral no-op apply: tofu/terraform does NOT rewrite
+    the state with a bumped serial when the persisted state is unchanged
+    (e.g. a resource with a perpetual phantom diff — write-only attributes
+    re-sent every apply). In that case the post-apply state is byte-identical
+    to the state we downloaded, so there is nothing to upload — and uploading
+    it would collide with the existing serial and be mis-flagged as a state
+    divergence."""
+    try:
+        if state_path.exists() and state_path.stat().st_size > 0:
+            return hashlib.sha256(state_path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+    return None
+
+
 def _run_apply_phase(
     cfg: RunnerConfig,
     *,
@@ -322,6 +340,12 @@ def _run_apply_phase(
     """Apply-phase body: download plan binary, run apply, upload state
     (FATAL on failure), apply-result POST."""
     log = structlog.get_logger("runner.job_entrypoint")
+
+    # Snapshot the pre-apply state so we can tell whether apply actually
+    # changed it. tofu overwrites terraform.tfstate in place, so a digest
+    # taken now (the state we downloaded) versus after apply tells us if
+    # the serial was bumped. See _state_digest for why this matters.
+    pre_apply_state_digest = _state_digest(strip_dir / "terraform.tfstate")
 
     # Download plan file from plan phase. Best-effort — when missing,
     # apply re-plans inline. Routed through `download_to_file` so the
@@ -421,8 +445,23 @@ def _run_apply_phase(
     # State upload — FATAL if non-empty state file exists and upload
     # fails. Apply may have written state even on a failed apply (partial
     # apply). Always try to upload if the file exists.
+    #
+    # ...UNLESS the apply was serial-neutral: if the post-apply state is
+    # byte-identical to the state we downloaded, tofu did not bump the
+    # serial (a no-op apply driven by a perpetual phantom diff). Re-uploading
+    # it would collide with the already-recorded serial and be mis-flagged as
+    # a state divergence. There is nothing to persist — the API already holds
+    # this exact state — so skip the upload cleanly. Only skip on a successful
+    # apply (rc == 0); a failed/partial apply must still try to upload whatever
+    # state was written.
     state_path = strip_dir / "terraform.tfstate"
-    if state_path.exists() and state_path.stat().st_size > 0:
+    if (
+        rc == 0
+        and pre_apply_state_digest is not None
+        and _state_digest(state_path) == pre_apply_state_digest
+    ):
+        log.info("state unchanged after apply — skipping upload (serial-neutral no-op)")
+    elif state_path.exists() and state_path.stat().st_size > 0:
         try:
             ok = uploads.upload_state(cfg, state_path)
             if not ok:

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -165,6 +165,58 @@ class TestUploadStateDuplicateSerial:
         mock_db.add.assert_called_once()
         mock_storage.put.assert_called_once()
 
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_existing_serial_same_md5_is_idempotent_200(self, mock_get_storage, *_mocks):
+        """A serial-neutral no-op apply (state byte-identical to the recorded
+        state at the same serial) is NOT a divergence. The API treats it as an
+        idempotent success (200), does NOT insert a new row, does NOT store the
+        blob, and clears any stale state_diverged flag — so the runner never
+        signals state-diverged. This is the defence-in-depth half of the
+        auth0-perpetual-diff fix (the runner also skips the upload entirely)."""
+        import hashlib
+
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id)
+
+        state_json = json.dumps({"version": 4, "serial": 8, "lineage": "abc"})
+        body_md5 = hashlib.md5(state_json.encode()).hexdigest()  # noqa: S324
+
+        mock_db = AsyncMock()
+        # The existing state version at serial 8 has the SAME content hash.
+        existing_sv = MagicMock(spec=StateVersion)
+        existing_sv.md5 = body_md5
+        ws = MagicMock()
+        ws.state_diverged = True  # stale flag from a prior mis-fire
+        # db.get: first _get_run(Run), then db.get(Workspace) in the no-op branch.
+        mock_db.get.side_effect = [run, ws]
+        lookup = MagicMock()
+        lookup.scalar_one_or_none.return_value = existing_sv
+        mock_db.execute.return_value = lookup
+
+        mock_storage = AsyncMock()
+        mock_get_storage.return_value = mock_storage
+
+        app = _make_app(_runner_user(run_id), mock_db)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/state",
+                content=state_json,
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 200
+        # No new row, no blob write — there is nothing to persist.
+        mock_db.add.assert_not_called()
+        mock_storage.put.assert_not_called()
+        # Stale divergence flag cleared.
+        assert ws.state_diverged is False
+        mock_db.commit.assert_awaited()
+
 
 # ── upload_plan_json_output (#280) ─────────────────────────────────────
 

--- a/services/tests/runner/test_job_entrypoint.py
+++ b/services/tests/runner/test_job_entrypoint.py
@@ -136,6 +136,87 @@ class TestWorkDirOverride:
         assert str(seen["work_dir"]) == str(custom)
 
 
+class TestStateDigest:
+    def test_returns_none_for_missing_file(self, tmp_path) -> None:
+        assert job_entrypoint._state_digest(tmp_path / "absent.tfstate") is None
+
+    def test_returns_none_for_empty_file(self, tmp_path) -> None:
+        p = tmp_path / "empty.tfstate"
+        p.write_bytes(b"")
+        assert job_entrypoint._state_digest(p) is None
+
+    def test_hashes_content(self, tmp_path) -> None:
+        p = tmp_path / "s.tfstate"
+        p.write_bytes(b'{"serial": 8}')
+        d1 = job_entrypoint._state_digest(p)
+        assert d1 is not None and len(d1) == 64
+        # Identical content → identical digest; changed content → different.
+        p.write_bytes(b'{"serial": 8}')
+        assert job_entrypoint._state_digest(p) == d1
+        p.write_bytes(b'{"serial": 9}')
+        assert job_entrypoint._state_digest(p) != d1
+
+
+class TestApplyPhaseStateUploadSkip:
+    """Serial-neutral no-op apply: when tofu applies but leaves the state
+    byte-identical (a perpetual phantom diff, e.g. auth0 write-only secrets),
+    the runner must NOT upload — there is nothing to persist and a re-upload at
+    the unchanged serial would be mis-flagged as a state divergence."""
+
+    def _cfg(self):
+        from terrapod.runner.runner_config import RunnerConfig
+
+        # has_api False (empty TP_API_URL) skips the plan-file / plan-artifacts
+        # downloads so the test exercises only the apply + state-upload decision.
+        return RunnerConfig.from_env(
+            env={"TP_API_URL": "", "TP_RUN_ID": "", "TP_BACKEND": "tofu", "TP_VERSION": "1.12.1"}
+        )
+
+    def _run(self, tmp_path, *, apply_writes: bytes | None):
+        state = tmp_path / "terraform.tfstate"
+        state.write_bytes(b'{"serial": 164, "stable": true}')
+
+        def _fake_run_apply(cfg, **kwargs):
+            if apply_writes is not None:
+                state.write_bytes(apply_writes)
+            return 0
+
+        with (
+            patch.object(job_entrypoint.plan_apply, "run_apply", side_effect=_fake_run_apply),
+            patch.object(job_entrypoint.uploads, "upload_state", return_value=True) as up,
+            patch.object(job_entrypoint.uploads, "signal_state_diverged") as div,
+            patch.object(job_entrypoint.uploads, "post_apply_result") as par,
+        ):
+            rc = job_entrypoint._run_apply_phase(
+                self._cfg(),
+                binary="/tmp/bin/tofu",
+                var_file_argv=[],
+                strip_dir=tmp_path,
+                child_grace=10.0,
+            )
+        return rc, up, div, par
+
+    def test_skips_upload_when_state_unchanged(self, tmp_path) -> None:
+        # apply_writes=None → run_apply leaves the state file untouched.
+        rc, up, div, par = self._run(tmp_path, apply_writes=None)
+        assert rc == 0
+        up.assert_not_called()
+        div.assert_not_called()
+        par.assert_called_once()
+
+    def test_skips_upload_when_apply_rewrites_identical_bytes(self, tmp_path) -> None:
+        # tofu rewrites the file but with byte-identical content (serial unchanged).
+        rc, up, div, par = self._run(tmp_path, apply_writes=b'{"serial": 164, "stable": true}')
+        assert rc == 0
+        up.assert_not_called()
+
+    def test_uploads_when_state_changed(self, tmp_path) -> None:
+        rc, up, div, par = self._run(tmp_path, apply_writes=b'{"serial": 165, "changed": true}')
+        assert rc == 0
+        up.assert_called_once()
+        div.assert_not_called()
+
+
 class TestModuleSurface:
     def test_main_callable(self) -> None:
         assert callable(job_entrypoint.main)


### PR DESCRIPTION
## Problem

A live apply on `helios-auth0-local-dev` errored with the workspace flagged **state-diverged**, despite the apply succeeding (`0 added, 1 changed, 0 destroyed`). The runner uploaded state at a serial that already existed → API returned **409** → runner signalled `state-diverged` and errored the run.

Root cause: **tofu/terraform only bumps the state serial when the persisted state actually changes.** A resource with a perpetual phantom diff — write-only attributes re-sent every apply (auth0 client secrets), provider-normalised values — makes the plan report `1 changed` while the apply leaves the state **byte-identical**. The serial stays put. The runner then re-uploaded that unchanged state, collided with the recorded serial, and mis-flagged a divergence that doesn't exist (the API's state already matched the runner's exactly).

## Fix (two layers)

1. **Runner (primary)** — snapshot the downloaded state's SHA-256 before apply, compare after. If the post-apply state is byte-identical, skip the upload entirely (nothing to persist). Only skips on a clean `rc == 0` apply; a failed/partial apply still uploads whatever state it wrote.
2. **API (defence-in-depth)** — an upload whose serial already exists **and whose md5 matches** the recorded state is treated as an idempotent no-op → `200` + clears any stale `state_diverged` flag, instead of `409`. A *different* body at an existing serial is still a genuine `409` conflict.

## Tests
- `services/tests/runner/test_job_entrypoint.py` — `_state_digest` + apply-phase skip/upload decision (skip on identical bytes, skip on identical rewrite, upload on change).
- `services/tests/api/test_run_artifacts.py` — same-md5 existing serial → idempotent `200` + flag cleared; different md5 → `409`.

## Live smoke (local stack)
Agent workspace on the live listener: **create apply → serial 1 uploaded**, **update apply → serial 2 uploaded**, both `applied`, runner orchestrator ran cleanly with no false `state-diverged`. A real change is never skipped. The serial-neutral skip branch is unit-tested (a phantom-diff provider can't be reproduced with stock providers).