### PR TITLE
v0.44.0 — whole-project review backlog: UX a11y, test/SDK coverage, security hardening, registry/docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,15 +240,26 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Registry](docs/registry.md) | Private module/provider registry, caching layers |
 | [Registry Publishing](docs/registry-publishing.md) | Publishing providers/modules with `terrapod-publish` and the client-signed publish protocol |
 | [VCS Integration](docs/vcs-integration.md) | GitHub and GitLab setup, polling, webhooks |
+| [VCS Workflows](docs/vcs-workflows.md) | PR/MR comment commands, speculative plans, apply-on-merge |
 | [Policies (OPA)](docs/policies.md) | Rego policy authoring, advisory vs mandatory enforcement, label-based scoping, admin override |
 | [Autodiscovery](docs/autodiscovery.md) | Atlantis-style monorepo workspace autodiscovery |
 | [Drift Detection](docs/drift-detection.md) | Scheduled plan-only runs to detect infrastructure drift |
+| [Drift Ignore Rules](docs/drift-ignore-rules.md) | Suppress known/expected drift by resource address or attribute |
 | [Run Triggers](docs/run-triggers.md) | Cross-workspace dependency chains |
+| [Terragrunt](docs/terragrunt.md) | CLI-driven and agent-mode Terragrunt support |
+| [Remote State](docs/remote-state.md) | State versioning, locking, rollback, the `cloud` backend |
+| [AI Plan Summary](docs/ai-plan-summary.md) | LLM plan summaries, risk assessment, failure analysis, chat |
 | [Notifications](docs/notifications.md) | Webhook, Slack, and email alerts on run events |
 | [Run Tasks](docs/run-tasks.md) | Pre/post-plan webhook hooks for external validation |
 | [Audit Logging](docs/audit-logging.md) | Immutable event log, query API, retention |
+| [Artifact Retention](docs/artifact-retention.md) | Retention + purge of run logs, plans, and config tarballs |
+| [Runners](docs/runners.md) | Agent pools, the listener/runner ARC model, custom runner images |
 | [Cloud Credentials](docs/cloud-credentials.md) | AWS IRSA, GCP WIF, Azure WI setup |
+| [Service Catalog](docs/service-catalog.md) | No-code self-service provisioning over the module registry |
 | [Monitoring](docs/monitoring.md) | Prometheus metrics, scraping, recommended alerts |
+| [Optional Webhook Ingress](docs/deployment-webhook-ingress.md) | Split public webhook ingress so the management plane can stay private |
+| [Security Hardening](docs/security-hardening.md) | Pod hardening defaults, secrets, network posture |
+| [Production Checklist](docs/production-checklist.md) | Pre-go-live checklist for a production deployment |
 | [Disaster Recovery](docs/disaster-recovery.md) | Break-glass state recovery from object storage |
 
 ---

--- a/alembic/versions/166efacb7b5d_ca_key_truthful_name.py
+++ b/alembic/versions/166efacb7b5d_ca_key_truthful_name.py
@@ -1,0 +1,23 @@
+"""Rename certificate_authority.ca_key_encrypted to ca_key_pem.
+
+The column never held an application-encrypted value — it is a NoEncryption
+PKCS8 PEM, protected at rest by database encryption (same as sensitive
+variables and VCS tokens). Rename it so the schema doesn't claim a property
+it doesn't have. Pure rename, no data change.
+
+Revision ID: 166efacb7b5d
+Revises: a675f90f82e7
+"""
+
+from alembic import op
+
+revision = "166efacb7b5d"
+down_revision = "a675f90f82e7"
+
+
+def upgrade() -> None:
+    op.alter_column("certificate_authority", "ca_key_encrypted", new_column_name="ca_key_pem")
+
+
+def downgrade() -> None:
+    op.alter_column("certificate_authority", "ca_key_pem", new_column_name="ca_key_encrypted")

--- a/alembic/versions/a675f90f82e7_state_version_sha256.py
+++ b/alembic/versions/a675f90f82e7_state_version_sha256.py
@@ -1,0 +1,30 @@
+"""Add sha256 to state_versions for collision-resistant divergence checks.
+
+The state-divergence equality check (does a re-uploaded state at an existing
+serial match the recorded one, or is it a genuine conflict?) previously
+compared md5. An md5 collision could make two distinct states compare equal
+and suppress a real divergence flag. Add a Terrapod-internal sha256 column
+(md5 stays for the go-tfe state-version contract) and use it for the compare,
+falling back to md5 for legacy rows written before this column existed.
+
+Revision ID: a675f90f82e7
+Revises: 1c014bf5ae6d
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "a675f90f82e7"
+down_revision = "1c014bf5ae6d"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "state_versions",
+        sa.Column("sha256", sa.String(64), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("state_versions", "sha256")

--- a/alembic/versions/e9503007edfc_vcs_connection_webhook_secret.py
+++ b/alembic/versions/e9503007edfc_vcs_connection_webhook_secret.py
@@ -1,0 +1,26 @@
+"""Add per-connection webhook_secret to vcs_connections.
+
+A single global vcs.github.webhook_secret validated webhooks for every GitHub
+installation, so any installation that learned the one secret could forge a
+valid signature for any other. Add an optional per-connection secret; when set
+it validates that connection's inbound webhooks, falling back to the global
+secret when null (so existing single-secret deployments are unaffected).
+
+Revision ID: e9503007edfc
+Revises: 166efacb7b5d
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e9503007edfc"
+down_revision = "166efacb7b5d"
+
+
+def upgrade() -> None:
+    op.add_column("vcs_connections", sa.Column("webhook_secret", sa.String(255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("vcs_connections", "webhook_secret")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1771,11 +1771,19 @@ POST /api/terrapod/v1/vcs-connections
       "github-installation-id": 112887490,
       "github-account-login": "my-org",
       "github-account-type": "Organization",
-      "private-key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+      "private-key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+      "webhook-secret": "optional-per-connection-secret"
     }
   }
 }
 ```
+
+> `webhook-secret` (GitHub, optional) is **write-only** — it is never returned;
+> the response carries `has-webhook-secret` (boolean) instead. When set, this
+> connection's inbound webhooks are validated against it, falling back to the
+> global `vcs.github.webhook_secret` when absent. On `PATCH`, supply a
+> non-empty value to rotate, an explicit empty string to clear, or omit the
+> key to leave it untouched.
 
 **GitLab example:**
 ```json

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -21,8 +21,8 @@ my-vpc:
   serial: 42
   updated_at: '2026-03-25T10:30:00Z'
 production-rds:
-  workspace_id: 7fb95e74-6828-4673-c4gd-3d074g77bgb7
-  state_key: state/7fb95e74-6828-4673-c4gd-3d074g77bgb7/9b2c3d4e-5f6a-7890-bcde-f01234567890.tfstate
+  workspace_id: 7fb95e74-6828-4673-a4bd-3d074a77bcb7
+  state_key: state/7fb95e74-6828-4673-a4bd-3d074a77bcb7/9b2c3d4e-5f6a-7890-bcde-f01234567890.tfstate
   serial: 15
   updated_at: '2026-03-24T14:00:00Z'
 ```
@@ -158,3 +158,27 @@ During break-glass recovery with a local backend, there is no state locking. Coo
 ### Index Accuracy
 
 The state index is best-effort — it is updated on every state upload but failures are swallowed to avoid blocking state operations. In rare cases, the index may be slightly out of date. If you cannot find a workspace in the index, state files are stored at `state/<workspace_uuid>/<state_version_uuid>.tfstate` — list the workspace's directory to find the latest file by timestamp.
+
+## Routine Backup & Restore
+
+Break-glass recovery above operates on a **single** workspace's state from
+object storage. For protecting the whole platform, Terrapod has exactly two
+stateful components — back up both:
+
+| Component | Holds | Back up with |
+|---|---|---|
+| **PostgreSQL** | Workspaces, variables (incl. sensitive), runs, configuration-version metadata, registry metadata, roles/assignments, VCS connections, the CA keypair, audit log | Your database's native backup (RDS automated/manual snapshots, Azure Database backups, `pg_dump`, or a continuous-archiving tool like WAL-G/pgBackRest) |
+| **Object storage** | State versions, configuration-version tarballs, plan/apply logs, registry module + provider artifacts, the state index | The cloud provider's bucket-level protection (S3 Versioning + cross-region replication, Azure Blob soft-delete + versioning, GCS Object Versioning), or a periodic bucket sync to a separate account |
+
+Redis holds only ephemeral data (sessions, listener heartbeats, the scheduler's
+distributed locks, SSE channels) — it does **not** need backing up; a fresh
+Redis is fine after a restore.
+
+**Restore order:** restore PostgreSQL first, then point the new deployment at
+the restored object-storage bucket via Helm values. Because every artifact in
+object storage is addressed by the UUIDs recorded in PostgreSQL, a
+point-in-time PostgreSQL snapshot paired with a same-or-later object-storage
+state is self-consistent (extra orphaned objects are harmless). Keep the two
+backups loosely time-aligned to minimise orphans. The CA keypair lives in
+PostgreSQL, so a DB restore re-establishes listener trust without re-issuing
+certificates.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -130,8 +130,13 @@ for ad-hoc rewriting without a migration record.
   first-class equivalent. Recorded in the skipped-items report.
 - **`apply_requirements`** (`approved`, `mergeable`, `undiverged`) — no
   direct Terrapod equivalent. Recorded as advisory metadata.
-- **`terragrunt` projects** — Terrapod doesn't run terragrunt. Detected
-  and listed in the skipped-items report.
+- **`terragrunt` projects** — the migration tool does not auto-translate
+  terragrunt-driven Atlantis projects (their `terragrunt.hcl` dependency
+  graphs and `generate` blocks aren't mechanically convertible), so they're
+  detected and listed in the skipped-items report. This is a *migration-tool*
+  limitation, not a runtime one: Terrapod itself runs Terragrunt in agent
+  mode via the `terragrunt_enabled` workspace flag, so a skipped project can
+  be re-created by hand. See [terragrunt.md](terragrunt.md).
 - **PR comment history** — out of scope.
 
 ### Autodiscovery mode (no `atlantis.yaml`)

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -116,6 +116,29 @@ api:
 
 For production, use [External Secrets Operator](https://external-secrets.io/) to sync secrets from AWS Secrets Manager, Azure Key Vault, or GCP Secret Manager into Kubernetes Secrets automatically.
 
+### Dedicated token signing key
+
+Runner tokens and run-task callback tokens are stateless HMAC tokens. By
+default their signing key is derived from the database URL, which couples
+token-forgery resistance to the database credentials. To decouple them, set a
+dedicated secret via `api.tokenSigningKey` (injected as
+`TERRAPOD_TOKEN_SIGNING_KEY` from a K8s Secret, never a ConfigMap):
+
+```zsh
+kubectl -n terrapod create secret generic terrapod-token-signing \
+  --from-literal=token_signing_key="$(openssl rand -hex 32)"
+```
+
+```yaml
+api:
+  tokenSigningKey:
+    existingSecret: "terrapod-token-signing"
+    existingSecretKey: "token_signing_key"
+```
+
+Leaving it unset keeps the database-URL-derived key, so configuring it later
+does not invalidate any in-flight token.
+
 ## Network Policies
 
 Terrapod ships with NetworkPolicy templates that restrict pod-to-pod and pod-to-external traffic. Enable them:

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -578,6 +578,22 @@ api:
 
 When a push event arrives, the webhook handler validates the HMAC-SHA256 signature and triggers an immediate poll for the affected repository. The poller still does all the work -- the webhook just makes it faster.
 
+### Per-connection webhook secret
+
+The Helm value above sets a single **global** webhook secret used to validate
+every GitHub installation's webhooks. If you connect more than one GitHub
+installation, you can instead set a **per-connection** secret so that one
+installation's secret can't be used to forge another's webhooks.
+
+Set it when creating or editing a VCS connection — in the admin UI
+(*Admin → VCS Connections → Webhook Secret*), via the API as the write-only
+`webhook-secret` attribute, or via the Terraform provider's
+`terrapod_vcs_connection.webhook_secret`. It is never returned by the API
+(`has-webhook-secret` indicates only whether one is set). When a connection
+has its own secret, that connection's webhooks are validated against it; when
+it doesn't, validation falls back to the global secret — so existing
+single-secret deployments are unaffected.
+
 > GitLab webhook support is not yet implemented. GitLab connections use polling only.
 
 ---

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -118,5 +118,10 @@ export default defineConfig({
       testMatch: 'catalog.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
     },
+    {
+      name: 'sse-live-update',
+      testMatch: 'sse-live-update.spec.ts',
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
+    },
   ],
 });

--- a/e2e/tests/audit-log.spec.ts
+++ b/e2e/tests/audit-log.spec.ts
@@ -17,22 +17,26 @@ test.describe('Audit Log', () => {
     // Wait for initial data
     await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 10_000 });
 
-    // Record initial row count
-    const initialCount = await page.locator('table tbody tr').count();
-
-    // Apply POST filter — should show fewer or equal rows
+    // Apply the POST filter and wait for the *filtered* response to land before
+    // asserting — otherwise the badge check races the table refresh and reads
+    // the pre-filter (mixed-method) rows, which is what made this test flaky
+    // (#240). Tying the assertion to the request the click triggers makes it
+    // deterministic regardless of CI latency.
     await page.selectOption('#f-action', 'POST');
-    await page.click('button:has-text("Apply Filters")');
+    await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/admin/audit-log') && r.url().includes('action') && r.ok()
+      ),
+      page.click('button:has-text("Apply Filters")'),
+    ]);
 
-    // Table should still be visible (there will be POST entries from test setup)
     await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 10_000 });
 
-    // Every visible action badge should say POST
-    const badges = page.locator('table tbody tr td:nth-child(3)');
-    const count = await badges.count();
-    for (let i = 0; i < count; i++) {
-      await expect(badges.nth(i)).toContainText('POST');
-    }
+    // Assert there is no surviving row whose action cell is not POST. toHaveCount
+    // auto-retries, so it keeps polling until the table has fully re-rendered
+    // to the filtered set rather than snapshotting it once.
+    const nonPost = page.locator('table tbody tr td:nth-child(3)').filter({ hasNotText: 'POST' });
+    await expect(nonPost).toHaveCount(0, { timeout: 10_000 });
   });
 
   test('clear filters restores full list', async ({ page }) => {

--- a/e2e/tests/sse-live-update.spec.ts
+++ b/e2e/tests/sse-live-update.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * SSE live-update through the full proxy chain (#221).
+ *
+ * This is the half of the SSE contract that mocked services-tests
+ * structurally cannot prove: that an event published server-side travels
+ * CDN → ingress → BFF → API → browser EventSource and actually re-renders
+ * the page WITHOUT a manual reload. The services-tier test only proves
+ * `publish_workspace_event` was called.
+ *
+ * We open the workspace list, wait for its EventSource to connect, then
+ * mutate the org from a *separate* actor (a direct authenticated API call,
+ * i.e. not this page's own fetch) and assert the new row appears on the
+ * already-loaded page with no `page.reload()`.
+ */
+import { test, expect } from '@playwright/test';
+import { createWorkspace, getStoredToken, uniqueName } from '../helpers/api';
+
+test.describe('SSE live update', () => {
+  test('workspace list shows a workspace created by another actor without reload', async ({
+    page,
+  }) => {
+    const token = getStoredToken('admin.json');
+    const name = uniqueName('e2e-sse-live');
+
+    // Register the wait for the SSE stream to OPEN before navigating, so we
+    // can't miss it: the EventSource opens after hydration (just after load),
+    // and pub/sub has no replay — if we created the workspace before the
+    // stream was connected, the event would be dropped and the test would
+    // flake. Tying creation to "stream is open" makes it deterministic.
+    const sseConnected = page.waitForResponse(
+      (r) => r.url().includes('/api/terrapod/v1/workspace-events') && r.status() === 200,
+      { timeout: 20_000 }
+    );
+
+    await page.goto('/workspaces');
+    await expect(page.getByRole('heading', { name: 'Workspaces' })).toBeVisible();
+
+    // Not present yet — it doesn't exist.
+    await expect(page.locator(`text=${name}`)).toHaveCount(0);
+
+    await sseConnected;
+
+    // Second actor creates the workspace via the API (not this page's fetch).
+    await createWorkspace(token, name);
+
+    // The row appears on the already-loaded page, driven purely by the SSE
+    // event re-fetching the list. No reload.
+    await expect(page.locator(`text=${name}`)).toBeVisible({ timeout: 20_000 });
+  });
+});

--- a/go-terrapod/labels.go
+++ b/go-terrapod/labels.go
@@ -1,0 +1,86 @@
+package terrapod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// The labels browser is the read-only cross-entity label index served at
+// /api/terrapod/v1/labels. All three endpoints are RBAC-filtered: results
+// only include labels carried by entities the caller can read. Responses
+// are plain JSON ({"data": ...}), not JSON:API resources.
+
+// LabelKey is one distinct label key in use, with a count of distinct
+// values and a per-entity-type breakdown of how many entities carry it.
+type LabelKey struct {
+	Key          string         `json:"key"`
+	ValueCount   int            `json:"value-count"`
+	EntityCounts map[string]int `json:"entity-counts"`
+}
+
+// LabelValue is one distinct value for a given key, with a per-entity-type
+// count of how many entities carry key=value.
+type LabelValue struct {
+	Value        string         `json:"value"`
+	EntityCounts map[string]int `json:"entity-counts"`
+}
+
+// LabelEntity is the minimal shape of an entity tagged with a label —
+// enough to render a row and link to the entity's own page.
+type LabelEntity struct {
+	Type   string            `json:"type"`
+	ID     string            `json:"id"`
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
+}
+
+// ListLabelKeys returns all label keys in use across readable entities.
+func (c *Client) ListLabelKeys(ctx context.Context) ([]LabelKey, error) {
+	data, err := c.Get(ctx, "/api/terrapod/v1/labels")
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		Data []LabelKey `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parse label keys: %w", err)
+	}
+	return out.Data, nil
+}
+
+// ListLabelValues returns the distinct values for a key. An empty slice is
+// a valid response (no readable entity carries the key).
+func (c *Client) ListLabelValues(ctx context.Context, key string) ([]LabelValue, error) {
+	data, err := c.Get(ctx, "/api/terrapod/v1/labels/"+url.PathEscape(key))
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		Data []LabelValue `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parse label values: %w", err)
+	}
+	return out.Data, nil
+}
+
+// ListLabelEntities returns the entities tagged exactly key=value, grouped
+// by entity type ("workspaces", "agent-pools", "registry-modules",
+// "registry-providers"). Empty type lists are kept.
+func (c *Client) ListLabelEntities(ctx context.Context, key, value string) (map[string][]LabelEntity, error) {
+	path := fmt.Sprintf("/api/terrapod/v1/labels/%s/%s", url.PathEscape(key), url.PathEscape(value))
+	data, err := c.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		Data map[string][]LabelEntity `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parse label entities: %w", err)
+	}
+	return out.Data, nil
+}

