### PR TITLE
feat(ui): searchable workspace picker + live SSE for run-triggers, sharing & more

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -707,8 +707,13 @@ Server-Sent Events stream for real-time workspace updates. The stream emits even
 | `workspace_lock_change` | Workspace is locked or unlocked (includes `locked` boolean) |
 | `workspace_updated` | Workspace settings are modified |
 | `state_version_created` | New state version is uploaded |
+| `workspace_variable_change` | A workspace variable is created, updated, or deleted |
+| `workspace_notification_change` | A notification configuration is created, updated, or deleted |
+| `workspace_run_task_change` | A run task is created, updated, or deleted |
+| `run_trigger_change` | A run trigger to/from this workspace is added or removed (published to **both** the source and destination workspace channels, so inbound edges appear live) |
+| `remote_state_consumer_change` | A remote-state consumer grant to/from this workspace is added or removed (published to **both** the producer and consumer channels) |
 
-The stream sends `: keepalive` comments every ~1 second. Events are JSON-encoded in `data:` fields.
+The stream sends `: keepalive` comments every ~1 second. Events are JSON-encoded in `data:` fields. The web UI workspace detail page re-fetches the active tab on receipt of its corresponding event.
 
 **Required permission:** `read` on the workspace.
 

--- a/e2e/tests/workspaces.spec.ts
+++ b/e2e/tests/workspaces.spec.ts
@@ -49,6 +49,39 @@ test.describe('Workspaces', () => {
     await expect(page.getByRole('button', { name: 'Notifications' })).toBeVisible();
   });
 
