### PR TITLE
feat(auth): short-lived terraform login tokens (login_token_ttl_hours, default 12h)

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -279,6 +279,8 @@ The `terraform login` command uses OAuth2 Authorization Code with PKCE to obtain
 6. Terraform exchanges the code for an API token via `POST /oauth/token`
 7. The token is stored in `~/.terraform.d/credentials.tfrc.json`
 
+The token minted by `terraform login` is **short-lived** — its lifespan is `auth.login_token_ttl_hours` (default **12 hours**), so it expires at the end of a working session rather than living for the full `api_token_max_ttl_hours` cap. Re-run `terraform login` to get a fresh one. For long-lived automation, create a dedicated token (a [service token](#token-kinds--personal-vs-service-tokens) for scoped/M2M use) rather than relying on a login token.
+
 ### Prerequisites
 
 The `callback_base_url` must be set to the externally-reachable URL of the Terrapod instance:
@@ -437,16 +439,20 @@ curl -X DELETE https://terrapod.example.com/api/terrapod/v1/authentication-token
   -H "Authorization: Bearer $TERRAPOD_TOKEN"
 ```
 
-### Max TTL Configuration
+### Token Lifespan Configuration
 
 ```yaml
 api:
   config:
     auth:
-      api_token_max_ttl_hours: 8760  # 1 year (default). Set 0 for no limit
+      api_token_max_ttl_hours: 8760  # upper bound on ANY token. 1 year default; 0 = no limit
+      login_token_ttl_hours: 12      # lifespan of `terraform login` tokens; 0 = fall back to the cap
 ```
 
-The TTL is computed at validation time as `created_at + max_ttl`. Tokens older than this are rejected.
+- **`api_token_max_ttl_hours`** is the hard *cap* — the maximum lifetime any token may have. It's computed at validation time as `(rotated_at or created_at) + max_ttl`, so changing it retroactively re-dates every existing token. `0` removes the cap.
+- **`login_token_ttl_hours`** is the *actual* lifespan handed to the short-lived token that `terraform login` mints (default 12h). It's clamped to the cap. Set `0` to give login tokens no explicit lifespan (they then fall back to the cap — the old behaviour).
+
+A token created with an explicit `lifespan_hours` (e.g. via the API or the create form) expires at `created_at + min(lifespan_hours, cap)`; one created without (a bare `terraform login` before this setting existed) expires at the cap.
 
 ---
 

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -92,6 +92,7 @@ data:
       api_token_max_ttl_hours: {{ .Values.api.config.auth.api_token_max_ttl_hours | default 8760 }}
       {{- /* Rendered directly (no `| default`): 0 is meaningful for these and
              Helm's `default` would silently rewrite a configured 0 to the default. */}}
+      login_token_ttl_hours: {{ .Values.api.config.auth.login_token_ttl_hours }}
       service_token_max_ttl_hours: {{ .Values.api.config.auth.service_token_max_ttl_hours }}
       token_expiry_warning_days: {{ .Values.api.config.auth.token_expiry_warning_days }}
       bound_token_idle_days: {{ .Values.api.config.auth.bound_token_idle_days }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -507,6 +507,7 @@
             "callback_base_url": { "type": "string" },
             "session_ttl_hours": { "type": "integer", "minimum": 1 },
             "api_token_max_ttl_hours": { "type": "integer", "minimum": 0 },
+            "login_token_ttl_hours": { "type": "integer", "minimum": 0 },
             "service_token_max_ttl_hours": { "type": "integer", "minimum": 0 },
             "token_expiry_warning_days": { "type": "integer", "minimum": 0 },
             "bound_token_idle_days": { "type": "integer", "minimum": 0 },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -161,7 +161,10 @@ api:
       callback_base_url: ""
 
       session_ttl_hours: 12
-      api_token_max_ttl_hours: 8760  # 1 year; 0 = no limit
+      api_token_max_ttl_hours: 8760  # 1 year; upper bound on any token. 0 = no limit
+      # Lifespan of the token minted by `terraform login` — short-lived per-session
+      # CLI credentials, distinct from the max cap above. 0 falls back to the cap.
+      login_token_ttl_hours: 12
       # Service tokens (#495): separate (always-expiring) cap; warning lead time;
       # and the bound-token idle-login window (ON by default; 0 disables).
       service_token_max_ttl_hours: 8760

--- a/services/terrapod/api/routers/oauth.py
+++ b/services/terrapod/api/routers/oauth.py
@@ -23,6 +23,7 @@ from terrapod.auth.auth_state import (
     generate_state,
     store_auth_state,
 )
+from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
@@ -149,14 +150,18 @@ async def oauth_token(
             detail="PKCE verification failed",
         )
 
-    # Create a long-lived interactive API token (terraform login). Bound to
-    # the authenticating identity; created_by is the same identity.
+    # Create a short-lived interactive API token (terraform login). Bound to
+    # the authenticating identity; created_by is the same identity. The
+    # lifespan comes from auth.login_token_ttl_hours (default 12h) — these are
+    # per-session CLI credentials, not max-lifetime tokens. 0 falls back to the
+    # api_token_max_ttl_hours cap. create_api_token clamps to that cap either way.
     api_token, raw_token = await create_api_token(
         db=db,
         bound_to=auth_code.email,
         created_by=auth_code.email,
         kind="interactive",
         description=f"terraform login ({auth_code.provider_name})",
+        lifespan_hours=settings.auth.login_token_ttl_hours or None,
     )
     await db.commit()
 

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -320,6 +320,13 @@ class AuthConfig(BaseSettings):
         "of the tp:user_seen marker. 0 disables idle rejection. Detached tokens are exempt (#495). "
         "ON by default — convert existing automation tokens to detached before upgrade.",
     )
+    login_token_ttl_hours: int = Field(
+        default=12,
+        description="Lifespan in hours of the API token minted by `terraform login` (default: 12). "
+        "These are short-lived interactive credentials for a human's CLI session, distinct from the "
+        "api_token_max_ttl_hours cap (which is the upper bound on any token). Still clamped to that "
+        "cap. 0 = no per-login lifespan (falls back to the cap).",
+    )
     require_external_sso_for_roles: list[str] = Field(
         default_factory=list,
         description="Roles that require external SSO login (excludes local provider)",

--- a/services/tests/api/test_oauth.py
+++ b/services/tests/api/test_oauth.py
@@ -184,6 +184,10 @@ class TestOAuthToken:
         data = response.json()
         assert data["access_token"] == "raw-token.tpod.secret"
         assert data["token_type"] == "bearer"
+        # terraform login mints a SHORT-LIVED token, not a max-lifetime one:
+        # the lifespan comes from auth.login_token_ttl_hours (default 12h).
+        assert mock_create_token.call_args.kwargs["kind"] == "interactive"
+        assert mock_create_token.call_args.kwargs["lifespan_hours"] == 12
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")


### PR DESCRIPTION
`terraform login` previously minted a token with **no explicit lifespan**, so it inherited the `api_token_max_ttl_hours` cap — **1 year**. That's far too long-lived for an interactive, per-session CLI credential (and it's why every login token in the UI reads as created-date + 1 year).

This adds a dedicated lifespan for login tokens, defaulting to **12 hours**.

## Change

- **`auth.login_token_ttl_hours`** — new setting, default `12`. It's the lifespan handed to the token `terraform login` mints. Distinct from `api_token_max_ttl_hours` (the *cap* / upper bound on any token), and still clamped to it. `0` falls back to the cap (the old behaviour).
- **`oauth.py`** — the token exchange now passes `lifespan_hours=settings.auth.login_token_ttl_hours or None`.
- **Helm** — `values.yaml` + `values.schema.json` + configmap (rendered directly, 0-safe, matching the other token-TTL knobs).
- **Docs** — `authentication.md`: the terraform-login section now notes the short lifespan, and the config section distinguishes the cap from the per-login TTL (with the "create a service token for long-lived automation" pointer).

## Verification

- `test_oauth.py` asserts the login exchange mints `kind="interactive"` with `lifespan_hours=12`. Full Python suite: **2145 passed**.
- `helm lint` + `helm template` pass on `values.yaml` and `values-local.yaml`; the configmap renders `login_token_ttl_hours: 12`.
- Live: the running pod has the synced code path and resolves `login_token_ttl_hours = 12`, so a fresh `terraform login` now mints a 12h token (the interactive SSO login itself is the one manual step not driven here).

Standalone token-lifecycle fix; can ride the same minor release as the scoped-service-token work (#495).
