### PR TITLE
feat(registry): client-signed provider publishing + terrapod-publish CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,43 @@ jobs:
         run: go test ./... -v -count=1 -timeout 120s
         working-directory: migrate
 
+  # ── Publish Lint ──────────────────────────────────────
+  # terrapod-publish lives in publish/ with its own go.mod (pulls the
+  # ProtonMail OpenPGP libs that the SDK doesn't). Mirrors migrate's shape.
+  publish-lint:
+    name: Publish Lint
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: publish/go.mod
+          cache-dependency-path: publish/go.sum
+      - name: Vet
+        run: go vet ./...
+        working-directory: publish
+      - name: Build
+        run: go build ./...
+        working-directory: publish
+
+  # ── Publish Test ──────────────────────────────────────
+  publish-test:
+    name: Publish Test
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: publish/go.mod
+          cache-dependency-path: publish/go.sum
+      - name: Test
+        run: go test ./... -v -count=1 -timeout 120s
+        working-directory: publish
+
   # ── Python Test ────────────────────────────────────────
   python-test:
     # Sharded by directory so each shard gets its own Postgres /
@@ -963,9 +1000,49 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
 
+  release-publish:
+    name: Release — Publish tool (GoReleaser)
+    # Parallel with release-provider / release-migrate — all append to the
+    # Release that release-create made.
+    needs: [prepare, release-create]
+    if: |
+      always()
+      && needs.prepare.outputs.is_tag == 'true'
+      && needs.release-create.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: publish/go.mod
+          cache-dependency-path: publish/go.sum
+
+      - name: Import GPG signing key
+        id: gpg
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+          fingerprint=$(gpg --with-colons --import-options show-only --import <<< "${{ secrets.GPG_PRIVATE_KEY }}" | awk -F: '/^fpr:/{print $10; exit}')
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
+      - name: Build terrapod-publish binaries with GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --parallelism 6
+          workdir: publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
+
   release-finalize:
     name: Release — Finalize (notes + chart + SBOMs)
-    needs: [prepare, release-create, release-images, release-provider, release-migrate]
+    needs: [prepare, release-create, release-images, release-provider, release-migrate, release-publish]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
@@ -1092,6 +1169,8 @@ jobs:
       - go-terrapod-test
       - migrate-lint
       - migrate-test
+      - publish-lint
+      - publish-test
       - python-test
       - python-audit
       - npm-audit
@@ -1108,6 +1187,7 @@ jobs:
       - release-images
       - release-provider
       - release-migrate
+      - release-publish
       - release-finalize
     runs-on: ubuntu-latest
     steps:
@@ -1123,6 +1203,8 @@ jobs:
             "${{ needs.go-terrapod-test.result }}"
             "${{ needs.migrate-lint.result }}"
             "${{ needs.migrate-test.result }}"
+            "${{ needs.publish-lint.result }}"
+            "${{ needs.publish-test.result }}"
             "${{ needs.python-test.result }}"
             "${{ needs.python-audit.result }}"
             "${{ needs.npm-audit.result }}"
@@ -1139,6 +1221,7 @@ jobs:
             "${{ needs.release-images.result }}"
             "${{ needs.release-provider.result }}"
             "${{ needs.release-migrate.result }}"
+            "${{ needs.release-publish.result }}"
             "${{ needs.release-finalize.result }}"
           )
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,7 +797,8 @@ jobs:
   #                      artifact for release-finalize to upload.
   #   release-provider — GoReleaser provider, append mode.
   #   release-migrate  — GoReleaser migrate, append mode.
-  #   release-finalize — joins all four; sets real title + release notes
+  #   release-publish  — GoReleaser terrapod-publish, append mode.
+  #   release-finalize — joins all five; sets real title + release notes
   #                      and uploads the workflow artifact from
   #                      release-images.
   #
@@ -1050,6 +1051,7 @@ jobs:
       && needs.release-images.result == 'success'
       && needs.release-provider.result == 'success'
       && needs.release-migrate.result == 'success'
+      && needs.release-publish.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1134,11 +1136,11 @@ jobs:
   # ── Cleanup Tag on Failure ─────────────────────────────
   cleanup-tag:
     name: Cleanup Tag
