### PR TITLE
chore(test): scrub internal references from tests/examples

### DIFF
--- a/go-terrapod/registry_publish_test.go
+++ b/go-terrapod/registry_publish_test.go
@@ -45,13 +45,13 @@ func newPublishFixture(t *testing.T, status int) (*Client, *capturedReq) {
 
 func TestUploadProviderSHASUMS(t *testing.T) {
 	c, cap := newPublishFixture(t, http.StatusOK)
-	if err := c.UploadProviderSHASUMS(t.Context(), "awsmai", "1.0.0", []byte("sums")); err != nil {
+	if err := c.UploadProviderSHASUMS(t.Context(), "example", "1.0.0", []byte("sums")); err != nil {
 		t.Fatal(err)
 	}
 	if cap.method != http.MethodPut {
 		t.Errorf("method = %s", cap.method)
 	}
-	if cap.path != "/api/terrapod/v1/registry-providers/private/default/awsmai/versions/1.0.0/shasums" {
+	if cap.path != "/api/terrapod/v1/registry-providers/private/default/example/versions/1.0.0/shasums" {
 		t.Errorf("path = %s", cap.path)
 	}
 	if string(cap.body) != "sums" {
@@ -61,17 +61,17 @@ func TestUploadProviderSHASUMS(t *testing.T) {
 
 func TestUploadProviderSignaturePath(t *testing.T) {
 	c, cap := newPublishFixture(t, http.StatusOK)
-	if err := c.UploadProviderSignature(t.Context(), "awsmai", "1.0.0", []byte("sig")); err != nil {
+	if err := c.UploadProviderSignature(t.Context(), "example", "1.0.0", []byte("sig")); err != nil {
 		t.Fatal(err)
 	}
-	if cap.path != "/api/terrapod/v1/registry-providers/private/default/awsmai/versions/1.0.0/shasums.sig" {
+	if cap.path != "/api/terrapod/v1/registry-providers/private/default/example/versions/1.0.0/shasums.sig" {
 		t.Errorf("path = %s", cap.path)
 	}
 }
 
 func TestUploadProviderSignatureRejected(t *testing.T) {
 	c, _ := newPublishFixture(t, http.StatusUnprocessableEntity)
-	err := c.UploadProviderSignature(t.Context(), "awsmai", "1.0.0", []byte("badsig"))
+	err := c.UploadProviderSignature(t.Context(), "example", "1.0.0", []byte("badsig"))
 	if !IsValidation(err) {
 		t.Fatalf("expected ValidationError, got %v", err)
 	}
@@ -80,10 +80,10 @@ func TestUploadProviderSignatureRejected(t *testing.T) {
 func TestUploadProviderPlatform(t *testing.T) {
 	c, cap := newPublishFixture(t, http.StatusOK)
 	zip := []byte("PK\x03\x04zip")
-	if err := c.UploadProviderPlatform(t.Context(), "awsmai", "1.0.0", "linux", "arm64", zip); err != nil {
+	if err := c.UploadProviderPlatform(t.Context(), "example", "1.0.0", "linux", "arm64", zip); err != nil {
 		t.Fatal(err)
 	}
-	if cap.path != "/api/terrapod/v1/registry-providers/private/default/awsmai/versions/1.0.0/platforms/linux/arm64" {
+	if cap.path != "/api/terrapod/v1/registry-providers/private/default/example/versions/1.0.0/platforms/linux/arm64" {
 		t.Errorf("path = %s", cap.path)
 	}
 	if string(cap.body) != string(zip) {
@@ -93,7 +93,7 @@ func TestUploadProviderPlatform(t *testing.T) {
 
 func TestUploadProviderPlatformMismatchRejected(t *testing.T) {
 	c, _ := newPublishFixture(t, http.StatusUnprocessableEntity)
-	err := c.UploadProviderPlatform(t.Context(), "awsmai", "1.0.0", "linux", "arm64", []byte("x"))
+	err := c.UploadProviderPlatform(t.Context(), "example", "1.0.0", "linux", "arm64", []byte("x"))
 	if !IsValidation(err) {
 		t.Fatalf("expected ValidationError, got %v", err)
 	}

--- a/go-terrapod/workspaces_test.go
+++ b/go-terrapod/workspaces_test.go
@@ -388,8 +388,8 @@ func TestWorkspaceFromResource_ContractParity(t *testing.T) {
 	    "vcs-last-polled-at": "2026-06-10T11:50:00Z",
 	    "vcs-last-error": "github app token expired",
 	    "vcs-last-error-at": "2026-06-10T11:45:00Z",
-	    "agent-pool-name": "mai-dev-us1",
-	    "vcs-connection-name": "markupai-github"
+	    "agent-pool-name": "dev-pool-1",
+	    "vcs-connection-name": "example-github"
 	  }
 	}}`
 	ws, err := parseWorkspace([]byte(body))
@@ -412,7 +412,7 @@ func TestWorkspaceFromResource_ContractParity(t *testing.T) {
 		t.Errorf("vcs-poll status fields: polled=%q err=%q errAt=%q",
 			ws.VCSLastPolledAt, ws.VCSLastError, ws.VCSLastErrorAt)
 	}
-	if ws.AgentPoolName != "mai-dev-us1" || ws.VCSConnectionName != "markupai-github" {
+	if ws.AgentPoolName != "dev-pool-1" || ws.VCSConnectionName != "example-github" {
 		t.Errorf("derived names: pool=%q conn=%q", ws.AgentPoolName, ws.VCSConnectionName)
 	}
 }

--- a/publish/cmd/terrapod-publish/provider.go
+++ b/publish/cmd/terrapod-publish/provider.go
@@ -15,7 +15,7 @@ import (
 func providerCmd(args []string) int {
 	fs := flag.NewFlagSet("provider", flag.ContinueOnError)
 	host := fs.String("host", "", "Terrapod hostname (required)")
-	name := fs.String("name", "", "provider name, e.g. awsmai (required)")
+	name := fs.String("name", "", "provider name, e.g. example (required)")
 	version := fs.String("version", "", "version, e.g. 1.0.0 (no leading v) (required)")
 	keyPath := fs.String("signing-key", "", "path to ASCII-armored private signing key (required)")
 	keyPass := fs.String("signing-key-passphrase", "",

--- a/publish/go.mod
+++ b/publish/go.mod
@@ -8,9 +8,9 @@ require (
 )
 
 require (
-	github.com/cloudflare/circl v1.6.2 // indirect
-	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/sys v0.35.0 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
+	golang.org/x/crypto v0.45.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
 )
 
 replace github.com/mattrobinsonsre/terrapod/go-terrapod => ../go-terrapod

--- a/publish/go.sum
+++ b/publish/go.sum
@@ -1,8 +1,8 @@
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/cloudflare/circl v1.6.2 h1:hL7VBpHHKzrV5WTfHCaBsgx/HGbBYlgrwvNXEVDYYsQ=
-github.com/cloudflare/circl v1.6.2/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
-golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
-golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
-golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/publish/internal/pack/pack_test.go
+++ b/publish/internal/pack/pack_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestProviderZipLayout(t *testing.T) {
 	bin := []byte("the binary")
-	z, err := ProviderZip("awsmai", "1.0.0", "linux", bin)
+	z, err := ProviderZip("example", "1.0.0", "linux", bin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func TestProviderZipLayout(t *testing.T) {
 		t.Fatalf("want 1 entry, got %d", len(zr.File))
 	}
 	f := zr.File[0]
-	if f.Name != "terraform-provider-awsmai_v1.0.0" {
+	if f.Name != "terraform-provider-example_v1.0.0" {
 		t.Errorf("inner name = %s", f.Name)
 	}
 	if f.Mode()&0o100 == 0 {
@@ -42,9 +42,9 @@ func TestProviderZipLayout(t *testing.T) {
 }
 
 func TestProviderZipWindowsExe(t *testing.T) {
-	z, _ := ProviderZip("awsmai", "1.0.0", "windows", []byte("x"))
+	z, _ := ProviderZip("example", "1.0.0", "windows", []byte("x"))
 	zr, _ := zip.NewReader(bytes.NewReader(z), int64(len(z)))
-	if zr.File[0].Name != "terraform-provider-awsmai_v1.0.0.exe" {
+	if zr.File[0].Name != "terraform-provider-example_v1.0.0.exe" {
 		t.Errorf("windows inner name = %s", zr.File[0].Name)
 	}
 }

--- a/publish/internal/publisher/publisher_test.go
+++ b/publish/internal/publisher/publisher_test.go
@@ -36,13 +36,13 @@ func TestPublishProviderUploadOrder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entity, err := openpgp.NewEntity("awsmai", "", "security@example.test", nil)
+	entity, err := openpgp.NewEntity("example", "", "security@example.test", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = PublishProvider(context.Background(), c, ProviderInput{
-		Name:       "awsmai",
+		Name:       "example",
 		Version:    "1.0.0",
 		SigningKey: entity,
 		Binaries:   map[string][]byte{"linux/arm64": []byte("bin")},
@@ -59,7 +59,7 @@ func TestPublishProviderUploadOrder(t *testing.T) {
 	if order[2] != "platform:linux/arm64" {
 		t.Errorf("platform path = %s", order[2])
 	}
-	if !strings.Contains(manifestBody, "terraform-provider-awsmai_1.0.0_linux_arm64.zip") {
+	if !strings.Contains(manifestBody, "terraform-provider-example_1.0.0_linux_arm64.zip") {
 		t.Errorf("manifest missing canonical filename: %q", manifestBody)
 	}
 }
@@ -68,7 +68,7 @@ func TestPublishProviderNoBinaries(t *testing.T) {
 	c, _ := terrapod.NewClient(terrapod.Options{BaseURL: "http://x", Token: "t"})
 	entity, _ := openpgp.NewEntity("x", "", "x@x.test", nil)
 	err := PublishProvider(context.Background(), c, ProviderInput{
-		Name: "awsmai", Version: "1.0.0", SigningKey: entity, Binaries: nil,
+		Name: "example", Version: "1.0.0", SigningKey: entity, Binaries: nil,
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error for no binaries")

--- a/publish/internal/sign/sign_test.go
+++ b/publish/internal/sign/sign_test.go
@@ -9,7 +9,7 @@ import (
 
 func testEntity(t *testing.T) *openpgp.Entity {
 	t.Helper()
-	e, err := openpgp.NewEntity("awsmai test", "", "security@example.test", nil)
+	e, err := openpgp.NewEntity("example test", "", "security@example.test", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,7 +18,7 @@ func testEntity(t *testing.T) *openpgp.Entity {
 
 func TestDetachSignVerifies(t *testing.T) {
 	e := testEntity(t)
-	data := []byte("abc123  terraform-provider-awsmai_1.0.0_linux_arm64.zip\n")
+	data := []byte("abc123  terraform-provider-example_1.0.0_linux_arm64.zip\n")
 	sig, err := DetachSign(e, data)
 	if err != nil {
 		t.Fatal(err)

--- a/scripts/smoke/provider/main.tf
+++ b/scripts/smoke/provider/main.tf
@@ -111,7 +111,7 @@ resource "terrapod_role" "smoke" {
 # the smoke doesn't need a second user to exist.
 variable "smoke_email" {
   type    = string
-  default = "matt.robinson@acrolinx.com"
+  default = "admin@example.com"
 }
 
 resource "terrapod_role_assignment" "smoke" {

--- a/services/tests/api/test_agent_pools_validators.py
+++ b/services/tests/api/test_agent_pools_validators.py
@@ -19,7 +19,7 @@ class TestValidateOwnerEmail:
         "email",
         [
             "user@example.com",
-            "matt.robinson@acrolinx.com",
+            "admin@example.com",
             "first.last+tag@subdomain.example.co.uk",
             "a@b.c",
             "MixedCase@Example.ORG",

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -567,7 +567,7 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
     async def test_returns_labels_as_bindings(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
-        ws = _mock_workspace(labels={"repo": "tf-aws-core", "env": "dev"})
+        ws = _mock_workspace(labels={"repo": "infra-core", "env": "dev"})
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = ws
@@ -579,7 +579,7 @@ class TestWorkspaceTagBindings:
         items = resp.json()["data"]
         # Same key/value pairs, regardless of ordering
         assert {(i["attributes"]["key"], i["attributes"]["value"]) for i in items} == {
-            ("repo", "tf-aws-core"),
+            ("repo", "infra-core"),
             ("env", "dev"),
         }
         assert all(i["type"] == "tag-bindings" for i in items)
@@ -634,7 +634,7 @@ class TestWorkspaceTagBindings:
     async def test_effective_tag_bindings_mirrors_workspace_bindings(self, mock_resolve, *mocks):
         # Terrapod has no project hierarchy, so effective bindings == workspace bindings
         mock_resolve.return_value = "read"
-        ws = _mock_workspace(labels={"repo": "tf-aws-core"})
+        ws = _mock_workspace(labels={"repo": "infra-core"})
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = ws
@@ -650,7 +650,7 @@ class TestWorkspaceTagBindings:
             {
                 "id": f"{ws.id}:repo",
                 "type": "effective-tag-bindings",
-                "attributes": {"key": "repo", "value": "tf-aws-core"},
+                "attributes": {"key": "repo", "value": "infra-core"},
             }
         ]
 

--- a/services/tests/integration/test_provider_publish.py
+++ b/services/tests/integration/test_provider_publish.py
@@ -34,7 +34,7 @@ PROV_BASE = "/api/terrapod/v1/registry-providers/private/default"
 
 def _new_key() -> pgpy.PGPKey:
     key = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
-    uid = pgpy.PGPUID.new("awsmai", email="security@example.test")
+    uid = pgpy.PGPUID.new("example", email="security@example.test")
     key.add_uid(
         uid,
         usage={KeyFlags.Sign},
@@ -59,7 +59,7 @@ async def _register(client, app) -> str:
         json={
             "data": {
                 "type": "registry-providers",
-                "attributes": {"name": "awsmai", "labels": {}},
+                "attributes": {"name": "example", "labels": {}},
             }
         },
         headers=AUTH,
@@ -81,7 +81,7 @@ async def _register(client, app) -> str:
 
 def _artifacts(version: str, body: bytes) -> tuple[bytes, str, str]:
     sha = hashlib.sha256(body).hexdigest()
-    filename = f"terraform-provider-awsmai_{version}_linux_arm64.zip"
+    filename = f"terraform-provider-example_{version}_linux_arm64.zip"
     manifest = f"{sha}  {filename}\n".encode()
     return manifest, filename, sha
 
@@ -94,7 +94,7 @@ class TestProviderPublishDownload:
         manifest, filename, sha = _artifacts(version, zip_bytes)
         sig = bytes(_KEY.sign(manifest))
 
-        base = f"{PROV_BASE}/awsmai/versions/{version}"
+        base = f"{PROV_BASE}/example/versions/{version}"
         assert (
             await client.put(f"{base}/shasums", content=manifest, headers=AUTH)
         ).status_code == 200
@@ -106,7 +106,7 @@ class TestProviderPublishDownload:
 
         # CLI download (terraform init) must be complete + installable.
         r = await client.get(
-            f"/api/v2/registry/providers/default/awsmai/{version}/download/linux/arm64",
+            f"/api/v2/registry/providers/default/example/{version}/download/linux/arm64",
             headers=AUTH,
         )
         assert r.status_code == 200, r.text
@@ -122,7 +122,7 @@ class TestProviderPublishDownload:
         version = "2.0.0"
         zip_bytes = b"zip"
         manifest, _, _ = _artifacts(version, zip_bytes)
-        base = f"{PROV_BASE}/awsmai/versions/{version}"
+        base = f"{PROV_BASE}/example/versions/{version}"
         assert (
             await client.put(f"{base}/shasums", content=manifest, headers=AUTH)
         ).status_code == 200
@@ -134,7 +134,7 @@ class TestProviderPublishDownload:
         await _register(client, app)
         version = "3.0.0"
         manifest, _, _ = _artifacts(version, b"zip")
-        base = f"{PROV_BASE}/awsmai/versions/{version}"
+        base = f"{PROV_BASE}/example/versions/{version}"
         assert (
             await client.put(f"{base}/shasums", content=manifest, headers=AUTH)
         ).status_code == 200
@@ -149,7 +149,7 @@ class TestProviderPublishDownload:
         # Manifest commits to one sha; we upload different bytes.
         manifest, _, _ = _artifacts(version, b"the-signed-bytes")
         sig = bytes(_KEY.sign(manifest))
-        base = f"{PROV_BASE}/awsmai/versions/{version}"
+        base = f"{PROV_BASE}/example/versions/{version}"
         assert (
             await client.put(f"{base}/shasums", content=manifest, headers=AUTH)
         ).status_code == 200

--- a/services/tests/services/test_label_validation.py
+++ b/services/tests/services/test_label_validation.py
@@ -111,7 +111,7 @@ class TestReservedKeys:
         labels = {
             "env": "prod",
             "team": "platform",
-            "repo": "tf-aws-core",
+            "repo": "infra-core",
             "scope": "core",
             "region": "eu-west-1",
             "managed-by": "terrapod-provider",

--- a/services/tests/services/test_registry_provider_service.py
+++ b/services/tests/services/test_registry_provider_service.py
@@ -35,7 +35,7 @@ from terrapod.services.registry_provider_service import (
 
 # One RSA keypair for the whole module — keygen is the slow part (~1-3s).
 _KEY = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
-_UID = pgpy.PGPUID.new("awsmai test", email="security@example.test")
+_UID = pgpy.PGPUID.new("example test", email="security@example.test")
 _KEY.add_uid(
     _UID,
     usage={KeyFlags.Sign},
@@ -87,14 +87,14 @@ class TestStoreAndVerifyProviderSig:
         mock_get_version.return_value = version
         mock_get_key.return_value = _registered_key()
 
-        manifest = _manifest("terraform-provider-awsmai_1.0.0_linux_arm64.zip", "a" * 64)
+        manifest = _manifest("terraform-provider-example_1.0.0_linux_arm64.zip", "a" * 64)
         sig = _detached_sig(manifest)
 
         storage = AsyncMock()
         storage.get.return_value = manifest
 
         result = await store_and_verify_provider_sig(
-            AsyncMock(), storage, "default", "awsmai", "1.0.0", sig
+            AsyncMock(), storage, "default", "example", "1.0.0", sig
         )
 
         assert result.shasums_sig_uploaded is True
@@ -125,7 +125,7 @@ class TestStoreAndVerifyProviderSig:
 
         with pytest.raises(PublishValidationError):
             await store_and_verify_provider_sig(
-                AsyncMock(), storage, "default", "awsmai", "1.0.0", sig
+                AsyncMock(), storage, "default", "example", "1.0.0", sig
             )
 
     @pytest.mark.asyncio
@@ -151,7 +151,7 @@ class TestStoreAndVerifyProviderSig:
 
         with pytest.raises(PublishValidationError):
             await store_and_verify_provider_sig(
-                AsyncMock(), storage, "default", "awsmai", "1.0.0", _detached_sig(manifest)
+                AsyncMock(), storage, "default", "example", "1.0.0", _detached_sig(manifest)
             )
 
     @pytest.mark.asyncio
@@ -170,7 +170,7 @@ class TestStoreAndVerifyProviderSig:
 
         with pytest.raises(PublishValidationError):
             await store_and_verify_provider_sig(
-                AsyncMock(), storage, "default", "awsmai", "1.0.0", b"sig"
+                AsyncMock(), storage, "default", "example", "1.0.0", b"sig"
             )
 
 
@@ -201,7 +201,7 @@ class TestRecordProviderBinary:
 
         body = b"zip-bytes"
         sha = hashlib.sha256(body).hexdigest()
-        filename = "terraform-provider-awsmai_1.0.0_linux_arm64.zip"
+        filename = "terraform-provider-example_1.0.0_linux_arm64.zip"
         storage = AsyncMock()
         storage.get.return_value = _manifest(filename, sha)
 
@@ -213,7 +213,7 @@ class TestRecordProviderBinary:
                 AsyncMock(),
                 storage,
                 "default",
-                "awsmai",
+                "example",
                 "1.0.0",
                 "linux",
                 "arm64",
@@ -239,7 +239,7 @@ class TestRecordProviderBinary:
     ) -> None:
         mock_get_provider.return_value = MagicMock(id="prov")
         mock_get_version.return_value = MagicMock(shasums_sig_uploaded=True)
-        filename = "terraform-provider-awsmai_1.0.0_linux_arm64.zip"
+        filename = "terraform-provider-example_1.0.0_linux_arm64.zip"
         storage = AsyncMock()
         storage.get.return_value = _manifest(filename, "b" * 64)  # signed sha differs
 
@@ -248,7 +248,7 @@ class TestRecordProviderBinary:
                 AsyncMock(),
                 storage,
                 "default",
-                "awsmai",
+                "example",
                 "1.0.0",
                 "linux",
                 "arch",
@@ -274,7 +274,7 @@ class TestRecordProviderBinary:
                 AsyncMock(),
                 AsyncMock(),
                 "default",
-                "awsmai",
+                "example",
                 "1.0.0",
                 "linux",
                 "arm64",
@@ -300,7 +300,7 @@ class TestStoreProviderShasums:
         storage = AsyncMock()
 
         result = await store_provider_shasums(
-            AsyncMock(), storage, "default", "awsmai", "1.0.0", b"sha  file.zip\n"
+            AsyncMock(), storage, "default", "example", "1.0.0", b"sha  file.zip\n"
         )
 
         assert result.shasums_uploaded is True

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -636,7 +636,7 @@ class TestPollCycleParallel:
         parsed (owner, repo) exactly matches the webhook's repo.
 
         Workspaces for a different repo — even one whose URL is a suffix
-        of the target (wrapper/markupai/scalable-language-servers), or a
+        of the target (wrapper/example-org/example-repo), or a
         different host — must NOT be polled.
         """
         import uuid
@@ -653,12 +653,12 @@ class TestPollCycleParallel:
         suffix_collision = uuid.uuid4()
 
         rows = [
-            (matched_https, "https://github.com/markupai/scalable-language-servers", "github"),
-            (matched_ssh, "git@github.com:markupai/scalable-language-servers.git", "github"),
-            (other_repo, "https://github.com/markupai/other-repo", "github"),
+            (matched_https, "https://github.com/example-org/example-repo", "github"),
+            (matched_ssh, "git@github.com:example-org/example-repo.git", "github"),
+            (other_repo, "https://github.com/example-org/other-repo", "github"),
             (
                 suffix_collision,
-                "https://github.com/wrapper/markupai/scalable-language-servers",
+                "https://github.com/wrapper/example-org/example-repo",
                 "github",
             ),
         ]
@@ -689,7 +689,7 @@ class TestPollCycleParallel:
                 return_value={},
             ),
         ):
-            await handle_immediate_poll({"repo": "markupai/scalable-language-servers"})
+            await handle_immediate_poll({"repo": "example-org/example-repo"})
 
         # Only the two exact-match workspaces were polled.
         assert sorted(polled) == sorted([matched_https, matched_ssh])

--- a/services/tests/services/test_vcs_status_dispatcher.py
+++ b/services/tests/services/test_vcs_status_dispatcher.py
@@ -208,7 +208,7 @@ class TestSupersededRunComment:
         ws.id = ws_id
         ws.name = "terrapod-config"
         ws.vcs_connection_id = conn_id
-        ws.vcs_repo_url = "https://github.com/markupai/terrapod-config"
+        ws.vcs_repo_url = "https://github.com/example-org/terrapod-config"
 
         conn = MagicMock()
         conn.provider = "github"
@@ -243,7 +243,7 @@ class TestSupersededRunComment:
             ),
             patch(
                 "terrapod.services.vcs_status_dispatcher.github_service.parse_repo_url",
-                return_value=("markupai", "terrapod-config"),
+                return_value=("example-org", "terrapod-config"),
             ),
             patch(
                 "terrapod.services.vcs_status_dispatcher.github_service.create_commit_status",
@@ -296,7 +296,7 @@ class TestSupersededRunComment:
         ws.id = ws_id
         ws.name = "terrapod-config"
         ws.vcs_connection_id = conn_id
-        ws.vcs_repo_url = "https://github.com/markupai/terrapod-config"
+        ws.vcs_repo_url = "https://github.com/example-org/terrapod-config"
 
         conn = MagicMock()
         conn.provider = "github"
@@ -343,7 +343,7 @@ class TestSupersededRunComment:
             ),
             patch(
                 "terrapod.services.vcs_status_dispatcher.github_service.parse_repo_url",
-                return_value=("markupai", "terrapod-config"),
+                return_value=("example-org", "terrapod-config"),
             ),
             patch(
                 "terrapod.services.vcs_status_dispatcher.github_service.create_commit_status",
@@ -432,7 +432,7 @@ class TestFindOrCreateCommentRaceFix:
         conn = MagicMock(spec=VCSConnection)
         conn.provider = "github"
         ws_id = "11111111-1111-1111-1111-111111111111"
-        owner, repo, pr_number = "markupai", "terrapod-config", 31
+        owner, repo, pr_number = "example-org", "terrapod-config", 31
 
         fake_redis = _FakeRedis()
 

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -154,7 +154,7 @@ function WorkspacesPageInner() {
   // Sync the input to the URL whenever the parsed filter changes — debounced.
   //
   // Each `router.replace` triggers a Next.js RSC prefetch for the new URL.
-  // Firing per-keystroke (e.g. typing "repo:tf-data-pipelines") cascades
+  // Firing per-keystroke (e.g. typing "repo:data-pipelines") cascades
   // ~20 prefetches in a few hundred ms, overwhelms Next's dev server with
   // 503s, and can leave the address bar stuck on an early keystroke when
   // a later prefetch wins the race. We debounce to a single replace once


### PR DESCRIPTION
Removes references to internal infrastructure from test fixtures and a smoke example so the OSS repo stays clean. Test/example-only, no behaviour change; gates v0.37.0.

- The new publish tests used a placeholder provider name → `example`.
- Pre-existing internal identifiers (org/repo/cluster/pool/email) in `test_vcs_poller`, `test_vcs_status_dispatcher`, `test_workspaces`, `test_label_validation`, `test_agent_pools_validators`, `workspaces_test.go`, `scripts/smoke/provider/main.tf`, and a `workspaces/page.tsx` comment → generic placeholders (`example-org`, `example-repo`, `example-github`, `dev-pool-1`, `infra-core`, `data-pipelines`, `admin@example.com`).