### PR TITLE
fix(ai): frame drift-detection runs as drift reports, not proposals

### DIFF
--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -1111,6 +1111,7 @@ async def handle_ai_plan_summary(payload: dict) -> None:
             prompt_prefix=cfg.context.prompt_prefix,
             prompt_suffix=cfg.context.prompt_suffix,
             state_diverged=bool(ws.state_diverged),
+            drift_detection=bool(run.is_drift_detection),
         )
 
         try:

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -145,6 +145,10 @@ You will receive these inputs in the user message:
     resource_changes or CODE_DIFF. May be absent.
   • FLEET_CONTEXT — deployment-wide notes from the operator. May be empty.
   • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
+  • DRIFT_DETECTION (when set) — flags that this run is a scheduled
+    drift-detection check, not a response to a configuration change.
+    It changes how you frame the whole summary — see the drift-detection
+    rule below.
 
 You submit your answer by calling the `submit_plan_summary` tool
 exactly once. The tool's parameters carry the schema; the provider
@@ -191,6 +195,39 @@ CRITICAL — drift is NOT the apply change set:
       MUST NOT list them as `risk_factors`. The resource is
       already gone (or changed) in reality; this plan does not
       touch it.
+
+CRITICAL — a drift-detection run is a DETECTION report, not a proposal:
+
+  When DRIFT_DETECTION is set in the user message, this run was queued
+  automatically by Terrapod's scheduled drift checker — NOT by a code
+  change, a pull request, or an operator. It is plan-only; no apply
+  will follow. Its sole purpose is to report whether live
+  infrastructure has drifted from its recorded state. Frame the ENTIRE
+  summary that way:
+
+    • `resource_changes` here are NOT proposed feature changes. The
+      configuration did not change (CODE_DIFF is normally empty). Each
+      entry is the corrective action a future reconciling apply WOULD
+      take to undo an out-of-band change — i.e. it is describing
+      DRIFT. Report it as a finding about what changed in the live
+      world: "`aws_s3_bucket.logs` has drifted — bucket versioning was
+      disabled out-of-band; the recorded configuration expects it
+      enabled." Do NOT phrase it as "this plan will disable
+      versioning" — the run is detecting the drift, not causing it.
+    • Lead `description` with WHAT drifted and the likely nature of the
+      out-of-band change (manual console edit, another tool, an
+      external controller). If nothing drifted (no informative
+      `resource_changes`), say so plainly — "No drift detected; live
+      infrastructure matches recorded state." That is the success case
+      for a drift run, not an empty answer.
+    • `risk_factors` rate the operational significance of the drift
+      (is recorded state now wrong? has a security control been
+      silently disabled? would the next real apply revert a needed
+      manual fix?), not the routineness of a config change.
+    • Never call a drift-detection run "speculative", a "proposed
+      change", or something "for review/merge" — there is no proposal
+      and no PR. It is a scheduled health check that found (or did not
+      find) drift.
 
 CRITICAL — `risk_level` and `risk_factors` are paired, not independent:
 
