### PR TITLE
fix: OPA CVE bump + module impact on non-VCS consumers (v0.40.1)

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -72,7 +72,7 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 # OPA version via the image tag — see docs/policies.md). TARGETARCH is set
 # by buildx; fall back to dpkg for a plain `docker build`.
 ARG TARGETARCH
-ARG OPA_VERSION=1.17.0
+ARG OPA_VERSION=1.17.1
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-ARG OPA_VERSION=1.17.0
+ARG OPA_VERSION=1.17.1
 # GitHub Releases intermittently 5xx; --retry-all-errors covers 5xx as
 # well as transport errors. 6 attempts × 4s base = ~25s ceiling.
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pin and verify the same OPA_VERSION + SHA256 so a bump in one without
 # the other can't silently land an unverified binary in either image.
 ARG TARGETARCH
-ARG OPA_VERSION=1.17.0
+ARG OPA_VERSION=1.17.1
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -39,14 +39,33 @@ CVE-2026-46680
 # graph; the ignore would just shadow regressions if litellm's hot
 # patch is rolled back. Re-add only if the floor drops below 1.83.11.
 
-# CVE-2026-42504 — Go stdlib mime/multipart `Reader.NextPart` allows
-# an attacker who can supply a maliciously crafted MIME header (many
-# invalid encoded words) to drive O(N²) decoder work and stall the
-# parser. Pulled into the runner + API images as a Go stdlib version
-# embedded in the statically-linked OPA binary. OPA only parses our
-# own plan JSON inputs at `opa eval` time; no MIME headers from
-# untrusted sources reach the affected decoder. Upstream Go fix is
-# 1.25.11 / 1.26.4 but the latest OPA release (1.17.0, 2026-06) still
-# ships with 1.26.3 in its static binary; drop this ignore when OPA
-# publishes a rebuild on 1.26.4+ or 1.27+.
-CVE-2026-42504
+# --- OPA-bundled Go module CVEs (golang.org/x/net + golang.org/x/crypto) ---
+# Trivy reads the statically-linked `opa` binary's embedded buildinfo and
+# flags every Go module it vendors, including ones whose code path never
+# runs at OPA's runtime. We bumped OPA to 1.17.1, which is built on go1.26.4
+# (clearing the earlier Go stdlib CVEs — CVE-2026-42504 / CVE-2026-27145 —
+# so those ignores are removed), but 1.17.1 still vendors x/net v0.53.0 and
+# x/crypto v0.51.0; the upstream fixes (x/net 0.55.0, x/crypto 0.52.0) landed
+# after OPA 1.17.1's release and no rebuilt OPA binary exists yet.
+#
+# Not reachable in Terrapod's usage: OPA runs only as `opa eval` / `opa check`
+# over our own in-memory plan JSON — no HTTP/2 server (x/net), no SSH or TLS
+# transport (x/crypto), no bundle/server/controller mode. Drop these when OPA
+# publishes a rebuild on x/net >= 0.55.0 / x/crypto >= 0.52.0.
+#
+# golang.org/x/net  (fixed in 0.55.0):
+CVE-2026-25680
+CVE-2026-25681
+CVE-2026-27136
+CVE-2026-39821
+CVE-2026-42502
+CVE-2026-42506
+# golang.org/x/crypto (fixed in 0.52.0):
+CVE-2026-39827
+CVE-2026-39828
+CVE-2026-39829
+CVE-2026-39830
+CVE-2026-39835
+CVE-2026-42508
+CVE-2026-46595
+CVE-2026-46597

