### PR TITLE
feat(tokens): kind-aware scoped permission resolution (#495 Phase 2)

### DIFF
--- a/services/terrapod/api/dependencies.py
+++ b/services/terrapod/api/dependencies.py
@@ -53,10 +53,33 @@ class AuthenticatedUser:
 
     email: str
     display_name: str | None
-    roles: list[str]
+    roles: list[str]  # the principal's UN-attenuated live roles (user_effective input)
     provider_name: str
     auth_method: str  # "session", "api_token", or "runner_token"
     run_id: str | None = None  # Set only for runner_token auth
+    # Token kind (#495). For service tokens, `roles` stays the owner's live
+    # roles and `pinned_roles` carries the token's own scope; the per-resource
+    # min()/detached resolution happens in the resolve_*_for() wrappers, and
+    # the kind-attenuated platform-role view is computed by effective_platform_roles().
+    kind: str = "interactive"
+    pinned_roles: list[str] | None = None
+
+
+def effective_platform_roles(user: AuthenticatedUser) -> set[str]:
+    """Kind-attenuated platform-role set for name-based admin/audit gates (#495).
+
+    interactive -> the principal's live roles; service_bound -> live ∩ pinned;
+    service_detached -> pinned only. This is a DERIVED view used only by
+    platform gates (require_admin etc. + the inline "admin"/"audit" checks);
+    it is NEVER substituted for `user.roles`, which the per-resource min()
+    needs un-attenuated.
+    """
+    roles = set(user.roles)
+    if user.kind == "service_detached":
+        return set(user.pinned_roles or [])
+    if user.kind == "service_bound":
+        return roles & set(user.pinned_roles or [])
+    return roles
 
 
 async def _resolve_user_roles(db: AsyncSession, email: str) -> list[str]:
@@ -144,6 +167,8 @@ async def get_current_user(
                 roles=roles,
                 provider_name="api_token",
                 auth_method="api_token",
+                kind=api_token.kind,
+                pinned_roles=api_token.pinned_roles,
             )
 
         # Try session (Redis lookup)
@@ -228,6 +253,8 @@ async def authenticate_request(request: Request) -> AuthenticatedUser:
                 roles=roles,
                 provider_name="api_token",
                 auth_method="api_token",
+                kind=api_token.kind,
+                pinned_roles=api_token.pinned_roles,
             )
 
     # Try session (Redis only — no DB needed)
