### PR TITLE
feat(rbac): dedicated registry_permission on roles (modules + providers)

### DIFF
--- a/alembic/versions/2ad40c9b26b6_role_registry_permission.py
+++ b/alembic/versions/2ad40c9b26b6_role_registry_permission.py
@@ -1,0 +1,50 @@
+"""Role.registry_permission — dedicated registry RBAC level (modules + providers).
+
+Previously a role's registry permission was DERIVED from its
+`workspace_permission` (read/plan -> read, write -> write, admin -> admin),
+so a registry-write role implicitly carried workspace write too. This adds a
+first-class `registry_permission` (read/write/admin) so registry access is
+independent of workspace access — mirroring `pool_permission`.
+
+Back-compat: every existing role is backfilled from its current
+`workspace_permission` via the same mapping that was applied at resolution
+time, so no role's effective registry access changes on upgrade.
+
+Revision ID: 2ad40c9b26b6
+Revises: 3fbcb2885b93
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "2ad40c9b26b6"
+down_revision = "3fbcb2885b93"
+
+
+def upgrade() -> None:
+    # New rows default to "read" (matching pool_permission). Existing rows are
+    # backfilled below to preserve their current effective registry access.
+    op.add_column(
+        "roles",
+        sa.Column(
+            "registry_permission",
+            sa.String(20),
+            nullable=False,
+            server_default="read",
+        ),
+    )
+    # Preserve current behaviour: registry level was workspace_permission mapped
+    # read/plan -> read, write -> write, admin -> admin.
+    op.execute(
+        """
+        UPDATE roles SET registry_permission = CASE workspace_permission
+            WHEN 'admin' THEN 'admin'
+            WHEN 'write' THEN 'write'
+            ELSE 'read'
+        END
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("roles", "registry_permission")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2019,6 +2019,8 @@ POST /api/terrapod/v1/roles
       "name": "developer",
       "description": "Development workspace access",
       "workspace-permission": "write",
+      "pool-permission": "read",
+      "registry-permission": "read",
       "allow-labels": {"env": "dev"},
       "allow-names": [],
       "deny-labels": {},