--- a/go-terrapod/labels_test.go
+++ b/go-terrapod/labels_test.go
@@ -1,0 +1,78 @@
+package terrapod
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newLabelsFixture(t *testing.T) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/terrapod/v1/labels":
+			_, _ = w.Write([]byte(`{"data":[
+			  {"key":"env","value-count":2,"entity-counts":{"workspaces":5,"agent-pools":1}},
+			  {"key":"team","value-count":3,"entity-counts":{"workspaces":4}}
+			]}`))
+		case r.URL.Path == "/api/terrapod/v1/labels/env":
+			_, _ = w.Write([]byte(`{"data":[
+			  {"value":"prod","entity-counts":{"workspaces":3}},
+			  {"value":"dev","entity-counts":{"workspaces":2}}
+			]}`))
+		case strings.HasPrefix(r.URL.Path, "/api/terrapod/v1/labels/env/"):
+			_, _ = w.Write([]byte(`{"data":{
+			  "workspaces":[{"type":"workspaces","id":"ws-1","name":"prod-net","labels":{"env":"prod"}}],
+			  "agent-pools":[]
+			}}`))
+		default:
+			http.Error(w, "unhandled", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestListLabelKeys(t *testing.T) {
+	c := newLabelsFixture(t)
+	keys, err := c.ListLabelKeys(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 2 || keys[0].Key != "env" || keys[0].ValueCount != 2 {
+		t.Fatalf("unexpected keys: %+v", keys)
+	}
+	if keys[0].EntityCounts["workspaces"] != 5 {
+		t.Errorf("entity-counts not parsed: %+v", keys[0])
+	}
+}
+
+func TestListLabelValues(t *testing.T) {
+	c := newLabelsFixture(t)
+	vals, err := c.ListLabelValues(t.Context(), "env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vals) != 2 || vals[0].Value != "prod" {
+		t.Fatalf("unexpected values: %+v", vals)
+	}
+}
+
+func TestListLabelEntities(t *testing.T) {
+	c := newLabelsFixture(t)
+	grouped, err := c.ListLabelEntities(t.Context(), "env", "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(grouped["workspaces"]) != 1 || grouped["workspaces"][0].ID != "ws-1" {
+		t.Fatalf("unexpected entities: %+v", grouped)
+	}
+	if _, ok := grouped["agent-pools"]; !ok {
+		t.Errorf("empty type list should be preserved")
+	}
+}

--- a/go-terrapod/policies_test.go
+++ b/go-terrapod/policies_test.go
@@ -1,0 +1,78 @@
+package terrapod
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newPolicyFixture(t *testing.T) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/policies"):
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"data":{"id":"pol-111","type":"policies","attributes":{
+			  "name":"deny-public","description":"no public buckets","rego":"package x",
+			  "created-at":"2026-06-01T00:00:00Z","updated-at":"2026-06-01T00:00:00Z"
+			},"relationships":{"policy-set":{"data":{"id":"polset-aaa","type":"policy-sets"}}}}}`))
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/api/terrapod/v1/policies/"):
+			_, _ = w.Write([]byte(`{"data":{"id":"pol-111","type":"policies","attributes":{
+			  "name":"renamed","rego":"package y"
+			},"relationships":{"policy-set":{"data":{"id":"polset-aaa","type":"policy-sets"}}}}}`))
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/terrapod/v1/policies/"):
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unhandled", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestAddPolicy(t *testing.T) {
+	c := newPolicyFixture(t)
+	p, err := c.AddPolicy(t.Context(), "polset-aaa", AddPolicyRequest{
+		Name: "deny-public", Description: "no public buckets", Rego: "package x",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ID != "pol-111" {
+		t.Errorf("id = %q, want pol-111", p.ID)
+	}
+	if p.PolicySetID != "polset-aaa" {
+		t.Errorf("policy-set id = %q, want polset-aaa", p.PolicySetID)
+	}
+	if p.Name != "deny-public" || p.Rego != "package x" {
+		t.Errorf("unexpected policy: %+v", p)
+	}
+}
+
+func TestUpdatePolicy(t *testing.T) {
+	c := newPolicyFixture(t)
+	name := "renamed"
+	rego := "package y"
+	// Only the PATCH branch returns the "renamed" body, so a successful
+	// parse proves the method + path were correct.
+	p, err := c.UpdatePolicy(t.Context(), "pol-111", UpdatePolicyRequest{Name: &name, Rego: &rego})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name != "renamed" {
+		t.Errorf("name = %q, want renamed", p.Name)
+	}
+}
+
+func TestDeletePolicy(t *testing.T) {
+	c := newPolicyFixture(t)
+	if err := c.DeletePolicy(t.Context(), "pol-111"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go-terrapod/policy_sets.go
+++ b/go-terrapod/policy_sets.go
@@ -23,10 +23,10 @@ type PolicySet struct {
 	// VCS fields (populated when Source == "vcs").
 	// VCSConnectionID includes the "vcs-" prefix (e.g. "vcs-<uuid>"),
 	// matching the format used by VCS connection endpoints.
-	VCSConnectionID string `json:"vcs-connection-id,omitempty"`
-	VCSRepoURL      string `json:"vcs-repo-url,omitempty"`
-	VCSBranch       string `json:"vcs-branch,omitempty"`
-	PolicyPath      string `json:"policy-path,omitempty"`
+	VCSConnectionID  string `json:"vcs-connection-id,omitempty"`
+	VCSRepoURL       string `json:"vcs-repo-url,omitempty"`
+	VCSBranch        string `json:"vcs-branch,omitempty"`
+	PolicyPath       string `json:"policy-path,omitempty"`
 	VCSLastCommitSHA string `json:"vcs-last-commit-sha,omitempty"`
 	VCSLastSyncedAt  string `json:"vcs-last-synced-at,omitempty"`
 	VCSLastError     string `json:"vcs-last-error,omitempty"`
@@ -250,5 +250,106 @@ func policySetFromResource(res *Resource) *PolicySet {
 		VCSLastError:     GetStringAttr(res, "vcs-last-error"),
 		CreatedAt:        GetStringAttr(res, "created-at"),
 		UpdatedAt:        GetStringAttr(res, "updated-at"),
+	}
+}
+
+// ── Individual policies ──────────────────────────────────────────────
+//
+// A Policy is a single .rego document inside an inline (non-VCS) policy
+// set. VCS-sourced sets manage their policies from the linked repository,
+// so Add/Update/Delete on those return a 409 ConflictError.
+
+// Policy is a single Rego policy within a policy set.
+type Policy struct {
+	ID          string `json:"id"`
+	PolicySetID string `json:"policy-set-id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Rego        string `json:"rego"`
+	CreatedAt   string `json:"created-at,omitempty"`
+	UpdatedAt   string `json:"updated-at,omitempty"`
+}
+
+// AddPolicyRequest is the input shape for AddPolicy.
+type AddPolicyRequest struct {
+	Name        string
+	Description string
+	Rego        string
+}
+
+// UpdatePolicyRequest is the partial-update shape for UpdatePolicy.
+type UpdatePolicyRequest struct {
+	Name        *string
+	Description *string
+	Rego        *string
+}
+
+// AddPolicy adds a Rego policy to an inline policy set. The server runs
+// `opa check` on the Rego and returns 422 on a syntax error, 409 if the
+// set already has a policy with that name, and 409 if the set is
+// VCS-sourced.
+func (c *Client) AddPolicy(ctx context.Context, policySetID string, req AddPolicyRequest) (*Policy, error) {
+	attrs := map[string]any{"name": req.Name, "rego": req.Rego}
+	if req.Description != "" {
+		attrs["description"] = req.Description
+	}
+	body, err := MarshalResource("policies", attrs, nil)
+	if err != nil {
+		return nil, fmt.Errorf("marshal add policy: %w", err)
+	}
+	path := fmt.Sprintf("/api/terrapod/v1/policy-sets/%s/policies", url.PathEscape(policySetID))
+	data, err := c.Post(ctx, path, body)
+	if err != nil {
+		return nil, err
+	}
+	return parsePolicy(data)
+}
+
+// UpdatePolicy patches a single policy. A changed Rego is re-validated
+// (422 on syntax error); 409 if the parent set is VCS-sourced.
+func (c *Client) UpdatePolicy(ctx context.Context, policyID string, req UpdatePolicyRequest) (*Policy, error) {
+	attrs := map[string]any{}
+	if req.Name != nil {
+		attrs["name"] = *req.Name
+	}
+	if req.Description != nil {
+		attrs["description"] = *req.Description
+	}
+	if req.Rego != nil {
+		attrs["rego"] = *req.Rego
+	}
+	body, err := MarshalResourceWithID(policyID, "policies", attrs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal update policy: %w", err)
+	}
+	data, err := c.Patch(ctx, "/api/terrapod/v1/policies/"+url.PathEscape(policyID), body)
+	if err != nil {
+		return nil, err
+	}
+	return parsePolicy(data)
+}
+
+// DeletePolicy removes a single policy. 409 if the parent set is VCS-sourced.
+func (c *Client) DeletePolicy(ctx context.Context, policyID string) error {
+	return c.Delete(ctx, "/api/terrapod/v1/policies/"+url.PathEscape(policyID))
+}
+
+func parsePolicy(body []byte) (*Policy, error) {
+	res, err := ParseResource(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse policy response: %w", err)
+	}
+	return policyFromResource(res), nil
+}
+
+func policyFromResource(res *Resource) *Policy {
+	return &Policy{
+		ID:          res.ID,
+		PolicySetID: GetRelationshipID(res, "policy-set"),
+		Name:        GetStringAttr(res, "name"),
+		Description: GetStringAttr(res, "description"),
+		Rego:        GetStringAttr(res, "rego"),
+		CreatedAt:   GetStringAttr(res, "created-at"),
+		UpdatedAt:   GetStringAttr(res, "updated-at"),
 	}
 }

