### PR TITLE
feat(sdk,docs): go-terrapod api_tokens + service-token docs (#495 Phase 4)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2094,23 +2094,79 @@ DELETE /api/terrapod/v1/role-assignments/{provider}/{email}/{role}
 
 ## Authentication Tokens
 
+Authentication tokens come in three **kinds** (`kind` attribute):
+
+| Kind | Who creates | Effective permissions | Bound to |
+|---|---|---|---|
+| `interactive` | anyone (default) | the owner's full live roles | the owner |
+| `service_bound` | anyone | **intersection** of the token's `pinned-roles` and the owner's live roles, per resource | the owner — and the token is **rejected if the owner hasn't logged in within `auth.bound_token_idle_days`** (default 7) |
+| `service_detached` | admins only | the token's `pinned-roles` as an **absolute** scope | nobody (unbound) — survives any single person leaving |
+
+A `service_bound` token can never exceed its owner's access (the intersection caps it) and stops working when the owner is offboarded — see [authentication.md](authentication.md) and the offboarding runbook in [runbooks.md](runbooks.md). `service_detached` is the path for critical machine-to-machine automation.
+
+**Response attributes**: `description`, `kind`, `bound-to` (null for detached), `created-by`, `pinned-roles` (service tokens only; null for interactive), `token-type`, `created-at`, `rotated-at`, `last-used-at`, `expires-at`, `lifespan-hours`, and `token` (the raw secret — present only in create/rotate responses). Service tokens always carry an expiry, capped by `auth.service_token_max_ttl_hours` (default 8760 / 1 year).
+
 ### Create Token
 
 ```
 POST /api/terrapod/v1/users/{user_id}/authentication-tokens
 ```
 
-### List Tokens
+Request attributes: `description`, `kind` (default `interactive`), `lifespan_hours`, `pinned_roles` (service kinds). `service_detached` is admin-only (`403` otherwise) and is created unbound regardless of `{user_id}`.
+
+### List Own Tokens
 
 ```
 GET /api/terrapod/v1/users/{user_id}/authentication-tokens
 ```
+
+Never includes detached tokens (they are unbound).
+
+### List All Tokens (admin)
+
+```
+GET /api/terrapod/v1/admin/authentication-tokens[?kind={kind}]
+```
+
+Admin-only. Optional `kind` filter (`interactive` / `service_bound` / `service_detached`); a valid-but-empty kind returns `[]`, not an error.
 
 ### Show Token
 
 ```
 GET /api/terrapod/v1/authentication-tokens/{id}
 ```
+
+### Re-tag Token (change kind)
+
+```
+PATCH /api/terrapod/v1/authentication-tokens/{id}
+```
+
+`interactive` ↔ `service_bound` is owner-or-admin. Converting **to/from** `service_detached` is admin-only and unbinds/rebinds the token. Request attributes: `kind`, `pinned_roles`.
+
+### Rotate Token
+
+```
+POST /api/terrapod/v1/authentication-tokens/{id}/actions/rotate
+```
+
+Mints a fresh secret (returned once in `token`) and resets the expiry clock; the old secret stops working immediately. Surfaced as a "Rotate" action on service tokens in the UI.
+
+### List Expiring Service Tokens
+
+```
+GET /api/terrapod/v1/authentication-tokens/expiring
+```
+
+Service tokens within `auth.token_expiry_warning_days` (default 14) of expiry, **scoped to the caller**: own bound service tokens for everyone, plus all detached tokens for admins. Drives the in-app expiry banner — no user is warned about another user's bound tokens.
+
+### Revoke All Tokens for a User (admin)
+
+```
+POST /api/terrapod/v1/admin/authentication-tokens/actions/revoke-all
+```
+
+Admin-only urgent-offboarding lever. Body `{"email": "..."}`; revokes every token bound to that identity and returns `{"data": {"email": ..., "revoked": N}}`. Detached tokens are unbound and unaffected.
 
 ### Delete Token
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -336,6 +336,46 @@ Example: `abc123def456.tpod.ghijklmnopqrstuvwxyz0123456789`
 - Max lifetime enforced via `auth.api_token_max_ttl_hours` config
 - Changing the max TTL retroactively affects all existing tokens
 
+### Token Kinds — Personal vs Service Tokens
+
+Every token has a **kind** that determines how its permissions are resolved:
+
+| Kind | Who can create | Effective permissions | Bound to | Best for |
+|---|---|---|---|---|
+| **`interactive`** (default) | anyone | the owner's full live roles | the owner | a person's CLI / `terraform login` token |
+| **`service_bound`** | anyone | the **intersection** of the token's pinned roles and the owner's live roles, resolved per resource | the owner | scoped automation that should never outlive the person who made it |
+| **`service_detached`** | **admins only** | the token's pinned roles as an **absolute** scope | nobody (unbound) | critical machine-to-machine automation that must survive any one person leaving |
+
+The intersection for `service_bound` is the key safety property: you can pin a token to a subset of your roles, but it can never grant more than you currently have. Pick the pinned roles from your own roles in the create form; the UI filters to exactly that set.
+
+`service_detached` tokens are the supported path for long-lived, business-critical automation. Because they are unbound and admin-managed, they don't break when an individual is offboarded — but they also don't inherit anyone's live permissions, so their pinned scope is the whole story. Keep it minimal.
+
+#### Offboarding safety — the idle-login guard
+
+A **`service_bound`** (or `interactive`) token is **rejected if its owner hasn't successfully logged in within `auth.bound_token_idle_days`** (default 7). Terrapod records the last successful login per user in Redis (`tp:user_seen:{email}`); once that window lapses, every token bound to the user stops authenticating until they log in again.
+
+This means a user who is cut off from SSO (account disabled at the IdP) automatically loses their bound tokens within a week — without any cleanup action — closing the "ex-employee's CI token still works weeks later" gap. For an **immediate** cut-off, use the [revoke-all offboarding runbook](runbooks.md). Critical M2M automation should use **`service_detached`** tokens (admin-managed, exempt from the idle guard) so it isn't affected by any individual's login activity.
+
+```yaml
+api:
+  config:
+    auth:
+      bound_token_idle_days: 7            # reject bound tokens after this idle window (0 = disabled)
+      service_token_max_ttl_hours: 8760   # hard cap on service-token lifespan (always expires)
+      token_expiry_warning_days: 14       # in-app expiry banner lead time
+```
+
+### Rotating a Service Token
+
+Rotate a token to swap its secret without re-wiring its identity or scope:
+
+```zsh
+curl -X POST https://terrapod.example.com/api/terrapod/v1/authentication-tokens/{token-id}/actions/rotate \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN"
+```
+
+The response carries the new secret in `attributes.token` (shown once); the old secret stops working immediately and the expiry clock resets. In the UI this is the **Rotate** action on each service token.
+
 ### Creating Tokens via API
 
 ```zsh
@@ -353,6 +393,26 @@ curl -X POST https://terrapod.example.com/api/terrapod/v1/users/{user_id}/authen
 ```
 
 The response includes the raw token value in `attributes.token`. Store it securely -- it cannot be retrieved again.
+
+To create a **detached** service token (admin only) scoped to specific roles:
+
+```zsh
+curl -X POST https://terrapod.example.com/api/terrapod/v1/users/{admin_user}/authentication-tokens \
+  -H "Authorization: Bearer $TERRAPOD_TOKEN" \
+  -H "Content-Type: application/vnd.api+json" \
+  -d '{
+    "data": {
+      "type": "authentication-tokens",
+      "attributes": {
+        "description": "prod deploy pipeline",
+        "kind": "service_detached",
+        "pinned_roles": ["prod-deployer"]
+      }
+    }
+  }'
+```
+
+The token comes back with `"bound-to": null` and the pinned roles as its absolute scope. For a `service_bound` token, set `"kind": "service_bound"` and pick `pinned_roles` from your own roles (the effective scope is the intersection with your live access).
 
 ### Creating Tokens via Web UI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ See [Architecture](architecture.md) for the full breakdown.
 |---|---|
 | [Getting Started](getting-started.md) | Local development setup, first workspace, first plan/apply |
 | [Architecture](architecture.md) | System components, storage, runners, auth flows |
-| [Authentication](authentication.md) | Local auth, OIDC, SAML, terraform login, API tokens |
+| [Authentication](authentication.md) | Local auth, OIDC, SAML, terraform login, API tokens, scoped service tokens (bound/detached) + offboarding idle guard |
 | [RBAC](rbac.md) | Permission model, label-based access control, custom roles |
 | [VCS Integration](vcs-integration.md) | GitHub and GitLab setup, polling, webhooks |
 | [VCS Workflows](vcs-workflows.md) | merge_then_apply (default) vs apply_then_merge (Atlantis-style, opt-in) |

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -929,3 +929,57 @@ service=terrapod-api logger=terrapod.services.vcs_status_dispatcher
 - Errored rows stop accumulating: `SELECT count(*) FROM plan_summaries WHERE status='errored' AND created_at > now() - interval '15 minutes';` returns 0.
 - The run-detail UI panel renders summaries with `status='ready'` (after re-enable + a new plan).
 - If you emergency-disabled, no `plan_summaries` row appears for new runs and the UI panel doesn't render at all.
+
+---
+
+## Offboarding a User — Revoking Their Tokens
+
+When a person leaves or must be cut off from Terrapod, their **personal (`interactive`) and `service_bound`** API tokens must stop working. There are two layers — an automatic one and an immediate one.
+
+### Symptoms / Trigger
+
+- A user account is disabled at the IdP, or HR/security requests immediate revocation.
+- You need to confirm that an ex-user's CI/automation tokens can no longer authenticate.
+
+### Diagnosis
+
+1. **List the user's bound tokens** (admin):
+   ```bash
+   curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+     "https://<terrapod>/api/terrapod/v1/admin/authentication-tokens" \
+   | jq '.data[] | select(.attributes."bound-to"=="<email>") | {id, kind, "expires-at": .attributes."expires-at"}'
+   ```
+2. **Check their last login** — bound tokens are auto-rejected after the idle window:
+   ```bash
+   # The Redis marker that arms the idle guard (TTL = auth.bound_token_idle_days)
+   redis-cli --scan --pattern 'tp:user_seen:<email>'
+   ```
+   If the key is **absent**, the user is already past the idle window and all their bound tokens are already being rejected.
+
+### Resolution
+
+**Automatic (no action needed):** a `service_bound`/`interactive` token is rejected once its owner hasn't logged in for `auth.bound_token_idle_days` (default 7). Disabling the user at the IdP — so they can no longer complete SSO — is sufficient for the token to lapse within that window. This is the "they can't use a token weeks after offboarding" guarantee, and it requires no operator cleanup.
+
+**Immediate (urgent cut-off):** when you can't wait out the idle window, revoke every token bound to the identity in one call:
+
+```bash
+curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://<terrapod>/api/terrapod/v1/admin/authentication-tokens/actions/revoke-all" \
+  -d '{"email": "<email>"}'
+# -> {"data": {"email": "<email>", "revoked": N}}
+```
+
+This deletes all bound tokens immediately and busts the user's cached role resolution. **Detached (`service_detached`) tokens are unbound and are intentionally NOT affected** — they belong to automation, not the person. If the leaver was the only human who knew a detached token's secret, **rotate** that token instead:
+
+```bash
+curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "https://<terrapod>/api/terrapod/v1/authentication-tokens/<token-id>/actions/rotate"
+```
+
+### Verification
+
+- `revoke-all` returned a `revoked` count matching the diagnosis list.
+- Re-running the diagnosis list query returns no tokens for the email.
+- An attempt to use one of the revoked tokens returns `401`.
+- For the idle path: with the `tp:user_seen:<email>` key absent, a previously-working bound token now returns `401`.

--- a/go-terrapod/api_tokens.go
+++ b/go-terrapod/api_tokens.go
@@ -1,0 +1,227 @@
+package terrapod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// APIToken is a user / automation authentication token (#495). Kind is one of
+// "interactive", "service_bound", or "service_detached":
+//
+//   - interactive: a person's CLI/login token, carrying their live roles.
+//   - service_bound: a service token whose effective permissions are the
+//     intersection of PinnedRoles and BoundTo's live roles; it stops working
+//     when that account is removed (offboarding-safe by construction).
+//   - service_detached: an admin-managed token with PinnedRoles as its absolute
+//     scope, bound to no user (BoundTo empty) — for critical machine-to-machine
+//     automation that must survive any one person leaving.
+//
+// Token holds the raw secret and is populated only by CreateAPIToken and
+// RotateAPIToken; every other read leaves it empty.
+type APIToken struct {
+	ID            string   `json:"id"`
+	Token         string   `json:"token,omitempty"` // raw value — create / rotate only
+	Description   string   `json:"description,omitempty"`
+	Kind          string   `json:"kind"`
+	BoundTo       string   `json:"bound-to,omitempty"` // empty for detached
+	CreatedBy     string   `json:"created-by,omitempty"`
+	PinnedRoles   []string `json:"pinned-roles,omitempty"` // service tokens only
+	TokenType     string   `json:"token-type,omitempty"`
+	CreatedAt     string   `json:"created-at,omitempty"`
+	RotatedAt     string   `json:"rotated-at,omitempty"`
+	LastUsedAt    string   `json:"last-used-at,omitempty"`
+	ExpiresAt     string   `json:"expires-at,omitempty"`
+	LifespanHours int64    `json:"lifespan-hours,omitempty"`
+}
+
+// CreateAPITokenRequest is the input for CreateAPIToken. Kind defaults to
+// "interactive" when empty. PinnedRoles is only meaningful for the service
+// kinds (ignored for interactive). LifespanHours=0 uses the server default cap.
+type CreateAPITokenRequest struct {
+	Description   string
+	Kind          string
+	PinnedRoles   []string
+	LifespanHours int64
+}
+
+// CreateAPIToken issues a token for the given user. The path user must be the
+// caller (or the caller must be an admin). service_detached is admin-only and
+// is created unbound regardless of the path user. The returned token's Token
+// field holds the raw secret — store it immediately; the API never returns it
+// again.
+func (c *Client) CreateAPIToken(ctx context.Context, userID string, req CreateAPITokenRequest) (*APIToken, error) {
+	// The create request body uses snake_case attribute keys (Pydantic model),
+	// unlike the kebab-case keys the response serialises with.
+	attrs := map[string]any{}
+	if req.Description != "" {
+		attrs["description"] = req.Description
+	}
+	if req.Kind != "" {
+		attrs["kind"] = req.Kind
+	}
+	if req.LifespanHours > 0 {
+		attrs["lifespan_hours"] = req.LifespanHours
+	}
+	if len(req.PinnedRoles) > 0 {
+		attrs["pinned_roles"] = req.PinnedRoles
+	}
+	body, err := MarshalResource("authentication-tokens", attrs, nil)
+	if err != nil {
+		return nil, fmt.Errorf("marshal create api-token: %w", err)
+	}
+	data, err := c.Post(ctx,
+		fmt.Sprintf("/api/terrapod/v1/users/%s/authentication-tokens", url.PathEscape(userID)),
+		body)
+	if err != nil {
+		return nil, err
+	}
+	return parseAPIToken(data)
+}
+
+// ListUserAPITokens lists a user's own tokens (never includes detached tokens).
+// The path user must be the caller, or the caller must be an admin.
+func (c *Client) ListUserAPITokens(ctx context.Context, userID string) ([]APIToken, error) {
+	return c.listAPITokens(ctx,
+		fmt.Sprintf("/api/terrapod/v1/users/%s/authentication-tokens", url.PathEscape(userID)))
+}
+
+// ListAllAPITokens lists every token across all users (admin only). Pass a kind
+// ("interactive", "service_bound", "service_detached") to filter, or "" for all.
+func (c *Client) ListAllAPITokens(ctx context.Context, kind string) ([]APIToken, error) {
+	path := "/api/terrapod/v1/admin/authentication-tokens"
+	if kind != "" {
+		path += "?kind=" + url.QueryEscape(kind)
+	}
+	return c.listAPITokens(ctx, path)
+}
+
+// ListExpiringAPITokens returns service tokens nearing expiry, scoped to the
+// caller: their own bound service tokens, plus all detached tokens when the
+// caller is an admin. Drives the in-app expiry warnings.
+func (c *Client) ListExpiringAPITokens(ctx context.Context) ([]APIToken, error) {
+	return c.listAPITokens(ctx, "/api/terrapod/v1/authentication-tokens/expiring")
+}
+
+// GetAPIToken fetches one token's metadata by id (the raw Token is never present).
+func (c *Client) GetAPIToken(ctx context.Context, tokenID string) (*APIToken, error) {
+	data, err := c.Get(ctx,
+		fmt.Sprintf("/api/terrapod/v1/authentication-tokens/%s", url.PathEscape(tokenID)))
+	if err != nil {
+		return nil, err
+	}
+	return parseAPIToken(data)
+}
+
+// RotateAPIToken mints a fresh secret for a token and resets its expiry clock.
+// The old secret stops working immediately. The returned token's Token field
+// holds the new raw secret.
+func (c *Client) RotateAPIToken(ctx context.Context, tokenID string) (*APIToken, error) {
+	data, err := c.Post(ctx,
+		fmt.Sprintf("/api/terrapod/v1/authentication-tokens/%s/actions/rotate", url.PathEscape(tokenID)),
+		nil)
+	if err != nil {
+		return nil, err
+	}
+	return parseAPIToken(data)
+}
+
+// RetagAPIToken changes a token's kind. interactive <-> service_bound is
+// owner-or-admin; converting to/from service_detached is admin-only (and
+// unbinds / rebinds the token). pinnedRoles sets the new scope for the service
+// kinds (pass nil to leave it unchanged for a bound token; it is cleared when
+// converting to interactive).
+func (c *Client) RetagAPIToken(ctx context.Context, tokenID, kind string, pinnedRoles []string) (*APIToken, error) {
+	attrs := map[string]any{"kind": kind}
+	if pinnedRoles != nil {
+		attrs["pinned_roles"] = pinnedRoles
+	}
+	body, err := MarshalResource("authentication-tokens", attrs, nil)
+	if err != nil {
+		return nil, fmt.Errorf("marshal retag api-token: %w", err)
+	}
+	data, err := c.Patch(ctx,
+		fmt.Sprintf("/api/terrapod/v1/authentication-tokens/%s", url.PathEscape(tokenID)),
+		body)
+	if err != nil {
+		return nil, err
+	}
+	return parseAPIToken(data)
+}
+
+// RevokeAPIToken deletes a single token by id.
+func (c *Client) RevokeAPIToken(ctx context.Context, tokenID string) error {
+	return c.Delete(ctx,
+		fmt.Sprintf("/api/terrapod/v1/authentication-tokens/%s", url.PathEscape(tokenID)))
+}
+
+// RevokeAllAPITokensForUser revokes every token bound to an identity — the
+// urgent-offboarding lever (admin only). Returns the number revoked. Detached
+// tokens are unbound and are not affected.
+func (c *Client) RevokeAllAPITokensForUser(ctx context.Context, email string) (int64, error) {
+	body, err := json.Marshal(map[string]string{"email": email})
+	if err != nil {
+		return 0, fmt.Errorf("marshal revoke-all: %w", err)
+	}
+	data, err := c.Post(ctx,
+		"/api/terrapod/v1/admin/authentication-tokens/actions/revoke-all", body)
+	if err != nil {
+		return 0, err
+	}
+	// Plain (non-JSON:API) response: {"data": {"email": ..., "revoked": N}}.
+	var resp struct {
+		Data struct {
+			Email   string `json:"email"`
+			Revoked int64  `json:"revoked"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return 0, fmt.Errorf("parse revoke-all response: %w", err)
+	}
+	return resp.Data.Revoked, nil
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────
+
+func (c *Client) listAPITokens(ctx context.Context, path string) ([]APIToken, error) {
+	data, err := c.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	resources, err := ParseResourceList(data)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]APIToken, 0, len(resources))
+	for i := range resources {
+		out = append(out, *apiTokenFromResource(&resources[i]))
+	}
+	return out, nil
+}
+
+func parseAPIToken(body []byte) (*APIToken, error) {
+	res, err := ParseResource(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse api-token response: %w", err)
+	}
+	return apiTokenFromResource(res), nil
+}
+
+func apiTokenFromResource(res *Resource) *APIToken {
+	return &APIToken{
+		ID:            res.ID,
+		Token:         GetStringAttr(res, "token"),
+		Description:   GetStringAttr(res, "description"),
+		Kind:          GetStringAttr(res, "kind"),
+		BoundTo:       GetStringAttr(res, "bound-to"),
+		CreatedBy:     GetStringAttr(res, "created-by"),
+		PinnedRoles:   GetListAttr(res, "pinned-roles"),
+		TokenType:     GetStringAttr(res, "token-type"),
+		CreatedAt:     GetStringAttr(res, "created-at"),
+		RotatedAt:     GetStringAttr(res, "rotated-at"),
+		LastUsedAt:    GetStringAttr(res, "last-used-at"),
+		ExpiresAt:     GetStringAttr(res, "expires-at"),
+		LifespanHours: GetIntAttr(res, "lifespan-hours"),
+	}
+}

--- a/go-terrapod/api_tokens_test.go
+++ b/go-terrapod/api_tokens_test.go
@@ -1,0 +1,168 @@
+package terrapod
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newAPITokenFixture(t *testing.T) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody string
+		if r.Body != nil {
+			b, _ := io.ReadAll(r.Body)
+			reqBody = string(b)
+			_ = r.Body.Close()
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/actions/rotate"):
+			_, _ = w.Write([]byte(`{"data":{"id":"at-svc","type":"authentication-tokens","attributes":{
+			  "token":"rotated-secret","kind":"service_bound","bound-to":"dev"}}}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/actions/revoke-all"):
+			// echo a revoked count; assert the email made it into the body
+			if !strings.Contains(reqBody, "leaver@example.com") {
+				http.Error(w, "missing email", http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"email":"leaver@example.com","revoked":4}}`))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/users/"):
+			// create — echo back kind + pinned-roles so the caller can assert
+			if !strings.Contains(reqBody, "service_bound") || !strings.Contains(reqBody, "deployer") {
+				http.Error(w, "bad create body", http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"data":{"id":"at-new","type":"authentication-tokens","attributes":{
+			  "token":"raw-secret","kind":"service_bound","bound-to":"dev","created-by":"dev",
+			  "pinned-roles":["deployer"]}}}`))
+		case r.Method == http.MethodPatch:
+			_, _ = w.Write([]byte(`{"data":{"id":"at-svc","type":"authentication-tokens","attributes":{
+			  "kind":"service_detached","bound-to":null,"pinned-roles":["deployer"]}}}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/expiring"):
+			_, _ = w.Write([]byte(`{"data":[
+			  {"id":"at-exp","type":"authentication-tokens","attributes":{"kind":"service_bound","expires-at":"2030-01-01T00:00:00Z"}}
+			]}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/admin/authentication-tokens"):
+			// assert the kind filter was forwarded
+			if r.URL.Query().Get("kind") != "service_detached" {
+				http.Error(w, "missing kind filter", http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":[
+			  {"id":"at-det","type":"authentication-tokens","attributes":{"kind":"service_detached","bound-to":null}}
+			]}`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/users/"):
+			_, _ = w.Write([]byte(`{"data":[
+			  {"id":"at-own","type":"authentication-tokens","attributes":{"kind":"interactive","bound-to":"dev"}}
+			]}`))
+		case r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{"id":"at-svc","type":"authentication-tokens","attributes":{
+			  "kind":"service_bound","bound-to":"dev","pinned-roles":["deployer"]}}}`))
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unhandled", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestCreateAPIToken(t *testing.T) {
+	c := newAPITokenFixture(t)
+	tok, err := c.CreateAPIToken(t.Context(), "dev", CreateAPITokenRequest{
+		Description: "ci",
+		Kind:        "service_bound",
+		PinnedRoles: []string{"deployer"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Token != "raw-secret" {
+		t.Errorf("raw token should be returned on create: %+v", tok)
+	}
+	if tok.Kind != "service_bound" || len(tok.PinnedRoles) != 1 || tok.PinnedRoles[0] != "deployer" {
+		t.Errorf("kind/pinned-roles not parsed: %+v", tok)
+	}
+}
+
+func TestListUserAPITokens(t *testing.T) {
+	c := newAPITokenFixture(t)
+	list, err := c.ListUserAPITokens(t.Context(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].Kind != "interactive" {
+		t.Errorf("list: %+v", list)
+	}
+}
+
+func TestListAllAPITokensKindFilter(t *testing.T) {
+	c := newAPITokenFixture(t)
+	list, err := c.ListAllAPITokens(t.Context(), "service_detached")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].Kind != "service_detached" || list[0].BoundTo != "" {
+		t.Errorf("filtered list: %+v", list)
+	}
+}
+
+func TestListExpiringAPITokens(t *testing.T) {
+	c := newAPITokenFixture(t)
+	list, err := c.ListExpiringAPITokens(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].ExpiresAt == "" {
+		t.Errorf("expiring: %+v", list)
+	}
+}
+
+func TestRotateAPIToken(t *testing.T) {
+	c := newAPITokenFixture(t)
+	tok, err := c.RotateAPIToken(t.Context(), "at-svc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Token != "rotated-secret" {
+		t.Errorf("rotate should return a fresh secret: %+v", tok)
+	}
+}
+
+func TestRetagAPITokenToDetached(t *testing.T) {
+	c := newAPITokenFixture(t)
+	tok, err := c.RetagAPIToken(t.Context(), "at-svc", "service_detached", []string{"deployer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Kind != "service_detached" || tok.BoundTo != "" {
+		t.Errorf("retag to detached should unbind: %+v", tok)
+	}
+}
+
+func TestRevokeAllAPITokensForUser(t *testing.T) {
+	c := newAPITokenFixture(t)
+	n, err := c.RevokeAllAPITokensForUser(t.Context(), "leaver@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 4 {
+		t.Errorf("expected 4 revoked, got %d", n)
+	}
+}
+
+func TestRevokeAPIToken(t *testing.T) {
+	c := newAPITokenFixture(t)
+	if err := c.RevokeAPIToken(t.Context(), "at-svc"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
The final implementation PR for **#495** (scoped service tokens + token-expiry warnings), completing a single minor release built across four PRs: #498 (model + idle guard + rotation), #499 (kind-aware resolution), #500 (web UI + expiry banner), and this one — the **Go SDK + documentation**.

## go-terrapod — `api_tokens.go`

First typed coverage of the user **authentication-token** surface (the SDK previously only covered agent-pool tokens). Methods:

- `CreateAPIToken(userID, {Description, Kind, PinnedRoles, LifespanHours})` — create personal / bound / detached.
- `ListUserAPITokens`, `ListAllAPITokens(kind)` (admin kind filter), `ListExpiringAPITokens`, `GetAPIToken`.
- `RotateAPIToken`, `RetagAPIToken(id, kind, pinnedRoles)`, `RevokeAPIToken`, `RevokeAllAPITokensForUser(email)`.

This is the Go path operators need to **script detached machine-to-machine tokens** — exactly the use case the detached kind exists for. 8 table-style tests (httptest), `go vet` + `gofmt` clean, full SDK suite green.

## Documentation

- **`api-reference.md`** — token-kinds table, response attributes (`kind`, `bound-to`, `pinned-roles`, …), and every new endpoint: admin list + `?kind=` filter, re-tag, rotate, expiring, revoke-all.
- **`authentication.md`** — personal vs service tokens, the bound (intersection) / detached (absolute) model, the **idle-login offboarding guard** (`bound_token_idle_days`), rotation, and a detached-create example.
- **`runbooks.md`** — a new **"Offboarding a User"** runbook: the automatic idle-window lapse ("can't use a token weeks after offboarding" with zero cleanup) *and* the immediate `revoke-all` lever, with detached tokens called out as intentionally unaffected (rotate instead).
- **`index.md`** — authentication row now mentions scoped service tokens.

## Helm

The three config knobs (`service_token_max_ttl_hours`, `token_expiry_warning_days`, `bound_token_idle_days`) landed in Phase 1; `values.yaml` ↔ `values.schema.json` are already in sync (re-verified: `helm lint` + `helm template` pass on `values-local.yaml`).

## Verification

- `go build ./...` + full `go test ./...` green; `go vet`/`gofmt` clean.
- `helm lint` + `helm template` pass.
- Internal-reference scan clean on all changed docs + SDK files.

After this merges, **#495 is fully delivered** and the single minor release can be cut.