@@ -2027,6 +2029,8 @@ POST /api/terrapod/v1/roles
   }
 }
 ```
+
+A role carries three independent permission scalars: `workspace-permission` (`read`/`plan`/`write`/`admin`), `pool-permission` (`read`/`write`/`admin`), and `registry-permission` (`read`/`write`/`admin`, covering both modules and providers). All default to `read`. `registry-permission` is independent of `workspace-permission`, so a role can grant registry write (e.g. provider-publish CI) without any workspace access.
 
 **Required permission:** Platform `admin`.
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -29,9 +29,11 @@ Modules and providers use a similar three-level hierarchy (no "plan" concept):
 | **write** | read + create versions, upload artifacts |
 | **admin** | write + update/delete module/provider, change labels |
 
-A role's `workspace_permission` maps to registry permissions: `plan` maps to `read`.
+Each custom role has its own `registry_permission` field (default: `read`), **independent of `workspace_permission`** — so a role can grant registry write (e.g. for provider-publish CI) without granting any workspace access. Modules and providers share this single field. Resolution order mirrors workspaces (platform admin → audit → owner → label RBAC → `access: everyone` floor → none).
 
-**Runner tokens** receive implicit `read` access to all registry modules and providers. This allows runner Jobs to download modules and providers during `terraform init` without requiring explicit label-based permissions on each registry resource.
+> Earlier versions derived the registry level from `workspace_permission`. That mapping was removed in favour of the dedicated field; on upgrade, every existing role's `registry_permission` is backfilled from its `workspace_permission` (read/plan→read, write→write, admin→admin), so no role's effective access changes.
+
+**Runner tokens** receive implicit `read` access to all registry modules and providers, regardless of any role's `registry_permission`. This is resolved from the runner's auth method (not its roles), so runner Jobs can download modules and providers during `terraform init` without explicit label-based permissions on each registry resource.
 
 ### Pool Permission Levels
 

--- a/e2e/tests/roles.spec.ts
+++ b/e2e/tests/roles.spec.ts
@@ -25,13 +25,17 @@ test.describe('Roles & Assignments', () => {
 
     await page.fill('#r-name', roleName);
     await page.selectOption('#r-perm', 'write');
+    // Registry permission is its own field, independent of workspace (#registry-permission).
+    await page.selectOption('#r-registry-perm', 'write');
     await page.fill('#r-desc', 'E2E test role');
 
     // Submit button says "Create Role"
     await page.click('button[type="submit"]:has-text("Create Role")');
 
-    // Role should appear in the list
-    await expect(page.locator(`h3:has-text("${roleName}")`)).toBeVisible({ timeout: 10_000 });
+    // Role should appear in the list, carrying the registry badge.
+    const card = page.locator(`div:has(h3:has-text("${roleName}"))`).first();
+    await expect(card.locator(`h3:has-text("${roleName}")`)).toBeVisible({ timeout: 10_000 });
+    await expect(card.locator('text=registry: write')).toBeVisible();
   });
 
   test('create assignment on assignments tab', async ({ page }) => {

--- a/go-terrapod/roles.go
+++ b/go-terrapod/roles.go
@@ -27,6 +27,7 @@ type Role struct {
 
 	WorkspacePermission string `json:"workspace-permission"` // read | plan | write | admin
 	PoolPermission      string `json:"pool-permission,omitempty"`
+	RegistryPermission  string `json:"registry-permission,omitempty"` // read | write | admin (modules + providers)
 
 	BuiltIn   bool   `json:"built-in"`
 	CreatedAt string `json:"created-at,omitempty"`
@@ -49,6 +50,7 @@ type CreateRoleRequest struct {
 
 	WorkspacePermission string
 	PoolPermission      string
+	RegistryPermission  string
 }
 
 // UpdateRoleRequest is the partial-update shape. Name is immutable.
@@ -65,6 +67,7 @@ type UpdateRoleRequest struct {
 
 	WorkspacePermission string
 	PoolPermission      string
+	RegistryPermission  string
 }
 
 // CreateRole creates a custom role. Admin required.
@@ -128,6 +131,9 @@ func roleCreateAttrs(req CreateRoleRequest) map[string]any {
 	if req.PoolPermission != "" {
 		attrs["pool-permission"] = req.PoolPermission
 	}
+	if req.RegistryPermission != "" {
+		attrs["registry-permission"] = req.RegistryPermission
+	}
 	if req.Description != "" {
 		attrs["description"] = req.Description
 	}
@@ -147,6 +153,9 @@ func roleUpdateAttrs(req UpdateRoleRequest) map[string]any {
 	}
 	if req.PoolPermission != "" {
 		attrs["pool-permission"] = req.PoolPermission
+	}
+	if req.RegistryPermission != "" {
+		attrs["registry-permission"] = req.RegistryPermission
 	}
 	if req.Description != nil {
 		attrs["description"] = *req.Description
@@ -241,6 +250,7 @@ func roleFromItem(item *roleDataItem) (*Role, error) {
 		DenyNames           []string          `json:"deny-names"`
 		WorkspacePermission string            `json:"workspace-permission"`
 		PoolPermission      string            `json:"pool-permission"`
+		RegistryPermission  string            `json:"registry-permission"`
 		BuiltIn             bool              `json:"built-in"`
 		CreatedAt           string            `json:"created-at"`
 		UpdatedAt           string            `json:"updated-at"`
@@ -259,6 +269,7 @@ func roleFromItem(item *roleDataItem) (*Role, error) {
 		DenyNames:           attrs.DenyNames,
 		WorkspacePermission: attrs.WorkspacePermission,
 		PoolPermission:      attrs.PoolPermission,
+		RegistryPermission:  attrs.RegistryPermission,
 		BuiltIn:             attrs.BuiltIn,
 		CreatedAt:           attrs.CreatedAt,
 		UpdatedAt:           attrs.UpdatedAt,

--- a/go-terrapod/roles_test.go
+++ b/go-terrapod/roles_test.go
@@ -24,7 +24,7 @@ func newRoleFixture(t *testing.T) (*Client, *[]byte) {
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"data":{"name":"sre","type":"roles","attributes":{
 			  "description":"SRE team",
-			  "workspace-permission":"admin","pool-permission":"admin",
+			  "workspace-permission":"admin","pool-permission":"admin","registry-permission":"write",
 			  "allow-labels":{"team":"sre"},"allow-names":["prod-*"],
 			  "deny-labels":{},"deny-names":[],
 			  "built-in":false
@@ -65,6 +65,7 @@ func TestCreateRole_FullShape(t *testing.T) {
 		Description:         "SRE team",
 		WorkspacePermission: "admin",
 		PoolPermission:      "admin",
+		RegistryPermission:  "write",
 		AllowLabels:         map[string]string{"team": "sre"},
 		AllowNames:          []string{"prod-*"},
 	})
@@ -73,6 +74,9 @@ func TestCreateRole_FullShape(t *testing.T) {
 	}
 	if r.Name != "sre" || r.AllowLabels["team"] != "sre" || r.WorkspacePermission != "admin" {
 		t.Errorf("role: %+v", r)
+	}
+	if r.RegistryPermission != "write" {
+		t.Errorf("registry-permission not parsed: %+v", r)
 	}
 	// Body shape — "name" at data level, attributes contain the rest.
 	var req struct {
@@ -88,6 +92,9 @@ func TestCreateRole_FullShape(t *testing.T) {
 	}
 	if req.Data.Attributes["workspace-permission"] != "admin" {
 		t.Errorf("workspace-permission missing: %+v", req.Data.Attributes)
+	}
+	if req.Data.Attributes["registry-permission"] != "write" {
+		t.Errorf("registry-permission not sent: %+v", req.Data.Attributes)
 	}
 }
 

--- a/provider/internal/datasources/role/data_source.go
+++ b/provider/internal/datasources/role/data_source.go
@@ -28,6 +28,7 @@ type roleDataSourceModel struct {
 	DenyLabels          types.Map    `tfsdk:"deny_labels"`
 	DenyNames           types.List   `tfsdk:"deny_names"`
 	WorkspacePermission types.String `tfsdk:"workspace_permission"`
+	RegistryPermission  types.String `tfsdk:"registry_permission"`
 	BuiltIn             types.Bool   `tfsdk:"built_in"`
 	CreatedAt           types.String `tfsdk:"created_at"`
 	UpdatedAt           types.String `tfsdk:"updated_at"`
@@ -52,6 +53,7 @@ func (d *roleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 			"deny_labels":          schema.MapAttribute{Computed: true, ElementType: types.StringType, Description: "Deny labels."},
 			"deny_names":           schema.ListAttribute{Computed: true, ElementType: types.StringType, Description: "Deny name patterns."},
 			"workspace_permission": schema.StringAttribute{Computed: true, Description: "Permission level."},
+			"registry_permission":  schema.StringAttribute{Computed: true, Description: "Registry (modules + providers) permission level: read, write, or admin."},
 			"built_in":             schema.BoolAttribute{Computed: true, Description: "Whether the role is built-in."},
 			"created_at":           schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
 			"updated_at":           schema.StringAttribute{Computed: true, Description: "Update timestamp."},
@@ -96,6 +98,7 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		config.Description = types.StringNull()
 	}
 	config.WorkspacePermission = types.StringValue(role.WorkspacePermission)
+	config.RegistryPermission = types.StringValue(role.RegistryPermission)
 	config.BuiltIn = types.BoolValue(role.BuiltIn)
 	config.CreatedAt = types.StringValue(role.CreatedAt)
 	config.UpdatedAt = types.StringValue(role.UpdatedAt)

--- a/provider/internal/resources/role/resource.go
+++ b/provider/internal/resources/role/resource.go
@@ -48,6 +48,7 @@ type roleModel struct {
 	DenyNames           types.List   `tfsdk:"deny_names"`
 	WorkspacePermission types.String `tfsdk:"workspace_permission"`
 	PoolPermission      types.String `tfsdk:"pool_permission"`
+	RegistryPermission  types.String `tfsdk:"registry_permission"`
 
 	BuiltIn   types.Bool   `tfsdk:"built_in"`
 	CreatedAt types.String `tfsdk:"created_at"`
@@ -115,6 +116,14 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			},
 			"pool_permission": schema.StringAttribute{
 				Description: "Agent pool permission level: read, write, or admin. Defaults to read.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"registry_permission": schema.StringAttribute{
+				Description: "Registry permission level for modules and providers: read, write, or admin. Defaults to read.",
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
@@ -253,6 +262,9 @@ func buildCreateRoleRequest(m *roleModel) terrapod.CreateRoleRequest {
 	if !m.PoolPermission.IsNull() && !m.PoolPermission.IsUnknown() {
 		req.PoolPermission = m.PoolPermission.ValueString()
 	}
+	if !m.RegistryPermission.IsNull() && !m.RegistryPermission.IsUnknown() {
+		req.RegistryPermission = m.RegistryPermission.ValueString()
+	}
 	if !m.Description.IsNull() {
 		req.Description = m.Description.ValueString()
 	}
@@ -281,6 +293,9 @@ func buildUpdateRoleRequest(m *roleModel) terrapod.UpdateRoleRequest {
 	}
 	if !m.PoolPermission.IsNull() && !m.PoolPermission.IsUnknown() {
 		req.PoolPermission = m.PoolPermission.ValueString()
+	}
+	if !m.RegistryPermission.IsNull() && !m.RegistryPermission.IsUnknown() {
+		req.RegistryPermission = m.RegistryPermission.ValueString()
 	}
 	if !m.Description.IsNull() && !m.Description.IsUnknown() {
 		d := m.Description.ValueString()
@@ -312,6 +327,11 @@ func readRoleFromSDK(ctx context.Context, role *terrapod.Role, m *roleModel) dia
 		m.PoolPermission = types.StringValue(role.PoolPermission)
 	} else {
 		m.PoolPermission = types.StringValue("read")
+	}
+	if role.RegistryPermission != "" {
+		m.RegistryPermission = types.StringValue(role.RegistryPermission)
+	} else {
+		m.RegistryPermission = types.StringValue("read")
 	}
 
 	m.BuiltIn = types.BoolValue(role.BuiltIn)

--- a/services/terrapod/api/routers/roles.py
+++ b/services/terrapod/api/routers/roles.py
@@ -31,6 +31,7 @@ logger = get_logger(__name__)
 
 VALID_PERMISSIONS = {"read", "plan", "write", "admin"}
 VALID_POOL_PERMISSIONS = {"read", "write", "admin"}
+VALID_REGISTRY_PERMISSIONS = {"read", "write", "admin"}
 
 
 def _rfc3339(dt) -> str:
@@ -51,6 +52,7 @@ def _role_json(role: Role) -> dict:
             "deny-names": role.deny_names,
             "workspace-permission": role.workspace_permission,
             "pool-permission": role.pool_permission,
+            "registry-permission": role.registry_permission,
             "built-in": False,
             "created-at": _rfc3339(role.created_at),
             "updated-at": _rfc3339(role.updated_at),
@@ -70,6 +72,7 @@ def _builtin_role_json(name: str, info: dict) -> dict:
             "deny-names": [],
             "workspace-permission": "admin" if name == "admin" else "read",
             "pool-permission": "admin" if name == "admin" else "read",
+            "registry-permission": "admin" if name == "admin" else "read",
             "built-in": True,
             "created-at": "",
             "updated-at": "",
@@ -124,6 +127,10 @@ async def create_role(
     if pool_perm not in VALID_POOL_PERMISSIONS:
         raise HTTPException(status_code=422, detail=f"Invalid pool-permission: {pool_perm}")
 
+    registry_perm = attrs.get("registry-permission", "read")
+    if registry_perm not in VALID_REGISTRY_PERMISSIONS:
+        raise HTTPException(status_code=422, detail=f"Invalid registry-permission: {registry_perm}")
+
     role = Role(
         name=name,
         description=attrs.get("description", ""),
@@ -133,6 +140,7 @@ async def create_role(
         deny_names=attrs.get("deny-names", []),
         workspace_permission=ws_perm,
         pool_permission=pool_perm,
+        registry_permission=registry_perm,
     )
     db.add(role)
     await db.commit()
@@ -199,6 +207,13 @@ async def update_role(
         if pool_perm not in VALID_POOL_PERMISSIONS:
             raise HTTPException(status_code=422, detail=f"Invalid pool-permission: {pool_perm}")
         role.pool_permission = pool_perm
+    if "registry-permission" in attrs:
+        registry_perm = attrs["registry-permission"]
+        if registry_perm not in VALID_REGISTRY_PERMISSIONS:
+            raise HTTPException(
+                status_code=422, detail=f"Invalid registry-permission: {registry_perm}"
+            )
+        role.registry_permission = registry_perm
 
     await db.commit()
     await db.refresh(role)

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -103,6 +103,9 @@ class Role(Base):
     pool_permission: Mapped[str] = mapped_column(
         String(20), nullable=False, default="read", server_default="read"
     )  # read, write, admin
+    registry_permission: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="read", server_default="read"
+    )  # read, write, admin — modules + providers share this
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False

--- a/services/terrapod/services/registry_rbac_service.py
+++ b/services/terrapod/services/registry_rbac_service.py
@@ -25,15 +25,6 @@ logger = get_logger(__name__)
 
 REGISTRY_PERMISSION_HIERARCHY = {"read": 0, "write": 1, "admin": 2}
 
-# Map workspace_permission values to registry permission levels.
-# "plan" has no meaning for registry resources → maps to "read".
-_WS_PERM_TO_REGISTRY = {
-    "read": "read",
-    "plan": "read",
-    "write": "write",
-    "admin": "admin",
-}
-
 
 def has_registry_permission(effective: str | None, required: str) -> bool:
     """Check if effective permission meets the required level."""
@@ -79,7 +70,7 @@ async def resolve_registry_permission(
     2. Platform audit → read
     3. Runner token → read (runners must download modules/providers to execute)
     4. Resource owner → admin
-    5. Label-based RBAC (custom roles) → mapped workspace_permission
+    5. Label-based RBAC (custom roles) → role.registry_permission
     6. 'everyone' role with access: everyone label → read
     7. Default → None (no access)
 
@@ -139,7 +130,8 @@ async def resolve_registry_permission(
                 matched = True
 
             if matched:
-                registry_perm = _WS_PERM_TO_REGISTRY.get(role.workspace_permission, "read")
+                # Dedicated registry level, independent of workspace_permission.
+                registry_perm = role.registry_permission
                 if best is None or REGISTRY_PERMISSION_HIERARCHY.get(
                     registry_perm, -1
                 ) > REGISTRY_PERMISSION_HIERARCHY.get(best, -1):

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -28,7 +28,7 @@ def _user(email="admin@example.com", roles=None):
     )
 
 
-def _mock_role(name="dev-team", ws_perm="read"):
+def _mock_role(name="dev-team", ws_perm="read", reg_perm="read"):
     role = MagicMock()
     role.name = name
     role.description = "A custom role"
@@ -38,6 +38,7 @@ def _mock_role(name="dev-team", ws_perm="read"):
     role.deny_names = []
     role.workspace_permission = ws_perm
     role.pool_permission = "read"
+    role.registry_permission = reg_perm
     role.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     role.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return role
@@ -293,6 +294,84 @@ class TestCreateRole:
                 headers=_AUTH,
             )
         assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_with_registry_permission(self, *mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/roles",
+                json={
+                    "data": {
+                        "name": "registry-publish-role",
+                        "attributes": {
+                            "workspace-permission": "read",
+                            "registry-permission": "write",
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 201
+        assert resp.json()["data"]["attributes"]["registry-permission"] == "write"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_invalid_registry_permission_rejected(self, *mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/roles",
+                json={
+                    "data": {
+                        "name": "bad-registry",
+                        "attributes": {
+                            "workspace-permission": "read",
+                            "registry-permission": "superadmin",
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_list_includes_registry_permission(self, *mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        role = _mock_role("reg-role", reg_perm="write")
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [role]
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/roles", headers=_AUTH)
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        custom_entry = next(r for r in data if r["name"] == "reg-role")
+        assert custom_entry["attributes"]["registry-permission"] == "write"
+        # Built-in admin should have registry-permission: admin
+        admin_entry = next(r for r in data if r["name"] == "admin")
+        assert admin_entry["attributes"]["registry-permission"] == "admin"
+        # Built-in audit/everyone get registry read
+        audit_entry = next(r for r in data if r["name"] == "audit")
+        assert audit_entry["attributes"]["registry-permission"] == "read"
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/services/test_registry_rbac.py
+++ b/services/tests/services/test_registry_rbac.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.services.registry_rbac_service import (
-    _WS_PERM_TO_REGISTRY,
     REGISTRY_PERMISSION_HIERARCHY,
     has_registry_permission,
     resolve_registry_permission,
@@ -45,23 +44,6 @@ class TestHasRegistryPermission:
                 assert has_registry_permission(effective, required) is expected
 
 
-# ── Permission mapping ─────────────────────────────────────────────────
-
-
-class TestPermissionMapping:
-    def test_read_maps_to_read(self):
-        assert _WS_PERM_TO_REGISTRY["read"] == "read"
-
-    def test_plan_maps_to_read(self):
-        assert _WS_PERM_TO_REGISTRY["plan"] == "read"
-
-    def test_write_maps_to_write(self):
-        assert _WS_PERM_TO_REGISTRY["write"] == "write"
-
-    def test_admin_maps_to_admin(self):
-        assert _WS_PERM_TO_REGISTRY["admin"] == "admin"
-
-
 # ── resolve_registry_permission ────────────────────────────────────────
 
 
@@ -73,9 +55,13 @@ def _mock_db_with_roles(roles=None):
     return db
 
 
+_WS_TO_REG = {"read": "read", "plan": "read", "write": "write", "admin": "admin"}
+
+
 def _mock_role(
     name,
     workspace_permission="read",
+    registry_permission=None,
     allow_labels=None,
     allow_names=None,
     deny_labels=None,
@@ -84,6 +70,10 @@ def _mock_role(
     role = MagicMock()
     role.name = name
     role.workspace_permission = workspace_permission
+    # Default registry level to mirror workspace_permission unless set explicitly.
+    role.registry_permission = (
+        registry_permission if registry_permission is not None else _WS_TO_REG[workspace_permission]
+    )
     role.allow_labels = allow_labels or {}
     role.allow_names = allow_names or []
     role.deny_labels = deny_labels or {}
@@ -117,7 +107,7 @@ class TestResolveRegistryPermission:
     async def test_custom_role_label_match(self):
         role = _mock_role(
             "mod-team",
-            workspace_permission="write",
+            registry_permission="write",
             allow_labels={"team": ["platform"]},
         )
         db = _mock_db_with_roles([role])
@@ -126,11 +116,13 @@ class TestResolveRegistryPermission:
         )
         assert result == "write"
 
-    async def test_plan_permission_maps_to_read(self):
-        """A role with workspace_permission='plan' grants registry 'read'."""
+    async def test_uses_registry_permission_not_workspace(self):
+        """The registry level is the role's registry_permission, independent of
+        workspace_permission (the old derive-from-workspace mapping is gone)."""
         role = _mock_role(
             "plan-role",
-            workspace_permission="plan",
+            workspace_permission="admin",
+            registry_permission="read",
             allow_names=["my-module"],
         )
         db = _mock_db_with_roles([role])

--- a/services/tests/services/test_registry_rbac_service.py
+++ b/services/tests/services/test_registry_rbac_service.py
@@ -1,4 +1,5 @@
-"""Tests for registry RBAC — permission resolution, owner, runner token read, plan→read mapping."""
+"""Tests for registry RBAC — permission resolution, owner, runner-token read, and the
+dedicated registry_permission field (independent of workspace_permission)."""
 
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,11 +11,14 @@ from terrapod.services.registry_rbac_service import (
     resolve_registry_permission,
 )
 
+_WS_TO_REG = {"read": "read", "plan": "read", "write": "write", "admin": "admin"}
+
 
 def _make_role(
     *,
     name="custom-role",
     workspace_permission="read",
+    registry_permission=None,
     allow_labels=None,
     allow_names=None,
     deny_labels=None,
@@ -23,6 +27,12 @@ def _make_role(
     role = MagicMock()
     role.name = name
     role.workspace_permission = workspace_permission
+    # Default the registry level to mirror workspace_permission so tests that
+    # only specify a workspace level still express their intended registry
+    # access; pass registry_permission explicitly to decouple them.
+    role.registry_permission = (
+        registry_permission if registry_permission is not None else _WS_TO_REG[workspace_permission]
+    )
     role.allow_labels = allow_labels or {}
     role.allow_names = allow_names or []
     role.deny_labels = deny_labels or {}
@@ -99,7 +109,7 @@ class TestResolveRegistryPermission:
 
     @pytest.mark.asyncio
     async def test_label_based_access(self):
-        role = _make_role(workspace_permission="write", allow_labels={"scope": ["public"]})
+        role = _make_role(registry_permission="write", allow_labels={"scope": ["public"]})
         db = _mock_db_with_roles([role])
         result = await resolve_registry_permission(
             db, "user@test.com", ["custom-role"], "my-module", {"scope": "public"}, ""
@@ -107,12 +117,55 @@ class TestResolveRegistryPermission:
         assert result == "write"
 
     @pytest.mark.asyncio
-    async def test_plan_permission_maps_to_read(self):
-        """workspace_permission=plan maps to registry read."""
-        role = _make_role(workspace_permission="plan", allow_labels={"scope": ["public"]})
+    async def test_registry_permission_independent_of_workspace(self):
+        """The registry level comes from registry_permission, NOT workspace_permission.
+
+        A role with admin workspace access but read-only registry access grants
+        only registry read — the old derive-from-workspace behaviour is gone.
+        """
+        role = _make_role(
+            workspace_permission="admin",
+            registry_permission="read",
+            allow_labels={"scope": ["public"]},
+        )
         db = _mock_db_with_roles([role])
         result = await resolve_registry_permission(
             db, "user@test.com", ["custom-role"], "my-module", {"scope": "public"}, ""
+        )
+        assert result == "read"
+
+    @pytest.mark.asyncio
+    async def test_registry_admin_via_dedicated_field(self):
+        role = _make_role(
+            workspace_permission="read",
+            registry_permission="admin",
+            allow_labels={"scope": ["public"]},
+        )
+        db = _mock_db_with_roles([role])
+        result = await resolve_registry_permission(
+            db, "user@test.com", ["custom-role"], "my-module", {"scope": "public"}, ""
+        )
+        assert result == "admin"
+
+    @pytest.mark.asyncio
+    async def test_runner_token_read_unaffected_by_registry_permission(self):
+        """Runner tokens get registry read regardless of any role's registry level.
+
+        The runner read comes from the auth_method path, BEFORE the custom-role
+        loop — switching the role loop to registry_permission must not change it.
+        Runners carry the 'everyone' role only, so no custom role applies, but a
+        matching write role here would still floor at read (it only raises).
+        """
+        role = _make_role(registry_permission="admin", allow_labels={"scope": ["public"]})
+        db = _mock_db_with_roles([role])
+        result = await resolve_registry_permission(
+            db,
+            "runner@system",
+            ["everyone"],  # runners carry everyone only — the admin role won't match
+            "my-module",
+            {"scope": "public"},
+            "",
+            auth_method="runner_token",
         )
         assert result == "read"
 

--- a/services/tests/services/test_token_scoped_rbac.py
+++ b/services/tests/services/test_token_scoped_rbac.py
@@ -44,11 +44,19 @@ def _workspace(*, name="ws-1", labels=None, owner_email=None):
     return ws
 
 
-def _role(*, name, workspace_permission="read", pool_permission="read", allow_names=None):
+def _role(
+    *,
+    name,
+    workspace_permission="read",
+    pool_permission="read",
+    registry_permission="read",
+    allow_names=None,
+):
     role = MagicMock()
     role.name = name
     role.workspace_permission = workspace_permission
     role.pool_permission = pool_permission
+    role.registry_permission = registry_permission
     role.allow_labels = {}
     role.allow_names = allow_names or []
     role.deny_labels = {}
@@ -232,7 +240,7 @@ class TestPoolAndRegistryForResolution:
         assert perm == "write"
 
     async def test_registry_detached_pinned_only(self):
-        writer = _role(name="mod-writer", workspace_permission="write", allow_names=["mod-1"])
+        writer = _role(name="mod-writer", registry_permission="write", allow_names=["mod-1"])
         db = _db_with_roles([writer])
         u = _user(email="", roles=[], kind="service_detached", pinned=["mod-writer"])
         perm = await registry_rbac_service.resolve_registry_permission_for(

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -21,6 +21,7 @@ interface Role {
     'built-in': boolean
     'workspace-permission': string | null
     'pool-permission': string | null
+    'registry-permission': string | null
     'allow-labels': Record<string, string>
     'allow-names': string[]
     'deny-labels': Record<string, string>
@@ -66,6 +67,7 @@ export default function RolesPage() {
   const [roleAllowNames, setRoleAllowNames] = useState('')
   const [roleDenyLabels, setRoleDenyLabels] = useState('')
   const [rolePoolPermission, setRolePoolPermission] = useState('read')
+  const [roleRegistryPermission, setRoleRegistryPermission] = useState('read')
   const [roleDenyNames, setRoleDenyNames] = useState('')
   const [creatingRole, setCreatingRole] = useState(false)
 
@@ -77,6 +79,7 @@ export default function RolesPage() {
   const [editRoleAllowNames, setEditRoleAllowNames] = useState('')
   const [editRoleDenyLabels, setEditRoleDenyLabels] = useState('')
   const [editRolePoolPermission, setEditRolePoolPermission] = useState('read')
+  const [editRoleRegistryPermission, setEditRoleRegistryPermission] = useState('read')
   const [editRoleDenyNames, setEditRoleDenyNames] = useState('')
   const [savingRole, setSavingRole] = useState(false)
 
@@ -179,6 +182,7 @@ export default function RolesPage() {
         description: roleDesc,
         'workspace-permission': rolePermission,
         'pool-permission': rolePoolPermission,
+        'registry-permission': roleRegistryPermission,
       }
       if (roleAllowLabels.trim()) attrs['allow-labels'] = parseLabels(roleAllowLabels)
       if (roleAllowNames.trim()) attrs['allow-names'] = roleAllowNames.split(',').map((s) => s.trim()).filter(Boolean)
@@ -199,6 +203,7 @@ export default function RolesPage() {
       setRoleDesc('')
       setRolePermission('read')
       setRolePoolPermission('read')
+      setRoleRegistryPermission('read')
       setRoleAllowLabels('')
       setRoleAllowNames('')
       setRoleDenyLabels('')
@@ -217,6 +222,7 @@ export default function RolesPage() {
     setEditRoleDesc(role.attributes.description || '')
     setEditRolePermission(role.attributes['workspace-permission'] || 'read')
     setEditRolePoolPermission(role.attributes['pool-permission'] || 'read')
+    setEditRoleRegistryPermission(role.attributes['registry-permission'] || 'read')
     setEditRoleAllowLabels(formatLabels(role.attributes['allow-labels'] || {}))
     setEditRoleAllowNames((role.attributes['allow-names'] || []).join(', '))
     setEditRoleDenyLabels(formatLabels(role.attributes['deny-labels'] || {}))
@@ -233,6 +239,7 @@ export default function RolesPage() {
         description: editRoleDesc,
         'workspace-permission': editRolePermission,
         'pool-permission': editRolePoolPermission,
+        'registry-permission': editRoleRegistryPermission,
         'allow-labels': parseLabels(editRoleAllowLabels),
         'allow-names': editRoleAllowNames.split(',').map((s) => s.trim()).filter(Boolean),
         'deny-labels': parseLabels(editRoleDenyLabels),
@@ -417,6 +424,15 @@ export default function RolesPage() {
                       <option value="admin">admin</option>
                     </select>
                   </div>
+                  <div>
+                    <label htmlFor="r-registry-perm" className="block text-sm font-medium text-slate-300 mb-1">Registry Permission</label>
+                    <select id="r-registry-perm" value={roleRegistryPermission} onChange={(e) => setRoleRegistryPermission(e.target.value)}
+                      className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent">
+                      <option value="read">read</option>
+                      <option value="write">write</option>
+                      <option value="admin">admin</option>
+                    </select>
+                  </div>
                 </div>
                 <div>
                   <label htmlFor="r-desc" className="block text-sm font-medium text-slate-300 mb-1">Description</label>
@@ -500,6 +516,15 @@ export default function RolesPage() {
                               </select>
                             </div>
                             <div>
+                              <label className="block text-xs text-slate-500 mb-1">Registry Permission</label>
+                              <select value={editRoleRegistryPermission} onChange={(e) => setEditRoleRegistryPermission(e.target.value)}
+                                className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500">
+                                <option value="read">read</option>
+                                <option value="write">write</option>
+                                <option value="admin">admin</option>
+                              </select>
+                            </div>
+                            <div>
                               <label className="block text-xs text-slate-500 mb-1">Allow Labels</label>
                               <input type="text" value={editRoleAllowLabels} onChange={(e) => setEditRoleAllowLabels(e.target.value)}
                                 className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
@@ -537,6 +562,11 @@ export default function RolesPage() {
                               {a['pool-permission'] && a['pool-permission'] !== 'read' && (
                                 <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${permissionBadge(a['pool-permission'])}`}>
                                   pool: {a['pool-permission']}