-    needs: [prepare, build-images, scan-images, create-manifests, release-create, release-images, release-provider, release-migrate, release-finalize]
+    needs: [prepare, build-images, scan-images, create-manifests, release-create, release-images, release-provider, release-migrate, release-publish, release-finalize]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
-      && (needs.build-images.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release-create.result == 'failure' || needs.release-images.result == 'failure' || needs.release-provider.result == 'failure' || needs.release-migrate.result == 'failure' || needs.release-finalize.result == 'failure')
+      && (needs.build-images.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release-create.result == 'failure' || needs.release-images.result == 'failure' || needs.release-provider.result == 'failure' || needs.release-migrate.result == 'failure' || needs.release-publish.result == 'failure' || needs.release-finalize.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [API Reference](docs/api-reference.md) | All API endpoints with examples |
 | [Deployment](docs/deployment.md) | Production Helm deployment, storage backends, scaling |
 | [Registry](docs/registry.md) | Private module/provider registry, caching layers |
+| [Registry Publishing](docs/registry-publishing.md) | Publishing providers/modules with `terrapod-publish` and the client-signed publish protocol |
 | [VCS Integration](docs/vcs-integration.md) | GitHub and GitLab setup, polling, webhooks |
 | [Policies (OPA)](docs/policies.md) | Rego policy authoring, advisory vs mandatory enforcement, label-based scoping, admin override |
 | [Autodiscovery](docs/autodiscovery.md) | Atlantis-style monorepo workspace autodiscovery |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1419,7 +1419,7 @@ GET  /api/terrapod/v1/registry-modules
 POST /api/terrapod/v1/registry-modules
 GET  /api/terrapod/v1/registry-modules/private/default/{name}/{provider}
 DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{provider}
-POST /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/versions
+PUT  /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/versions/{version}/upload
 DELETE /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/versions/{version}
 ```
 
@@ -1447,9 +1447,27 @@ All module responses (show and list) include a `permissions` object:
 }
 ```
 
-### Version Upload
+### Version Upload (Streamed)
 
-Create a version, then upload the tarball to the presigned URL returned in the response.
+```
+PUT /api/terrapod/v1/registry-modules/private/default/{name}/{provider}/versions/{version}/upload
+```
+
+A single streamed `PUT` of the gzipped module source tarball. The version
+is created **implicitly on upload** — there is no separate create step and
+no presigned URL. The server extracts the module interface (inputs and
+outputs) and triggers impact runs on any linked workspaces (see
+[Module Impact Analysis](#registry----modules) and the workspace-links
+section below).
+
+**Required permission:** `write` on the module (the owner has `admin`).
+
+**Tooling:** the [`terrapod-publish`](registry-publishing.md) CLI packages
+the source directory and performs this upload.
+
+> **Removed in the client-signed model:** the previous
+> `POST .../versions` create-then-upload-to-presigned-URL flow has been
+> **removed** in favour of the single streamed `PUT` above.
 
 ### Workspace Links (Module Impact Analysis)
 
@@ -1474,6 +1492,11 @@ GET /api/v2/registry/providers/{namespace}/{type}/versions
 GET /api/v2/registry/providers/{namespace}/{type}/{version}/download/{os}/{arch}
 ```
 
+The download response advertises the **publisher's own** GPG public key
+in `signing_keys.gpg_public_keys`. Terrapod never re-signs a provider — the
+signature `terraform init` verifies is the one the publisher produced at
+publish time (see [Publishing a Version](#publishing-a-version-client-signed)).
+
 ### TFE V2 Management API
 
 ```
@@ -1481,11 +1504,52 @@ GET  /api/terrapod/v1/registry-providers
 POST /api/terrapod/v1/registry-providers
 GET  /api/terrapod/v1/registry-providers/private/default/{name}
 DELETE /api/terrapod/v1/registry-providers/private/default/{name}
-POST /api/terrapod/v1/registry-providers/private/default/{name}/versions
 GET  /api/terrapod/v1/registry-providers/private/default/{name}/versions
 DELETE /api/terrapod/v1/registry-providers/private/default/{name}/versions/{version}
-POST /api/terrapod/v1/registry-providers/private/default/{name}/versions/{version}/platforms
 ```
+
+### Publishing a Version (Client-Signed)
+
+Provider publishing is **client-signed, direct, and streamed**. The
+publisher computes `SHA256SUMS` over the platform zips and GPG-signs it
+with its own key; the server verifies that signature against a
+**registered** GPG public key and never re-signs. The version is created
+**implicitly on the first upload** — there is no separate create-version
+or finalize step.
+
+Uploads must happen in this exact order:
+
+```
+PUT /api/terrapod/v1/registry-providers/private/default/{name}/versions/{version}/shasums
+PUT /api/terrapod/v1/registry-providers/private/default/{name}/versions/{version}/shasums.sig
+PUT /api/terrapod/v1/registry-providers/private/default/{name}/versions/{version}/platforms/{os}/{arch}
+```
+
+1. **`PUT .../shasums`** — the raw `SHA256SUMS` manifest (one
+   `{sha}  {zipname}` line per platform).
+2. **`PUT .../shasums.sig`** — the detached GPG signature over the
+   manifest. **The server verifies it against a registered GPG key here
+   (the trust gate).** Returns **422** if the key isn't registered or the
+   signature doesn't verify. Binaries are refused until this succeeds.
+3. **`PUT .../platforms/{os}/{arch}`** (one per platform) — each zip is
+   streamed to disk and its SHA checked against the signed manifest.
+   Returns **422** on a SHA mismatch, or if the signature has not yet been
+   verified.
+
+**Required permission:** `write` on the provider (the owner has `admin`).
+
+**Tooling:** the [`terrapod-publish`](registry-publishing.md) CLI performs
+these three uploads (in order) and does all packaging, hashing, and GPG
+signing client-side. The server never re-signs — the
+[download response](#cli-protocol-for-terraform-init) advertises the
+publisher's own public key in `signing_keys.gpg_public_keys`.
+
+> **Removed in the client-signed model:** the previous presigned-URL
+> flow — `POST .../versions` (create version) and
+> `POST .../versions/{version}/platforms` (create platform, returning a
+> presigned upload URL) — has been **removed**. There is no
+> server-side re-signing and no presigned-URL or finalize step for
+> provider versions. Use the three streamed `PUT` endpoints above.
 
 ### Update Provider
 
@@ -1519,6 +1583,11 @@ POST   /api/terrapod/v1/gpg-keys
 GET    /api/terrapod/v1/gpg-keys/{namespace}/{key_id}
 DELETE /api/terrapod/v1/gpg-keys/{namespace}/{key_id}
 ```
+
+The **public** key registered here is the trust anchor for client-signed
+provider publishing: `PUT .../shasums.sig` is verified against it. Register
+a key before publishing a provider (or use the `terrapod_gpg_key` provider
+resource). See [Publishing to the Private Registry](registry-publishing.md).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Runners](runners.md) | Custom runner images, private registries, Job configuration |
 | [Cloud Credentials](cloud-credentials.md) | AWS IRSA, GCP WIF, Azure WI setup |
 | [Registry](registry.md) | Private module/provider registry, caching layers |
+| [Registry Publishing](registry-publishing.md) | Publishing providers/modules with the `terrapod-publish` CLI and the client-signed publish protocol |
 | [Monitoring](monitoring.md) | Prometheus metrics, scraping, recommended alerts |
 | [Deployment](deployment.md) | Production Helm deployment, storage backends, scaling |
 | [Split-networking deployments](deployment-network-isolation.md) | Three-Ingress model: management / webhook / internal agent path, with split-hostname runner config |

--- a/docs/registry-publishing.md
+++ b/docs/registry-publishing.md
@@ -1,0 +1,470 @@
+# Publishing to the Private Registry with `terrapod-publish`
+
+Terrapod ships a CLI, `terrapod-publish`, that publishes providers and
+modules to a self-hosted Terrapod private registry. It is the operator-
+facing companion to the registry: build your provider binaries (or point
+it at a module directory), and `terrapod-publish` packages, signs, and
+uploads everything.
+
+This page is the operator runbook for publishing. For the registry's
+read side (`terraform init` consumption, caching, RBAC, VCS-driven
+publishing) see [Registry](registry.md).
+
+> This page covers **direct, client-signed publishing**. If your modules
+> live in git and you'd rather have Terrapod watch the tag stream and
+> publish versions automatically, see
+> [VCS-Driven Module Publishing](registry.md#vcs-driven-module-publishing).
+
+---
+
+## The client-signed model
+
+Provider publishing in Terrapod is **client-signed, direct, and
+streamed**. The publisher — not the server — owns the GPG signature over
+the provider's `SHA256SUMS` manifest.
+
+1. `terrapod-publish` zips each provider platform binary, computes
+   `SHA256SUMS` over the zips, and **GPG-signs `SHA256SUMS` with the
+   publisher's own private key** (pure-Go OpenPGP — no `gpg` binary on
+   the publishing host).
+2. The manifest, then the detached signature, then each platform zip are
+   streamed directly to the API in a fixed order. There are no presigned
+   URLs and no separate "finalize" step.
+3. The server verifies the signature against a **registered** GPG public
+   key before it will accept any binary. The signature is the trust
+   gate: a binary whose SHA doesn't appear in the signed manifest, or a
+   signature from an unregistered key, is rejected with `422`.
+4. The server **never re-signs**. When `terraform init` downloads the
+   provider, the download response advertises the publisher's own public
+   key in `signing_keys.gpg_public_keys`. The chain of custody runs
+   publisher → registry → consumer with one signature throughout.
+
+Because the server trusts the signature rather than the upload identity,
+the publisher's GPG **public** key must be registered with Terrapod
+before the first publish. Registration is the one-time setup step below.
+
+Modules are simpler — there is no signature. A module publish is a single
+streamed upload of the gzipped source tarball. The server extracts the
+module interface (inputs/outputs) and triggers impact runs on any linked
+workspaces. See [Module Impact Analysis](registry.md#module-impact-analysis).
+
+---
+
+## Prerequisites
+
+Before the first publish you need three things in place: a registered GPG
+public key, a provider (or module) slot, and an API token. The first two
+are best managed declaratively with the `terrapod` Terraform provider in
+a small `terrapod-config` repo, so they live in version control and can
+be reviewed — but the equivalent API calls are shown for completeness.
+
+### 1. Register the publisher's GPG public key
+
+The server verifies provider signatures against keys you register ahead
+of time. Register the **public** half of the key `terrapod-publish` will
+sign with.
+
+Declaratively (recommended), in your `terrapod-config`:
+
+```hcl
+resource "terrapod_gpg_key" "publisher" {
+  ascii_armor = file("${path.module}/publisher-public-key.asc")
+}
+```
+
+Or directly against the API:
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN" \
+  -H "Content-Type: application/vnd.api+json" \
+  https://terrapod.example.internal/api/terrapod/v1/gpg-keys \
+  -d @- <<'JSON'
+{
+  "data": {
+    "type": "gpg-keys",
+    "attributes": {
+      "ascii-armor": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----\n"
+    }
+  }
+}
+JSON
+```
+
+The `key_id` is extracted from the armor at creation time. Only the
+public key is registered — the private key never leaves the publishing
+host.
+
+### 2. Create the provider (or module) slot
+
+The registry entry must exist before a version can be uploaded. The
+version itself is created **implicitly on first upload** — there is no
+separate version-create step.
+
+Provider, declaratively:
+
+```hcl
+resource "terrapod_registry_provider" "example" {
+  name = "example"
+}
+```
+
+Module, declaratively:
+
+```hcl
+resource "terrapod_registry_module" "vpc" {
+  name     = "vpc"
+  provider = "aws"
+}
+```
+
+Or via the API:
+
+```bash
+# Provider slot
+curl -sS -X POST \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN" \
+  -H "Content-Type: application/vnd.api+json" \
+  https://terrapod.example.internal/api/terrapod/v1/registry-providers \
+  -d '{"data":{"type":"registry-providers","attributes":{"name":"example"}}}'
+
+# Module slot
+curl -sS -X POST \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN" \
+  -H "Content-Type: application/vnd.api+json" \
+  https://terrapod.example.internal/api/terrapod/v1/registry-modules \
+  -d '{"data":{"type":"registry-modules","attributes":{"name":"vpc","provider":"aws"}}}'
+```
+
+Creating a slot requires any authenticated user; the creator becomes the
+owner (registry `admin`). Publishing versions requires `write` on the
+slot. See [Registry RBAC](registry.md#rbac).
+
+### 3. An API token
+
+`terrapod-publish` authenticates with a Terrapod API token. The simplest
+way to get one is `terraform login terrapod.example.internal`, which
+stores the token in `~/.terraform.d/credentials.tfrc.json` — the CLI
+reads it from there automatically. For CI, create a long-lived token
+(`settings → tokens` in the UI, or `POST /api/terrapod/v1/account/tokens`)
+and pass it via `$TERRAPOD_TOKEN`. See [Auth resolution](#auth-resolution).
+
+---
+
+## Installing `terrapod-publish`
+
+`terrapod-publish` is a Go binary published as a GitHub Release artifact
+on every Terrapod release tag, alongside `terrapod-migrate` and the
+Terraform provider. Each release publishes:
+
+- **macOS universal** — a single fat binary that runs natively on Intel
+  and Apple Silicon.
+- **Linux** — amd64 + arm64.
+- **Windows** — amd64 + arm64.
+
+Each archive ships with a SHA256 checksum file, detached-GPG-signed with
+the project signing key.
+
+Download the artifact for your platform from the
+[Releases page](https://github.com/mattrobinsonsre/terrapod/releases),
+verify the checksum, and place the binary on your `PATH`:
+
+```bash
+tar -xzf terrapod-publish_linux_amd64.tar.gz
+sudo install terrapod-publish /usr/local/bin/
+terrapod-publish --version
+```
+
+---
+
+## Publishing a provider
+
+```
+terrapod-publish provider \
+  --host HOST \
+  --name NAME \
+  --version VERSION \
+  --signing-key KEY.asc \
+  --binary OS/ARCH=PATH [--binary OS/ARCH=PATH ...]
+```
+
+The CLI does the packaging, hashing, and signing entirely in Go. You
+supply only the **pre-built provider binaries** — one per platform.
+Cross-compilation (`go build` with `GOOS`/`GOARCH`) stays in your build
+pipeline; `terrapod-publish` never invokes the Go toolchain.
+
+| Flag | Meaning |
+|---|---|
+| `--host` | Terrapod hostname (e.g. `terrapod.example.internal`). |
+| `--name` | Provider name — the slot you created (e.g. `example`). |
+| `--version` | Semantic version, no `v` prefix (e.g. `1.4.0`). |
+| `--signing-key` | Path to the **private** signing key in ASCII-armored form. Its public half must already be registered (prerequisite 1). |
+| `--binary OS/ARCH=PATH` | A built binary for one platform. Repeatable. The CLI zips each, computes its SHA, and includes it in the signed manifest. |
+| `--signing-key-passphrase` | Passphrase for the signing key. Omit for a passphrase-less key. Also `$TERRAPOD_SIGNING_KEY_PASSPHRASE`. |
+| `--token` | API token. See [Auth resolution](#auth-resolution). |
+
+### What the CLI does, in order
+
+For a provider with N platforms, `terrapod-publish` performs these uploads
+against the API in this exact order:
+
+1. `PUT .../versions/{version}/shasums` — the `SHA256SUMS` manifest.
+2. `PUT .../versions/{version}/shasums.sig` — the detached signature.
+   The server verifies it against your registered key over the manifest.
+   **This is the trust gate** — a bad or unregistered signature fails here
+   with `422`, and no binaries are accepted.
+3. `PUT .../versions/{version}/platforms/{os}/{arch}` (× N) — each zip is
+   streamed to disk and its SHA checked against the signed manifest;
+   `422` on mismatch.
+
+The version is created implicitly when the manifest lands; there is no
+explicit create or finalize call.
+
+### Worked example: publish six platforms
+
+Build the six standard platforms in your pipeline. A provider's binary is
+just the compiled plugin executable — name it
+`terraform-provider-{name}_v{version}`:
+
+```bash
+VERSION=1.4.0
+NAME=example
+OUT=dist
+
+for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
+  os="${platform%/*}"; arch="${platform#*/}"
+  ext=""; [ "$os" = "windows" ] && ext=".exe"
+  GOOS="$os" GOARCH="$arch" go build \
+    -o "$OUT/$os/$arch/terraform-provider-${NAME}_v${VERSION}${ext}" \
+    ./...
+done
+```
+
+Then publish all six in one invocation:
+
+```bash
+terrapod-publish provider \
+  --host terrapod.example.internal \
+  --name "$NAME" \
+  --version "$VERSION" \
+  --signing-key ./publisher-private-key.asc \
+  --binary linux/amd64=dist/linux/amd64/terraform-provider-example_v1.4.0 \
+  --binary linux/arm64=dist/linux/arm64/terraform-provider-example_v1.4.0 \
+  --binary darwin/amd64=dist/darwin/amd64/terraform-provider-example_v1.4.0 \
+  --binary darwin/arm64=dist/darwin/arm64/terraform-provider-example_v1.4.0 \
+  --binary windows/amd64=dist/windows/amd64/terraform-provider-example_v1.4.0.exe \
+  --binary windows/arm64=dist/windows/arm64/terraform-provider-example_v1.4.0.exe
+```
+
+After a successful publish, consumers can pull the provider:
+
+```hcl
+terraform {
+  required_providers {
+    example = {
+      source  = "terrapod.example.internal/default/example"
+      version = "1.4.0"
+    }
+  }
+}
+```
+
+`terraform init` fetches the platform zip and the publisher's public key
+(advertised in `signing_keys.gpg_public_keys`) and verifies the signature
+itself — exactly as it would against the public registry.
+
+---
+
+## Publishing a module
+
+```
+terrapod-publish module \
+  --host HOST \
+  --name NAME \
+  --provider PROVIDER \
+  --version VERSION \
+  --source ./moduledir
+```
+
+Modules are unsigned. The CLI gzips the contents of `--source` into a
+tarball and streams it in a single `PUT` to the module upload endpoint.
+The server extracts the module interface (inputs and outputs) and triggers
+impact runs on any linked workspaces.
+
+| Flag | Meaning |
+|---|---|
+| `--host` | Terrapod hostname. |
+| `--name` | Module name — the slot you created (e.g. `vpc`). |
+| `--provider` | The module's provider segment (e.g. `aws`). |
+| `--version` | Semantic version, no `v` prefix. |
+| `--source` | Path to the module directory to package. |
+| `--token` | API token. See [Auth resolution](#auth-resolution). |
+
+```bash
+terrapod-publish module \
+  --host terrapod.example.internal \
+  --name vpc \
+  --provider aws \
+  --version 2.1.0 \
+  --source ./modules/vpc
+```
+
+Consume it the usual way:
+
+```hcl
+module "vpc" {
+  source  = "terrapod.example.internal/default/vpc/aws"
+  version = "2.1.0"
+}
+```
+
+---
+
+## Auth resolution
+
+`terrapod-publish` resolves the API token from the first source that
+yields a value, in this order:
+
+1. The `--token` flag.
+2. The `$TERRAPOD_TOKEN` environment variable.
+3. `~/.terraform.d/credentials.tfrc.json` — the token stored by
+   `terraform login HOST` for the matching host.
+
+For interactive use, `terraform login terrapod.example.internal` once and
+the CLI picks the token up automatically. For CI, prefer `$TERRAPOD_TOKEN`
+sourced from a secret store.
+
+The signing-key passphrase resolves from `--signing-key-passphrase`, then
+`$TERRAPOD_SIGNING_KEY_PASSPHRASE`. Omit both for a passphrase-less key.
+
+---
+
+## CI example (GitHub Actions)
+
+Build the provider binaries per platform, then publish on a version tag.
+Cross-compilation is plain `go build`; `terrapod-publish` handles the rest.
+
+```yaml
+# .github/workflows/publish-provider.yml
+name: publish-provider
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Build provider binaries
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NAME=example
+          for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
+            os="${platform%/*}"; arch="${platform#*/}"
+            ext=""; [ "$os" = "windows" ] && ext=".exe"
+            GOOS="$os" GOARCH="$arch" go build \
+              -o "dist/$os/$arch/terraform-provider-${NAME}_v${VERSION}${ext}" ./...
+          done
+
+      - name: Install terrapod-publish
+        run: |
+          curl -sSL -o tp.tar.gz \
+            https://github.com/mattrobinsonsre/terrapod/releases/latest/download/terrapod-publish_linux_amd64.tar.gz
+          tar -xzf tp.tar.gz
+          sudo install terrapod-publish /usr/local/bin/
+
+      - name: Publish provider
+        env:
+          TERRAPOD_TOKEN: ${{ secrets.TERRAPOD_TOKEN }}
+          TERRAPOD_SIGNING_KEY_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          printf '%s' "${{ secrets.SIGNING_PRIVATE_KEY }}" > signing-key.asc
+          terrapod-publish provider \
+            --host terrapod.example.internal \
+            --name example \
+            --version "$VERSION" \
+            --signing-key signing-key.asc \
+            --binary linux/amd64=dist/linux/amd64/terraform-provider-example_v${VERSION} \
+            --binary linux/arm64=dist/linux/arm64/terraform-provider-example_v${VERSION} \
+            --binary darwin/amd64=dist/darwin/amd64/terraform-provider-example_v${VERSION} \
+            --binary darwin/arm64=dist/darwin/arm64/terraform-provider-example_v${VERSION} \
+            --binary windows/amd64=dist/windows/amd64/terraform-provider-example_v${VERSION}.exe \
+            --binary windows/arm64=dist/windows/arm64/terraform-provider-example_v${VERSION}.exe
+          rm -f signing-key.asc
+```
+
+The token and signing material come from repository/organization secrets.
+The signing **public** key was registered with Terrapod once, ahead of
+time (prerequisite 1); CI only ever holds the private key transiently.
+
+For a module the CI step collapses to a single `terrapod-publish module`
+call with `--source` pointed at the module directory — no build step, no
+signing key.
+
+---
+
+## Troubleshooting
+
+### `422 Unprocessable Entity`
+
+The trust gate or a content check rejected the upload. The three common
+causes:
+
+- **Unregistered signing key.** The signature verified cryptographically
+  but the key isn't registered with Terrapod, or the wrong key was used.
+  Register the **public** half of your signing key
+  (`POST /api/terrapod/v1/gpg-keys` or the `terrapod_gpg_key` resource)
+  and confirm the `key_id` matches the key behind `--signing-key`.
+- **Signature doesn't verify.** The detached signature doesn't validate
+  against the manifest. This usually means the manifest and signature came
+  from different runs, or the signing key doesn't match the registered
+  public key. Re-run the publish so the manifest and signature are
+  produced together.
+- **SHA mismatch on a platform.** A platform zip's SHA doesn't match the
+  entry in the signed manifest — typically a binary changed between
+  signing and upload, or the wrong file was passed to `--binary`. Re-run
+  the full publish so the manifest covers exactly the binaries uploaded.
+
+Binaries are refused until the signature is verified, and they must be
+uploaded **after** the manifest and signature. The CLI always uploads in
+the correct order (manifest → signature → platforms); a `422` on a
+platform upload from a hand-rolled client almost always means the order
+was wrong or the signature step was skipped.
+
+### `401 Unauthorized`
+
+No usable token was found, or the token is invalid/expired. Check the
+[auth resolution](#auth-resolution) order: pass `--token`, set
+`$TERRAPOD_TOKEN`, or run `terraform login HOST`. If the token was issued
+a long time ago, it may have hit the configured API-token max TTL — mint a
+fresh one.
+
+### `403 Forbidden`
+
+The token is valid but lacks permission. Publishing a version requires
+`write` on the registry slot (the creator/owner has `admin`). Check the
+slot's `permissions` block in its show/list response, or have an admin
+grant you access. See [Registry RBAC](registry.md#rbac).
+
+### `404 Not Found`
+
+The provider or module slot doesn't exist. Create it first (prerequisite
+2) — the version is created implicitly on upload, but the slot is not.
+
+---
+
+## See also
+
+- [Registry](registry.md) — consuming providers/modules, caching, RBAC,
+  VCS-driven module publishing.
+- [API Reference — Registry](api-reference.md#registry----providers) —
+  the raw publish endpoints.
+- [Migration](migration.md) — `terrapod-migrate`, for bulk-importing an
+  existing TFE/HCP private registry.

--- a/go-terrapod/registry_publish.go
+++ b/go-terrapod/registry_publish.go
@@ -1,0 +1,62 @@
+package terrapod
+
+import (
+	"context"
+	"fmt"
+)
+
+// Registry publishing — client-signed, direct uploads.
+//
+// Providers are published in three steps, in order: the SHA256SUMS manifest,
+// its detached signature (verified server-side against a registered GPG key —
+// the trust gate), then each platform zip (validated against the signed
+// manifest as it is received). The server never re-signs; the publisher owns
+// the signature. Modules are a single tarball upload (the server extracts the
+// interface and triggers linked-workspace impact runs).
+//
+// All uploads go to the authenticated Terrapod API (not presigned object
+// storage), so the bearer token is required and the request Content-Type is
+// informational only.
+
+const (
+	providerPublishBase = "/api/terrapod/v1/registry-providers/private/default"
+	modulePublishBase   = "/api/terrapod/v1/registry-modules/private/default"
+)
+
+// UploadProviderSHASUMS uploads the client-built SHA256SUMS manifest for a
+// provider version (the first publish step). Upserts the version.
+func (c *Client) UploadProviderSHASUMS(ctx context.Context, name, version string, shasums []byte) error {
+	path := fmt.Sprintf("%s/%s/versions/%s/shasums", providerPublishBase, name, version)
+	_, err := c.PutRaw(ctx, path, "text/plain", shasums)
+	return err
+}
+
+// UploadProviderSignature uploads the detached SHA256SUMS signature and
+// triggers server-side verification against a registered GPG key. Returns a
+// *ValidationError (HTTP 422) if the signature is missing its manifest, is from
+// an unregistered key, or fails verification.
+func (c *Client) UploadProviderSignature(ctx context.Context, name, version string, sig []byte) error {
+	path := fmt.Sprintf("%s/%s/versions/%s/shasums.sig", providerPublishBase, name, version)
+	_, err := c.PutRaw(ctx, path, "application/pgp-signature", sig)
+	return err
+}
+
+// UploadProviderPlatform uploads one built+zipped provider platform binary. The
+// server validates the zip's sha against the signed manifest before accepting
+// it; a mismatch (or uploading before the signature is verified) returns a
+// *ValidationError (HTTP 422). goos/goarch are the Go OS/arch (e.g. linux,
+// arm64).
+func (c *Client) UploadProviderPlatform(ctx context.Context, name, version, goos, goarch string, zip []byte) error {
+	path := fmt.Sprintf("%s/%s/versions/%s/platforms/%s/%s", providerPublishBase, name, version, goos, goarch)
+	_, err := c.PutRaw(ctx, path, "application/zip", zip)
+	return err
+}
+
+// UploadModuleVersion uploads a gzipped module source tarball for a version.
+// Upserts the version; the server extracts the module interface and triggers
+// runs on linked workspaces.
+func (c *Client) UploadModuleVersion(ctx context.Context, name, provider, version string, tarball []byte) error {
+	path := fmt.Sprintf("%s/%s/%s/versions/%s/upload", modulePublishBase, name, provider, version)
+	_, err := c.PutRaw(ctx, path, "application/gzip", tarball)
+	return err
+}

--- a/go-terrapod/registry_publish_test.go
+++ b/go-terrapod/registry_publish_test.go
@@ -1,0 +1,113 @@
+package terrapod
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// captures the last request the publish helpers made.
+type capturedReq struct {
+	method string
+	path   string
+	body   []byte
+	ctype  string
+}
+
+func newPublishFixture(t *testing.T, status int) (*Client, *capturedReq) {
+	t.Helper()
+	cap := &capturedReq{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.method = r.Method
+		cap.path = r.URL.Path
+		cap.ctype = r.Header.Get("Content-Type")
+		if r.Body != nil {
+			cap.body, _ = io.ReadAll(r.Body)
+			_ = r.Body.Close()
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		if status >= 400 {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"errors":[{"detail":"signature failed verification"}]}`))
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"data":{"id":"v","type":"registry-provider-versions","attributes":{}}}`))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c, cap
+}
+
+func TestUploadProviderSHASUMS(t *testing.T) {
+	c, cap := newPublishFixture(t, http.StatusOK)
+	if err := c.UploadProviderSHASUMS(t.Context(), "awsmai", "1.0.0", []byte("sums")); err != nil {
+		t.Fatal(err)
+	}
+	if cap.method != http.MethodPut {
+		t.Errorf("method = %s", cap.method)
+	}
+	if cap.path != "/api/terrapod/v1/registry-providers/private/default/awsmai/versions/1.0.0/shasums" {
+		t.Errorf("path = %s", cap.path)
+	}
+	if string(cap.body) != "sums" {
+		t.Errorf("body wrapped/altered: %q", cap.body)
+	}
+}
+
+func TestUploadProviderSignaturePath(t *testing.T) {
+	c, cap := newPublishFixture(t, http.StatusOK)
+	if err := c.UploadProviderSignature(t.Context(), "awsmai", "1.0.0", []byte("sig")); err != nil {
+		t.Fatal(err)
+	}
+	if cap.path != "/api/terrapod/v1/registry-providers/private/default/awsmai/versions/1.0.0/shasums.sig" {
+		t.Errorf("path = %s", cap.path)
+	}
+}
+
+func TestUploadProviderSignatureRejected(t *testing.T) {
+	c, _ := newPublishFixture(t, http.StatusUnprocessableEntity)
+	err := c.UploadProviderSignature(t.Context(), "awsmai", "1.0.0", []byte("badsig"))
+	if !IsValidation(err) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+}
+
+func TestUploadProviderPlatform(t *testing.T) {
+	c, cap := newPublishFixture(t, http.StatusOK)
+	zip := []byte("PK\x03\x04zip")
+	if err := c.UploadProviderPlatform(t.Context(), "awsmai", "1.0.0", "linux", "arm64", zip); err != nil {
+		t.Fatal(err)
+	}
+	if cap.path != "/api/terrapod/v1/registry-providers/private/default/awsmai/versions/1.0.0/platforms/linux/arm64" {
+		t.Errorf("path = %s", cap.path)
+	}
+	if string(cap.body) != string(zip) {
+		t.Errorf("zip body altered")
+	}
+}
+
+func TestUploadProviderPlatformMismatchRejected(t *testing.T) {
+	c, _ := newPublishFixture(t, http.StatusUnprocessableEntity)
+	err := c.UploadProviderPlatform(t.Context(), "awsmai", "1.0.0", "linux", "arm64", []byte("x"))
+	if !IsValidation(err) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+}
+
+func TestUploadModuleVersion(t *testing.T) {
+	c, cap := newPublishFixture(t, http.StatusOK)
+	if err := c.UploadModuleVersion(t.Context(), "vpc", "aws", "1.2.3", []byte("targz")); err != nil {
+		t.Fatal(err)
+	}
+	if cap.path != "/api/terrapod/v1/registry-modules/private/default/vpc/aws/versions/1.2.3/upload" {
+		t.Errorf("path = %s", cap.path)
+	}
+	if string(cap.body) != "targz" {
+		t.Errorf("tarball body altered")
+	}
+}

--- a/publish/.goreleaser.yml
+++ b/publish/.goreleaser.yml
@@ -1,0 +1,61 @@
+# GoReleaser config for terrapod-publish.
+#
+# Built and published alongside the Terraform provider on every Terrapod
+# release tag. The provider's own .goreleaser.yml creates the GitHub Release;
+# we append our archives + checksums to it with `release.mode: append`, which
+# avoids the second invocation trying (and failing) to create a duplicate
+# release. Mirrors migrate/.goreleaser.yml.
+#
+# Distribution targets:
+#   - Linux  amd64 + arm64
+#   - Windows amd64 + arm64
+#   - macOS  universal (Apple "Universal 2" fat binary via lipo)
+version: 2
+
+project_name: terrapod-publish
+
+builds:
+  - main: ./cmd/terrapod-publish
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.Version={{ .Version }}"
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    binary: terrapod-publish
+
+universal_binaries:
+  - replace: true
+
+archives:
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+
+release:
+  mode: append
+
+changelog:
+  disable: true

--- a/publish/cmd/terrapod-publish/auth.go
+++ b/publish/cmd/terrapod-publish/auth.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// resolveToken returns the API token in precedence order: the explicit flag,
+// then $TERRAPOD_TOKEN, then the terraform CLI credentials file for the host.
+func resolveToken(flagToken, host string) (string, error) {
+	if flagToken != "" {
+		return flagToken, nil
+	}
+	if env := os.Getenv("TERRAPOD_TOKEN"); env != "" {
+		return env, nil
+	}
+	if tok := tokenFromCredentialsFile(host); tok != "" {
+		return tok, nil
+	}
+	return "", fmt.Errorf(
+		"no API token found: pass --token, set TERRAPOD_TOKEN, or run `terraform login %s`", host)
+}
+
+// tokenFromCredentialsFile reads ~/.terraform.d/credentials.tfrc.json and
+// returns the token stored for host (the file `terraform login` writes).
+func tokenFromCredentialsFile(host string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".terraform.d", "credentials.tfrc.json"))
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		Credentials map[string]struct {
+			Token string `json:"token"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return ""
+	}
+	return doc.Credentials[host].Token
+}

