### PR TITLE
feat(tokens): service-token model + idle-login + rotation + expiry warnings (Phase 1, #495)

### DIFF
--- a/alembic/versions/3fbcb2885b93_service_token_kind_columns.py
+++ b/alembic/versions/3fbcb2885b93_service_token_kind_columns.py
@@ -1,0 +1,63 @@
+"""Service-token model: kind, bound_to, created_by, rotated_at, pinned_roles (#495).
+
+Phase 1 of scoped service tokens + expiry warnings. Adds the structured
+token-kind distinction and splits the single `user_email` column into a
+binding (`bound_to`, NULL <=> detached) and an audit field (`created_by`).
+
+Ordered to be safe on a populated table:
+  1. add `created_by` nullable, backfill `COALESCE(user_email, '')` (handles
+     any legacy NULL-owner rows), then SET NOT NULL;
+  2. rename `user_email` -> `bound_to` (values preserved, so every existing
+     token stays *bound*, never silently detached) and re-create its index
+     under the new name to avoid permanent model<->DB drift;
+  3. add `kind` (existing rows default to 'interactive'), `rotated_at`,
+     `pinned_roles`.
+`token_type` is RETAINED (legacy, superseded by `kind`) for response
+back-compat; dropped in a later release.
+
+Revision ID: 3fbcb2885b93
+Revises: 56599efa894a
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "3fbcb2885b93"
+down_revision = "56599efa894a"
+
+
+def upgrade() -> None:
+    # 1. created_by — minter/audit record, distinct from the binding.
+    op.add_column("api_tokens", sa.Column("created_by", sa.String(255), nullable=True))
+    op.execute("UPDATE api_tokens SET created_by = COALESCE(user_email, '')")
+    op.alter_column("api_tokens", "created_by", nullable=False, server_default="")
+
+    # 2. user_email -> bound_to (NULL <=> detached). Drop the old-named index
+    #    while the column still exists, rename, then create the new index.
+    op.drop_index("ix_api_tokens_user_email", table_name="api_tokens")
+    op.alter_column("api_tokens", "user_email", new_column_name="bound_to")
+    op.create_index("ix_api_tokens_bound_to", "api_tokens", ["bound_to"])
+
+    # 3. New columns.
+    op.add_column(
+        "api_tokens",
+        sa.Column("kind", sa.String(20), nullable=False, server_default="interactive"),
+    )
+    op.add_column(
+        "api_tokens",
+        sa.Column("rotated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("api_tokens", sa.Column("pinned_roles", JSONB, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api_tokens", "pinned_roles")
+    op.drop_column("api_tokens", "rotated_at")
+    op.drop_column("api_tokens", "kind")
+
+    op.drop_index("ix_api_tokens_bound_to", table_name="api_tokens")
+    op.alter_column("api_tokens", "bound_to", new_column_name="user_email")
+    op.create_index("ix_api_tokens_user_email", "api_tokens", ["user_email"])
+
+    op.drop_column("api_tokens", "created_by")

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -90,6 +90,11 @@ data:
       {{- end }}
       session_ttl_hours: {{ .Values.api.config.auth.session_ttl_hours | default 12 }}
       api_token_max_ttl_hours: {{ .Values.api.config.auth.api_token_max_ttl_hours | default 8760 }}
+      {{- /* Rendered directly (no `| default`): 0 is meaningful for these and
+             Helm's `default` would silently rewrite a configured 0 to the default. */}}
+      service_token_max_ttl_hours: {{ .Values.api.config.auth.service_token_max_ttl_hours }}
+      token_expiry_warning_days: {{ .Values.api.config.auth.token_expiry_warning_days }}
+      bound_token_idle_days: {{ .Values.api.config.auth.bound_token_idle_days }}
       {{- if .Values.api.config.auth.require_external_sso_for_roles }}
       require_external_sso_for_roles:
         {{- range .Values.api.config.auth.require_external_sso_for_roles }}

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -75,6 +75,10 @@ api:
       local_enabled: true
       callback_base_url: "https://terrapod.local"
       session_ttl_hours: 12
+      # Disable bound-token idle-login rejection in local dev (#495): otherwise
+      # a curl/CLI token stops working 7 days after the last interactive login,
+      # which is noise for local testing. Production keeps the default (7).
+      bound_token_idle_days: 0
 
     # AI plan-summary (#401) — Bedrock Converse via LiteLLM. The
     # terrapod-testing IAM user's static keys (delivered via the

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -507,6 +507,9 @@
             "callback_base_url": { "type": "string" },
             "session_ttl_hours": { "type": "integer", "minimum": 1 },
             "api_token_max_ttl_hours": { "type": "integer", "minimum": 0 },
+            "service_token_max_ttl_hours": { "type": "integer", "minimum": 0 },
+            "token_expiry_warning_days": { "type": "integer", "minimum": 0 },
+            "bound_token_idle_days": { "type": "integer", "minimum": 0 },
             "require_external_sso_for_roles": {
               "type": "array",
               "items": { "type": "string" }

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -162,6 +162,11 @@ api:
 
       session_ttl_hours: 12
       api_token_max_ttl_hours: 8760  # 1 year; 0 = no limit
+      # Service tokens (#495): separate (always-expiring) cap; warning lead time;
+      # and the bound-token idle-login window (ON by default; 0 disables).
+      service_token_max_ttl_hours: 8760
+      token_expiry_warning_days: 14
+      bound_token_idle_days: 7
       require_external_sso_for_roles: []
 
       # ── SSO / Identity Providers ──────────────────────────────────────

--- a/services/terrapod/api/dependencies.py
+++ b/services/terrapod/api/dependencies.py
@@ -134,7 +134,7 @@ async def get_current_user(
         api_token = await validate_api_token(db, token)
         if api_token is not None:
             # Resolve roles from DB (cached in Redis for 60s)
-            email = api_token.user_email or ""
+            email = api_token.bound_to or ""
             roles = await _resolve_user_roles(db, email) if email else []
 
             request.state.user_email = email  # for audit middleware
@@ -219,7 +219,7 @@ async def authenticate_request(request: Request) -> AuthenticatedUser:
     async with get_db_session() as db:
         api_token = await validate_api_token(db, token)
         if api_token is not None:
-            email = api_token.user_email or ""
+            email = api_token.bound_to or ""
             roles = await _resolve_user_roles(db, email) if email else []
             request.state.user_email = email
             return AuthenticatedUser(

--- a/services/terrapod/api/routers/oauth.py
+++ b/services/terrapod/api/routers/oauth.py
@@ -149,12 +149,14 @@ async def oauth_token(
             detail="PKCE verification failed",
         )
 
-    # Create a long-lived API token (no expiry by default)
+    # Create a long-lived interactive API token (terraform login). Bound to
+    # the authenticating identity; created_by is the same identity.
     api_token, raw_token = await create_api_token(
         db=db,
-        user_email=auth_code.email,
+        bound_to=auth_code.email,
+        created_by=auth_code.email,
+        kind="interactive",
         description=f"terraform login ({auth_code.provider_name})",
-        token_type="user",
     )
     await db.commit()
 

--- a/services/terrapod/api/routers/tokens.py
+++ b/services/terrapod/api/routers/tokens.py
@@ -1,24 +1,29 @@
-"""TFE V2 API token CRUD endpoints.
+"""Terrapod-native API token CRUD + service-token management (#495).
 
-Implements the authentication-tokens endpoints in JSON:API format
-compatible with the TFE V2 API.
+JSON:API-shaped token management. Terrapod-native surface — mounted ONLY
+under /api/terrapod/v1/ (the CLI mints tokens via the /oauth flow, never
+here). Do NOT move any of this to /api/v2/ or tfe_v2.py.
 
-UX CONTRACT: Token endpoints are consumed by the web frontend:
-  - web/src/app/settings/tokens/page.tsx (token CRUD)
-  Changes to response shapes, attribute names, or status codes here MUST be
-  matched by corresponding updates to that frontend page.
+UX CONTRACT: consumed by the web frontend
+  - web/src/app/settings/tokens/page.tsx
+Changes to response shapes, attribute names, or status codes here MUST be
+matched by corresponding updates to that page.
 
 Endpoints:
-    POST   /api/terrapod/v1/users/:user_id/authentication-tokens — create user token
-    GET    /api/terrapod/v1/users/:user_id/authentication-tokens — list user tokens
-    GET    /api/terrapod/v1/admin/authentication-tokens — list all tokens (admin only)
-    GET    /api/terrapod/v1/authentication-tokens/:id — show token (value is null)
-    DELETE /api/terrapod/v1/authentication-tokens/:id — revoke token
+    POST   /users/:user_id/authentication-tokens                  — create token
+    GET    /users/:user_id/authentication-tokens                  — list user tokens
+    GET    /admin/authentication-tokens                           — list all (admin) [?kind=]
+    POST   /admin/authentication-tokens/actions/revoke-all        — revoke all for a user (admin)
+    GET    /authentication-tokens/expiring                        — caller-scoped expiring service tokens
+    GET    /authentication-tokens/:id                             — show token (value null)
+    PATCH  /authentication-tokens/:id                             — re-tag kind (interactive<->service_bound)
+    POST   /authentication-tokens/:id/actions/rotate              — rotate secret + reset expiry
+    DELETE /authentication-tokens/:id                             — revoke token
 """
 
-from datetime import timedelta
+from datetime import UTC
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,15 +33,33 @@ from terrapod.auth.api_tokens import (
     create_api_token,
     get_token_by_id,
     list_all_tokens,
+    list_expiring_service_tokens,
     list_user_tokens,
+    revoke_all_for_user,
     revoke_token,
+    rotate_token,
+    token_expires_at,
 )
 from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
+from terrapod.redis.client import get_redis_client
 
 router = APIRouter(tags=["tokens"])
 logger = get_logger(__name__)
+
+# Kinds a user may create / re-tag in Phase 1. service_detached (admin-only,
+# absolute scope) is gated until the scoped-resolution phase lands.
+_CREATABLE_KINDS = {"interactive", "service_bound"}
+_ALL_KINDS = {"interactive", "service_bound", "service_detached"}
+_TOKEN_ROLES_PREFIX = "tp:token_roles:"
+
+
+def _rfc3339(dt) -> str | None:  # type: ignore[no-untyped-def]
+    """RFC3339 with a trailing Z (not +00:00) — go-tfe/contract compatible."""
+    if dt is None:
+        return None
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 class CreateTokenRequest(BaseModel):
@@ -46,6 +69,8 @@ class CreateTokenRequest(BaseModel):
         class Attributes(BaseModel):
             description: str = ""
             lifespan_hours: int | None = None
+            kind: str = "interactive"
+            pinned_roles: list[str] | None = None
 
         type: str = "authentication-tokens"
         attributes: Attributes = Attributes()
@@ -53,24 +78,38 @@ class CreateTokenRequest(BaseModel):
     data: Data = Data()
 
 
+class PatchTokenRequest(BaseModel):
+    """JSON:API request for re-tagging a token's kind."""
+
+    class Data(BaseModel):
+        class Attributes(BaseModel):
+            kind: str
+
+        type: str = "authentication-tokens"
+        attributes: Attributes
+
+    data: Data
+
+
+class RevokeAllRequest(BaseModel):
+    email: str
+
+
 def _token_to_jsonapi(token, raw_value: str | None = None) -> dict:  # type: ignore[no-untyped-def]
     """Convert an APIToken model to JSON:API format."""
-    # Compute expiry from per-token lifespan or global max
-    effective_ttl = token.lifespan_hours or settings.auth.api_token_max_ttl_hours
-    if effective_ttl > 0 and token.created_at:
-        expires_at = (token.created_at + timedelta(hours=effective_ttl)).isoformat()
-    else:
-        expires_at = None
-
     attributes: dict = {
         "description": token.description,
+        "kind": token.kind,
+        "bound-to": token.bound_to,
+        "created-by": token.created_by,
+        # token-type retained for response back-compat (superseded by kind).
         "token-type": token.token_type,
-        "created-by": token.user_email,
-        "created-at": token.created_at.isoformat() if token.created_at else None,
-        "last-used-at": token.last_used_at.isoformat() if token.last_used_at else None,
-        "expires-at": expires_at,
+        "created-at": _rfc3339(token.created_at),
+        "rotated-at": _rfc3339(token.rotated_at),
+        "last-used-at": _rfc3339(token.last_used_at),
+        "expires-at": _rfc3339(token_expires_at(token)),
         "lifespan-hours": token.lifespan_hours,
-        # The raw token value is only included at creation time
+        # The raw token value is only included at creation/rotation time.
         "token": raw_value,
     }
     return {
@@ -78,6 +117,14 @@ def _token_to_jsonapi(token, raw_value: str | None = None) -> dict:  # type: ign
         "type": "authentication-tokens",
         "attributes": attributes,
     }
+
+
+def _is_admin(user: AuthenticatedUser) -> bool:
+    return "admin" in user.roles
+
+
+def _username(user: AuthenticatedUser) -> str:
+    return user.email.split("@")[0] if user.email else ""
 
 
 @router.post("/users/{user_id}/authentication-tokens")
@@ -90,21 +137,38 @@ async def create_user_token(
     """Create an authentication token for a user.
 
     The user_id in the path must match the authenticated user (or admin).
+    Anyone may create `interactive` or `service_bound` tokens (bound to
+    themselves). `service_detached` is admin-only and not yet creatable
+    (gated until the scoped-resolution phase).
     """
-    # user_id is the username (email prefix) — match against current user
-    username = user.email.split("@")[0] if user.email else ""
-    if user_id != username and "admin" not in user.roles:
+    if user_id != _username(user) and not _is_admin(user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot create tokens for other users",
         )
 
+    kind = body.data.attributes.kind
+    if kind == "service_detached":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Detached service tokens are not yet available",
+        )
+    if kind not in _CREATABLE_KINDS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid token kind: {kind}",
+        )
+
+    pinned = body.data.attributes.pinned_roles if kind == "service_bound" else None
+
     api_token, raw_token = await create_api_token(
         db=db,
-        user_email=user.email,
+        bound_to=user.email,
+        created_by=user.email,
+        kind=kind,
         description=body.data.attributes.description,
-        token_type="user",
         lifespan_hours=body.data.attributes.lifespan_hours,
+        pinned_roles=pinned,
     )
 
     return JSONResponse(
@@ -119,36 +183,81 @@ async def list_user_tokens_endpoint(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List authentication tokens for a user."""
-    username = user.email.split("@")[0] if user.email else ""
-    if user_id != username and "admin" not in user.roles:
+    """List a user's own tokens (never includes detached tokens)."""
+    if user_id != _username(user) and not _is_admin(user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot list tokens for other users",
         )
 
     tokens = await list_user_tokens(db, user.email)
-    return JSONResponse(
-        content={"data": [_token_to_jsonapi(t) for t in tokens]},
-    )
+    return JSONResponse(content={"data": [_token_to_jsonapi(t) for t in tokens]})
 
 
 @router.get("/admin/authentication-tokens")
 async def list_all_tokens_endpoint(
+    kind: str | None = Query(default=None),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """List all authentication tokens across all users (admin only)."""
-    if "admin" not in user.roles:
+    """List all authentication tokens across all users (admin only).
+
+    Optional ``?kind=`` filter. A valid-but-unpopulated kind (e.g.
+    service_detached before it exists) returns an empty set, not an error.
+    """
+    if not _is_admin(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    if kind is not None and kind not in _ALL_KINDS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid token kind: {kind}",
+        )
+
+    tokens = await list_all_tokens(db, kind=kind)
+    return JSONResponse(content={"data": [_token_to_jsonapi(t) for t in tokens]})
+
+
+@router.post("/admin/authentication-tokens/actions/revoke-all")
+async def revoke_all_tokens_for_user(
+    body: RevokeAllRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Revoke every token bound to an identity — urgent offboarding (admin only)."""
+    if not _is_admin(user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
         )
 
-    tokens = await list_all_tokens(db)
-    return JSONResponse(
-        content={"data": [_token_to_jsonapi(t) for t in tokens]},
+    count = await revoke_all_for_user(db, body.email)
+    await db.commit()
+    # Bust the cached role resolution for the now-token-less identity.
+    await get_redis_client().delete(f"{_TOKEN_ROLES_PREFIX}{body.email}")
+
+    return JSONResponse(content={"data": {"email": body.email, "revoked": count}})
+
+
+@router.get("/authentication-tokens/expiring")
+async def list_expiring_tokens(
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Service tokens nearing expiry, scoped to the caller (#495).
+
+    Own ``service_bound`` for everyone; plus all ``service_detached`` for
+    admins. Drives the in-app nav-bar/login warnings.
+    """
+    tokens = await list_expiring_service_tokens(
+        db,
+        caller_email=user.email,
+        is_admin=_is_admin(user),
+        within_days=settings.auth.token_expiry_warning_days,
     )
+    return JSONResponse(content={"data": [_token_to_jsonapi(t) for t in tokens]})
 
 
 @router.get("/authentication-tokens/{token_id}")
@@ -160,21 +269,71 @@ async def show_token(
     """Show an authentication token (value is null — only available at creation)."""
     api_token = await get_token_by_id(db, token_id)
     if api_token is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
+
+    if api_token.bound_to != user.email and not _is_admin(user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    return JSONResponse(content={"data": _token_to_jsonapi(api_token)})
+
+
+@router.patch("/authentication-tokens/{token_id}")
+async def retag_token(
+    token_id: str,
+    body: PatchTokenRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Re-tag a token's kind between interactive and service_bound.
+
+    Owner or admin. Converting to/from service_detached is admin-only and
+    not yet supported (scoped-resolution phase).
+    """
+    api_token = await get_token_by_id(db, token_id)
+    if api_token is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
+
+    if api_token.bound_to != user.email and not _is_admin(user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    new_kind = body.data.attributes.kind
+    if new_kind == "service_detached" or api_token.kind == "service_detached":
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Token not found",
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Converting to/from detached is not yet available",
+        )
+    if new_kind not in _CREATABLE_KINDS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid token kind: {new_kind}",
         )
 
-    # Only the token owner or admin can view
-    if api_token.user_email != user.email and "admin" not in user.roles:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Access denied",
-        )
+    api_token.kind = new_kind
+    await db.commit()
+    await db.refresh(api_token)
+    return JSONResponse(content={"data": _token_to_jsonapi(api_token)})
 
-    return JSONResponse(
-        content={"data": _token_to_jsonapi(api_token)},
-    )
+
+@router.post("/authentication-tokens/{token_id}/actions/rotate")
+async def rotate_token_endpoint(
+    token_id: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Rotate a token's secret + reset its expiry clock (owner or admin)."""
+    api_token = await get_token_by_id(db, token_id)
+    if api_token is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
+
+    if api_token.bound_to != user.email and not _is_admin(user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    rotated = await rotate_token(db, token_id)
+    assert rotated is not None  # just fetched it above
+    token, raw_token = rotated
+    await db.commit()
+
+    return JSONResponse(content={"data": _token_to_jsonapi(token, raw_value=raw_token)})
 
 
 @router.delete("/authentication-tokens/{token_id}")
@@ -183,24 +342,14 @@ async def delete_token(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Revoke (delete) an authentication token."""
+    """Revoke (delete) an authentication token (owner or admin)."""
     api_token = await get_token_by_id(db, token_id)
     if api_token is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Token not found",
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
 
-    # Only the token owner or admin can revoke
-    if api_token.user_email != user.email and "admin" not in user.roles:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Access denied",
-        )
+    if api_token.bound_to != user.email and not _is_admin(user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
     await revoke_token(db, token_id)
 
-    return JSONResponse(
-        status_code=status.HTTP_204_NO_CONTENT,
-        content=None,
-    )
+    return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)

--- a/services/terrapod/auth/api_tokens.py
+++ b/services/terrapod/auth/api_tokens.py
@@ -5,17 +5,24 @@ The raw token value is only available at creation time. Lookup is by hash
 (indexed column) on every request.
 
 Token format: {random_id}.tpod.{random_secret}
+
+Three kinds (#495): interactive (terraform login / UI), service_bound
+(user-bound automation; effective perms = min(pinned, owner live)),
+service_detached (admin-managed M2M; absolute pinned perms). Expiry is
+kind-aware (separate caps) and basis-aware (rotated_at or created_at);
+user-bound tokens are subject to idle-login rejection.
 """
 
 import hashlib
 import secrets
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from terrapod.auth.recent_users import user_seen_within_window
 from terrapod.config import settings
-from terrapod.db.models import APIToken, now_utc
+from terrapod.db.models import APIToken, User, now_utc
 from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -23,6 +30,13 @@ logger = get_logger(__name__)
 # Minimum interval between last_used_at updates (seconds).
 # Avoids a DB write on every single API request.
 LAST_USED_UPDATE_INTERVAL = 60
+
+# Service tokens ALWAYS expire — if the service cap is misconfigured to 0
+# ("no limit"), fall back to this so a service token is never unbounded (#495).
+_SERVICE_TTL_FALLBACK_HOURS = 8760
+
+_USER_BOUND_KINDS = ("interactive", "service_bound")
+_SERVICE_KINDS = ("service_bound", "service_detached")
 
 
 def _generate_token_id() -> str:
@@ -42,34 +56,69 @@ def hash_token(raw_token: str) -> str:
     return hashlib.sha256(raw_token.encode()).hexdigest()
 
 
+def _max_ttl_hours_for_kind(kind: str) -> int:
+    """Max-lifetime cap (hours) for a token kind.
+
+    Service kinds use a separate (longer) cap and ALWAYS expire — a `0`
+    ("no limit") is never honoured for them. Interactive keeps the historic
+    `0 = no limit` behaviour.
+    """
+    if kind in _SERVICE_KINDS:
+        cap = settings.auth.service_token_max_ttl_hours
+        return cap if cap > 0 else _SERVICE_TTL_FALLBACK_HOURS
+    return settings.auth.api_token_max_ttl_hours
+
+
+def token_expires_at(token: APIToken) -> datetime | None:
+    """When the token expires, or None if it never does.
+
+    Expiry basis is ``rotated_at or created_at`` so rotation resets the
+    clock. The per-token ``lifespan_hours`` takes precedence over the
+    kind's global cap. None is only returned for interactive tokens when
+    the global cap is 0 and no per-token lifespan is set.
+    """
+    cap = _max_ttl_hours_for_kind(token.kind)
+    ttl = token.lifespan_hours if token.lifespan_hours is not None else cap
+    if token.kind in _SERVICE_KINDS and ttl <= 0:
+        # service tokens never go unbounded
+        ttl = cap
+    if ttl <= 0:
+        return None
+    basis = token.rotated_at or token.created_at
+    return basis + timedelta(hours=ttl)
+
+
 async def create_api_token(
     db: AsyncSession,
-    user_email: str,
+    *,
+    bound_to: str | None,
+    created_by: str,
+    kind: str = "interactive",
     description: str = "",
-    token_type: str = "user",
     lifespan_hours: int | None = None,
+    pinned_roles: list[str] | None = None,
 ) -> tuple[APIToken, str]:
     """Create an API token. Returns (model, raw_token_value).
 
-    The raw token value is only available at creation time.
-
-    If lifespan_hours is provided, it is clamped to the global max TTL.
-    If None, the token uses the global max TTL at validation time.
+    The raw token value is only available at creation time. ``bound_to`` is
+    the owning identity (None for detached); ``created_by`` is the minter
+    (audit). ``lifespan_hours`` is clamped to the kind's cap.
     """
     raw_token = _generate_raw_token()
     token_id = _generate_token_id()
 
-    # Clamp lifespan to global max if set
-    max_ttl = settings.auth.api_token_max_ttl_hours
-    if lifespan_hours is not None and max_ttl > 0:
-        lifespan_hours = min(lifespan_hours, max_ttl)
+    cap = _max_ttl_hours_for_kind(kind)
+    if lifespan_hours is not None and cap > 0:
+        lifespan_hours = min(lifespan_hours, cap)
 
     api_token = APIToken(
         id=token_id,
         token_hash=hash_token(raw_token),
         description=description,
-        user_email=user_email,
-        token_type=token_type,
+        kind=kind,
+        bound_to=bound_to,
+        created_by=created_by,
+        pinned_roles=pinned_roles,
         lifespan_hours=lifespan_hours,
     )
 
@@ -79,19 +128,46 @@ async def create_api_token(
     logger.info(
         "API token created",
         token_id=token_id,
-        user_email=user_email,
-        token_type=token_type,
+        kind=kind,
+        bound_to=bound_to,
+        created_by=created_by,
         lifespan_hours=lifespan_hours,
     )
 
     return api_token, raw_token
 
 
+async def _bound_token_owner_active(db: AsyncSession, email: str | None) -> bool:
+    """Whether a user-bound token's owner is still valid (#495).
+
+    Rejected when: no owner; a local ``users`` row exists and is inactive;
+    or the idle-login window has lapsed (no ``tp:user_seen`` marker). SSO
+    identities have no ``users`` row, so an absent row is NOT a rejection —
+    the idle window is what offboards them.
+    """
+    if not email:
+        return False
+
+    # Local-account deactivation (only local users have a row + is_active).
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+    if user is not None and not user.is_active:
+        return False
+
+    # Idle-login window (disabled when bound_token_idle_days == 0).
+    if settings.auth.bound_token_idle_days > 0:
+        if not await user_seen_within_window(email):
+            return False
+
+    return True
+
+
 async def validate_api_token(db: AsyncSession, raw_token: str) -> APIToken | None:
     """Validate a Bearer token against the database.
 
-    SHA-256 hash the token, look up by hash. Check expiry.
-    Update last_used_at (rate-limited to once per minute).
+    SHA-256 hash the token, look up by hash. Check kind-aware expiry, then
+    idle-login rejection for user-bound tokens (detached are exempt). Update
+    last_used_at (rate-limited to once per minute).
     """
     token_hash = hash_token(raw_token)
 
@@ -101,20 +177,19 @@ async def validate_api_token(db: AsyncSession, raw_token: str) -> APIToken | Non
     if api_token is None:
         return None
 
-    # Check token lifetime: per-token lifespan takes precedence, else global max
     now = now_utc()
-    effective_ttl = (
-        api_token.lifespan_hours
-        if api_token.lifespan_hours is not None
-        else settings.auth.api_token_max_ttl_hours
-    )
-    if effective_ttl > 0:
-        expiry = api_token.created_at + timedelta(hours=effective_ttl)
-        if now > expiry:
-            logger.debug("API token expired", token_id=api_token.id, ttl_hours=effective_ttl)
+    expiry = token_expires_at(api_token)
+    if expiry is not None and now > expiry:
+        logger.debug("API token expired", token_id=api_token.id)
+        return None
+
+    # Idle-login rejection — user-bound tokens only; detached are exempt.
+    if api_token.kind in _USER_BOUND_KINDS:
+        if not await _bound_token_owner_active(db, api_token.bound_to):
+            logger.debug("API token rejected: owner idle or inactive", token_id=api_token.id)
             return None
 
-    # Update last_used_at (rate-limited)
+    # Update last_used_at (rate-limited). Driven off last_used_at, never rotated_at.
     should_update = (
         api_token.last_used_at is None
         or (now - api_token.last_used_at).total_seconds() > LAST_USED_UPDATE_INTERVAL
@@ -127,26 +202,82 @@ async def validate_api_token(db: AsyncSession, raw_token: str) -> APIToken | Non
     return api_token
 
 
-async def list_user_tokens(db: AsyncSession, user_email: str) -> list[APIToken]:
-    """List all API tokens for a user."""
+async def list_user_tokens(db: AsyncSession, email: str) -> list[APIToken]:
+    """List a user's own tokens.
+
+    Filters on ``bound_to == email``, so detached tokens (bound_to NULL) are
+    naturally excluded from any per-user view.
+    """
     result = await db.execute(
-        select(APIToken)
-        .where(APIToken.user_email == user_email)
-        .order_by(APIToken.created_at.desc())
+        select(APIToken).where(APIToken.bound_to == email).order_by(APIToken.created_at.desc())
     )
     return list(result.scalars().all())
 
 
-async def list_all_tokens(db: AsyncSession) -> list[APIToken]:
-    """List all API tokens (admin use)."""
-    result = await db.execute(select(APIToken).order_by(APIToken.created_at.desc()))
+async def list_all_tokens(db: AsyncSession, kind: str | None = None) -> list[APIToken]:
+    """List all API tokens (admin use), optionally filtered by kind."""
+    stmt = select(APIToken).order_by(APIToken.created_at.desc())
+    if kind:
+        stmt = stmt.where(APIToken.kind == kind)
+    result = await db.execute(stmt)
     return list(result.scalars().all())
+
+
+async def list_expiring_service_tokens(
+    db: AsyncSession,
+    caller_email: str,
+    is_admin: bool,
+    within_days: int,
+) -> list[APIToken]:
+    """Service tokens nearing expiry, scoped to the caller (#495).
+
+    Every caller sees their own ``service_bound`` tokens; admins additionally
+    see all ``service_detached`` tokens. Single query for the in-scope
+    candidates, then the kind-aware expiry filter is applied in Python (no
+    per-token query).
+    """
+    conds = [(APIToken.bound_to == caller_email) & (APIToken.kind == "service_bound")]
+    if is_admin:
+        conds.append(APIToken.kind == "service_detached")
+
+    result = await db.execute(select(APIToken).where(or_(*conds)))
+    candidates = result.scalars().all()
+
+    threshold = now_utc() + timedelta(days=within_days)
+    expiring = []
+    for token in candidates:
+        expiry = token_expires_at(token)
+        if expiry is not None and expiry <= threshold:
+            expiring.append(token)
+    expiring.sort(key=lambda t: token_expires_at(t) or now_utc())
+    return expiring
 
 
 async def get_token_by_id(db: AsyncSession, token_id: str) -> APIToken | None:
     """Get a token by its public ID."""
     result = await db.execute(select(APIToken).where(APIToken.id == token_id))
     return result.scalar_one_or_none()
+
+
+async def rotate_token(db: AsyncSession, token_id: str) -> tuple[APIToken, str] | None:
+    """Roll a token's secret and reset its expiry clock (#495).
+
+    Single-row UPDATE: new hash + ``rotated_at = now`` (the expiry basis),
+    keeping the same kind/binding/scope/description. Returns (model,
+    raw_token) or None if the token doesn't exist. The old secret is invalid
+    immediately. Authorization is enforced by the caller.
+    """
+    token = await get_token_by_id(db, token_id)
+    if token is None:
+        return None
+
+    raw_token = _generate_raw_token()
+    token.token_hash = hash_token(raw_token)
+    token.rotated_at = now_utc()
+    await db.flush()
+
+    logger.info("API token rotated", token_id=token_id, kind=token.kind)
+    return token, raw_token
 
 
 async def revoke_token(db: AsyncSession, token_id: str) -> bool:
@@ -165,3 +296,17 @@ async def revoke_token(db: AsyncSession, token_id: str) -> bool:
 
     logger.info("API token revoked", token_id=token_id)
     return True
+
+
+async def revoke_all_for_user(db: AsyncSession, email: str) -> int:
+    """Revoke (delete) every token bound to an identity (urgent offboarding, #495).
+
+    Single DELETE over ``bound_to == email`` (detached tokens, bound_to NULL,
+    are untouched). Returns the number of tokens removed. The caller is
+    responsible for invalidating the cached roles for the email after commit.
+    """
+    result = await db.execute(delete(APIToken).where(APIToken.bound_to == email))
+    await db.flush()
+    count = result.rowcount or 0
+    logger.info("Revoked all tokens for user", email=email, count=count)
+    return count

--- a/services/terrapod/auth/recent_users.py
+++ b/services/terrapod/auth/recent_users.py
@@ -17,6 +17,36 @@ logger = get_logger(__name__)
 RECENT_USER_PREFIX = "tp:recent_user:"
 RECENT_USER_TTL = 604800  # 7 days in seconds
 
+# Provider-agnostic "last interactive login" marker, keyed by email only
+# (#495). Distinct from RECENT_USER (which is provider-scoped, for admin
+# autocomplete): this one is load-bearing for auth — a user-bound token is
+# rejected once this marker has expired (the owner hasn't logged in within
+# the idle window). Set on every login in `process_login`; its TTL is the
+# configured idle window. Single-key GET/SET only — never pipelined across
+# prefixes (cluster cross-slot rule).
+USER_SEEN_PREFIX = "tp:user_seen:"
+
+
+async def mark_user_seen(email: str, ttl_seconds: int) -> None:
+    """Refresh the idle-login marker for an identity (#495).
+
+    Called on every interactive login. `ttl_seconds` is the idle window
+    (``bound_token_idle_days`` × 86400). A non-positive TTL means idle
+    rejection is disabled, so there's nothing to mark.
+    """
+    if ttl_seconds <= 0 or not email:
+        return
+    redis = get_redis_client()
+    await redis.set(f"{USER_SEEN_PREFIX}{email}", "1", ex=ttl_seconds)
+
+
+async def user_seen_within_window(email: str) -> bool:
+    """True if the identity has logged in within the idle window (#495)."""
+    if not email:
+        return False
+    redis = get_redis_client()
+    return (await redis.get(f"{USER_SEEN_PREFIX}{email}")) is not None
+
 
 @dataclass
 class RecentUser:

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -299,8 +299,26 @@ class AuthConfig(BaseSettings):
     )
     api_token_max_ttl_hours: int = Field(
         default=8760,
-        description="Maximum API token lifetime in hours (default: 8760 = 1 year). "
-        "0 = no limit. Computed at validation time as created_at + this value.",
+        description="Maximum interactive API token lifetime in hours (default: 8760 = 1 year). "
+        "0 = no limit. Expiry = (rotated_at or created_at) + this value.",
+    )
+    service_token_max_ttl_hours: int = Field(
+        default=8760,
+        description="Maximum service-token (service_bound/service_detached) lifetime in hours "
+        "(default: 8760 = 1 year). Separate from the interactive cap. Service tokens ALWAYS "
+        "expire: this is never treated as unbounded even if set to 0 (#495).",
+    )
+    token_expiry_warning_days: int = Field(
+        default=14,
+        description="How many days ahead to surface in-app warnings for service tokens nearing "
+        "expiry (#495).",
+    )
+    bound_token_idle_days: int = Field(
+        default=7,
+        description="Idle-login window in days for user-bound tokens (interactive + service_bound): "
+        "a bound token is rejected if its owner has not logged in within this window. Also the TTL "
+        "of the tp:user_seen marker. 0 disables idle rejection. Detached tokens are exempt (#495). "
+        "ON by default — convert existing automation tokens to detached before upgrade.",
     )
     require_external_sso_for_roles: list[str] = Field(
         default_factory=list,

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -161,17 +161,31 @@ class APIToken(Base):
     id: Mapped[str] = mapped_column(String(63), primary_key=True)  # "at-{uuid7}"
     token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
     description: Mapped[str] = mapped_column(String(255), nullable=False, default="")
-    user_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    token_type: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="user"
-    )  # "user", "organization"
+    # Token kind (#495): interactive (terraform login / UI), service_bound
+    # (user-bound automation; perms = min(pinned, owner live)), service_detached
+    # (admin-managed M2M; absolute pinned perms; exempt from idle-login rejection).
+    kind: Mapped[str] = mapped_column(String(20), nullable=False, default="interactive")
+    # Owning identity. NULL <=> detached (no user binding). Bare email string,
+    # NOT an FK: SSO users have no `users` row (sso_service: "SSO users are NOT
+    # stored in the users table"), so an FK would reject their tokens. Integrity
+    # via live role-intersection + idle-login window + local is_active check.
+    bound_to: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # The minter (audit). Always set, even for detached (its only creator record).
+    created_by: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    # Token's own pinned role set (service tokens). Resolved through label-RBAC.
+    pinned_roles: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+    # Legacy TFE-shaped field, superseded by `kind`. Retained (unread) for
+    # response back-compat; dropped in a later release.
+    token_type: Mapped[str] = mapped_column(String(20), nullable=False, default="user")
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False
     )
+    # Set by the rotate action; expiry basis = rotated_at or created_at.
+    rotated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     lifespan_hours: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
-    __table_args__ = (Index("ix_api_tokens_user_email", "user_email"),)
+    __table_args__ = (Index("ix_api_tokens_bound_to", "bound_to"),)
 
 
 class AgentPool(Base):

--- a/services/terrapod/services/sso_service.py
+++ b/services/terrapod/services/sso_service.py
@@ -17,9 +17,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.metrics import AUTH_LOGIN
 from terrapod.auth.claims_mapper import map_claims_to_roles
-from terrapod.auth.recent_users import record_recent_user
+from terrapod.auth.recent_users import mark_user_seen, record_recent_user
 from terrapod.auth.sso import AuthenticatedIdentity
-from terrapod.config import ClaimsToRolesMapping
+from terrapod.config import ClaimsToRolesMapping, settings
 from terrapod.db.models import PlatformRoleAssignment, RoleAssignment, User
 from terrapod.logging_config import get_logger
 
@@ -102,6 +102,12 @@ async def process_login(
     all_roles = sorted(roles)
 
     await db.commit()
+
+    # Refresh the idle-login marker (#495). This is load-bearing for auth —
+    # a user-bound token is rejected once this marker expires — so it is NOT
+    # in the best-effort block below: a Redis failure here should surface
+    # rather than silently let tokens die within the idle window later.
+    await mark_user_seen(identity.email, settings.auth.bound_token_idle_days * 86400)
 
     # Record recent user in Redis (fire-and-forget, don't block login)
     try:

--- a/services/tests/api/test_auth_dependency.py
+++ b/services/tests/api/test_auth_dependency.py
@@ -41,7 +41,7 @@ class TestGetCurrentUser:
     ):
         """If token matches an API token, session is not checked."""
         mock_token = MagicMock()
-        mock_token.user_email = "bot@example.com"
+        mock_token.bound_to = "bot@example.com"
         mock_validate_token.return_value = mock_token
 
         request = _mock_request()

--- a/services/tests/api/test_service_tokens.py
+++ b/services/tests/api/test_service_tokens.py
@@ -1,0 +1,247 @@
+"""Services-API tests for the service-token endpoints (#495).
+
+Covers create (kind gating), admin kind-filter, rotate, expiring, revoke-all,
+re-tag, and the HARD INVARIANT that no token path is mounted under /api/v2.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser
+
+
+def _make_app(user: AuthenticatedUser):
+    app = create_app()
+    from terrapod.api.dependencies import get_current_user
+    from terrapod.db.session import get_db
+
+    async def override_auth():
+        return user
+
+    async def override_db():
+        return AsyncMock()
+
+    app.dependency_overrides[get_current_user] = override_auth
+    app.dependency_overrides[get_db] = override_db
+    return app
+
+
+def _user(email="dev@example.com", roles=None):
+    return AuthenticatedUser(
+        email=email,
+        display_name="Dev",
+        roles=roles or [],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _token_mock(**kw):
+    t = MagicMock()
+    t.id = kw.get("id", "at-svc")
+    t.description = kw.get("description", "")
+    t.kind = kw.get("kind", "service_bound")
+    t.bound_to = kw.get("bound_to", "dev@example.com")
+    t.created_by = kw.get("created_by", "dev@example.com")
+    t.token_type = "user"
+    t.pinned_roles = kw.get("pinned_roles")
+    t.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    t.rotated_at = kw.get("rotated_at")
+    t.last_used_at = None
+    t.lifespan_hours = None
+    return t
+
+
+def _client(app):
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+_APP_PATCHES = (
+    patch("terrapod.api.app.init_storage", new_callable=AsyncMock),
+    patch("terrapod.api.app.init_redis"),
+    patch("terrapod.api.app.init_db"),
+)
+
+
+def _app_patched(fn):
+    for p in _APP_PATCHES:
+        fn = p(fn)
+    return fn
+
+
+@_app_patched
+@patch("terrapod.api.routers.tokens.create_api_token")
+async def test_create_service_bound(mock_create, *_):
+    mock_create.return_value = (
+        _token_mock(kind="service_bound", pinned_roles=["plan-only"]),
+        "raw.tpod.secret",
+    )
+    app = _make_app(_user())
+    async with _client(app) as c:
+        r = await c.post(
+            "/api/terrapod/v1/users/dev/authentication-tokens",
+            json={"data": {"attributes": {"kind": "service_bound", "pinned_roles": ["plan-only"]}}},
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 201
+    attrs = r.json()["data"]["attributes"]
+    assert attrs["kind"] == "service_bound"
+    assert attrs["token"] == "raw.tpod.secret"
+    assert attrs["bound-to"] == "dev@example.com"
+
+
+@_app_patched
+async def test_create_detached_gated_422(*_):
+    app = _make_app(_user(roles=["admin"]))
+    async with _client(app) as c:
+        r = await c.post(
+            "/api/terrapod/v1/users/dev/authentication-tokens",
+            json={"data": {"attributes": {"kind": "service_detached"}}},
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 422
+
+
+@_app_patched
+@patch("terrapod.api.routers.tokens.list_all_tokens")
+async def test_admin_list_kind_filter(mock_list, *_):
+    mock_list.return_value = [_token_mock(kind="service_bound")]
+    app = _make_app(_user(roles=["admin"]))
+    async with _client(app) as c:
+        r = await c.get(
+            "/api/terrapod/v1/admin/authentication-tokens?kind=service_bound",
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 200
+    # the kind filter is passed through to the query
+    assert mock_list.call_args.kwargs.get("kind") == "service_bound"
+
+
+@_app_patched
+async def test_admin_list_detached_filter_is_valid_not_422(*_):
+    # service_detached is a valid kind: filtering by it returns empty, not 422
+    app = _make_app(_user(roles=["admin"]))
+    with patch("terrapod.api.routers.tokens.list_all_tokens", return_value=[]):
+        async with _client(app) as c:
+            r = await c.get(
+                "/api/terrapod/v1/admin/authentication-tokens?kind=service_detached",
+                headers={"Authorization": "Bearer x"},
+            )
+    assert r.status_code == 200
+    assert r.json()["data"] == []
+
+
+@_app_patched
+async def test_admin_list_non_admin_forbidden(*_):
+    app = _make_app(_user())  # no admin role
+    async with _client(app) as c:
+        r = await c.get(
+            "/api/terrapod/v1/admin/authentication-tokens",
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 403
+
+
+@_app_patched
+@patch("terrapod.api.routers.tokens.rotate_token")
+@patch("terrapod.api.routers.tokens.get_token_by_id")
+async def test_rotate_returns_new_value(mock_get, mock_rotate, *_):
+    tok = _token_mock(bound_to="dev@example.com", rotated_at=datetime(2026, 6, 1, tzinfo=UTC))
+    mock_get.return_value = tok
+    mock_rotate.return_value = (tok, "rotated.tpod.secret")
+    app = _make_app(_user())
+    async with _client(app) as c:
+        r = await c.post(
+            "/api/terrapod/v1/authentication-tokens/at-svc/actions/rotate",
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 200
+    assert r.json()["data"]["attributes"]["token"] == "rotated.tpod.secret"
+
+
+@_app_patched
+@patch("terrapod.api.routers.tokens.get_token_by_id")
+async def test_rotate_non_owner_forbidden(mock_get, *_):
+    mock_get.return_value = _token_mock(bound_to="someone-else@example.com")
+    app = _make_app(_user())  # not owner, not admin
+    async with _client(app) as c:
+        r = await c.post(
+            "/api/terrapod/v1/authentication-tokens/at-svc/actions/rotate",
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 403
+
+
+@_app_patched
+@patch("terrapod.api.routers.tokens.get_redis_client")
+@patch("terrapod.api.routers.tokens.revoke_all_for_user")
+async def test_revoke_all_admin(mock_revoke_all, mock_redis, *_):
+    mock_revoke_all.return_value = 4
+    mock_redis.return_value = MagicMock(delete=AsyncMock())
+    app = _make_app(_user(roles=["admin"]))
+    async with _client(app) as c:
+        r = await c.post(
+            "/api/terrapod/v1/admin/authentication-tokens/actions/revoke-all",
+            json={"email": "leaver@example.com"},
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 200
+    assert r.json()["data"] == {"email": "leaver@example.com", "revoked": 4}
+    mock_redis.return_value.delete.assert_awaited_once()
+
+
+@_app_patched
+async def test_revoke_all_non_admin_forbidden(*_):
+    app = _make_app(_user())
+    async with _client(app) as c:
+        r = await c.post(
+            "/api/terrapod/v1/admin/authentication-tokens/actions/revoke-all",
+            json={"email": "x@example.com"},
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 403
+
+
+@_app_patched
+@patch("terrapod.api.routers.tokens.list_expiring_service_tokens")
+async def test_expiring_caller_scoped(mock_expiring, *_):
+    mock_expiring.return_value = [_token_mock(kind="service_bound")]
+    app = _make_app(_user())
+    async with _client(app) as c:
+        r = await c.get(
+            "/api/terrapod/v1/authentication-tokens/expiring",
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 200
+    assert len(r.json()["data"]) == 1
+    # caller scoping is passed to the query
+    assert mock_expiring.call_args.kwargs["caller_email"] == "dev@example.com"
+    assert mock_expiring.call_args.kwargs["is_admin"] is False
+
+
+@_app_patched
+@patch("terrapod.api.routers.tokens.get_token_by_id")
+async def test_retag_to_detached_gated_422(mock_get, *_):
+    mock_get.return_value = _token_mock(kind="interactive", bound_to="dev@example.com")
+    app = _make_app(_user(roles=["admin"]))
+    async with _client(app) as c:
+        r = await c.patch(
+            "/api/terrapod/v1/authentication-tokens/at-svc",
+            json={"data": {"attributes": {"kind": "service_detached"}}},
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 422
+
+
+def test_no_token_path_under_api_v2():
+    """HARD INVARIANT (#495): token management is Terrapod-native only."""
+    app = create_app()
+    offenders = [
+        route.path
+        for route in app.routes
+        if getattr(route, "path", "").startswith("/api/v2") and "authentication-token" in route.path
+    ]
+    assert offenders == [], f"token paths leaked under /api/v2: {offenders}"

--- a/services/tests/api/test_tfe_v2.py
+++ b/services/tests/api/test_tfe_v2.py
@@ -157,8 +157,11 @@ class TestTokenCRUD:
         mock_token.id = "at-abc123"
         mock_token.description = "my token"
         mock_token.token_type = "user"
-        mock_token.user_email = "test@example.com"
+        mock_token.kind = "interactive"
+        mock_token.bound_to = "test@example.com"
+        mock_token.created_by = "test@example.com"
         mock_token.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        mock_token.rotated_at = None
         mock_token.last_used_at = None
         mock_token.lifespan_hours = None
         mock_create.return_value = (mock_token, "raw.tpod.secret")
@@ -208,8 +211,11 @@ class TestTokenCRUD:
         mock_token.id = "at-abc123"
         mock_token.description = "test"
         mock_token.token_type = "user"
-        mock_token.user_email = "test@example.com"
+        mock_token.kind = "interactive"
+        mock_token.bound_to = "test@example.com"
+        mock_token.created_by = "test@example.com"
         mock_token.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        mock_token.rotated_at = None
         mock_token.last_used_at = None
         mock_token.lifespan_hours = None
         mock_list.return_value = [mock_token]
@@ -251,7 +257,7 @@ class TestTokenCRUD:
     ):
         mock_token = MagicMock()
         mock_token.id = "at-abc123"
-        mock_token.user_email = "test@example.com"
+        mock_token.bound_to = "test@example.com"
         mock_get_token.return_value = mock_token
         mock_revoke.return_value = True
 
@@ -285,7 +291,7 @@ class TestTokenCRUD:
     ):
         mock_token = MagicMock()
         mock_token.id = "at-abc123"
-        mock_token.user_email = "other@example.com"
+        mock_token.bound_to = "other@example.com"
         mock_get_token.return_value = mock_token
 
         user = AuthenticatedUser(

--- a/services/tests/auth/test_api_tokens.py
+++ b/services/tests/auth/test_api_tokens.py
@@ -1,6 +1,12 @@
-"""Tests for API token system — create, validate, revoke, config-driven expiry, hash storage."""
+"""Tests for the API token system (#495).
+
+Covers token generation/hashing, kind-aware + basis-aware expiry
+(token_expires_at), create/validate with idle-login rejection, rotate, and
+revoke-all-for-user.
+"""
 
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,79 +18,151 @@ from terrapod.auth.api_tokens import (
     create_api_token,
     hash_token,
     list_user_tokens,
+    revoke_all_for_user,
     revoke_token,
+    rotate_token,
+    token_expires_at,
     validate_api_token,
 )
 
 
+def _tok(**kw):
+    """A lightweight token stub for the pure expiry helper."""
+    base = {
+        "kind": "interactive",
+        "lifespan_hours": None,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "rotated_at": None,
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
 class TestTokenGeneration:
     def test_token_id_format(self):
-        token_id = _generate_token_id()
-        assert token_id.startswith("at-")
-        assert len(token_id) > 5
+        assert _generate_token_id().startswith("at-")
 
     def test_raw_token_format(self):
         raw = _generate_raw_token()
         assert ".tpod." in raw
-        parts = raw.split(".tpod.")
-        assert len(parts) == 2
-        assert len(parts[0]) > 5  # random_id
-        assert len(parts[1]) > 20  # random_secret
+        a, b = raw.split(".tpod.")
+        assert len(a) > 5 and len(b) > 20
 
     def test_raw_token_is_unique(self):
-        t1 = _generate_raw_token()
-        t2 = _generate_raw_token()
-        assert t1 != t2
+        assert _generate_raw_token() != _generate_raw_token()
 
 
 class TestHashToken:
     def test_hash_is_deterministic(self):
-        raw = "test-token-value.tpod.secret123"
-        h1 = hash_token(raw)
-        h2 = hash_token(raw)
-        assert h1 == h2
+        assert hash_token("x.tpod.y") == hash_token("x.tpod.y")
 
     def test_hash_is_hex_sha256(self):
         h = hash_token("test")
-        assert len(h) == 64  # SHA-256 produces 64 hex chars
+        assert len(h) == 64
         assert all(c in "0123456789abcdef" for c in h)
 
     def test_different_tokens_different_hashes(self):
-        h1 = hash_token("token-a")
-        h2 = hash_token("token-b")
-        assert h1 != h2
+        assert hash_token("a") != hash_token("b")
+
+
+class TestTokenExpiry:
+    """Pure token_expires_at(): kind-aware cap + rotated_at-or-created_at basis."""
+
+    @patch("terrapod.auth.api_tokens.settings")
+    def test_interactive_zero_global_is_unlimited(self, ms):
+        ms.auth.api_token_max_ttl_hours = 0
+        assert token_expires_at(_tok(kind="interactive")) is None
+
+    @patch("terrapod.auth.api_tokens.settings")
+    def test_interactive_uses_global_cap(self, ms):
+        ms.auth.api_token_max_ttl_hours = 24
+        created = datetime(2026, 1, 1, tzinfo=UTC)
+        assert token_expires_at(
+            _tok(kind="interactive", created_at=created)
+        ) == created + timedelta(hours=24)
+
+    @patch("terrapod.auth.api_tokens.settings")
+    def test_per_token_lifespan_takes_precedence(self, ms):
+        ms.auth.api_token_max_ttl_hours = 0  # global unlimited
+        created = datetime(2026, 1, 1, tzinfo=UTC)
+        # an explicit lifespan still expires even when the global is unlimited
+        assert token_expires_at(
+            _tok(kind="interactive", lifespan_hours=5, created_at=created)
+        ) == created + timedelta(hours=5)
+
+    @patch("terrapod.auth.api_tokens.settings")
+    def test_service_always_expires_even_when_global_zero(self, ms):
+        # service cap misconfigured to 0 -> falls back, never unbounded
+        ms.auth.service_token_max_ttl_hours = 0
+        exp = token_expires_at(_tok(kind="service_detached"))
+        assert exp is not None
+
+    @patch("terrapod.auth.api_tokens.settings")
+    def test_service_uses_service_cap_not_interactive(self, ms):
+        ms.auth.service_token_max_ttl_hours = 10
+        ms.auth.api_token_max_ttl_hours = 999
+        created = datetime(2026, 1, 1, tzinfo=UTC)
+        assert token_expires_at(
+            _tok(kind="service_bound", created_at=created)
+        ) == created + timedelta(hours=10)
+
+    @patch("terrapod.auth.api_tokens.settings")
+    def test_rotated_at_is_the_basis(self, ms):
+        ms.auth.api_token_max_ttl_hours = 24
+        created = datetime(2026, 1, 1, tzinfo=UTC)
+        rotated = datetime(2026, 6, 1, tzinfo=UTC)
+        # expiry measured from rotated_at, not created_at
+        assert token_expires_at(
+            _tok(kind="interactive", created_at=created, rotated_at=rotated)
+        ) == rotated + timedelta(hours=24)
 
 
 class TestCreateAPIToken:
     @pytest.fixture
     def mock_db(self):
-        db = AsyncMock(spec=AsyncSession)
-        return db
+        return AsyncMock(spec=AsyncSession)
 
-    async def test_create_returns_model_and_raw_token(self, mock_db):
-        api_token, raw_token = await create_api_token(
+    @patch("terrapod.auth.api_tokens.settings")
+    async def test_create_interactive(self, ms, mock_db):
+        ms.auth.api_token_max_ttl_hours = 8760
+        token, raw = await create_api_token(
             db=mock_db,
-            user_email="test@example.com",
-            description="test token",
+            bound_to="test@example.com",
+            created_by="test@example.com",
+            kind="interactive",
+            description="t",
         )
-
-        assert api_token.user_email == "test@example.com"
-        assert api_token.description == "test token"
-        assert api_token.token_type == "user"
-        assert api_token.id.startswith("at-")
-        assert ".tpod." in raw_token
-        # Verify hash matches
-        assert api_token.token_hash == hash_token(raw_token)
+        assert token.bound_to == "test@example.com"
+        assert token.created_by == "test@example.com"
+        assert token.kind == "interactive"
+        assert token.id.startswith("at-")
+        assert token.token_hash == hash_token(raw)
         mock_db.add.assert_called_once()
         mock_db.flush.assert_called_once()
 
-    async def test_create_org_token(self, mock_db):
-        api_token, _ = await create_api_token(
+    @patch("terrapod.auth.api_tokens.settings")
+    async def test_create_service_bound_with_pinned_roles(self, ms, mock_db):
+        ms.auth.service_token_max_ttl_hours = 8760
+        token, _ = await create_api_token(
             db=mock_db,
-            user_email="test@example.com",
-            token_type="organization",
+            bound_to="dev@example.com",
+            created_by="dev@example.com",
+            kind="service_bound",
+            pinned_roles=["plan-only"],
         )
-        assert api_token.token_type == "organization"
+        assert token.kind == "service_bound"
+        assert token.pinned_roles == ["plan-only"]
+
+    @patch("terrapod.auth.api_tokens.settings")
+    async def test_lifespan_clamped_to_cap(self, ms, mock_db):
+        ms.auth.api_token_max_ttl_hours = 100
+        token, _ = await create_api_token(
+            db=mock_db,
+            bound_to="a@b.com",
+            created_by="a@b.com",
+            lifespan_hours=9999,
+        )
+        assert token.lifespan_hours == 100
 
 
 class TestValidateAPIToken:
@@ -92,138 +170,152 @@ class TestValidateAPIToken:
     def mock_db(self):
         return AsyncMock(spec=AsyncSession)
 
-    @patch("terrapod.auth.api_tokens.settings")
-    async def test_validate_valid_token(self, mock_settings, mock_db):
-        mock_settings.auth.api_token_max_ttl_hours = 0
-        raw_token = "abc123.tpod.secret456"
-        mock_token = MagicMock()
-        mock_token.last_used_at = None
-        mock_token.id = "at-test"
-        mock_token.created_at = datetime.now(UTC)
-        mock_token.lifespan_hours = None
-
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_token
-        mock_db.execute.return_value = mock_result
-
-        result = await validate_api_token(mock_db, raw_token)
-
-        assert result is mock_token
-        # Should update last_used_at since it was None
-        assert mock_db.execute.call_count == 2  # select + update
-
-    async def test_validate_nonexistent_token(self, mock_db):
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        mock_db.execute.return_value = mock_result
-
-        result = await validate_api_token(mock_db, "nonexistent.tpod.token")
-        assert result is None
+    def _result_for(self, token):
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = token
+        return r
 
     @patch("terrapod.auth.api_tokens.settings")
-    async def test_validate_rejects_token_past_max_ttl(self, mock_settings, mock_db):
-        """Token created 2 hours ago is rejected when max TTL is 1 hour."""
-        mock_settings.auth.api_token_max_ttl_hours = 1
-        mock_token = MagicMock()
-        mock_token.created_at = datetime.now(UTC) - timedelta(hours=2)
-        mock_token.id = "at-expired"
-        mock_token.lifespan_hours = None
+    async def test_valid_detached_token_returned(self, ms, mock_db):
+        # detached is exempt from idle — isolates the happy path
+        ms.auth.service_token_max_ttl_hours = 8760
+        token = MagicMock(
+            kind="service_detached",
+            created_at=datetime.now(UTC),
+            rotated_at=None,
+            last_used_at=None,
+            lifespan_hours=None,
+            id="at-d",
+        )
+        mock_db.execute.return_value = self._result_for(token)
+        assert await validate_api_token(mock_db, "x.tpod.y") is token
+        assert mock_db.execute.call_count == 2  # select + last_used update
 
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_token
-        mock_db.execute.return_value = mock_result
-
-        result = await validate_api_token(mock_db, "old.tpod.token")
-        assert result is None
-
-    @patch("terrapod.auth.api_tokens.settings")
-    async def test_validate_accepts_token_within_max_ttl(self, mock_settings, mock_db):
-        """Token created 1 hour ago is accepted when max TTL is 24 hours."""
-        mock_settings.auth.api_token_max_ttl_hours = 24
-        mock_token = MagicMock()
-        mock_token.created_at = datetime.now(UTC) - timedelta(hours=1)
-        mock_token.last_used_at = None
-        mock_token.id = "at-valid"
-        mock_token.lifespan_hours = None
-
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_token
-        mock_db.execute.return_value = mock_result
-
-        result = await validate_api_token(mock_db, "valid.tpod.token")
-        assert result is mock_token
+    async def test_nonexistent_token(self, mock_db):
+        mock_db.execute.return_value = self._result_for(None)
+        assert await validate_api_token(mock_db, "no.tpod.token") is None
 
     @patch("terrapod.auth.api_tokens.settings")
-    async def test_validate_no_max_ttl_never_expires(self, mock_settings, mock_db):
-        """With max TTL=0, tokens never expire regardless of age."""
-        mock_settings.auth.api_token_max_ttl_hours = 0
-        mock_token = MagicMock()
-        mock_token.created_at = datetime(2020, 1, 1, tzinfo=UTC)
-        mock_token.last_used_at = None
-        mock_token.id = "at-ancient"
-        mock_token.lifespan_hours = None
+    async def test_expired_token_rejected(self, ms, mock_db):
+        ms.auth.service_token_max_ttl_hours = 1
+        token = MagicMock(
+            kind="service_detached",
+            created_at=datetime.now(UTC) - timedelta(hours=2),
+            rotated_at=None,
+            lifespan_hours=None,
+            id="at-old",
+        )
+        mock_db.execute.return_value = self._result_for(token)
+        assert await validate_api_token(mock_db, "old.tpod.token") is None
 
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_token
-        mock_db.execute.return_value = mock_result
+    @patch("terrapod.auth.api_tokens._bound_token_owner_active", new_callable=AsyncMock)
+    @patch("terrapod.auth.api_tokens.settings")
+    async def test_bound_token_rejected_when_owner_idle(self, ms, owner_active, mock_db):
+        ms.auth.service_token_max_ttl_hours = 8760
+        owner_active.return_value = False
+        token = MagicMock(
+            kind="service_bound",
+            bound_to="gone@example.com",
+            created_at=datetime.now(UTC),
+            rotated_at=None,
+            lifespan_hours=None,
+            id="at-idle",
+        )
+        mock_db.execute.return_value = self._result_for(token)
+        assert await validate_api_token(mock_db, "idle.tpod.token") is None
 
-        result = await validate_api_token(mock_db, "ancient.tpod.token")
-        assert result is mock_token
+    @patch("terrapod.auth.api_tokens._bound_token_owner_active", new_callable=AsyncMock)
+    @patch("terrapod.auth.api_tokens.settings")
+    async def test_bound_token_accepted_when_owner_active(self, ms, owner_active, mock_db):
+        ms.auth.api_token_max_ttl_hours = 0
+        owner_active.return_value = True
+        token = MagicMock(
+            kind="interactive",
+            bound_to="here@example.com",
+            created_at=datetime.now(UTC),
+            rotated_at=None,
+            last_used_at=None,
+            lifespan_hours=None,
+            id="at-ok",
+        )
+        mock_db.execute.return_value = self._result_for(token)
+        assert await validate_api_token(mock_db, "ok.tpod.token") is token
 
     @patch("terrapod.auth.api_tokens.settings")
-    async def test_validate_skips_last_used_update_when_recent(self, mock_settings, mock_db):
-        """last_used_at is not updated if it was updated less than 60s ago."""
-        mock_settings.auth.api_token_max_ttl_hours = 0
+    async def test_skips_last_used_update_when_recent(self, ms, mock_db):
+        ms.auth.service_token_max_ttl_hours = 8760
         now = datetime.now(UTC)
-        mock_token = MagicMock()
-        mock_token.created_at = now
-        mock_token.last_used_at = now - timedelta(seconds=30)
-        mock_token.id = "at-test"
-        mock_token.lifespan_hours = None
-
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_token
-        mock_db.execute.return_value = mock_result
-
+        token = MagicMock(
+            kind="service_detached",
+            created_at=now,
+            rotated_at=None,
+            last_used_at=now - timedelta(seconds=30),
+            lifespan_hours=None,
+            id="at-r",
+        )
+        mock_db.execute.return_value = self._result_for(token)
         await validate_api_token(mock_db, "recent.tpod.token")
-        # Only the select query, no update
-        assert mock_db.execute.call_count == 1
+        assert mock_db.execute.call_count == 1  # select only, no update
+
+
+class TestRotateToken:
+    async def test_rotate_sets_new_hash_and_rotated_at(self):
+        mock_db = AsyncMock(spec=AsyncSession)
+        token = MagicMock(id="at-1", token_hash="oldhash", rotated_at=None, kind="service_bound")
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = token
+        mock_db.execute.return_value = r
+
+        result = await rotate_token(mock_db, "at-1")
+        assert result is not None
+        returned, raw = result
+        assert returned is token
+        assert token.token_hash == hash_token(raw)
+        assert token.token_hash != "oldhash"
+        assert token.rotated_at is not None
+
+    async def test_rotate_missing_token(self):
+        mock_db = AsyncMock(spec=AsyncSession)
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = r
+        assert await rotate_token(mock_db, "at-x") is None
+
+
+class TestRevokeAllForUser:
+    async def test_revoke_all_returns_count(self):
+        mock_db = AsyncMock(spec=AsyncSession)
+        r = MagicMock()
+        r.rowcount = 3
+        mock_db.execute.return_value = r
+        count = await revoke_all_for_user(mock_db, "leaver@example.com")
+        assert count == 3
+        mock_db.flush.assert_awaited_once()
 
 
 class TestListUserTokens:
     async def test_list_returns_tokens(self):
         mock_db = AsyncMock(spec=AsyncSession)
-        mock_tokens = [MagicMock(id="at-1"), MagicMock(id="at-2")]
-
-        mock_result = MagicMock()
-        mock_result.scalars.return_value.all.return_value = mock_tokens
-        mock_db.execute.return_value = mock_result
-
-        tokens = await list_user_tokens(mock_db, "test@example.com")
-        assert len(tokens) == 2
+        r = MagicMock()
+        r.scalars.return_value.all.return_value = [MagicMock(id="at-1"), MagicMock(id="at-2")]
+        mock_db.execute.return_value = r
+        assert len(await list_user_tokens(mock_db, "test@example.com")) == 2
 
 
 class TestRevokeToken:
-    async def test_revoke_existing_token(self):
+    async def test_revoke_existing(self):
         mock_db = AsyncMock(spec=AsyncSession)
-        mock_token = MagicMock(id="at-123")
+        token = MagicMock(id="at-123")
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = token
+        mock_db.execute.return_value = r
+        assert await revoke_token(mock_db, "at-123") is True
+        mock_db.delete.assert_called_once_with(token)
 
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_token
-        mock_db.execute.return_value = mock_result
-
-        result = await revoke_token(mock_db, "at-123")
-        assert result is True
-        mock_db.delete.assert_called_once_with(mock_token)
-        mock_db.flush.assert_called_once()
-
-    async def test_revoke_nonexistent_token(self):
+    async def test_revoke_nonexistent(self):
         mock_db = AsyncMock(spec=AsyncSession)
-
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        mock_db.execute.return_value = mock_result
-
-        result = await revoke_token(mock_db, "at-nonexistent")
-        assert result is False
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = r
+        assert await revoke_token(mock_db, "at-x") is False
         mock_db.delete.assert_not_called()

--- a/services/tests/auth/test_role_assignments.py
+++ b/services/tests/auth/test_role_assignments.py
@@ -26,9 +26,10 @@ class TestProcessLogin:
             raw_claims={"groups": ["terrapod:dev", "terrapod:viewer"]},
         )
 
+    @patch("terrapod.services.sso_service.mark_user_seen")
     @patch("terrapod.services.sso_service.record_recent_user")
     async def test_sso_login_merges_groups_and_internal_roles(
-        self, mock_record, mock_db, sso_identity
+        self, mock_record, mock_mark, mock_db, sso_identity
     ):
         """Groups from IDP + internal assignments are merged and deduplicated."""
         mock_record.return_value = None
@@ -55,8 +56,11 @@ class TestProcessLogin:
         assert "dev" in result.roles
         assert "viewer" in result.roles
 
+    @patch("terrapod.services.sso_service.mark_user_seen")
     @patch("terrapod.services.sso_service.record_recent_user")
-    async def test_sso_login_with_claims_mapping(self, mock_record, mock_db, sso_identity):
+    async def test_sso_login_with_claims_mapping(
+        self, mock_record, mock_mark, mock_db, sso_identity
+    ):
         """Claims-to-roles mapping adds additional roles."""
         from terrapod.config import ClaimsToRolesMapping
 
@@ -122,11 +126,16 @@ class TestProcessLogin:
         with pytest.raises(ValueError, match="disabled"):
             await process_login(db=mock_db, identity=identity, claims_rules=[])
 
+    @patch("terrapod.services.sso_service.mark_user_seen")
     @patch("terrapod.services.sso_service.record_recent_user")
     async def test_record_recent_user_failure_does_not_break_login(
-        self, mock_record, mock_db, sso_identity
+        self, mock_record, mock_mark, mock_db, sso_identity
     ):
-        """record_recent_user failure is swallowed — login still succeeds."""
+        """record_recent_user failure is swallowed — login still succeeds.
+
+        mark_user_seen is mocked: it is load-bearing (set outside the
+        best-effort block) so it is NOT swallowed in production.
+        """
         mock_record.side_effect = Exception("Redis down")
 
         role_result = MagicMock()


### PR DESCRIPTION
Phase 1 of **#495** (scoped service tokens + expiry warnings). Lands the structured token model, kind-aware expiry, idle-login offboarding, rotation, and the caller-scoped expiry-warning API.

**Deliberately ships no escalation surface.** Detached resolution, the `min()` intersection, and platform-admin/audit attenuation are **Phase 2** — here `service_bound` and `interactive` still resolve to the owner's full live roles (never broader than today), `service_detached` creation is `422`-gated, and floor-suppression isn't needed because nothing resolves a token's own scope yet.

## What's in
- **Model + migration (`3fbcb2885b93`)** — `APIToken` gains `kind` (`interactive|service_bound|service_detached`), `bound_to` (renamed from `user_email`; `NULL`=detached), `created_by` (NOT NULL, audit), `rotated_at`, `pinned_roles`; `token_type` retained for response back-compat. Ordered B5-safe migration: add `created_by` nullable → backfill `COALESCE(user_email,'')` → `SET NOT NULL` → rename `user_email`→`bound_to` → drop/recreate index → add cols. Real `downgrade()`.
- **Config** — `service_token_max_ttl_hours`, `token_expiry_warning_days`, `bound_token_idle_days` (idle **ON by default**; `0` disables). Plumbed through `values.yaml`/`values.schema.json`/`configmap` (rendered *direct*, no `| default`, to avoid the Helm `0`-is-empty bug); `values-local` sets idle=0 for dev.
- **Logic** — kind-aware + `rotated_at`-basis expiry (`token_expires_at`; service tokens *always* expire, never unbounded even at global `0`); idle-login rejection via a `tp:user_seen` marker set in `process_login` **outside** the best-effort block (load-bearing) and read in `validate_api_token` (so **both** `get_current_user` and `authenticate_request` inherit it; sessions exempt); `rotate_token` (single-row, resets the expiry clock); `revoke_all_for_user` (+ `tp:token_roles` cache bust); caller-scoped `list_expiring_service_tokens` (single OR-query, no N+1).
- **Router** (`tokens.py`, Terrapod-native `/api/terrapod/v1/` only) — create (kind gating, detached→422), admin `?kind=` filter, rotate, re-tag, expiring, revoke-all; `Z`-uniform serializer emitting `kind`/`bound-to`/`created-by`.

## Tests
- Rewrote `test_api_tokens` (expiry-basis matrix, idle rejection, rotate, revoke-all); new `test_service_tokens` (12 — create/gate/filter/rotate/expiring/revoke-all + the **`/api/v2` guard test**); fixed `test_auth_dependency`/`test_tfe_v2`/`process_login` tests for the new shape.
- **`make test` green: 2124 passed.** ruff + `helm lint`/`template` (both values files) clean.

## Verification
- **`make test` green: 2124 passed.** ruff + `helm lint`/`template` (both values files) clean.
- **Live Tilt smoke (passed):** migration backfill (`kind=interactive`, `bound_to=created_by`); create interactive + `service_bound`; detached create → 422; admin `?kind=` filter; **rotate advances `expires-at`** (basis = `rotated_at`); caller-scoped expiring endpoint; admin revoke-all; delete → 204; configmap renders all three knobs. Idle-rejection is config-disabled in local dev (`bound_token_idle_days=0`) so not exercised live — its logic is unit-tested.

Spec: #495.