+                                </span>
+                              )}
+                              {a['registry-permission'] && a['registry-permission'] !== 'read' && (
+                                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${permissionBadge(a['registry-permission'])}`}>
+                                  registry: {a['registry-permission']}
                                 </span>
                               )}
                             </div>


### PR DESCRIPTION
Adds a first-class **`registry_permission`** field to roles, removing the wart where the registry (module + provider) level was *derived* from `workspace_permission` — which meant a registry-write role implicitly carried workspace write too.

Now registry access is **independent** of workspace access (mirroring `pool_permission`), so a role can grant exactly registry write — e.g. for provider-publish CI — and nothing else.

## Change

- **`Role.registry_permission`** column (`read`/`write`/`admin`, default `read`). Migration **backfills** every existing role from its `workspace_permission` (`read`/`plan`→`read`, `write`→`write`, `admin`→`admin`), so **no role's effective access changes on upgrade**. Real `downgrade()`.
- **`registry_rbac_service`** resolves from `role.registry_permission`. The **runner-token implicit registry read** (resolved from `auth_method`, *before* the custom-role loop) and the `audit` / `access:everyone` floors are **untouched** — covered by an explicit regression test.
- **roles router** serializes `registry-permission` (custom roles + builtins: `admin`→`admin`, `audit`/`everyone`→`read`) and validates it on create/update.
- **Consumers:** go-terrapod (`RegistryPermission` field + round-trip test), terraform provider (role resource + data source), web roles page (selector + badge).
- **Docs:** `rbac.md`, `api-reference.md`.

## Single field for modules + providers

They share one resolver, so one `registry_permission` covers both — matching the single-scalar pattern of `workspace_permission` / `pool_permission`.

## Verification

- **2146 Python tests** pass (incl. runner-token-read regression + registry-independent-of-workspace); go-terrapod + provider build/test; `make lint` clean; `npm run build` clean.
- **Live Tilt smoke:** migration applied + backfill verified (existing roles `read→read`, builtins serialize correctly); a `registry_permission=write` / `workspace_permission=read` role pinned to a **detached** token gave `can-create-version: true` (registry write) with `can-update/destroy: false` (not admin) on a matching provider, and **403 on a workspace** (no workspace leak).

## Follow-up

The awsmai-publish role (terrapod-config #47) becomes truly least-privilege once this releases: `registry_permission = "write"` + `workspace_permission = "read"`.
