### PR TITLE
fix(web): tokens-page UX — dismissible/masked reveal + kind-aware expiry colour

### DIFF
--- a/e2e/tests/tokens.spec.ts
+++ b/e2e/tests/tokens.spec.ts
@@ -16,9 +16,22 @@ test.describe('API Tokens', () => {
     // Submit button inside form says "Create"
     await page.click('button[type="submit"]:has-text("Create")');
 
-    // Success banner should show the raw token (shared by create + rotate).
+    // Success banner appears (shared by create + rotate).
     await expect(page.locator('text=Token ready')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('code')).toBeVisible();
+    const code = page.locator('code').first();
+    await expect(code).toBeVisible();
+
+    // The secret is masked by default — the raw value (…tpod…) is not shown.
+    await expect(code).not.toContainText('tpod');
+    // Show reveals it; Hide masks it again.
+    await page.click('button:has-text("Show")');
+    await expect(code).toContainText('.tpod.');
+    await page.click('button:has-text("Hide")');
+    await expect(code).not.toContainText('tpod');
+
+    // The banner can be dismissed.
+    await page.click('button[aria-label="Dismiss token"]');
+    await expect(page.locator('text=Token ready')).not.toBeVisible();
   });
 
   test('new token appears in table with a Kind column', async ({ page }) => {

--- a/web/src/app/settings/tokens/page.tsx
+++ b/web/src/app/settings/tokens/page.tsx
@@ -83,6 +83,7 @@ export default function TokensPage() {
   const [pinnedRoles, setPinnedRoles] = useState<Set<string>>(new Set())
   const [creating, setCreating] = useState(false)
   const [createdToken, setCreatedToken] = useState<string | null>(null)
+  const [showToken, setShowToken] = useState(false)
   const [showAll, setShowAll] = useState(false)
   const [kindFilter, setKindFilter] = useState<string>('all')
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -185,6 +186,7 @@ export default function TokensPage() {
       }
       const data = await res.json()
       setCreatedToken(data.data?.attributes?.token || null)
+      setShowToken(false)
       resetCreateForm()
       setShowCreate(false)
       await loadTokens()
@@ -210,6 +212,7 @@ export default function TokensPage() {
       }
       const data = await res.json()
       setCreatedToken(data.data?.attributes?.token || null)
+      setShowToken(false)
       await loadTokens()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to rotate token')
@@ -332,13 +335,31 @@ export default function TokensPage() {
         {error && <ErrorBanner message={error} />}
 
         {createdToken && (
-          <div className="mb-6 p-4 bg-green-900/30 rounded-lg border border-green-800/50">
+          <div className="relative mb-6 p-4 pr-10 bg-green-900/30 rounded-lg border border-green-800/50">
+            <button
+              onClick={() => { setCreatedToken(null); setShowToken(false) }}
+              aria-label="Dismiss token"
+              className="absolute top-2 right-2 text-green-400 hover:text-green-200 transition-colors"
+            >
+              ✕
+            </button>
             <p className="text-sm text-green-300 font-medium mb-1">Token ready</p>
             <p className="text-xs text-green-400 mb-2">Copy this token now — it will not be shown again.</p>
             <div className="flex items-center gap-2">
-              <code className="flex-1 text-sm text-green-200 bg-green-900/30 p-2 rounded font-mono overflow-x-auto">
-                {createdToken}
+              <code
+                className={`flex-1 text-sm text-green-200 bg-green-900/30 p-2 rounded font-mono overflow-x-auto ${
+                  showToken ? '' : 'select-none'
+                }`}
+              >
+                {showToken ? createdToken : '•'.repeat(48)}
               </code>
+              <button
+                onClick={() => setShowToken((v) => !v)}
+                aria-pressed={showToken}
+                className="px-3 py-1 rounded text-xs font-medium bg-green-800/50 hover:bg-green-700/50 text-green-200 transition-colors flex-shrink-0 w-14"
+              >
+                {showToken ? 'Hide' : 'Show'}
+              </button>
               <button
                 onClick={() => navigator.clipboard.writeText(createdToken)}
                 className="px-3 py-1 rounded text-xs font-medium bg-green-800/50 hover:bg-green-700/50 text-green-200 transition-colors flex-shrink-0"

--- a/web/src/app/settings/tokens/page.tsx
+++ b/web/src/app/settings/tokens/page.tsx
@@ -286,12 +286,25 @@ export default function TokensPage() {
     })
   }
 
-  function expiryColor(iso: string | null): string {
+  // A token minted by `terraform login` / `tofu login` — the server always
+  // sets this exact description prefix on the OAuth token-exchange (#502).
+  // These are intentionally short-lived (login_token_ttl_hours, default 12h),
+  // so an imminent expiry is by design, not a foot-gun worth warning about.
+  // Every other token — including manually-created personal tokens — keeps the
+  // amber "nearing expiry" warning.
+  function isLoginToken(tok: Token): boolean {
+    return (
+      tok.attributes.kind === 'interactive' &&
+      (tok.attributes.description || '').startsWith('terraform login')
+    )
+  }
+
+  function expiryColor(iso: string | null, isLogin: boolean): string {
     if (!iso) return 'text-slate-400'
     const now = Date.now()
     const expires = new Date(iso).getTime()
     if (expires <= now) return 'text-red-400'
-    if (expires - now < 30 * 24 * 60 * 60 * 1000) return 'text-amber-400'
+    if (!isLogin && expires - now < 30 * 24 * 60 * 60 * 1000) return 'text-amber-400'
     return 'text-slate-400'
   }
 
@@ -565,7 +578,7 @@ export default function TokensPage() {
                       <td className="px-4 py-3 text-slate-400 text-xs">
                         {formatDate(tok.attributes['last-used-at'])}
                       </td>
-                      <td className={`px-4 py-3 text-xs ${expiryColor(tok.attributes['expires-at'])}`}>
+                      <td className={`px-4 py-3 text-xs ${expiryColor(tok.attributes['expires-at'], isLoginToken(tok))}`}>
                         {formatDate(tok.attributes['expires-at'])}
                       </td>
                       <td className="px-4 py-3 text-right whitespace-nowrap">


### PR DESCRIPTION
Two small tokens-page UX fixes found while reviewing the scoped-service-token work (#495) and the short-lived login tokens (#502).

## 1. Token reveal banner (create + rotate)

The one-time **"Token ready"** banner had no close control and showed the raw secret in the clear.

- **Separate ✕ dismiss** in the corner. **Copy stays copy-only** — it never closes the banner; Copy and Dismiss are distinct buttons.
- The secret is **masked (`••••`) by default** with a **Show / Hide** toggle; **Copy still copies the real value** regardless of mask state (masked dots aren't selectable; the revealed token is). A fresh reveal always starts masked.

## 2. Expiry colour for login tokens

`login_token_ttl_hours` (#502) makes `terraform/tofu login` tokens expire in ~12h, which tripped the amber "nearing expiry" warning. A near-term expiry is **by design** for a login token, so it shouldn't warn.

- Suppress the amber warning **only** for login-generated tokens (description starts with `terraform login`, which the OAuth exchange sets server-side for both terraform and tofu).
- **Manually-created personal tokens keep the amber warning** (a genuine "renew this" signal), as do service tokens. Expired → red for all.

## Verification

- `npm run build` clean; ESLint 0 errors on the changed file.
- `e2e/tests/tokens.spec.ts`: masked-by-default, Show reveals `.tpod.`, Hide re-masks, ✕ dismisses.
- **Live Tilt browser smoke**: Copy doesn't dismiss; ✕ closes; and the expiry colours render login→neutral, manual-personal→amber, service→amber.