### PR TITLE
fix: v0.43.0 hardening — post-review P0s + security/correctness P1s

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | Database | PostgreSQL |
 | Cache / Sessions | Redis |
 | Object storage | AWS S3, Azure Blob, GCS, or filesystem (native SDKs) |
-| Frontend | Next.js 15 / React 19 / TypeScript / Tailwind CSS / Radix UI |
+| Frontend | Next.js 16 / React 19 / TypeScript / Tailwind CSS / Radix UI |
 | Runner listener | Python (same codebase as API) |
 | Auth | authlib (OIDC), python3-saml (SAML) |
 | Deployment | Helm chart on Kubernetes |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ This document describes the internal architecture of Terrapod, covering system c
 
 | Component | Purpose | Implementation |
 |---|---|---|
-| **Next.js Web** | Single ingress entry point; serves UI pages and proxies API calls | Next.js 15, React 19, Tailwind CSS, Radix UI |
+| **Next.js Web** | Single ingress entry point; serves UI pages and proxies API calls | Next.js 16, React 19, Tailwind CSS, Radix UI |
 | **FastAPI API** | All business logic, TFE V2 API, auth, registry, VCS polling | Python 3.13+, FastAPI, SQLAlchemy async, Pydantic |
 | **Runner Listener** | Receives run events via SSE, creates K8s Jobs, reports status, streams logs | Same Python codebase as API, different entrypoint |
 | **Runner Jobs** | Ephemeral containers that execute `terraform` or `tofu` | Slim Debian image (`python:3.13-slim`) with git/openssh-client/opa; pure-Python orchestrator |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -32,9 +32,10 @@ producing half-migrated state.
 
 ## Status
 
-The migration tool ships in **v0.27.0**. Until then, this page is a
-forward-looking spec; the relevant subcommands are stubbed in the binary
-with placeholders that exit non-zero.
+Available since **v0.27.0**. The `apply`, `status`, `rewrite`, `verify`,
+`cutover`, and `module` subcommands are fully implemented; `terrapod-migrate`
+ships as a GitHub Release artifact (universal-macOS + linux/windows
+amd64+arm64).
 
 ## Subcommands
 

--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -91,6 +91,10 @@ Two things to note:
 
 Resolution order mirrors the other axes: platform admin → platform audit (read) → label-based RBAC via `catalog_permission` → none (no `everyone` floor).
 
