### PR TITLE
chore(ci): make code-scanning suppressions actually stick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,6 +455,7 @@ jobs:
               --exclude "reports" \
               --exclude-rule "python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5" \
               --exclude-rule "python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure" \
+              --exclude-rule "python.flask.security.audit.directly-returned-format-string.directly-returned-format-string" \
               --sarif \
               --output "/src/semgrep-results.sarif"
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -1694,7 +1694,6 @@ def _request_base_url(request: Request | None) -> str:
         proto = request.headers.get("x-forwarded-proto") or request.url.scheme
         candidate = xfh.split(",", 1)[0].strip()
         if _is_safe_host(candidate) and _is_safe_scheme(proto):
-            # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
             return f"{proto}://{candidate}"  # both parts validated above
         return fallback
     host = request.headers.get("host")
@@ -1704,7 +1703,6 @@ def _request_base_url(request: Request | None) -> str:
         # so the scheme reflects what FastAPI saw on the wire.
         scheme = request.url.scheme
         if _is_safe_scheme(scheme):
-            # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
             return f"{scheme}://{host}"  # both parts validated above
     return fallback
 

--- a/services/terrapod/runner/phases/setup_script.py
+++ b/services/terrapod/runner/phases/setup_script.py
@@ -42,9 +42,11 @@ def run(script: str, *, env: dict[str, str] | None = None) -> None:
     # prep) before plan/apply. Source is the workspace's TP_SETUP_SCRIPT
     # field, only writable by users with workspace `admin`; the runner's
     # auth boundary, not subprocess flags, is what gates this.
-    result = subprocess.run(  # noqa: S602  # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+    result = subprocess.run(  # noqa: S602
         script,
-        shell=True,
+        # Semgrep matches this rule on the shell=True argument, so the
+        # suppression must sit on this line (not the subprocess.run() line).
+        shell=True,  # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
         check=False,
         env=env,
     )

--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -100,8 +100,6 @@ async def _apply_drift_ignore_rules(run: Run, rules: list[str]) -> str:
     `"drifted"` so a runtime hiccup never *silences* drift the
     operator intended to surface.
     """
-    import json
-
     from terrapod.services.drift_ignore_classifier import classify_drift
     from terrapod.storage import get_storage
     from terrapod.storage.keys import plan_json_output_key


### PR DESCRIPTION
Four open code-scanning alerts (https://github.com/mattrobinsonsre/terrapod/security/code-scanning) kept reopening despite being suppressed twice (#469), because the suppressions were not taking effect in CI. Root-caused and fixed each.

## Findings

| # | Sev | Rule | File | Fix |
|---|---|---|---|---|
| 184 | error | `subprocess-shell-true` | `setup_script.py:47` | `# nosemgrep` was on the `subprocess.run(` line, but Semgrep matches the rule on the `shell=True` arg — moved it onto that line (reproduced: now 0 findings). Intentional admin-gated setup-script shell, isolated Job; rule stays active elsewhere. |
| 186/187 | warning | `directly-returned-format-string` | `tfe_v2.py:1698,1708` | False positives on validated host/scheme f-strings. Inline `nosemgrep` is brittle because the `p/*` rules are fetched live each run and the match range drifts. Switched to `--exclude-rule` in `ci.yml` (the repo's existing mechanism) + dropped the dead comments. Flask rule; this is FastAPI returning validated strings. |
| 188 | note | `py/repeated-import` | `drift_detection_service.py:103` | Real, trivial — `import json` duplicated the module-level import. Removed the redundant local one. |

## Verification
- Re-ran the exact CI Semgrep image (`semgrep/semgrep:1.117`, `p/python` + `p/owasp-top-ten`) on both edited files with the new `--exclude-rule`: **0 findings** (was 1 blocking).
- `json` still resolves via the module-level import (used at L128/L492).
- ruff check + format clean (pre-commit).
- No runtime behaviour changes.

## Follow-up (not in this PR)
The Semgrep step scans the `/src` docker mount, so its SARIF paths are `/src/...` absolute (vs CodeQL's repo-relative). Worth switching to repo-relative paths (and/or pinning the registry rules) so suppressed/fixed findings correlate and auto-close cleanly instead of drifting. Tracked separately.