@@ -357,6 +394,7 @@ def render_prompt(
     prompt_prefix: str = "",
     prompt_suffix: str = "",
     state_diverged: bool = False,
+    drift_detection: bool = False,
 ) -> tuple[str, str]:
     """Render the system + user messages for the Chat Completions request.
 
@@ -401,6 +439,14 @@ def render_prompt(
             "(the runner could not upload post-apply state to Terrapod; "
             "real infrastructure may have been mutated by the partial "
             "apply but Terrapod's recorded state no longer reflects it.)"
+        )
+    if drift_detection and kind == "plan_summary":
+        user_parts.append(
+            "DRIFT_DETECTION: true\n"
+            "(scheduled drift-detection run — plan-only, no apply will "
+            "follow. resource_changes describe drift between recorded "
+            "state and live infrastructure, not proposed configuration "
+            "changes. Frame the summary as drift findings.)"
         )
     user_parts.append(f"{primary_input_label}:\n```{primary_input_lang}\n{primary_input}\n```")
     if code_diff.strip():

--- a/services/tests/services/test_summariser_prompt.py
+++ b/services/tests/services/test_summariser_prompt.py
@@ -193,6 +193,73 @@ def test_code_diff_described_in_skill_prompt():
     assert "resource_drift" in system
 
 
+# ── drift_detection framing ──────────────────────────────────────────────
+
+
+def test_drift_detection_block_renders_in_user_message():
+    """A drift-detection run frames the plan as a drift report, not a
+    proposal. The user message must carry the DRIFT_DETECTION marker so
+    the model switches framing.
+    """
+    _, user = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input='{"resource_changes":[]}',
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated="",
+        drift_detection=True,
+    )
+    assert "DRIFT_DETECTION: true" in user
+
+
+def test_drift_detection_block_omitted_by_default():
+    _, user = render_prompt(
+        kind="plan_summary",
+        fleet_context="",
+        workspace_context="",
+        primary_input="{}",
+        primary_input_label="PLAN_JSON",
+        primary_input_lang="json",
+        code_context_truncated="",
+    )
+    assert "DRIFT_DETECTION: true" not in user
+
+
+def test_drift_detection_block_only_for_plan_summary():
+    """The flag is a plan-summary concept. A failure-analysis render must
+    not emit the drift block even if the flag is passed (a drift run that
+    errored is analysed as a failure, not summarised as drift).
+    """
+    _, user = render_prompt(
+        kind="failure_analysis",
+        fleet_context="",
+        workspace_context="",
+        primary_input="Error: boom",
+        primary_input_label="PLAN_LOG",
+        primary_input_lang="text",
+        code_context_truncated="",
+        drift_detection=True,
+    )
+    assert "DRIFT_DETECTION: true" not in user
+
+
+def test_drift_detection_described_in_plan_summary_skill():
+    """The plan-summary skill prompt must teach the model what a
+    drift-detection run is and how to frame it — otherwise the marker in
+    the user message is undefined noise.
+    """
+    skill = PLAN_SUMMARY_SKILL_PROMPT
+    assert "DRIFT_DETECTION" in skill
+    assert "drift-detection run" in skill
+    # The model must be told NOT to call it a speculative/proposed change.
+    assert "speculative" in skill
+    # The success case ("no drift") must be spelled out so the model
+    # doesn't return an empty/confused answer on a clean drift run.
+    assert "No drift detected" in skill
+
+
 def test_plan_summary_skill_forbids_empty_risk_factors_at_elevated_level():
     """The prompt MUST state that an empty risk_factors array is
     permitted only when risk_level == "low". The JSON Schema can't


### PR DESCRIPTION
## Problem

The AI plan summary on a **scheduled drift-detection run** talked about the plan as if it were a speculative proposed change ("this plan will …", framed for review). But a drift-detection run is plan-only and never applies — its `resource_changes` describe the gap between *recorded state* and *live infrastructure* (i.e. drift that someone introduced out-of-band), not a proposal an operator is reviewing.

## Fix

Thread the run's `is_drift_detection` flag into the summariser prompt, mirroring the existing `state_diverged` mechanism:

- `render_prompt(..., drift_detection=True)` adds a `DRIFT_DETECTION: true` marker block to the user message (plan-summary kind only).
- The plan-summary skill prompt gains a `CRITICAL` section instructing the model to, on a drift run:
  - report `resource_changes` as **drift findings** ("`aws_s3_bucket.logs` has drifted — versioning was disabled out-of-band; recorded config expects it enabled"), not "this plan will disable versioning";
  - lead with what drifted and the likely cause (manual console edit, another tool, external controller);
  - spell out the **success case** — "No drift detected; live infrastructure matches recorded state" — so a clean drift run doesn't produce an empty/confused answer;
  - rate the **operational significance** of the drift in `risk_factors`;
  - never call it "speculative", a "proposed change", or something "for review/merge".
- `summariser.py` passes `drift_detection=bool(run.is_drift_detection)` at the call site.

No behaviour change for normal CLI/VCS runs (flag defaults to `False`); the existing `resource_drift` partitioning within apply plans is untouched.

## Tests

`tests/services/test_summariser_prompt.py` gains 4 cases: the block renders for `plan_summary` when set, is omitted by default, is omitted for `failure_analysis` even when the flag is passed, and the skill prompt documents the flag + success case. Full summariser/AI suite green (266 passed).