--- a/publish/cmd/terrapod-publish/main.go
+++ b/publish/cmd/terrapod-publish/main.go
@@ -1,0 +1,67 @@
+// Command terrapod-publish publishes providers and modules to a Terrapod
+// private registry. Provider artifacts are zipped and the SHA256SUMS manifest
+// is GPG-signed entirely in-process (pure Go, no gpg/zip/tar binaries).
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Version is stamped at build time via -ldflags "-X main.Version=...".
+var Version = "dev"
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	rest := os.Args[2:]
+	switch os.Args[1] {
+	case "provider":
+		os.Exit(providerCmd(rest))
+	case "module":
+		os.Exit(moduleCmd(rest))
+	case "version", "-v", "--version":
+		fmt.Println(Version)
+	case "help", "-h", "--help":
+		usage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `terrapod-publish — publish providers and modules to a Terrapod private registry
+
+Usage:
+  terrapod-publish provider --host H --name N --version V --signing-key KEY \
+                            --binary OS/ARCH=PATH [--binary OS/ARCH=PATH ...]
+  terrapod-publish module   --host H --name N --provider P --version V --source DIR
+
+Auth resolution order: --token, then $TERRAPOD_TOKEN, then
+~/.terraform.d/credentials.tfrc.json for the target host (i.e. `+"`terraform login`"+`).
+`)
+}
+
+// multiFlag is a repeatable string flag.
+type multiFlag []string
+
+func (m *multiFlag) String() string  { return strings.Join(*m, ",") }
+func (m *multiFlag) Set(v string) error {
+	*m = append(*m, v)
+	return nil
+}
+
+// firstMissing returns the name of the first empty required flag, or "".
+func firstMissing(required []struct{ name, val string }) string {
+	for _, r := range required {
+		if r.val == "" {
+			return r.name
+		}
+	}
+	return ""
+}

--- a/publish/cmd/terrapod-publish/module.go
+++ b/publish/cmd/terrapod-publish/module.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/mattrobinsonsre/terrapod/publish/internal/publisher"
+)
+
+func moduleCmd(args []string) int {
+	fs := flag.NewFlagSet("module", flag.ContinueOnError)
+	host := fs.String("host", "", "Terrapod hostname (required)")
+	name := fs.String("name", "", "module name (required)")
+	provider := fs.String("provider", "", "module provider, e.g. aws (required)")
+	version := fs.String("version", "", "version, e.g. 1.2.3 (no leading v) (required)")
+	source := fs.String("source", "", "path to the module source directory (required)")
+	token := fs.String("token", "", "API token (else $TERRAPOD_TOKEN or credentials.tfrc.json)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if m := firstMissing([]struct{ name, val string }{
+		{"host", *host}, {"name", *name}, {"provider", *provider},
+		{"version", *version}, {"source", *source},
+	}); m != "" {
+		fmt.Fprintf(os.Stderr, "missing required flag: --%s\n", m)
+		return 2
+	}
+
+	tok, err := resolveToken(*token, *host)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	client, err := terrapod.NewClient(terrapod.Options{BaseURL: *host, Token: tok})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "client: %v\n", err)
+		return 1
+	}
+
+	err = publisher.PublishModule(
+		context.Background(), client, *name, *provider, *version, *source,
+		func(s string) { fmt.Fprintf(os.Stderr, "==> %s\n", s) },
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "publish failed: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/publish/cmd/terrapod-publish/provider.go
+++ b/publish/cmd/terrapod-publish/provider.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/mattrobinsonsre/terrapod/publish/internal/publisher"
+	"github.com/mattrobinsonsre/terrapod/publish/internal/sign"
+)
+
+func providerCmd(args []string) int {
+	fs := flag.NewFlagSet("provider", flag.ContinueOnError)
+	host := fs.String("host", "", "Terrapod hostname (required)")
+	name := fs.String("name", "", "provider name, e.g. awsmai (required)")
+	version := fs.String("version", "", "version, e.g. 1.0.0 (no leading v) (required)")
+	keyPath := fs.String("signing-key", "", "path to ASCII-armored private signing key (required)")
+	keyPass := fs.String("signing-key-passphrase", "",
+		"passphrase for the signing key (or $TERRAPOD_SIGNING_KEY_PASSPHRASE)")
+	token := fs.String("token", "", "API token (else $TERRAPOD_TOKEN or credentials.tfrc.json)")
+	var binaries multiFlag
+	fs.Var(&binaries, "binary", "platform binary as OS/ARCH=PATH (repeatable, required)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if m := firstMissing([]struct{ name, val string }{
+		{"host", *host}, {"name", *name}, {"version", *version}, {"signing-key", *keyPath},
+	}); m != "" {
+		fmt.Fprintf(os.Stderr, "missing required flag: --%s\n", m)
+		return 2
+	}
+	if len(binaries) == 0 {
+		fmt.Fprintln(os.Stderr, "missing required flag: --binary (at least one)")
+		return 2
+	}
+
+	armored, err := os.ReadFile(*keyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read signing key: %v\n", err)
+		return 1
+	}
+	pass := *keyPass
+	if pass == "" {
+		pass = os.Getenv("TERRAPOD_SIGNING_KEY_PASSPHRASE")
+	}
+	entity, err := sign.LoadPrivateKey(string(armored), pass)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load signing key: %v\n", err)
+		return 1
+	}
+
+	bins := make(map[string][]byte, len(binaries))
+	for _, spec := range binaries {
+		platform, path, ok := strings.Cut(spec, "=")
+		if !ok || platform == "" || path == "" {
+			fmt.Fprintf(os.Stderr, "invalid --binary %q, want OS/ARCH=PATH\n", spec)
+			return 2
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "read binary %s: %v\n", path, err)
+			return 1
+		}
+		bins[platform] = data
+	}
+
+	tok, err := resolveToken(*token, *host)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	client, err := terrapod.NewClient(terrapod.Options{BaseURL: *host, Token: tok})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "client: %v\n", err)
+		return 1
+	}
+
+	err = publisher.PublishProvider(context.Background(), client, publisher.ProviderInput{
+		Name:       *name,
+		Version:    *version,
+		SigningKey: entity,
+		Binaries:   bins,
+	}, func(s string) { fmt.Fprintf(os.Stderr, "==> %s\n", s) })
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "publish failed: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/publish/go.mod
+++ b/publish/go.mod
@@ -1,0 +1,16 @@
+module github.com/mattrobinsonsre/terrapod/publish
+
+go 1.26
+
+require (
+	github.com/ProtonMail/go-crypto v1.4.1
+	github.com/mattrobinsonsre/terrapod/go-terrapod v0.0.0-00010101000000-000000000000
+)
+
+require (
+	github.com/cloudflare/circl v1.6.2 // indirect
+	golang.org/x/crypto v0.41.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+)
+
+replace github.com/mattrobinsonsre/terrapod/go-terrapod => ../go-terrapod

--- a/publish/go.sum
+++ b/publish/go.sum
@@ -1,0 +1,8 @@
+github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
+github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
+github.com/cloudflare/circl v1.6.2 h1:hL7VBpHHKzrV5WTfHCaBsgx/HGbBYlgrwvNXEVDYYsQ=
+github.com/cloudflare/circl v1.6.2/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
+golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/publish/internal/pack/pack.go
+++ b/publish/internal/pack/pack.go
@@ -1,0 +1,121 @@
+// Package pack builds the on-the-wire artifacts for a Terrapod registry
+// publish — provider platform zips, the SHA256SUMS manifest, and gzipped
+// module source tarballs — using only the Go standard library (no shelling
+// out to zip/tar/sha256sum).
+package pack
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// ProviderZip builds a terraform-provider distribution zip in memory. The zip
+// holds a single entry, the binary, named `terraform-provider-<name>_v<version>`
+// (with `.exe` on windows) and marked executable (0755) — the layout
+// terraform/tofu expect when installing from a network mirror.
+func ProviderZip(name, version, goos string, binary []byte) ([]byte, error) {
+	inner := fmt.Sprintf("terraform-provider-%s_v%s", name, version)
+	if goos == "windows" {
+		inner += ".exe"
+	}
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	hdr := &zip.FileHeader{Name: inner, Method: zip.Deflate}
+	hdr.SetMode(0o755)
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := w.Write(binary); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// ProviderZipName is the canonical registry filename for a platform zip — it
+// MUST match the name the server reconstructs and the entry in SHA256SUMS.
+func ProviderZipName(name, version, goos, goarch string) string {
+	return fmt.Sprintf("terraform-provider-%s_%s_%s_%s.zip", name, version, goos, goarch)
+}
+
+// SHA256SUMS renders a manifest over the given files (filename -> contents) in
+// the `<hex-sha256>  <filename>\n` format, sorted by filename for determinism.
+func SHA256SUMS(files map[string][]byte) []byte {
+	names := make([]string, 0, len(files))
+	for n := range files {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var buf bytes.Buffer
+	for _, n := range names {
+		sum := sha256.Sum256(files[n])
+		fmt.Fprintf(&buf, "%x  %s\n", sum, n)
+	}
+	return buf.Bytes()
+}
+
+// TarGzDir builds a gzipped tar of a module source directory. Entry paths are
+// relative to dir (forward slashes). `.git` and `.terraform` directories are
+// skipped; symlinks and other non-regular files are ignored.
+func TarGzDir(dir string) ([]byte, error) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	walkErr := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if info.IsDir() {
+			if info.Name() == ".git" || info.Name() == ".terraform" {
+				return filepath.SkipDir
+			}
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(tw, f)
+		return err
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/publish/internal/pack/pack_test.go
+++ b/publish/internal/pack/pack_test.go
@@ -1,0 +1,98 @@
+package pack
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProviderZipLayout(t *testing.T) {
+	bin := []byte("the binary")
+	z, err := ProviderZip("awsmai", "1.0.0", "linux", bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(z), int64(len(z)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(zr.File) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(zr.File))
+	}
+	f := zr.File[0]
+	if f.Name != "terraform-provider-awsmai_v1.0.0" {
+		t.Errorf("inner name = %s", f.Name)
+	}
+	if f.Mode()&0o100 == 0 {
+		t.Errorf("inner entry not executable: %v", f.Mode())
+	}
+	rc, _ := f.Open()
+	got, _ := io.ReadAll(rc)
+	rc.Close()
+	if string(got) != string(bin) {
+		t.Errorf("content = %q", got)
+	}
+}
+
+func TestProviderZipWindowsExe(t *testing.T) {
+	z, _ := ProviderZip("awsmai", "1.0.0", "windows", []byte("x"))
+	zr, _ := zip.NewReader(bytes.NewReader(z), int64(len(z)))
+	if zr.File[0].Name != "terraform-provider-awsmai_v1.0.0.exe" {
+		t.Errorf("windows inner name = %s", zr.File[0].Name)
+	}
+}
+
+func TestSHA256SUMSFormatAndOrder(t *testing.T) {
+	files := map[string][]byte{
+		"b.zip": []byte("bbb"),
+		"a.zip": []byte("aaa"),
+	}
+	out := string(SHA256SUMS(files))
+	wantA := fmt.Sprintf("%x  a.zip\n", sha256.Sum256([]byte("aaa")))
+	wantB := fmt.Sprintf("%x  b.zip\n", sha256.Sum256([]byte("bbb")))
+	if out != wantA+wantB {
+		t.Errorf("manifest = %q, want sorted a then b", out)
+	}
+}
+
+func TestTarGzDirRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "main.tf"), []byte("resource {}"), 0o644)
+	os.MkdirAll(filepath.Join(dir, ".git"), 0o755)
+	os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte("ref"), 0o644)
+	os.MkdirAll(filepath.Join(dir, "sub"), 0o755)
+	os.WriteFile(filepath.Join(dir, "sub", "vars.tf"), []byte("variable {}"), 0o644)
+
+	gz, err := TarGzDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gr, _ := gzip.NewReader(bytes.NewReader(gz))
+	tr := tar.NewReader(gr)
+	found := map[string]bool{}
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		found[h.Name] = true
+	}
+	if !found["main.tf"] || !found["sub/vars.tf"] {
+		t.Errorf("missing expected entries: %v", found)
+	}
+	for n := range found {
+		if n == ".git" || n == ".git/HEAD" {
+			t.Errorf(".git should be skipped, found %s", n)
+		}
+	}
+}