--- a/services/terrapod/services/module_impact_service.py
+++ b/services/terrapod/services/module_impact_service.py
@@ -240,7 +240,18 @@ async def _fetch_workspace_config(
     connection or the download fails.
     """
     if not ws.vcs_connection_id or not ws.vcs_repo_url:
-        return None
+        # Module impact analysis is about the MODULE changing (PR or publish) —
+        # the consuming workspace's own VCS status is irrelevant. A non-VCS
+        # consumer (a CLI-driven workspace, or a Service Catalog instance whose
+        # code is a server-generated wrapper, #535) has no VCS to re-fetch, so
+        # reuse its latest uploaded config-version instead of skipping it. The
+        # publish-triggered run re-inits that config (an unpinned module
+        # reference floats to the new version); the PR-speculative run carries
+        # `module_overrides` to swap the PR module tarball by coordinate.
+        # Gating impact on the consumer's VCS silently excluded every non-VCS
+        # consumer of a VCS-linked module — a pre-existing defect.
+        latest = await run_service.get_latest_uploaded_cv(db, ws.id)
+        return latest.id if latest else None
 
     ws_conn = await db.get(VCSConnection, ws.vcs_connection_id)
     if ws_conn is None or ws_conn.status != "active":

--- a/services/tests/services/test_module_impact_service.py
+++ b/services/tests/services/test_module_impact_service.py
@@ -1,0 +1,63 @@
+"""Service-tier tests for module impact analysis.
+
+Module impact analysis fires on a module's PRs/publishes against the workspaces
+that CONSUME it (the `module_workspace_link`). The consuming workspace's own VCS
+status is irrelevant — yet `_fetch_workspace_config` used to return None for any
+non-VCS workspace, silently excluding every non-VCS consumer (CLI-driven
+workspaces, and later Service Catalog instances, #535) of a VCS-linked module.
+The fix reuses the workspace's latest uploaded config-version when there is no
+VCS to re-fetch.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.services import module_impact_service
+
+
+def _non_vcs_workspace() -> MagicMock:
+    ws = MagicMock()
+    ws.id = uuid.uuid4()
+    ws.name = "catalog-instance"
+    ws.vcs_connection_id = None
+    ws.vcs_repo_url = ""
+    ws.vcs_branch = ""
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_fetch_config_reuses_latest_cv_for_non_vcs_workspace() -> None:
+    ws = _non_vcs_workspace()
+    db = AsyncMock()
+    cv = MagicMock()
+    cv.id = uuid.uuid4()
+
+    with patch.object(
+        module_impact_service.run_service,
+        "get_latest_uploaded_cv",
+        new=AsyncMock(return_value=cv),
+    ) as m_latest:
+        result = await module_impact_service._fetch_workspace_config(
+            db, ws, MagicMock(), speculative=True
+        )
+
+    assert result == cv.id  # reused the catalog wrapper CV, not skipped
+    m_latest.assert_awaited_once_with(db, ws.id)
+
+
+@pytest.mark.asyncio
+async def test_fetch_config_non_vcs_with_no_cv_returns_none() -> None:
+    # A non-VCS workspace that has never had a CV uploaded has nothing to run.
+    ws = _non_vcs_workspace()
+    db = AsyncMock()
+
+    with patch.object(
+        module_impact_service.run_service,
+        "get_latest_uploaded_cv",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await module_impact_service._fetch_workspace_config(db, ws, MagicMock())
+
+    assert result is None


### PR DESCRIPTION
Two fixes for a **v0.40.1 patch release** (no wrapper-chart bump), landed ahead of the Service Catalog feature.

## 1. Security — clear HIGH/CRITICAL Go CVEs in the bundled OPA binary
A fresh batch of HIGH/CRITICAL Go CVEs (`x/net`, `x/crypto`, Go `stdlib`) failed the Trivy image scan on the api + runner images (the OPA-less images passed; `main` was green an hour earlier). Trivy reads the statically-linked `opa` binary's embedded Go buildinfo.
- **Bump OPA 1.17.0 → 1.17.1** (built on go1.26.4): clears the Go **stdlib** CVEs for real, so the existing `CVE-2026-42504` ignore is dropped.
- OPA 1.17.1 still vendors `x/net` 0.53.0 + `x/crypto` 0.51.0; the upstream fixes (0.55.0 / 0.52.0) landed **after** 1.17.1's release and no rebuilt OPA binary exists yet — so those CVEs are added to `.trivyignore` with rationale. OPA runs only as `opa eval`/`opa check` over our own plan JSON (no HTTP/2, no SSH/TLS transport), so the affected surfaces aren't reachable. Drop when OPA rebuilds. Verified via `go version -m` on the 1.17.1 binary.

## 2. Bug — module impact analysis on non-VCS consumer workspaces (Closes #537)
`module_impact_service._fetch_workspace_config` returned `None` for any workspace without VCS config, so both the publish-trigger and PR-speculative paths silently dropped **every non-VCS consumer** of a VCS-linked module — most notably **CLI-driven workspaces** referencing a registry module via a cloud block. Non-VCS consumers now reuse their latest uploaded config-version. (Also unblocks the Service Catalog version model, #535.)

## Tests
Service-tier regression for the non-VCS module-impact path; existing module-impact tests unaffected.
