### PR TITLE
fix(runs): clear state_diverged when a run reaches applied

### DIFF
--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -443,6 +443,22 @@ async def transition_run(
     if target_status == "applied" and not run.plan_only:
         await fire_run_triggers(db, run.workspace_id)
 
+    # A successful (non-speculative) apply brings tofu/terraform state into
+    # agreement with the recorded state — by definition there is no divergence
+    # right now, so clear any stale state_diverged flag. This is the ONLY thing
+    # that clears it for a workspace whose applies are serial-neutral no-ops (a
+    # perpetual phantom diff — write-only attributes re-sent every apply, e.g.
+    # auth0 client secrets): tofu doesn't bump the serial, the runner skips the
+    # redundant state upload, so the upload-path clear (run_artifacts / tfe_v2
+    # state-version content) never fires. Without this the flag — once set —
+    # sticks forever even though every subsequent apply succeeds. db.get is
+    # identity-mapped, so this shares the session-cached Workspace with the
+    # drift-status block below (no extra round trip).
+    if target_status == "applied" and not run.plan_only:
+        ws = await db.get(Workspace, run.workspace_id)
+        if ws is not None and ws.state_diverged:
+            ws.state_diverged = False
+
     # A successful non-speculative apply means tofu/terraform just
     # brought state into agreement with the configured infrastructure
     # — by definition, drift is zero right now. Reset drift_status to

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -287,6 +287,51 @@ class TestTransitionRun:
         assert ws.drift_status == ""
         assert ws.drift_last_checked_at is None
 
+    @patch("terrapod.services.run_service.fire_run_triggers", new_callable=AsyncMock)
+    async def test_applied_clears_state_diverged(self, mock_fire):
+        """A successful non-speculative apply brings state into agreement with
+        reality, so a stale state_diverged flag must clear. This is the ONLY
+        thing that clears it for a workspace whose applies are serial-neutral
+        no-ops (perpetual phantom diff): the runner skips the redundant state
+        upload, so the upload-path clear never fires.
+        """
+        db = AsyncMock(spec=AsyncSession)
+        ws = MagicMock()
+        ws.drift_detection_enabled = False
+        ws.state_diverged = True
+        db.get = AsyncMock(return_value=ws)
+
+        run = _mock_run(
+            status="applying",
+            source="tfe-api",
+            plan_only=False,
+            apply_started_at=datetime.now(UTC),
+        )
+        await transition_run(db, run, "applied")
+
+        assert ws.state_diverged is False
+
+    @patch("terrapod.services.run_service.fire_run_triggers", new_callable=AsyncMock)
+    async def test_applied_does_not_clear_state_diverged_for_plan_only(self, mock_fire):
+        """plan_only runs don't mutate infrastructure, so they don't resolve a
+        divergence. Leave the flag set.
+        """
+        db = AsyncMock(spec=AsyncSession)
+        ws = MagicMock()
+        ws.drift_detection_enabled = False
+        ws.state_diverged = True
+        db.get = AsyncMock(return_value=ws)
+
+        run = _mock_run(
+            status="applying",
+            source="tfe-api",
+            plan_only=True,
+            apply_started_at=datetime.now(UTC),
+        )
+        await transition_run(db, run, "applied")
+
+        assert ws.state_diverged is True  # untouched
+
     async def test_error_message_stored(self):
         db = AsyncMock(spec=AsyncSession)
         run = _mock_run(status="planning")


### PR DESCRIPTION
## Problem

After v0.36.2, plan/apply succeeds on phantom-diff workspaces (e.g. `helios-auth0-local-dev`) but the **/workspaces "State Diverged" banner never clears**.

Root cause: `state_diverged` was only ever cleared on a successful **state upload** (`run_artifacts.py:468`, `tfe_v2.py:1963`). v0.36.2 made the runner correctly *skip* the upload on a serial-neutral no-op apply (tofu doesn't bump the serial → nothing to persist). So for a workspace whose applies are all no-ops, the apply succeeds but never uploads → the stale flag sticks **forever**, even though state is provably consistent.

## Fix

Clear `state_diverged` on the `applied` transition in `run_service.transition_run`, independent of whether new state was uploaded. A successful non-speculative apply means tofu/terraform brought state into agreement with reality — there's no divergence by definition. `plan_only` runs don't mutate infra, so they don't clear it. `db.get` is identity-mapped, so this shares the session-cached `Workspace` with the drift-status block right below it (no extra round trip).

This also **auto-heals workspaces already stuck** from before the fix — they clear on their next apply/drift run, no DB surgery.

## Tests
`services/tests/services/test_run_service.py`:
- `test_applied_clears_state_diverged` — applied + non-plan-only + flag set → cleared.
- `test_applied_does_not_clear_state_diverged_for_plan_only` — plan_only → flag untouched.

The clear lives inside the apply→applied transition already smoked end-to-end in v0.36.2. The no-op-specific path can't be reproduced with stock providers (needs a phantom-diff provider), so it's unit-test-covered.