### PR TITLE
fix(ai-summary): scope CODE_DIFF tfvars to the var-files a workspace loads

### DIFF
--- a/docs/ai-plan-summary.md
+++ b/docs/ai-plan-summary.md
@@ -283,6 +283,14 @@ the bulk of the request):
   between this run's config version and the previously-applied
   config version. Empty when there's no prior CV (first run, or
   GC'd). Capped at `ai_summary.code_diff_max_bytes` (default 100 KB).
+  `.tfvars` files are **scoped to the var-files this workspace loads**
+  (its `var_files`, plus auto-loaded `terraform.tfvars` / `*.auto.tfvars`).
+  In a monorepo one repo holds one var-file per environment but each
+  workspace loads only its own; without this scoping a change to
+  `envs/prod-us1.tfvars` would appear in the `stg-us1` workspace's diff
+  and inflate its risk even though that workspace's plan has no changes.
+  When a workspace declares no `var_files`, all `.tfvars` are included
+  (no signal to scope by).
 - `CODE_CONTEXT` — concatenated `.tf` files from this run's
   config-version tarball. Capped at
   `ai_summary.code_context_max_bytes` (default 200 KB).

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -270,18 +270,64 @@ def _resource_change_is_informative(r: object) -> bool:
     return any(a not in ("no-op", "read") for a in actions)
 
 
-def _extract_tf_files_to_dir(tarball: bytes, target: pathlib.Path) -> int:
+def _tfvars_is_loaded(member_name: str, var_files: set[str]) -> bool:
+    """Whether a ``.tfvars`` file in the CV tarball is actually loaded by
+    this workspace.
+
+    terraform/tofu auto-load ``terraform.tfvars`` and ``*.auto.tfvars``
+    regardless; every other ``.tfvars`` is loaded ONLY when passed via
+    ``-var-file`` (the workspace's ``var_files``). In a monorepo a single
+    repo holds one ``.tfvars`` per environment, but each workspace loads
+    only its own — so the *other* environments' var-files must be excluded
+    from CODE_DIFF, or an unrelated env's change inflates this workspace's
+    risk (the model rates the diff it's shown).
+
+    When ``var_files`` is empty the workspace declares no explicit
+    var-files, so we can't tell which non-auto tfvars matter — keep the
+    pre-existing behaviour and include them all rather than risk dropping a
+    file the workspace does use.
+
+    Matching is rooting-robust: a ``var_files`` entry is relative to the
+    workspace ``working_directory`` while the tarball may be rooted at the
+    repo (or vice-versa), so we accept an exact match, a path-suffix match
+    in either direction, and a basename match (env var-file names are
+    unique in practice, e.g. ``stg-us1.tfvars`` vs ``prod-us1.tfvars``).
+    """
+    base = member_name.rsplit("/", 1)[-1]
+    if base == "terraform.tfvars" or base.endswith(".auto.tfvars"):
+        return True
+    if not var_files:
+        return True
+    if member_name in var_files:
+        return True
+    if any(member_name.endswith("/" + vf) or vf.endswith("/" + member_name) for vf in var_files):
+        return True
+    return base in {vf.rsplit("/", 1)[-1] for vf in var_files}
+
+
+def _extract_tf_files_to_dir(
+    tarball: bytes, target: pathlib.Path, var_files: set[str] | None = None
+) -> int:
     """Extract *.tf / *.tfvars files from a config-version tarball.
+
+    ``.tf`` files always apply and are always written. ``.tfvars`` files
+    are filtered to those the workspace actually loads (see
+    :func:`_tfvars_is_loaded`) so a monorepo's other-environment var-files
+    don't pollute CODE_DIFF.
 
     Returns the number of files written. Defends against zip-slip via
     member-name normalisation; skips entries whose path escapes target.
     """
+    vf = var_files or set()
     written = 0
     with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
         for member in tar:
             if not member.isfile():
                 continue
-            if not (member.name.endswith(".tf") or member.name.endswith(".tfvars")):
+            if member.name.endswith(".tfvars"):
+                if not _tfvars_is_loaded(member.name, vf):
+                    continue
+            elif not member.name.endswith(".tf"):
                 continue
             safe = pathlib.PurePosixPath(member.name).as_posix()
             if safe.startswith("/") or ".." in safe.split("/"):
@@ -296,7 +342,12 @@ def _extract_tf_files_to_dir(tarball: bytes, target: pathlib.Path) -> int:
     return written
 
 
