### PR TITLE
perf(ci): cache Next.js build + npm store in the web image build

### DIFF
--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Terrapod Web UI Dockerfile
 # Builds the Next.js application
 #
@@ -13,8 +14,10 @@ WORKDIR /app
 # Copy package files
 COPY web/package.json web/package-lock.json* ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies. The BuildKit cache mount persists npm's download cache
+# across CI runs so `npm ci` is fast even when the layer must re-run (e.g. a
+# changed lockfile); it's build-time only and not part of any image layer.
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # Copy source code
 COPY web/ .
@@ -23,9 +26,12 @@ COPY web/ .
 # which writes .next/, next-env.d.ts, etc.)
 RUN chown -R 1001:1001 /app
 
-# Build the application
+# Build the application. The BuildKit cache mount persists Next.js's
+# incremental build cache (.next/cache) across builds — the layer that always
+# re-runs when source changes — turning a full recompile into an incremental
+# one. Build-time only; not copied into the runtime image.
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm run build
+RUN --mount=type=cache,target=/app/.next/cache npm run build
 
 # Production image — standalone mode (minimal, no full node_modules)
 FROM node:26-alpine


### PR DESCRIPTION
Speeds up the `terrapod-web` image build (the long pole in CI, ~3m on arm64) by warming the layers that currently always run cold.

## What
Two BuildKit cache mounts in `docker/Dockerfile.web`:
- `--mount=type=cache,target=/app/.next/cache` on `npm run build` — persists Next.js's incremental compiler cache. This is the layer that re-runs on **every** source change, so the existing `cache-to: type=gha,mode=max` couldn't help it; now a full recompile becomes incremental.
- `--mount=type=cache,target=/root/.npm` on `npm ci` — persists npm's download cache when the lockfile changes.

Adds `# syntax=docker/dockerfile:1` for the cache-mount syntax. Both mounts are build-time only — neither is copied into the runtime image.

## Safety
Requires BuildKit, which is the default builder on Docker 23+. **Verified locally**: a full `docker build` of the web image on Docker 29 (rancher-desktop) succeeds — the syntax directive, both mounts, and the runtime-stage COPYs of `.next/standalone`/`.next/static` all build cleanly. No impact on Tilt/local dev (Tilt builds through the same BuildKit daemon).

Unrelated to v0.37.0 — pure CI/build-time improvement.