--- a/publish/internal/publisher/publisher.go
+++ b/publish/internal/publisher/publisher.go
@@ -1,0 +1,107 @@
+// Package publisher orchestrates a registry publish over the go-terrapod SDK:
+// build artifacts (pack), sign the manifest (sign), then upload in the order
+// the server validates.
+package publisher
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/mattrobinsonsre/terrapod/publish/internal/pack"
+	"github.com/mattrobinsonsre/terrapod/publish/internal/sign"
+)
+
+// ProviderInput describes a provider version to publish.
+type ProviderInput struct {
+	Name       string
+	Version    string
+	SigningKey *openpgp.Entity
+	// Binaries maps "<goos>/<goarch>" to the raw, already-built provider binary.
+	Binaries map[string][]byte
+}
+
+// Progress receives one human-readable line per publish step (may be nil).
+type Progress func(string)
+
+func note(p Progress, format string, a ...any) {
+	if p != nil {
+		p(fmt.Sprintf(format, a...))
+	}
+}
+
+// PublishProvider zips each platform binary, builds + signs the SHA256SUMS
+// manifest, and uploads in the order the server enforces: manifest, then the
+// signature (the trust gate — the server verifies it against the registered
+// key before accepting binaries), then each platform zip (validated against
+// the signed manifest as it is received). It never sends the private key; only
+// the detached signature crosses the wire.
+func PublishProvider(ctx context.Context, c *terrapod.Client, in ProviderInput, p Progress) error {
+	if len(in.Binaries) == 0 {
+		return fmt.Errorf("no platform binaries to publish")
+	}
+	zips := make(map[string][]byte, len(in.Binaries)) // platform -> zip
+	files := make(map[string][]byte, len(in.Binaries)) // filename -> zip (for the manifest)
+	for platform, bin := range in.Binaries {
+		goos, goarch, err := splitPlatform(platform)
+		if err != nil {
+			return err
+		}
+		z, err := pack.ProviderZip(in.Name, in.Version, goos, bin)
+		if err != nil {
+			return fmt.Errorf("zip %s: %w", platform, err)
+		}
+		zips[platform] = z
+		files[pack.ProviderZipName(in.Name, in.Version, goos, goarch)] = z
+	}
+
+	manifest := pack.SHA256SUMS(files)
+	sig, err := sign.DetachSign(in.SigningKey, manifest)
+	if err != nil {
+		return fmt.Errorf("sign SHA256SUMS: %w", err)
+	}
+
+	note(p, "uploading SHA256SUMS (%d platforms)", len(files))
+	if err := c.UploadProviderSHASUMS(ctx, in.Name, in.Version, manifest); err != nil {
+		return fmt.Errorf("upload SHA256SUMS: %w", err)
+	}
+	note(p, "uploading + verifying signature (key %s)", sign.KeyID(in.SigningKey))
+	if err := c.UploadProviderSignature(ctx, in.Name, in.Version, sig); err != nil {
+		return fmt.Errorf("upload signature: %w", err)
+	}
+	for platform, z := range zips {
+		goos, goarch, _ := splitPlatform(platform)
+		note(p, "uploading %s (%d bytes)", platform, len(z))
+		if err := c.UploadProviderPlatform(ctx, in.Name, in.Version, goos, goarch, z); err != nil {
+			return fmt.Errorf("upload %s: %w", platform, err)
+		}
+	}
+	note(p, "published %s %s", in.Name, in.Version)
+	return nil
+}
+
+// PublishModule tars + gzips a module source directory and uploads it. The
+// server extracts the module interface and triggers linked-workspace runs.
+func PublishModule(ctx context.Context, c *terrapod.Client, name, provider, version, sourceDir string, p Progress) error {
+	note(p, "packing %s", sourceDir)
+	tarball, err := pack.TarGzDir(sourceDir)
+	if err != nil {
+		return fmt.Errorf("pack %s: %w", sourceDir, err)
+	}
+	note(p, "uploading module tarball (%d bytes)", len(tarball))
+	if err := c.UploadModuleVersion(ctx, name, provider, version, tarball); err != nil {
+		return fmt.Errorf("upload module: %w", err)
+	}
+	note(p, "published %s/%s %s", name, provider, version)
+	return nil
+}
+
+func splitPlatform(s string) (goos, goarch string, err error) {
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid platform %q, want <goos>/<goarch>", s)
+	}
+	return parts[0], parts[1], nil
+}