-def _build_code_diff(prev_tarball: bytes | None, cur_tarball: bytes, max_bytes: int) -> str:
+def _build_code_diff(
+    prev_tarball: bytes | None,
+    cur_tarball: bytes,
+    max_bytes: int,
+    var_files: set[str] | None = None,
+) -> str:
     """Return a unified diff of *.tf / *.tfvars between two CV tarballs.
 
     Returns "" when:
@@ -322,8 +373,8 @@ def _build_code_diff(prev_tarball: bytes | None, cur_tarball: bytes, max_bytes: 
         prev_dir.mkdir()
         cur_dir.mkdir()
         try:
-            prev_n = _extract_tf_files_to_dir(prev_tarball, prev_dir)
-            cur_n = _extract_tf_files_to_dir(cur_tarball, cur_dir)
+            prev_n = _extract_tf_files_to_dir(prev_tarball, prev_dir, var_files)
+            cur_n = _extract_tf_files_to_dir(cur_tarball, cur_dir, var_files)
         except tarfile.TarError as e:
             logger.debug("CODE_DIFF: tarball extract failed", error=str(e))
             return ""
@@ -398,14 +449,18 @@ async def _find_previously_applied_cv_id(
     return (await db.execute(stmt)).scalar_one_or_none()
 
 
-async def _gather_inputs(db: AsyncSession, run: Run, kind: str) -> tuple[str, str, str, str, str]:
+async def _gather_inputs(
+    db: AsyncSession, run: Run, kind: str, var_files: set[str] | None = None
+) -> tuple[str, str, str, str, str]:
     """Return ``(primary_input, primary_label, primary_lang, code_context, code_diff)``.
 
     primary_input is the (cleaned) plan JSON for ``plan_summary`` or
     the plan log for ``failure_analysis``. code_context is the
     concatenated current .tf source. code_diff is a unified diff of
     *.tf / *.tfvars between this run's CV and the previously-applied