+### Granting catalog access
+
+`catalog_permission` is set on a **custom role**, exactly like `workspace_permission` / `pool_permission` / `registry_permission` — via the admin **Roles** page, the API (`catalog-permission` attribute on `POST/PATCH /api/terrapod/v1/roles`), the `terrapod_role` provider resource (`catalog_permission`), or `go-terrapod`'s `CatalogPermission` field. Assign the role to a user/group, scope it with the role's allow/deny labels, and that user can browse (`read`) or self-serve (`use`) the matching catalog items. Until a role grants it, only platform `admin` (and an item's owner) can reach the catalog.
+
 ## Catalog-managed workspace guardrails
 
 A workspace created by the catalog is **catalog-managed**, and the catalog owns its configuration and access. Two guardrails enforce this so an instance can't drift away from its catalog definition out of band.

--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -32,7 +32,11 @@ Provisioning a catalog item creates an ordinary **agent-mode, non-VCS workspace*
 The generated configuration is a small, predictable set of files:
 
 ```hcl
-# main.tf  (generated)
+# main.tf  (generated) — the module call plus one root `variable` block per
+# catalog input. The variable declarations are intentionally UNTYPED: the
+# module-interface `type` string isn't reliably valid HCL for complex types
+# (object/tuple), so the wrapper omits it and lets the supplied value carry its
+# own type. Values arrive correctly-typed as workspace terraform variables.
 module "this" {
   source  = "terrapod.example.com/default/vpc/aws"
   version = "1.4.0"          # resolved from the item's version policy / instance pin
@@ -42,9 +46,9 @@ module "this" {
   # ...
 }
 
-# variables.tf  (generated) — a root `variable` block per catalog input
-variable "cidr_block" { type = string }
-variable "name"       { type = string }
+variable "cidr_block" {}
+variable "name" {}
+# a sensitive input adds only the marker:  variable "secret" { sensitive = true }
 
 # providers.tf  (generated) — rendered from the item's provider templates
 provider "aws" {

--- a/e2e/tests/variables.spec.ts
+++ b/e2e/tests/variables.spec.ts
@@ -99,8 +99,9 @@ test.describe('Variables', () => {
     const row = page.locator(`tr:has-text("${varKey}")`);
     await expect(row).toBeVisible({ timeout: 10_000 });
 
-    // Delete it
+    // Delete it — two-click inline confirm (Delete → Confirm)
     await row.locator('button:has-text("Delete")').click();
+    await row.locator('button:has-text("Confirm")').click();
 
     // Should be gone
     await expect(row).not.toBeVisible({ timeout: 10_000 });

--- a/go-terrapod/roles.go
+++ b/go-terrapod/roles.go
@@ -28,6 +28,7 @@ type Role struct {
 	WorkspacePermission string `json:"workspace-permission"` // read | plan | write | admin
 	PoolPermission      string `json:"pool-permission,omitempty"`
 	RegistryPermission  string `json:"registry-permission,omitempty"` // read | write | admin (modules + providers)
+	CatalogPermission   string `json:"catalog-permission,omitempty"`  // none | read | use | admin
 
 	BuiltIn   bool   `json:"built-in"`
 	CreatedAt string `json:"created-at,omitempty"`
@@ -51,6 +52,7 @@ type CreateRoleRequest struct {
 	WorkspacePermission string
 	PoolPermission      string
 	RegistryPermission  string
+	CatalogPermission   string
 }
 
 // UpdateRoleRequest is the partial-update shape. Name is immutable.
@@ -68,6 +70,7 @@ type UpdateRoleRequest struct {
 	WorkspacePermission string
 	PoolPermission      string
 	RegistryPermission  string
+	CatalogPermission   string
 }
 
 // CreateRole creates a custom role. Admin required.
@@ -134,6 +137,9 @@ func roleCreateAttrs(req CreateRoleRequest) map[string]any {
 	if req.RegistryPermission != "" {
 		attrs["registry-permission"] = req.RegistryPermission
 	}
+	if req.CatalogPermission != "" {
+		attrs["catalog-permission"] = req.CatalogPermission
+	}
 	if req.Description != "" {
 		attrs["description"] = req.Description
 	}
@@ -156,6 +162,9 @@ func roleUpdateAttrs(req UpdateRoleRequest) map[string]any {
 	}
 	if req.RegistryPermission != "" {
 		attrs["registry-permission"] = req.RegistryPermission
+	}
+	if req.CatalogPermission != "" {
+		attrs["catalog-permission"] = req.CatalogPermission
 	}
 	if req.Description != nil {
 		attrs["description"] = *req.Description
@@ -251,6 +260,7 @@ func roleFromItem(item *roleDataItem) (*Role, error) {
 		WorkspacePermission string            `json:"workspace-permission"`
 		PoolPermission      string            `json:"pool-permission"`
 		RegistryPermission  string            `json:"registry-permission"`
+		CatalogPermission   string            `json:"catalog-permission"`
 		BuiltIn             bool              `json:"built-in"`
 		CreatedAt           string            `json:"created-at"`
 		UpdatedAt           string            `json:"updated-at"`
@@ -270,6 +280,7 @@ func roleFromItem(item *roleDataItem) (*Role, error) {
 		WorkspacePermission: attrs.WorkspacePermission,
 		PoolPermission:      attrs.PoolPermission,
 		RegistryPermission:  attrs.RegistryPermission,
+		CatalogPermission:   attrs.CatalogPermission,
 		BuiltIn:             attrs.BuiltIn,
 		CreatedAt:           attrs.CreatedAt,
 		UpdatedAt:           attrs.UpdatedAt,

--- a/provider/internal/datasources/role/data_source.go
+++ b/provider/internal/datasources/role/data_source.go
@@ -28,7 +28,9 @@ type roleDataSourceModel struct {
 	DenyLabels          types.Map    `tfsdk:"deny_labels"`
 	DenyNames           types.List   `tfsdk:"deny_names"`
 	WorkspacePermission types.String `tfsdk:"workspace_permission"`
+	PoolPermission      types.String `tfsdk:"pool_permission"`
 	RegistryPermission  types.String `tfsdk:"registry_permission"`
+	CatalogPermission   types.String `tfsdk:"catalog_permission"`
 	BuiltIn             types.Bool   `tfsdk:"built_in"`
 	CreatedAt           types.String `tfsdk:"created_at"`
 	UpdatedAt           types.String `tfsdk:"updated_at"`
@@ -53,7 +55,9 @@ func (d *roleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 			"deny_labels":          schema.MapAttribute{Computed: true, ElementType: types.StringType, Description: "Deny labels."},
 			"deny_names":           schema.ListAttribute{Computed: true, ElementType: types.StringType, Description: "Deny name patterns."},
 			"workspace_permission": schema.StringAttribute{Computed: true, Description: "Permission level."},
+			"pool_permission":      schema.StringAttribute{Computed: true, Description: "Agent pool permission level: read, write, or admin."},
 			"registry_permission":  schema.StringAttribute{Computed: true, Description: "Registry (modules + providers) permission level: read, write, or admin."},
+			"catalog_permission":   schema.StringAttribute{Computed: true, Description: "Service-catalog permission level: none, read, use, or admin."},
 			"built_in":             schema.BoolAttribute{Computed: true, Description: "Whether the role is built-in."},
 			"created_at":           schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
 			"updated_at":           schema.StringAttribute{Computed: true, Description: "Update timestamp."},
@@ -98,7 +102,9 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		config.Description = types.StringNull()
 	}
 	config.WorkspacePermission = types.StringValue(role.WorkspacePermission)
+	config.PoolPermission = types.StringValue(role.PoolPermission)
 	config.RegistryPermission = types.StringValue(role.RegistryPermission)
+	config.CatalogPermission = types.StringValue(role.CatalogPermission)
 	config.BuiltIn = types.BoolValue(role.BuiltIn)
 	config.CreatedAt = types.StringValue(role.CreatedAt)
 	config.UpdatedAt = types.StringValue(role.UpdatedAt)

--- a/provider/internal/resources/role/resource.go
+++ b/provider/internal/resources/role/resource.go
@@ -49,6 +49,7 @@ type roleModel struct {
 	WorkspacePermission types.String `tfsdk:"workspace_permission"`
 	PoolPermission      types.String `tfsdk:"pool_permission"`
 	RegistryPermission  types.String `tfsdk:"registry_permission"`
+	CatalogPermission   types.String `tfsdk:"catalog_permission"`
 
 	BuiltIn   types.Bool   `tfsdk:"built_in"`
 	CreatedAt types.String `tfsdk:"created_at"`
@@ -124,6 +125,14 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			},
 			"registry_permission": schema.StringAttribute{
 				Description: "Registry permission level for modules and providers: read, write, or admin. Defaults to read.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"catalog_permission": schema.StringAttribute{
+				Description: "Service-catalog permission level: none, read, use, or admin. Opt-in (no everyone floor); defaults to none.",
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
@@ -265,6 +274,9 @@ func buildCreateRoleRequest(m *roleModel) terrapod.CreateRoleRequest {
 	if !m.RegistryPermission.IsNull() && !m.RegistryPermission.IsUnknown() {
 		req.RegistryPermission = m.RegistryPermission.ValueString()
 	}
+	if !m.CatalogPermission.IsNull() && !m.CatalogPermission.IsUnknown() {
+		req.CatalogPermission = m.CatalogPermission.ValueString()
+	}
 	if !m.Description.IsNull() {
 		req.Description = m.Description.ValueString()
 	}
@@ -296,6 +308,9 @@ func buildUpdateRoleRequest(m *roleModel) terrapod.UpdateRoleRequest {
 	}
 	if !m.RegistryPermission.IsNull() && !m.RegistryPermission.IsUnknown() {
 		req.RegistryPermission = m.RegistryPermission.ValueString()
+	}
+	if !m.CatalogPermission.IsNull() && !m.CatalogPermission.IsUnknown() {
+		req.CatalogPermission = m.CatalogPermission.ValueString()
 	}
 	if !m.Description.IsNull() && !m.Description.IsUnknown() {
 		d := m.Description.ValueString()
@@ -332,6 +347,11 @@ func readRoleFromSDK(ctx context.Context, role *terrapod.Role, m *roleModel) dia
 		m.RegistryPermission = types.StringValue(role.RegistryPermission)
 	} else {
 		m.RegistryPermission = types.StringValue("read")
+	}
+	if role.CatalogPermission != "" {
+		m.CatalogPermission = types.StringValue(role.CatalogPermission)
+	} else {
+		m.CatalogPermission = types.StringValue("none")
 	}
 
 	m.BuiltIn = types.BoolValue(role.BuiltIn)

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -489,6 +489,28 @@ def create_application() -> FastAPI:
 
         return response
 
+    # Uncaught unique/constraint violations are a CONFLICT, not a server error.
+    # Many create endpoints pre-check then INSERT, which races under multiple
+    # replicas (the SELECT can't see a concurrent uncommitted INSERT); the loser
+    # hits the unique constraint. get_db has already rolled the session back by
+    # the time we get here. Hot paths still catch IntegrityError in-handler for a
+    # specific message (e.g. catalog "name already exists"); this is the net so
+    # the generic case is 409, not 500. Registered before the Exception handler
+    # so the more specific type wins.
+    from sqlalchemy.exc import IntegrityError
+
+    @app.exception_handler(IntegrityError)
+    async def integrity_error_handler(request: Request, exc: IntegrityError) -> JSONResponse:
+        logger.warning(
+            "Integrity constraint violation",
+            path=str(request.url.path),
+            error=str(getattr(exc, "orig", exc)),
+        )
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "Resource already exists or violates a constraint"},
+        )
+
     # Global exception handler
     @app.exception_handler(Exception)
     async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:

--- a/services/terrapod/api/routers/binary_cache.py
+++ b/services/terrapod/api/routers/binary_cache.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_admin
+from terrapod.api.serialization import rfc3339
 from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -154,7 +155,7 @@ async def list_cached_binaries_endpoint(
                         "arch": e.arch,
                         "shasum": e.shasum,
                         "download-url": e.download_url,
-                        "cached-at": e.cached_at.isoformat() if e.cached_at else None,
+                        "cached-at": rfc3339(e.cached_at),
                     },
                 }
                 for e in entries
@@ -235,7 +236,7 @@ async def list_cached_providers_endpoint(
                         "os": e.os,
                         "arch": e.arch,
                         "shasum": e.shasum,
-                        "cached-at": e.cached_at.isoformat() if e.cached_at else None,
+                        "cached-at": rfc3339(e.cached_at),
                     },
                 }
                 for e in entries

--- a/services/terrapod/api/routers/gpg_keys.py
+++ b/services/terrapod/api/routers/gpg_keys.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.api.serialization import rfc3339
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.gpg_key_service import (
@@ -75,8 +76,8 @@ def _gpg_key_to_jsonapi(key) -> dict:  # type: ignore[no-untyped-def]
             "namespace": "default",
             "source": key.source,
             "source-url": key.source_url,
-            "created-at": key.created_at.isoformat() if key.created_at else None,
-            "updated-at": key.updated_at.isoformat() if key.updated_at else None,
+            "created-at": rfc3339(key.created_at),
+            "updated-at": rfc3339(key.updated_at),
         },
     }
 

--- a/services/terrapod/api/routers/oauth.py
+++ b/services/terrapod/api/routers/oauth.py
@@ -11,6 +11,7 @@ Endpoints:
 
 import base64
 import hashlib
+import hmac
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -199,4 +200,6 @@ def _verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
 
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     computed_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-    return computed_challenge == code_challenge
+    # Timing-safe — the PKCE challenge is attacker-influenced in the token
+    # exchange; match every other secret comparison in the codebase.
+    return hmac.compare_digest(computed_challenge, code_challenge)

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -41,6 +41,7 @@ from terrapod.api.dependencies import (
     require_non_runner,
 )
 from terrapod.api.labels import validate_labels
+from terrapod.api.serialization import rfc3339
 from terrapod.db.models import ModuleWorkspaceLink, RegistryModuleVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -162,8 +163,8 @@ def _module_to_jsonapi(module, effective_permission: str | None = None) -> dict:
             "vcs-tag-pattern": module.vcs_tag_pattern,
             "vcs-last-tag": module.vcs_last_tag,
             "version-statuses": versions,
-            "created-at": module.created_at.isoformat() if module.created_at else None,
-            "updated-at": module.updated_at.isoformat() if module.updated_at else None,
+            "created-at": rfc3339(module.created_at),
+            "updated-at": rfc3339(module.updated_at),
             "permissions": {
                 "can-update": has_registry_permission(perm, "admin"),
                 "can-destroy": has_registry_permission(perm, "admin"),
@@ -598,9 +599,7 @@ async def create_module_version_endpoint(
                 "attributes": {
                     "version": mod_version.version,
                     "status": mod_version.upload_status,
-                    "created-at": mod_version.created_at.isoformat()
-                    if mod_version.created_at
-                    else None,
+                    "created-at": rfc3339(mod_version.created_at),
                 },
                 "links": {
                     "upload": upload_url.url,
@@ -714,9 +713,7 @@ async def upload_module_version_endpoint(
                 "attributes": {
                     "version": mod_version.version,
                     "status": mod_version.upload_status,
-                    "created-at": mod_version.created_at.isoformat()
-                    if mod_version.created_at
-                    else None,
+                    "created-at": rfc3339(mod_version.created_at),
                 },
             }
         },
@@ -828,7 +825,7 @@ def _link_to_jsonapi(link: ModuleWorkspaceLink) -> dict:
         "attributes": {
             "workspace-id": f"ws-{link.workspace_id}",
             "workspace-name": ws.name if ws else "",
-            "created-at": link.created_at.isoformat() if link.created_at else None,
+            "created-at": rfc3339(link.created_at),
             "created-by": link.created_by,
         },
     }

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -49,6 +49,7 @@ from terrapod.api.dependencies import (
     require_non_runner,
 )
 from terrapod.api.labels import validate_labels
+from terrapod.api.serialization import rfc3339
 from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -121,8 +122,8 @@ def _provider_to_jsonapi(provider, effective_permission: str | None = None) -> d
             "namespace": provider.namespace,
             "labels": provider.labels or {},
             "owner-email": provider.owner_email,
-            "created-at": provider.created_at.isoformat() if provider.created_at else None,
-            "updated-at": provider.updated_at.isoformat() if provider.updated_at else None,
+            "created-at": rfc3339(provider.created_at),
+            "updated-at": rfc3339(provider.updated_at),
             "permissions": {
                 "can-update": has_registry_permission(perm, "admin"),
                 "can-destroy": has_registry_permission(perm, "admin"),
@@ -145,7 +146,7 @@ def _version_to_jsonapi(version, upload_links: dict | None = None) -> dict:  # t
             "shasums-uploaded": version.shasums_uploaded,
             "shasums-sig-uploaded": version.shasums_sig_uploaded,
             "platforms": platforms,
-            "created-at": version.created_at.isoformat() if version.created_at else None,
+            "created-at": rfc3339(version.created_at),
         },
     }
     if upload_links:

--- a/services/terrapod/api/routers/roles.py
+++ b/services/terrapod/api/routers/roles.py
@@ -32,6 +32,9 @@ logger = get_logger(__name__)
 VALID_PERMISSIONS = {"read", "plan", "write", "admin"}
 VALID_POOL_PERMISSIONS = {"read", "write", "admin"}
 VALID_REGISTRY_PERMISSIONS = {"read", "write", "admin"}
+# Catalog access is an opt-in extension: "none" (default) grants nothing, so it
+# is a valid value here (unlike the other axes, which floor at "read").
+VALID_CATALOG_PERMISSIONS = {"none", "read", "use", "admin"}
 
 
 def _rfc3339(dt) -> str:
@@ -53,6 +56,7 @@ def _role_json(role: Role) -> dict:
             "workspace-permission": role.workspace_permission,
             "pool-permission": role.pool_permission,
             "registry-permission": role.registry_permission,
+            "catalog-permission": role.catalog_permission,
             "built-in": False,
             "created-at": _rfc3339(role.created_at),
             "updated-at": _rfc3339(role.updated_at),
@@ -73,6 +77,11 @@ def _builtin_role_json(name: str, info: dict) -> dict:
             "workspace-permission": "admin" if name == "admin" else "read",
             "pool-permission": "admin" if name == "admin" else "read",
             "registry-permission": "admin" if name == "admin" else "read",
+            # Catalog is opt-in with no `everyone` floor: admin → admin,
+            # audit → read, everyone → none (grants nothing).
+            "catalog-permission": (
+                "admin" if name == "admin" else "read" if name == "audit" else "none"
+            ),
             "built-in": True,
             "created-at": "",
             "updated-at": "",
@@ -131,6 +140,10 @@ async def create_role(
     if registry_perm not in VALID_REGISTRY_PERMISSIONS:
         raise HTTPException(status_code=422, detail=f"Invalid registry-permission: {registry_perm}")
 
+    catalog_perm = attrs.get("catalog-permission", "none")
+    if catalog_perm not in VALID_CATALOG_PERMISSIONS:
+        raise HTTPException(status_code=422, detail=f"Invalid catalog-permission: {catalog_perm}")
+
     role = Role(
         name=name,
         description=attrs.get("description", ""),
@@ -141,6 +154,7 @@ async def create_role(
         workspace_permission=ws_perm,
         pool_permission=pool_perm,
         registry_permission=registry_perm,
+        catalog_permission=catalog_perm,
     )
     db.add(role)
     await db.commit()
@@ -214,6 +228,13 @@ async def update_role(
                 status_code=422, detail=f"Invalid registry-permission: {registry_perm}"
             )
         role.registry_permission = registry_perm
+    if "catalog-permission" in attrs:
+        catalog_perm = attrs["catalog-permission"]
+        if catalog_perm not in VALID_CATALOG_PERMISSIONS:
+            raise HTTPException(
+                status_code=422, detail=f"Invalid catalog-permission: {catalog_perm}"
+            )
+        role.catalog_permission = catalog_perm
 
     await db.commit()
     await db.refresh(role)

--- a/services/terrapod/api/routers/users.py
+++ b/services/terrapod/api/routers/users.py
@@ -192,9 +192,10 @@ class UserUpdateRequest(BaseModel):
 async def _revoke_all_user_access(db: AsyncSession, email: str) -> None:
     """Full offboarding revocation: web sessions, the cached token-role set
     (`tp:token_roles:`, 60s TTL — otherwise a deactivated admin keeps cached
-    admin roles on API-token requests), and every API token bound to the
-    identity (including detached service tokens the idle-active check can't
-    catch). Used by both deactivate and delete so neither leaves a window."""
+    admin roles on API-token requests), and every API token *bound to* the
+    identity (`bound_to == email`). Detached service tokens (`bound_to` NULL)
+    are org-level, not this user's, so they are intentionally left alone. Used
+    by both deactivate and delete so neither leaves a window."""
     from terrapod.api.dependencies import _TOKEN_ROLES_PREFIX
     from terrapod.auth.api_tokens import revoke_all_for_user
     from terrapod.auth.sessions import revoke_all_user_sessions

--- a/services/terrapod/api/routers/users.py
+++ b/services/terrapod/api/routers/users.py
@@ -189,6 +189,22 @@ class UserUpdateRequest(BaseModel):
     data: UserUpdateData
 
 
+async def _revoke_all_user_access(db: AsyncSession, email: str) -> None:
+    """Full offboarding revocation: web sessions, the cached token-role set
+    (`tp:token_roles:`, 60s TTL — otherwise a deactivated admin keeps cached
+    admin roles on API-token requests), and every API token bound to the
+    identity (including detached service tokens the idle-active check can't
+    catch). Used by both deactivate and delete so neither leaves a window."""
+    from terrapod.api.dependencies import _TOKEN_ROLES_PREFIX
+    from terrapod.auth.api_tokens import revoke_all_for_user
+    from terrapod.auth.sessions import revoke_all_user_sessions
+    from terrapod.redis.client import get_redis_client
+
+    await revoke_all_user_sessions(email)
+    await get_redis_client().delete(_TOKEN_ROLES_PREFIX + email)
+    await revoke_all_for_user(db, email)
+
+
 @router.patch("/users/{email}")
 async def update_user(
     email: str,
@@ -220,11 +236,8 @@ async def update_user(
     if attrs.is_active is not None:
         target.is_active = attrs.is_active
         if not attrs.is_active:
-            # Revoke all sessions for deactivated user
-            from terrapod.auth.sessions import revoke_all_user_sessions
-
-            await revoke_all_user_sessions(email)
-            logger.info("Deactivated user and revoked sessions", target_email=email, by=user.email)
+            await _revoke_all_user_access(db, email)
+            logger.info("Deactivated user and revoked access", target_email=email, by=user.email)
 
     await db.commit()
     await db.refresh(target)
@@ -237,16 +250,14 @@ async def delete_user(
     user: AuthenticatedUser = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    """Delete a user (admin only). Cascades: revokes sessions, deletes role assignments."""
+    """Delete a user (admin only). Cascades: revokes sessions + token-role cache
+    + API tokens, deletes role assignments."""
     result = await db.execute(select(User).where(User.email == email))
     target = result.scalar_one_or_none()
     if target is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    # Revoke sessions
-    from terrapod.auth.sessions import revoke_all_user_sessions
-
-    await revoke_all_user_sessions(email)
+    await _revoke_all_user_access(db, email)
 
     # Delete role assignments
     await db.execute(delete(RoleAssignment).where(RoleAssignment.email == email))

--- a/services/terrapod/api/serialization.py
+++ b/services/terrapod/api/serialization.py
@@ -1,0 +1,19 @@
+"""Shared JSON:API serialization helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def rfc3339(dt: datetime | None) -> str | None:
+    """Serialize a tz-aware UTC datetime as RFC3339 with a trailing ``Z``
+    (never ``+00:00``).
+
+    Rule 10 / go-tfe compatibility: ``datetime.isoformat()`` on a tz-aware UTC
+    column emits ``...+00:00``, which `go-tfe` rejects. This is the one canonical
+    serializer — prefer it over per-router ``_rfc3339`` copies that have drifted
+    (some used bare ``.isoformat()`` and regressed the ``Z`` suffix).
+    """
+    if dt is None:
+        return None
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -7,6 +7,7 @@ Triggered handler: handle_drift_run_completed() updates workspace drift_status b
 on the run outcome and fires drift_detected notifications when drift is found.
 """
 
+import asyncio
 import json
 import uuid
 
@@ -124,8 +125,12 @@ async def _apply_drift_ignore_rules(run: Run, rules: list[str]) -> str:
         )
         return "drifted"
 
+    # Rule 13: parsing a multi-MB plan JSON and recursing every resource
+    # change in classify_drift is CPU-bound — run both off the event loop so
+    # this handler (driven by the drift_run_completed trigger on an API
+    # replica) never stalls /health while a large plan is classified.
     try:
-        plan = json.loads(raw)
+        plan = await asyncio.to_thread(json.loads, raw)
     except (ValueError, TypeError) as e:
         logger.warning(
             "drift_ignore: plan JSON unparseable; treating as drift",
@@ -135,7 +140,7 @@ async def _apply_drift_ignore_rules(run: Run, rules: list[str]) -> str:
         return "drifted"
 
     try:
-        still_drifted, suppressed = classify_drift(plan, rules)
+        still_drifted, suppressed = await asyncio.to_thread(classify_drift, plan, rules)
     except Exception as e:
         logger.warning(
             "drift_ignore: classifier crashed; treating as drift",

--- a/services/tests/api/test_provider_mirror.py
+++ b/services/tests/api/test_provider_mirror.py
@@ -1,0 +1,45 @@
+"""Services-API auth-gate tests for the provider network mirror
+(`routers/provider_mirror.py`).
+
+CLAUDE.md pins this as a HARD fact: the `{version}.json` / `index.json` mirror
+endpoints are AUTHENTICATED (the returned download URLs are not). The caching
+*service* is unit-tested, but nothing asserted the *router* declares the auth
+dependency — so dropping `Depends(get_current_user)` would pass every existing
+test. These prove the gate is wired: the override only fires if the route
+actually depends on `get_current_user`.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+
+_BASE = "http://test"
+_INDEX = "/v1/providers/registry.terraform.io/hashicorp/null/index.json"
+_VERSION = "/v1/providers/registry.terraform.io/hashicorp/null/3.2.1.json"
+
+
+def _deny() -> AuthenticatedUser:
+    raise HTTPException(status_code=401, detail="unauthorized")
+
+
+@patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+@patch("terrapod.api.app.init_redis")
+@patch("terrapod.api.app.init_db")
+class TestProviderMirrorAuthGate:
+    async def test_index_declares_auth_dependency(self, *_mocks):
+        app = create_app()
+        app.dependency_overrides[get_current_user] = _deny  # only fires if declared
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_INDEX)
+        assert resp.status_code == 401
+
+    async def test_version_declares_auth_dependency(self, *_mocks):
+        app = create_app()
+        app.dependency_overrides[get_current_user] = _deny
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_VERSION)
+        assert resp.status_code == 401

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -352,6 +352,88 @@ class TestCreateRole:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
+    async def test_create_with_catalog_permission(self, *mocks):
+        """A custom role can carry catalog-permission so non-admins can be
+        granted catalog use (the v0.42.0 axis was ungrantable via any consumer)."""
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/roles",
+                json={
+                    "data": {
+                        "name": "catalog-user-role",
+                        "attributes": {
+                            "workspace-permission": "read",
+                            "catalog-permission": "use",
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 201
+        assert resp.json()["data"]["attributes"]["catalog-permission"] == "use"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_invalid_catalog_permission_rejected(self, *mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/roles",
+                json={
+                    "data": {
+                        "name": "bad-catalog",
+                        "attributes": {
+                            "workspace-permission": "read",
+                            "catalog-permission": "superuse",
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_defaults_catalog_permission_to_none(self, *mocks):
+        """Omitting catalog-permission defaults to 'none' (opt-in, no floor)."""
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/roles",
+                json={
+                    "data": {
+                        "name": "no-catalog-role",
+                        "attributes": {"workspace-permission": "read"},
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 201
+        assert resp.json()["data"]["attributes"]["catalog-permission"] == "none"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
     async def test_list_includes_registry_permission(self, *mocks):
         user = _user(roles=["admin"])
         app, mock_db = _make_app(user)

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -28,7 +28,7 @@ def _user(email="admin@example.com", roles=None):
     )
 
 
-def _mock_role(name="dev-team", ws_perm="read", reg_perm="read"):
+def _mock_role(name="dev-team", ws_perm="read", reg_perm="read", catalog_perm="none"):
     role = MagicMock()
     role.name = name
     role.description = "A custom role"
@@ -39,6 +39,7 @@ def _mock_role(name="dev-team", ws_perm="read", reg_perm="read"):
     role.workspace_permission = ws_perm
     role.pool_permission = "read"
     role.registry_permission = reg_perm
+    role.catalog_permission = catalog_perm
     role.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     role.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return role
@@ -173,6 +174,31 @@ class TestCreateRole:
                 headers=_AUTH,
             )
         assert resp.status_code == 201
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_concurrent_duplicate_returns_409_not_500(self, *mocks):
+        """The pre-check then INSERT races under multiple replicas; the loser
+        hits the unique constraint. The global IntegrityError handler maps that
+        to 409, not a 500."""
+        from sqlalchemy.exc import IntegrityError
+
+        user = _user(roles=["admin"])
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None  # pre-check sees no row
+        mock_db.execute.return_value = mock_result
+        mock_db.commit = AsyncMock(side_effect=IntegrityError("dup", {}, Exception()))
+        app, _ = _make_app(user, mock_db=mock_db)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/roles",
+                json={"data": {"name": "racy", "attributes": {"workspace-permission": "read"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 409
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/api/test_serialization.py
+++ b/services/tests/api/test_serialization.py
@@ -1,0 +1,22 @@
+"""Tests for the shared RFC3339 serializer (Rule 10 / go-tfe compat)."""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from terrapod.api.serialization import rfc3339
+
+
+def test_none_returns_none():
+    assert rfc3339(None) is None
+
+
+def test_utc_emits_trailing_z_not_offset():
+    dt = datetime(2026, 6, 24, 12, 30, 5, tzinfo=UTC)
+    out = rfc3339(dt)
+    assert out == "2026-06-24T12:30:05Z"
+    assert "+00:00" not in out
+
+
+def test_non_utc_is_converted_to_utc_z():
+    # A +02:00 wall-clock time normalises to UTC with a Z suffix.
+    dt = datetime(2026, 6, 24, 14, 30, 5, tzinfo=timezone(timedelta(hours=2)))
+    assert rfc3339(dt) == "2026-06-24T12:30:05Z"

--- a/services/tests/api/test_users.py
+++ b/services/tests/api/test_users.py
@@ -1,5 +1,7 @@
 """Tests for user management endpoints."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi import HTTPException
 
@@ -77,3 +79,30 @@ class TestRequireAdmin:
         with pytest.raises(HTTPException) as exc_info:
             await require_admin(user=_regular_user())
         assert exc_info.value.status_code == 403
+
+
+class TestOffboardingRevocation:
+    """Deactivating or deleting a user must revoke not just web sessions but the
+    cached token-role set AND every API token bound to the identity — otherwise
+    a deactivated admin keeps cached admin roles (60s TTL) on API-token requests
+    and detached service tokens survive offboarding entirely."""
+
+    @pytest.mark.asyncio
+    @patch("terrapod.redis.client.get_redis_client")
+    @patch("terrapod.auth.sessions.revoke_all_user_sessions", new_callable=AsyncMock)
+    @patch("terrapod.auth.api_tokens.revoke_all_for_user", new_callable=AsyncMock)
+    async def test_revokes_sessions_token_cache_and_api_tokens(
+        self, mock_tokens, mock_sessions, mock_redis
+    ):
+        from terrapod.api.routers import users
+
+        redis = AsyncMock()
+        mock_redis.return_value = redis
+        db = AsyncMock()
+
+        await users._revoke_all_user_access(db, "gone@example.com")
+
+        mock_sessions.assert_awaited_once_with("gone@example.com")
+        mock_tokens.assert_awaited_once_with(db, "gone@example.com")
+        redis.delete.assert_awaited_once()
+        assert "gone@example.com" in redis.delete.call_args.args[0]

--- a/services/tests/api/test_users.py
+++ b/services/tests/api/test_users.py
@@ -84,8 +84,8 @@ class TestRequireAdmin:
 class TestOffboardingRevocation:
     """Deactivating or deleting a user must revoke not just web sessions but the
     cached token-role set AND every API token bound to the identity — otherwise
-    a deactivated admin keeps cached admin roles (60s TTL) on API-token requests
-    and detached service tokens survive offboarding entirely."""
+    a deactivated admin keeps cached admin roles (60s TTL) on API-token requests.
+    (Detached/org-level tokens, bound_to NULL, are intentionally left alone.)"""
 
     @pytest.mark.asyncio
     @patch("terrapod.redis.client.get_redis_client")

--- a/services/tests/api/test_vcs_events.py
+++ b/services/tests/api/test_vcs_events.py
@@ -1,0 +1,112 @@
+"""Services-API tests for the GitHub webhook receiver (`routers/vcs_events.py`).
+
+This is a publicly-reachable, unauthenticated endpoint whose only defense is
+HMAC-SHA256 signature validation + an installation allow-list. Its helper
+(`validate_webhook_signature`) was unit-tested in isolation, but the router
+itself — reject-on-bad-signature, ping handshake, enqueue-on-valid-push,
+unknown-installation rejection, malformed-body handling — had no coverage.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.config import settings
+
+_BASE = "http://test"
+_PUSH = {
+    "repository": {"full_name": "acme/infra"},
+    "installation": {"id": 4242},
+}
+
+
+@pytest.fixture(autouse=True)
+def _webhook_secret():
+    original = settings.vcs.github.webhook_secret
+    settings.vcs.github.webhook_secret = "shhh"
+    yield
+    settings.vcs.github.webhook_secret = original
+
+
+def _app():
+    return create_app()
+
+
+@patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+@patch("terrapod.api.app.init_redis")
+@patch("terrapod.api.app.init_db")
+class TestGithubWebhook:
+    async def test_not_configured_returns_404(self, *_mocks):
+        settings.vcs.github.webhook_secret = ""  # disable
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-events/github", content=b"{}")
+        assert resp.status_code == 404
+
+    @patch("terrapod.api.routers.vcs_events.validate_webhook_signature", return_value=False)
+    async def test_invalid_signature_rejected_401(self, _sig, *_mocks):
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/vcs-events/github",
+                content=b"{}",
+                headers={"X-Hub-Signature-256": "sha256=bogus"},
+            )
+        assert resp.status_code == 401
+
+    @patch("terrapod.api.routers.vcs_events.validate_webhook_signature", return_value=True)
+    async def test_ping_acks_pong(self, _sig, *_mocks):
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/vcs-events/github",
+                content=b"{}",
+                headers={"X-GitHub-Event": "ping"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "pong"
+
+    @patch("terrapod.api.routers.vcs_events.enqueue_trigger", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.vcs_events._resolve_connection", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.vcs_events.validate_webhook_signature", return_value=True)
+    async def test_valid_push_enqueues_immediate_poll(
+        self, _sig, mock_resolve, mock_enqueue, *_mocks
+    ):
+        mock_resolve.return_value = MagicMock()  # known installation
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/vcs-events/github",
+                content=json.dumps(_PUSH).encode(),
+                headers={"X-GitHub-Event": "push"},
+            )
+        assert resp.status_code == 200
+        triggers = [call.args[0] for call in mock_enqueue.await_args_list]
+        assert "vcs_immediate_poll" in triggers
+
+    @patch("terrapod.api.routers.vcs_events.enqueue_trigger", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.vcs_events._resolve_connection", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.vcs_events.validate_webhook_signature", return_value=True)
+    async def test_unknown_installation_does_not_enqueue(
+        self, _sig, mock_resolve, mock_enqueue, *_mocks
+    ):
+        mock_resolve.return_value = None  # unknown installation
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/vcs-events/github",
+                content=json.dumps(_PUSH).encode(),
+                headers={"X-GitHub-Event": "push"},
+            )
+        # 200 so GitHub stops retrying, but no work enqueued.
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "unknown installation"
+        mock_enqueue.assert_not_awaited()
+
+    @patch("terrapod.api.routers.vcs_events.validate_webhook_signature", return_value=True)
+    async def test_malformed_json_returns_400(self, _sig, *_mocks):
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/vcs-events/github",
+                content=b"not json{{{",
+                headers={"X-GitHub-Event": "push"},
+            )
+        assert resp.status_code == 400

--- a/services/tests/services/test_drift_detection_service.py
+++ b/services/tests/services/test_drift_detection_service.py
@@ -539,3 +539,49 @@ class TestCreateDriftRunNonVcs:
 
         assert result is None
         mock_create.assert_not_called()
+
+
+class TestApplyDriftIgnoreRules:
+    """`_apply_drift_ignore_rules` (#482) classifies a drift plan against the
+    workspace's ignore rules. The plan parse + classifier run off the event loop
+    (Rule 13) — these assert the branch outcomes survive that offload, plus the
+    conservative fallbacks."""
+
+    @patch("terrapod.services.drift_ignore_classifier.classify_drift")
+    @patch("terrapod.storage.get_storage")
+    async def test_all_suppressed_is_no_drift(self, mock_storage, mock_classify):
+        from terrapod.services import drift_detection_service as mod
+
+        store = MagicMock()
+        store.get = AsyncMock(return_value=b'{"resource_changes": []}')
+        mock_storage.return_value = store
+        mock_classify.return_value = (False, [{"address": "x"}])  # nothing still drifted
+        run = MagicMock(id=uuid.uuid4(), workspace_id=uuid.uuid4())
+
+        assert await mod._apply_drift_ignore_rules(run, ["ignore_tags"]) == "no_drift"
+        mock_classify.assert_called_once()
+
+    @patch("terrapod.services.drift_ignore_classifier.classify_drift")
+    @patch("terrapod.storage.get_storage")
+    async def test_remaining_change_is_drifted(self, mock_storage, mock_classify):
+        from terrapod.services import drift_detection_service as mod
+
+        store = MagicMock()
+        store.get = AsyncMock(return_value=b'{"resource_changes": [{"address": "y"}]}')
+        mock_storage.return_value = store
+        mock_classify.return_value = (True, [])  # a change survived the rules
+        run = MagicMock(id=uuid.uuid4(), workspace_id=uuid.uuid4())
+
+        assert await mod._apply_drift_ignore_rules(run, ["ignore_tags"]) == "drifted"
+
+    @patch("terrapod.storage.get_storage")
+    async def test_unparseable_plan_falls_back_to_drifted(self, mock_storage):
+        from terrapod.services import drift_detection_service as mod
+
+        store = MagicMock()
+        store.get = AsyncMock(return_value=b"not json{{{")
+        mock_storage.return_value = store
+        run = MagicMock(id=uuid.uuid4(), workspace_id=uuid.uuid4())
+
+        # A runtime hiccup must never SILENCE drift the operator wanted surfaced.
+        assert await mod._apply_drift_ignore_rules(run, ["ignore_tags"]) == "drifted"

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -22,6 +22,7 @@ interface Role {
     'workspace-permission': string | null
     'pool-permission': string | null
     'registry-permission': string | null
+    'catalog-permission': string | null
     'allow-labels': Record<string, string>
     'allow-names': string[]
     'deny-labels': Record<string, string>
@@ -68,6 +69,7 @@ export default function RolesPage() {
   const [roleDenyLabels, setRoleDenyLabels] = useState('')
   const [rolePoolPermission, setRolePoolPermission] = useState('read')
   const [roleRegistryPermission, setRoleRegistryPermission] = useState('read')
+  const [roleCatalogPermission, setRoleCatalogPermission] = useState('none')
   const [roleDenyNames, setRoleDenyNames] = useState('')
   const [creatingRole, setCreatingRole] = useState(false)
 
@@ -80,6 +82,7 @@ export default function RolesPage() {
   const [editRoleDenyLabels, setEditRoleDenyLabels] = useState('')
   const [editRolePoolPermission, setEditRolePoolPermission] = useState('read')
   const [editRoleRegistryPermission, setEditRoleRegistryPermission] = useState('read')
+  const [editRoleCatalogPermission, setEditRoleCatalogPermission] = useState('none')
   const [editRoleDenyNames, setEditRoleDenyNames] = useState('')
   const [savingRole, setSavingRole] = useState(false)
 
@@ -183,6 +186,7 @@ export default function RolesPage() {
         'workspace-permission': rolePermission,
         'pool-permission': rolePoolPermission,
         'registry-permission': roleRegistryPermission,
+        'catalog-permission': roleCatalogPermission,
       }
       if (roleAllowLabels.trim()) attrs['allow-labels'] = parseLabels(roleAllowLabels)
       if (roleAllowNames.trim()) attrs['allow-names'] = roleAllowNames.split(',').map((s) => s.trim()).filter(Boolean)
@@ -204,6 +208,7 @@ export default function RolesPage() {
       setRolePermission('read')
       setRolePoolPermission('read')
       setRoleRegistryPermission('read')
+      setRoleCatalogPermission('none')
       setRoleAllowLabels('')
       setRoleAllowNames('')
       setRoleDenyLabels('')
@@ -223,6 +228,7 @@ export default function RolesPage() {
     setEditRolePermission(role.attributes['workspace-permission'] || 'read')
     setEditRolePoolPermission(role.attributes['pool-permission'] || 'read')
     setEditRoleRegistryPermission(role.attributes['registry-permission'] || 'read')
+    setEditRoleCatalogPermission(role.attributes['catalog-permission'] || 'none')
     setEditRoleAllowLabels(formatLabels(role.attributes['allow-labels'] || {}))
     setEditRoleAllowNames((role.attributes['allow-names'] || []).join(', '))
     setEditRoleDenyLabels(formatLabels(role.attributes['deny-labels'] || {}))
@@ -240,6 +246,7 @@ export default function RolesPage() {
         'workspace-permission': editRolePermission,
         'pool-permission': editRolePoolPermission,
         'registry-permission': editRoleRegistryPermission,
+        'catalog-permission': editRoleCatalogPermission,
         'allow-labels': parseLabels(editRoleAllowLabels),
         'allow-names': editRoleAllowNames.split(',').map((s) => s.trim()).filter(Boolean),
         'deny-labels': parseLabels(editRoleDenyLabels),
@@ -433,6 +440,16 @@ export default function RolesPage() {
                       <option value="admin">admin</option>
                     </select>
                   </div>
+                  <div>
+                    <label htmlFor="r-catalog-perm" className="block text-sm font-medium text-slate-300 mb-1">Catalog Permission</label>
+                    <select id="r-catalog-perm" value={roleCatalogPermission} onChange={(e) => setRoleCatalogPermission(e.target.value)}
+                      className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent">
+                      <option value="none">none</option>
+                      <option value="read">read</option>
+                      <option value="use">use</option>
+                      <option value="admin">admin</option>
+                    </select>
+                  </div>
                 </div>
                 <div>
                   <label htmlFor="r-desc" className="block text-sm font-medium text-slate-300 mb-1">Description</label>
@@ -525,6 +542,16 @@ export default function RolesPage() {
                               </select>
                             </div>
                             <div>
+                              <label className="block text-xs text-slate-500 mb-1">Catalog Permission</label>
+                              <select value={editRoleCatalogPermission} onChange={(e) => setEditRoleCatalogPermission(e.target.value)}
+                                className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500">
+                                <option value="none">none</option>
+                                <option value="read">read</option>
+                                <option value="use">use</option>
+                                <option value="admin">admin</option>
+                              </select>
+                            </div>
+                            <div>
                               <label className="block text-xs text-slate-500 mb-1">Allow Labels</label>
                               <input type="text" value={editRoleAllowLabels} onChange={(e) => setEditRoleAllowLabels(e.target.value)}
                                 className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500" />
@@ -567,6 +594,11 @@ export default function RolesPage() {
                               {a['registry-permission'] && a['registry-permission'] !== 'read' && (
                                 <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${permissionBadge(a['registry-permission'])}`}>
                                   registry: {a['registry-permission']}