+  test('run-triggers tab uses a searchable workspace picker', async ({ page }) => {
+    const src = `e2e-trg-src-${Date.now()}`;
+    const dest = `e2e-trg-dest-${Date.now()}`;
+
+    for (const name of [src, dest]) {
+      await page.goto('/workspaces');
+      await page.click('button:has-text("New Workspace")');
+      await page.fill('input[placeholder*="workspace"]', name);
+      await page.click('button:has-text("Create Workspace")');
+      await expect(page.locator(`text=${name}`).first()).toBeVisible({ timeout: 10_000 });
+    }
+
+    // Open the destination workspace's Run Triggers tab
+    await page.goto('/workspaces');
+    await page.click(`text=${dest}`);
+    await page.getByRole('button', { name: 'Run Triggers' }).click();
+
+    // The picker is a search box + clickable list — NOT a free-text name input
+    // (a typo can't 404 any more). Filter to the source, then click to add.
+    const search = page.locator('input[placeholder*="Search workspaces to add"]');
+    await expect(search).toBeVisible();
+    await search.fill(src);
+
+    const srcButton = page.getByRole('button', { name: src });
+    await expect(srcButton).toBeVisible({ timeout: 10_000 });
+    await srcButton.click();
+
+    // The inbound edge appears live (id-based add → refetch), with a Remove control
+    await expect(page.getByRole('button', { name: 'Remove' }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
   test('workspace settings can be updated', async ({ page }) => {
     // Create a workspace
     const wsName = `e2e-settings-${Date.now()}`;

--- a/services/terrapod/api/routers/notification_configurations.py
+++ b/services/terrapod/api/routers/notification_configurations.py
@@ -158,6 +158,10 @@ async def create_notification_configuration(
     await db.refresh(nc, attribute_names=["workspace"])
     await db.commit()
 
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(ws.id), "workspace_notification_change")
+
     logger.info(
         "Notification configuration created",
         nc_id=str(nc.id),
@@ -256,6 +260,10 @@ async def update_notification_configuration(
     # Reload for serialization
     await db.refresh(nc, attribute_names=["workspace"])
 
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(nc.workspace_id), "workspace_notification_change")
+
     logger.info("Notification configuration updated", nc_id=str(nc.id))
 
     return JSONResponse(content={"data": _nc_json(nc)})
@@ -271,8 +279,14 @@ async def delete_notification_configuration(
     nc = await _get_nc(nc_id, db)
     await _require_ws_permission(nc.workspace, "admin", user, db)
 
+    nc_ws_id = str(nc.workspace_id)
+
     await db.delete(nc)
     await db.commit()
+
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(nc_ws_id, "workspace_notification_change")
 
     logger.info("Notification configuration deleted", nc_id=nc_id)
 

--- a/services/terrapod/api/routers/remote_state_consumers.py
+++ b/services/terrapod/api/routers/remote_state_consumers.py
@@ -172,6 +172,13 @@ async def create_remote_state_consumer(
     await db.refresh(row, attribute_names=["producer_workspace", "consumer_workspace"])
     await db.commit()
 
+    # Live-update both Sharing tabs: the producer gets a new outbound consumer,
+    # the consumer a new inbound producer it may now read from.
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(producer.id), "remote_state_consumer_change")
+    await publish_workspace_event(str(consumer.id), "remote_state_consumer_change")
+
     logger.info(
         "Remote-state consumer authorized",
         edge_id=str(row.id),
@@ -372,11 +379,20 @@ async def delete_remote_state_consumer(
 
     await _require_ws_permission(row.producer_workspace, "admin", user, db)
 
+    producer_id = str(row.producer_workspace_id)
+    consumer_id = str(row.consumer_workspace_id)
+    revoked_edge_id = str(row.id)
+
     await db.delete(row)
     await db.commit()
 
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(producer_id, "remote_state_consumer_change")
+    await publish_workspace_event(consumer_id, "remote_state_consumer_change")
+
     logger.info(
         "Remote-state consumer revoked",
-        edge_id=str(row.id),
+        edge_id=revoked_edge_id,
         by=user.email,
     )

--- a/services/terrapod/api/routers/run_tasks.py
+++ b/services/terrapod/api/routers/run_tasks.py
@@ -225,6 +225,10 @@ async def create_run_task(
     await db.refresh(rt, attribute_names=["workspace"])
     await db.commit()
 
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(ws.id), "workspace_run_task_change")
+
     logger.info("Run task created", task_id=str(rt.id), workspace=ws.name, stage=stage)
 
     return JSONResponse(content={"data": _run_task_json(rt)}, status_code=201)
@@ -315,6 +319,10 @@ async def update_run_task(
     await db.commit()
     await db.refresh(rt, attribute_names=["workspace"])
 
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(rt.workspace_id), "workspace_run_task_change")
+
     logger.info("Run task updated", task_id=str(rt.id))
 
     return JSONResponse(content={"data": _run_task_json(rt)})
@@ -330,8 +338,14 @@ async def delete_run_task(
     rt = await _get_run_task(rt_id, db)
     await _require_ws_permission(rt.workspace, "admin", user, db)
 
+    rt_ws_id = str(rt.workspace_id)
+
     await db.delete(rt)
     await db.commit()
+
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(rt_ws_id, "workspace_run_task_change")
 
     logger.info("Run task deleted", task_id=rt_id)
 

--- a/services/terrapod/api/routers/run_triggers.py
+++ b/services/terrapod/api/routers/run_triggers.py
@@ -144,6 +144,14 @@ async def create_run_trigger(
 
     await db.commit()
 
+    # Live-update both endpoints' Run Triggers tabs: the destination gets a new
+    # outbound edge, the source a new inbound edge. The inbound edge in
+    # particular would otherwise never appear without a manual refresh.
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(ws.id), "run_trigger_change")
+    await publish_workspace_event(str(source_ws.id), "run_trigger_change")
+
     logger.info(
         "Run trigger created",
         trigger_id=str(trigger.id),
@@ -235,7 +243,17 @@ async def delete_run_trigger(
     ws = trigger.workspace
     await _require_ws_permission(ws, "admin", user, db)
 
+    # Capture both endpoint ids before the row is gone.
+    dest_id = str(trigger.workspace_id)
+    source_id = str(trigger.source_workspace_id)
+    trigger_id = str(trigger.id)
+
     await db.delete(trigger)
     await db.commit()
 
-    logger.info("Run trigger deleted", trigger_id=str(trigger.id))
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(dest_id, "run_trigger_change")
+    await publish_workspace_event(source_id, "run_trigger_change")
+
+    logger.info("Run trigger deleted", trigger_id=trigger_id)

--- a/services/terrapod/api/routers/variables.py
+++ b/services/terrapod/api/routers/variables.py
@@ -140,6 +140,10 @@ async def create_workspace_var(
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(ws.id), "workspace_variable_change")
+
     return JSONResponse(content={"data": _var_json(var)}, status_code=201)
 
 
@@ -181,6 +185,10 @@ async def update_workspace_var(
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(ws.id), "workspace_variable_change")
+
     return JSONResponse(content={"data": _var_json(var)})
 
 
@@ -206,6 +214,10 @@ async def delete_workspace_var(
 
     await variable_service.delete_variable(db, var)
     await db.commit()
+
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(ws.id), "workspace_variable_change")
 
 
 # ── Variable Sets ────────────────────────────────────────────────────────

--- a/services/tests/api/test_remote_state_consumers.py
+++ b/services/tests/api/test_remote_state_consumers.py
@@ -260,7 +260,8 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
-    async def test_create_happy_path(self, mock_resolve, *_):
+    @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
+    async def test_create_happy_path(self, mock_publish, mock_resolve, *_):
         """Admin on producer → 201, and the response JSON carries the
         producer + consumer names (i.e. the row's relationships actually
         get populated)."""
@@ -309,6 +310,12 @@ class TestCreateConsumer:
         assert body["data"]["type"] == "remote-state-consumers"
         attrs = body["data"]["attributes"]
         assert attrs["producer-workspace-name"] == "producer"
+        # SSE: both producer + consumer channels get remote_state_consumer_change.
+        assert {c.args[1] for c in mock_publish.await_args_list} == {"remote_state_consumer_change"}
+        assert {c.args[0] for c in mock_publish.await_args_list} == {
+            str(producer.id),
+            str(consumer.id),
+        }
         assert attrs["consumer-workspace-name"] == "consumer"
         # Relationship ids are present and prefixed
         rels = body["data"]["relationships"]

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -67,7 +67,8 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
-    async def test_create_run_trigger(self, mock_resolve, *mocks):
+    @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
+    async def test_create_run_trigger(self, mock_publish, mock_resolve, *mocks):
         """Happy path: create a run trigger → 201."""
         mock_resolve.return_value = "admin"
         dest_ws = _mock_workspace(name="dest")
@@ -111,6 +112,12 @@ class TestCreateRunTrigger:
             )
         assert resp.status_code == 201
         assert resp.json()["data"]["type"] == "run-triggers"
+        # SSE: both the destination and source workspace channels get a
+        # run_trigger_change event so inbound + outbound edges appear live.
+        published = {c.args[1] for c in mock_publish.await_args_list}
+        assert published == {"run_trigger_change"}
+        published_ids = {c.args[0] for c in mock_publish.await_args_list}
+        assert {str(dest_ws.id), str(source_ws.id)} == published_ids
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/web/src/app/registry/modules/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[name]/[provider]/page.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { Upload, FolderOpen, GitBranch, Link2, Plus, Trash2, Search } from 'lucide-react'
+import { Upload, FolderOpen, GitBranch, Link2, Plus, Trash2 } from 'lucide-react'
 import * as Dialog from '@radix-ui/react-dialog'
 import NavBar from '@/components/nav-bar'
+import { WorkspacePicker } from '@/components/workspace-picker'
 import { PageHeader } from '@/components/page-header'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
@@ -199,8 +200,6 @@ export default function ModuleDetailPage() {
   }
   const [workspaceLinks, setWorkspaceLinks] = useState<WorkspaceLink[]>([])
   const [showLinkPicker, setShowLinkPicker] = useState(false)
-  const [wsSearchQuery, setWsSearchQuery] = useState('')
-  const [wsSearchResults, setWsSearchResults] = useState<{ id: string; name: string }[]>([])
   const [linkingWs, setLinkingWs] = useState('')
 
   useEffect(() => {
@@ -289,28 +288,6 @@ export default function ModuleDetailPage() {
     }
   }
 
-  async function searchWorkspaces(query: string) {
-    try {
-      const res = await apiFetch('/api/v2/organizations/default/workspaces')
-      if (res.ok) {
-        const data = await res.json()
-        const all = (data.data || []).map((ws: { id: string; attributes: { name: string } }) => ({
-          id: ws.id,
-          name: ws.attributes.name,
-        }))
-        const linked = new Set(workspaceLinks.map(l => l.attributes['workspace-id']))
-        const filtered = all.filter(
-          (ws: { id: string; name: string }) =>
-            !linked.has(ws.id) &&
-            (!query || ws.name.toLowerCase().includes(query.toLowerCase()))
-        )
-        setWsSearchResults(filtered.slice(0, 20))
-      }
-    } catch {
-      // ignore
-    }
-  }
-
   async function handleLinkWorkspace(wsId: string) {
     setLinkingWs(wsId)
     setError('')
@@ -330,7 +307,6 @@ export default function ModuleDetailPage() {
         throw new Error(data.detail || `Link failed (${res.status})`)
       }
       setShowLinkPicker(false)
-      setWsSearchQuery('')
       await loadWorkspaceLinks()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to link workspace')
@@ -751,7 +727,7 @@ export default function ModuleDetailPage() {
                     <h3 className="text-sm font-medium text-slate-300">Linked Workspaces</h3>
                   </div>
                   <button
-                    onClick={() => { setShowLinkPicker(!showLinkPicker); if (!showLinkPicker) searchWorkspaces('') }}
+                    onClick={() => setShowLinkPicker(!showLinkPicker)}
                     className="text-xs text-brand-400 hover:text-brand-300 flex items-center gap-1"
                   >
                     <Plus size={12} />
@@ -764,32 +740,13 @@ export default function ModuleDetailPage() {
                 </p>
 
                 {showLinkPicker && (
-                  <div className="mb-3 p-3 bg-slate-900/50 rounded-lg border border-slate-700/30">
-                    <div className="flex items-center gap-2 mb-2">
-                      <Search size={14} className="text-slate-400" />
-                      <input
-                        type="text"
-                        value={wsSearchQuery}
-                        onChange={(e) => { setWsSearchQuery(e.target.value); searchWorkspaces(e.target.value) }}
-                        placeholder="Search workspaces..."
-                        className="flex-1 px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
-                      />
-                    </div>
-                    <div className="max-h-40 overflow-y-auto space-y-1">
-                      {wsSearchResults.length === 0 ? (
-                        <p className="text-xs text-slate-500 py-2 text-center">No workspaces found</p>
-                      ) : wsSearchResults.map(ws => (
-                        <button
-                          key={ws.id}
-                          onClick={() => handleLinkWorkspace(ws.id)}
-                          disabled={linkingWs === ws.id}
-                          className="w-full text-left px-2 py-1.5 rounded text-sm text-slate-300 hover:bg-slate-700/50 transition-colors disabled:opacity-50"
-                        >
-                          {ws.name}
-                          {linkingWs === ws.id && <span className="text-xs text-slate-500 ml-2">Linking...</span>}
-                        </button>
-                      ))}
-                    </div>
+                  <div className="mb-3">
+                    <WorkspacePicker
+                      placeholder="Search workspaces to link…"
+                      excludeIds={workspaceLinks.map((l) => l.attributes['workspace-id'])}
+                      busyId={linkingWs}
+                      onSelect={(ws) => handleLinkWorkspace(ws.id)}
+                    />
                   </div>
                 )}
 

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -11,6 +11,7 @@ import { SortableHeader } from '@/components/sortable-header'
 import { LabelsEditor } from '@/components/labels-editor'
 import { HealthConditions } from '@/components/health-conditions'
 import { PlanSummaryBadges } from '@/components/plan-summary-badges'
+import { WorkspacePicker } from '@/components/workspace-picker'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
@@ -369,7 +370,7 @@ function WorkspaceDetailContent() {
   const [rscOutbound, setRscOutbound] = useState<RemoteStateEdge[]>([])
   const [rscInbound, setRscInbound] = useState<RemoteStateEdge[]>([])
   const [rscLoading, setRscLoading] = useState(false)
-  const [rscAddName, setRscAddName] = useState('')
+  const [rscAddingId, setRscAddingId] = useState('')
   const [rscAdding, setRscAdding] = useState(false)
 
   // Run Triggers — cross-workspace apply-fires-plan dependency edges
@@ -384,7 +385,7 @@ function WorkspaceDetailContent() {
   const [trgInbound, setTrgInbound] = useState<RunTriggerEdge[]>([])
   const [trgOutbound, setTrgOutbound] = useState<RunTriggerEdge[]>([])
   const [trgLoading, setTrgLoading] = useState(false)
-  const [trgAddName, setTrgAddName] = useState('')
+  const [trgAddingId, setTrgAddingId] = useState('')
   const [trgAdding, setTrgAdding] = useState(false)
 
   // Notifications
@@ -537,8 +538,15 @@ function WorkspaceDetailContent() {
   // Real-time workspace events via SSE (run status, lock/unlock, state, settings)
   useRunEvents(workspaceId, useCallback((event) => {
     loadWorkspace()
+    const ev = event.event
+    const reconnect = ev === 'reconnect'
     if (activeTab === 'runs') loadRuns()
-    if (activeTab === 'state' && (event.event === 'state_version_created' || event.event === 'reconnect')) loadStateVersions()
+    if (activeTab === 'state' && (ev === 'state_version_created' || reconnect)) loadStateVersions()
+    if (activeTab === 'variables' && (ev === 'workspace_variable_change' || reconnect)) loadVariables()
+    if (activeTab === 'notifications' && (ev === 'workspace_notification_change' || reconnect)) loadNotifications()
+    if (activeTab === 'run-tasks' && (ev === 'workspace_run_task_change' || reconnect)) loadRunTasks()
+    if (activeTab === 'run-triggers' && (ev === 'run_trigger_change' || reconnect)) loadRunTriggers()
+    if (activeTab === 'sharing' && (ev === 'remote_state_consumer_change' || reconnect)) loadRemoteStateConsumers()
   }, [activeTab, loadRuns, loadWorkspace]))
 
   async function loadVariables() {
@@ -713,20 +721,11 @@ function WorkspaceDetailContent() {
     }
   }
 
-  async function addRemoteStateConsumer() {
-    const name = rscAddName.trim()
-    if (!name) return
+  async function addRemoteStateConsumer(consumerId: string) {
+    if (!consumerId) return
+    setRscAddingId(consumerId)
     setRscAdding(true)
     try {
-      // Resolve consumer workspace name → id via the by-name endpoint.
-      const lookup = await apiFetch(`/api/v2/organizations/default/workspaces/${encodeURIComponent(name)}`)
-      if (!lookup.ok) {
-        throw new Error(lookup.status === 404 ? `Workspace "${name}" not found` : 'Failed to resolve consumer workspace')
-      }
-      const wsBody = await lookup.json()
-      const consumerId = wsBody.data?.id
-      if (!consumerId) throw new Error('Workspace lookup returned no id')
-
       const res = await apiFetch(
         `/api/terrapod/v1/workspaces/${workspaceId}/remote-state-consumers`,
         {
@@ -741,12 +740,12 @@ function WorkspaceDetailContent() {
         const err = await res.json().catch(() => ({ detail: 'Failed to authorize consumer' }))
         throw new Error(err.detail || 'Failed to authorize consumer')
       }
-      setRscAddName('')
       await loadRemoteStateConsumers()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to authorize consumer')
     } finally {
       setRscAdding(false)
+      setRscAddingId('')
     }
   }
 
@@ -795,19 +794,11 @@ function WorkspaceDetailContent() {
     }
   }
 
-  async function addRunTrigger() {
-    const name = trgAddName.trim()
-    if (!name) return
+  async function addRunTrigger(sourceId: string) {
+    if (!sourceId) return
+    setTrgAddingId(sourceId)
     setTrgAdding(true)
     try {
-      const lookup = await apiFetch(`/api/v2/organizations/default/workspaces/${encodeURIComponent(name)}`)
-      if (!lookup.ok) {
-        throw new Error(lookup.status === 404 ? `Workspace "${name}" not found` : 'Failed to resolve source workspace')
-      }
-      const wsBody = await lookup.json()
-      const sourceId = wsBody.data?.id
-      if (!sourceId) throw new Error('Workspace lookup returned no id')
-
       const res = await apiFetch(
         `/api/terrapod/v1/workspaces/${workspaceId}/run-triggers`,
         {
@@ -822,12 +813,12 @@ function WorkspaceDetailContent() {
         const err = await res.json().catch(() => ({ detail: 'Failed to add run trigger' }))
         throw new Error(err.detail || 'Failed to add run trigger')
       }
-      setTrgAddName('')
       await loadRunTriggers()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add run trigger')
     } finally {
       setTrgAdding(false)
+      setTrgAddingId('')
     }
   }
 
@@ -3343,26 +3334,15 @@ function WorkspaceDetailContent() {
               )}
 
               {perms['can-update'] && (
-                <form
-                  onSubmit={(e) => { e.preventDefault(); addRunTrigger() }}
-                  className="mt-3 flex items-center gap-2"
-                >
-                  <input
-                    type="text"
-                    value={trgAddName}
-                    onChange={(e) => setTrgAddName(e.target.value)}
-                    placeholder="Add source workspace by name"
-                    className="flex-1 rounded border border-slate-700 bg-slate-900 px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500"
+                <div className="mt-3" data-testid="run-trigger-picker">
+                  <WorkspacePicker
+                    placeholder="Search workspaces to add as a source…"
+                    excludeIds={[workspaceId, ...trgInbound.map((e) => e.sourceableId)]}
+                    busyId={trgAddingId}
                     disabled={trgAdding}
+                    onSelect={(ws) => addRunTrigger(ws.id)}
                   />
-                  <button
-                    type="submit"
-                    disabled={trgAdding || !trgAddName.trim()}
-                    className="rounded bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-500 disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    {trgAdding ? 'Adding…' : 'Add'}
-                  </button>
-                </form>
+                </div>
               )}
             </div>
 
@@ -3435,26 +3415,15 @@ function WorkspaceDetailContent() {
               )}
 
               {perms['can-update'] && (
-                <form
-                  onSubmit={(e) => { e.preventDefault(); addRemoteStateConsumer() }}
-                  className="mt-3 flex items-center gap-2"
-                >
-                  <input
-                    type="text"
-                    value={rscAddName}
-                    onChange={(e) => setRscAddName(e.target.value)}
-                    placeholder="Authorize consumer workspace by name"
-                    className="flex-1 rounded border border-slate-700 bg-slate-900 px-3 py-1.5 text-sm text-slate-200 placeholder-slate-500"
+                <div className="mt-3" data-testid="remote-state-consumer-picker">
+                  <WorkspacePicker
+                    placeholder="Search workspaces to authorize as a consumer…"
+                    excludeIds={[workspaceId, ...rscOutbound.map((e) => e.consumerId)]}
+                    busyId={rscAddingId}
                     disabled={rscAdding}
+                    onSelect={(ws) => addRemoteStateConsumer(ws.id)}
                   />
-                  <button
-                    type="submit"
-                    disabled={rscAdding || !rscAddName.trim()}
-                    className="rounded bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-500 disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    {rscAdding ? 'Authorizing…' : 'Authorize'}
-                  </button>
-                </form>
+                </div>
               )}
             </div>
 

--- a/web/src/components/workspace-picker.tsx
+++ b/web/src/components/workspace-picker.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Search } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+
+export interface WorkspaceOption {
+  id: string
+  name: string
+}
+
+interface WorkspacePickerProps {
+  /** Workspace IDs to exclude from results (e.g. already-linked, or self). */
+  excludeIds?: string[]
+  /** Called when a workspace is clicked. The parent performs the write + refetch. */
+  onSelect: (ws: WorkspaceOption) => Promise<void> | void
+  placeholder?: string
+  /** ID of the workspace currently being acted on — shows an inline spinner on that row. */
+  busyId?: string
+  /** Disable the whole picker (e.g. while a parent op is in flight). */
+  disabled?: boolean
+  /** Max rows to show (default 20). */
+  limit?: number
+}
+
+/**
+ * Search-and-click workspace picker. Replaces free-text "type the exact name"
+ * inputs (run triggers, remote-state sharing, module links) so a typo can't
+ * 404 — you pick from a filtered, clickable list that excludes ineligible
+ * workspaces. Resolves to a workspace id, so callers POST by id directly with
+ * no name→id lookup.
+ */
+export function WorkspacePicker({
+  excludeIds = [],
+  onSelect,
+  placeholder = 'Search workspaces…',
+  busyId,
+  disabled,
+  limit = 20,
+}: WorkspacePickerProps) {
+  const [query, setQuery] = useState('')
+  const [all, setAll] = useState<WorkspaceOption[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // join() gives a stable dependency so the Set isn't rebuilt every render.
+  const excluded = useMemo(() => new Set(excludeIds), [excludeIds.join(',')]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    let active = true
+    ;(async () => {
+      try {
+        const res = await apiFetch('/api/v2/organizations/default/workspaces')
+        if (res.ok && active) {
+          const data = await res.json()
+          setAll(
+            (data.data || []).map((ws: { id: string; attributes: { name: string } }) => ({
+              id: ws.id,
+              name: ws.attributes.name,
+            }))
+          )
+        }
+      } catch {
+        // best-effort; empty list renders "No workspaces found"
+      } finally {
+        if (active) setLoading(false)
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const q = query.trim().toLowerCase()
+  const results = all
+    .filter((ws) => !excluded.has(ws.id) && (!q || ws.name.toLowerCase().includes(q)))
+    .slice(0, limit)
+
+  return (
+    <div className="p-3 bg-slate-900/50 rounded-lg border border-slate-700/30">
+      <div className="flex items-center gap-2 mb-2">
+        <Search size={14} className="text-slate-400" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          autoFocus
+          className="flex-1 px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50"
+        />
+      </div>
+      <div className="max-h-40 overflow-y-auto space-y-1">
+        {loading ? (
+          <p className="text-xs text-slate-500 py-2 text-center">Loading…</p>
+        ) : results.length === 0 ? (
+          <p className="text-xs text-slate-500 py-2 text-center">No workspaces found</p>
+        ) : (
+          results.map((ws) => (
+            <button
+              key={ws.id}
+              type="button"
+              onClick={() => onSelect(ws)}
+              disabled={disabled || busyId === ws.id}
+              className="w-full text-left px-2 py-1.5 rounded text-sm text-slate-300 hover:bg-slate-700/50 transition-colors disabled:opacity-50"
+            >
+              {ws.name}
+              {busyId === ws.id && <span className="text-xs text-slate-500 ml-2">Adding…</span>}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Improves existing features (no new scope) — two UX gaps that converged on the same surfaces.

## 1. Searchable workspace picker
**Run Triggers** and **Sharing** (remote-state consumers) made you type a workspace's *exact name* into a free-text input that 404'd on a typo. New shared **`<WorkspacePicker>`** (search box + clickable list that excludes self + already-linked) replaces those inputs and is retrofitted onto the **module-link** page too — all three now resolve to a workspace **id** (no name→id lookup, no 404). Extracted from the existing module-link pattern.

## 2. Live SSE for static-until-refresh tabs
Several workspace-detail tabs showed server-mutable data but never updated without a manual refresh — worst for **Run Triggers / Sharing**, where an *inbound* edge is created by *another* workspace and you literally couldn't see it appear. Added publishes on the existing per-workspace run-events channel:

| Mutation | Event | Channels |
|---|---|---|
| run-triggers create/delete | `run_trigger_change` | **both** source + destination |
| remote-state consumers create/delete | `remote_state_consumer_change` | **both** producer + consumer |
| variables CRUD | `workspace_variable_change` | workspace |
| notifications CRUD | `workspace_notification_change` | workspace |
| run-tasks CRUD | `workspace_run_task_change` | workspace |

The workspace-detail page re-fetches the active tab on its event. No new SSE endpoint, no `next.config.js`/BFF change (rides `tp:run_events:{workspace_id}`).

## Tests / verification
- `npm run build` (Next.js prerender) ✓ · `make test` Python ✓ (incl. new services-api publish assertions on run-triggers + remote-state)
- New **e2e spec**: run-triggers tab uses the picker → add via click → inbound edge appears live.
- `docs/api-reference.md` SSE event table updated.
- **Live-smoked in Playwright** against the Tilt stack: added a trigger via the picker, the inbound edge appeared live and the picker excluded it; Sharing picker renders the consumer search.

Targeted for a **patch** release (existing-feature improvement) but run through the full minor-release audit.