-    CV (when both tarballs are available).
+    CV (when both tarballs are available), with ``.tfvars`` scoped to the
+    var-files this workspace actually loads (``var_files``) so a monorepo's
+    other-environment var-files don't pollute the diff.
     """
     storage = get_storage()
     cfg = settings.ai_summary
@@ -482,7 +537,11 @@ async def _gather_inputs(db: AsyncSession, run: Run, kind: str) -> tuple[str, st
             if prev_tarball is not None:
                 try:
                     code_diff = await asyncio.to_thread(
-                        _build_code_diff, prev_tarball, cur_tarball, cfg.code_diff_max_bytes
+                        _build_code_diff,
+                        prev_tarball,
+                        cur_tarball,
+                        cfg.code_diff_max_bytes,
+                        var_files,
                     )
                 except Exception as e:
                     logger.debug("Failed to build code_diff", error=str(e))
@@ -1086,7 +1145,9 @@ async def handle_ai_plan_summary(payload: dict) -> None:
             await _emit_summary_event("plan_summary_skipped", ws.id, run_id)
             return
 
-        primary, label, lang, code_context, code_diff = await _gather_inputs(db, run, kind)
+        primary, label, lang, code_context, code_diff = await _gather_inputs(
+            db, run, kind, set(ws.var_files or [])
+        )
         if not primary:
             await _upsert_summary(
                 db,
@@ -1461,8 +1522,12 @@ async def post_followup(
     await db.flush()
 
     # Build the cacheable prefix — SAME inputs the initial summary
-    # used, so the provider's prompt cache serves the prefix hit.
-    primary, label, lang, code_context, code_diff = await _gather_inputs(db, run, plan_summary.kind)
+    # used, so the provider's prompt cache serves the prefix hit. That
+    # includes the var-file scoping of CODE_DIFF — pass the same
+    # var_files or the prefix diverges and the cache misses.
+    primary, label, lang, code_context, code_diff = await _gather_inputs(
+        db, run, plan_summary.kind, set(workspace.var_files or [])
+    )
     if not primary:
         # The CV/log was GC'd or never existed. Record an errored
         # assistant row so the transcript is uniform, commit, surface.

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -134,6 +134,66 @@ def test_extract_tf_sources_returns_empty_on_corrupt_tarball():
     assert summariser._extract_tf_sources(b"not a tarball", 100) == ""
 
 
+# ── CODE_DIFF var-file scoping ───────────────────────────────────────────
+
+
+def test_tfvars_is_loaded_auto_loaded_always_included():
+    # terraform.tfvars and *.auto.tfvars are auto-loaded regardless of var_files
+    assert summariser._tfvars_is_loaded("terraform.tfvars", set()) is True
+    assert summariser._tfvars_is_loaded("foo.auto.tfvars", {"envs/stg.tfvars"}) is True
+    assert summariser._tfvars_is_loaded("a/b/terraform.tfvars", {"envs/stg.tfvars"}) is True
+
+
+def test_tfvars_is_loaded_empty_var_files_includes_all():
+    # No declared var-files → can't tell, keep pre-existing include-all behaviour
+    assert summariser._tfvars_is_loaded("envs/prod-us1.tfvars", set()) is True
+
+
+def test_tfvars_is_loaded_matches_declared_var_file_and_excludes_others():
+    vf = {"envs/stg-us1.tfvars"}
+    assert summariser._tfvars_is_loaded("envs/stg-us1.tfvars", vf) is True
+    # Other environments' var-files are NOT loaded by this workspace
+    assert summariser._tfvars_is_loaded("envs/prod-us1.tfvars", vf) is False
+    assert summariser._tfvars_is_loaded("envs/dev-us1.tfvars", vf) is False
+
+
+def test_tfvars_is_loaded_rooting_robust_suffix_and_basename():
+    # var_file relative to working_directory; tarball rooted at repo (or v.v.)
+    assert summariser._tfvars_is_loaded("terraform/envs/stg.tfvars", {"envs/stg.tfvars"}) is True
+    # basename fallback (env var-file names are unique in practice)
+    assert summariser._tfvars_is_loaded("stg-us1.tfvars", {"envs/stg-us1.tfvars"}) is True
+
+
+def test_extract_tf_files_scopes_tfvars_to_var_files(tmp_path):
+    tarball = _build_tarball(
+        {
+            "main.tf": b'resource "aws_db_instance" "x" {}',
+            "envs/stg-us1.tfvars": b'engine_version = "16.11"',
+            "envs/prod-us1.tfvars": b'engine_version = "16.13"',
+            "envs/dev-us1.tfvars": b'engine_version = "16.11"',
+        }
+    )
+    n = summariser._extract_tf_files_to_dir(tarball, tmp_path, {"envs/stg-us1.tfvars"})
+    written = {p.relative_to(tmp_path).as_posix() for p in tmp_path.rglob("*") if p.is_file()}
+    assert n == 2
+    assert written == {"main.tf", "envs/stg-us1.tfvars"}
+    # The other environments' var-files — the source of the false risk — are gone
+    assert "envs/prod-us1.tfvars" not in written
+    assert "envs/dev-us1.tfvars" not in written
+
+
+def test_extract_tf_files_no_var_files_keeps_all_tfvars(tmp_path):
+    tarball = _build_tarball(
+        {
+            "main.tf": b"x",
+            "envs/stg.tfvars": b"a",
+            "envs/prod.tfvars": b"b",
+        }
+    )
+    n = summariser._extract_tf_files_to_dir(tarball, tmp_path, set())
+    assert n == 3  # no var_files declared → include-all (no regression)
+
+
 # ── JSON parsing ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
The AI plan-summary `CODE_DIFF` diffed **every** `*.tf` / `*.tfvars` between config versions. In a monorepo where one repo holds one var-file per environment, a change to one environment's var-file appeared in **every** workspace's diff. Workspaces that the change does not affect — whose plan reports zero changes — then had the model rate risk off that irrelevant diff: an empty plan came back **medium risk** because another environment's var-file bumped a value the workspace never loads.

## Root cause

`_extract_tf_files_to_dir` (used to build `CODE_DIFF`) extracted all `.tfvars` from the config-version tarball, ignoring which ones the workspace actually loads. terraform/tofu only load a `.tfvars` if it is auto-loaded (`terraform.tfvars` / `*.auto.tfvars`) or passed via `-var-file` (the workspace's `var_files`). Other environments' var-files are never loaded — but were still fed to the model.

## Fix

Scope `.tfvars` in the diff to what the workspace loads:
- `.tf` files always apply → always included (unchanged).
- `.tfvars` → included only if auto-loaded or in the workspace's `var_files`.
- Matching is rooting-robust (exact / path-suffix / basename) since `var_files` is relative to the working directory while the tarball may be repo-rooted.
- Workspaces with **no** declared `var_files` keep the include-all behaviour (no signal to scope by) — no regression for single-config workspaces.
- The follow-up/chat path passes the same `var_files`, so the cacheable prompt prefix stays byte-identical and still cache-hits.

`CODE_CONTEXT` was already `.tf`-only, so it needed no change.

## Effect on the reported case

For a PR that touches `envs/prod-us1.tfvars`, the `stg-us1` workspace (which loads only `envs/stg-us1.tfvars`) now gets an **empty** `CODE_DIFF`, its plan has no changes, and the summary is correctly low-risk — instead of medium-risk off another env's edit.

## Tests

- `_tfvars_is_loaded`: auto-loaded inclusion, empty-`var_files` include-all, declared-match + other-env exclusion, rooting-robust suffix/basename matching.
- `_extract_tf_files_to_dir`: asserts only `main.tf` + the workspace's own var-file are extracted (other envs dropped); and that empty `var_files` keeps all.
- Full `tests/services` + `tests/api` green (1579 passed).