--- a/go-terrapod/vcs_connections.go
+++ b/go-terrapod/vcs_connections.go
@@ -25,6 +25,7 @@ type VCSConnection struct {
 	GithubInstallationID int64  `json:"github-installation-id,omitempty"`
 	Status               string `json:"status,omitempty"`
 	HasToken             bool   `json:"has-token"`
+	HasWebhookSecret     bool   `json:"has-webhook-secret"`
 	GithubAccountLogin   string `json:"github-account-login,omitempty"`
 	GithubAccountType    string `json:"github-account-type,omitempty"`
 	CreatedAt            string `json:"created-at,omitempty"`
@@ -42,6 +43,7 @@ type CreateVCSConnectionRequest struct {
 	GithubInstallationID int64
 	PrivateKey           string // GitHub App PEM
 	Token                string // GitLab PAT
+	WebhookSecret        string // GitHub per-connection webhook secret (write-only, optional)
 }
 
 // UpdateVCSConnectionRequest patches a VCS connection — the
@@ -55,6 +57,10 @@ type UpdateVCSConnectionRequest struct {
 	GithubInstallationID *int64
 	PrivateKey           string // pass non-empty to rotate
 	Token                string // pass non-empty to rotate
+	// WebhookSecret rotation: pass a non-empty value to set/rotate, an
+	// explicit empty string to clear (fall back to the global secret), or
+	// leave nil to keep the stored value untouched.
+	WebhookSecret *string
 }
 
 // CreateVCSConnection registers a new VCS connection. Requires
@@ -143,6 +149,9 @@ func vcsConnCreateAttrs(req CreateVCSConnectionRequest) map[string]any {
 	if req.Token != "" {
 		attrs["token"] = req.Token
 	}
+	if req.WebhookSecret != "" {
+		attrs["webhook-secret"] = req.WebhookSecret
+	}
 	return attrs
 }
 
@@ -169,6 +178,11 @@ func vcsConnUpdateAttrs(req UpdateVCSConnectionRequest) map[string]any {
 	if req.Token != "" {
 		attrs["token"] = req.Token
 	}
+	// nil ↦ leave untouched; non-nil (incl. "") ↦ set/clear. The server
+	// treats an explicit empty string as "clear" (fall back to global).
+	if req.WebhookSecret != nil {
+		attrs["webhook-secret"] = *req.WebhookSecret
+	}
 	return attrs
 }
 
@@ -190,6 +204,7 @@ func vcsConnFromResource(res *Resource) *VCSConnection {
 		GithubInstallationID: GetIntAttr(res, "github-installation-id"),
 		Status:               GetStringAttr(res, "status"),
 		HasToken:             GetBoolAttr(res, "has-token"),
+		HasWebhookSecret:     GetBoolAttr(res, "has-webhook-secret"),
 		GithubAccountLogin:   GetStringAttr(res, "github-account-login"),
 		GithubAccountType:    GetStringAttr(res, "github-account-type"),
 		CreatedAt:            GetStringAttr(res, "created-at"),

--- a/go-terrapod/workspace_bulk.go
+++ b/go-terrapod/workspace_bulk.go
@@ -1,0 +1,115 @@
+package terrapod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// WorkspaceFilter is the structured, server-side workspace selector used by
+// SearchWorkspaces and BulkUpdateWorkspaces. All present dimensions are
+// AND-combined. An empty filter is rejected (422) — set All to match every
+// workspace on purpose. These map to the management API's
+// /workspaces/actions/{search,bulk-update} endpoints (admin only).
+type WorkspaceFilter struct {
+	WorkspaceIDs     []string          `json:"workspace_ids,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	NamePrefix       string            `json:"name_prefix,omitempty"`
+	NameGlob         string            `json:"name_glob,omitempty"`
+	ExecutionBackend string            `json:"execution_backend,omitempty"`
+	ExecutionMode    string            `json:"execution_mode,omitempty"`
+	TerraformVersion string            `json:"terraform_version,omitempty"`
+	AgentPoolID      string            `json:"agent_pool_id,omitempty"`
+	VCSConnectionID  string            `json:"vcs_connection_id,omitempty"`
+	OwnerEmail       string            `json:"owner_email,omitempty"`
+	DriftStatus      string            `json:"drift_status,omitempty"`
+	Locked           *bool             `json:"locked,omitempty"`
+	HasVCS           *bool             `json:"has_vcs,omitempty"`
+	All              bool              `json:"all,omitempty"`
+}
+
+// WorkspaceSummary is the trimmed workspace shape returned by the bulk
+// search/preview endpoints (not a full JSON:API workspace resource).
+type WorkspaceSummary struct {
+	ID               string            `json:"id"`
+	Name             string            `json:"name"`
+	ExecutionMode    string            `json:"execution-mode"`
+	ExecutionBackend string            `json:"execution-backend"`
+	TerraformVersion string            `json:"terraform-version"`
+	AgentPoolID      *string           `json:"agent-pool-id"`
+	Labels           map[string]string `json:"labels"`
+}
+
+// SearchWorkspacesResult is the response from SearchWorkspaces.
+type SearchWorkspacesResult struct {
+	Matched    int                `json:"matched"`
+	Workspaces []WorkspaceSummary `json:"workspaces"`
+}
+
+// SearchWorkspaces resolves a structured filter to the matching workspaces
+// with no side effects (the discovery half of the bulk workflow). Admin
+// only. An empty/zero filter returns a 422 ValidationError.
+func (c *Client) SearchWorkspaces(ctx context.Context, filter WorkspaceFilter) (*SearchWorkspacesResult, error) {
+	body, err := json.Marshal(map[string]any{"filter": filter})
+	if err != nil {
+		return nil, fmt.Errorf("marshal search filter: %w", err)
+	}
+	data, err := c.Post(ctx, "/api/terrapod/v1/workspaces/actions/search", body)
+	if err != nil {
+		return nil, err
+	}
+	var out SearchWorkspacesResult
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parse search response: %w", err)
+	}
+	return &out, nil
+}
+
+// WorkspaceChange is one workspace's diff in a bulk-update result.
+type WorkspaceChange struct {
+	ID   string         `json:"id"`
+	Name string         `json:"name"`
+	Diff map[string]any `json:"diff,omitempty"`
+}
+
+// BulkUpdateResult is the response from BulkUpdateWorkspaces. When DryRun
+// was true, WouldChange is populated; when false, Changes + Applied are.
+type BulkUpdateResult struct {
+	DryRun      bool              `json:"dry_run"`
+	Matched     int               `json:"matched"`
+	Applied     int               `json:"applied"`
+	Changes     []WorkspaceChange `json:"changes,omitempty"`
+	WouldChange []WorkspaceChange `json:"would_change,omitempty"`
+	Unchanged   []WorkspaceChange `json:"unchanged,omitempty"`
+	Errors      []string          `json:"errors,omitempty"`
+}
+
+// BulkUpdateWorkspaces applies `update` to every workspace matching
+// `filter` in a single all-or-nothing transaction. `update` is the
+// homogeneous settings/run-task/notification change set (hyphenated JSON:API
+// attribute keys, e.g. "execution-mode", "terraform-version", "labels",
+// "run-tasks", "notification-configurations"); it is validated once up
+// front (422 on an invalid update). When dryRun is true the identical code
+// path runs and rolls back, so the preview is exactly what an apply would
+// change. Admin only; never triggers runs.
+func (c *Client) BulkUpdateWorkspaces(
+	ctx context.Context, filter WorkspaceFilter, update map[string]any, dryRun bool,
+) (*BulkUpdateResult, error) {
+	body, err := json.Marshal(map[string]any{
+		"filter":  filter,
+		"update":  update,
+		"dry_run": dryRun,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal bulk-update: %w", err)
+	}
+	data, err := c.Post(ctx, "/api/terrapod/v1/workspaces/actions/bulk-update", body)
+	if err != nil {
+		return nil, err
+	}
+	var out BulkUpdateResult
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parse bulk-update response: %w", err)
+	}
+	return &out, nil
+}

--- a/go-terrapod/workspace_bulk_test.go
+++ b/go-terrapod/workspace_bulk_test.go
@@ -1,0 +1,85 @@
+package terrapod
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearchWorkspaces(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/terrapod/v1/workspaces/actions/search" || r.Method != http.MethodPost {
+			http.Error(w, "unhandled", http.StatusNotFound)
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		_, _ = w.Write([]byte(`{"matched":1,"workspaces":[
+		  {"id":"ws-1","name":"prod","execution-mode":"agent","execution-backend":"tofu",
+		   "terraform-version":"1.9.0","agent-pool-id":"apool-9","labels":{"env":"prod"}}
+		]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := c.SearchWorkspaces(t.Context(), WorkspaceFilter{Labels: map[string]string{"env": "prod"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Matched != 1 || len(res.Workspaces) != 1 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.Workspaces[0].Name != "prod" || res.Workspaces[0].AgentPoolID == nil {
+		t.Errorf("unexpected workspace: %+v", res.Workspaces[0])
+	}
+	// Filter was sent under the snake_case "labels" dimension.
+	filter, _ := gotBody["filter"].(map[string]any)
+	if filter == nil || filter["labels"] == nil {
+		t.Errorf("filter not forwarded: %+v", gotBody)
+	}
+}
+
+func TestBulkUpdateWorkspaces_DryRun(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/terrapod/v1/workspaces/actions/bulk-update" {
+			http.Error(w, "unhandled", http.StatusNotFound)
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		_, _ = w.Write([]byte(`{"dry_run":true,"matched":2,"would_change":[
+		  {"id":"ws-1","name":"a","diff":{"terraform_version":{"from":"1.8.0","to":"1.9.0"}}}
+		],"unchanged":[{"id":"ws-2","name":"b"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := c.BulkUpdateWorkspaces(
+		t.Context(),
+		WorkspaceFilter{All: true},
+		map[string]any{"terraform-version": "1.9.0"},
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.DryRun || res.Matched != 2 || len(res.WouldChange) != 1 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if gotBody["dry_run"] != true {
+		t.Errorf("dry_run not forwarded: %+v", gotBody)
+	}
+	if update, _ := gotBody["update"].(map[string]any); update["terraform-version"] != "1.9.0" {
+		t.Errorf("update not forwarded: %+v", gotBody)
+	}
+}

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -68,6 +68,13 @@ spec:
                   name: {{ include "terrapod.fullname" . }}-storage
                   key: hmac-secret
                   optional: true
+            {{- if .Values.api.tokenSigningKey.existingSecret }}
+            - name: TERRAPOD_TOKEN_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.tokenSigningKey.existingSecret }}
+                  key: {{ .Values.api.tokenSigningKey.existingSecretKey | default "token_signing_key" }}
+            {{- end }}
             {{- if .Values.postgresql.existingSecret }}
             - name: TERRAPOD_DATABASE_URL
               valueFrom:

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -36,6 +36,14 @@
         "autoscaling": { "$ref": "#/$defs/autoscalingSpec" },
         "pdb": { "$ref": "#/$defs/pdbSpec" },
         "config": { "$ref": "#/$defs/apiConfig" },
+        "tokenSigningKey": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "existingSecret": { "type": "string" },
+            "existingSecretKey": { "type": "string" }
+          }
+        },
         "strategy": { "$ref": "#/$defs/strategySpec" },
         "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
         "preStopSleepSeconds": { "type": "integer", "minimum": 0 },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -43,6 +43,16 @@ api:
   # command: ["uvicorn", "terrapod.api.app:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
   command: []
 
+  # Dedicated HMAC secret for stateless tokens (runner tokens + run-task
+  # callback tokens). When unset, the signing key falls back to
+  # sha256(database_url) — functionally fine, but it couples token-forgery
+  # resistance to the database credentials. Point this at a K8s Secret to
+  # decouple them. Leaving it unset does NOT invalidate in-flight tokens on
+  # upgrade. Inject via secretKeyRef (the key is a secret, never a ConfigMap).
+  tokenSigningKey:
+    existingSecret: ""               # name of a K8s Secret holding the key
+    existingSecretKey: "token_signing_key"  # key within that Secret
+
   # Service configuration
   service:
     type: ClusterIP

--- a/provider/internal/datasources/vcs_connection/data_source.go
+++ b/provider/internal/datasources/vcs_connection/data_source.go
@@ -27,6 +27,7 @@ type vcsConnectionDataSourceModel struct {
 	ServerURL            types.String `tfsdk:"server_url"`
 	Status               types.String `tfsdk:"status"`
 	HasToken             types.Bool   `tfsdk:"has_token"`
+	HasWebhookSecret     types.Bool   `tfsdk:"has_webhook_secret"`
 	GithubAppID          types.Int64  `tfsdk:"github_app_id"`
 	GithubInstallationID types.Int64  `tfsdk:"github_installation_id"`
 	GithubAccountLogin   types.String `tfsdk:"github_account_login"`
@@ -53,6 +54,7 @@ func (d *vcsConnectionDataSource) Schema(_ context.Context, _ datasource.SchemaR
 			"server_url":             schema.StringAttribute{Computed: true, Description: "Server URL."},
 			"status":                 schema.StringAttribute{Computed: true, Description: "Connection status."},
 			"has_token":              schema.BoolAttribute{Computed: true, Description: "Whether a token is configured."},
+			"has_webhook_secret":     schema.BoolAttribute{Computed: true, Description: "Whether a per-connection webhook secret is configured."},
 			"github_app_id":          schema.Int64Attribute{Computed: true, Description: "GitHub App ID."},
 			"github_installation_id": schema.Int64Attribute{Computed: true, Description: "GitHub installation ID."},
 			"github_account_login":   schema.StringAttribute{Computed: true, Description: "GitHub account login."},
@@ -104,6 +106,7 @@ func (d *vcsConnectionDataSource) Read(ctx context.Context, req datasource.ReadR
 		config.Provider = types.StringValue(c.Provider)
 		config.Status = types.StringValue(c.Status)
 		config.HasToken = types.BoolValue(c.HasToken)
+		config.HasWebhookSecret = types.BoolValue(c.HasWebhookSecret)
 		config.CreatedAt = types.StringValue(c.CreatedAt)
 		config.UpdatedAt = types.StringValue(c.UpdatedAt)
 

--- a/provider/internal/resources/vcs_connection/resource.go
+++ b/provider/internal/resources/vcs_connection/resource.go
@@ -52,9 +52,11 @@ type vcsConnectionModel struct {
 	GithubInstallationID types.Int64  `tfsdk:"github_installation_id"`
 	PrivateKey           types.String `tfsdk:"private_key"`
 	Token                types.String `tfsdk:"token"`
+	WebhookSecret        types.String `tfsdk:"webhook_secret"`
 
 	Status             types.String `tfsdk:"status"`
 	HasToken           types.Bool   `tfsdk:"has_token"`
+	HasWebhookSecret   types.Bool   `tfsdk:"has_webhook_secret"`
 	GithubAccountLogin types.String `tfsdk:"github_account_login"`
 	GithubAccountType  types.String `tfsdk:"github_account_type"`
 	CreatedAt          types.String `tfsdk:"created_at"`
@@ -138,6 +140,14 @@ func (r *vcsConnectionResource) Schema(_ context.Context, _ resource.SchemaReque
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"webhook_secret": schema.StringAttribute{
+				Description: "Optional per-connection GitHub webhook HMAC secret. Write-only; never returned by the API. When set, this connection's inbound webhooks are validated against it instead of the global secret. Changing this forces a new resource (rotate in-place via the Terrapod CLI / API).",
+				Optional:    true,
+				Sensitive:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 
 			"status": schema.StringAttribute{
 				Description: "The connection status.",
@@ -145,6 +155,10 @@ func (r *vcsConnectionResource) Schema(_ context.Context, _ resource.SchemaReque
 			},
 			"has_token": schema.BoolAttribute{
 				Description: "Whether the connection has a token/key configured.",
+				Computed:    true,
+			},
+			"has_webhook_secret": schema.BoolAttribute{
+				Description: "Whether the connection has a per-connection webhook secret configured.",
 				Computed:    true,
 			},
 			"github_account_login": schema.StringAttribute{
@@ -233,10 +247,12 @@ func (r *vcsConnectionResource) Read(ctx context.Context, req resource.ReadReque
 	// Preserve write-only fields from state — the API never echoes them back.
 	privateKey := state.PrivateKey
 	token := state.Token
+	webhookSecret := state.WebhookSecret
 
 	readVCSConnectionFromSDK(v, &state)
 	state.PrivateKey = privateKey
 	state.Token = token
+	state.WebhookSecret = webhookSecret
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -292,6 +308,9 @@ func buildCreateVCSConnectionRequest(m *vcsConnectionModel) terrapod.CreateVCSCo
 	if !m.Token.IsNull() && !m.Token.IsUnknown() {
 		req.Token = m.Token.ValueString()
 	}
+	if !m.WebhookSecret.IsNull() && !m.WebhookSecret.IsUnknown() {
+		req.WebhookSecret = m.WebhookSecret.ValueString()
+	}
 	return req
 }
 
@@ -321,6 +340,7 @@ func readVCSConnectionFromSDK(v *terrapod.VCSConnection, m *vcsConnectionModel) 
 
 	m.Status = types.StringValue(v.Status)
 	m.HasToken = types.BoolValue(v.HasToken)
+	m.HasWebhookSecret = types.BoolValue(v.HasWebhookSecret)
 
 	if v.GithubAccountLogin != "" {
 		m.GithubAccountLogin = types.StringValue(v.GithubAccountLogin)

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -280,11 +280,11 @@ async def create_module_endpoint(
         try:
             conn_id = _uuid.UUID(attrs.vcs_connection_id.removeprefix("vcs-"))
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail="Invalid vcs_connection_id") from exc
+            raise HTTPException(status_code=422, detail="Invalid vcs_connection_id") from exc
 
         result = await db.execute(sa_select(VCSConnection).where(VCSConnection.id == conn_id))
         if result.scalars().first() is None:
-            raise HTTPException(status_code=400, detail="VCS connection not found")
+            raise HTTPException(status_code=422, detail="VCS connection not found")
         module.vcs_connection_id = conn_id
         module.source = "vcs"
     if attrs.vcs_repo_url:
@@ -532,11 +532,11 @@ async def update_module_endpoint(
             try:
                 conn_id = _uuid.UUID(str(vcs_conn_val).removeprefix("vcs-"))
             except ValueError as exc:
-                raise HTTPException(status_code=400, detail="Invalid vcs_connection_id") from exc
+                raise HTTPException(status_code=422, detail="Invalid vcs_connection_id") from exc
 
             result = await db.execute(sa_select(VCSConnection).where(VCSConnection.id == conn_id))
             if result.scalars().first() is None:
-                raise HTTPException(status_code=400, detail="VCS connection not found")
+                raise HTTPException(status_code=422, detail="VCS connection not found")
             module.vcs_connection_id = conn_id
             module.source = "vcs"
         else:
@@ -777,11 +777,11 @@ async def update_module_vcs_endpoint(
         try:
             conn_id = _uuid.UUID(attrs.vcs_connection_id.removeprefix("vcs-"))
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail="Invalid vcs_connection_id") from exc
+            raise HTTPException(status_code=422, detail="Invalid vcs_connection_id") from exc
 
         result = await db.execute(sa_select(VCSConnection).where(VCSConnection.id == conn_id))
         if result.scalars().first() is None:
-            raise HTTPException(status_code=400, detail="VCS connection not found")
+            raise HTTPException(status_code=422, detail="VCS connection not found")
         module.vcs_connection_id = conn_id
     else:
         module.vcs_connection_id = None

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -31,6 +31,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response, 
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -581,8 +582,34 @@ async def create_module_version_endpoint(
         )
 
     version_str = body.data.attributes.version
-    mod_version, upload_url = await create_module_version(db, storage, module.id, version_str)
-    await db.commit()
+
+    # Pre-check for an existing version so a duplicate returns a clean 409
+    # instead of an IntegrityError on flush (which would otherwise abort the
+    # transaction after we'd already minted a presigned upload URL). The unique
+    # constraint on (module_id, version) is the backstop for the race.
+    existing = await db.execute(
+        select(RegistryModuleVersion).where(
+            RegistryModuleVersion.module_id == module.id,
+            RegistryModuleVersion.version == version_str,
+        )
+    )
+    if existing.scalars().first() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Version {version_str} already exists for this module",
+        )
+
+    try:
+        mod_version, upload_url = await create_module_version(db, storage, module.id, version_str)
+        await db.commit()
+    except IntegrityError:
+        # Race: a concurrent create inserted the same version between our
+        # pre-check and flush. Roll back and surface the same 409.
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Version {version_str} already exists for this module",
+        ) from None
 
     logger.info(
         "Module version created",

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -65,26 +65,32 @@ async def _get_run(run_id: str, db: AsyncSession) -> Run:
     return run
 
 
-def _read_state_metadata(path: str) -> tuple[int, str, str]:
-    """Read (serial, lineage, md5) from a state file on disk.
+def _read_state_metadata(path: str) -> tuple[int, str, str, str]:
+    """Read (serial, lineage, md5, sha256) from a state file on disk.
 
-    Runs in a worker thread (CLAUDE.md #13): the md5 is hashed over the
-    full state and `json.load` parses it, both of which would block the
+    Runs in a worker thread (CLAUDE.md #13): the hashes are computed over
+    the full state and `json.load` parses it, both of which would block the
     event loop on a multi-MB state if run inline. The file lives on the
     ephemeral PVC, never in the worker heap.
+
+    md5 is kept for the TFE/go-tfe state-version contract; sha256 is the
+    hash used for the divergence equality check (an md5 collision must not
+    suppress a genuine divergence flag). Both are computed in one pass.
     """
-    h = hashlib.md5()  # noqa: S324  # nosemgrep: insecure-hash-algorithm-md5
+    h_md5 = hashlib.md5()  # noqa: S324  # nosemgrep: insecure-hash-algorithm-md5
+    h_sha = hashlib.sha256()
     with open(path, "rb") as fh:
         while True:
             buf = fh.read(1024 * 1024)
             if not buf:
                 break
-            h.update(buf)
+            h_md5.update(buf)
+            h_sha.update(buf)
     with open(path, "rb") as fh:
         state_data = json.load(fh)
     serial = state_data.get("serial", 0)
     lineage = state_data.get("lineage", "")
-    return serial, lineage, h.hexdigest()
+    return serial, lineage, h_md5.hexdigest(), h_sha.hexdigest()
 
 
 def _summarize_plan_file(path: str) -> dict | None:
@@ -442,12 +448,12 @@ async def upload_state(
     tmp_path, state_size = await stream_to_tempfile(request, suffix=".state.json")
     try:
         try:
-            serial, lineage, md5 = await asyncio.to_thread(_read_state_metadata, tmp_path)
+            serial, lineage, md5, sha256 = await asyncio.to_thread(_read_state_metadata, tmp_path)
         except (json.JSONDecodeError, UnicodeDecodeError) as exc:
             raise HTTPException(status_code=400, detail="Invalid state JSON") from exc
 
         return await _persist_runner_state(
-            db, run, run_id, tmp_path, state_size, serial, lineage, md5
+            db, run, run_id, tmp_path, state_size, serial, lineage, md5, sha256
         )
     finally:
         try:
@@ -465,6 +471,7 @@ async def _persist_runner_state(
     serial: int,
     lineage: str,
     md5: str,
+    sha256: str,
 ) -> Response:
     """Divergence check + StateVersion insert + stream-to-storage for a state upload.
 
@@ -500,7 +507,15 @@ async def _persist_runner_state(
         )
     ).scalar_one_or_none()
     if existing is not None:
-        if existing.md5 == md5:
+        # Prefer the collision-resistant sha256 for the equality check; an md5
+        # collision must not be able to make two distinct states compare equal
+        # and suppress a genuine divergence flag. Fall back to md5 only when the
+        # existing row predates the sha256 column (legacy rows have sha256 == "").
+        if existing.sha256:
+            states_match = existing.sha256 == sha256
+        else:
+            states_match = existing.md5 == md5
+        if states_match:
             # Serial-neutral no-op apply: state is provably identical. Clear any
             # stale divergence flag and return success so the runner does NOT
             # signal state-diverged and the run transitions to applied.
@@ -523,6 +538,7 @@ async def _persist_runner_state(
         serial=serial,
         lineage=lineage,
         md5=md5,
+        sha256=sha256,
         state_size=state_size,
         run_id=run.id,
         created_by=run.created_by or None,

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -990,6 +990,15 @@ async def create_workspace(
     await db.refresh(ws)
 
     logger.info("Workspace created", workspace=name, owner=user.email)
+
+    # Broadcast to the workspace-list SSE channel so any open list page
+    # re-fetches and shows the new workspace without a manual reload.
+    # Best-effort (the publisher swallows its own errors) — never blocks
+    # or fails the create.
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(ws.id), "workspace_created")
+
     return JSONResponse(
         content=_workspace_json(ws, "admin"),
         status_code=201,

--- a/services/terrapod/api/routers/variables.py
+++ b/services/terrapod/api/routers/variables.py
@@ -487,11 +487,20 @@ async def update_varset_var(
         vsv.category = attrs["category"]
     if "hcl" in attrs:
         vsv.hcl = attrs["hcl"]
+    was_sensitive = vsv.sensitive
     if "value" in attrs:
         vsv.value = attrs["value"]
         vsv.version_id = variable_service._version_hash(vsv.key, attrs["value"], vsv.category)
     if "sensitive" in attrs:
         vsv.sensitive = attrs["sensitive"]
+
+    # Security: a sensitive → non-sensitive downgrade must not expose the
+    # previously-hidden value. If no fresh value was supplied in the same
+    # request, clear it so the old secret is never returned in plaintext
+    # (mirrors variable_service.update_variable for workspace vars).
+    if was_sensitive and vsv.sensitive is False and "value" not in attrs:
+        vsv.value = ""
+        vsv.version_id = variable_service._version_hash(vsv.key, "", vsv.category)
 
     await db.commit()
     await db.refresh(vsv)

--- a/services/terrapod/api/routers/vcs_connections.py
+++ b/services/terrapod/api/routers/vcs_connections.py
@@ -60,6 +60,9 @@ def _connection_json(conn: VCSConnection) -> dict:
         attrs["github-installation-id"] = conn.github_installation_id
         attrs["github-account-login"] = conn.github_account_login
         attrs["github-account-type"] = conn.github_account_type
+        # Write-only: surface only whether a per-connection webhook secret is
+        # set, never the value (same pattern as has-token).
+        attrs["has-webhook-secret"] = bool(conn.webhook_secret)
 
     return {
         "id": f"vcs-{conn.id}",
@@ -157,6 +160,9 @@ async def create_connection(
             raise HTTPException(status_code=422, detail="token is required for GitLab connections")
         token_value = token
 
+    # Optional per-connection webhook secret (GitHub only). Write-only.
+    webhook_secret = (attrs.get("webhook-secret") or "") if provider == "github" else ""
+
     conn = VCSConnection(
         id=generate_uuid7(),
         provider=provider,
@@ -168,6 +174,7 @@ async def create_connection(
         github_installation_id=int(attrs.get("github-installation-id", 0)),
         github_account_login=attrs.get("github-account-login", ""),
         github_account_type=attrs.get("github-account-type", ""),
+        webhook_secret=webhook_secret or None,
         status="active",
     )
     db.add(conn)
@@ -267,6 +274,11 @@ async def update_connection(
         new_key = attrs.get("private-key") or ""
         if new_key:
             conn.token = new_key
+        # Webhook-secret rotation (write-only). Supply a non-empty value to
+        # set/rotate; pass an explicit empty string to clear it (fall back to
+        # the global secret); omit the key entirely to leave it untouched.
+        if "webhook-secret" in attrs:
+            conn.webhook_secret = (attrs.get("webhook-secret") or "").strip() or None
     elif conn.provider == "gitlab":
         new_token = attrs.get("token") or ""
         if new_token:

--- a/services/terrapod/api/routers/vcs_connections.py
+++ b/services/terrapod/api/routers/vcs_connections.py
@@ -161,7 +161,9 @@ async def create_connection(
         token_value = token
 
     # Optional per-connection webhook secret (GitHub only). Write-only.
-    webhook_secret = (attrs.get("webhook-secret") or "") if provider == "github" else ""
+    # Trimmed to match the PATCH path so a whitespace-only value is treated
+    # as unset rather than stored verbatim.
+    webhook_secret = (attrs.get("webhook-secret") or "").strip() if provider == "github" else ""
 
     conn = VCSConnection(
         id=generate_uuid7(),

--- a/services/terrapod/api/routers/vcs_events.py
+++ b/services/terrapod/api/routers/vcs_events.py
@@ -64,27 +64,14 @@ async def github_webhook(request: Request) -> Response:
         runs on this PR (#282, hook fast path for the poller's
         _reconcile_closed_pr_sessions)
     """
-    # Check if webhooks are configured
-    if not settings.vcs.github.webhook_secret:
-        raise HTTPException(
-            status_code=404,
-            detail="Webhooks not configured",
-        )
-
     payload = await request.body()
-
-    # Validate signature
-    signature = request.headers.get("X-Hub-Signature-256", "")
-    if not validate_webhook_signature(payload, signature):
-        logger.warning("Invalid webhook signature")
-        raise HTTPException(status_code=401, detail="Invalid signature")
-
-    # Handle ping event (GitHub sends this when webhook is first configured)
     event_type = request.headers.get("X-GitHub-Event", "")
-    if event_type == "ping":
-        logger.info("GitHub webhook ping received")
-        return JSONResponse(content={"message": "pong"})
+    signature = request.headers.get("X-Hub-Signature-256", "")
 
+    # Parse the body first so we can resolve which connection the event is for
+    # (installation.id) and pick that connection's webhook secret. Parsing
+    # untrusted JSON is safe; NO action is taken until the signature is
+    # verified against the resolved secret below.
     try:
         body = json.loads(payload)
     except json.JSONDecodeError:
@@ -92,14 +79,30 @@ async def github_webhook(request: Request) -> Response:
 
     repo = body.get("repository", {})
     full_name = repo.get("full_name", "")
-
-    # Resolve installation.id → VCSConnection. Reject unknown
-    # installations so a webhook from an unrelated installation can't
-    # enqueue work even if it knows the global webhook secret (Q10 in
-    # #282). The poll still serves as the source of truth — this just
-    # closes the noise / abuse vector at the webhook surface.
     installation_id = (body.get("installation") or {}).get("id", 0)
     conn = await _resolve_connection(installation_id)
+
+    # Effective secret: the connection's own webhook secret takes precedence;
+    # otherwise fall back to the global vcs.github.webhook_secret. A
+    # per-connection secret means a webhook from one installation can't be
+    # forged by another that only knows the global secret.
+    effective_secret = (conn.webhook_secret if conn else None) or settings.vcs.github.webhook_secret
+    if not effective_secret:
+        raise HTTPException(status_code=404, detail="Webhooks not configured")
+
+    # Validate signature against the effective secret BEFORE any action.
+    if not validate_webhook_signature(payload, signature, effective_secret):
+        logger.warning("Invalid webhook signature")
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    # Handle ping event (GitHub sends this when webhook is first configured)
+    if event_type == "ping":
+        logger.info("GitHub webhook ping received")
+        return JSONResponse(content={"message": "pong"})
+
+    # Reject unknown installations so a webhook from an unrelated installation
+    # can't enqueue work (Q10 in #282). The poll remains the source of truth —
+    # this just closes the noise / abuse vector at the webhook surface.
     if conn is None:
         logger.info(
             "Webhook event for unknown installation",

--- a/services/terrapod/auth/ca.py
+++ b/services/terrapod/auth/ca.py
@@ -8,7 +8,6 @@ Handles Terrapod's runner-only certificate needs.
 """
 
 import datetime
-from pathlib import Path
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -23,9 +22,6 @@ logger = get_logger(__name__)
 
 # Module-level CA singleton, initialized in lifespan
 _ca: "CertificateAuthority | None" = None
-
-# Default CA data directory
-CA_DATA_DIR = Path("/var/lib/terrapod/ca")
 
 
 class CertificateAuthority:
@@ -287,7 +283,7 @@ async def init_ca(db: AsyncSession) -> CertificateAuthority:
     if ca_record:
         ca = CertificateAuthority.load(
             ca_record.ca_cert.encode(),
-            ca_record.ca_key_encrypted.encode(),
+            ca_record.ca_key_pem.encode(),
         )
         logger.info(
             "Loaded CA from database",
@@ -301,7 +297,7 @@ async def init_ca(db: AsyncSession) -> CertificateAuthority:
 
         ca_record = CertificateAuthorityModel(
             ca_cert=cert_pem,
-            ca_key_encrypted=key_pem,
+            ca_key_pem=key_pem,
         )
         db.add(ca_record)
         await db.commit()
@@ -311,17 +307,11 @@ async def init_ca(db: AsyncSession) -> CertificateAuthority:
             fingerprint=get_certificate_fingerprint(ca.ca_cert)[:16],
         )
 
-    # Write to filesystem as cache
-    try:
-        CA_DATA_DIR.mkdir(parents=True, exist_ok=True)
-        cert_path = CA_DATA_DIR / "ca.crt"
-        key_path = CA_DATA_DIR / "ca.key"
-        cert_path.write_bytes(serialize_certificate(ca.ca_cert))
-        key_path.write_bytes(serialize_private_key(ca.ca_key))
-        key_path.chmod(0o600)
-    except OSError as e:
-        logger.warning("Failed to write CA cache to filesystem", error=str(e))
-
+    # The database is the single source of truth for the CA, loaded on every
+    # startup. We deliberately do NOT also write the CA *private key* to the
+    # pod filesystem — that cache was never read back (init_ca always loads
+    # from the DB) and writing the private key to disk is needless attack
+    # surface.
     _ca = ca
     return _ca
 

--- a/services/terrapod/auth/download_tickets.py
+++ b/services/terrapod/auth/download_tickets.py
@@ -58,18 +58,17 @@ DEFAULT_TTL_SECONDS = 300
 # Hard cap. A caller asking for more is silently clamped.
 MAX_TTL_SECONDS = 1800
 
-_signing_key: bytes | None = None
-
 
 def _get_signing_key() -> bytes:
-    """Get the stable signing key (same key as runner tokens use)."""
-    global _signing_key  # noqa: PLW0603
-    if _signing_key is not None:
-        return _signing_key
-    from terrapod.config import settings
+    """Get the stable HMAC signing key (shared with runner + run-task tokens).
 
-    _signing_key = hashlib.sha256(str(settings.database_url).encode()).digest()
-    return _signing_key
+    Uses the dedicated `token_signing_key` secret when configured, else falls
+    back to `sha256(database_url)` (see auth.token_signing) — so a configured
+    secret decouples download-ticket forgery from the database credentials too.
+    """
+    from terrapod.auth.token_signing import get_token_signing_key
+
+    return get_token_signing_key()
 
 
 def _b64encode(s: str) -> str:

--- a/services/terrapod/auth/runner_tokens.py
+++ b/services/terrapod/auth/runner_tokens.py
@@ -12,18 +12,12 @@ import hmac
 import time
 import uuid
 
-_signing_key: bytes | None = None
+from terrapod.auth.token_signing import get_token_signing_key
 
 
 def _get_signing_key() -> bytes:
-    """Get a stable signing key derived from the database URL."""
-    global _signing_key  # noqa: PLW0603
-    if _signing_key is not None:
-        return _signing_key
-    from terrapod.config import settings
-
-    _signing_key = hashlib.sha256(str(settings.database_url).encode()).digest()
-    return _signing_key
+    """Get the stable HMAC signing key (dedicated secret, or DB-URL fallback)."""
+    return get_token_signing_key()
 
 
 def generate_runner_token(run_id: str | uuid.UUID, ttl: int = 3600) -> str:

--- a/services/terrapod/auth/token_signing.py
+++ b/services/terrapod/auth/token_signing.py
@@ -1,0 +1,42 @@
+"""Shared signing-key derivation for stateless HMAC tokens.
+
+Runner tokens (`runner_tokens.py`) and run-task callback tokens
+(`run_task_service.py`) are both stateless HMAC-SHA256 tokens verified
+purely from their signature. They share one signing key.
+
+Historically that key was derived solely from the database URL, which
+couples database credentials to token-forgery resistance: anyone who
+learns the DB URL can mint valid runner/callback tokens. To decouple
+them, set a dedicated secret via `TERRAPOD_TOKEN_SIGNING_KEY` (Helm:
+`api.tokenSigningKey`). When it is empty (the default), the key falls
+back to `sha256(database_url)` exactly as before — so upgrading without
+configuring the secret does NOT invalidate any in-flight token.
+"""
+
+import hashlib
+
+_signing_key: bytes | None = None
+
+
+def get_token_signing_key() -> bytes:
+    """Return the process-wide 32-byte HMAC signing key.
+
+    Uses the dedicated `token_signing_key` secret when configured,
+    otherwise falls back to `sha256(database_url)` for backward
+    compatibility. Cached after first derivation.
+    """
+    global _signing_key  # noqa: PLW0603
+    if _signing_key is not None:
+        return _signing_key
+    from terrapod.config import settings
+
+    configured = (settings.token_signing_key or "").strip()
+    material = configured if configured else str(settings.database_url)
+    _signing_key = hashlib.sha256(material.encode()).digest()
+    return _signing_key
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear the cached key (tests that mutate config only)."""
+    global _signing_key  # noqa: PLW0603
+    _signing_key = None

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -1041,6 +1041,18 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Token signing — dedicated secret for stateless HMAC tokens (runner
+    # tokens + run-task callback tokens). When empty, the signing key falls
+    # back to sha256(database_url) for backward compatibility (no in-flight
+    # token is invalidated by upgrading). Set this (Helm: api.tokenSigningKey
+    # / env TERRAPOD_TOKEN_SIGNING_KEY) to decouple token-forgery resistance
+    # from database credentials. See auth/token_signing.py.
+    token_signing_key: str = Field(
+        default="",
+        description="Dedicated HMAC secret for runner + run-task tokens "
+        "(falls back to sha256(database_url) when empty).",
+    )
+
     # Database
     database_url: PostgresDsn = Field(
         default="postgresql+asyncpg://terrapod:terrapod@localhost:5432/terrapod",

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -985,6 +985,12 @@ class VCSConnection(Base):
         String(20), nullable=False, default=""
     )  # Organization, User (GitHub only)
 
+    # Per-connection webhook HMAC secret (GitHub). Optional: when set it is
+    # used to validate this connection's inbound webhooks, falling back to the
+    # global vcs.github.webhook_secret when null. Write-only via the API and
+    # protected at rest by database encryption (same as `token`).
+    webhook_secret: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
     status: Mapped[str] = mapped_column(
         String(20), nullable=False, default="active"
     )  # active, suspended, removed

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -487,7 +487,13 @@ class StateVersion(Base):
     )
     serial: Mapped[int] = mapped_column(Integer, nullable=False)
     lineage: Mapped[str] = mapped_column(String(63), nullable=False, default="")
+    # `md5` is part of the TFE/go-tfe state-version contract and is kept for
+    # compatibility. `sha256` is Terrapod-internal and is the hash used for
+    # the state-divergence equality check (an md5 collision must not be able
+    # to suppress a genuine divergence flag). Nullable/empty for rows written
+    # before the column existed — the divergence check falls back to md5 then.
     md5: Mapped[str] = mapped_column(String(32), nullable=False, default="")
+    sha256: Mapped[str] = mapped_column(String(64), nullable=False, default="", server_default="")
     state_size: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     run_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -938,7 +938,11 @@ class CertificateAuthorityModel(Base):
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
     ca_cert: Mapped[str] = mapped_column(Text, nullable=False)
-    ca_key_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    # The CA private key as a PKCS8 PEM. This is NOT application-encrypted
+    # (the old column name `ca_key_encrypted` was misleading) — at-rest
+    # protection comes from database encryption (RDS/Azure/GCS-managed),
+    # the same model used for sensitive variables and VCS tokens.
+    ca_key_pem: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False
     )

--- a/services/terrapod/services/github_service.py
+++ b/services/terrapod/services/github_service.py
@@ -268,19 +268,24 @@ async def get_installation_token(conn: VCSConnection) -> str:
     return token
 
 
-def validate_webhook_signature(payload: bytes, signature_header: str) -> bool:
-    """Validate GitHub webhook HMAC-SHA256 signature.
+def validate_webhook_signature(
+    payload: bytes, signature_header: str, secret: str | None = None
+) -> bool:
+    """Validate a GitHub webhook HMAC-SHA256 signature.
 
-    Only used when webhooks are enabled (webhook_secret is configured).
+    `secret` is the effective webhook secret to validate against — the
+    per-connection secret when the connection sets one, otherwise the global
+    `vcs.github.webhook_secret`. Falls back to the global secret when not
+    passed (backward-compatible). Returns False if no secret is available.
     """
-    secret = settings.vcs.github.webhook_secret
-    if not secret:
+    effective = secret if secret else settings.vcs.github.webhook_secret
+    if not effective:
         return False
 
     if not signature_header.startswith("sha256="):
         return False
 
-    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    expected = hmac.new(effective.encode(), payload, hashlib.sha256).hexdigest()
     received = signature_header.removeprefix("sha256=")
 
     return hmac.compare_digest(expected, received)

--- a/services/terrapod/services/run_task_service.py
+++ b/services/terrapod/services/run_task_service.py
@@ -32,21 +32,15 @@ RESULT_TERMINAL_STATES = frozenset({"passed", "failed", "errored", "unreachable"
 _CALLBACK_TOKEN_TTL = 3600
 
 
-_signing_key: bytes | None = None
-
-
 def _get_signing_key() -> bytes:
-    """Get a stable signing key for callback tokens.
+    """Get the stable HMAC signing key for callback tokens.
 
-    Derives from the database URL as a stable per-deployment secret.
+    Uses the dedicated `token_signing_key` secret when configured, else
+    falls back to `sha256(database_url)` (see auth.token_signing).
     """
-    global _signing_key  # noqa: PLW0603
-    if _signing_key is not None:
-        return _signing_key
-    from terrapod.config import settings
+    from terrapod.auth.token_signing import get_token_signing_key
 
-    _signing_key = hashlib.sha256(str(settings.database_url).encode()).digest()
-    return _signing_key
+    return get_token_signing_key()
 
 
 def generate_callback_token(result_id: uuid.UUID) -> str:

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -46,6 +46,7 @@ import asyncio
 import datetime as dt
 import io
 import json
+import os
 import pathlib
 import subprocess
 import tarfile
@@ -315,7 +316,14 @@ def _build_code_diff(prev_tarball: bytes | None, cur_tarball: bytes, max_bytes: 
     if max_bytes <= 0 or prev_tarball is None:
         return ""
 
-    with tempfile.TemporaryDirectory(prefix="tp-aisum-diff-") as tmp:
+    # Land the extraction on the CSP-attached PVC when configured (matches
+    # cv_diff_service / vcs_archive_cache / provider_cache_service). Only .tf
+    # /.tfvars text is extracted here, so the small-file exemption applies and
+    # /tmp is acceptable too — but the PVC keeps an unexpectedly large .tf off
+    # the RAM-backed tmpfs.
+    configured = settings.vcs.tmpdir
+    diff_dir = configured if configured and os.path.isdir(configured) else None
+    with tempfile.TemporaryDirectory(prefix="tp-aisum-diff-", dir=diff_dir) as tmp:
         tmp_root = pathlib.Path(tmp)
         prev_dir = tmp_root / "previous"
         cur_dir = tmp_root / "current"

--- a/services/terrapod/services/variable_service.py
+++ b/services/terrapod/services/variable_service.py
@@ -84,12 +84,24 @@ async def update_variable(
     if hcl is not None:
         var.hcl = hcl
 
+    was_sensitive = var.sensitive
+
     if value is not None:
         var.value = value
         var.version_id = _version_hash(var.key, value, var.category)
 
     if sensitive is not None:
         var.sensitive = sensitive
+
+    # Security: downgrading a variable from sensitive → non-sensitive would
+    # otherwise return its previously-hidden value in plaintext (the response
+    # masks the value only while `sensitive` is true). A value entered AS a
+    # secret must not become world-readable by flipping a flag. If the caller
+    # didn't supply a fresh value in the same request, clear it so the old
+    # secret is never exposed — the operator must re-enter it.
+    if was_sensitive and sensitive is False and value is None:
+        var.value = ""
+        var.version_id = _version_hash(var.key, "", var.category)
 
     await db.flush()
     return var

--- a/services/tests/api/test_binary_cache.py
+++ b/services/tests/api/test_binary_cache.py
@@ -1,0 +1,296 @@
+"""Tests for the terraform/tofu binary-cache + provider-cache router.
+
+Covers the runner-facing download redirect, the admin list/warm/purge
+surfaces (admin-gated), and the upstream-version suggestion endpoint —
+happy paths plus auth/RBAC and the disabled-cache + upstream-failure
+error branches.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.config import settings
+from terrapod.db.session import get_db
+from terrapod.storage import get_storage
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+_DL = "/api/terrapod/v1/binary-cache/terraform/1.9.0/linux/amd64"
+
+
+def _user(email="admin@example.com", roles=None):
+    return AuthenticatedUser(
+        email=email,
+        display_name="Admin",
+        roles=roles or ["admin"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _make_app(user=None):
+    app = create_app()
+    if user is not None:
+        app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_storage] = lambda: AsyncMock()
+    return app
+
+
+def _cached_binary():
+    e = MagicMock()
+    e.id = uuid.uuid4()
+    e.tool = "terraform"
+    e.version = "1.9.0"
+    e.os = "linux"
+    e.arch = "amd64"
+    e.shasum = "abc123"
+    e.download_url = "https://example.test/terraform_1.9.0.zip"
+    e.cached_at = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
+    return e
+
+
+def _cached_provider():
+    e = MagicMock()
+    e.id = uuid.uuid4()
+    e.hostname = "registry.terraform.io"
+    e.namespace = "hashicorp"
+    e.type = "aws"
+    e.version = "5.0.0"
+    e.os = "linux"
+    e.arch = "amd64"
+    e.shasum = "deadbeef"
+    e.cached_at = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
+    return e
+
+
+class TestDownloadBinary:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_no_auth_returns_401(self, *mocks):
+        app = create_app()
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+        app.dependency_overrides[get_storage] = lambda: AsyncMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_DL)
+        assert resp.status_code == 401
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.get_or_cache_binary", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.binary_cache.resolve_version", new_callable=AsyncMock)
+    async def test_happy_path_redirects(self, mock_resolve, mock_get, *mocks):
+        mock_resolve.return_value = "1.9.0"
+        mock_get.return_value = "https://example.test/terraform_1.9.0.zip"
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url=_BASE, follow_redirects=False
+        ) as c:
+            resp = await c.get(_DL, headers=_AUTH)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://example.test/terraform_1.9.0.zip"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_disabled_cache_returns_404(self, *mocks):
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            with patch.object(settings.registry.binary_cache, "enabled", False):
+                resp = await c.get(_DL, headers=_AUTH)
+        assert resp.status_code == 404
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.resolve_version", new_callable=AsyncMock)
+    async def test_value_error_returns_400(self, mock_resolve, *mocks):
+        mock_resolve.side_effect = ValueError("unknown version")
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_DL, headers=_AUTH)
+        assert resp.status_code == 400
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.get_or_cache_binary", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.binary_cache.resolve_version", new_callable=AsyncMock)
+    async def test_upstream_failure_returns_502(self, mock_resolve, mock_get, *mocks):
+        mock_resolve.return_value = "1.9.0"
+        mock_get.side_effect = RuntimeError("upstream 500")
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_DL, headers=_AUTH)
+        assert resp.status_code == 502
+
+
+class TestAvailableVersions:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.list_available_versions", new_callable=AsyncMock)
+    async def test_happy_path(self, mock_list, *mocks):
+        mock_list.return_value = ["1.9.0", "1.8.5"]
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/binary-cache/versions?tool=tofu", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"] == ["1.9.0", "1.8.5"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.list_available_versions", new_callable=AsyncMock)
+    async def test_bad_tool_returns_400(self, mock_list, *mocks):
+        mock_list.side_effect = ValueError("unknown tool")
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/binary-cache/versions?tool=nope", headers=_AUTH)
+        assert resp.status_code == 400
+
+
+class TestAdminListBinaries:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_non_admin_returns_403(self, *mocks):
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/admin/binary-cache", headers=_AUTH)
+        assert resp.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.list_cached_binaries", new_callable=AsyncMock)
+    async def test_admin_lists_jsonapi(self, mock_list, *mocks):
+        mock_list.return_value = [_cached_binary()]
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/admin/binary-cache", headers=_AUTH)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"][0]["type"] == "cached-binaries"
+        assert body["data"][0]["attributes"]["tool"] == "terraform"
+        assert body["data"][0]["attributes"]["download-url"].endswith(".zip")
+
+
+class TestAdminWarm:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_non_admin_returns_403(self, *mocks):
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/admin/binary-cache/warm",
+                json={"tool": "terraform", "version": "1.9.0"},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.warm_binary", new_callable=AsyncMock)
+    async def test_admin_warm_happy(self, mock_warm, *mocks):
+        mock_warm.return_value = "https://example.test/terraform_1.9.0.zip"
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/admin/binary-cache/warm",
+                json={"tool": "terraform", "version": "1.9.0"},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cached"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.warm_binary", new_callable=AsyncMock)
+    async def test_admin_warm_value_error_returns_400(self, mock_warm, *mocks):
+        mock_warm.side_effect = ValueError("bad version")
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/admin/binary-cache/warm",
+                json={"tool": "terraform", "version": "nope"},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 400
+
+
+class TestAdminPurge:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.purge_binary", new_callable=AsyncMock)
+    async def test_admin_purge_binary(self, mock_purge, *mocks):
+        mock_purge.return_value = 2
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(
+                "/api/terrapod/v1/admin/binary-cache/terraform/1.9.0", headers=_AUTH
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "purged", "count": 2}
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_purge_binary_non_admin_403(self, *mocks):
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(
+                "/api/terrapod/v1/admin/binary-cache/terraform/1.9.0", headers=_AUTH
+            )
+        assert resp.status_code == 403
+
+
+class TestProviderCacheAdmin:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.list_cached_providers", new_callable=AsyncMock)
+    async def test_admin_list_providers(self, mock_list, *mocks):
+        mock_list.return_value = [_cached_provider()]
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/admin/provider-cache", headers=_AUTH)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"][0]["type"] == "cached-providers"
+        assert body["data"][0]["attributes"]["provider-type"] == "aws"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_list_providers_non_admin_403(self, *mocks):
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/admin/provider-cache", headers=_AUTH)
+        assert resp.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.binary_cache.purge_cached_provider", new_callable=AsyncMock)
+    async def test_admin_purge_provider(self, mock_purge, *mocks):
+        mock_purge.return_value = 3
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(
+                "/api/terrapod/v1/admin/provider-cache/registry.terraform.io/hashicorp/aws/5.0.0",
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "purged", "count": 3}

--- a/services/tests/api/test_gpg_keys.py
+++ b/services/tests/api/test_gpg_keys.py
@@ -1,0 +1,197 @@
+"""Tests for the GPG-key management router (provider signing keys).
+
+Covers create (happy + invalid-armor 422), list, show (happy + bad-uuid
+404 + not-found 404), delete (happy 204 + not-found 404), and the
+unauthenticated 401 gate.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+_KEYS = "/api/terrapod/v1/gpg-keys"
+
+
+def _user(roles=None):
+    return AuthenticatedUser(
+        email="user@example.com",
+        display_name="User",
+        roles=roles or ["everyone"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _make_app(user=None):
+    app = create_app()
+    if user is not None:
+        app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    return app
+
+
+def _mock_key(key_id="1C11AB2FF1189D6C"):
+    k = MagicMock()
+    k.id = uuid.uuid4()
+    k.key_id = key_id
+    k.ascii_armor = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END..."
+    k.source = "terrapod"
+    k.source_url = None
+    k.created_at = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
+    k.updated_at = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
+    return k
+
+
+def _create_body():
+    return {
+        "data": {
+            "type": "gpg-keys",
+            "attributes": {
+                "namespace": "default",
+                "ascii-armor": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END...",
+            },
+        }
+    }
+
+
+class TestAuth:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_list_no_auth_401(self, *mocks):
+        app = create_app()
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_KEYS)
+        assert resp.status_code == 401
+
+
+class TestCreate:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.create_gpg_key", new_callable=AsyncMock)
+    async def test_happy_path_201(self, mock_create, *mocks):
+        mock_create.return_value = _mock_key()
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(_KEYS, json=_create_body(), headers=_AUTH)
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["data"]["type"] == "gpg-keys"
+        assert body["data"]["attributes"]["key-id"] == "1C11AB2FF1189D6C"
+        assert body["data"]["attributes"]["namespace"] == "default"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.create_gpg_key", new_callable=AsyncMock)
+    async def test_invalid_armor_422(self, mock_create, *mocks):
+        mock_create.side_effect = ValueError("no PGP block found")
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(_KEYS, json=_create_body(), headers=_AUTH)
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_missing_armor_422(self, *mocks):
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                _KEYS,
+                json={"data": {"type": "gpg-keys", "attributes": {"namespace": "default"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+
+class TestList:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.list_gpg_keys", new_callable=AsyncMock)
+    async def test_list_returns_keys(self, mock_list, *mocks):
+        mock_list.return_value = [_mock_key(), _mock_key(key_id="AAAA1111BBBB2222")]
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_KEYS, headers=_AUTH)
+        assert resp.status_code == 200
+        assert len(resp.json()["data"]) == 2
+
+
+class TestShow:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.get_gpg_key", new_callable=AsyncMock)
+    async def test_show_happy(self, mock_get, *mocks):
+        key = _mock_key()
+        mock_get.return_value = key
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"{_KEYS}/{key.id}", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attributes"]["key-id"] == "1C11AB2FF1189D6C"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_show_bad_uuid_404(self, *mocks):
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"{_KEYS}/not-a-uuid", headers=_AUTH)
+        assert resp.status_code == 404
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.get_gpg_key", new_callable=AsyncMock)
+    async def test_show_not_found_404(self, mock_get, *mocks):
+        mock_get.return_value = None
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"{_KEYS}/{uuid.uuid4()}", headers=_AUTH)
+        assert resp.status_code == 404
+
+
+class TestDelete:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.delete_gpg_key", new_callable=AsyncMock)
+    async def test_delete_happy_204(self, mock_delete, *mocks):
+        mock_delete.return_value = True
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(f"{_KEYS}/{uuid.uuid4()}", headers=_AUTH)
+        assert resp.status_code == 204
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.delete_gpg_key", new_callable=AsyncMock)
+    async def test_delete_not_found_404(self, mock_delete, *mocks):
+        mock_delete.return_value = False
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(f"{_KEYS}/{uuid.uuid4()}", headers=_AUTH)
+        assert resp.status_code == 404
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_delete_bad_uuid_404(self, *mocks):
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(f"{_KEYS}/xyz", headers=_AUTH)
+        assert resp.status_code == 404

--- a/services/tests/api/test_labels_router.py
+++ b/services/tests/api/test_labels_router.py
@@ -1,0 +1,114 @@
+"""Tests for the read-only labels-browser router.
+
+The wrapper utility `validate_labels` is covered separately in
+test_labels_wrapper.py; this file covers the three browse endpoints
+(`/labels`, `/labels/{key}`, `/labels/{key}/{value}`) — auth gate plus
+the happy paths that forward to labels_service and pass the
+RBAC-bearing user through.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+
+
+def _user(roles=None):
+    return AuthenticatedUser(
+        email="user@example.com",
+        display_name="User",
+        roles=roles or ["everyone"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _make_app(user=None):
+    app = create_app()
+    if user is not None:
+        app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    return app
+
+
+class TestAuth:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_no_auth_401(self, *mocks):
+        app = create_app()
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/labels")
+        assert resp.status_code == 401
+
+
+class TestListKeys:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.labels_service.aggregate_keys", new_callable=AsyncMock)
+    async def test_happy(self, mock_agg, *mocks):
+        mock_agg.return_value = [
+            {"key": "team", "value-count": 3, "counts": {"workspaces": 5}},
+        ]
+        user = _user()
+        app = _make_app(user)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/labels", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["key"] == "team"
+        # The RBAC-bearing user is forwarded to the service.
+        assert mock_agg.call_args[0][1] is user
+
+
+class TestListValues:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.labels_service.aggregate_values_for_key", new_callable=AsyncMock)
+    async def test_happy(self, mock_agg, *mocks):
+        mock_agg.return_value = [{"value": "platform", "counts": {"workspaces": 2}}]
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/labels/team", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["value"] == "platform"
+        assert mock_agg.call_args[0][2] == "team"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.labels_service.aggregate_values_for_key", new_callable=AsyncMock)
+    async def test_empty_is_valid(self, mock_agg, *mocks):
+        mock_agg.return_value = []
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/labels/unknown", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"] == []
+
+
+class TestListEntities:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.services.labels_service.list_entities_for_label", new_callable=AsyncMock)
+    async def test_happy(self, mock_list, *mocks):
+        mock_list.return_value = {
+            "workspaces": [{"id": "ws-1", "name": "prod"}],
+        }
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/terrapod/v1/labels/team/platform", headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["workspaces"][0]["id"] == "ws-1"
+        # key + value forwarded positionally after (db, user).
+        assert mock_list.call_args[0][2] == "team"
+        assert mock_list.call_args[0][3] == "platform"

--- a/services/tests/api/test_registry_module_interface.py
+++ b/services/tests/api/test_registry_module_interface.py
@@ -150,3 +150,38 @@ class TestCreateModuleVersionDuplicate:
         assert resp.status_code == 409
         # No insert was attempted — the pending row never exists.
         db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.registry_modules.create_module_version", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission_for")
+    @patch("terrapod.api.routers.registry_modules.get_module")
+    async def test_concurrent_insert_race_rolls_back_to_409(
+        self, mock_get_module, mock_perm, mock_create, *_mocks
+    ):
+        """If a concurrent create wins between the pre-check and our flush, the
+        IntegrityError is caught, rolled back, and surfaced as 409 (not a 500)."""
+        from sqlalchemy.exc import IntegrityError
+
+        from terrapod.storage import get_storage
+
+        app, db = _make_app()
+        app.dependency_overrides[get_storage] = lambda: AsyncMock()
+        mock_get_module.return_value = _mock_module()
+        mock_perm.return_value = "admin"
+        # Pre-check finds nothing → we proceed; then the flush races and raises.
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        db.rollback = AsyncMock()
+        mock_create.side_effect = IntegrityError("dup", {}, Exception())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/registry-modules/private/default/vpc/aws/versions",
+                json={
+                    "data": {"type": "registry-module-versions", "attributes": {"version": "1.0.0"}}
+                },
+            )
+        assert resp.status_code == 409
+        db.rollback.assert_awaited()

--- a/services/tests/api/test_registry_module_interface.py
+++ b/services/tests/api/test_registry_module_interface.py
@@ -118,3 +118,35 @@ class TestModuleInterfaceEndpoint:
                 "/api/terrapod/v1/registry-modules/private/default/vpc/aws/9.9.9/interface"
             )
         assert resp.status_code == 404
+
+
+class TestCreateModuleVersionDuplicate:
+    @pytest.mark.asyncio
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission_for")
+    @patch("terrapod.api.routers.registry_modules.get_module")
+    async def test_duplicate_version_returns_409(self, mock_get_module, mock_perm, *_mocks):
+        """Creating a version that already exists returns a clean 409 (not a
+        500 from an IntegrityError) and does NOT leave a dangling pending row."""
+        from terrapod.storage import get_storage
+
+        app, db = _make_app()
+        app.dependency_overrides[get_storage] = lambda: AsyncMock()
+        module = _mock_module()
+        mock_get_module.return_value = module
+        mock_perm.return_value = "admin"
+        # The pre-check query finds an existing version → 409 before any insert.
+        db.execute = AsyncMock(return_value=_scalar_result(_mock_version()))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/registry-modules/private/default/vpc/aws/versions",
+                json={
+                    "data": {"type": "registry-module-versions", "attributes": {"version": "1.0.0"}}
+                },
+            )
+        assert resp.status_code == 409
+        # No insert was attempted — the pending row never exists.
+        db.add.assert_not_called()

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -264,6 +264,42 @@ class TestUploadStateDuplicateSerial:
         assert resp.status_code == 200
         mock_db.add.assert_not_called()
 
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_existing_serial_different_sha256_is_divergence_409(
+        self, mock_get_storage, *_mocks
+    ):
+        """Same serial but a DIFFERENT sha256 is a genuine divergence — the
+        whole reason for the sha256 column (an md5 collision must not let it
+        slip through as an idempotent no-op). It must 409, not 200."""
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id)
+
+        state_json = json.dumps({"version": 4, "serial": 8, "lineage": "abc"})
+
+        mock_db = AsyncMock()
+        existing_sv = MagicMock(spec=StateVersion)
+        existing_sv.md5 = "deadbeef"
+        existing_sv.sha256 = "a-different-sha256-than-the-upload"
+        mock_db.get.return_value = run
+        lookup = MagicMock()
+        lookup.scalar_one_or_none.return_value = existing_sv
+        mock_db.execute.return_value = lookup
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/state",
+                content=state_json,
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+        assert resp.status_code == 409
+        mock_db.add.assert_not_called()
+
 
 # ── upload_plan_json_output (#280) ─────────────────────────────────────
 

--- a/services/tests/api/test_run_artifacts.py
+++ b/services/tests/api/test_run_artifacts.py
@@ -187,11 +187,15 @@ class TestUploadStateDuplicateSerial:
 
         state_json = json.dumps({"version": 4, "serial": 8, "lineage": "abc"})
         body_md5 = hashlib.md5(state_json.encode()).hexdigest()  # noqa: S324
+        body_sha = hashlib.sha256(state_json.encode()).hexdigest()
 
         mock_db = AsyncMock()
         # The existing state version at serial 8 has the SAME content hash.
+        # The divergence check prefers sha256 (collision-resistant); md5 stays
+        # for the go-tfe contract.
         existing_sv = MagicMock(spec=StateVersion)
         existing_sv.md5 = body_md5
+        existing_sv.sha256 = body_sha
         ws = MagicMock()
         ws.state_diverged = True  # stale flag from a prior mis-fire
         # db.get: first _get_run(Run), then db.get(Workspace) in the no-op branch.
@@ -219,6 +223,46 @@ class TestUploadStateDuplicateSerial:
         # Stale divergence flag cleared.
         assert ws.state_diverged is False
         mock_db.commit.assert_awaited()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.run_artifacts.get_storage")
+    async def test_legacy_row_without_sha256_falls_back_to_md5(self, mock_get_storage, *_mocks):
+        """A row written before the sha256 column existed has sha256 == "".
+        The divergence check must fall back to md5 for it (so a pre-upgrade
+        no-op apply is still recognised as idempotent, not flagged diverged)."""
+        import hashlib
+
+        run_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        run = _mock_run(run_id=run_id, ws_id=ws_id)
+
+        state_json = json.dumps({"version": 4, "serial": 8, "lineage": "abc"})
+        body_md5 = hashlib.md5(state_json.encode()).hexdigest()  # noqa: S324
+
+        mock_db = AsyncMock()
+        existing_sv = MagicMock(spec=StateVersion)
+        existing_sv.md5 = body_md5
+        existing_sv.sha256 = ""  # legacy row, pre-sha256-column
+        ws = MagicMock()
+        ws.state_diverged = False
+        mock_db.get.side_effect = [run, ws]
+        lookup = MagicMock()
+        lookup.scalar_one_or_none.return_value = existing_sv
+        mock_db.execute.return_value = lookup
+        mock_get_storage.return_value = AsyncMock()
+
+        app = _make_app(_runner_user(run_id), mock_db)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            resp = await client.put(
+                f"/api/terrapod/v1/runs/{run.id}/artifacts/state",
+                content=state_json,
+                headers={**_AUTH, "Content-Type": "application/json"},
+            )
+
+        assert resp.status_code == 200
+        mock_db.add.assert_not_called()
 
 
 # ── upload_plan_json_output (#280) ─────────────────────────────────────

--- a/services/tests/api/test_variables.py
+++ b/services/tests/api/test_variables.py
@@ -389,3 +389,95 @@ class TestVariableSetCRUD:
                 headers=_AUTH,
             )
         assert resp.status_code == 403
+
+
+def _mock_vsvar(key="db_pass", value="s3cr3t", sensitive=True):
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.variable_set_id = uuid.uuid4()
+    v.key = key
+    v.value = value
+    v.sensitive = sensitive
+    v.category = "terraform"
+    v.hcl = False
+    v.description = ""
+    v.version_id = "old-hash"
+    v.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    v.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return v
+
+
+class TestVarsetVarSensitiveDowngrade:
+    """The varset-var PATCH path must clear a previously-hidden secret when a
+    var is flipped sensitive→non-sensitive without a fresh value (mirrors the
+    workspace-var service-tier rule; the router does it inline)."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.variables._get_varset")
+    async def test_downgrade_without_value_clears_secret(self, mock_get_vs, *_mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_get_vs.return_value = _mock_varset()
+        vsv = _mock_vsvar(sensitive=True, value="s3cr3t")
+        lookup = MagicMock()
+        lookup.scalar_one_or_none.return_value = vsv
+        mock_db.execute = AsyncMock(return_value=lookup)
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/varsets/varset-{uuid.uuid4()}/relationships/vars/var-{vsv.id}",
+                json={"data": {"attributes": {"sensitive": False}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert vsv.sensitive is False
+        assert vsv.value == ""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.variables._get_varset")
+    async def test_downgrade_with_fresh_value_keeps_it(self, mock_get_vs, *_mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_get_vs.return_value = _mock_varset()
+        vsv = _mock_vsvar(sensitive=True, value="s3cr3t")
+        lookup = MagicMock()
+        lookup.scalar_one_or_none.return_value = vsv
+        mock_db.execute = AsyncMock(return_value=lookup)
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/varsets/varset-{uuid.uuid4()}/relationships/vars/var-{vsv.id}",
+                json={"data": {"attributes": {"sensitive": False, "value": "now-public"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert vsv.value == "now-public"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.variables._get_varset")
+    async def test_non_sensitive_edit_keeps_value(self, mock_get_vs, *_mocks):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_get_vs.return_value = _mock_varset()
+        vsv = _mock_vsvar(sensitive=False, value="keep-me")
+        lookup = MagicMock()
+        lookup.scalar_one_or_none.return_value = vsv
+        mock_db.execute = AsyncMock(return_value=lookup)
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/varsets/varset-{uuid.uuid4()}/relationships/vars/var-{vsv.id}",
+                json={"data": {"attributes": {"description": "new"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert vsv.value == "keep-me"

--- a/services/tests/api/test_vcs_connections.py
+++ b/services/tests/api/test_vcs_connections.py
@@ -49,6 +49,7 @@ def _mock_conn(
     github_account_login="example",
     github_account_type="Organization",
     status="active",
+    webhook_secret=None,
 ):
     c = MagicMock()
     c.id = conn_id or uuid.uuid4()
@@ -61,6 +62,7 @@ def _mock_conn(
     c.github_account_login = github_account_login
     c.github_account_type = github_account_type
     c.status = status
+    c.webhook_secret = webhook_secret
     c.created_at = datetime(2026, 5, 9, tzinfo=UTC)
     c.updated_at = datetime(2026, 5, 9, tzinfo=UTC)
     return c
@@ -540,3 +542,108 @@ class TestDeleteConnection:
                 f"/api/terrapod/v1/vcs-connections/vcs-{uuid.uuid4()}", headers=_AUTH
             )
         assert resp.status_code == 404
+
+
+# ── Per-connection webhook secret (write-only) ────────────────────────────
+
+
+class TestWebhookSecret:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_with_secret_sets_flag_and_never_echoes(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(None))  # no dup install
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "gh-wh",
+                    "provider": "github",
+                    "github-app-id": 1,
+                    "github-installation-id": 2,
+                    "private-key": "-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----",
+                    "webhook-secret": "my-per-conn-secret",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 201, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["has-webhook-secret"] is True
+        # The raw value must never be echoed anywhere in the response.
+        assert "webhook-secret" not in attrs
+        assert "my-per-conn-secret" not in resp.text
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_without_secret_flag_false(self, *_mocks):
+        app, db = _make_app(_admin())
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "gh-nowh",
+                    "provider": "github",
+                    "github-app-id": 1,
+                    "github-installation-id": 3,
+                    "private-key": "-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----",
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/vcs-connections", json=body, headers=_AUTH)
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["data"]["attributes"]["has-webhook-secret"] is False
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.vcs_connections._get_connection", new_callable=AsyncMock)
+    async def test_patch_rotate_set_clear_omit(self, mock_get, *_mocks):
+        app, db = _make_app(_admin())
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        # Rotate: non-empty value → set.
+        conn = _mock_conn(webhook_secret=None)
+        mock_get.return_value = conn
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn.id}",
+                json={"data": {"attributes": {"webhook-secret": "rotated"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn.webhook_secret == "rotated"
+
+        # Clear: explicit empty string → None (fall back to global).
+        conn2 = _mock_conn(webhook_secret="existing")
+        mock_get.return_value = conn2
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn2.id}",
+                json={"data": {"attributes": {"webhook-secret": ""}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn2.webhook_secret is None
+
+        # Omit: key absent → untouched.
+        conn3 = _mock_conn(webhook_secret="keep")
+        mock_get.return_value = conn3
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/terrapod/v1/vcs-connections/vcs-{conn3.id}",
+                json={"data": {"attributes": {"name": "renamed"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+        assert conn3.webhook_secret == "keep"

--- a/services/tests/api/test_vcs_events.py
+++ b/services/tests/api/test_vcs_events.py
@@ -110,3 +110,61 @@ class TestGithubWebhook:
                 headers={"X-GitHub-Event": "push"},
             )
         assert resp.status_code == 400
+
+    @patch("terrapod.api.routers.vcs_events.enqueue_trigger", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.vcs_events._resolve_connection", new_callable=AsyncMock)
+    async def test_per_connection_secret_takes_precedence(
+        self, mock_resolve, mock_enqueue, *_mocks
+    ):
+        """A connection with its own webhook secret validates against THAT
+        secret, not the global one — using the REAL signature validator."""
+        import hashlib
+        import hmac
+
+        conn = MagicMock()
+        conn.webhook_secret = "per-conn-secret"
+        mock_resolve.return_value = conn
+        payload = json.dumps(_PUSH).encode()
+
+        # Signed with the per-connection secret → accepted.
+        good = "sha256=" + hmac.new(b"per-conn-secret", payload, hashlib.sha256).hexdigest()
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/vcs-events/github",
+                content=payload,
+                headers={"X-GitHub-Event": "push", "X-Hub-Signature-256": good},
+            )
+        assert resp.status_code == 200
+
+        # Signed with the GLOBAL secret → rejected, because the per-connection
+        # secret takes precedence and the global signature won't match it.
+        bad = "sha256=" + hmac.new(b"shhh", payload, hashlib.sha256).hexdigest()
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/vcs-events/github",
+                content=payload,
+                headers={"X-GitHub-Event": "push", "X-Hub-Signature-256": bad},
+            )
+        assert resp.status_code == 401
+
+    @patch("terrapod.api.routers.vcs_events.enqueue_trigger", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.vcs_events._resolve_connection", new_callable=AsyncMock)
+    async def test_falls_back_to_global_secret(self, mock_resolve, mock_enqueue, *_mocks):
+        """A connection WITHOUT its own secret validates against the global
+        one (REAL validator)."""
+        import hashlib
+        import hmac
+
+        conn = MagicMock()
+        conn.webhook_secret = None  # no per-connection secret
+        mock_resolve.return_value = conn
+        payload = json.dumps(_PUSH).encode()
+
+        good = "sha256=" + hmac.new(b"shhh", payload, hashlib.sha256).hexdigest()
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/terrapod/v1/vcs-events/github",
+                content=payload,
+                headers={"X-GitHub-Event": "push", "X-Hub-Signature-256": good},
+            )
+        assert resp.status_code == 200

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -102,7 +102,11 @@ class TestCreateWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    async def test_create_returns_201(self, *mocks):
+    @patch(
+        "terrapod.redis.client.publish_workspace_event",
+        new_callable=AsyncMock,
+    )
+    async def test_create_returns_201(self, mock_publish, *mocks):
         user = _user(roles=["admin"])
         app, mock_db = _make_app(user)
         # No existing workspace
@@ -122,6 +126,11 @@ class TestCreateWorkspace:
         assert data["type"] == "workspaces"
         assert data["attributes"]["name"] == "new-ws"
         assert data["attributes"]["owner-email"] == user.email
+        # The create path broadcasts a workspace_created event so any open
+        # workspace-list page live-updates via SSE (services-tier half of the
+        # SSE contract; the browser half is e2e/tests/sse-live-update.spec.ts).
+        mock_publish.assert_awaited_once()
+        assert mock_publish.await_args.args[1] == "workspace_created"
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/auth/test_download_tickets.py
+++ b/services/tests/auth/test_download_tickets.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 
 import pytest
 
-from terrapod.auth import download_tickets
 from terrapod.auth.download_tickets import (
     DEFAULT_TTL_SECONDS,
     MAX_TTL_SECONDS,
@@ -23,16 +22,19 @@ from terrapod.auth.download_tickets import (
 
 @pytest.fixture(autouse=True)
 def _reset_signing_key():
-    """Reset the module-level signing key cache between tests."""
-    download_tickets._signing_key = None
+    """Reset the shared signing-key cache between tests."""
+    from terrapod.auth import token_signing
+
+    token_signing._reset_cache_for_tests()
     yield
-    download_tickets._signing_key = None
+    token_signing._reset_cache_for_tests()
 
 
 @pytest.fixture
 def _mock_settings():
-    """Deterministic database_url so the derived key is stable across tests."""
+    """Deterministic key so it's stable across tests (DB-URL fallback path)."""
     with patch("terrapod.config.settings") as mock_settings:
+        mock_settings.token_signing_key = ""
         mock_settings.database_url = "postgresql+asyncpg://test:test@localhost/test"
         yield mock_settings
 
@@ -135,9 +137,11 @@ class TestVerificationFailures:
         assert verify_ticket(ticket) is None
 
     def test_signing_key_change_invalidates_old_tickets(self, _mock_settings):
+        from terrapod.auth import token_signing
+
         ticket = mint_ticket("cv", "abc-123", "u@example.com")
         # Pretend the database password rotated — derived key changes.
-        download_tickets._signing_key = None
+        token_signing._reset_cache_for_tests()
         _mock_settings.database_url = "postgresql+asyncpg://test:OTHER@localhost/test"
         assert verify_ticket(ticket) is None
 

--- a/services/tests/auth/test_runner_tokens.py
+++ b/services/tests/auth/test_runner_tokens.py
@@ -15,18 +15,19 @@ from terrapod.auth.runner_tokens import (
 
 @pytest.fixture(autouse=True)
 def _reset_signing_key():
-    """Reset the module-level signing key cache between tests."""
-    import terrapod.auth.runner_tokens as mod
+    """Reset the shared signing-key cache between tests."""
+    from terrapod.auth import token_signing
 
-    mod._signing_key = None
+    token_signing._reset_cache_for_tests()
     yield
-    mod._signing_key = None
+    token_signing._reset_cache_for_tests()
 
 
 @pytest.fixture
 def _mock_settings():
-    """Patch settings.database_url for deterministic signing key."""
+    """Patch settings for a deterministic signing key (DB-URL fallback path)."""
     with patch("terrapod.config.settings") as mock_settings:
+        mock_settings.token_signing_key = ""
         mock_settings.database_url = "postgresql+asyncpg://test:test@localhost/test"
         yield mock_settings
 

--- a/services/tests/auth/test_token_signing.py
+++ b/services/tests/auth/test_token_signing.py
@@ -1,0 +1,69 @@
+"""Tests for the shared token signing-key derivation.
+
+Verifies the dedicated-secret override and the backward-compatible
+database-URL fallback (so upgrading without configuring the secret does
+not invalidate in-flight runner / callback tokens).
+"""
+
+import hashlib
+from unittest.mock import patch
+
+import pytest
+
+from terrapod.auth import token_signing
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    token_signing._reset_cache_for_tests()
+    yield
+    token_signing._reset_cache_for_tests()
+
+
+def _settings(token_key, db_url="postgresql+asyncpg://u:p@h/db"):
+    with patch("terrapod.config.settings") as s:
+        s.token_signing_key = token_key
+        s.database_url = db_url
+        return s
+
+
+def test_empty_key_falls_back_to_database_url():
+    """No dedicated secret → key == sha256(database_url) (unchanged behaviour)."""
+    db_url = "postgresql+asyncpg://u:p@h/db"
+    with patch("terrapod.config.settings") as s:
+        s.token_signing_key = ""
+        s.database_url = db_url
+        key = token_signing.get_token_signing_key()
+    assert key == hashlib.sha256(db_url.encode()).digest()
+
+
+def test_dedicated_secret_overrides_database_url():
+    """A configured secret is used instead of the DB URL."""
+    with patch("terrapod.config.settings") as s:
+        s.token_signing_key = "super-secret-signing-key"
+        s.database_url = "postgresql+asyncpg://u:p@h/db"
+        key = token_signing.get_token_signing_key()
+    assert key == hashlib.sha256(b"super-secret-signing-key").digest()
+    # And it is distinct from the DB-URL-derived key.
+    assert key != hashlib.sha256(b"postgresql+asyncpg://u:p@h/db").digest()
+
+
+def test_whitespace_only_key_falls_back():
+    """A whitespace-only secret is treated as unset."""
+    db_url = "postgresql+asyncpg://u:p@h/db"
+    with patch("terrapod.config.settings") as s:
+        s.token_signing_key = "   "
+        s.database_url = db_url
+        key = token_signing.get_token_signing_key()
+    assert key == hashlib.sha256(db_url.encode()).digest()
+
+
+def test_key_is_cached():
+    """Derivation is cached after first call."""
+    with patch("terrapod.config.settings") as s:
+        s.token_signing_key = "k1"
+        s.database_url = "postgresql+asyncpg://u:p@h/db"
+        first = token_signing.get_token_signing_key()
+    # Second call must not re-read settings (patch removed) and returns cached.
+    second = token_signing.get_token_signing_key()
+    assert first == second

--- a/services/tests/auth/test_token_signing.py
+++ b/services/tests/auth/test_token_signing.py
@@ -20,13 +20,6 @@ def _reset():
     token_signing._reset_cache_for_tests()
 
 
-def _settings(token_key, db_url="postgresql+asyncpg://u:p@h/db"):
-    with patch("terrapod.config.settings") as s:
-        s.token_signing_key = token_key
-        s.database_url = db_url
-        return s
-
-
 def test_empty_key_falls_back_to_database_url():
     """No dedicated secret → key == sha256(database_url) (unchanged behaviour)."""
     db_url = "postgresql+asyncpg://u:p@h/db"

--- a/services/tests/services/test_variable_service.py
+++ b/services/tests/services/test_variable_service.py
@@ -113,6 +113,46 @@ class TestUpdateVariable:
         await update_variable(db, var, value="v2")
         assert var.version_id == _version_hash("k", "v2", "terraform")
 
+    async def test_downgrade_without_value_clears_secret(self):
+        """sensitive → non-sensitive with no new value must wipe the old value
+        so the previously-hidden secret can't be returned in plaintext."""
+        db = AsyncMock(spec=AsyncSession)
+        var = MagicMock()
+        var.key = "k"
+        var.value = "the-secret"
+        var.sensitive = True
+        var.category = "terraform"
+
+        await update_variable(db, var, sensitive=False)
+        assert var.sensitive is False
+        assert var.value == ""
+        assert var.version_id == _version_hash("k", "", "terraform")
+
+    async def test_downgrade_with_fresh_value_keeps_it(self):
+        """A downgrade that supplies a new value keeps that value (re-submit)."""
+        db = AsyncMock(spec=AsyncSession)
+        var = MagicMock()
+        var.key = "k"
+        var.value = "the-secret"
+        var.sensitive = True
+        var.category = "terraform"
+
+        await update_variable(db, var, value="now-public", sensitive=False)
+        assert var.sensitive is False
+        assert var.value == "now-public"
+
+    async def test_non_sensitive_update_does_not_clear_value(self):
+        """Editing an already-non-sensitive var without a value leaves it intact."""
+        db = AsyncMock(spec=AsyncSession)
+        var = MagicMock()
+        var.key = "k"
+        var.value = "keep-me"
+        var.sensitive = False
+        var.category = "terraform"
+
+        await update_variable(db, var, description="new desc")
+        assert var.value == "keep-me"
+
 
 # ── resolve_variables ──────────────────────────────────────────────────
 

--- a/web/src/app/admin/vcs-connections/page.tsx
+++ b/web/src/app/admin/vcs-connections/page.tsx
@@ -24,6 +24,7 @@ interface VCSConnection {
     'github-installation-id': string | null
     'github-account-login': string | null
     'has-token': boolean
+    'has-webhook-secret'?: boolean
     'created-at': string
   }
 }
@@ -46,6 +47,7 @@ export default function VCSConnectionsPage() {
   const [appId, setAppId] = useState('')
   const [installationId, setInstallationId] = useState('')
   const [privateKey, setPrivateKey] = useState('')
+  const [webhookSecret, setWebhookSecret] = useState('')
   const [pemDragOver, setPemDragOver] = useState(false)
   const pemFileRef = useRef<HTMLInputElement>(null)
   // GitLab fields
@@ -59,7 +61,7 @@ export default function VCSConnectionsPage() {
 
   function resetForm() {
     setName(''); setServerUrl(''); setAppId(''); setInstallationId('')
-    setPrivateKey(''); setToken(''); setProvider('github'); setEditId(null)
+    setPrivateKey(''); setToken(''); setWebhookSecret(''); setProvider('github'); setEditId(null)
   }
 
   function startEdit(conn: VCSConnection) {
@@ -76,6 +78,7 @@ export default function VCSConnectionsPage() {
     // Credentials are write-only — never returned. Leave blank = keep.
     setPrivateKey('')
     setToken('')
+    setWebhookSecret('')
     setShowCreate(true)
     setError(''); setSuccess('')
   }
@@ -131,6 +134,8 @@ export default function VCSConnectionsPage() {
         // On edit, credentials are optional — only send when rotating.
         if (privateKey) attrs['private-key'] = privateKey
         else if (!editing) attrs['private-key'] = privateKey
+        // Optional per-connection webhook secret — only send when set/rotating.
+        if (webhookSecret) attrs['webhook-secret'] = webhookSecret
       } else {
         if (token) attrs.token = token
         else if (!editing) attrs.token = token
@@ -284,6 +289,22 @@ export default function VCSConnectionsPage() {
                       if (f) f.text().then(t => setPrivateKey(t))
                     }}
                   />
+                </div>
+                <div>
+                  <label htmlFor="gh-webhook-secret" className="block text-sm font-medium text-slate-300 mb-1">
+                    Webhook Secret <span className="text-slate-500 font-normal">(optional)</span>
+                  </label>
+                  <input id="gh-webhook-secret" type="password" value={webhookSecret}
+                    onChange={(e) => setWebhookSecret(e.target.value)}
+                    placeholder={editId !== null
+                      ? (connections.find((c) => c.id === editId)?.attributes['has-webhook-secret']
+                          ? 'Set — leave blank to keep, enter a new value to rotate'
+                          : 'Leave blank to use the global secret')
+                      : 'Leave blank to use the global webhook secret'}
+                    className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
+                  <p className="mt-1 text-xs text-slate-500">
+                    Per-connection HMAC secret for this installation&apos;s webhooks. When unset, the global secret is used.
+                  </p>
                 </div>
               </div>
             ) : (

--- a/web/src/app/catalog/[id]/page.tsx
+++ b/web/src/app/catalog/[id]/page.tsx
@@ -9,6 +9,7 @@ import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { LabelsEditor } from '@/components/labels-editor'
+import { Modal } from '@/components/modal'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 
@@ -405,7 +406,7 @@ export default function CatalogItemPage() {
         const data = await res.json().catch(() => ({}))
         throw new Error(data.detail || `Failed to orphan (${res.status})`)
       }
-      setActionResult(`Orphaned ${orphanInstance.attributes.name} — workspace removed, infrastructure left running (untracked).`)
+      setActionResult(`Orphaned ${orphanInstance.attributes.name} — catalog record deleted; its infrastructure is left running, untracked and unmanaged.`)
       setOrphanInstance(null)
       setOrphanConfirm('')
       await loadInstances()
@@ -533,6 +534,13 @@ export default function CatalogItemPage() {
                     <option key={p.id} value={p.id}>{p.attributes.name}</option>
                   ))}
                 </select>
+                {selectablePools.length === 0 && (
+                  <p className="mt-1 text-xs text-amber-400">
+                    {pools.length === 0
+                      ? 'No agent pools are available to you. You need write access to an agent pool to provision — ask an administrator to grant it.'
+                      : 'None of the agent pools you can access are allowed by this catalog item. Ask an administrator to widen the item’s allowed pools or grant you access to one of them.'}
+                  </p>
+                )}
               </div>
               <div>
                 <label htmlFor="prov-version" className="block text-sm font-medium text-slate-300 mb-1">Version</label>
@@ -576,7 +584,7 @@ export default function CatalogItemPage() {
                 onChange={(e) => setProvAutoApply(e.target.checked)}
                 className="rounded border-slate-600 bg-slate-700 text-brand-600 focus:ring-brand-500"
               />
-              <span className="text-sm text-amber-300">Auto-apply applies changes without review — a brave choice for production.</span>
+              <span className="text-sm text-amber-300">Auto-apply applies changes without a manual review step.</span>
             </label>
 
             <button
@@ -642,8 +650,13 @@ export default function CatalogItemPage() {
 
       {/* Reconfigure modal */}
       {reconfigInstance && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-          <div className="bg-slate-800 rounded-lg border border-slate-700 w-full max-w-2xl max-h-[90vh] overflow-y-auto p-5">
+        <Modal
+          open
+          onClose={() => setReconfigInstance(null)}
+          title={`Reconfigure ${reconfigInstance.attributes.name}`}
+          panelClassName="bg-slate-800 rounded-lg border border-slate-700 w-full max-w-2xl max-h-[90vh] overflow-y-auto p-5"
+        >
+          <div>
             <h3 className="text-lg font-semibold text-slate-100 mb-1">Reconfigure {reconfigInstance.attributes.name}</h3>
             <p className="text-sm text-slate-400 mb-4">Update inputs and/or version, then queue a run.</p>
             {reconfigError && <ErrorBanner message={reconfigError} />}
@@ -687,7 +700,7 @@ export default function CatalogItemPage() {
                   onChange={(e) => setReconfigAutoApply(e.target.checked)}
                   className="rounded border-slate-600 bg-slate-700 text-brand-600 focus:ring-brand-500"
                 />
-                <span className="text-sm text-amber-300">Auto-apply applies changes without review — a brave choice for production.</span>
+                <span className="text-sm text-amber-300">Auto-apply applies changes without a manual review step.</span>
               </label>
               <div className="flex justify-end gap-2 pt-2">
                 <button type="button" onClick={() => setReconfigInstance(null)} className="px-4 py-2 rounded-lg text-sm font-medium text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
@@ -697,13 +710,18 @@ export default function CatalogItemPage() {
               </div>
             </form>
           </div>
-        </div>
+        </Modal>
       )}
 
       {/* Destroy confirm modal */}
       {destroyInstance && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-          <div className="bg-slate-800 rounded-lg border border-slate-700 w-full max-w-md p-5">
+        <Modal
+          open
+          onClose={() => setDestroyInstance(null)}
+          title={`Destroy ${destroyInstance.attributes.name}`}
+          panelClassName="bg-slate-800 rounded-lg border border-slate-700 w-full max-w-md p-5"
+        >
+          <div>
             <h3 className="text-lg font-semibold text-slate-100 mb-1">Destroy {destroyInstance.attributes.name}?</h3>
             <p className="text-sm text-slate-400 mb-4">
               This queues a destroy run that tears down this instance&apos;s infrastructure. On a successful apply the workspace is archived. This cannot be undone.
@@ -725,12 +743,17 @@ export default function CatalogItemPage() {
               </button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
 
       {orphanInstance && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-          <div className="bg-slate-800 rounded-lg border border-red-900/60 w-full max-w-md p-5">
+        <Modal
+          open
+          onClose={() => { setOrphanInstance(null); setOrphanConfirm('') }}
+          title={`Orphan ${orphanInstance.attributes.name}`}
+          panelClassName="bg-slate-800 rounded-lg border border-red-900/60 w-full max-w-md p-5"
+        >
+          <div>
             <h3 className="text-lg font-semibold text-slate-100 mb-1">Orphan {orphanInstance.attributes.name}?</h3>
             <p className="text-sm text-slate-400 mb-3">
               This deletes the catalog instance record but does <span className="text-amber-300 font-medium">not</span> destroy its infrastructure — the provisioned resources keep running, <span className="text-amber-300 font-medium">untracked and unmanaged</span>. This is discouraged. To reclaim the infrastructure, cancel and use <span className="text-slate-200 font-medium">Destroy</span> instead.
@@ -758,7 +781,7 @@ export default function CatalogItemPage() {
               </button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </>
   )

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, Suspense } from 'react'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
+import { ConnectionStatus } from '@/components/connection-status'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
@@ -542,7 +543,7 @@ function WorkspaceDetailContent() {
   }, [vcsRef])
 
   // Real-time workspace events via SSE (run status, lock/unlock, state, settings)
-  useRunEvents(workspaceId, useCallback((event) => {
+  const { connected: sseConnected } = useRunEvents(workspaceId, useCallback((event) => {
     loadWorkspace()
     const ev = event.event
     const reconnect = ev === 'reconnect'
@@ -1544,6 +1545,7 @@ function WorkspaceDetailContent() {
         <PageHeader
           title={attrs.name}
           description={`${attrs['execution-mode']} execution mode`}
+          actions={<ConnectionStatus connected={sseConnected} />}
         />
 
         {error && <ErrorBanner message={error} />}

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import Convert from 'ansi-to-html'
 import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
+import { ConnectionStatus } from '@/components/connection-status'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { PlanSummaryBadges } from '@/components/plan-summary-badges'
@@ -383,7 +384,7 @@ function RunDetailPageInner() {
   }, [router, loadRun])
 
   // Real-time updates via SSE — reload run on status change, refresh logs on log_updated
-  useRunEvents(workspaceId, useCallback((event) => {
+  const { connected: sseConnected } = useRunEvents(workspaceId, useCallback((event) => {
     const bareId = runId.replace(/^run-/, '')
     if (event.event === 'reconnect' || (event.event === 'run_status_change' && event.run_id === bareId)) {
       loadRun()
@@ -591,6 +592,7 @@ function RunDetailPageInner() {
           description={attrs.message || `${attrs.source} run`}
           actions={
             <div className="flex items-center gap-2">
+              <ConnectionStatus connected={sseConnected} />
               {attrs['is-destroy'] && (
                 <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-900/50 text-red-300">
                   destroy

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
+import { ConnectionStatus } from '@/components/connection-status'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
@@ -391,7 +392,7 @@ function WorkspacesPageInner() {
   // workspaces.length) so the FIRST workspace created from another tab / the
   // CLI / a VCS push live-appears on an empty org instead of requiring a
   // manual refresh — the empty state is exactly where live-update matters most.
-  useWorkspaceListEvents(true, useCallback(() => {
+  const { connected: sseConnected } = useWorkspaceListEvents(true, useCallback(() => {
     loadWorkspaces()
   }, []))
 
@@ -504,12 +505,15 @@ function WorkspacesPageInner() {
           title="Workspaces"
           description="Manage Terraform workspaces, state, and runs"
           actions={
-            <button
-              onClick={() => setShowCreate(!showCreate)}
-              className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors btn-smoke"
-            >
-              {showCreate ? 'Cancel' : 'New Workspace'}
-            </button>
+            <div className="flex items-center gap-3">
+              <ConnectionStatus connected={sseConnected} />
+              <button
+                onClick={() => setShowCreate(!showCreate)}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors btn-smoke"
+              >
+                {showCreate ? 'Cancel' : 'New Workspace'}
+              </button>
+            </div>
           }
         />
 

--- a/web/src/components/modal.tsx
+++ b/web/src/components/modal.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+/**
+ * Accessible modal dialog primitive.
+ *
+ * Provides what every inline `fixed inset-0` modal in the app was missing:
+ * `role="dialog"` + `aria-modal`, Escape-to-close, a focus trap (Tab cycles
+ * within the dialog), initial focus into the dialog, focus restoration to the
+ * previously-focused element on close, and backdrop-click-to-close. Especially
+ * important on destructive flows (catalog destroy / orphan) that a keyboard or
+ * screen-reader user otherwise can't perceive or dismiss.
+ */
+
+const FOCUSABLE =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  panelClassName = 'bg-slate-800 rounded-lg border border-slate-700 w-full max-w-lg p-5',
+}: {
+  open: boolean
+  onClose: () => void
+  /** Accessible name for the dialog (screen readers). */
+  title?: string
+  children: React.ReactNode
+  /** Full visual classes for the panel (bg/border/rounded/width/padding). */
+  panelClassName?: string
+}) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const restoreRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    restoreRef.current = document.activeElement as HTMLElement
+    const panel = panelRef.current
+    const first = panel?.querySelector<HTMLElement>(FOCUSABLE)
+    ;(first ?? panel)?.focus()
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab' || !panel) return
+      const items = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE))
+      if (items.length === 0) return
+      const firstEl = items[0]
+      const lastEl = items[items.length - 1]
+      if (e.shiftKey && document.activeElement === firstEl) {
+        e.preventDefault()
+        lastEl.focus()
+      } else if (!e.shiftKey && document.activeElement === lastEl) {
+        e.preventDefault()
+        firstEl.focus()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      restoreRef.current?.focus?.()
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        tabIndex={-1}
+        className={`shadow-xl focus:outline-none ${panelClassName}`}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -191,12 +191,16 @@ export default function NavBar() {
                 href="https://github.com/mattrobinsonsre/terrapod/blob/main/docs/index.md"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Documentation"
                 className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
               >
                 <BookOpen size={20} />
               </a>
               <button
                 onClick={() => setMenuOpen(!menuOpen)}
+                aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+                aria-expanded={menuOpen}
+                aria-controls="mobile-nav-menu"
                 className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
               >
                 {menuOpen ? <X size={20} /> : <Menu size={20} />}
@@ -211,7 +215,7 @@ export default function NavBar() {
             </div>
           </div>
           {menuOpen && (
-            <div className="md:hidden flex flex-col gap-1 pb-3">
+            <div id="mobile-nav-menu" className="md:hidden flex flex-col gap-1 pb-3">
               {navLinks}
               <NavLink href="/api-docs" onClick={closeMenu}>
                 <Code size={16} />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -44,3 +44,29 @@ export async function apiFetch(path: string, init?: RequestInit): Promise<Respon
 
   return res
 }
+
+/**
+ * Extract a human-readable message from a failed API response.
+ *
+ * Handles the shapes the API actually returns — JSON:API `{ errors: [{ detail }] }`,
+ * FastAPI `{ detail }` (string or validation array), and `{ message }` — falling
+ * back to the status code. Use at call sites instead of hand-rolling error
+ * extraction (or, worse, swallowing the failure): `setError(await parseApiError(res))`.
+ */
+export async function parseApiError(res: Response, fallback = 'Request failed'): Promise<string> {
+  try {
+    const body = await res.clone().json()
+    if (Array.isArray(body?.errors) && body.errors[0]?.detail) return String(body.errors[0].detail)
+    if (typeof body?.detail === 'string') return body.detail
+    if (Array.isArray(body?.detail) && body.detail[0]?.msg) {
+      // FastAPI validation error: [{ loc, msg, type }]
+      const first = body.detail[0]
+      const field = Array.isArray(first.loc) ? first.loc[first.loc.length - 1] : ''
+      return field ? `${field}: ${first.msg}` : String(first.msg)
+    }
+    if (typeof body?.message === 'string') return body.message
+  } catch {
+    // not JSON
+  }
+  return `${fallback} (${res.status})`
+}


### PR DESCRIPTION
Implements the deferred backlog from the post-v0.42.0 whole-project review (the items not already shipped in v0.43.0). Grouped into five themes; every change ships with tests at the right tier.

## UX & accessibility
- Accessible `<Modal>` primitive (role=dialog, aria-modal, Escape, focus trap + restore, backdrop click) adopted by the catalog reconfigure/destroy/orphan flows.
- Live `<ConnectionStatus>` on the workspace list, workspace detail, and run detail headers — a dropped SSE stream is now visible.
- `parseApiError` helper so call sites render the API's real error detail; catalog provision now diagnoses an empty agent-pool dropdown; nav-bar aria-labels; copy fixes.

## Test coverage
- New router tests for binary-cache, gpg-keys, and the labels browser.
- Deterministic SSE-through-proxy live-update e2e (#221): a second actor creates a workspace via the API and the open list re-renders with no reload — the create path now broadcasts `workspace_created`.
- De-flaked the audit-log method-filter spec (#240).

## SDK coverage
- go-terrapod: individual-policy CRUD (`AddPolicy`/`UpdatePolicy`/`DeletePolicy`), workspace bulk (`SearchWorkspaces`/`BulkUpdateWorkspaces`), labels browser (`ListLabelKeys`/`Values`/`Entities`), all with httptest coverage.
- registry_modules: bad-VCS-ref errors now return 422 (matching the SDK's `classifyError`) instead of 400.

## Security (defense-in-depth)
- **Dedicated token signing key** — runner + run-task HMAC tokens can use `api.tokenSigningKey` instead of `sha256(database_url)`; empty default keeps the old key byte-for-byte (no token invalidated on upgrade).
- **Sensitive→non-sensitive variable downgrade** clears the value so the previously-hidden secret can't leak; the operator must re-enter it.
- **State-divergence check** now uses a collision-resistant sha256 (new `state_versions.sha256` column; `md5` kept for the go-tfe contract; legacy rows fall back to md5).
- **CA hygiene** — drop the never-read CA private-key disk cache; rename `ca_key_encrypted` → `ca_key_pem` (it was a NoEncryption PKCS8 PEM).
- **Per-connection GitHub webhook secret** — optional secret on `VCSConnection`; the receiver validates against the connection's own secret, falling back to the global one. Full stack: model + migration, API (write-only `webhook-secret`, read-only `has-webhook-secret`), go-terrapod, provider, web UI.

## Registry/backend + docs
- Registry module-version create pre-checks for a duplicate → clean 409 (no IntegrityError 500, no dangling pending row).
- AI summariser code-diff extraction lands on the CSP PVC when configured.
- Docs: README docs-table sync, migration.md terragrunt correction, DR invalid-UUID fix + a Routine Backup & Restore section, security-hardening token-signing-key, and the per-connection webhook secret in vcs-integration.md + api-reference.md.

## Migrations
Three additive/rename migrations (all up+down): `state_versions.sha256`, `certificate_authority.ca_key_encrypted`→`ca_key_pem`, `vcs_connections.webhook_secret`.

## Verification
- `make test` (unit + services-api + integration): 2370 passed.
- `make lint`, go-terrapod `go test ./...`, provider `go build`, `web npm run build`, `helm lint`/`template` (both values files): all green.

## Deferred (noted honestly)
Two catalog edge-cases found in the v0.42.0 F-gate smoke (a `./`-prefixed module tarball extracting an empty interface; a partial provider-version 502) need live reproduction to fix safely and are not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