+                                </span>
+                              )}
+                              {a['catalog-permission'] && a['catalog-permission'] !== 'none' && (
+                                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${permissionBadge(a['catalog-permission'])}`}>
+                                  catalog: {a['catalog-permission']}
                                 </span>
                               )}
                             </div>

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -419,6 +419,7 @@ function WorkspaceDetailContent() {
   const [rtHmacKey, setRtHmacKey] = useState('')
   const [addingRunTask, setAddingRunTask] = useState(false)
   const [deleteRtId, setDeleteRtId] = useState<string | null>(null)
+  const [deleteVarId, setDeleteVarId] = useState<string | null>(null)
 
   // Sorting for runs tab
   type RunSortKey = 'id' | 'status' | 'type' | 'source' | 'created-by' | 'created-at'
@@ -1226,6 +1227,7 @@ function WorkspaceDetailContent() {
     try {
       const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/vars/${varId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete variable')
+      setDeleteVarId(null)
       await loadVariables()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete variable')
@@ -2440,7 +2442,14 @@ function WorkspaceDetailContent() {
                             <td className="px-4 py-3 text-right">
                               <div className="flex justify-end gap-2">
                                 <button onClick={() => startEditingVar(v)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
-                                <button onClick={() => handleDeleteVariable(v.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
+                                {deleteVarId === v.id ? (
+                                  <>
+                                    <button onClick={() => setDeleteVarId(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
+                                    <button onClick={() => handleDeleteVariable(v.id)} className="text-xs text-red-400 hover:text-red-300">Confirm</button>
+                                  </>
+                                ) : (
+                                  <button onClick={() => setDeleteVarId(v.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
+                                )}
                               </div>
                             </td>
                           )}

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { Suspense, useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import Convert from 'ansi-to-html'
@@ -308,7 +308,18 @@ function LogPanel({
   )
 }
 
+// useSearchParams() requires a Suspense boundary or `next build` fails to
+// statically analyse the route (Next 16). Matches the convention used by every
+// other useSearchParams page (login, workspaces, labels, …).
 export default function RunDetailPage() {
+  return (
+    <Suspense fallback={null}>
+      <RunDetailPageInner />
+    </Suspense>
+  )
+}
+
+function RunDetailPageInner() {
   const router = useRouter()
   const params = useParams()
   const workspaceId = params.id as string

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -387,8 +387,11 @@ function WorkspacesPageInner() {
     loadWorkspaces()
   }, [router])
 
-  // Real-time workspace list updates via SSE
-  useWorkspaceListEvents(workspaces.length > 0, useCallback(() => {
+  // Real-time workspace list updates via SSE. Always-on (not gated on
+  // workspaces.length) so the FIRST workspace created from another tab / the
+  // CLI / a VCS push live-appears on an empty org instead of requiring a
+  // manual refresh — the empty state is exactly where live-update matters most.
+  useWorkspaceListEvents(true, useCallback(() => {
     loadWorkspaces()
   }, []))
 


### PR DESCRIPTION
Hardening release implementing the verified findings from the post-v0.42.0 whole-project third-party review (security · docs · UX · completeness · tests · API-contract). Scope per the agreed plan: **all P0s + the security/backend-correctness P1s** (UX-polish and SDK-coverage P1/P2 deferred to a later cycle).

## Headline (P0)

- **catalog_permission was ungrantable through every consumer** — `Role.catalog_permission` existed and `catalog_rbac_service` resolved it, but the roles router/SDK/provider/web never exposed it, so with no `everyone` floor **no non-admin could ever be granted catalog `use`**. The v0.42.0 self-service catalog was admin-only in practice. Now wired end-to-end: roles router (serialize + create/update validate + builtin synthesis), `go-terrapod`, `terraform_role` **resource and data source**, and the web Roles page. `none|read|use|admin`, default `none`.

## Other P0s

- **Rule 13 event-loop stall** — drift-ignore ran `json.loads` + `classify_drift` inline on the API event loop; a multi-MB drift plan stalled the replica (and `/health`). Now `asyncio.to_thread`.
- **Web** — workspace-list SSE was gated on `workspaces.length > 0` (first workspace on an empty org never live-appeared); variable Delete was one-click (now two-click confirm); the run-detail page used `useSearchParams()` with no Suspense boundary (a `next build` breaker on Next 16) — now wrapped.
- **Docs** — `migration.md` claimed the tool is stubbed/unreleased (false since v0.27.0); `service-catalog.md` showed typed wrapper variables (code emits **untyped**).
- **Tests** — added router tests for the public GitHub webhook receiver (`vcs_events`) and the provider-mirror auth gate (both had zero router-level coverage; the mirror gate would silently regress if `Depends(get_current_user)` were dropped).

## Security + correctness P1s

- **Offboarding** — deactivate/delete now revoke the cached token-role set (`tp:token_roles:`) and every API token bound to the identity, not just web sessions (a deactivated admin previously kept cached admin roles for up to 60s).
- **PKCE** verifier comparison is now timing-safe (`hmac.compare_digest`).
- **Global `IntegrityError` → 409** (was 500) — many create endpoints pre-check then INSERT, racing under multiple replicas; the loser hit the unique constraint and 500'd. Hot paths still catch it in-handler for a specific message.
- **RFC3339 `Z`** — `registry_modules`/`registry_providers`/`gpg_keys`/`binary_cache` emitted bare `.isoformat()` (`+00:00`, violating Rule 10 / go-tfe compat); routed through one canonical `api/serialization.rfc3339`.
- Next.js 15 → 16 doc bump (matches `package.json ^16.2.9`).

## Verification

- Python full suite green (2326); web `npm run build` (confirms the Suspense fix); go-terrapod tests; provider build/vet; helm lint + template (default + local).
- Pre-release audit (D leak-scan / B helm-schema / E versions / G vuln-ignores) clean; independent adversarial third-party review run on the diff — its two SHOULD-FIX items (role data source + offboarding docstring) are fixed in this PR.

This release contains no new Helm values, no migrations, and no destructive/blast-radius surface change, so no live F-gate smoke is required.
