### PR TITLE
chore(deps): ignore @zxcvbn-ts/* at v4 (close the per-package split)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,13 @@ updates:
       # eslint-plugin-react (via eslint-config-next) doesn't support ESLint 10 yet
       - dependency-name: eslint
         versions: [">=10"]
-      # @zxcvbn-ts/language-common v4 ships compressed dictionaries that
-      # require @zxcvbn-ts/core@4 + @zxcvbn-ts/dictionary-compression;
-      # core is pinned at ^3.0.4. Hold until the coordinated v4 upgrade.
-      - dependency-name: "@zxcvbn-ts/language-common"
+      # The @zxcvbn-ts v4 line ships compressed dictionaries and must move
+      # as a SET (core + language-common + dictionary-compression) with
+      # code changes in admin/users; core is pinned at ^3.0.4. Ignore the
+      # whole scope at v4 — a per-package ignore just lets dependabot
+      # propose the other halves separately (it split this into
+      # language-common and core PRs). Lift when doing the coordinated v4 upgrade.
+      - dependency-name: "@zxcvbn-ts/*"
         versions: [">=4"]
 
   - package-ecosystem: docker


### PR DESCRIPTION
Dependabot splits the held zxcvbn v4 upgrade into separate per-package PRs — `@zxcvbn-ts/language-common` (#509) and `@zxcvbn-ts/core` (#515). The name-specific ignore I added in #513 only silenced `language-common`, so `core` reopened as #515.

Widens the existing npm `ignore` to the whole `@zxcvbn-ts/*` scope at `>=4`, so every package in the v4 set (core, language-common, dictionary-compression) stays held until the coordinated upgrade — no more whack-a-mole.

#509 and #515 are already closed; this stops dependabot reopening either. Lift the ignore when doing the v4 upgrade (bump core + language-common together + the `admin/users` code changes).

YAML validated.