### PR TITLE
feat(web): scoped service tokens UI + expiry warnings (#495 Phase 3)

### DIFF
--- a/e2e/tests/tokens.spec.ts
+++ b/e2e/tests/tokens.spec.ts
@@ -4,6 +4,8 @@ test.describe('API Tokens', () => {
   test('token list page loads', async ({ page }) => {
     await page.goto('/settings/tokens');
     await expect(page.locator('h1:has-text("API Tokens")')).toBeVisible();
+    // Kind column is part of the scoped-service-token surface (#495).
+    await expect(page.locator('th:has-text("Kind")')).toBeVisible();
   });
 
   test('create token shows success banner with raw token', async ({ page }) => {
@@ -16,8 +18,8 @@ test.describe('API Tokens', () => {
     // Submit button inside form says "Create"
     await page.click('button[type="submit"]:has-text("Create")');
 
-    // Success banner should show the raw token
-    await expect(page.locator('text=Token created successfully')).toBeVisible({ timeout: 10_000 });
+    // Success banner should show the raw token (shared by create + rotate).
+    await expect(page.locator('text=Token ready')).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('code')).toBeVisible();
   });
 
@@ -53,5 +55,42 @@ test.describe('API Tokens', () => {
 
     // Should be removed
     await expect(row).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test('create a service token, see its kind badge + rotate it (#495)', async ({ page }) => {
+    const desc = `e2e-service-${Date.now()}`;
+
+    await page.goto('/settings/tokens');
+    await page.click('button:has-text("Create Token")');
+    await page.fill('#tok-desc', desc);
+
+    // Choose the bound service kind; the kind-specific help + role picker appear.
+    await page.selectOption('#tok-kind', 'service_bound');
+    await page.click('button[type="submit"]:has-text("Create")');
+
+    // Banner + the new row carries the service badge.
+    await expect(page.locator('text=Token ready')).toBeVisible({ timeout: 10_000 });
+    const row = page.locator(`tr:has-text("${desc}")`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row.locator('text=Service · bound')).toBeVisible();
+
+    // Service tokens expose a Rotate action that mints a fresh secret.
+    await page.on('dialog', (d) => d.accept());
+    await row.locator('button:has-text("Rotate")').click();
+    await expect(page.locator('text=Token ready')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('code')).toBeVisible();
+  });
+
+  test('admin can filter all tokens by kind (#495)', async ({ page }) => {
+    await page.goto('/settings/tokens');
+
+    // The All Tokens view is admin-only and exposes the kind filter.
+    await page.click('button:has-text("All Tokens")');
+    await expect(page.locator('#kind-filter')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('th:has-text("Bound To")')).toBeVisible();
+
+    // Filtering by a valid-but-maybe-empty kind must not error the page.
+    await page.selectOption('#kind-filter', 'service_detached');
+    await expect(page.locator('h1:has-text("API Tokens")')).toBeVisible();
   });
 });

--- a/e2e/tests/tokens.spec.ts
+++ b/e2e/tests/tokens.spec.ts
@@ -4,8 +4,6 @@ test.describe('API Tokens', () => {
   test('token list page loads', async ({ page }) => {
     await page.goto('/settings/tokens');
     await expect(page.locator('h1:has-text("API Tokens")')).toBeVisible();
-    // Kind column is part of the scoped-service-token surface (#495).
-    await expect(page.locator('th:has-text("Kind")')).toBeVisible();
   });
 
   test('create token shows success banner with raw token', async ({ page }) => {
@@ -23,7 +21,7 @@ test.describe('API Tokens', () => {
     await expect(page.locator('code')).toBeVisible();
   });
 
-  test('new token appears in table', async ({ page }) => {
+  test('new token appears in table with a Kind column', async ({ page }) => {
     const desc = `e2e-list-${Date.now()}`;
 
     await page.goto('/settings/tokens');
@@ -32,8 +30,10 @@ test.describe('API Tokens', () => {
     await page.fill('#tok-desc', desc);
     await page.click('button[type="submit"]:has-text("Create")');
 
-    // Wait for the token to appear in the table
+    // Wait for the token to appear in the table, then the table exists so the
+    // Kind column header (scoped-service-token surface, #495) is present.
     await expect(page.locator(`td:has-text("${desc}")`)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('th:has-text("Kind")')).toBeVisible();
   });
 
   test('revoke token removes it from table', async ({ page }) => {
@@ -75,19 +75,24 @@ test.describe('API Tokens', () => {
     await expect(row.locator('text=Service · bound')).toBeVisible();
 
     // Service tokens expose a Rotate action that mints a fresh secret.
-    await page.on('dialog', (d) => d.accept());
+    page.on('dialog', (d) => d.accept());
     await row.locator('button:has-text("Rotate")').click();
     await expect(page.locator('text=Token ready')).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('code')).toBeVisible();
   });
 
-  test('admin can filter all tokens by kind (#495)', async ({ page }) => {
+  test('admin All Tokens view exposes the kind filter + Bound To column (#495)', async ({ page }) => {
+    // Seed a token so the table (and thus the Bound To header) renders.
     await page.goto('/settings/tokens');
+    await page.click('button:has-text("Create Token")');
+    await page.fill('#tok-desc', `e2e-all-${Date.now()}`);
+    await page.click('button[type="submit"]:has-text("Create")');
+    await expect(page.locator('text=Token ready')).toBeVisible({ timeout: 10_000 });
 
-    // The All Tokens view is admin-only and exposes the kind filter.
+    // The All Tokens view is admin-only and exposes the kind filter + Bound To.
     await page.click('button:has-text("All Tokens")');
     await expect(page.locator('#kind-filter')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('th:has-text("Bound To")')).toBeVisible();
+    await expect(page.locator('th:has-text("Bound To")')).toBeVisible({ timeout: 10_000 });
 
     // Filtering by a valid-but-maybe-empty kind must not error the page.
     await page.selectOption('#kind-filter', 'service_detached');

--- a/web/src/app/settings/tokens/page.tsx
+++ b/web/src/app/settings/tokens/page.tsx
@@ -16,8 +16,10 @@ interface Token {
   id: string
   attributes: {
     description: string
-    'token-type': string
+    kind: string
+    'bound-to': string | null
     'created-by': string
+    'pinned-roles': string[] | null
     'created-at': string | null
     'last-used-at': string | null
     'expires-at': string | null
@@ -33,6 +35,41 @@ const LIFESPAN_OPTIONS = [
   { label: '1 year', hours: 8760 },
 ]
 
+// Token kinds (#495). interactive = a person's CLI/login token; service_bound =
+// a service token whose effective permissions are the AND of its pinned roles
+// and its owner's live roles (dies when the owner is offboarded); detached =
+// an admin-managed service token with an absolute pinned scope, bound to no
+// user (survives any single person leaving).
+const KIND_META: Record<string, { label: string; badge: string; help: string }> = {
+  interactive: {
+    label: 'Personal',
+    badge: 'bg-slate-700 text-slate-300',
+    help: 'A personal token for the CLI and ad-hoc automation. Carries your full live permissions.',
+  },
+  service_bound: {
+    label: 'Service · bound',
+    badge: 'bg-sky-900/50 text-sky-300 border border-sky-800/50',
+    help: 'A service token scoped to a subset of your roles. Its access is the intersection of those roles and your own — and it stops working if your account is removed.',
+  },
+  service_detached: {
+    label: 'Service · detached',
+    badge: 'bg-amber-900/50 text-amber-300 border border-amber-800/50',
+    help: 'An admin-managed service token with an absolute pinned scope, bound to no user. Use for critical machine-to-machine automation that must survive any one person leaving.',
+  },
+}
+
+function KindBadge({ kind }: { kind: string }) {
+  const meta = KIND_META[kind] ?? KIND_META.interactive
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${meta.badge}`}
+      title={meta.help}
+    >
+      {meta.label}
+    </span>
+  )
+}
+
 export default function TokensPage() {
   const router = useRouter()
   const [tokens, setTokens] = useState<Token[]>([])
@@ -42,21 +79,28 @@ export default function TokensPage() {
   const [showCreate, setShowCreate] = useState(false)
   const [description, setDescription] = useState('')
   const [lifespanHours, setLifespanHours] = useState<number>(8760)
+  const [kind, setKind] = useState<string>('interactive')
+  const [pinnedRoles, setPinnedRoles] = useState<Set<string>>(new Set())
   const [creating, setCreating] = useState(false)
   const [createdToken, setCreatedToken] = useState<string | null>(null)
   const [showAll, setShowAll] = useState(false)
+  const [kindFilter, setKindFilter] = useState<string>('all')
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [revoking, setRevoking] = useState(false)
+  const [rotatingId, setRotatingId] = useState<string | null>(null)
   const [admin, setAdmin] = useState(false)
   const [userId, setUserId] = useState('')
+  const [ownRoles, setOwnRoles] = useState<string[]>([])
+  const [allRoles, setAllRoles] = useState<string[]>([])
 
-  type TokenSortKey = 'description' | 'created-by' | 'created-at' | 'last-used-at' | 'expires-at'
+  type TokenSortKey = 'description' | 'kind' | 'bound-to' | 'created-at' | 'last-used-at' | 'expires-at'
   const { sortedItems: sortedTokens, sortState, toggleSort } = useSortable<Token, TokenSortKey>(
     tokens, 'created-at', 'desc',
     useCallback((item: Token, key: TokenSortKey) => {
       switch (key) {
         case 'description': return item.attributes.description
-        case 'created-by': return item.attributes['created-by']
+        case 'kind': return item.attributes.kind
+        case 'bound-to': return item.attributes['bound-to'] ?? ''
         case 'created-at': return item.attributes['created-at']
         case 'last-used-at': return item.attributes['last-used-at']
         case 'expires-at': return item.attributes['expires-at']
@@ -65,21 +109,39 @@ export default function TokensPage() {
   )
 
   useEffect(() => {
-    if (!getAuthState()) { router.push('/login'); return }
+    const auth = getAuthState()
+    if (!auth) { router.push('/login'); return }
     setAdmin(isAdmin())
     setUserId(getUserId())
+    // A bound token can only be scoped to a subset of the creator's own roles
+    // (the AND caps it), so offer exactly those — minus the implicit everyone.
+    setOwnRoles((auth.roles || []).filter((r) => r !== 'everyone'))
   }, [router])
 
   useEffect(() => {
     if (!userId) return
     loadTokens()
-  }, [userId, showAll])
+  }, [userId, showAll, kindFilter])
+
+  // Detached tokens pin an absolute scope from any role; only admins create
+  // them, and only admins can list all roles for the picker.
+  useEffect(() => {
+    if (!admin) return
+    apiFetch('/api/terrapod/v1/roles')
+      .then((r) => (r.ok ? r.json() : { data: [] }))
+      .then((d) => setAllRoles((d.data || []).map((role: { name: string }) => role.name).filter(Boolean)))
+      .catch(() => {})
+  }, [admin])
 
   async function loadTokens() {
     try {
-      const url = showAll
-        ? '/api/terrapod/v1/admin/authentication-tokens'
-        : `/api/terrapod/v1/users/${userId}/authentication-tokens`
+      let url: string
+      if (showAll) {
+        url = '/api/terrapod/v1/admin/authentication-tokens'
+        if (kindFilter !== 'all') url += `?kind=${kindFilter}`
+      } else {
+        url = `/api/terrapod/v1/users/${userId}/authentication-tokens`
+      }
       const res = await apiFetch(url)
       if (!res.ok) throw new Error('Failed to load tokens')
       const data = await res.json()
@@ -91,24 +153,31 @@ export default function TokensPage() {
     }
   }
 
+  function resetCreateForm() {
+    setDescription('')
+    setLifespanHours(8760)
+    setKind('interactive')
+    setPinnedRoles(new Set())
+  }
+
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault()
     setCreating(true)
     setError('')
     setCreatedToken(null)
     try {
+      const attributes: Record<string, unknown> = {
+        description,
+        lifespan_hours: lifespanHours,
+        kind,
+      }
+      if (kind !== 'interactive') {
+        attributes.pinned_roles = [...pinnedRoles]
+      }
       const res = await apiFetch(`/api/terrapod/v1/users/${userId}/authentication-tokens`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/vnd.api+json' },
-        body: JSON.stringify({
-          data: {
-            type: 'authentication-tokens',
-            attributes: {
-              description,
-              lifespan_hours: lifespanHours,
-            },
-          },
-        }),
+        body: JSON.stringify({ data: { type: 'authentication-tokens', attributes } }),
       })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
@@ -116,14 +185,36 @@ export default function TokensPage() {
       }
       const data = await res.json()
       setCreatedToken(data.data?.attributes?.token || null)
-      setDescription('')
-      setLifespanHours(8760)
+      resetCreateForm()
       setShowCreate(false)
       await loadTokens()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create token')
     } finally {
       setCreating(false)
+    }
+  }
+
+  async function handleRotate(tokenId: string) {
+    if (!confirm('Rotate this token? The current secret stops working immediately and a new one is issued.')) return
+    setRotatingId(tokenId)
+    setError('')
+    setCreatedToken(null)
+    try {
+      const res = await apiFetch(`/api/terrapod/v1/authentication-tokens/${tokenId}/actions/rotate`, {
+        method: 'POST',
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.detail || `Failed to rotate token (${res.status})`)
+      }
+      const data = await res.json()
+      setCreatedToken(data.data?.attributes?.token || null)
+      await loadTokens()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to rotate token')
+    } finally {
+      setRotatingId(null)
     }
   }
 
@@ -176,6 +267,14 @@ export default function TokensPage() {
     }
   }
 
+  function togglePinnedRole(name: string) {
+    setPinnedRoles((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name); else next.add(name)
+      return next
+    })
+  }
+
   function formatDate(iso: string | null): string {
     if (!iso) return 'Never'
     return new Date(iso).toLocaleDateString(undefined, {
@@ -193,6 +292,12 @@ export default function TokensPage() {
     return 'text-slate-400'
   }
 
+  // Detached is admin-only (the server enforces 403); only offer it to admins.
+  const kindOptions = admin
+    ? ['interactive', 'service_bound', 'service_detached']
+    : ['interactive', 'service_bound']
+  const rolePickerSource = kind === 'service_detached' ? allRoles : ownRoles
+
   return (
     <>
       <NavBar />
@@ -204,7 +309,7 @@ export default function TokensPage() {
             <div className="flex items-center gap-3">
               {admin && (
                 <button
-                  onClick={() => setShowAll(!showAll)}
+                  onClick={() => { setShowAll(!showAll); setSelected(new Set()) }}
                   className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                     showAll
                       ? 'bg-amber-600 hover:bg-amber-500 text-white'
@@ -228,7 +333,7 @@ export default function TokensPage() {
 
         {createdToken && (
           <div className="mb-6 p-4 bg-green-900/30 rounded-lg border border-green-800/50">
-            <p className="text-sm text-green-300 font-medium mb-1">Token created successfully</p>
+            <p className="text-sm text-green-300 font-medium mb-1">Token ready</p>
             <p className="text-xs text-green-400 mb-2">Copy this token now — it will not be shown again.</p>
             <div className="flex items-center gap-2">
               <code className="flex-1 text-sm text-green-200 bg-green-900/30 p-2 rounded font-mono overflow-x-auto">
@@ -245,39 +350,113 @@ export default function TokensPage() {
         )}
 
         {showCreate && (
-          <form onSubmit={handleCreate} className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6 flex items-end gap-3">
-            <div className="flex-1">
-              <label htmlFor="tok-desc" className="block text-sm font-medium text-slate-300 mb-1">Description</label>
-              <input
-                id="tok-desc"
-                type="text"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="CI/CD pipeline token"
-                className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
-              />
-            </div>
-            <div className="w-40">
-              <label htmlFor="tok-lifespan" className="block text-sm font-medium text-slate-300 mb-1">Lifespan</label>
-              <select
-                id="tok-lifespan"
-                value={lifespanHours}
-                onChange={(e) => setLifespanHours(Number(e.target.value))}
-                className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+          <form onSubmit={handleCreate} className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4 mb-6 space-y-4">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="flex-1 min-w-[200px]">
+                <label htmlFor="tok-desc" className="block text-sm font-medium text-slate-300 mb-1">Description</label>
+                <input
+                  id="tok-desc"
+                  type="text"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="CI/CD pipeline token"
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                />
+              </div>
+              <div className="w-48">
+                <label htmlFor="tok-kind" className="block text-sm font-medium text-slate-300 mb-1">Kind</label>
+                <select
+                  id="tok-kind"
+                  value={kind}
+                  onChange={(e) => { setKind(e.target.value); setPinnedRoles(new Set()) }}
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                >
+                  {kindOptions.map((k) => (
+                    <option key={k} value={k}>{KIND_META[k].label}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="w-40">
+                <label htmlFor="tok-lifespan" className="block text-sm font-medium text-slate-300 mb-1">Lifespan</label>
+                <select
+                  id="tok-lifespan"
+                  value={lifespanHours}
+                  onChange={(e) => setLifespanHours(Number(e.target.value))}
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                >
+                  {LIFESPAN_OPTIONS.map((opt) => (
+                    <option key={opt.hours} value={opt.hours}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+              <button
+                type="submit"
+                disabled={creating}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors"
               >
-                {LIFESPAN_OPTIONS.map((opt) => (
-                  <option key={opt.hours} value={opt.hours}>{opt.label}</option>
-                ))}
-              </select>
+                {creating ? 'Creating...' : 'Create'}
+              </button>
             </div>
-            <button
-              type="submit"
-              disabled={creating}
-              className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors"
-            >
-              {creating ? 'Creating...' : 'Create'}
-            </button>
+
+            <p className="text-xs text-slate-400">{KIND_META[kind].help}</p>
+
+            {kind !== 'interactive' && (
+              <div>
+                <label className="block text-sm font-medium text-slate-300 mb-2">
+                  Pinned roles
+                  <span className="text-slate-500 font-normal">
+                    {' '}— the scope this token is limited to
+                    {kind === 'service_bound' ? ' (capped to your own access)' : ''}
+                  </span>
+                </label>
+                {rolePickerSource.length === 0 ? (
+                  <p className="text-xs text-slate-500 italic">
+                    {kind === 'service_detached'
+                      ? 'No custom roles defined. Create roles under Admin → Roles first.'
+                      : 'You hold no scoped roles to pin. This token would have no access.'}
+                  </p>
+                ) : (
+                  <div className="flex flex-wrap gap-2">
+                    {rolePickerSource.map((name) => (
+                      <label
+                        key={name}
+                        className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors ${
+                          pinnedRoles.has(name)
+                            ? 'bg-brand-900/30 border-brand-700/50 text-brand-200'
+                            : 'bg-slate-700/50 border-slate-600/50 text-slate-300 hover:bg-slate-700'
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={pinnedRoles.has(name)}
+                          onChange={() => togglePinnedRole(name)}
+                          className="rounded border-slate-600 bg-slate-700 text-brand-600 focus:ring-brand-500"
+                        />
+                        {name}
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </form>
+        )}
+
+        {admin && showAll && (
+          <div className="mb-4 flex items-center gap-2">
+            <label htmlFor="kind-filter" className="text-sm text-slate-400">Kind</label>
+            <select
+              id="kind-filter"
+              value={kindFilter}
+              onChange={(e) => setKindFilter(e.target.value)}
+              className="px-3 py-1.5 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+            >
+              <option value="all">All kinds</option>
+              <option value="interactive">Personal</option>
+              <option value="service_bound">Service · bound</option>
+              <option value="service_detached">Service · detached</option>
+            </select>
+          </div>
         )}
 
         {selected.size > 0 && (
@@ -317,7 +496,8 @@ export default function TokensPage() {
                     />
                   </th>
                   <SortableHeader label="Description" sortKey="description" sortState={sortState} onSort={toggleSort} />
-                  {showAll && <SortableHeader label="Created By" sortKey="created-by" sortState={sortState} onSort={toggleSort} />}
+                  <SortableHeader label="Kind" sortKey="kind" sortState={sortState} onSort={toggleSort} />
+                  {showAll && <SortableHeader label="Bound To" sortKey="bound-to" sortState={sortState} onSort={toggleSort} />}
                   <SortableHeader label="Created" sortKey="created-at" sortState={sortState} onSort={toggleSort} />
                   <SortableHeader label="Last Used" sortKey="last-used-at" sortState={sortState} onSort={toggleSort} />
                   <SortableHeader label="Expires" sortKey="expires-at" sortState={sortState} onSort={toggleSort} />
@@ -325,43 +505,68 @@ export default function TokensPage() {
                 </tr>
               </thead>
               <tbody>
-                {sortedTokens.map((tok) => (
-                  <tr key={tok.id} className={`border-b border-slate-700/30 last:border-0 ${selected.has(tok.id) ? 'bg-brand-900/10' : ''}`}>
-                    <td className="w-10 px-4 py-3">
-                      <input
-                        type="checkbox"
-                        checked={selected.has(tok.id)}
-                        onChange={() => toggleSelect(tok.id)}
-                        className="rounded border-slate-600 bg-slate-700 text-brand-600 focus:ring-brand-500"
-                      />
-                    </td>
-                    <td className="px-4 py-3 text-slate-200">
-                      {tok.attributes.description || <span className="text-slate-500 italic">No description</span>}
-                    </td>
-                    {showAll && (
-                      <td className="px-4 py-3 text-slate-400 text-xs">
-                        {tok.attributes['created-by']}
+                {sortedTokens.map((tok) => {
+                  const isService = tok.attributes.kind !== 'interactive'
+                  const pinned = tok.attributes['pinned-roles'] || []
+                  return (
+                    <tr key={tok.id} className={`border-b border-slate-700/30 last:border-0 ${selected.has(tok.id) ? 'bg-brand-900/10' : ''}`}>
+                      <td className="w-10 px-4 py-3">
+                        <input
+                          type="checkbox"
+                          checked={selected.has(tok.id)}
+                          onChange={() => toggleSelect(tok.id)}
+                          className="rounded border-slate-600 bg-slate-700 text-brand-600 focus:ring-brand-500"
+                        />
                       </td>
-                    )}
-                    <td className="px-4 py-3 text-slate-400 text-xs">
-                      {formatDate(tok.attributes['created-at'])}
-                    </td>
-                    <td className="px-4 py-3 text-slate-400 text-xs">
-                      {formatDate(tok.attributes['last-used-at'])}
-                    </td>
-                    <td className={`px-4 py-3 text-xs ${expiryColor(tok.attributes['expires-at'])}`}>
-                      {formatDate(tok.attributes['expires-at'])}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <button
-                        onClick={() => handleRevoke(tok.id)}
-                        className="text-xs text-red-400 hover:text-red-300 transition-colors"
-                      >
-                        Revoke
-                      </button>
-                    </td>
-                  </tr>
-                ))}
+                      <td className="px-4 py-3 text-slate-200">
+                        {tok.attributes.description || <span className="text-slate-500 italic">No description</span>}
+                        {isService && pinned.length > 0 && (
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {pinned.map((r) => (
+                              <span key={r} className="inline-block px-1.5 py-0.5 rounded bg-slate-700/60 text-slate-400 text-[10px] font-mono">
+                                {r}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <KindBadge kind={tok.attributes.kind} />
+                      </td>
+                      {showAll && (
+                        <td className="px-4 py-3 text-slate-400 text-xs">
+                          {tok.attributes['bound-to'] || <span className="text-amber-400/80 italic">detached</span>}
+                        </td>
+                      )}
+                      <td className="px-4 py-3 text-slate-400 text-xs">
+                        {formatDate(tok.attributes['created-at'])}
+                      </td>
+                      <td className="px-4 py-3 text-slate-400 text-xs">
+                        {formatDate(tok.attributes['last-used-at'])}
+                      </td>
+                      <td className={`px-4 py-3 text-xs ${expiryColor(tok.attributes['expires-at'])}`}>
+                        {formatDate(tok.attributes['expires-at'])}
+                      </td>
+                      <td className="px-4 py-3 text-right whitespace-nowrap">
+                        {isService && (
+                          <button
+                            onClick={() => handleRotate(tok.id)}
+                            disabled={rotatingId === tok.id}
+                            className="text-xs text-brand-400 hover:text-brand-300 disabled:text-slate-500 transition-colors mr-3"
+                          >
+                            {rotatingId === tok.id ? 'Rotating...' : 'Rotate'}
+                          </button>
+                        )}
+                        <button
+                          onClick={() => handleRevoke(tok.id)}
+                          className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                        >
+                          Revoke
+                        </button>
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           </div>

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation'
 import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, FileText, BookOpen, Code, LogOut, Menu, X, Tags, Compass, Wrench, ScrollText } from 'lucide-react'
 import { clearAuth, isAdmin, isAdminOrAudit } from '@/lib/auth'
 import { SessionExpiryBanner } from '@/components/session-expiry-banner'
+import { TokenExpiryBanner } from '@/components/token-expiry-banner'
 
 function NavLink({
   href,
@@ -131,6 +132,7 @@ export default function NavBar() {
   return (
     <>
       <SessionExpiryBanner />
+      <TokenExpiryBanner />
       <nav className="border-b border-slate-800 bg-slate-900/80 backdrop-blur-sm sticky top-0 z-10">
         <div className="px-4 sm:px-6 lg:px-8">
           {/* Desktop nav */}

--- a/web/src/components/token-expiry-banner.tsx
+++ b/web/src/components/token-expiry-banner.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { apiFetch } from '@/lib/api'
+import { getAuthState } from '@/lib/auth'
+
+interface ExpiringToken {
+  id: string
+  attributes: {
+    description: string
+    kind: string
+    'bound-to': string | null
+    'expires-at': string | null
+  }
+}
+
+// Dismissed per browser-tab session — deliberately not persisted across
+// sessions so a genuinely-expiring token re-surfaces next login, but the
+// operator isn't nagged on every navigation.
+const DISMISS_KEY = 'tp:token_expiry_dismissed'
+
+/**
+ * Warns about service tokens nearing expiry. The list is scoped server-side
+ * (`/authentication-tokens/expiring`): every user sees their own bound service
+ * tokens; admins additionally see unbound (detached) ones. Nobody is warned
+ * about other users' bound tokens — so the banner stays signal, not noise.
+ */
+export function TokenExpiryBanner() {
+  const [count, setCount] = useState(0)
+  const [days, setDays] = useState<number | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    if (!getAuthState()) return
+    // Already dismissed this session — don't even fetch; count stays 0 so the
+    // banner renders nothing (no synchronous setState in the effect).
+    if (sessionStorage.getItem(DISMISS_KEY)) return
+    apiFetch('/api/terrapod/v1/authentication-tokens/expiring')
+      .then((r) => (r.ok ? r.json() : { data: [] }))
+      .then((d) => {
+        const tokens: ExpiringToken[] = d.data || []
+        setCount(tokens.length)
+        // Compute the soonest-expiry countdown here (in the effect, not during
+        // render) so the component stays pure across re-renders.
+        const soonest = tokens
+          .map((t) => t.attributes['expires-at'])
+          .filter((v): v is string => Boolean(v))
+          .sort()[0]
+        setDays(
+          soonest
+            ? Math.max(0, Math.ceil((new Date(soonest).getTime() - Date.now()) / 86_400_000))
+            : null,
+        )
+      })
+      .catch(() => {})
+  }, [])
+
+  if (dismissed || count === 0) return null
+
+  const dismiss = () => {
+    sessionStorage.setItem(DISMISS_KEY, '1')
+    setDismissed(true)
+  }
+
+  return (
+    <div className="bg-amber-900/50 border-b border-amber-700/50 px-4 py-2 text-sm text-amber-200 flex items-center justify-center gap-3">
+      <span>
+        {count} service token{count !== 1 ? 's' : ''} expiring
+        {days !== null ? ` within ${days} day${days !== 1 ? 's' : ''}` : ' soon'} —{' '}
+        <Link href="/settings/tokens" className="underline hover:text-amber-100">
+          review
+        </Link>
+      </span>
+      <button
+        onClick={dismiss}
+        className="text-amber-400 hover:text-amber-200 transition-colors"
+        aria-label="Dismiss token expiry warning"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
Part of **#495** (scoped service tokens + token-expiry warnings), the third PR toward a single minor release. Phase 1 (#498) landed the data model; Phase 2 (#499) landed the kind-aware server-side resolution. This is **Phase 3: the web UI** — the tokens page and the expiry-warning banner.

Does not close #495; go-terrapod typed methods + Helm/docs + the release cut follow.

## Tokens page (`/settings/tokens`)

- **Kind column** with a tooltip per kind: *Personal* (interactive), *Service · bound*, *Service · detached*.
- **Create form** gains a **Kind** selector and a **pinned-roles picker**:
  - `service_bound` → pick from the **creator's own roles** (the AND caps a bound token to its owner's access anyway, so that's the meaningful set; `everyone` is filtered out).
  - `service_detached` → **admin-only**, picks from **all roles** (the server enforces the 403; the option only appears for admins).
- **Rotate** action on service tokens — mints a fresh secret and resets expiry, surfaced in the same one-time reveal banner as creation.
- **Bound To** column (replacing *Created By*) + a **kind filter** in the admin *All Tokens* view; pinned-role chips under each service token; detached tokens render *detached* in Bound-To.

## Expiry-warning banner (nav-bar)

A dismissible amber banner warns about service tokens nearing expiry. The list is **scoped server-side** (`/authentication-tokens/expiring`): every user sees their own bound service tokens; admins additionally see unbound (detached) ones. Nobody is warned about other users' bound tokens — so it stays signal, not noise. Dismissed per browser-tab session (re-surfaces next login).

## Verification

- `npm run build` clean; ESLint 0 errors on the changed files (incl. the React purity/effect rules).
- `e2e/tests/tokens.spec.ts` extended: kind column, service-token create → badge → rotate, and the admin kind filter + Bound To column.
- **Live Tilt browser smoke** (Playwright, real BFF→API→DB): created a `service_bound` token with a pinned role → row shows the *Service · bound* badge, the pinned-role chip, and a working **Rotate** (new secret revealed); the admin *All Tokens* view shows the kind filter + Bound To column, and filtering by `service_bound` returns exactly that token with its bound-to.
