### PR TITLE
fix(ci): pin Trivy --platform to matrix arch for arm64 image scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -854,6 +854,15 @@ jobs:
       # re-running Trivy locally. exit-code: '0' keeps this informational.
       - name: Trivy findings (table, informational)
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          # The per-arch tag (sha-XXX-arm64) is an OCI index whose only child
+          # is the matrix arch. Without this, Trivy defaults to the runner's
+          # platform (linux/amd64) when pulling the image from GHCR on branch/
+          # tag builds and fails with "no child with platform linux/amd64".
+          # (PR builds load the image into the local daemon, so they never hit
+          # the remote-pull default — which is why this only broke on main.)
+          # Trivy reads TRIVY_PLATFORM as the --platform flag.
+          TRIVY_PLATFORM: linux/${{ matrix.arch }}
         with:
           image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-${{ matrix.arch }}
           format: table
@@ -864,6 +873,10 @@ jobs:
 
       - name: Scan with Trivy
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          # See the note on the informational step above — pin the pulled
+          # platform to the matrix arch so the arm64 scan resolves its child.
+          TRIVY_PLATFORM: linux/${{ matrix.arch }}
         with:
           image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-${{ matrix.arch }}
           format: sarif


### PR DESCRIPTION
The arch-split image scan added in #531 fails on branch/tag pushes for every arm64 image:

```
FATAL: no child with platform linux/amd64 in index ghcr.io/.../terrapod-api:sha-XXX-arm64
```

On branch/tag builds the scan job lets Trivy pull the per-arch tag from GHCR. That tag is an OCI index whose only child is the matrix arch, but Trivy defaults to the runner's platform (`linux/amd64`) when resolving a pulled image, so the arm64 index has no matching child and the scan aborts. PR builds `docker load` the image into the local daemon instead of pulling, so they never hit the remote-pull default — which is why PR CI on #531 was green and only the post-merge main CI went red.

Fix: set `TRIVY_PLATFORM=linux/${matrix.arch}` on both Trivy steps (Trivy reads it as the `--platform` flag) so each arch's scan resolves its own child. Safe for the PR local-load path too — the loaded single-arch image matches the requested platform.

Verification note: this path only executes on a branch/tag push, not on PRs, so the real proof is the post-merge main-branch run going green.