### PR TITLE
fix(ai-summary): ground plan risk in PLAN_JSON, not CODE_DIFF

### DIFF
--- a/docs/ai-plan-summary.md
+++ b/docs/ai-plan-summary.md
@@ -283,9 +283,20 @@ the bulk of the request):
   between this run's config version and the previously-applied
   config version. Empty when there's no prior CV (first run, or
   GC'd). Capped at `ai_summary.code_diff_max_bytes` (default 100 KB).
+  **Background only.** The prompt grounds `risk_level` strictly in
+  `PLAN_JSON` (terraform's authoritative statement of what *this*
+  workspace changes — it already resolved which var-files load,
+  rendered templates, and evaluated modules); `CODE_DIFF` and
+  `CODE_CONTEXT` are there to help the model *explain* a planned
+  change, and may never raise risk above what the plan justifies. So
+  in a shared monorepo, a PR that edits one environment's var-file
+  shows up in every other environment's `CODE_DIFF` but those
+  workspaces plan no changes and are rated low risk. An empty plan is
+  always low risk regardless of how large the diff is.
 - `CODE_CONTEXT` — concatenated `.tf` files from this run's
   config-version tarball. Capped at
-  `ai_summary.code_context_max_bytes` (default 200 KB).
+  `ai_summary.code_context_max_bytes` (default 200 KB). Background
+  only, like `CODE_DIFF` — never a risk source.
 - Tool-call instruction (initial-summary path only) — "Now call
   the `submit_plan_summary` tool exactly once with your structured
   answer."

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -138,11 +138,17 @@ You will receive these inputs in the user message:
   • CODE_DIFF — unified diff of *.tf / *.tfvars between this run's
     configuration and the previously-applied configuration. May be
     absent (first run on this workspace, or the prior CV has been
-    GC'd). When present, this is the authoritative record of what
-    changed in source.
+    GC'd). It is BACKGROUND ONLY — context to help you explain WHY a
+    change in PLAN_JSON is happening. It is NOT itself a change set:
+    it can contain edits to files this workspace does not load (e.g.
+    another environment's var-file in a shared monorepo) and can omit
+    files that are not *.tf / *.tfvars (templates, JSON policies,
+    user-data scripts). Never derive what-changes — or risk — from it.
+    See the risk-grounding rule below.
   • CODE_CONTEXT — concatenated *.tf source for THIS run's
     configuration. Use it to look up declarations referenced by
-    resource_changes or CODE_DIFF. May be absent.
+    resource_changes. Background only, like CODE_DIFF — never a risk
+    source. May be absent.
   • FLEET_CONTEXT — deployment-wide notes from the operator. May be empty.
   • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
   • DRIFT_DETECTION (when set) — flags that this run is a scheduled
@@ -163,9 +169,8 @@ CRITICAL — trust `change.actions`, not snapshots:
   actions array contains `create`, `update`, or `delete` (in any
   combination), OR `change.importing` is set. Do not infer changes
   from `before` / `after` field contents — those carry state context,
-  not the diff. CODE_DIFF (when present) is a second authoritative
-  signal: if a resource's declaration is not touched by CODE_DIFF
-  AND its `actions` is no-op, it is unchanged. Never describe it.
+  not the diff. A resource whose `actions` is no-op is unchanged for
+  this workspace — never describe it, no matter what CODE_DIFF shows.
 
 CRITICAL — drift is NOT the apply change set:
 
@@ -228,6 +233,27 @@ CRITICAL — a drift-detection run is a DETECTION report, not a proposal:
       change", or something "for review/merge" — there is no proposal
       and no PR. It is a scheduled health check that found (or did not
       find) drift.
+
+CRITICAL — risk is grounded in PLAN_JSON, never in CODE_DIFF:
+
+  Rate `risk_level` SOLELY from the changes in PLAN_JSON — its
+  `resource_changes` plus the `resource_drift` reversions described
+  above. PLAN_JSON is terraform's authoritative statement of what THIS
+  workspace actually changes: it has already resolved which var-files
+  load, rendered every template, and evaluated every module. CODE_DIFF
+  and CODE_CONTEXT are background to help you EXPLAIN those changes —
+  they must NEVER raise `risk_level` above what PLAN_JSON's changes
+  justify.
+
+  In particular: if PLAN_JSON has no informative `resource_changes`
+  (and no `resource_drift`), `risk_level` is `low` and `risk_factors`
+  is `[]` — even when CODE_DIFF is large. A source change that produces
+  no planned change for THIS workspace is not a risk to it. This is the
+  common shared-monorepo case: one repo holds many environments, a
+  change edits one environment's var-file, and every OTHER environment's
+  workspace sees that edit in CODE_DIFF but plans zero changes. Their
+  risk is `low`. Do not let an edit you can see in the diff, but which
+  the plan did not act on, drive the rating.
 
 CRITICAL — `risk_level` and `risk_factors` are paired, not independent:
 

--- a/services/tests/services/test_summariser_prompt.py
+++ b/services/tests/services/test_summariser_prompt.py
@@ -53,6 +53,25 @@ def test_render_failure_analysis_uses_failure_skill():
     assert "PLAN_LOG" in user
 
 
+def test_plan_summary_prompt_grounds_risk_in_plan_not_code_diff():
+    """Risk must be grounded in PLAN_JSON; CODE_DIFF is explanatory only.
+
+    Regression: in a shared monorepo, a PR editing one environment's
+    var-file appeared in every other environment's CODE_DIFF, so the
+    model rated an otherwise-empty plan as elevated risk off the diff.
+    The durable fix is the prompt rule that risk tracks the plan, not the
+    diff — assert that rule is present so it can't be silently dropped.
+    """
+    prompt = PLAN_SUMMARY_SKILL_PROMPT
+    # The grounding rule and its empty-plan corollary.
+    assert "grounded in PLAN_JSON" in prompt
+    assert "SOLELY" in prompt
+    assert "no informative `resource_changes`" in prompt
+    # CODE_DIFF explicitly demoted to background-only, not a risk source.
+    assert "BACKGROUND ONLY" in prompt
+    assert "never derive what-changes — or risk — from it" in prompt.lower()
+
+
 def test_render_unknown_kind_raises():
     with pytest.raises(ValueError):
         render_prompt(


### PR DESCRIPTION
The AI plan-summary rated risk partly off `CODE_DIFF`, which the prompt called "the authoritative record of what changed". In a shared monorepo — one repo, many environments, one var-file each — a PR that edits **one** environment's var-file appears in **every other** environment's diff. Those workspaces, whose plan has **no changes**, were then rated elevated risk off a diff that does not affect them (e.g. the `stg-us1` workspace flagged medium because a PR bumped `envs/prod-us1.tfvars`).

## Why not just filter the diff

A first cut scoped `.tfvars` in the diff to the workspace's `var_files`. That works for the reported case but is fragile: basing risk on the *assembled file-set* is wrong in both directions —

- **over-inclusive:** other environments' var-files (the reported bug), and
- **under-inclusive:** the diff only carries `*.tf` / `*.tfvars`, so a changed `*.tftpl` template, JSON policy, or user-data script that the plan genuinely depends on is invisible to it.

Layering a var-file heuristic on top doesn't fix the second half and adds a new thing to get wrong.

## The fix

The authoritative signal already exists: **the plan.** `PLAN_JSON` is terraform's statement of what *this* workspace changes — it already resolved which var-files load, rendered every template, and evaluated every module. So:

- Reframe the prompt: `risk_level` derives **SOLELY** from `PLAN_JSON` (`resource_changes` + the `resource_drift` reversions). `CODE_DIFF` / `CODE_CONTEXT` are demoted to explain-the-why **background** that may *never* raise risk above what the plan justifies.
- Explicit corollary: an empty plan is **low** risk regardless of how large the diff is.

No file-set heuristic, so nothing relevant can be accidentally filtered out (the template concern), and nothing irrelevant can inflate risk (the monorepo concern).

## Scope / blast radius

Prompt + test + docs only — no code-path change. Risk grounding is a prompt instruction; the run lifecycle, CODE_DIFF assembly, plans, and applies are untouched.

## Tests

- Prompt-introspection test asserting the grounding rule + background-only framing are present (so they can't be silently dropped).
- `tests/services/test_summariser*.py` green (112 passed).

Supersedes #511 (the var-file-filter approach), which I am closing in favour of this.