--- a/publish/internal/publisher/publisher_test.go
+++ b/publish/internal/publisher/publisher_test.go
@@ -1,0 +1,76 @@
+package publisher
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+)
+
+func TestPublishProviderUploadOrder(t *testing.T) {
+	var order []string
+	var manifestBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/shasums"):
+			order = append(order, "shasums")
+			manifestBody = string(body)
+		case strings.HasSuffix(r.URL.Path, "/shasums.sig"):
+			order = append(order, "sig")
+		case strings.Contains(r.URL.Path, "/platforms/"):
+			order = append(order, "platform:"+r.URL.Path[strings.LastIndex(r.URL.Path, "/platforms/")+len("/platforms/"):])
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"id":"v","type":"x","attributes":{}}}`))
+	}))
+	defer srv.Close()
+
+	c, err := terrapod.NewClient(terrapod.Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entity, err := openpgp.NewEntity("awsmai", "", "security@example.test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = PublishProvider(context.Background(), c, ProviderInput{
+		Name:       "awsmai",
+		Version:    "1.0.0",
+		SigningKey: entity,
+		Binaries:   map[string][]byte{"linux/arm64": []byte("bin")},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The signature MUST be uploaded before any platform binary (the server's
+	// trust gate); the manifest first of all.
+	if len(order) != 3 || order[0] != "shasums" || order[1] != "sig" {
+		t.Fatalf("upload order = %v, want shasums, sig, platform", order)
+	}
+	if order[2] != "platform:linux/arm64" {
+		t.Errorf("platform path = %s", order[2])
+	}
+	if !strings.Contains(manifestBody, "terraform-provider-awsmai_1.0.0_linux_arm64.zip") {
+		t.Errorf("manifest missing canonical filename: %q", manifestBody)
+	}
+}
+
+func TestPublishProviderNoBinaries(t *testing.T) {
+	c, _ := terrapod.NewClient(terrapod.Options{BaseURL: "http://x", Token: "t"})
+	entity, _ := openpgp.NewEntity("x", "", "x@x.test", nil)
+	err := PublishProvider(context.Background(), c, ProviderInput{
+		Name: "awsmai", Version: "1.0.0", SigningKey: entity, Binaries: nil,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for no binaries")
+	}
+}

--- a/publish/internal/sign/sign.go
+++ b/publish/internal/sign/sign.go
@@ -1,0 +1,60 @@
+// Package sign produces the detached OpenPGP signature over SHA256SUMS that the
+// Terrapod registry verifies against a publisher's registered GPG key. It uses
+// the pure-Go ProtonMail/go-crypto OpenPGP implementation — no gpg binary.
+package sign
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+)
+
+// LoadPrivateKey parses an ASCII-armored private key. If the key material is
+// passphrase-protected, passphrase is used to unlock it (pass "" for an
+// unprotected key). The returned entity is ready to sign.
+func LoadPrivateKey(armored, passphrase string) (*openpgp.Entity, error) {
+	keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(armored))
+	if err != nil {
+		return nil, err
+	}
+	if len(keyring) == 0 {
+		return nil, errors.New("no key found in armored private key")
+	}
+	entity := keyring[0]
+	if entity.PrivateKey == nil {
+		return nil, errors.New("armored block is a public key, not a private key")
+	}
+	if passphrase != "" {
+		pw := []byte(passphrase)
+		if entity.PrivateKey.Encrypted {
+			if err := entity.PrivateKey.Decrypt(pw); err != nil {
+				return nil, err
+			}
+		}
+		for _, sk := range entity.Subkeys {
+			if sk.PrivateKey != nil && sk.PrivateKey.Encrypted {
+				_ = sk.PrivateKey.Decrypt(pw)
+			}
+		}
+	}
+	return entity, nil
+}
+
+// DetachSign produces a binary detached signature over data — exactly the
+// format `gpg --detach-sign` emits and that terraform/tofu (and Terrapod's
+// pgpy verifier) expect for SHA256SUMS.sig.
+func DetachSign(entity *openpgp.Entity, data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := openpgp.DetachSign(&buf, entity, bytes.NewReader(data), nil); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// KeyID returns the 16-hex-char long key ID of the entity's primary key,
+// uppercased — the form Terrapod stores and matches signatures against.
+func KeyID(entity *openpgp.Entity) string {
+	return strings.ToUpper(entity.PrimaryKey.KeyIdString())
+}

--- a/publish/internal/sign/sign_test.go
+++ b/publish/internal/sign/sign_test.go
@@ -1,0 +1,69 @@
+package sign
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+)
+
+func testEntity(t *testing.T) *openpgp.Entity {
+	t.Helper()
+	e, err := openpgp.NewEntity("awsmai test", "", "security@example.test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func TestDetachSignVerifies(t *testing.T) {
+	e := testEntity(t)
+	data := []byte("abc123  terraform-provider-awsmai_1.0.0_linux_arm64.zip\n")
+	sig, err := DetachSign(e, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sig) == 0 {
+		t.Fatal("empty signature")
+	}
+	// Round-trip: the signature must verify against the entity over the bytes.
+	signer, err := openpgp.CheckDetachedSignature(
+		openpgp.EntityList{e}, bytes.NewReader(data), bytes.NewReader(sig), nil)
+	if err != nil {
+		t.Fatalf("signature did not verify: %v", err)
+	}
+	if signer.PrimaryKey.KeyId != e.PrimaryKey.KeyId {
+		t.Errorf("verified by unexpected key")
+	}
+}
+
+func TestDetachSignRejectsTamper(t *testing.T) {
+	e := testEntity(t)
+	sig, _ := DetachSign(e, []byte("original"))
+	_, err := openpgp.CheckDetachedSignature(
+		openpgp.EntityList{e}, bytes.NewReader([]byte("tampered")), bytes.NewReader(sig), nil)
+	if err == nil {
+		t.Fatal("expected verification failure on tampered data")
+	}
+}
+
+func TestKeyIDFormat(t *testing.T) {
+	e := testEntity(t)
+	id := KeyID(e)
+	if len(id) != 16 {
+		t.Errorf("key id = %q, want 16 hex chars", id)
+	}
+	if id != bytesToUpper(id) {
+		t.Errorf("key id not uppercased: %q", id)
+	}
+}
+
+func bytesToUpper(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'a' && c <= 'f' {
+			b[i] = c - 32
+		}
+	}
+	return string(b)
+}

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -14,28 +14,37 @@ CLI Protocol:
     GET  /api/v2/registry/providers/{namespace}/{name}/versions
     GET  /api/v2/registry/providers/{namespace}/{name}/{version}/download/{os}/{arch}
 
-TFE V2 Management:
+TFE V2 Management + client-signed publish (no presigned URLs, no finalize):
     POST   /api/terrapod/v1/registry-providers
     GET    /api/terrapod/v1/registry-providers
     GET    /api/terrapod/v1/registry-providers/private/default/{name}
     DELETE /api/terrapod/v1/registry-providers/private/default/{name}
-    POST   .../private/default/{name}/versions
     GET    .../private/default/{name}/versions
     DELETE .../private/default/{name}/versions/{ver}
-    POST   .../private/default/{name}/versions/{ver}/platforms
+    PUT    .../private/default/{name}/versions/{ver}/shasums         (client manifest)
+    PUT    .../private/default/{name}/versions/{ver}/shasums.sig     (signature; trust gate)
+    PUT    .../private/default/{name}/versions/{ver}/platforms/{os}/{arch}  (streamed zip)
     GET    .../private/default/{name}/versions/{ver}/platforms
     DELETE .../private/default/{name}/versions/{ver}/platforms/{os}/{arch}
+
+Publishing is client-signed and CLI-only (terrapod-publish): the browser UI
+is read-only for versions. The old presigned create-version / create-platform
+POSTs and the server-signed `/upload` PUT were removed.
 """
 
-import uuid
+import asyncio
+import hashlib
+import os
+import tempfile
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_non_runner
 from terrapod.api.labels import validate_labels
+from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.platform_provider_service import (
@@ -45,9 +54,8 @@ from terrapod.services.platform_provider_service import (
     get_version_list as platform_get_version_list,
 )
 from terrapod.services.registry_provider_service import (
+    PublishValidationError,
     create_provider,
-    create_provider_platform,
-    create_provider_version,
     delete_provider,
     delete_provider_platform,
     delete_provider_version,
@@ -57,7 +65,9 @@ from terrapod.services.registry_provider_service import (
     list_provider_platforms,
     list_provider_versions,
     list_providers,
-    upload_provider_binary,
+    record_provider_binary,
+    store_and_verify_provider_sig,
+    store_provider_shasums,
 )
 from terrapod.services.registry_rbac_service import (
     REGISTRY_PERMISSION_HIERARCHY,
@@ -88,32 +98,6 @@ class CreateProviderRequest(BaseModel):
             labels: dict = {}
 
         type: str = "registry-providers"
-        attributes: Attributes
-
-    data: Data
-
-
-class CreateProviderVersionRequest(BaseModel):
-    class Data(BaseModel):
-        class Attributes(BaseModel):
-            version: str
-            key_id: str = ""
-            protocols: list[str] = ["5.0"]
-
-        type: str = "registry-provider-versions"
-        attributes: Attributes
-
-    data: Data
-
-
-class CreateProviderPlatformRequest(BaseModel):
-    class Data(BaseModel):
-        class Attributes(BaseModel):
-            os: str
-            arch: str
-            filename: str
-
-        type: str = "registry-provider-platforms"
         attributes: Attributes
 
     data: Data
@@ -491,55 +475,98 @@ async def update_provider_endpoint(
 # --- Version Management ---
 
 
-@management_router.post(_BASE + "/private/default/{name}/versions")
-async def create_provider_version_endpoint(
+# Per-platform provider zips can be large; stream them to the PVC. Manifest +
+# signature are tiny and read into memory.
+_MAX_PROVIDER_BINARY_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB hard cap per platform zip
+_MAX_SHASUMS_BYTES = 1 * 1024 * 1024  # 1 MiB — SHA256SUMS / .sig are tiny
+
+
+def _resolve_ephemeral_tmpdir() -> str | None:
+    """Resolve the API pod's ephemeral-storage PVC mount for large tempfiles.
+
+    Matches `run_artifacts._resolve_ephemeral_tmpdir`. On the API pod `/tmp`
+    is a RAM-backed emptyDir; provider zips (tens to hundreds of MB) MUST land
+    on the dedicated PVC at `settings.vcs.tmpdir`. None falls back to the
+    system default for local dev and tests.
+    """
+    configured = settings.vcs.tmpdir
+    if configured and os.path.isdir(configured):
+        return configured
+    return None
+
+
+@management_router.put(_BASE + "/private/default/{name}/versions/{version}/shasums")
+async def upload_provider_shasums_endpoint(
     name: str,
-    body: CreateProviderVersionRequest,
+    version: str,
+    request: Request,
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     storage: ObjectStore = Depends(get_storage),
 ) -> JSONResponse:
-    """Create a provider version and get upload URLs. Requires write."""
+    """Upload the client-built SHA256SUMS manifest (first publish step). Requires write.
+
+    Upserts the version. The manifest is not yet trusted — the detached
+    signature must be uploaded next and verify against a registered key.
+    """
     provider = await get_provider(db, "default", name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
-
     await _require_provider_permission(db, user, provider, "write")
 
-    attrs = body.data.attributes
+    data = await request.body()
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty SHA256SUMS body")
+    if len(data) > _MAX_SHASUMS_BYTES:
+        raise HTTPException(status_code=413, detail="SHA256SUMS too large")
 
-    # Resolve GPG key if key_id provided
-    gpg_key_uuid: uuid.UUID | None = None
-    if attrs.key_id:
-        from terrapod.services.gpg_key_service import get_gpg_key_by_key_id
-
-        gpg_key = await get_gpg_key_by_key_id(db, attrs.key_id)
-        if gpg_key is not None:
-            gpg_key_uuid = gpg_key.id
-
-    prov_version, shasums_url, sig_url = await create_provider_version(
-        db, storage, provider.id, attrs.version, gpg_key_uuid, attrs.protocols
-    )
+    prov_version = await store_provider_shasums(db, storage, "default", name, version, data)
     await db.commit()
     await db.refresh(prov_version, attribute_names=["platforms"])
-
-    logger.info(
-        "Provider version created",
-        provider_id=str(provider.id),
-        version=attrs.version,
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"data": _version_to_jsonapi(prov_version)},
     )
 
+
+@management_router.put(_BASE + "/private/default/{name}/versions/{version}/shasums.sig")
+async def upload_provider_shasums_sig_endpoint(
+    name: str,
+    version: str,
+    request: Request,
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    storage: ObjectStore = Depends(get_storage),
+) -> JSONResponse:
+    """Upload + verify the detached SHA256SUMS signature — the trust gate. Requires write.
+
+    Verifies the signature against a *registered* GPG key over the previously
+    uploaded manifest; 422 on any failure. On success the signing key is linked
+    so the CLI download advertises it and binary uploads are unblocked.
+    """
+    provider = await get_provider(db, "default", name)
+    if provider is None:
+        raise HTTPException(status_code=404, detail="Provider not found")
+    await _require_provider_permission(db, user, provider, "write")
+
+    data = await request.body()
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty signature body")
+    if len(data) > _MAX_SHASUMS_BYTES:
+        raise HTTPException(status_code=413, detail="Signature too large")
+
+    try:
+        prov_version = await store_and_verify_provider_sig(
+            db, storage, "default", name, version, data
+        )
+    except PublishValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(prov_version, attribute_names=["platforms"])
+    logger.info("Provider SHA256SUMS signature verified", provider=name, version=version)
     return JSONResponse(
-        status_code=status.HTTP_201_CREATED,
-        content={
-            "data": _version_to_jsonapi(
-                prov_version,
-                upload_links={
-                    "shasums-upload": shasums_url.url,
-                    "shasums-sig-upload": sig_url.url,
-                },
-            )
-        },
+        status_code=status.HTTP_200_OK,
+        content={"data": _version_to_jsonapi(prov_version)},
     )
 
 
@@ -596,38 +623,6 @@ async def delete_provider_version_endpoint(
 # --- Platform Management ---
 
 
-@management_router.post(_BASE + "/private/default/{name}/versions/{version}/platforms")
-async def create_provider_platform_endpoint(
-    name: str,
-    version: str,
-    body: CreateProviderPlatformRequest,
-    user: AuthenticatedUser = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    storage: ObjectStore = Depends(get_storage),
-) -> JSONResponse:
-    """Create a platform entry and get an upload URL. Requires write."""
-    provider = await get_provider(db, "default", name)
-    if provider is None:
-        raise HTTPException(status_code=404, detail="Provider not found")
-
-    await _require_provider_permission(db, user, provider, "write")
-
-    prov_version = await get_provider_version(db, provider.id, version)
-    if prov_version is None:
-        raise HTTPException(status_code=404, detail="Provider version not found")
-
-    attrs = body.data.attributes
-    platform, upload_url = await create_provider_platform(
-        db, storage, prov_version.id, attrs.os, attrs.arch, attrs.filename
-    )
-    await db.commit()
-
-    return JSONResponse(
-        status_code=status.HTTP_201_CREATED,
-        content={"data": _platform_to_jsonapi(platform, upload_link=upload_url.url)},
-    )
-
-
 @management_router.get(_BASE + "/private/default/{name}/versions/{version}/platforms")
 async def list_provider_platforms_endpoint(
     name: str,
@@ -662,42 +657,93 @@ async def list_provider_platforms_endpoint(
     )
 
 
-@management_router.put(
-    _BASE + "/private/default/{name}/versions/{version}/platforms/{os}/{arch}/upload"
-)
-async def upload_provider_binary_endpoint(
+@management_router.put(_BASE + "/private/default/{name}/versions/{version}/platforms/{os}/{arch}")
+async def upload_provider_platform_endpoint(
     name: str,
     version: str,
-    os: str,
-    arch: str,
     request: Request,
+    os_: str = Path(alias="os"),
+    arch: str = Path(),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     storage: ObjectStore = Depends(get_storage),
 ) -> JSONResponse:
-    """Upload a provider binary directly. Requires write. Idempotent."""
+    """Stream + validate a provider platform zip, then store it. Requires write. Idempotent.
+
+    The version's SHA256SUMS and its verified signature must already be
+    uploaded (trust gate) — else 422. The body is streamed to the ephemeral
+    PVC (never buffered in RAM), its sha-256 computed on the fly, and checked
+    against the signed manifest before the file is committed to storage. The
+    server never re-signs.
+    """
     provider = await get_provider(db, "default", name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
-
     await _require_provider_permission(db, user, provider, "write")
 
-    data = await request.body()
-    if not data:
-        raise HTTPException(status_code=400, detail="Empty request body")
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            if int(declared) > _MAX_PROVIDER_BINARY_BYTES:
+                raise HTTPException(status_code=413, detail="provider binary too large")
+        except ValueError:
+            pass
 
-    platform = await upload_provider_binary(db, storage, "default", name, version, os, arch, data)
-    await db.commit()
+    tmpdir = _resolve_ephemeral_tmpdir()
+    fd, tmp_path = await asyncio.to_thread(tempfile.mkstemp, suffix=".provider.zip", dir=tmpdir)
+    f = await asyncio.to_thread(os.fdopen, fd, "wb")
+    hasher = hashlib.sha256()
+    received = 0
+    try:
+        async for chunk in request.stream():
+            if not chunk:
+                continue
+            received += len(chunk)
+            if received > _MAX_PROVIDER_BINARY_BYTES:
+                raise HTTPException(status_code=413, detail="provider binary exceeded size cap")
+            hasher.update(chunk)
+            await asyncio.to_thread(f.write, chunk)
+        await asyncio.to_thread(f.flush)
+        await asyncio.to_thread(f.close)
+        if received == 0:
+            raise HTTPException(status_code=400, detail="Empty request body")
+
+        filename = f"terraform-provider-{name}_{version}_{os_}_{arch}.zip"
+        try:
+            platform = await record_provider_binary(
+                db,
+                storage,
+                "default",
+                name,
+                version,
+                os_,
+                arch,
+                sha256=hasher.hexdigest(),
+                filename=filename,
+                tmp_path=tmp_path,
+            )
+        except PublishValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        await db.commit()
+    finally:
+        if not f.closed:
+            try:
+                await asyncio.to_thread(f.close)
+            except OSError:
+                pass
+        try:
+            await asyncio.to_thread(os.unlink, tmp_path)
+        except OSError:
+            pass
 
     logger.info(
         "Provider binary uploaded",
         provider=name,
         version=version,
-        os=os,
+        os=os_,
         arch=arch,
-        size=len(data),
+        size=received,
     )
-
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content={"data": _platform_to_jsonapi(platform)},

--- a/services/terrapod/services/gpg_key_service.py
+++ b/services/terrapod/services/gpg_key_service.py
@@ -81,6 +81,48 @@ async def sign_data(private_key_armor: str, data: bytes) -> bytes:
     return await asyncio.to_thread(_sign_data_sync, private_key_armor, data)
 
 
+def _extract_signature_key_id_sync(sig_bytes: bytes) -> str | None:
+    try:
+        sig = pgpy.PGPSignature.from_blob(sig_bytes)
+        signer = sig.signer
+        if not signer:
+            return None
+        return signer.replace(" ", "")[-16:].upper()
+    except Exception:
+        return None
+
+
+async def extract_signature_key_id(sig_bytes: bytes) -> str | None:
+    """Read the issuer key ID out of a detached OpenPGP signature.
+
+    Returns the 16-char key ID of the key that produced the signature, or
+    None if the blob is not a parseable signature. Used to look up which
+    registered GPG key a provider publisher signed SHA256SUMS with.
+    """
+    return await asyncio.to_thread(_extract_signature_key_id_sync, sig_bytes)
+
+
+def _verify_detached_signature_sync(public_key_armor: str, data: bytes, sig_bytes: bytes) -> bool:
+    try:
+        pub, _ = pgpy.PGPKey.from_blob(public_key_armor)
+        sig = pgpy.PGPSignature.from_blob(sig_bytes)
+        return bool(pub.verify(data, sig))
+    except Exception:
+        return False
+
+
+async def verify_detached_signature(public_key_armor: str, data: bytes, sig_bytes: bytes) -> bool:
+    """Verify a detached binary signature over ``data`` with a public key.
+
+    Returns True only if the signature is valid for the given bytes under
+    the given ASCII-armored public key. Any parse/verify failure returns
+    False (never raises) so callers can map it cleanly to HTTP 422.
+    """
+    return await asyncio.to_thread(
+        _verify_detached_signature_sync, public_key_armor, data, sig_bytes
+    )
+
+
 def _derive_public_key_sync(private_key_armor: str) -> str:
     key, _ = pgpy.PGPKey.from_blob(private_key_armor)
     if not key.is_public:

--- a/services/terrapod/services/registry_provider_service.py
+++ b/services/terrapod/services/registry_provider_service.py
@@ -1,11 +1,13 @@
 """Service layer for private provider registry operations.
 
-Handles CRUD for registry providers, versions, and platforms, with presigned
-URL generation for binary upload/download via object storage.
+Handles CRUD for registry providers plus the client-signed publish path:
+store the SHA256SUMS manifest, verify its detached signature against a
+registered GPG key (the trust gate), then accept per-platform binaries that
+match the signed manifest. The server never re-signs; downloads are served
+via presigned GET URLs.
 """
 
 import asyncio
-import hashlib
 import uuid
 
 from sqlalchemy import select
@@ -24,9 +26,28 @@ from terrapod.storage.keys import (
     provider_shasums_key,
     provider_shasums_sig_key,
 )
-from terrapod.storage.protocol import ObjectStore, PresignedURL
+from terrapod.storage.protocol import ObjectStore
 
 logger = get_logger(__name__)
+
+
+class PublishValidationError(Exception):
+    """A client-signed publish step failed validation.
+
+    The router maps this to HTTP 422 so a bad / untrusted / mismatched
+    upload is rejected loudly at publish time rather than silently at
+    `tofu init`.
+    """
+
+
+def _parse_shasums(data: bytes) -> dict[str, str]:
+    """Parse a SHA256SUMS manifest into ``{filename: lowercase-sha}``."""
+    out: dict[str, str] = {}
+    for line in data.decode("utf-8", "replace").splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            out[parts[-1]] = parts[0].lower()
+    return out
 
 
 # --- Provider CRUD ---
@@ -103,36 +124,91 @@ async def delete_provider(
 # --- Version CRUD ---
 
 
-async def create_provider_version(
+async def store_provider_shasums(
     db: AsyncSession,
     storage: ObjectStore,
-    provider_id: uuid.UUID,
+    namespace: str,
+    name: str,
     version: str,
-    gpg_key_id: uuid.UUID | None = None,
-    protocols: list[str] | None = None,
-) -> tuple[RegistryProviderVersion, PresignedURL, PresignedURL]:
-    """Create a provider version and return upload URLs for shasums + sig."""
-    result = await db.execute(select(RegistryProvider).where(RegistryProvider.id == provider_id))
-    provider = result.scalars().first()
+    data: bytes,
+) -> RegistryProviderVersion:
+    """Store a client-supplied SHA256SUMS manifest (first publish step).
+
+    Upserts the version row and persists the manifest verbatim. The
+    manifest is NOT trusted until its detached signature is uploaded and
+    verified by store_and_verify_provider_sig — binary uploads are gated
+    on that.
+    """
+    provider = await get_provider(db, namespace, name)
     if provider is None:
-        raise ValueError(f"Provider {provider_id} not found")
+        raise ValueError(f"Provider {namespace}/{name} not found")
 
-    prov_version = RegistryProviderVersion(
-        provider_id=provider_id,
-        version=version,
-        gpg_key_id=gpg_key_id,
-        protocols=protocols or ["5.0"],
-    )
-    db.add(prov_version)
+    prov_version = await upsert_provider_version(db, provider.id, version)
+    key = provider_shasums_key(namespace, name, version)
+    await storage.put(key, data, "text/plain")
+    prov_version.shasums_uploaded = True
     await db.flush()
+    return prov_version
 
-    # Generate presigned upload URLs for shasums files
-    shasums_key = provider_shasums_key(provider.namespace, provider.name, version)
-    sig_key = provider_shasums_sig_key(provider.namespace, provider.name, version)
-    shasums_url = await storage.presigned_put_url(shasums_key, content_type="text/plain")
-    sig_url = await storage.presigned_put_url(sig_key, content_type="application/octet-stream")
 
-    return prov_version, shasums_url, sig_url
+async def store_and_verify_provider_sig(
+    db: AsyncSession,
+    storage: ObjectStore,
+    namespace: str,
+    name: str,
+    version: str,
+    sig_bytes: bytes,
+) -> RegistryProviderVersion:
+    """Verify + store the detached SHA256SUMS signature — the trust gate.
+
+    Reads back the previously-uploaded SHA256SUMS, confirms the detached
+    signature was produced by a *registered* GPG key, and verifies it
+    cryptographically over the manifest bytes. On success the signing key
+    is linked to the version so the CLI download response advertises it as
+    a signing key. Raises PublishValidationError (-> HTTP 422) on any
+    failure, so binaries are never accepted under an untrusted manifest.
+    The server never re-signs — the client owns the signature.
+    """
+    from terrapod.services.gpg_key_service import (
+        extract_signature_key_id,
+        get_gpg_key_by_key_id,
+        verify_detached_signature,
+    )
+
+    provider = await get_provider(db, namespace, name)
+    if provider is None:
+        raise ValueError(f"Provider {namespace}/{name} not found")
+    prov_version = await get_provider_version(db, provider.id, version)
+    if prov_version is None:
+        raise PublishValidationError("upload SHA256SUMS before its signature")
+
+    shasums_key = provider_shasums_key(namespace, name, version)
+    try:
+        shasums_bytes = await storage.get(shasums_key)
+    except Exception as exc:
+        raise PublishValidationError("SHA256SUMS must be uploaded before its signature") from exc
+
+    key_id = await extract_signature_key_id(sig_bytes)
+    if not key_id:
+        raise PublishValidationError("could not parse a key ID from the signature")
+
+    gpg_key = await get_gpg_key_by_key_id(db, key_id)
+    if gpg_key is None:
+        raise PublishValidationError(
+            f"signature key {key_id} is not registered; add it via /api/terrapod/v1/gpg-keys first"
+        )
+
+    if not await verify_detached_signature(gpg_key.ascii_armor, shasums_bytes, sig_bytes):
+        raise PublishValidationError(
+            f"SHA256SUMS signature failed verification against registered key {key_id}"
+        )
+
+    sig_key = provider_shasums_sig_key(namespace, name, version)
+    await storage.put(sig_key, sig_bytes, "application/pgp-signature")
+    prov_version.gpg_key_id = gpg_key.id
+    prov_version.shasums_sig_uploaded = True
+    await db.flush()
+    return prov_version
 
 
 async def list_provider_versions(
@@ -191,47 +267,74 @@ async def delete_provider_version(
 # --- Platform CRUD ---
 
 
-async def create_provider_platform(
+async def record_provider_binary(
     db: AsyncSession,
     storage: ObjectStore,
-    version_id: uuid.UUID,
+    namespace: str,
+    name: str,
+    version: str,
     os_: str,
     arch: str,
+    *,
+    sha256: str,
     filename: str,
-) -> tuple[RegistryProviderPlatform, PresignedURL]:
-    """Create a platform entry and return an upload URL for the binary."""
-    # Look up the version to get provider info for storage key
-    result = await db.execute(
-        select(RegistryProviderVersion)
-        .where(RegistryProviderVersion.id == version_id)
-        .options(selectinload(RegistryProviderVersion.provider))
-    )
-    prov_version = result.scalars().first()
+    tmp_path: str,
+) -> RegistryProviderPlatform:
+    """Validate a streamed provider binary against the signed manifest, then store it.
+
+    Preconditions (PublishValidationError -> HTTP 422):
+      - the version's SHA256SUMS.sig is already verified (trust established);
+      - the uploaded zip's filename appears in SHA256SUMS;
+      - the uploaded zip's sha matches the signed manifest entry.
+
+    Only then is the validated tempfile streamed from the PVC into object
+    storage and the platform row marked uploaded. The server never re-signs
+    — the client owns the manifest and signature.
+    """
+    provider = await get_provider(db, namespace, name)
+    if provider is None:
+        raise ValueError(f"Provider {namespace}/{name} not found")
+    prov_version = await get_provider_version(db, provider.id, version)
     if prov_version is None:
-        raise ValueError(f"Provider version {version_id} not found")
+        raise PublishValidationError(
+            "upload and verify SHA256SUMS + SHA256SUMS.sig before uploading binaries"
+        )
+    if not prov_version.shasums_sig_uploaded:
+        raise PublishValidationError(
+            "upload and verify SHA256SUMS + SHA256SUMS.sig before uploading binaries"
+        )
 
-    provider = prov_version.provider
+    shasums_bytes = await storage.get(provider_shasums_key(namespace, name, version))
+    sums = _parse_shasums(shasums_bytes)
+    expected = sums.get(filename)
+    if expected is None:
+        raise PublishValidationError(f"{filename} is not listed in the signed SHA256SUMS")
+    if expected != sha256.lower():
+        raise PublishValidationError(
+            f"{filename}: uploaded sha {sha256.lower()} does not match signed manifest {expected}"
+        )
 
-    platform = RegistryProviderPlatform(
-        version_id=version_id,
-        os=os_,
-        arch=arch,
-        filename=filename,
-        upload_status="pending",
-    )
-    db.add(platform)
+    # Stream the validated tempfile into object storage (constant memory).
+    key = provider_binary_key(namespace, name, version, os_, arch)
+
+    async def _chunks():
+        with open(tmp_path, "rb") as src:  # noqa: ASYNC230 -- bounded reads off the PVC
+            while True:
+                buf = await asyncio.to_thread(src.read, 1024 * 1024)
+                if not buf:
+                    break
+                yield buf
+
+    await storage.put_stream(key, _chunks(), content_type="application/zip")
+
+    platform = await upsert_provider_platform(db, prov_version.id, os_, arch)
+    platform.shasum = sha256.lower()
+    platform.filename = filename
+    platform.upload_status = "uploaded"
+    # The terraform h1 dirhash is computed lazily by the mirror on first
+    # read (memory-safe for large archives); not eagerly computed here.
     await db.flush()
-
-    key = provider_binary_key(
-        provider.namespace,
-        provider.name,
-        prov_version.version,
-        os_,
-        arch,
-    )
-    upload_url = await storage.presigned_put_url(key, content_type="application/zip")
-
-    return platform, upload_url
+    return platform
 
 
 async def list_provider_platforms(
@@ -317,7 +420,10 @@ async def get_provider_download_info(
         )
     )
     platform = result.scalars().first()
-    if platform is None:
+    if platform is None or platform.upload_status != "uploaded":
+        # Hide platforms whose binary hasn't been validated + stored yet, so
+        # the CLI download path agrees with the version-list path (which also
+        # filters on upload_status) — never serve a half-published platform.
         return None
 
     # Generate presigned URLs
@@ -415,132 +521,6 @@ async def upsert_provider_platform(
     )
     db.add(platform)
     await db.flush()
-    return platform
-
-
-async def regenerate_shasums(
-    db: AsyncSession,
-    storage: ObjectStore,
-    namespace: str,
-    name: str,
-    version_id: uuid.UUID,
-    version_str: str,
-) -> None:
-    """Regenerate SHA256SUMS from all uploaded platforms, sign, and link GPG key."""
-    from terrapod.services.gpg_key_service import get_or_create_signing_key, sign_data
-
-    result = await db.execute(
-        select(RegistryProviderPlatform)
-        .where(
-            RegistryProviderPlatform.version_id == version_id,
-            RegistryProviderPlatform.upload_status == "uploaded",
-        )
-        .order_by(RegistryProviderPlatform.os, RegistryProviderPlatform.arch)
-    )
-    platforms = list(result.scalars().all())
-
-    lines = []
-    for p in platforms:
-        if p.shasum and p.filename:
-            lines.append(f"{p.shasum}  {p.filename}")
-
-    content = "\n".join(lines) + "\n" if lines else ""
-    content_bytes = content.encode()
-    shasums_k = provider_shasums_key(namespace, name, version_str)
-    await storage.put(shasums_k, content_bytes, "text/plain")
-
-    # Look up the version record
-    ver_result = await db.execute(
-        select(RegistryProviderVersion).where(RegistryProviderVersion.id == version_id)
-    )
-    prov_version = ver_result.scalars().first()
-    if prov_version is None:
-        return
-
-    prov_version.shasums_uploaded = True
-
-    # Sign SHA256SUMS and store the detached signature
-    if content_bytes:
-        try:
-            gpg_key, private_armor = await get_or_create_signing_key(db)
-            sig_bytes = await sign_data(private_armor, content_bytes)
-            sig_k = provider_shasums_sig_key(namespace, name, version_str)
-            await storage.put(sig_k, sig_bytes, "application/pgp-signature")
-            prov_version.shasums_sig_uploaded = True
-            prov_version.gpg_key_id = gpg_key.id
-            logger.info(
-                "SHA256SUMS signed",
-                provider=f"{namespace}/{name}",
-                version=version_str,
-                gpg_key_id=gpg_key.key_id,
-            )
-        except Exception:
-            logger.warning(
-                "Failed to sign SHA256SUMS, provider will work without signatures",
-                provider=f"{namespace}/{name}",
-                version=version_str,
-                exc_info=True,
-            )
-
-    await db.flush()
-
-
-async def upload_provider_binary(
-    db: AsyncSession,
-    storage: ObjectStore,
-    namespace: str,
-    name: str,
-    version_str: str,
-    os_: str,
-    arch: str,
-    data: bytes,
-) -> RegistryProviderPlatform:
-    """Upload a provider binary directly. Upserts version + platform, stores binary."""
-    provider = await get_provider(db, namespace, name)
-    if provider is None:
-        raise ValueError(f"Provider {namespace}/{name} not found")
-
-    prov_version = await upsert_provider_version(db, provider.id, version_str)
-    platform = await upsert_provider_platform(db, prov_version.id, os_, arch)
-
-    # Compute SHA-256
-    sha256 = hashlib.sha256(data).hexdigest()
-
-    # Store binary
-    filename = f"terraform-provider-{name}_{version_str}_{os_}_{arch}.zip"
-    key = provider_binary_key(namespace, name, version_str, os_, arch)
-    await storage.put(key, data, "application/zip")
-
-    # Update platform record
-    platform.shasum = sha256
-    platform.filename = filename
-    platform.upload_status = "uploaded"
-
-    # Eagerly compute the terraform/tofu h1 dirhash from the uploaded
-    # archive so the mirror's Tier-0 lookup can serve it without a
-    # lazy backfill on the first download. Best-effort — h1 compute
-    # failure (corrupt zip, etc.) is logged but doesn't fail the
-    # upload; the lazy backfill in `_serve_from_registry` will retry
-    # on the next read.
-    try:
-        from terrapod.services.provider_cache_service import _compute_h1_from_zip_bytes
-
-        h1 = await asyncio.to_thread(_compute_h1_from_zip_bytes, data)
-        platform.h1_hash = h1.removeprefix("h1:")
-    except Exception:
-        logger.warning(
-            "Eager h1 compute failed at provider upload; will lazy-backfill on first read",
-            provider=f"{namespace}/{name}",
-            version=version_str,
-            platform=f"{os_}_{arch}",
-            exc_info=True,
-        )
-
-    await db.flush()
-
-    # Regenerate SHA256SUMS for this version
-    await regenerate_shasums(db, storage, namespace, name, prov_version.id, version_str)
-
     return platform
 
 

--- a/services/tests/integration/test_provider_publish.py
+++ b/services/tests/integration/test_provider_publish.py
@@ -1,0 +1,162 @@
+"""Integration: the client-signed provider publish -> CLI-download contract.
+
+Publishes a *synthetic* provider end-to-end through the real API + Postgres +
+filesystem storage (register key -> upload SHA256SUMS -> upload signature ->
+upload a platform zip) and asserts the `terraform init` download response is
+complete and installable: shasum populated, the signing key advertised, every
+URL resolvable. This is the contract that every bug the publish audit found
+(null shasum, stuck `pending` status, empty signing_keys) would have broken.
+
+The bytes are not a real provider — `tofu init` against a live registry is the
+Tilt smoke's job; here we only assert the server publish/serve contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pgpy
+import pytest
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
+
+from tests.integration.conftest import AUTH, admin_user, set_auth
+
+pytestmark = pytest.mark.asyncio
+
+PROV_BASE = "/api/terrapod/v1/registry-providers/private/default"
+
+
+def _new_key() -> pgpy.PGPKey:
+    key = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = pgpy.PGPUID.new("awsmai", email="security@example.test")
+    key.add_uid(
+        uid,
+        usage={KeyFlags.Sign},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+# Keygen is the slow part — generate once, register per test (DB is truncated
+# between tests). _OTHER is an unregistered key for the negative case.
+_KEY = _new_key()
+_OTHER = _new_key()
+
+
+async def _register(client, app) -> str:
+    """Register the provider slot + the signing public key; return its key id."""
+    set_auth(app, admin_user())
+    r = await client.post(
+        "/api/terrapod/v1/registry-providers",
+        json={
+            "data": {
+                "type": "registry-providers",
+                "attributes": {"name": "awsmai", "labels": {}},
+            }
+        },
+        headers=AUTH,
+    )
+    assert r.status_code in (200, 201), r.text
+    r = await client.post(
+        "/api/terrapod/v1/gpg-keys",
+        json={
+            "data": {
+                "type": "gpg-keys",
+                "attributes": {"namespace": "default", "ascii-armor": str(_KEY.pubkey)},
+            }
+        },
+        headers=AUTH,
+    )
+    assert r.status_code in (200, 201), r.text
+    return r.json()["data"]["attributes"]["key-id"]
+
+
+def _artifacts(version: str, body: bytes) -> tuple[bytes, str, str]:
+    sha = hashlib.sha256(body).hexdigest()
+    filename = f"terraform-provider-awsmai_{version}_linux_arm64.zip"
+    manifest = f"{sha}  {filename}\n".encode()
+    return manifest, filename, sha
+
+
+class TestProviderPublishDownload:
+    async def test_full_publish_is_installable(self, app, client):
+        key_id = await _register(client, app)
+        version = "1.0.0"
+        zip_bytes = b"PK\x03\x04 synthetic provider zip"
+        manifest, filename, sha = _artifacts(version, zip_bytes)
+        sig = bytes(_KEY.sign(manifest))
+
+        base = f"{PROV_BASE}/awsmai/versions/{version}"
+        assert (
+            await client.put(f"{base}/shasums", content=manifest, headers=AUTH)
+        ).status_code == 200
+        assert (
+            await client.put(f"{base}/shasums.sig", content=sig, headers=AUTH)
+        ).status_code == 200
+        r = await client.put(f"{base}/platforms/linux/arm64", content=zip_bytes, headers=AUTH)
+        assert r.status_code == 200, r.text
+
+        # CLI download (terraform init) must be complete + installable.
+        r = await client.get(
+            f"/api/v2/registry/providers/default/awsmai/{version}/download/linux/arm64",
+            headers=AUTH,
+        )
+        assert r.status_code == 200, r.text
+        info = r.json()
+        assert info["shasum"] == sha
+        assert info["filename"] == filename
+        assert info["download_url"] and info["shasums_url"] and info["shasums_signature_url"]
+        keys = info["signing_keys"]["gpg_public_keys"]
+        assert keys and keys[0]["key_id"] == key_id
+
+    async def test_binary_before_signature_is_rejected(self, app, client):
+        await _register(client, app)
+        version = "2.0.0"
+        zip_bytes = b"zip"
+        manifest, _, _ = _artifacts(version, zip_bytes)
+        base = f"{PROV_BASE}/awsmai/versions/{version}"
+        assert (
+            await client.put(f"{base}/shasums", content=manifest, headers=AUTH)
+        ).status_code == 200
+        # No verified signature yet -> binary upload must be refused.
+        r = await client.put(f"{base}/platforms/linux/arm64", content=zip_bytes, headers=AUTH)
+        assert r.status_code == 422, r.text
+
+    async def test_unregistered_signing_key_is_rejected(self, app, client):
+        await _register(client, app)
+        version = "3.0.0"
+        manifest, _, _ = _artifacts(version, b"zip")
+        base = f"{PROV_BASE}/awsmai/versions/{version}"
+        assert (
+            await client.put(f"{base}/shasums", content=manifest, headers=AUTH)
+        ).status_code == 200
+        # Signed by a key that was never registered -> 422 at the trust gate.
+        sig = bytes(_OTHER.sign(manifest))
+        r = await client.put(f"{base}/shasums.sig", content=sig, headers=AUTH)
+        assert r.status_code == 422, r.text
+
+    async def test_sha_mismatch_is_rejected(self, app, client):
+        await _register(client, app)
+        version = "4.0.0"
+        # Manifest commits to one sha; we upload different bytes.
+        manifest, _, _ = _artifacts(version, b"the-signed-bytes")
+        sig = bytes(_KEY.sign(manifest))
+        base = f"{PROV_BASE}/awsmai/versions/{version}"
+        assert (
+            await client.put(f"{base}/shasums", content=manifest, headers=AUTH)
+        ).status_code == 200
+        assert (
+            await client.put(f"{base}/shasums.sig", content=sig, headers=AUTH)
+        ).status_code == 200
+        r = await client.put(
+            f"{base}/platforms/linux/arm64", content=b"DIFFERENT bytes", headers=AUTH
+        )
+        assert r.status_code == 422, r.text

--- a/services/tests/services/test_registry_provider_service.py
+++ b/services/tests/services/test_registry_provider_service.py
@@ -1,85 +1,307 @@
-"""Tests for the registry provider service layer.
+"""Tests for the client-signed provider publish path in the registry service.
 
-Focuses on the eager-h1 path at upload-confirm: when a runner-side
-upload finalises a platform binary, we compute the terraform/tofu h1
-dirhash from the just-uploaded bytes and persist it on the
-`RegistryProviderPlatform` row, so the mirror's Tier-0 lookup can serve
-it without a lazy backfill on the first read.
+The publish protocol is: upload SHA256SUMS, then its detached signature
+(verified against a *registered* GPG key — the trust gate), then each
+platform zip (validated against the signed manifest as it streams in). The
+server never re-signs. These tests exercise the three service primitives
+(`store_provider_shasums`, `store_and_verify_provider_sig`,
+`record_provider_binary`) with a real pgpy keypair so the signature
+verification is genuine, not mocked.
 """
 
 from __future__ import annotations
 
-import io
-import zipfile
+import hashlib
+import os
+import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pgpy
 import pytest
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
+
+from terrapod.services.registry_provider_service import (
+    PublishValidationError,
+    record_provider_binary,
+    store_and_verify_provider_sig,
+    store_provider_shasums,
+)
+
+# One RSA keypair for the whole module — keygen is the slow part (~1-3s).
+_KEY = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+_UID = pgpy.PGPUID.new("awsmai test", email="security@example.test")
+_KEY.add_uid(
+    _UID,
+    usage={KeyFlags.Sign},
+    hashes=[HashAlgorithm.SHA256],
+    ciphers=[SymmetricKeyAlgorithm.AES256],
+    compression=[CompressionAlgorithm.ZLIB],
+)
+_PUB_ARMOR = str(_KEY.pubkey)
+_KEY_ID = _KEY.fingerprint.replace(" ", "")[-16:].upper()
 
 
-def _make_provider_zip() -> bytes:
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("terraform-provider-terrapod_v0.33.0", b"binary contents")
-    return buf.getvalue()
+def _detached_sig(data: bytes) -> bytes:
+    """A detached binary signature over raw bytes — exactly what gpg
+    --detach-sign / the Go client produce, and what tofu verifies."""
+    return bytes(_KEY.sign(data))
 
 
-class TestUploadProviderBinaryEagerH1:
-    """`upload_provider_binary` computes h1 from the uploaded bytes and
-    persists it on the platform row, so the mirror's Tier-0 lookup
-    doesn't have to lazy-backfill on the first download.
-    """
+def _registered_key() -> MagicMock:
+    gpg = MagicMock()
+    gpg.id = "gpgkey-uuid"
+    gpg.key_id = _KEY_ID
+    gpg.ascii_armor = _PUB_ARMOR
+    return gpg
+
+
+def _manifest(filename: str, sha: str) -> bytes:
+    return f"{sha}  {filename}\n".encode()
+
+
+class TestStoreAndVerifyProviderSig:
+    """The signature upload is the trust gate: it must verify against a
+    *registered* key over the *uploaded* manifest, or 422."""
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.gpg_key_service.get_gpg_key_by_key_id", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.registry_provider_service.get_provider_version",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
+    async def test_valid_signature_links_key(
+        self,
+        mock_get_provider: AsyncMock,
+        mock_get_version: AsyncMock,
+        mock_get_key: AsyncMock,
+    ) -> None:
+        mock_get_provider.return_value = MagicMock(id="prov")
+        version = MagicMock(gpg_key_id=None, shasums_sig_uploaded=False)
+        mock_get_version.return_value = version
+        mock_get_key.return_value = _registered_key()
+
+        manifest = _manifest("terraform-provider-awsmai_1.0.0_linux_arm64.zip", "a" * 64)
+        sig = _detached_sig(manifest)
+
+        storage = AsyncMock()
+        storage.get.return_value = manifest
+
+        result = await store_and_verify_provider_sig(
+            AsyncMock(), storage, "default", "awsmai", "1.0.0", sig
+        )
+
+        assert result.shasums_sig_uploaded is True
+        assert result.gpg_key_id == "gpgkey-uuid"
+        storage.put.assert_awaited_once()  # signature persisted
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.gpg_key_service.get_gpg_key_by_key_id", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.registry_provider_service.get_provider_version",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
+    async def test_tampered_manifest_rejected(
+        self,
+        mock_get_provider: AsyncMock,
+        mock_get_version: AsyncMock,
+        mock_get_key: AsyncMock,
+    ) -> None:
+        mock_get_provider.return_value = MagicMock(id="prov")
+        mock_get_version.return_value = MagicMock(gpg_key_id=None, shasums_sig_uploaded=False)
+        mock_get_key.return_value = _registered_key()
+
+        signed = _manifest("file.zip", "a" * 64)
+        sig = _detached_sig(signed)
+        storage = AsyncMock()
+        storage.get.return_value = signed + b"tampered\n"  # server reads a DIFFERENT manifest
+
+        with pytest.raises(PublishValidationError):
+            await store_and_verify_provider_sig(
+                AsyncMock(), storage, "default", "awsmai", "1.0.0", sig
+            )
+
+    @pytest.mark.asyncio
+    @patch("terrapod.services.gpg_key_service.get_gpg_key_by_key_id", new_callable=AsyncMock)
+    @patch(
+        "terrapod.services.registry_provider_service.get_provider_version",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
+    async def test_unregistered_key_rejected(
+        self,
+        mock_get_provider: AsyncMock,
+        mock_get_version: AsyncMock,
+        mock_get_key: AsyncMock,
+    ) -> None:
+        mock_get_provider.return_value = MagicMock(id="prov")
+        mock_get_version.return_value = MagicMock(gpg_key_id=None, shasums_sig_uploaded=False)
+        mock_get_key.return_value = None  # key not registered
+
+        manifest = _manifest("file.zip", "a" * 64)
+        storage = AsyncMock()
+        storage.get.return_value = manifest
+
+        with pytest.raises(PublishValidationError):
+            await store_and_verify_provider_sig(
+                AsyncMock(), storage, "default", "awsmai", "1.0.0", _detached_sig(manifest)
+            )
 
     @pytest.mark.asyncio
     @patch(
-        "terrapod.services.registry_provider_service.regenerate_shasums",
+        "terrapod.services.registry_provider_service.get_provider_version",
         new_callable=AsyncMock,
     )
+    @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
+    async def test_signature_before_manifest_rejected(
+        self, mock_get_provider: AsyncMock, mock_get_version: AsyncMock
+    ) -> None:
+        mock_get_provider.return_value = MagicMock(id="prov")
+        mock_get_version.return_value = MagicMock(gpg_key_id=None, shasums_sig_uploaded=False)
+        storage = AsyncMock()
+        storage.get.side_effect = FileNotFoundError("no manifest")
+
+        with pytest.raises(PublishValidationError):
+            await store_and_verify_provider_sig(
+                AsyncMock(), storage, "default", "awsmai", "1.0.0", b"sig"
+            )
+
+
+class TestRecordProviderBinary:
+    """Binary uploads are gated on a verified manifest and validated
+    against it byte-for-byte before storage."""
+
+    @pytest.mark.asyncio
     @patch(
         "terrapod.services.registry_provider_service.upsert_provider_platform",
         new_callable=AsyncMock,
     )
     @patch(
+        "terrapod.services.registry_provider_service.get_provider_version",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
+    async def test_matching_sha_stored(
+        self,
+        mock_get_provider: AsyncMock,
+        mock_get_version: AsyncMock,
+        mock_upsert_platform: AsyncMock,
+    ) -> None:
+        mock_get_provider.return_value = MagicMock(id="prov")
+        mock_get_version.return_value = MagicMock(shasums_sig_uploaded=True)
+        platform = MagicMock(shasum="", filename="", upload_status="pending")
+        mock_upsert_platform.return_value = platform
+
+        body = b"zip-bytes"
+        sha = hashlib.sha256(body).hexdigest()
+        filename = "terraform-provider-awsmai_1.0.0_linux_arm64.zip"
+        storage = AsyncMock()
+        storage.get.return_value = _manifest(filename, sha)
+
+        fd, tmp = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(body)
+            result = await record_provider_binary(
+                AsyncMock(),
+                storage,
+                "default",
+                "awsmai",
+                "1.0.0",
+                "linux",
+                "arm64",
+                sha256=sha,
+                filename=filename,
+                tmp_path=tmp,
+            )
+        finally:
+            os.unlink(tmp)
+
+        assert result.upload_status == "uploaded"
+        assert result.shasum == sha
+        storage.put_stream.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        "terrapod.services.registry_provider_service.get_provider_version",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
+    async def test_sha_mismatch_rejected(
+        self, mock_get_provider: AsyncMock, mock_get_version: AsyncMock
+    ) -> None:
+        mock_get_provider.return_value = MagicMock(id="prov")
+        mock_get_version.return_value = MagicMock(shasums_sig_uploaded=True)
+        filename = "terraform-provider-awsmai_1.0.0_linux_arm64.zip"
+        storage = AsyncMock()
+        storage.get.return_value = _manifest(filename, "b" * 64)  # signed sha differs
+
+        with pytest.raises(PublishValidationError):
+            await record_provider_binary(
+                AsyncMock(),
+                storage,
+                "default",
+                "awsmai",
+                "1.0.0",
+                "linux",
+                "arch",
+                sha256="a" * 64,
+                filename=filename,
+                tmp_path="/dev/null",
+            )
+
+    @pytest.mark.asyncio
+    @patch(
+        "terrapod.services.registry_provider_service.get_provider_version",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
+    async def test_binary_before_signature_rejected(
+        self, mock_get_provider: AsyncMock, mock_get_version: AsyncMock
+    ) -> None:
+        mock_get_provider.return_value = MagicMock(id="prov")
+        mock_get_version.return_value = MagicMock(shasums_sig_uploaded=False)  # not gated yet
+
+        with pytest.raises(PublishValidationError):
+            await record_provider_binary(
+                AsyncMock(),
+                AsyncMock(),
+                "default",
+                "awsmai",
+                "1.0.0",
+                "linux",
+                "arm64",
+                sha256="a" * 64,
+                filename="x.zip",
+                tmp_path="/dev/null",
+            )
+
+
+class TestStoreProviderShasums:
+    @pytest.mark.asyncio
+    @patch(
         "terrapod.services.registry_provider_service.upsert_provider_version",
         new_callable=AsyncMock,
     )
     @patch("terrapod.services.registry_provider_service.get_provider", new_callable=AsyncMock)
-    async def test_h1_persisted_on_successful_upload(
-        self,
-        mock_get_provider: AsyncMock,
-        mock_upsert_version: AsyncMock,
-        mock_upsert_platform: AsyncMock,
-        mock_regenerate_shasums: AsyncMock,
+    async def test_manifest_stored_and_flagged(
+        self, mock_get_provider: AsyncMock, mock_upsert_version: AsyncMock
     ) -> None:
-        from terrapod.services.registry_provider_service import upload_provider_binary
-
-        provider = MagicMock()
-        provider.id = "prov-id"
-        mock_get_provider.return_value = provider
-
-        prov_version = MagicMock()
-        prov_version.id = "ver-id"
-        mock_upsert_version.return_value = prov_version
-
-        platform = MagicMock()
-        platform.h1_hash = ""
-        platform.shasum = ""
-        platform.filename = ""
-        platform.upload_status = "pending"
-        mock_upsert_platform.return_value = platform
-
-        db = AsyncMock()
+        mock_get_provider.return_value = MagicMock(id="prov")
+        version = MagicMock(shasums_uploaded=False)
+        mock_upsert_version.return_value = version
         storage = AsyncMock()
 
-        data = _make_provider_zip()
-
-        await upload_provider_binary(
-            db, storage, "default", "terrapod", "0.33.0", "linux", "amd64", data
+        result = await store_provider_shasums(
+            AsyncMock(), storage, "default", "awsmai", "1.0.0", b"sha  file.zip\n"
         )
 
-        # h1 was computed and stored without the `h1:` prefix.
-        assert platform.h1_hash, "expected eager h1 compute to populate h1_hash"
-        assert not platform.h1_hash.startswith("h1:"), "stored value omits the prefix"
-        # And the rest of the upload flow ran.
-        assert platform.upload_status == "uploaded"
-        assert platform.shasum != ""
+        assert result.shasums_uploaded is True
         storage.put.assert_awaited_once()

--- a/web/src/app/registry/providers/[name]/page.tsx
+++ b/web/src/app/registry/providers/[name]/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { ChevronDown, ChevronRight, Upload, FolderOpen } from 'lucide-react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import * as Dialog from '@radix-ui/react-dialog'
 import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
@@ -51,22 +51,6 @@ interface Version {
   }
 }
 
-interface DetectedFile {
-  file: File
-  name: string
-  version: string
-  os: string
-  arch: string
-}
-
-function parseProviderFilename(filename: string): { name: string; version: string; os: string; arch: string } | null {
-  const match = filename.match(
-    /^terraform-provider-(.+?)_(\d+\.\d+\.\d+(?:-.+?)?)_([a-z]+)_([a-z0-9]+)\.zip$/
-  )
-  if (!match) return null
-  return { name: match[1], version: match[2], os: match[3], arch: match[4] }
-}
-
 export default function ProviderDetailPage() {
   const router = useRouter()
   const params = useParams<{ name: string }>()
@@ -76,26 +60,6 @@ export default function ProviderDetailPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [expandedVersion, setExpandedVersion] = useState<string | null>(null)
-
-  // Upload state
-  const [showUpload, setShowUpload] = useState(false)
-  const [detectedFiles, setDetectedFiles] = useState<DetectedFile[]>([])
-  const [uploading, setUploading] = useState(false)
-  const [uploadProgress, setUploadProgress] = useState<Record<string, number>>({})
-
-  // Advanced: create version/platform forms
-  const [showAdvanced, setShowAdvanced] = useState(false)
-  const [showCreateVersion, setShowCreateVersion] = useState(false)
-  const [newVersion, setNewVersion] = useState('')
-  const [newKeyId, setNewKeyId] = useState('')
-  const [newProtocols, setNewProtocols] = useState('5.0')
-  const [creatingVersion, setCreatingVersion] = useState(false)
-
-  const [platformForVersion, setPlatformForVersion] = useState<string | null>(null)
-  const [newOs, setNewOs] = useState('linux')
-  const [newArch, setNewArch] = useState('amd64')
-  const [newFilename, setNewFilename] = useState('')
-  const [creatingPlatform, setCreatingPlatform] = useState(false)
 
   // Provider metadata
   const [providerMeta, setProviderMeta] = useState<ProviderMeta | null>(null)
@@ -179,123 +143,6 @@ export default function ProviderDetailPage() {
     }
   }
 
-  const handleDirectorySelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files
-    if (!files) return
-
-    const detected: DetectedFile[] = []
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i]
-      const parsed = parseProviderFilename(file.name)
-      if (parsed) {
-        detected.push({ file, ...parsed })
-      }
-    }
-    detected.sort((a, b) => `${a.version}-${a.os}-${a.arch}`.localeCompare(`${b.version}-${b.os}-${b.arch}`))
-    setDetectedFiles(detected)
-  }, [])
-
-  async function handleUploadAll() {
-    if (detectedFiles.length === 0) return
-    setUploading(true)
-    setError('')
-    const progress: Record<string, number> = {}
-
-    try {
-      for (const df of detectedFiles) {
-        const key = `${df.version}-${df.os}-${df.arch}`
-        progress[key] = 0
-        setUploadProgress({ ...progress })
-
-        const arrayBuffer = await df.file.arrayBuffer()
-        const res = await apiFetch(
-          `${basePath}/versions/${df.version}/platforms/${df.os}/${df.arch}/upload`,
-          {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/zip' },
-            body: arrayBuffer,
-          }
-        )
-        if (!res.ok) {
-          const data = await res.json().catch(() => ({}))
-          throw new Error(data.detail || `Upload failed for ${df.file.name} (${res.status})`)
-        }
-        progress[key] = 100
-        setUploadProgress({ ...progress })
-      }
-
-      setDetectedFiles([])
-      setShowUpload(false)
-      setUploadProgress({})
-      await loadVersions()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Upload failed')
-    } finally {
-      setUploading(false)
-    }
-  }
-
-  async function handleCreateVersion(e: React.FormEvent) {
-    e.preventDefault()
-    setCreatingVersion(true)
-    setError('')
-    try {
-      const protocols = newProtocols.split(',').map(p => p.trim()).filter(Boolean)
-      const res = await apiFetch(`${basePath}/versions`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/vnd.api+json' },
-        body: JSON.stringify({
-          data: {
-            type: 'registry-provider-versions',
-            attributes: { version: newVersion, key_id: newKeyId, protocols },
-          },
-        }),
-      })
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        throw new Error(data.detail || `Failed to create version (${res.status})`)
-      }
-      setNewVersion('')
-      setNewKeyId('')
-      setShowCreateVersion(false)
-      await loadVersions()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create version')
-    } finally {
-      setCreatingVersion(false)
-    }
-  }
-
-  async function handleCreatePlatform(e: React.FormEvent) {
-    e.preventDefault()
-    if (!platformForVersion) return
-    setCreatingPlatform(true)
-    setError('')
-    try {
-      const res = await apiFetch(`${basePath}/versions/${platformForVersion}/platforms`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/vnd.api+json' },
-        body: JSON.stringify({
-          data: {
-            type: 'registry-provider-platforms',
-            attributes: { os: newOs, arch: newArch, filename: newFilename },
-          },
-        }),
-      })
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        throw new Error(data.detail || `Failed to create platform (${res.status})`)
-      }
-      setNewFilename('')
-      setPlatformForVersion(null)
-      await loadVersions()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create platform')
-    } finally {
-      setCreatingPlatform(false)
-    }
-  }
-
   async function handleDelete() {
     if (!deleteTarget) return
     setError('')
@@ -324,13 +171,6 @@ export default function ProviderDetailPage() {
     }
   }
 
-  // Group detected files by version for preview
-  const groupedFiles = detectedFiles.reduce<Record<string, DetectedFile[]>>((acc, df) => {
-    if (!acc[df.version]) acc[df.version] = []
-    acc[df.version].push(df)
-    return acc
-  }, {})
-
   const provPerms = providerMeta?.attributes.permissions || {} as ProviderPermissions
 
   return (
@@ -344,15 +184,6 @@ export default function ProviderDetailPage() {
           description="Provider registry"
           actions={
             <div className="flex gap-2">
-              {provPerms['can-create-version'] && (
-                <button
-                  onClick={() => { setShowUpload(!showUpload); setShowAdvanced(false) }}
-                  className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors flex items-center gap-2"
-                >
-                  <Upload size={16} />
-                  {showUpload ? 'Cancel' : 'Upload Binaries'}
-                </button>
-              )}
               {provPerms['can-destroy'] && (
                 <button
                   onClick={() => setDeleteTarget({ type: 'provider' })}
@@ -365,133 +196,15 @@ export default function ProviderDetailPage() {
           }
         />
 
-        {/* Upload section */}
-        {showUpload && (
-          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-5 mb-6 space-y-4">
-            <div>
-              <p className="text-sm text-slate-300 mb-3">
-                Select a directory containing provider binaries. Files matching the pattern{' '}
-                <code className="text-xs bg-slate-700 px-1.5 py-0.5 rounded text-brand-300">
-                  terraform-provider-*_VERSION_OS_ARCH.zip
-                </code>{' '}
-                will be detected automatically.
-              </p>
-              <label className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 cursor-pointer transition-colors border border-slate-600">
-                <FolderOpen size={16} />
-                Select Directory
-                {/* @ts-expect-error webkitdirectory is not in standard types */}
-                <input type="file" webkitdirectory="" multiple className="hidden" onChange={handleDirectorySelect} />
-              </label>
-            </div>
-
-            {detectedFiles.length > 0 && (
-              <>
-                <div className="space-y-3">
-                  {Object.entries(groupedFiles).map(([ver, files]) => (
-                    <div key={ver}>
-                      <h4 className="text-sm font-medium text-slate-300 mb-1">Version {ver}</h4>
-                      <div className="bg-slate-900/50 rounded-lg overflow-hidden">
-                        <table className="w-full text-sm">
-                          <thead>
-                            <tr className="text-slate-500 text-xs border-b border-slate-700/30">
-                              <th className="text-left px-3 py-1.5 font-medium">OS</th>
-                              <th className="text-left px-3 py-1.5 font-medium">Arch</th>
-                              <th className="text-left px-3 py-1.5 font-medium">Filename</th>
-                              <th className="text-right px-3 py-1.5 font-medium">Size</th>
-                              <th className="text-right px-3 py-1.5 font-medium w-24">Status</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {files.map((df) => {
-                              const key = `${df.version}-${df.os}-${df.arch}`
-                              const pct = uploadProgress[key]
-                              return (
-                                <tr key={key} className="border-t border-slate-700/20">
-                                  <td className="px-3 py-1.5 text-slate-300">{df.os}</td>
-                                  <td className="px-3 py-1.5 text-slate-300">{df.arch}</td>
-                                  <td className="px-3 py-1.5 text-slate-400 font-mono text-xs">{df.file.name}</td>
-                                  <td className="px-3 py-1.5 text-slate-400 text-right text-xs">
-                                    {(df.file.size / 1024 / 1024).toFixed(1)} MB
-                                  </td>
-                                  <td className="px-3 py-1.5 text-right">
-                                    {pct === undefined ? (
-                                      <span className="text-xs text-slate-500">Pending</span>
-                                    ) : pct === 100 ? (
-                                      <span className="text-xs text-green-400">Done</span>
-                                    ) : (
-                                      <span className="text-xs text-brand-400">Uploading...</span>
-                                    )}
-                                  </td>
-                                </tr>
-                              )
-                            })}
-                          </tbody>
-                        </table>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-
-                <button
-                  onClick={handleUploadAll}
-                  disabled={uploading}
-                  className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors flex items-center gap-2"
-                >
-                  <Upload size={16} />
-                  {uploading ? 'Uploading...' : `Upload ${detectedFiles.length} file(s)`}
-                </button>
-              </>
-            )}
-
-            {/* Advanced toggle */}
-            <div className="pt-2 border-t border-slate-700/30">
-              <button
-                onClick={() => setShowAdvanced(!showAdvanced)}
-                className="text-xs text-slate-500 hover:text-slate-400 transition-colors flex items-center gap-1"
-              >
-                {showAdvanced ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                Advanced (manual version/platform creation)
-              </button>
-            </div>
-
-            {showAdvanced && (
-              <div className="space-y-3 pt-2">
-                <button
-                  onClick={() => setShowCreateVersion(!showCreateVersion)}
-                  className="px-3 py-1.5 rounded text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors"
-                >
-                  {showCreateVersion ? 'Cancel' : 'Create Version Manually'}
-                </button>
-
-                {showCreateVersion && (
-                  <form onSubmit={handleCreateVersion} className="bg-slate-900/50 rounded-lg p-3 space-y-3">
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                      <div>
-                        <label htmlFor="pv-ver" className="block text-xs font-medium text-slate-400 mb-1">Version</label>
-                        <input id="pv-ver" type="text" value={newVersion} onChange={(e) => setNewVersion(e.target.value)} required placeholder="1.0.0"
-                          className="w-full px-2.5 py-1.5 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
-                      </div>
-                      <div>
-                        <label htmlFor="pv-key" className="block text-xs font-medium text-slate-400 mb-1">GPG Key ID</label>
-                        <input id="pv-key" type="text" value={newKeyId} onChange={(e) => setNewKeyId(e.target.value)} placeholder="optional"
-                          className="w-full px-2.5 py-1.5 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
-                      </div>
-                      <div>
-                        <label htmlFor="pv-proto" className="block text-xs font-medium text-slate-400 mb-1">Protocols</label>
-                        <input id="pv-proto" type="text" value={newProtocols} onChange={(e) => setNewProtocols(e.target.value)} placeholder="5.0"
-                          className="w-full px-2.5 py-1.5 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
-                      </div>
-                    </div>
-                    <button type="submit" disabled={creatingVersion}
-                      className="px-3 py-1.5 rounded text-xs font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors">
-                      {creatingVersion ? 'Creating...' : 'Create Version'}
-                    </button>
-                  </form>
-                )}
-              </div>
-            )}
-          </div>
-        )}
+        {/* Publishing note: provider versions are now published via the CLI */}
+        <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6">
+          <p className="text-sm text-slate-400">
+            Provider versions are published with the{' '}
+            <code className="text-xs bg-slate-700 px-1.5 py-0.5 rounded text-slate-300">terrapod-publish</code>{' '}
+            CLI, which client-signs the binaries. Uploading and signing provider binaries from the
+            browser is no longer supported. This page is read-only for versions and platforms.
+          </p>
+        </div>
 
         {/* Metadata: Owner & Labels */}
         {providerMeta && (
@@ -551,7 +264,7 @@ export default function ProviderDetailPage() {
         {loading ? (
           <LoadingSpinner />
         ) : versions.length === 0 ? (
-          <EmptyState message="No versions yet. Upload binaries to get started." />
+          <EmptyState message="No versions yet. Publish with the terrapod-publish CLI to get started." />
         ) : (
           <div className="space-y-3">
             {versions.map((v) => {
@@ -569,16 +282,14 @@ export default function ProviderDetailPage() {
                       {isExpanded ? <ChevronDown size={16} className="text-slate-500" /> : <ChevronRight size={16} className="text-slate-500" />}
                       <span className="font-mono text-slate-200">{v.attributes.version}</span>
                       <span className="text-xs text-slate-500">{v.attributes.platforms?.length || 0} platform(s)</span>
+                      {v.attributes['shasums-uploaded'] && (
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-slate-700 text-slate-400">SHASUMS</span>
+                      )}
+                      {v.attributes['shasums-sig-uploaded'] && (
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-slate-700 text-slate-400">SHASUMS.sig</span>
+                      )}
                     </div>
                     <div className="flex items-center gap-2">
-                      {provPerms['can-create-version'] && (
-                        <button
-                          onClick={(e) => { e.stopPropagation(); setPlatformForVersion(v.attributes.version) }}
-                          className="text-xs text-brand-400 hover:text-brand-300 transition-colors"
-                        >
-                          Add Platform
-                        </button>
-                      )}
                       {provPerms['can-destroy'] && (
                         <button
                           onClick={(e) => { e.stopPropagation(); setDeleteTarget({ type: 'version', version: v.attributes.version }) }}
@@ -627,48 +338,6 @@ export default function ProviderDetailPage() {
             })}
           </div>
         )}
-
-        {/* Add platform form dialog */}
-        <Dialog.Root open={platformForVersion !== null} onOpenChange={(open) => { if (!open) setPlatformForVersion(null) }}>
-          <Dialog.Portal>
-            <Dialog.Overlay className="fixed inset-0 bg-black/60" />
-            <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-slate-800 rounded-lg border border-slate-700 p-6 w-full max-w-md shadow-xl">
-              <Dialog.Title className="text-lg font-semibold text-slate-100">
-                Add Platform — {platformForVersion}
-              </Dialog.Title>
-              <form onSubmit={handleCreatePlatform} className="mt-4 space-y-3">
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label htmlFor="plt-os" className="block text-sm font-medium text-slate-300 mb-1">OS</label>
-                    <input id="plt-os" type="text" value={newOs} onChange={(e) => setNewOs(e.target.value)} required
-                      className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
-                  </div>
-                  <div>
-                    <label htmlFor="plt-arch" className="block text-sm font-medium text-slate-300 mb-1">Arch</label>
-                    <input id="plt-arch" type="text" value={newArch} onChange={(e) => setNewArch(e.target.value)} required
-                      className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
-                  </div>
-                </div>
-                <div>
-                  <label htmlFor="plt-file" className="block text-sm font-medium text-slate-300 mb-1">Filename</label>
-                  <input id="plt-file" type="text" value={newFilename} onChange={(e) => setNewFilename(e.target.value)} required
-                    placeholder="terraform-provider-aws_1.0.0_linux_amd64.zip"
-                    className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
-                </div>
-                <div className="flex justify-end gap-3 mt-4">
-                  <button type="button" onClick={() => setPlatformForVersion(null)}
-                    className="px-4 py-2 rounded-lg text-sm font-medium text-slate-300 hover:bg-slate-700 transition-colors">
-                    Cancel
-                  </button>
-                  <button type="submit" disabled={creatingPlatform}
-                    className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors">
-                    {creatingPlatform ? 'Creating...' : 'Create Platform'}
-                  </button>
-                </div>
-              </form>
-            </Dialog.Content>
-          </Dialog.Portal>
-        </Dialog.Root>
 
         {/* Delete confirmation dialog */}
         <Dialog.Root open={deleteTarget !== null} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>


### PR DESCRIPTION
## What

Reworks **private provider publishing** into a client-signed, direct, streamed protocol and adds **`terrapod-publish`** — a pure-Go CLI that builds, signs, and uploads providers (and modules) to the Terrapod registry. Intended as a minor release (**v0.37.0**).

## Why

The first real attempt to publish a private provider surfaced that the old **presigned** publish path could never produce an installable provider: nothing finalised the upload, so `platform.shasum` stayed null and `upload_status` stayed `pending` — and because the CLI version list filters platforms to `uploaded`, `terraform init` saw **zero platforms**. It had simply never been exercised before (the built-in provider and VCS module publishing use different paths).

## Server

- **Three ordered PUTs replace the presigned create-version/create-platform endpoints and the server-signed upload path:**
  1. `PUT …/versions/{version}/shasums` — the client-built `SHA256SUMS` manifest.
  2. `PUT …/versions/{version}/shasums.sig` — the detached signature. The server reads the issuer key id out of the signature, looks up the **registered** GPG key, and **verifies the signature against that stored public key** over the manifest. This is the trust gate — `422` on unregistered key / failed verify / missing manifest.
  3. `PUT …/versions/{version}/platforms/{os}/{arch}` — each zip is **streamed to the ephemeral PVC** (never buffered in RAM), its sha computed on the fly and checked against the signed manifest (`422` on mismatch), then streamed to object storage.
- **The server never re-signs** — the publisher owns the signature, so the `terraform init` download advertises the publisher's key in `signing_keys`. Trust is anchored in the public key Terrapod already holds, not in what the upload asserts.
- Binaries are refused until the signature verifies (ordering enforced). Downloads stay presigned-GET redirects.

## Clients & tooling

- **go-terrapod**: typed `UploadProviderSHASUMS` / `UploadProviderSignature` / `UploadProviderPlatform` / `UploadModuleVersion` + tests.
- **`publish/`** (new Go module): `terrapod-publish`. Pure-Go zip + `SHA256SUMS` (`archive/zip`, `crypto/sha256`) and detached OpenPGP signing (ProtonMail `go-crypto`) — no `gpg`/`zip`/`tar` binaries. Auth resolves `--token` → `$TERRAPOD_TOKEN` → `~/.terraform.d/credentials.tfrc.json`. Released per-tag like `terrapod-migrate`.
- **UI**: provider versions are now **list/view/delete only** — a browser can't produce a detached signature, so publishing is CLI-only.

## Tests

- Unit: real pgpy sign/verify trust-gate, sha-mismatch, ordering (services tier).
- Integration: full publish → `terraform init` download contract on real Postgres + storage (shasum populated, signing key advertised, URLs resolve; negative cases 422).
- Go: `pack` (zip layout / exec bit / manifest / tar.gz), `sign` (detached-sig round-trip + tamper), `publisher` (upload order).
- Full Python suite green (2102 passed); `npm run build` green.

## Docs

New `docs/registry-publishing.md` + `api-reference` / `index` / `README` updates.

## Module-side note

Modules need no server change — their direct `…/versions/{version}/upload` path already finalises (interface parse + impact trigger); `terrapod-publish module` uses it.