@@ -386,8 +413,8 @@ async def get_current_session(
 async def require_admin(
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> AuthenticatedUser:
-    """Dependency to require admin role."""
-    if "admin" not in user.roles:
+    """Dependency to require admin role (kind-attenuated for service tokens)."""
+    if "admin" not in effective_platform_roles(user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
@@ -398,8 +425,8 @@ async def require_admin(
 async def require_admin_or_audit(
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> AuthenticatedUser:
-    """Dependency to require admin or audit role."""
-    if not ({"admin", "audit"} & set(user.roles)):
+    """Dependency to require admin or audit role (kind-attenuated for service tokens)."""
+    if not ({"admin", "audit"} & effective_platform_roles(user)):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin or audit access required",

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -240,8 +240,7 @@ async def _require_pool_permission(
     """
     perm = await resolve_pool_permission_for(
         db,
-        user_email=user.email,
-        user_roles=user.roles,
+        user,
         pool_name=pool.name,
         pool_labels=pool.labels or {},
         owner_email=pool.owner_email or "",
@@ -269,8 +268,7 @@ async def list_pools(
     for p in pools:
         perm = await resolve_pool_permission_for(
             db,
-            user_email=user.email,
-            user_roles=user.roles,
+            user,
             pool_name=p.name,
             pool_labels=p.labels or {},
             owner_email=p.owner_email or "",
@@ -362,8 +360,7 @@ async def update_pool(
         if new_labels != (pool.labels or {}) or new_owner != pool.owner_email:
             new_perm = await resolve_pool_permission_for(
                 db,
-                user_email=user.email,
-                user_roles=user.roles,
+                user,
                 pool_name=attrs.get("name") or pool.name,
                 pool_labels=new_labels,
                 owner_email=new_owner or "",

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -46,7 +46,7 @@ from terrapod.services.pool_rbac_service import (
     POOL_PERMISSION_HIERARCHY,
     fetch_custom_roles,
     has_pool_permission,
-    resolve_pool_permission,
+    resolve_pool_permission_for,
 )
 
 router = APIRouter(tags=["agent-pools"])
@@ -237,7 +237,7 @@ async def _require_pool_permission(
     Returns the effective permission. Raises 404 if no access, 403 if
     insufficient.
     """
-    perm = await resolve_pool_permission(
+    perm = await resolve_pool_permission_for(
         db,
         user_email=user.email,
         user_roles=user.roles,
@@ -266,7 +266,7 @@ async def list_pools(
     custom_roles = await fetch_custom_roles(db, user.roles)
     result = []
     for p in pools:
-        perm = await resolve_pool_permission(
+        perm = await resolve_pool_permission_for(
             db,
             user_email=user.email,
             user_roles=user.roles,
@@ -359,7 +359,7 @@ async def update_pool(
         new_labels = labels_arg if labels_arg is not _UNSET else (pool.labels or {})
         new_owner = (owner_arg or None) if owner_arg is not _UNSET else pool.owner_email
         if new_labels != (pool.labels or {}) or new_owner != pool.owner_email:
-            new_perm = await resolve_pool_permission(
+            new_perm = await resolve_pool_permission_for(
                 db,
                 user_email=user.email,
                 user_roles=user.roles,

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -34,6 +34,7 @@ from terrapod.api.dependencies import (
     DEFAULT_ORG,
     AuthenticatedUser,
     ListenerIdentity,
+    effective_platform_roles,
     get_current_user,
     get_listener_identity,
     require_admin,
@@ -355,7 +356,7 @@ async def update_pool(
 
     # Self-lockout check: warn if label/owner change would reduce user's access.
     # Platform admins are immune (their access doesn't depend on labels/owner).
-    if "admin" not in set(user.roles) and not attrs.get("force"):
+    if "admin" not in effective_platform_roles(user) and not attrs.get("force"):
         new_labels = labels_arg if labels_arg is not _UNSET else (pool.labels or {})
         new_owner = (owner_arg or None) if owner_arg is not _UNSET else pool.owner_email
         if new_labels != (pool.labels or {}) or new_owner != pool.owner_email:
@@ -688,13 +689,13 @@ async def delete_listener(
     pool_id_str = listener.get("pool_id", "")
     if not pool_id_str:
         # Orphaned listener — require platform admin to clean up
-        if "admin" not in set(user.roles):
+        if "admin" not in effective_platform_roles(user):
             raise HTTPException(status_code=403, detail="Admin access required")
     else:
         pool = await agent_pool_service.get_pool(db, uuid.UUID(pool_id_str))
         if pool is None:
             # Pool deleted but listener Redis key persists — require platform admin
-            if "admin" not in set(user.roles):
+            if "admin" not in effective_platform_roles(user):
                 raise HTTPException(status_code=403, detail="Admin access required")
         else:
             await _require_pool_permission(pool, user, db, "admin")

--- a/services/terrapod/api/routers/config_versions.py
+++ b/services/terrapod/api/routers/config_versions.py
@@ -34,7 +34,10 @@ from terrapod.db.models import ConfigurationVersion, Run, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import cv_diff_service, run_service
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 from terrapod.storage import get_storage
 from terrapod.storage.keys import config_version_key
 from terrapod.storage.protocol import ObjectNotFoundError
@@ -110,7 +113,7 @@ async def create_configuration_version(
 ) -> JSONResponse:
     """Create a configuration version. Requires write on workspace."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "write"):
         raise HTTPException(status_code=403, detail="Requires write permission on workspace")
 
@@ -157,7 +160,7 @@ async def list_configuration_versions(
     RBAC: requires `read` on the workspace.
     """
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Workspace not found")
 
@@ -237,7 +240,7 @@ async def download_configuration_version(
     if ws is None:
         # Workspace deleted out from under us — treat as gone.
         raise HTTPException(status_code=404, detail="Configuration version not found")
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Configuration version not found")
 
@@ -294,7 +297,7 @@ async def mint_download_ticket(
     ws = await db.get(Workspace, cv.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Configuration version not found")
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Configuration version not found")
 
@@ -440,7 +443,7 @@ async def diff_configuration_versions(
     ws = await db.get(Workspace, from_cv.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Configuration version not found")
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Configuration version not found")
 

--- a/services/terrapod/api/routers/notification_configurations.py
+++ b/services/terrapod/api/routers/notification_configurations.py
@@ -33,7 +33,10 @@ from terrapod.services.notification_service import (
     deliver_notification,
     record_delivery_response,
 )
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 
 router = APIRouter(tags=["notification-configurations"])
 logger = get_logger(__name__)
@@ -87,7 +90,7 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
 async def _require_ws_permission(
     ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/services/terrapod/api/routers/policy_sets.py
+++ b/services/terrapod/api/routers/policy_sets.py
@@ -60,7 +60,10 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import policy_engine, policy_set_service, run_service
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 
 router = APIRouter(tags=["policy-sets"])
 logger = get_logger(__name__)
@@ -547,7 +550,7 @@ async def _get_run_for_read(db: AsyncSession, run_id: str, user: AuthenticatedUs
     ws = await db.get(Workspace, run.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(status_code=403, detail="Requires read permission on workspace")
     return run
@@ -593,7 +596,7 @@ async def override_run_policy(
     ws = await db.get(Workspace, run.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "admin"):
         raise HTTPException(status_code=403, detail="Requires admin permission on workspace")
 

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -32,7 +32,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_non_runner
+from terrapod.api.dependencies import (
+    AuthenticatedUser,
+    effective_platform_roles,
+    get_current_user,
+    require_non_runner,
+)
 from terrapod.api.labels import validate_labels
 from terrapod.db.models import ModuleWorkspaceLink, RegistryModuleVersion, Workspace
 from terrapod.db.session import get_db
@@ -464,7 +469,7 @@ async def update_module_endpoint(
     attrs = body.get("data", {}).get("attributes", {})
 
     if "owner-email" in attrs:
-        if "admin" not in user.roles:
+        if "admin" not in effective_platform_roles(user):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only platform admins can change owner",
@@ -479,7 +484,7 @@ async def update_module_endpoint(
         if (
             new_labels != (module.labels or {})
             and not attrs.get("force")
-            and "admin" not in user.roles
+            and "admin" not in effective_platform_roles(user)
             and module.owner_email != user.email
         ):
             new_perm = await resolve_registry_permission_for(

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -50,7 +50,7 @@ from terrapod.services.registry_module_service import (
 from terrapod.services.registry_rbac_service import (
     REGISTRY_PERMISSION_HIERARCHY,
     has_registry_permission,
-    resolve_registry_permission,
+    resolve_registry_permission_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.protocol import ObjectStore
@@ -182,14 +182,12 @@ async def list_module_versions_cli(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Module not found")
@@ -219,14 +217,12 @@ async def download_module_cli(
     """Get download URL for a module version (CLI protocol). Requires read."""
     module = await get_module(db, namespace, name, provider)
     if module is not None:
-        perm = await resolve_registry_permission(
+        perm = await resolve_registry_permission_for(
             db,
-            user.email,
-            user.roles,
+            user,
             module.name,
             module.labels or {},
             module.owner_email,
-            auth_method=user.auth_method,
         )
         if not has_registry_permission(perm, "read"):
             raise HTTPException(status_code=404, detail="Module version not found")
@@ -315,14 +311,12 @@ async def list_modules_endpoint(
     modules = await list_modules(db)
     visible = []
     for m in modules:
-        perm = await resolve_registry_permission(
+        perm = await resolve_registry_permission_for(
             db,
-            user.email,
-            user.roles,
+            user,
             m.name,
             m.labels or {},
             m.owner_email,
-            auth_method=user.auth_method,
         )
         if perm is not None:
             visible.append(_module_to_jsonapi(m, perm))
@@ -341,14 +335,12 @@ async def show_module_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Module not found")
@@ -374,14 +366,12 @@ async def module_interface_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Module not found")
@@ -424,14 +414,12 @@ async def delete_module_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -460,14 +448,12 @@ async def update_module_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -496,14 +482,12 @@ async def update_module_endpoint(
             and "admin" not in user.roles
             and module.owner_email != user.email
         ):
-            new_perm = await resolve_registry_permission(
+            new_perm = await resolve_registry_permission_for(
                 db,
-                user.email,
-                user.roles,
+                user,
                 module.name,
                 new_labels,
                 module.owner_email,
-                auth_method=user.auth_method,
             )
             if new_perm is None or REGISTRY_PERMISSION_HIERARCHY.get(
                 new_perm, -1
@@ -575,14 +559,12 @@ async def create_module_version_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "write"):
         raise HTTPException(
@@ -633,14 +615,12 @@ async def delete_module_version_endpoint(
     """Delete a specific module version. Requires admin on module."""
     module = await get_module(db, "default", name, provider)
     if module is not None:
-        perm = await resolve_registry_permission(
+        perm = await resolve_registry_permission_for(
             db,
-            user.email,
-            user.roles,
+            user,
             module.name,
             module.labels or {},
             module.owner_email,
-            auth_method=user.auth_method,
         )
         if not has_registry_permission(perm, "admin"):
             raise HTTPException(
@@ -676,14 +656,12 @@ async def upload_module_version_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "write"):
         raise HTTPException(
@@ -755,14 +733,12 @@ async def update_module_vcs_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -849,14 +825,12 @@ async def list_workspace_links(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Module not found")
@@ -884,14 +858,12 @@ async def create_workspace_link(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -957,14 +929,12 @@ async def delete_workspace_link(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         module.name,
         module.labels or {},
         module.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -42,7 +42,12 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_non_runner
+from terrapod.api.dependencies import (
+    AuthenticatedUser,
+    effective_platform_roles,
+    get_current_user,
+    require_non_runner,
+)
 from terrapod.api.labels import validate_labels
 from terrapod.config import settings
 from terrapod.db.session import get_db
@@ -406,7 +411,7 @@ async def update_provider_endpoint(
     attrs = body.get("data", {}).get("attributes", {})
 
     if "owner-email" in attrs:
-        if "admin" not in user.roles:
+        if "admin" not in effective_platform_roles(user):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only platform admins can change owner",
@@ -421,7 +426,7 @@ async def update_provider_endpoint(
         if (
             new_labels != (provider.labels or {})
             and not attrs.get("force")
-            and "admin" not in user.roles
+            and "admin" not in effective_platform_roles(user)
             and provider.owner_email != user.email
         ):
             new_perm = await resolve_registry_permission_for(

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -72,7 +72,7 @@ from terrapod.services.registry_provider_service import (
 from terrapod.services.registry_rbac_service import (
     REGISTRY_PERMISSION_HIERARCHY,
     has_registry_permission,
-    resolve_registry_permission,
+    resolve_registry_permission_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.protocol import ObjectStore
@@ -175,14 +175,12 @@ async def _require_provider_permission(
     required: str,
 ) -> None:
     """Check registry permission on a provider or raise 403."""
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, required):
         raise HTTPException(
@@ -215,14 +213,12 @@ async def list_provider_versions_cli(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Provider not found")
@@ -271,14 +267,12 @@ async def download_provider_cli(
 
     provider = await get_provider(db, namespace, name)
     if provider is not None:
-        perm = await resolve_registry_permission(
+        perm = await resolve_registry_permission_for(
             db,
-            user.email,
-            user.roles,
+            user,
             provider.name,
             provider.labels or {},
             provider.owner_email,
-            auth_method=user.auth_method,
         )
         if not has_registry_permission(perm, "read"):
             raise HTTPException(status_code=404, detail="Provider platform not found")
@@ -326,14 +320,12 @@ async def list_providers_endpoint(
     providers = await list_providers(db)
     visible = []
     for p in providers:
-        perm = await resolve_registry_permission(
+        perm = await resolve_registry_permission_for(
             db,
-            user.email,
-            user.roles,
+            user,
             p.name,
             p.labels or {},
             p.owner_email,
-            auth_method=user.auth_method,
         )
         if perm is not None:
             visible.append(_provider_to_jsonapi(p, perm))
@@ -351,14 +343,12 @@ async def show_provider_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Provider not found")
@@ -400,14 +390,12 @@ async def update_provider_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "admin"):
         raise HTTPException(
@@ -436,14 +424,12 @@ async def update_provider_endpoint(
             and "admin" not in user.roles
             and provider.owner_email != user.email
         ):
-            new_perm = await resolve_registry_permission(
+            new_perm = await resolve_registry_permission_for(
                 db,
-                user.email,
-                user.roles,
+                user,
                 provider.name,
                 new_labels,
                 provider.owner_email,
-                auth_method=user.auth_method,
             )
             if new_perm is None or REGISTRY_PERMISSION_HIERARCHY.get(
                 new_perm, -1
@@ -581,14 +567,12 @@ async def list_provider_versions_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Provider not found")
@@ -635,14 +619,12 @@ async def list_provider_platforms_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission(
+    perm = await resolve_registry_permission_for(
         db,
-        user.email,
-        user.roles,
+        user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
-        auth_method=user.auth_method,
     )
     if not has_registry_permission(perm, "read"):
         raise HTTPException(status_code=404, detail="Provider not found")

--- a/services/terrapod/api/routers/remote_state_consumers.py
+++ b/services/terrapod/api/routers/remote_state_consumers.py
@@ -34,7 +34,10 @@ from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.db.models import Workspace, WorkspaceRemoteStateConsumer
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 
 router = APIRouter(tags=["remote-state-consumers"])
 logger = get_logger(__name__)
@@ -97,7 +100,7 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
 async def _require_ws_permission(
     ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/services/terrapod/api/routers/run_tasks.py
+++ b/services/terrapod/api/routers/run_tasks.py
@@ -38,7 +38,10 @@ from terrapod.services.run_task_service import (
     resolve_stage,
     verify_callback_token,
 )
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 
 router = APIRouter(prefix="/api/v2", tags=["run-tasks"])
 
@@ -153,7 +156,7 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
 async def _require_ws_permission(
     ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -371,7 +374,7 @@ async def list_task_stages(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(status_code=403, detail="Requires read permission on workspace")
 
@@ -402,7 +405,7 @@ async def show_task_stage(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(status_code=403, detail="Requires read permission on workspace")
 
@@ -431,7 +434,7 @@ async def override_task_stage(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "admin"):
         raise HTTPException(status_code=403, detail="Requires admin permission on workspace")
 

--- a/services/terrapod/api/routers/run_triggers.py
+++ b/services/terrapod/api/routers/run_triggers.py
@@ -25,7 +25,10 @@ from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.db.models import RunTrigger, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 
 router = APIRouter(tags=["run-triggers"])
 logger = get_logger(__name__)
@@ -79,7 +82,7 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
 async def _require_ws_permission(
     ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -57,7 +57,10 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service, run_service
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 from terrapod.storage import get_storage
 from terrapod.storage.keys import apply_log_key, plan_json_output_key, plan_log_key
 from terrapod.storage.protocol import ObjectNotFoundError
@@ -268,7 +271,7 @@ async def _require_run_ws_permission(
     ws = await db.get(Workspace, run.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -409,7 +412,7 @@ async def create_run(
 
     # Check permission: plan-only requires plan, apply requires write
     required = "plan" if plan_only else "write"
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -546,7 +549,7 @@ async def list_workspace_runs(
 ) -> JSONResponse:
     """List runs for a workspace. Requires read."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -1326,7 +1329,7 @@ async def run_events_stream(
 
     async with get_db_session() as db:
         ws = await _get_workspace(workspace_id, db)
-        perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+        perm = await resolve_workspace_permission_for(db, user, ws)
         if not has_permission(perm, "read"):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/services/terrapod/api/routers/state_management.py
+++ b/services/terrapod/api/routers/state_management.py
@@ -23,7 +23,10 @@ from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.db.models import StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 from terrapod.storage import get_storage
 from terrapod.storage.keys import state_key
 
@@ -51,7 +54,7 @@ async def _require_sv_workspace_permission(
     ws = await db.get(Workspace, sv.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -224,7 +227,7 @@ async def upload_state_manual(
     from terrapod.api.routers.tfe_v2 import _get_workspace_by_id
 
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "write"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -387,7 +387,7 @@ async def account_details(
                 "attributes": {
                     "username": username,
                     "email": user.email,
-                    "is-service-account": user.auth_method == "api_token",
+                    "is-service-account": user.kind in ("service_bound", "service_detached"),
                     "avatar-url": "",
                     "v2-only": False,
                     "permissions": {
@@ -922,8 +922,7 @@ async def create_workspace(
             raise HTTPException(status_code=404, detail="Agent pool not found")
         pool_perm = await resolve_pool_permission_for(
             db,
-            user_email=user.email,
-            user_roles=user.roles,
+            user,
             pool_name=target_pool.name,
             pool_labels=target_pool.labels or {},
             owner_email=target_pool.owner_email or "",
@@ -1436,8 +1435,7 @@ async def update_workspace(
                 raise HTTPException(status_code=404, detail="Agent pool not found")
             pool_perm = await resolve_pool_permission_for(
                 db,
-                user_email=user.email,
-                user_roles=user.roles,
+                user,
                 pool_name=target_pool.name,
                 pool_labels=target_pool.labels or {},
                 owner_email=target_pool.owner_email or "",

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -63,7 +63,7 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service as _agent_pool_service
-from terrapod.services.pool_rbac_service import has_pool_permission, resolve_pool_permission
+from terrapod.services.pool_rbac_service import has_pool_permission, resolve_pool_permission_for
 from terrapod.services.workspace_rbac_service import (
     PERMISSION_HIERARCHY,
     has_permission,
@@ -919,7 +919,7 @@ async def create_workspace(
         target_pool = await _agent_pool_service.get_pool(db, agent_pool_id)
         if target_pool is None:
             raise HTTPException(status_code=404, detail="Agent pool not found")
-        pool_perm = await resolve_pool_permission(
+        pool_perm = await resolve_pool_permission_for(
             db,
             user_email=user.email,
             user_roles=user.roles,
@@ -1433,7 +1433,7 @@ async def update_workspace(
             target_pool = await _agent_pool_service.get_pool(db, new_pool_id)
             if target_pool is None:
                 raise HTTPException(status_code=404, detail="Agent pool not found")
-            pool_perm = await resolve_pool_permission(
+            pool_perm = await resolve_pool_permission_for(
                 db,
                 user_email=user.email,
                 user_roles=user.roles,

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -48,6 +48,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from terrapod.api.dependencies import (
     DEFAULT_ORG,
     AuthenticatedUser,
+    effective_platform_roles,
     get_current_user,
     require_non_runner,
 )
@@ -390,7 +391,7 @@ async def account_details(
                     "avatar-url": "",
                     "v2-only": False,
                     "permissions": {
-                        "can-create-organizations": "admin" in user.roles,
+                        "can-create-organizations": "admin" in effective_platform_roles(user),
                         "can-change-email": False,
                         "can-change-username": False,
                     },
@@ -424,13 +425,13 @@ async def show_organization(
                     "created-at": "2025-01-01T00:00:00.000Z",
                     "email": "",
                     "permissions": {
-                        "can-update": "admin" in user.roles,
+                        "can-update": "admin" in effective_platform_roles(user),
                         "can-destroy": False,
                         "can-access-via-teams": False,
                         "can-create-module": True,
                         "can-create-team": False,
                         "can-create-workspace": True,
-                        "can-manage-users": "admin" in user.roles,
+                        "can-manage-users": "admin" in effective_platform_roles(user),
                         "can-manage-subscription": False,
                         "can-manage-sso": False,
                         "can-update-oauth": False,
@@ -439,7 +440,7 @@ async def show_organization(
                         "can-update-api-token": True,
                         "can-traverse": True,
                         "can-start-trial": False,
-                        "can-update-agent-pools": "admin" in user.roles,
+                        "can-update-agent-pools": "admin" in effective_platform_roles(user),
                         "can-manage-tags": True,
                         "can-manage-varsets": True,
                         "can-read-varsets": True,
@@ -1271,7 +1272,7 @@ async def update_workspace(
 
     # owner-email can only be changed by platform admin
     if "owner-email" in attrs:
-        if "admin" not in user.roles:
+        if "admin" not in effective_platform_roles(user):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only platform admins can change workspace owner",
@@ -1383,7 +1384,7 @@ async def update_workspace(
         if (
             new_labels != (ws.labels or {})
             and not attrs.get("force")
-            and "admin" not in user.roles
+            and "admin" not in effective_platform_roles(user)
             and ws.owner_email != user.email
         ):
             old_labels = ws.labels

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -67,7 +67,7 @@ from terrapod.services.pool_rbac_service import has_pool_permission, resolve_poo
 from terrapod.services.workspace_rbac_service import (
     PERMISSION_HIERARCHY,
     has_permission,
-    resolve_workspace_permission,
+    resolve_workspace_permission_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.keys import state_index_key, state_key
@@ -828,7 +828,7 @@ async def list_workspaces(
     # Filter to workspaces user has at least read access to
     visible = []
     for ws in workspaces:
-        perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+        perm = await resolve_workspace_permission_for(db, user, ws)
         if perm is not None:
             visible.append(_workspace_json(ws, perm, latest_run=latest_runs.get(ws.id))["data"])
 
@@ -851,7 +851,7 @@ async def show_workspace(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if perm is None:
         # Runner-token consumers can resolve the producer workspace by name
         # so the OpenTofu `remote` backend's first hop (workspace lookup) in
@@ -1004,7 +1004,7 @@ async def _require_ws_permission(
 ) -> tuple[Workspace, str]:
     """Load workspace and check permission. Returns (workspace, effective_permission)."""
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -1101,7 +1101,7 @@ async def show_workspace_by_id(
     state-read endpoints further down.
     """
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         if await _runner_state_read_allowed(db, user, ws):
             perm = "read"
@@ -1388,7 +1388,7 @@ async def update_workspace(
         ):
             old_labels = ws.labels
             ws.labels = new_labels
-            new_perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+            new_perm = await resolve_workspace_permission_for(db, user, ws)
             ws.labels = old_labels  # revert before deciding
             if new_perm is None or PERMISSION_HIERARCHY.get(
                 new_perm, -1
@@ -1593,7 +1593,7 @@ async def current_state_version(
     """
     ws = await _get_workspace_by_id(workspace_id, db)
     if not await _runner_state_read_allowed(db, user, ws):
-        perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+        perm = await resolve_workspace_permission_for(db, user, ws)
         if not has_permission(perm, "read"):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -1638,7 +1638,7 @@ async def download_state(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
     if not await _runner_state_read_allowed(db, user, ws):
-        perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+        perm = await resolve_workspace_permission_for(db, user, ws)
         if not has_permission(perm, "plan"):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -1783,7 +1783,7 @@ async def show_state_version(
     # Check read permission on workspace
     ws = await db.get(Workspace, sv.workspace_id)
     if ws is not None:
-        perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+        perm = await resolve_workspace_permission_for(db, user, ws)
         if perm is None:
             raise HTTPException(status_code=404, detail="State version not found")
 
@@ -2039,7 +2039,7 @@ async def unlock_workspace(
 ) -> JSONResponse:
     """Unlock a workspace. Plan for own lock, admin for force-unlock."""
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
 
     # Check: at minimum plan permission required
     if not has_permission(perm, "plan"):

--- a/services/terrapod/api/routers/tokens.py
+++ b/services/terrapod/api/routers/tokens.py
@@ -103,6 +103,10 @@ def _token_to_jsonapi(token, raw_value: str | None = None) -> dict:  # type: ign
         "kind": token.kind,
         "bound-to": token.bound_to,
         "created-by": token.created_by,
+        # The token's pinned scope (service tokens). Null for interactive
+        # tokens. The tokens UI surfaces this so an operator can see exactly
+        # what a service token is scoped to.
+        "pinned-roles": token.pinned_roles,
         # token-type retained for response back-compat (superseded by kind).
         "token-type": token.token_type,
         "created-at": _rfc3339(token.created_at),

--- a/services/terrapod/api/routers/tokens.py
+++ b/services/terrapod/api/routers/tokens.py
@@ -48,8 +48,8 @@ from terrapod.redis.client import get_redis_client
 router = APIRouter(tags=["tokens"])
 logger = get_logger(__name__)
 
-# Kinds a user may create / re-tag in Phase 1. service_detached (admin-only,
-# absolute scope) is gated until the scoped-resolution phase lands.
+# Kinds anyone may create / re-tag bound to themselves. service_detached is
+# admin-only and handled separately (unbound, admin-pinned absolute scope).
 _CREATABLE_KINDS = {"interactive", "service_bound"}
 _ALL_KINDS = {"interactive", "service_bound", "service_detached"}
 _TOKEN_ROLES_PREFIX = "tp:token_roles:"
@@ -79,11 +79,12 @@ class CreateTokenRequest(BaseModel):
 
 
 class PatchTokenRequest(BaseModel):
-    """JSON:API request for re-tagging a token's kind."""
+    """JSON:API request for re-tagging a token's kind (and pinned roles on convert)."""
 
     class Data(BaseModel):
         class Attributes(BaseModel):
             kind: str
+            pinned_roles: list[str] | None = None
 
         type: str = "authentication-tokens"
         attributes: Attributes
@@ -138,8 +139,8 @@ async def create_user_token(
 
     The user_id in the path must match the authenticated user (or admin).
     Anyone may create `interactive` or `service_bound` tokens (bound to
-    themselves). `service_detached` is admin-only and not yet creatable
-    (gated until the scoped-resolution phase).
+    themselves). `service_detached` is admin-only and unbound — the admin
+    pins its absolute scope.
     """
     if user_id != _username(user) and not _is_admin(user):
         raise HTTPException(
@@ -148,22 +149,32 @@ async def create_user_token(
         )
 
     kind = body.data.attributes.kind
-    if kind == "service_detached":
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Detached service tokens are not yet available",
-        )
-    if kind not in _CREATABLE_KINDS:
+    if kind not in _ALL_KINDS:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Invalid token kind: {kind}",
         )
 
-    pinned = body.data.attributes.pinned_roles if kind == "service_bound" else None
+    if kind == "service_detached":
+        # Detached tokens are admin-only and unbound (no owner); the admin
+        # pins the absolute scope. Effective-admin is kind-attenuated.
+        if "admin" not in effective_platform_roles(user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Detached service tokens are admin-only",
+            )
+        bound_to = None
+        pinned = body.data.attributes.pinned_roles or []
+    elif kind == "service_bound":
+        bound_to = user.email
+        pinned = body.data.attributes.pinned_roles
+    else:  # interactive
+        bound_to = user.email
+        pinned = None
 
     api_token, raw_token = await create_api_token(
         db=db,
-        bound_to=user.email,
+        bound_to=bound_to,
         created_by=user.email,
         kind=kind,
         description=body.data.attributes.description,
@@ -284,10 +295,11 @@ async def retag_token(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """Re-tag a token's kind between interactive and service_bound.
+    """Re-tag a token's kind.
 
-    Owner or admin. Converting to/from service_detached is admin-only and
-    not yet supported (scoped-resolution phase).
+    interactive <-> service_bound is owner-or-admin. Converting to/from
+    service_detached is admin-only: TO detached unbinds the token and pins
+    the supplied absolute scope; FROM detached binds it to the acting admin.
     """
     api_token = await get_token_by_id(db, token_id)
     if api_token is None:
@@ -297,20 +309,42 @@ async def retag_token(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
     new_kind = body.data.attributes.kind
-    if new_kind == "service_detached" or api_token.kind == "service_detached":
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Converting to/from detached is not yet available",
-        )
-    if new_kind not in _CREATABLE_KINDS:
+    if new_kind not in _ALL_KINDS:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Invalid token kind: {new_kind}",
         )
 
-    api_token.kind = new_kind
+    if (new_kind == "service_detached" or api_token.kind == "service_detached") and (
+        "admin" not in effective_platform_roles(user)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Converting to/from detached is admin-only",
+        )
+
+    affected = {api_token.bound_to}
+    if new_kind == "service_detached":
+        api_token.kind = "service_detached"
+        api_token.bound_to = None
+        api_token.pinned_roles = body.data.attributes.pinned_roles or []
+    else:
+        api_token.kind = new_kind
+        if api_token.bound_to is None:  # coming from detached → bind to the acting admin
+            api_token.bound_to = user.email
+        if new_kind == "interactive":
+            api_token.pinned_roles = None
+        elif body.data.attributes.pinned_roles is not None:
+            api_token.pinned_roles = body.data.attributes.pinned_roles
+    affected.add(api_token.bound_to)
+
     await db.commit()
     await db.refresh(api_token)
+    # Bust cached role resolution for any affected identity (#495 B3).
+    redis = get_redis_client()
+    for email in affected:
+        if email:
+            await redis.delete(f"{_TOKEN_ROLES_PREFIX}{email}")
     return JSONResponse(content={"data": _token_to_jsonapi(api_token)})
 
 

--- a/services/terrapod/api/routers/tokens.py
+++ b/services/terrapod/api/routers/tokens.py
@@ -28,7 +28,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.api.dependencies import AuthenticatedUser, effective_platform_roles, get_current_user
 from terrapod.auth.api_tokens import (
     create_api_token,
     get_token_by_id,
@@ -120,7 +120,7 @@ def _token_to_jsonapi(token, raw_value: str | None = None) -> dict:  # type: ign
 
 
 def _is_admin(user: AuthenticatedUser) -> bool:
-    return "admin" in user.roles
+    return "admin" in effective_platform_roles(user)
 
 
 def _username(user: AuthenticatedUser) -> str:

--- a/services/terrapod/api/routers/variables.py
+++ b/services/terrapod/api/routers/variables.py
@@ -37,7 +37,10 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import variable_service
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 
 router = APIRouter(prefix="/api/v2", tags=["variables"])
 logger = get_logger(__name__)
@@ -96,7 +99,7 @@ async def list_workspace_vars(
 ) -> JSONResponse:
     """List all variables for a workspace. Requires read."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Requires read permission on workspace"
@@ -114,7 +117,7 @@ async def create_workspace_var(
 ) -> JSONResponse:
     """Create a variable for a workspace. Requires write."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "write"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Requires write permission on workspace"
@@ -157,7 +160,7 @@ async def update_workspace_var(
 ) -> JSONResponse:
     """Update a workspace variable. Requires write."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "write"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Requires write permission on workspace"
@@ -201,7 +204,7 @@ async def delete_workspace_var(
 ) -> None:
     """Delete a workspace variable. Requires write."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "write"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Requires write permission on workspace"

--- a/services/terrapod/api/routers/workspace_bulk.py
+++ b/services/terrapod/api/routers/workspace_bulk.py
@@ -29,7 +29,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from terrapod.api.dependencies import AuthenticatedUser, require_admin
+from terrapod.api.dependencies import AuthenticatedUser, effective_platform_roles, require_admin
 from terrapod.api.labels import validate_labels
 from terrapod.db.models import (
     AgentPool,
@@ -220,7 +220,7 @@ async def _validate_update(
                     raise HTTPException(status_code=422, detail="agent-pool-id not found")
                 # Assigning a pool requires pool `write` (platform admin bypass) —
                 # mirrors the single-workspace rule.
-                if "admin" not in user.roles:
+                if "admin" not in effective_platform_roles(user):
                     perm = await pool_rbac_service.resolve_pool_permission(
                         db, user.email, user.roles, pool.name, pool.labels, pool.owner_email
                     )

--- a/services/terrapod/api/routers/workspace_extensions.py
+++ b/services/terrapod/api/routers/workspace_extensions.py
@@ -20,7 +20,10 @@ from sse_starlette.sse import EventSourceResponse
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services.workspace_rbac_service import has_permission, resolve_workspace_permission
+from terrapod.services.workspace_rbac_service import (
+    has_permission,
+    resolve_workspace_permission_for,
+)
 
 router = APIRouter(tags=["workspace-extensions"])
 logger = get_logger(__name__)
@@ -92,7 +95,7 @@ async def list_vcs_refs(
     )
 
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -145,7 +148,7 @@ async def dismiss_drift(
     from terrapod.api.routers.tfe_v2 import _get_workspace_by_id
 
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission(db, user.email, user.roles, ws)
+    perm = await resolve_workspace_permission_for(db, user, ws)
     if not has_permission(perm, "plan"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/services/terrapod/services/labels_service.py
+++ b/services/terrapod/services/labels_service.py
@@ -62,14 +62,15 @@ async def _readable_workspaces(db: AsyncSession, user: AuthenticatedUser) -> lis
     result = await db.execute(select(Workspace).order_by(Workspace.name))
     workspaces = list(result.scalars().all())
     preloaded = await workspace_rbac_service.fetch_custom_roles(db, user.roles)
+    token_preloaded = await workspace_rbac_service.fetch_custom_roles(db, user.pinned_roles or [])
     out: list[Workspace] = []
     for ws in workspaces:
-        perm = await workspace_rbac_service.resolve_workspace_permission(
+        perm = await workspace_rbac_service.resolve_workspace_permission_for(
             db,
-            user_email=user.email,
-            user_roles=user.roles,
-            workspace=ws,
+            user,
+            ws,
             preloaded_roles=preloaded,
+            token_preloaded_roles=token_preloaded,
         )
         if perm is not None:
             out.append(ws)
@@ -80,16 +81,17 @@ async def _readable_pools(db: AsyncSession, user: AuthenticatedUser) -> list[Age
     result = await db.execute(select(AgentPool).order_by(AgentPool.name))
     pools = list(result.scalars().all())
     preloaded = await pool_rbac_service.fetch_custom_roles(db, user.roles)
+    token_preloaded = await pool_rbac_service.fetch_custom_roles(db, user.pinned_roles or [])
     out: list[AgentPool] = []
     for p in pools:
-        perm = await pool_rbac_service.resolve_pool_permission(
+        perm = await pool_rbac_service.resolve_pool_permission_for(
             db,
-            user_email=user.email,
-            user_roles=user.roles,
+            user,
             pool_name=p.name,
             pool_labels=p.labels or {},
             owner_email=p.owner_email or "",
             preloaded_roles=preloaded,
+            token_preloaded_roles=token_preloaded,
         )
         if perm is not None:
             out.append(p)
@@ -100,16 +102,17 @@ async def _readable_modules(db: AsyncSession, user: AuthenticatedUser) -> list[R
     result = await db.execute(select(RegistryModule).order_by(RegistryModule.name))
     modules = list(result.scalars().all())
     preloaded = await registry_rbac_service.fetch_custom_roles(db, user.roles)
+    token_preloaded = await registry_rbac_service.fetch_custom_roles(db, user.pinned_roles or [])
     out: list[RegistryModule] = []
     for m in modules:
-        perm = await registry_rbac_service.resolve_registry_permission(
+        perm = await registry_rbac_service.resolve_registry_permission_for(
             db,
-            user_email=user.email,
-            user_roles=user.roles,
+            user,
             resource_name=m.name,
             resource_labels=m.labels or {},
             owner_email=m.owner_email or "",
             preloaded_roles=preloaded,
+            token_preloaded_roles=token_preloaded,
         )
         if perm is not None:
             out.append(m)
@@ -120,16 +123,17 @@ async def _readable_providers(db: AsyncSession, user: AuthenticatedUser) -> list
     result = await db.execute(select(RegistryProvider).order_by(RegistryProvider.name))
     providers = list(result.scalars().all())
     preloaded = await registry_rbac_service.fetch_custom_roles(db, user.roles)
+    token_preloaded = await registry_rbac_service.fetch_custom_roles(db, user.pinned_roles or [])
     out: list[RegistryProvider] = []
     for p in providers:
-        perm = await registry_rbac_service.resolve_registry_permission(
+        perm = await registry_rbac_service.resolve_registry_permission_for(
             db,
-            user_email=user.email,
-            user_roles=user.roles,
+            user,
             resource_name=p.name,
             resource_labels=p.labels or {},
             owner_email=p.owner_email or "",
             preloaded_roles=preloaded,
+            token_preloaded_roles=token_preloaded,
         )
         if perm is not None:
             out.append(p)

--- a/services/terrapod/services/pool_rbac_service.py
+++ b/services/terrapod/services/pool_rbac_service.py
@@ -10,6 +10,8 @@ Resolution order: platform admin > audit > owner > label RBAC > everyone > none
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,6 +19,9 @@ from terrapod.auth.builtin_roles import BUILTIN_ROLE_NAMES
 from terrapod.db.models import Role
 from terrapod.logging_config import get_logger
 from terrapod.services.rbac_service import matches_labels, merge_labels
+
+if TYPE_CHECKING:
+    from terrapod.api.dependencies import AuthenticatedUser
 
 logger = get_logger(__name__)
 
@@ -57,6 +62,7 @@ async def resolve_pool_permission(
     owner_email: str | None,
     *,
     preloaded_roles: list[Role] | None = None,
+    apply_everyone_floor: bool = True,
 ) -> str | None:
     """Returns highest permission level (read/write/admin), or None.
 
@@ -125,9 +131,68 @@ async def resolve_pool_permission(
                 ) > POOL_PERMISSION_HIERARCHY.get(best, -1):
                     best = pool_perm
 
-    # 5. 'everyone' role: if pool has label access=everyone, grant read
-    if pool_labels.get("access") == "everyone":
+    # 5. 'everyone' role: if pool has label access=everyone, grant read.
+    # Suppressed for token-scope resolution (apply_everyone_floor=False, #495).
+    if apply_everyone_floor and pool_labels.get("access") == "everyone":
         if best is None:
             best = "read"
 
     return best
+
+
+def min_pool_permission(a: str | None, b: str | None) -> str | None:
+    """Lower of two pool permission levels (None = no access; None dominates)."""
+    if a is None or b is None:
+        return None
+    return a if POOL_PERMISSION_HIERARCHY[a] <= POOL_PERMISSION_HIERARCHY[b] else b
+
+
+async def resolve_pool_permission_for(
+    db: AsyncSession,
+    user: AuthenticatedUser,
+    pool_name: str,
+    pool_labels: dict,
+    owner_email: str | None,
+    *,
+    preloaded_roles: list[Role] | None = None,
+    token_preloaded_roles: list[Role] | None = None,
+) -> str | None:
+    """Kind-aware pool permission (#495).
+
+    interactive -> resolve(user roles); service_bound -> min(user, token);
+    service_detached -> token scope only (pinned roles, no owner, floor off).
+    """
+    if user.kind == "service_detached":
+        return await resolve_pool_permission(
+            db,
+            "",
+            user.pinned_roles or [],
+            pool_name,
+            pool_labels,
+            owner_email,
+            preloaded_roles=token_preloaded_roles,
+            apply_everyone_floor=False,
+        )
+
+    user_eff = await resolve_pool_permission(
+        db,
+        user.email,
+        user.roles,
+        pool_name,
+        pool_labels,
+        owner_email,
+        preloaded_roles=preloaded_roles,
+    )
+    if user.kind == "service_bound":
+        token_eff = await resolve_pool_permission(
+            db,
+            "",
+            user.pinned_roles or [],
+            pool_name,
+            pool_labels,
+            owner_email,
+            preloaded_roles=token_preloaded_roles,
+            apply_everyone_floor=False,
+        )
+        return min_pool_permission(user_eff, token_eff)
+    return user_eff

--- a/services/terrapod/services/registry_rbac_service.py
+++ b/services/terrapod/services/registry_rbac_service.py
@@ -8,6 +8,8 @@ Permission hierarchy: read < write < admin
 Resolution order: platform admin > audit > owner > label RBAC > everyone > none
 """
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,6 +17,9 @@ from terrapod.auth.builtin_roles import BUILTIN_ROLE_NAMES
 from terrapod.db.models import Role
 from terrapod.logging_config import get_logger
 from terrapod.services.rbac_service import matches_labels, merge_labels
+
+if TYPE_CHECKING:
+    from terrapod.api.dependencies import AuthenticatedUser
 
 logger = get_logger(__name__)
 
@@ -65,6 +70,7 @@ async def resolve_registry_permission(
     auth_method: str = "",
     *,
     preloaded_roles: list[Role] | None = None,
+    apply_everyone_floor: bool = True,
 ) -> str | None:
     """Returns highest permission level (read/write/admin), or None.
 
@@ -139,9 +145,73 @@ async def resolve_registry_permission(
                 ) > REGISTRY_PERMISSION_HIERARCHY.get(best, -1):
                     best = registry_perm
 
-    # 6. 'everyone' role: if resource has label access=everyone, grant read
-    if resource_labels.get("access") == "everyone":
+    # 6. 'everyone' role: if resource has label access=everyone, grant read.
+    # Suppressed for token-scope resolution (apply_everyone_floor=False, #495).
+    if apply_everyone_floor and resource_labels.get("access") == "everyone":
         if best is None:
             best = "read"
 
     return best
+
+
+def min_registry_permission(a: str | None, b: str | None) -> str | None:
+    """Lower of two registry permission levels (None = no access; None dominates)."""
+    if a is None or b is None:
+        return None
+    return a if REGISTRY_PERMISSION_HIERARCHY[a] <= REGISTRY_PERMISSION_HIERARCHY[b] else b
+
+
+async def resolve_registry_permission_for(
+    db: AsyncSession,
+    user: "AuthenticatedUser",
+    resource_name: str,
+    resource_labels: dict,
+    owner_email: str,
+    *,
+    preloaded_roles: list[Role] | None = None,
+    token_preloaded_roles: list[Role] | None = None,
+) -> str | None:
+    """Kind-aware registry permission (#495).
+
+    interactive -> resolve(user roles, real auth_method); service_bound ->
+    min(user, token); service_detached -> token scope only. Token-side
+    resolution uses no owner identity, no runner floor, and the everyone-floor
+    suppressed.
+    """
+    if user.kind == "service_detached":
+        return await resolve_registry_permission(
+            db,
+            "",
+            user.pinned_roles or [],
+            resource_name,
+            resource_labels,
+            owner_email,
+            auth_method="",
+            preloaded_roles=token_preloaded_roles,
+            apply_everyone_floor=False,
+        )
+
+    user_eff = await resolve_registry_permission(
+        db,
+        user.email,
+        user.roles,
+        resource_name,
+        resource_labels,
+        owner_email,
+        auth_method=user.auth_method,
+        preloaded_roles=preloaded_roles,
+    )
+    if user.kind == "service_bound":
+        token_eff = await resolve_registry_permission(
+            db,
+            "",
+            user.pinned_roles or [],
+            resource_name,
+            resource_labels,
+            owner_email,
+            auth_method="",
+            preloaded_roles=token_preloaded_roles,
+            apply_everyone_floor=False,
+        )
+        return min_registry_permission(user_eff, token_eff)
+    return user_eff

--- a/services/terrapod/services/workspace_rbac_service.py
+++ b/services/terrapod/services/workspace_rbac_service.py
@@ -7,6 +7,8 @@ Permission hierarchy: read < plan < write < admin
 Resolution order: platform admin > audit > owner > label RBAC > everyone > none
 """
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +16,9 @@ from terrapod.auth.builtin_roles import BUILTIN_ROLE_NAMES
 from terrapod.db.models import Role, Workspace
 from terrapod.logging_config import get_logger
 from terrapod.services.rbac_service import matches_labels, merge_labels
+
+if TYPE_CHECKING:
+    from terrapod.api.dependencies import AuthenticatedUser
 
 logger = get_logger(__name__)
 
@@ -50,6 +55,7 @@ async def resolve_workspace_permission(
     workspace: Workspace,
     *,
     preloaded_roles: list[Role] | None = None,
+    apply_everyone_floor: bool = True,
 ) -> str | None:
     """Returns the highest permission level for a user on a workspace, or None.
 
@@ -121,10 +127,67 @@ async def resolve_workspace_permission(
                 ):
                     best = perm
 
-    # 5. 'everyone' role: if workspace has label access=everyone, grant read
+    # 5. 'everyone' role: if workspace has label access=everyone, grant read.
+    # Suppressed (apply_everyone_floor=False) when resolving a token's own
+    # pinned scope, so a zero-scope service token does not inherit read on
+    # every access:everyone resource (#495 — the floor is label-gated, so
+    # dropping `everyone` from the role list alone would not suppress it).
     resource_labels = workspace.labels or {}
-    if resource_labels.get("access") == "everyone":
+    if apply_everyone_floor and resource_labels.get("access") == "everyone":
         if best is None:
             best = "read"
 
     return best
+
+
+def min_workspace_permission(a: str | None, b: str | None) -> str | None:
+    """Lower of two workspace permission levels (None = no access; None dominates)."""
+    if a is None or b is None:
+        return None
+    return a if PERMISSION_HIERARCHY[a] <= PERMISSION_HIERARCHY[b] else b
+
+
+async def resolve_workspace_permission_for(
+    db: AsyncSession,
+    user: "AuthenticatedUser",
+    workspace: Workspace,
+    *,
+    preloaded_roles: list[Role] | None = None,
+    token_preloaded_roles: list[Role] | None = None,
+) -> str | None:
+    """Kind-aware workspace permission for an authenticated principal (#495).
+
+    - interactive       -> resolve(user's live roles)
+    - service_bound     -> min(user_effective, token_effective)
+    - service_detached  -> token_effective only
+
+    ``token_effective`` resolves the token's pinned roles with no owner
+    identity (empty email) and the everyone-floor suppressed. Pass the per-side
+    ``fetch_custom_roles`` results as ``preloaded_roles`` (owner) and
+    ``token_preloaded_roles`` (pinned) for loop callers; None for a single
+    resolve.
+    """
+    if user.kind == "service_detached":
+        return await resolve_workspace_permission(
+            db,
+            "",
+            user.pinned_roles or [],
+            workspace,
+            preloaded_roles=token_preloaded_roles,
+            apply_everyone_floor=False,
+        )
+
+    user_eff = await resolve_workspace_permission(
+        db, user.email, user.roles, workspace, preloaded_roles=preloaded_roles
+    )
+    if user.kind == "service_bound":
+        token_eff = await resolve_workspace_permission(
+            db,
+            "",
+            user.pinned_roles or [],
+            workspace,
+            preloaded_roles=token_preloaded_roles,
+            apply_everyone_floor=False,
+        )
+        return min_workspace_permission(user_eff, token_eff)
+    return user_eff

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -213,7 +213,7 @@ class TestListPoolsRBAC:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -250,7 +250,7 @@ class TestListPoolsRBAC:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -287,7 +287,7 @@ class TestPoolStatus:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -321,7 +321,7 @@ class TestPoolStatus:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -349,7 +349,7 @@ class TestPoolStatus:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_show_pool_includes_status(
@@ -443,7 +443,7 @@ class TestDerivePoolStatus:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -485,7 +485,7 @@ class TestListListenersReplicaCount:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_listeners_carry_replica_count(
@@ -526,7 +526,7 @@ class TestListListenersReplicaCount:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_replica_count_omitted_when_listener_does_not_track_pods(
@@ -565,7 +565,7 @@ class TestListListenersReplicaCount:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_replica_count_included_for_mixed_listeners(
@@ -608,7 +608,7 @@ class TestShowPoolRBAC:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_show_pool_with_read(
@@ -637,7 +637,7 @@ class TestShowPoolRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_show_pool_no_access_returns_404(self, mock_resolve, mock_get_pool, *mocks):
@@ -733,7 +733,7 @@ class TestUpdatePoolRBAC:
     @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_update_pool_with_labels(self, mock_resolve, mock_get_pool, mock_update, *mocks):
@@ -768,7 +768,7 @@ class TestUpdatePoolRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_update_pool_write_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
@@ -803,7 +803,7 @@ class TestDeletePoolRBAC:
     )
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_delete_pool_with_admin(
@@ -829,7 +829,7 @@ class TestDeletePoolRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_delete_pool_no_access_returns_404(self, mock_resolve, mock_get_pool, *mocks):
@@ -856,7 +856,7 @@ class TestTokenEndpointRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_list_tokens_read_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
@@ -880,7 +880,7 @@ class TestTokenEndpointRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_create_token_read_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
@@ -910,7 +910,7 @@ class TestUpdatePoolSelfLockout:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_label_change_reducing_access_returns_409(
@@ -942,7 +942,7 @@ class TestUpdatePoolSelfLockout:
     @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_force_bypasses_lockout_check(
@@ -975,7 +975,7 @@ class TestUpdatePoolSelfLockout:
     @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_platform_admin_immune_to_lockout(
@@ -1016,7 +1016,7 @@ class TestDeleteListenerRBAC:
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_listener")
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_delete_listener_with_pool_admin(
@@ -1043,7 +1043,7 @@ class TestDeleteListenerRBAC:
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_listener")
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission",
+        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     async def test_delete_listener_read_only_returns_403(

--- a/services/tests/api/test_ai_summary.py
+++ b/services/tests/api/test_ai_summary.py
@@ -127,7 +127,7 @@ class TestGetPlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_returns_summary_when_present(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         run = _mock_run()
@@ -159,7 +159,7 @@ class TestGetPlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_returns_404_when_no_summary(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         run = _mock_run()
@@ -182,7 +182,7 @@ class TestGetPlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_plan_response_includes_ai_summary_url(self, mock_resolve, *mocks):
         """GET /plans/{id} advertises the ai-summary-url even when no row exists yet."""
         mock_resolve.return_value = "read"
@@ -208,7 +208,7 @@ class TestGetPlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_plan_response_omits_ai_summary_url_when_disabled(self, mock_resolve, *mocks):
         """AI globally disabled → plan response carries no ai-summary-url
         so the UI doesn't fetch /plan-summary and waste a round-trip
@@ -240,7 +240,7 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_get_includes_ai_summary_fields(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace(ai_summary_mode="enabled", ai_summary_context="vault prod")
@@ -263,7 +263,7 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_patch_accepts_valid_mode(self, mock_resolve, *mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
@@ -294,7 +294,7 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_patch_rejects_invalid_mode(self, mock_resolve, *mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
@@ -315,7 +315,7 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_patch_rejects_oversize_context(self, mock_resolve, *mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
@@ -336,7 +336,7 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_patch_rejects_non_string_context(self, mock_resolve, *mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
@@ -367,7 +367,7 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_planned_run_returns_202_and_enqueues(
         self, mock_enq, mock_resolve, *_mocks
@@ -417,7 +417,7 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_plan_phase_errored_picks_failure_analysis(
         self, mock_enq, mock_resolve, *_mocks
@@ -456,7 +456,7 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_apply_phase_errored_picks_failure_analysis(
         self, mock_enq, mock_resolve, *_mocks
@@ -499,7 +499,7 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_409_when_no_summary_kind_applies(
         self, mock_enq, mock_resolve, *_mocks
@@ -558,7 +558,7 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_403_when_no_workspace_read(self, mock_enq, mock_resolve, *_mocks):
         """No workspace read → 403 (the permission helper raises)."""

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -85,7 +85,7 @@ class TestWorkspaceDriftAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_workspace_includes_drift_attributes(self, mock_resolve, *mocks):
         """GET workspace includes drift fields in response."""
         mock_resolve.return_value = "read"
@@ -109,7 +109,7 @@ class TestWorkspaceDriftAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_update_drift_settings(self, mock_resolve, *mocks):
         """PATCH workspace drift-detection-enabled updates model."""
         mock_resolve.return_value = "admin"
@@ -141,7 +141,7 @@ class TestWorkspaceDriftAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_drift_interval_minimum_enforced(self, mock_resolve, *mocks):
         """Interval below minimum is clamped to configured floor."""
         mock_resolve.return_value = "admin"
@@ -177,7 +177,7 @@ class TestRunDriftAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_run_includes_drift_fields(self, mock_resolve, *mocks):
         """GET run includes is-drift-detection and has-changes."""
         mock_resolve.return_value = "read"
@@ -253,7 +253,7 @@ class TestDismissDriftAction:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission_for")
     async def test_dismiss_drift_clears_state_and_keeps_detection_enabled(
         self, mock_resolve, *mocks
     ):
@@ -289,7 +289,7 @@ class TestDismissDriftAction:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission_for")
     async def test_dismiss_drift_requires_plan_permission(self, mock_resolve, *mocks):
         """Read-only users cannot dismiss drift."""
         mock_resolve.return_value = "read"
@@ -313,7 +313,7 @@ class TestDismissDriftAction:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission_for")
     async def test_dismiss_drift_is_idempotent(self, mock_resolve, *mocks):
         """Dismissing a workspace with no drift reported is a no-op (still 200)."""
         mock_resolve.return_value = "plan"

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -156,7 +156,7 @@ class TestRunJsonModuleOverrides:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.get_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_run_json_includes_module_overrides(self, mock_resolve, mock_get_run, *mocks):
         overrides = {"default/eks/aws": "module_overrides/abc123/default/eks/aws.tar.gz"}
         run = _mock_run(module_overrides=overrides, source="module-test")
@@ -265,7 +265,7 @@ class TestRetryRunCopiesOverrides:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_retry_copies_module_overrides(
         self, mock_resolve, mock_get_run, mock_create_run, mock_queue, *mocks
     ):
@@ -304,7 +304,7 @@ class TestWorkspaceLinkCRUD:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission_for")
     @patch("terrapod.api.routers.registry_modules.get_module")
     async def test_list_workspace_links(self, mock_get_module, mock_resolve, *mocks):
         module = _mock_module()
@@ -333,7 +333,7 @@ class TestWorkspaceLinkCRUD:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission_for")
     @patch("terrapod.api.routers.registry_modules.get_module")
     async def test_create_workspace_link_requires_admin(
         self, mock_get_module, mock_resolve, *mocks

--- a/services/tests/api/test_notification_configurations.py
+++ b/services/tests/api/test_notification_configurations.py
@@ -74,7 +74,7 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_create_generic(self, mock_resolve, *mocks):
         """Create generic webhook → 201."""
         mock_resolve.return_value = "admin"
@@ -108,7 +108,7 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_create_invalid_type(self, mock_resolve, *mocks):
         """Invalid destination-type → 422."""
         mock_resolve.return_value = "admin"
@@ -139,7 +139,7 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_create_invalid_triggers(self, mock_resolve, *mocks):
         """Invalid trigger event → 422."""
         mock_resolve.return_value = "admin"
@@ -172,7 +172,7 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_create_requires_admin(self, mock_resolve, *mocks):
         """Write permission → 403."""
         mock_resolve.return_value = "write"
@@ -204,7 +204,7 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_create_email_requires_addresses(self, mock_resolve, *mocks):
         """Email type without email-addresses → 422."""
         mock_resolve.return_value = "admin"
@@ -236,7 +236,7 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_create_generic_requires_url(self, mock_resolve, *mocks):
         """Generic without url → 422."""
         mock_resolve.return_value = "admin"
@@ -272,7 +272,7 @@ class TestListNotificationConfigurations:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_list(self, mock_resolve, *mocks):
         """List returns configs. Read permission sufficient."""
         mock_resolve.return_value = "read"
@@ -304,7 +304,7 @@ class TestShowNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_show(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         nc = _mock_nc()
@@ -350,7 +350,7 @@ class TestUpdateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_update_name(self, mock_resolve, *mocks):
         """PATCH updates name → 200."""
         mock_resolve.return_value = "admin"
@@ -378,7 +378,7 @@ class TestUpdateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_update_requires_admin(self, mock_resolve, *mocks):
         """Write permission → 403."""
         mock_resolve.return_value = "write"
@@ -405,7 +405,7 @@ class TestDeleteNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     async def test_delete(self, mock_resolve, *mocks):
         """Admin can delete → 204."""
         mock_resolve.return_value = "admin"
@@ -432,7 +432,7 @@ class TestVerifyNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.notification_configurations.deliver_notification")
     @patch("terrapod.api.routers.notification_configurations.record_delivery_response")
     async def test_verify(self, mock_record, mock_deliver, mock_resolve, *mocks):

--- a/services/tests/api/test_remote_state_consumers.py
+++ b/services/tests/api/test_remote_state_consumers.py
@@ -154,7 +154,7 @@ class TestRunnerAuthzWiring:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id", new_callable=AsyncMock)
     @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
     async def test_current_state_version_grants_when_helper_returns_true(
@@ -192,7 +192,7 @@ class TestRunnerAuthzWiring:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id", new_callable=AsyncMock)
     @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
     async def test_current_state_version_falls_through_and_denies_runner(
@@ -221,7 +221,7 @@ class TestRunnerAuthzWiring:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
     async def test_download_state_falls_through_and_denies_runner(self, m_helper, m_resolve, *_):
         """Same wiring guarantee for the download endpoint — helper
@@ -259,7 +259,7 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
     @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
     async def test_create_happy_path(self, mock_publish, mock_resolve, *_):
         """Admin on producer → 201, and the response JSON carries the
@@ -325,7 +325,7 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
     async def test_create_requires_producer_admin(self, mock_resolve, *_):
         """Read on producer is not enough — mutation requires admin."""
         mock_resolve.return_value = "read"
@@ -349,7 +349,7 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
     async def test_create_self_reference_rejected(self, mock_resolve, *_):
         """A workspace listing itself is meaningless (already reads own state)."""
         mock_resolve.return_value = "admin"
@@ -370,7 +370,7 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
     async def test_create_duplicate_rejected(self, mock_resolve, *_):
         mock_resolve.return_value = "admin"
         producer = _mock_ws(name="producer")
@@ -399,7 +399,7 @@ class TestListConsumers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
     async def test_list_outbound_default(self, mock_resolve, *_):
         """No filter ⇒ outbound (workspaces I share to)."""
         mock_resolve.return_value = "read"
@@ -422,7 +422,7 @@ class TestListConsumers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
     async def test_list_invalid_filter_rejected(self, mock_resolve, *_):
         mock_resolve.return_value = "read"
         producer = _mock_ws()
@@ -444,7 +444,7 @@ class TestDeleteConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
     async def test_delete_happy(self, mock_resolve, *_):
         """Admin on producer → 204."""
         mock_resolve.return_value = "admin"
@@ -467,7 +467,7 @@ class TestDeleteConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
     async def test_delete_requires_producer_admin(self, mock_resolve, *_):
         """A consumer (or any non-admin) cannot revoke their own grant
         — only the producer's admin may delete an edge."""

--- a/services/tests/api/test_run_tasks.py
+++ b/services/tests/api/test_run_tasks.py
@@ -99,7 +99,7 @@ class TestCreateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_create(self, mock_resolve, *mocks):
         """Create run task → 201."""
         mock_resolve.return_value = "admin"
@@ -134,7 +134,7 @@ class TestCreateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_create_invalid_stage(self, mock_resolve, *mocks):
         """Invalid stage → 422."""
         mock_resolve.return_value = "admin"
@@ -166,7 +166,7 @@ class TestCreateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_create_requires_admin(self, mock_resolve, *mocks):
         """Write permission → 403."""
         mock_resolve.return_value = "write"
@@ -197,7 +197,7 @@ class TestCreateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_create_missing_url(self, mock_resolve, *mocks):
         """Missing url → 422."""
         mock_resolve.return_value = "admin"
@@ -233,7 +233,7 @@ class TestListRunTasks:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_list(self, mock_resolve, *mocks):
         """List returns tasks. Read permission sufficient."""
         mock_resolve.return_value = "read"
@@ -265,7 +265,7 @@ class TestShowRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_show(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         rt = _mock_run_task()
@@ -310,7 +310,7 @@ class TestUpdateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_update_name(self, mock_resolve, *mocks):
         """PATCH updates name → 200."""
         mock_resolve.return_value = "admin"
@@ -338,7 +338,7 @@ class TestUpdateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_update_requires_admin(self, mock_resolve, *mocks):
         """Write permission → 403."""
         mock_resolve.return_value = "write"
@@ -365,7 +365,7 @@ class TestDeleteRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
     async def test_delete(self, mock_resolve, *mocks):
         """Admin can delete → 204."""
         mock_resolve.return_value = "admin"

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -66,7 +66,7 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
     async def test_create_run_trigger(self, mock_publish, mock_resolve, *mocks):
         """Happy path: create a run trigger → 201."""
@@ -122,7 +122,7 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_create_self_referential_rejected(self, mock_resolve, *mocks):
         """Same source and destination workspace → 422."""
         mock_resolve.return_value = "admin"
@@ -151,7 +151,7 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_create_duplicate_rejected(self, mock_resolve, *mocks):
         """Same pair twice → 409."""
         mock_resolve.return_value = "admin"
@@ -191,7 +191,7 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_create_max_20_sources(self, mock_resolve, *mocks):
         """21st source → 422."""
         mock_resolve.return_value = "admin"
@@ -235,7 +235,7 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_create_requires_admin(self, mock_resolve, *mocks):
         """Non-admin → 403."""
         mock_resolve.return_value = "write"
@@ -270,7 +270,7 @@ class TestListRunTriggers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_list_inbound(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
@@ -296,7 +296,7 @@ class TestListRunTriggers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_list_outbound(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
@@ -322,7 +322,7 @@ class TestListRunTriggers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_list_requires_filter(self, mock_resolve, *mocks):
         """Missing filter → 422."""
         mock_resolve.return_value = "read"
@@ -348,7 +348,7 @@ class TestShowRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_show_run_trigger(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         trigger = _mock_trigger()
@@ -385,7 +385,7 @@ class TestDeleteRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
     async def test_delete_run_trigger(self, mock_resolve, *mocks):
         """Happy path → 204."""
         mock_resolve.return_value = "admin"

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -117,7 +117,7 @@ class TestCreateRun:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_create_plan_only_with_plan_perm(
         self, mock_resolve, mock_create_run, mock_queue, *mocks
     ):
@@ -153,7 +153,7 @@ class TestCreateRun:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_create_apply_needs_write_perm(self, mock_resolve, *mocks):
         """Plan-only=false (default) requires write permission."""
         mock_resolve.return_value = "plan"  # only plan, not write
@@ -195,7 +195,7 @@ class TestCreateRun:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_latest_uploaded_cv")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_non_vcs_no_cv_uses_latest_uploaded_cv(
         self, mock_resolve, mock_get_cv, mock_create_run, mock_queue, *mocks
     ):
@@ -239,7 +239,7 @@ class TestCreateRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.get_latest_uploaded_cv")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_non_vcs_no_cv_no_uploaded_cv_returns_422(
         self, mock_resolve, mock_get_cv, *mocks
     ):
@@ -277,7 +277,7 @@ class TestCreateRun:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_latest_uploaded_cv")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_vcs_workspace_with_empty_repo_url_falls_back_to_uploaded_cv(
         self, mock_resolve, mock_get_cv, mock_create_run, mock_queue, *mocks
     ):
@@ -327,7 +327,7 @@ class TestShowRun:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_show_with_read(self, mock_get_run, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
@@ -365,7 +365,7 @@ class TestConfirmRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_with_write_perm(self, mock_get_run, mock_resolve, mock_confirm, *mocks):
         mock_resolve.return_value = "write"
@@ -389,7 +389,7 @@ class TestConfirmRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_wrong_state_returns_409(
         self, mock_get_run, mock_resolve, mock_confirm, *mocks
@@ -414,7 +414,7 @@ class TestConfirmRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_no_changes_returns_422(
         self, mock_get_run, mock_resolve, mock_confirm, *mocks
@@ -454,7 +454,7 @@ class TestDiscardRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.discard_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_discard_with_plan_perm(self, mock_get_run, mock_resolve, mock_discard, *mocks):
         mock_resolve.return_value = "plan"
@@ -482,7 +482,7 @@ class TestCancelRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.cancel_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_cancel_with_plan_perm(self, mock_get_run, mock_resolve, mock_cancel, *mocks):
         mock_resolve.return_value = "plan"
@@ -505,7 +505,7 @@ class TestCancelRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.cancel_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_cancel_terminal_returns_409(
         self, mock_get_run, mock_resolve, mock_cancel, *mocks
@@ -534,7 +534,7 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_actions_block(self, mock_get_run, mock_resolve, *mocks):
         """Verify actions reflect run state."""
@@ -560,7 +560,7 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_no_changes_hides_confirm_and_discard(self, mock_get_run, mock_resolve, *mocks):
         """Planned run with has_changes=False must not advertise confirm/discard.
@@ -606,7 +606,7 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_is_cancelable_by_status(
         self,
@@ -634,7 +634,7 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_timestamps_rfc3339(self, mock_get_run, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
@@ -655,7 +655,7 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_auto_apply_not_confirmable(self, mock_get_run, mock_resolve, *mocks):
         """Auto-apply runs in planned state are NOT confirmable."""
@@ -683,7 +683,7 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_create_apply_blocked_on_vcs_remote_workspace(self, mock_resolve, *mocks):
         """Remote + VCS + plan_only=false → 422."""
         mock_resolve.return_value = "write"
@@ -717,7 +717,7 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_create_apply_blocked_even_with_spoofed_vcs_source(self, mock_resolve, *mocks):
         """Remote + VCS + CLI CV + source='vcs' spoofed → still 422."""
         mock_resolve.return_value = "write"
@@ -753,7 +753,7 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_create_apply_allowed_on_non_vcs_remote_workspace(
         self, mock_resolve, mock_create_run, mock_queue, *mocks
     ):
@@ -796,7 +796,7 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_create_plan_forced_on_vcs_remote_workspace(
         self, mock_resolve, mock_create_run, mock_queue, *mocks
     ):
@@ -837,7 +837,7 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_blocked_on_vcs_remote_workspace(
         self, mock_get_run, mock_resolve, *mocks
@@ -866,7 +866,7 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_allowed_for_ui_queued_vcs_run(
         self, mock_get_run, mock_resolve, mock_confirm, *mocks
@@ -897,7 +897,7 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_allowed_on_non_vcs_remote_workspace(
         self, mock_get_run, mock_resolve, mock_confirm, *mocks
@@ -1028,7 +1028,7 @@ class TestPlanJsonAttribute:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_attribute_present_when_uploaded(self, mock_get_run, mock_resolve, *_mocks):
         mock_resolve.return_value = "read"
@@ -1050,7 +1050,7 @@ class TestPlanJsonAttribute:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_attribute_absent_when_not_uploaded(self, mock_get_run, mock_resolve, *_mocks):
         """Don't advertise a URL we know would 404. Older / errored / failed-upload
@@ -1078,7 +1078,7 @@ class TestRetryRun:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_retry_attaches_latest_cv_when_source_has_none(
         self, mock_resolve, mock_get_run, mock_create_run, mock_queue, *mocks
     ):
@@ -1117,7 +1117,7 @@ class TestRetryRun:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     async def test_retry_rejects_when_workspace_has_no_cv(
         self, mock_resolve, mock_get_run, mock_create_run, *mocks
     ):

--- a/services/tests/api/test_service_tokens.py
+++ b/services/tests/api/test_service_tokens.py
@@ -107,6 +107,32 @@ async def test_create_detached_non_admin_403(*_):
 
 
 @_app_patched
+@patch("terrapod.api.routers.tokens.create_api_token")
+async def test_create_detached_admin_unbound(mock_create, *_):
+    # An admin CAN create a detached token; it is unbound (bound-to null) and
+    # carries the pinned scope the admin specified.
+    mock_create.return_value = (
+        _token_mock(kind="service_detached", bound_to=None, pinned_roles=["deployer"]),
+        "raw.tpod.secret",
+    )
+    app = _make_app(_user(roles=["admin"]))
+    async with _client(app) as c:
+        r = await c.post(
+            "/api/terrapod/v1/users/dev/authentication-tokens",
+            json={
+                "data": {"attributes": {"kind": "service_detached", "pinned_roles": ["deployer"]}}
+            },
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 201
+    attrs = r.json()["data"]["attributes"]
+    assert attrs["kind"] == "service_detached"
+    assert attrs["bound-to"] is None
+    # The endpoint pins the token unbound, regardless of the path username.
+    assert mock_create.call_args.kwargs["bound_to"] is None
+
+
+@_app_patched
 @patch("terrapod.api.routers.tokens.list_all_tokens")
 async def test_admin_list_kind_filter(mock_list, *_):
     mock_list.return_value = [_token_mock(kind="service_bound")]
@@ -237,6 +263,31 @@ async def test_retag_to_detached_non_admin_403(mock_get, *_):
             headers={"Authorization": "Bearer x"},
         )
     assert r.status_code == 403
+
+
+@_app_patched
+@patch("terrapod.api.routers.tokens.get_redis_client")
+@patch("terrapod.api.routers.tokens.get_token_by_id")
+async def test_retag_to_detached_admin_unbinds(mock_get, mock_redis, *_):
+    # An admin converting a bound token TO detached unbinds it, pins the
+    # supplied scope, and busts the role cache for the (former) owner.
+    mock_get.return_value = _token_mock(kind="service_bound", bound_to="dev@example.com")
+    mock_redis.return_value = MagicMock(delete=AsyncMock())
+    app = _make_app(_user(roles=["admin"]))
+    async with _client(app) as c:
+        r = await c.patch(
+            "/api/terrapod/v1/authentication-tokens/at-svc",
+            json={
+                "data": {"attributes": {"kind": "service_detached", "pinned_roles": ["deployer"]}}
+            },
+            headers={"Authorization": "Bearer x"},
+        )
+    assert r.status_code == 200
+    attrs = r.json()["data"]["attributes"]
+    assert attrs["kind"] == "service_detached"
+    assert attrs["bound-to"] is None
+    # The former owner's cached role resolution is invalidated.
+    mock_redis.return_value.delete.assert_any_await("tp:token_roles:dev@example.com")
 
 
 def test_no_token_path_under_api_v2():

--- a/services/tests/api/test_service_tokens.py
+++ b/services/tests/api/test_service_tokens.py
@@ -94,15 +94,16 @@ async def test_create_service_bound(mock_create, *_):
 
 
 @_app_patched
-async def test_create_detached_gated_422(*_):
-    app = _make_app(_user(roles=["admin"]))
+async def test_create_detached_non_admin_403(*_):
+    # Detached tokens are admin-only and unbound; a non-admin is refused.
+    app = _make_app(_user())  # no admin role
     async with _client(app) as c:
         r = await c.post(
             "/api/terrapod/v1/users/dev/authentication-tokens",
             json={"data": {"attributes": {"kind": "service_detached"}}},
             headers={"Authorization": "Bearer x"},
         )
-    assert r.status_code == 422
+    assert r.status_code == 403
 
 
 @_app_patched
@@ -224,16 +225,18 @@ async def test_expiring_caller_scoped(mock_expiring, *_):
 
 @_app_patched
 @patch("terrapod.api.routers.tokens.get_token_by_id")
-async def test_retag_to_detached_gated_422(mock_get, *_):
+async def test_retag_to_detached_non_admin_403(mock_get, *_):
+    # Converting a token TO detached is admin-only — even the token's own
+    # owner can't self-promote it to an unbound detached token.
     mock_get.return_value = _token_mock(kind="interactive", bound_to="dev@example.com")
-    app = _make_app(_user(roles=["admin"]))
+    app = _make_app(_user())  # owner of the token, but not admin
     async with _client(app) as c:
         r = await c.patch(
             "/api/terrapod/v1/authentication-tokens/at-svc",
             json={"data": {"attributes": {"kind": "service_detached"}}},
             headers={"Authorization": "Bearer x"},
         )
-    assert r.status_code == 422
+    assert r.status_code == 403
 
 
 def test_no_token_path_under_api_v2():

--- a/services/tests/api/test_service_tokens.py
+++ b/services/tests/api/test_service_tokens.py
@@ -91,6 +91,8 @@ async def test_create_service_bound(mock_create, *_):
     assert attrs["kind"] == "service_bound"
     assert attrs["token"] == "raw.tpod.secret"
     assert attrs["bound-to"] == "dev@example.com"
+    # The pinned scope is surfaced so the tokens UI can display it (#495).
+    assert attrs["pinned-roles"] == ["plan-only"]
 
 
 @_app_patched

--- a/services/tests/api/test_state_management.py
+++ b/services/tests/api/test_state_management.py
@@ -82,7 +82,7 @@ class TestDeleteStateVersion:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
     @patch("terrapod.api.routers.state_management.get_storage")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
     async def test_delete_non_current_state_version(
         self,
         mock_resolve,
@@ -126,7 +126,7 @@ class TestDeleteStateVersion:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
     async def test_delete_current_state_version_rejected(
         self,
         mock_resolve,
@@ -162,7 +162,7 @@ class TestDeleteStateVersion:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
     async def test_delete_state_requires_admin(
         self,
         mock_resolve,
@@ -203,7 +203,7 @@ class TestRollbackStateVersion:
     @patch("terrapod.api.metrics.STATE_VERSIONS_CREATED")
     @patch("terrapod.api.routers.tfe_v2._state_version_json")
     @patch("terrapod.api.routers.state_management.get_storage")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
     async def test_rollback_creates_new_version(
         self,
         mock_resolve,
@@ -255,7 +255,7 @@ class TestRollbackStateVersion:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.state_management.get_storage")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
     async def test_rollback_missing_storage_returns_404(
         self,
         mock_resolve,
@@ -301,7 +301,7 @@ class TestUploadState:
     @patch("terrapod.api.metrics.STATE_VERSIONS_CREATED")
     @patch("terrapod.api.routers.tfe_v2._state_version_json")
     @patch("terrapod.api.routers.state_management.get_storage")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id")
     async def test_upload_state_manual(
         self,
@@ -350,7 +350,7 @@ class TestUploadState:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id")
     async def test_upload_state_requires_write(
         self,
@@ -381,7 +381,7 @@ class TestUploadState:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id")
     async def test_upload_invalid_json_returns_400(
         self,
@@ -478,7 +478,7 @@ class TestRunDetailStateVersion:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission")
+    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_show_run_includes_state_version(
         self,

--- a/services/tests/api/test_tfe_v2.py
+++ b/services/tests/api/test_tfe_v2.py
@@ -163,6 +163,7 @@ class TestTokenCRUD:
         mock_token.kind = "interactive"
         mock_token.bound_to = "test@example.com"
         mock_token.created_by = "test@example.com"
+        mock_token.pinned_roles = None
         mock_token.created_at = datetime(2026, 1, 1, tzinfo=UTC)
         mock_token.rotated_at = None
         mock_token.last_used_at = None
@@ -217,6 +218,7 @@ class TestTokenCRUD:
         mock_token.kind = "interactive"
         mock_token.bound_to = "test@example.com"
         mock_token.created_by = "test@example.com"
+        mock_token.pinned_roles = None
         mock_token.created_at = datetime(2026, 1, 1, tzinfo=UTC)
         mock_token.rotated_at = None
         mock_token.last_used_at = None

--- a/services/tests/api/test_tfe_v2.py
+++ b/services/tests/api/test_tfe_v2.py
@@ -102,12 +102,15 @@ class TestAccountDetails:
     async def test_account_details_api_token_is_service_account(
         self, mock_init_db, mock_init_redis, mock_init_storage
     ):
+        # A service-kind token (service_bound/service_detached) is a service
+        # account; an interactive token (terraform login) is not (#495).
         user = AuthenticatedUser(
             email="bot@example.com",
             display_name=None,
             roles=[],
             provider_name="api_token",
             auth_method="api_token",
+            kind="service_bound",
         )
         app = _make_app_with_auth(user)
 

--- a/services/tests/api/test_variables.py
+++ b/services/tests/api/test_variables.py
@@ -72,7 +72,7 @@ class TestListVariables:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.list_variables")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_list_with_read_perm(self, mock_resolve, mock_list, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
@@ -96,7 +96,7 @@ class TestListVariables:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.list_variables")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_sensitive_values_masked(self, mock_resolve, mock_list, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
@@ -117,7 +117,7 @@ class TestListVariables:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_list_no_permission_returns_403(self, mock_resolve, *mocks):
         mock_resolve.return_value = None
         ws = _mock_workspace()
@@ -139,7 +139,7 @@ class TestCreateVariable:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.create_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_create_with_write_perm(self, mock_resolve, mock_create, *mocks):
         mock_resolve.return_value = "write"
         ws = _mock_workspace()
@@ -170,7 +170,7 @@ class TestCreateVariable:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_create_missing_key_returns_422(self, mock_resolve, *mocks):
         mock_resolve.return_value = "write"
         ws = _mock_workspace()
@@ -190,7 +190,7 @@ class TestCreateVariable:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_create_read_only_returns_403(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
@@ -211,7 +211,7 @@ class TestCreateVariable:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.create_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_create_encryption_error_returns_422(self, mock_resolve, mock_create, *mocks):
         mock_resolve.return_value = "write"
         mock_create.side_effect = ValueError("encryption not configured")
@@ -239,7 +239,7 @@ class TestUpdateVariable:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.update_variable")
     @patch("terrapod.api.routers.variables.variable_service.get_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_update_with_write_perm(self, mock_resolve, mock_get, mock_update, *mocks):
         mock_resolve.return_value = "write"
         ws = _mock_workspace()
@@ -264,7 +264,7 @@ class TestUpdateVariable:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.get_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_update_not_found_returns_404(self, mock_resolve, mock_get, *mocks):
         mock_resolve.return_value = "write"
         mock_get.return_value = None
@@ -292,7 +292,7 @@ class TestDeleteVariable:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.delete_variable")
     @patch("terrapod.api.routers.variables.variable_service.get_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission")
+    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
     async def test_delete_with_write_perm(self, mock_resolve, mock_get, mock_delete, *mocks):
         mock_resolve.return_value = "write"
         ws = _mock_workspace()

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -93,7 +93,7 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.api.routers.tfe_v2.resolve_pool_permission",
+        "terrapod.api.routers.tfe_v2.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
@@ -141,7 +141,7 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.api.routers.tfe_v2.resolve_pool_permission",
+        "terrapod.api.routers.tfe_v2.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
@@ -224,7 +224,7 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.api.routers.tfe_v2.resolve_pool_permission",
+        "terrapod.api.routers.tfe_v2.resolve_pool_permission_for",
         new_callable=AsyncMock,
     )
     @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -160,7 +160,7 @@ class TestShowWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_show_by_name(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace(name="test-ws")
@@ -183,7 +183,7 @@ class TestShowWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_show_no_permission_returns_404(self, mock_resolve, *mocks):
         """TFE behavior: workspace invisible (404) when no permission, not 403."""
         mock_resolve.return_value = None
@@ -224,7 +224,7 @@ class TestShowWorkspaceById:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_show_by_id_with_read(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
@@ -245,7 +245,7 @@ class TestShowWorkspaceById:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_show_by_id_no_permission_returns_403(self, mock_resolve, *mocks):
         mock_resolve.return_value = None
         ws = _mock_workspace()
@@ -266,7 +266,7 @@ class TestUpdateWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_update_requires_admin(self, mock_resolve, *mocks):
         mock_resolve.return_value = "write"  # not admin
         ws = _mock_workspace()
@@ -286,7 +286,7 @@ class TestUpdateWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_update_owner_requires_platform_admin(self, mock_resolve, *mocks):
         """owner-email change requires platform admin, not just workspace admin."""
         mock_resolve.return_value = "admin"
@@ -314,7 +314,7 @@ class TestDeleteWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_delete_with_admin_returns_204(self, mock_resolve, *mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
@@ -330,7 +330,7 @@ class TestDeleteWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_delete_without_admin_returns_403(self, mock_resolve, *mocks):
         mock_resolve.return_value = "write"
         ws = _mock_workspace()
@@ -351,7 +351,7 @@ class TestLockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_lock_with_plan_permission(self, mock_resolve, *mocks):
         mock_resolve.return_value = "plan"
         ws = _mock_workspace(locked=False)
@@ -372,7 +372,7 @@ class TestLockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_lock_already_locked_returns_409(self, mock_resolve, *mocks):
         mock_resolve.return_value = "plan"
         ws = _mock_workspace(locked=True, lock_id="lock-other@test.com")
@@ -391,7 +391,7 @@ class TestLockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_lock_read_only_returns_403(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace()
@@ -412,7 +412,7 @@ class TestUnlockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_unlock_own_lock(self, mock_resolve, *mocks):
         mock_resolve.return_value = "plan"
         ws = _mock_workspace(locked=True, lock_id="lock-test@example.com")
@@ -433,7 +433,7 @@ class TestUnlockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_force_unlock_requires_admin(self, mock_resolve, *mocks):
         """Non-admin with plan perm can't force-unlock another user's lock."""
         mock_resolve.return_value = "plan"
@@ -453,7 +453,7 @@ class TestUnlockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_admin_can_force_unlock(self, mock_resolve, *mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace(locked=True, lock_id="lock-other@test.com")
@@ -478,7 +478,7 @@ class TestPermissionsBlock:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_read_user_permissions(self, mock_resolve, *mocks):
         """Read permission: can read, but not update/destroy/queue."""
         mock_resolve.return_value = "read"
@@ -504,7 +504,7 @@ class TestPermissionsBlock:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_admin_user_permissions(self, mock_resolve, *mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
@@ -564,7 +564,7 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_returns_labels_as_bindings(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace(labels={"repo": "infra-core", "env": "dev"})
@@ -593,7 +593,7 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_empty_labels_returns_empty_array(self, mock_resolve, *mocks):
         mock_resolve.return_value = "read"
         ws = _mock_workspace(labels={})
@@ -612,7 +612,7 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_no_permission_blocks_access(self, mock_resolve, *mocks):
         mock_resolve.return_value = None
         ws = _mock_workspace()
@@ -630,7 +630,7 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_effective_tag_bindings_mirrors_workspace_bindings(self, mock_resolve, *mocks):
         # Terrapod has no project hierarchy, so effective bindings == workspace bindings
         mock_resolve.return_value = "read"
@@ -764,7 +764,7 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_default_workspace_serializes_default_workflow(self, mock_resolve, *_mocks):
         """Default-mode regression: an existing workspace serializes with the
         new attributes at default values. Frontend / providers must see the
@@ -790,7 +790,7 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_invalid_workflow_value_rejected(self, mock_resolve, *_mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
@@ -812,7 +812,7 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_apply_then_merge_requires_vcs_connection(self, mock_resolve, *_mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()  # no VCS connection
@@ -833,7 +833,7 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_apply_then_merge_incompatible_with_auto_apply(self, mock_resolve, *_mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace(auto_apply=True)
@@ -855,7 +855,7 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_combined_flip_off_auto_apply_and_into_apply_then_merge_succeeds(
         self, mock_resolve, *_mocks
     ):
@@ -892,7 +892,7 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_workflow_flip_blocked_by_active_pr_runs(self, mock_resolve, *_mocks):
         """Q4 of the design: cannot flip vcs-workflow with PR runs in flight.
         Operator must cancel/discard them first."""
@@ -922,7 +922,7 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_invalid_auto_merge_strategy_rejected(self, mock_resolve, *_mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()
@@ -943,7 +943,7 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
     async def test_auto_merge_toggle_persists(self, mock_resolve, *_mocks):
         mock_resolve.return_value = "admin"
         ws = _mock_workspace()

--- a/services/tests/services/test_token_scoped_rbac.py
+++ b/services/tests/services/test_token_scoped_rbac.py
@@ -1,0 +1,251 @@
+"""Token-scoped RBAC resolution (#495).
+
+Phase 2 of scoped service tokens introduces three token kinds and the
+kind-aware ``resolve_*_permission_for`` wrappers:
+
+* ``interactive``      -> resolve the principal's live roles (status quo).
+* ``service_bound``    -> ``min(user_effective, token_effective)`` per
+                          resource, so a bound token can only ever be a
+                          subset of its owner's live access.
+* ``service_detached`` -> ``token_effective`` alone (pinned roles only, no
+                          owner identity, no everyone-floor).
+
+These tests pin the intersection maths, the floor suppression, and the
+kind-attenuated platform-role view that the admin/audit gates consume.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from terrapod.api.dependencies import AuthenticatedUser, effective_platform_roles
+from terrapod.services import (
+    pool_rbac_service,
+    registry_rbac_service,
+    workspace_rbac_service,
+)
+
+
+def _user(*, email="dev@example.com", roles=None, kind="interactive", pinned=None):
+    return AuthenticatedUser(
+        email=email,
+        display_name=None,
+        roles=roles or [],
+        provider_name="api_token",
+        auth_method="api_token",
+        kind=kind,
+        pinned_roles=pinned,
+    )
+
+
+def _workspace(*, name="ws-1", labels=None, owner_email=None):
+    ws = MagicMock()
+    ws.name = name
+    ws.labels = labels or {}
+    ws.owner_email = owner_email
+    return ws
+
+
+def _role(*, name, workspace_permission="read", pool_permission="read", allow_names=None):
+    role = MagicMock()
+    role.name = name
+    role.workspace_permission = workspace_permission
+    role.pool_permission = pool_permission
+    role.allow_labels = {}
+    role.allow_names = allow_names or []
+    role.deny_labels = {}
+    role.deny_names = []
+    return role
+
+
+def _db_with_roles(roles):
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = roles
+    db.execute.return_value = result
+    return db
+
+
+# --------------------------------------------------------------------------
+# effective_platform_roles — kind attenuation of the admin/audit name-set
+# --------------------------------------------------------------------------
+
+
+class TestEffectivePlatformRoles:
+    def test_interactive_passes_live_roles_through(self):
+        u = _user(roles=["admin", "audit"], kind="interactive")
+        assert effective_platform_roles(u) == {"admin", "audit"}
+
+    def test_service_bound_intersects_live_and_pinned(self):
+        # Owner is admin, token pinned to a non-admin role -> no admin.
+        u = _user(roles=["admin"], kind="service_bound", pinned=["deployer"])
+        assert effective_platform_roles(u) == set()
+
+    def test_service_bound_keeps_role_in_both(self):
+        u = _user(roles=["admin", "deployer"], kind="service_bound", pinned=["admin"])
+        assert effective_platform_roles(u) == {"admin"}
+
+    def test_service_detached_uses_pinned_only(self):
+        # Detached carries no live-role identity; the pinned set is absolute.
+        u = _user(roles=[], kind="service_detached", pinned=["admin"])
+        assert effective_platform_roles(u) == {"admin"}
+
+    def test_service_bound_cannot_synthesize_admin_from_pin_alone(self):
+        # A non-admin owner pinning "admin" must NOT become admin.
+        u = _user(roles=["deployer"], kind="service_bound", pinned=["admin"])
+        assert effective_platform_roles(u) == set()
+
+
+# --------------------------------------------------------------------------
+# min_* helpers
+# --------------------------------------------------------------------------
+
+
+class TestMinHelpers:
+    def test_workspace_none_dominates(self):
+        assert workspace_rbac_service.min_workspace_permission("admin", None) is None
+        assert workspace_rbac_service.min_workspace_permission(None, "read") is None
+
+    def test_workspace_lower_wins(self):
+        assert workspace_rbac_service.min_workspace_permission("admin", "plan") == "plan"
+        assert workspace_rbac_service.min_workspace_permission("read", "write") == "read"
+
+    def test_pool_lower_wins(self):
+        assert pool_rbac_service.min_pool_permission("admin", "write") == "write"
+        assert pool_rbac_service.min_pool_permission("read", None) is None
+
+    def test_registry_lower_wins(self):
+        assert registry_rbac_service.min_registry_permission("write", "admin") == "write"
+        assert registry_rbac_service.min_registry_permission(None, "read") is None
+
+
+# --------------------------------------------------------------------------
+# resolve_workspace_permission_for — kind-aware resolution
+# --------------------------------------------------------------------------
+
+
+class TestWorkspaceForResolution:
+    async def test_interactive_uses_live_roles(self):
+        ws = _workspace(name="ws-1")
+        role = _role(name="deployer", workspace_permission="write", allow_names=["ws-1"])
+        db = _db_with_roles([role])
+        u = _user(roles=["deployer"], kind="interactive")
+        perm = await workspace_rbac_service.resolve_workspace_permission_for(db, u, ws)
+        assert perm == "write"
+
+    async def test_service_bound_is_intersection(self):
+        # Owner has write via "deployer"; token pinned to "viewer" (read).
+        # min(write, read) -> read.
+        ws = _workspace(name="ws-1")
+        deployer = _role(name="deployer", workspace_permission="write", allow_names=["ws-1"])
+        viewer = _role(name="viewer", workspace_permission="read", allow_names=["ws-1"])
+        db = _db_with_roles([deployer, viewer])
+        u = _user(roles=["deployer"], kind="service_bound", pinned=["viewer"])
+        # Pass both sides' preloaded role pools; the resolver filters by name
+        # in-code, so owner (deployer→write) and token (viewer→read) resolve
+        # to their own role rather than the union.
+        perm = await workspace_rbac_service.resolve_workspace_permission_for(
+            db, u, ws, preloaded_roles=[deployer, viewer], token_preloaded_roles=[deployer, viewer]
+        )
+        assert perm == "read"
+
+    async def test_service_bound_capped_by_owner(self):
+        # Token pinned to admin role, but owner only has read -> min -> read.
+        ws = _workspace(name="ws-1")
+        viewer = _role(name="viewer", workspace_permission="read", allow_names=["ws-1"])
+        superuser = _role(name="superuser", workspace_permission="admin", allow_names=["ws-1"])
+        db = _db_with_roles([viewer, superuser])
+        u = _user(roles=["viewer"], kind="service_bound", pinned=["superuser"])
+        perm = await workspace_rbac_service.resolve_workspace_permission_for(
+            db,
+            u,
+            ws,
+            preloaded_roles=[viewer, superuser],
+            token_preloaded_roles=[viewer, superuser],
+        )
+        assert perm == "read"
+
+    async def test_service_bound_owner_no_access_yields_none(self):
+        # Owner can't see the workspace at all -> bound token can't either.
+        ws = _workspace(name="ws-1")
+        superuser = _role(name="superuser", workspace_permission="admin", allow_names=["ws-1"])
+        db = _db_with_roles([superuser])
+        # Owner holds no role granting ws-1; pinned role would grant admin.
+        u = _user(roles=[], kind="service_bound", pinned=["superuser"])
+        perm = await workspace_rbac_service.resolve_workspace_permission_for(db, u, ws)
+        assert perm is None
+
+    async def test_service_detached_uses_pinned_only(self):
+        ws = _workspace(name="ws-1")
+        superuser = _role(name="superuser", workspace_permission="admin", allow_names=["ws-1"])
+        db = _db_with_roles([superuser])
+        # No live roles, no owner identity — pinned admin role stands alone.
+        u = _user(email="", roles=[], kind="service_detached", pinned=["superuser"])
+        perm = await workspace_rbac_service.resolve_workspace_permission_for(db, u, ws)
+        assert perm == "admin"
+
+    async def test_detached_does_not_get_everyone_floor(self):
+        # access:everyone grants interactive users read; a detached token with
+        # no matching pinned role gets nothing (floor suppressed).
+        ws = _workspace(name="ws-1", labels={"access": "everyone"})
+        db = _db_with_roles([])
+        detached = _user(email="", roles=[], kind="service_detached", pinned=[])
+        assert (
+            await workspace_rbac_service.resolve_workspace_permission_for(db, detached, ws) is None
+        )
+        # ...whereas an interactive everyone-holder gets the read floor.
+        interactive = _user(roles=["everyone"], kind="interactive")
+        assert (
+            await workspace_rbac_service.resolve_workspace_permission_for(db, interactive, ws)
+            == "read"
+        )
+
+    async def test_bound_token_does_not_get_everyone_floor_on_token_side(self):
+        # Owner gets read via the everyone floor; the token side has the floor
+        # suppressed, so min(read, None) -> None: a bound token cannot ride the
+        # everyone floor.
+        ws = _workspace(name="ws-1", labels={"access": "everyone"})
+        db = _db_with_roles([])
+        u = _user(roles=["everyone"], kind="service_bound", pinned=[])
+        perm = await workspace_rbac_service.resolve_workspace_permission_for(db, u, ws)
+        assert perm is None
+
+
+# --------------------------------------------------------------------------
+# pool + registry _for wrappers (smoke; share the workspace machinery)
+# --------------------------------------------------------------------------
+
+
+class TestPoolAndRegistryForResolution:
+    async def test_pool_service_bound_intersection(self):
+        writer = _role(name="pool-writer", pool_permission="write", allow_names=["pool-1"])
+        admin_r = _role(name="pool-admin", pool_permission="admin", allow_names=["pool-1"])
+        db = _db_with_roles([writer, admin_r])
+        u = _user(roles=["pool-admin"], kind="service_bound", pinned=["pool-writer"])
+        perm = await pool_rbac_service.resolve_pool_permission_for(
+            db,
+            u,
+            pool_name="pool-1",
+            pool_labels={},
+            owner_email=None,
+            preloaded_roles=[writer, admin_r],
+            token_preloaded_roles=[writer, admin_r],
+        )
+        assert perm == "write"
+
+    async def test_registry_detached_pinned_only(self):
+        writer = _role(name="mod-writer", workspace_permission="write", allow_names=["mod-1"])
+        db = _db_with_roles([writer])
+        u = _user(email="", roles=[], kind="service_detached", pinned=["mod-writer"])
+        perm = await registry_rbac_service.resolve_registry_permission_for(
+            db, u, resource_name="mod-1", resource_labels={}, owner_email=""
+        )
+        assert perm == "write"
+
+    async def test_registry_detached_ignores_owner_identity(self):
+        # Even if the detached token's (empty) email matched an owner, the
+        # detached path passes empty owner identity, so ownership can't apply.
+        db = _db_with_roles([])
+        u = _user(email="", roles=[], kind="service_detached", pinned=[])
+        perm = await registry_rbac_service.resolve_registry_permission_for(
+            db, u, resource_name="mod-1", resource_labels={}, owner_email=""
+        )
+        assert perm is None


### PR DESCRIPTION
Part of **#495** (scoped service tokens + token-expiry warnings), delivered as a single minor release across several PRs. **Phase 1** (#498) landed the data model, migration, token creation/validation, the idle-login rejection marker, and the config/Helm knobs. This is **Phase 2: kind-aware scoped permission resolution** — the server-side enforcement that makes the three token kinds actually *mean* something.

This PR does not close #495; the remaining phases (frontend tokens page + expiry banners, go-terrapod typed methods, docs, and the release cut) follow.

## What this adds

Three token kinds now resolve permissions differently everywhere RBAC is evaluated:

| Kind | Resolution |
|---|---|
| `interactive` | the principal's live roles (status quo — `terraform login` tokens) |
| `service_bound` | per-resource **`min(owner_effective, token_effective)`** — a bound token can never exceed its owner's live access |
| `service_detached` | `token_effective` alone (pinned roles, no owner identity, everyone-floor suppressed) |

### Mechanism

- **`AuthenticatedUser`** gains `kind` + `pinned_roles`. `roles` stays the principal's *un-attenuated* live roles (the `min()` input); `pinned_roles` carries the token's own scope.
- **`effective_platform_roles(user)`** — kind-attenuated admin/audit name-set for the platform gates (`require_admin`, inline `"admin"`/`"audit"` checks). interactive → live roles; bound → live ∩ pinned; detached → pinned. This is a *derived* view used only by name-based gates; it is never substituted for `user.roles`, which the per-resource `min()` needs un-attenuated. A non-admin owner pinning `admin` does **not** become admin.
- **`resolve_{workspace,pool,registry}_permission_for(db, user, …)`** wrappers wrap the existing positional resolvers with the kind logic, plus `min_*_permission()` helpers. All ~70 call sites + `labels_service` migrated to the wrappers.
- **`apply_everyone_floor` param** on each resolver — the `access:everyone` read floor is label-gated, not role-gated, so suppressing it for the token side needs an explicit flag (dropping the `everyone` role isn't enough). Bound/detached token-side resolution sets it off, so a service token can't ride the everyone floor.
- **Detached create/convert is admin-only** (403 for non-admins), unbinds the token, and busts the affected identities' cached role resolution.
- **`is-service-account`** is now derived from `kind` (`service_bound`/`service_detached`), not `auth_method`.
- **Serializer** now emits `pinned-roles` so the (Phase 3) tokens UI can show an operator exactly what a service token is scoped to.

## Tests

- `test_token_scoped_rbac.py` — `effective_platform_roles` attenuation (incl. the can't-synthesize-admin case), the `min_*` helpers, and `resolve_*_for` for all three kinds (intersection, owner-capping, detached pinned-only, everyone-floor suppression on the token side).
- `test_service_tokens.py` — admin detached create (unbound) + admin retag-to-detached (unbinds + cache bust) + the `pinned-roles` serializer assertion; the gate tests now assert the correct **403** (admin-only) rather than 422.
- Router-level resolver patches retargeted to the `_for` wrappers across the suite.
- Full suite green: **2145 passed**.

## Live Tilt smoke

Created a `service_bound` token owned by `admin` (platform admin → admin on every workspace), pinned to a read-only role matching one workspace's labels, against the real API + DB:

- GET the matching workspace → **200** (read)
- PATCH the matching workspace → **403** — capped to read despite the owner being admin (`min(admin, read) = read`)
- GET a non-matching workspace → **403** — token role doesn't match its labels (`min(admin, None) = None`)

The `pinned-roles` serializer gap was caught here and fixed in this PR.
