### PR TITLE
feat(auth): add PKCE to upstream OIDC authorize and token exchange

### DIFF
--- a/services/terrapod/api/routers/auth.py
+++ b/services/terrapod/api/routers/auth.py
@@ -175,6 +175,7 @@ async def authorize(
         code_challenge_method=code_challenge_method,
         idp_state=idp_state,
         nonce=auth_request.nonce,
+        idp_code_verifier=auth_request.code_verifier,
     )
     await store_auth_state(auth_state)
 
@@ -360,6 +361,7 @@ async def cli_sso_redirect(
         code_challenge_method=auth_state.code_challenge_method,
         idp_state=idp_state,
         nonce=auth_request.nonce,
+        idp_code_verifier=auth_request.code_verifier,
         credential_type="api_token",
     )
     await store_auth_state(new_state)
@@ -400,6 +402,7 @@ async def callback(
             callback_url=callback_url,
             code=code,
             state=state,
+            code_verifier=auth_state.idp_code_verifier,
         )
     except ValueError as e:
         logger.error("SSO callback failed", provider=auth_state.provider_name, error=str(e))

--- a/services/terrapod/auth/auth_state.py
+++ b/services/terrapod/auth/auth_state.py
@@ -33,6 +33,7 @@ class AuthState:
     code_challenge_method: str
     idp_state: str
     nonce: str | None = None
+    idp_code_verifier: str | None = None
     # "session" for web UI, "api_token" for terraform login
     credential_type: str = "session"
 

--- a/services/terrapod/auth/connectors/oidc.py
+++ b/services/terrapod/auth/connectors/oidc.py
@@ -5,6 +5,8 @@ Supports API audience for application-scoped permissions (Auth0, Okta, etc.)
 and /userinfo endpoint for additional claims.
 """
 
+import base64
+import hashlib
 import secrets
 from datetime import UTC, datetime
 from typing import Any
@@ -20,6 +22,14 @@ from terrapod.config import OIDCProviderConfig
 from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+
+def _generate_pkce_pair() -> tuple[str, str]:
+    """Return (code_verifier, S256 code_challenge) for upstream OIDC PKCE."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
 
 
 class OIDCConnector(SSOConnector):
@@ -80,6 +90,7 @@ class OIDCConnector(SSOConnector):
         discovery = await self._ensure_discovery()
         authorization_endpoint = discovery["authorization_endpoint"]
         nonce = secrets.token_urlsafe(32)
+        code_verifier, code_challenge = _generate_pkce_pair()
 
         params = {
             "response_type": "code",
@@ -88,6 +99,8 @@ class OIDCConnector(SSOConnector):
             "scope": " ".join(self._config.scopes),
             "state": state,
             "nonce": nonce,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
         }
 
         # Include audience if configured (requests API-scoped access token)
@@ -99,6 +112,7 @@ class OIDCConnector(SSOConnector):
             authorize_url=authorize_url,
             state=state,
             nonce=nonce,
+            code_verifier=code_verifier,
         )
 
     async def handle_callback(
@@ -108,6 +122,7 @@ class OIDCConnector(SSOConnector):
     ) -> AuthenticatedIdentity:
         """Exchange authorization code for tokens and extract identity."""
         code = kwargs["code"]
+        code_verifier = kwargs.get("code_verifier")
 
         discovery = await self._ensure_discovery()
         token_endpoint = discovery["token_endpoint"]
@@ -120,6 +135,8 @@ class OIDCConnector(SSOConnector):
             "client_id": self._config.client_id,
             "client_secret": self._config.client_secret,
         }
+        if code_verifier:
+            token_data["code_verifier"] = code_verifier
 
         async with httpx.AsyncClient() as client:
             resp = await client.post(token_endpoint, data=token_data)

--- a/services/terrapod/auth/sso.py
+++ b/services/terrapod/auth/sso.py
@@ -17,6 +17,7 @@ class AuthorizationRequest:
     authorize_url: str
     state: str  # IDP-facing state (not the client-facing state)
     nonce: str | None = None  # OIDC nonce for replay protection
+    code_verifier: str | None = None  # Upstream OIDC PKCE verifier for token exchange
 
 
 @dataclass

--- a/services/tests/auth/test_auth_state.py
+++ b/services/tests/auth/test_auth_state.py
@@ -47,6 +47,7 @@ class TestStoreAuthState:
             code_challenge_method="S256",
             idp_state="idp-state-xyz",
             nonce="nonce-456",
+            idp_code_verifier="upstream-verifier",
             credential_type="api_token",
         )
 
@@ -63,6 +64,7 @@ class TestStoreAuthState:
         assert stored_data["provider_name"] == "oidc"
         assert stored_data["credential_type"] == "api_token"
         assert stored_data["nonce"] == "nonce-456"
+        assert stored_data["idp_code_verifier"] == "upstream-verifier"
 
 
 class TestConsumeAuthState:
@@ -84,6 +86,7 @@ class TestConsumeAuthState:
             "code_challenge_method": "S256",
             "idp_state": "idp-state-xyz",
             "nonce": None,
+            "idp_code_verifier": "upstream-verifier",
             "credential_type": "session",
         }
         pipe.execute.return_value = [json.dumps(state_data), 1]
@@ -94,6 +97,7 @@ class TestConsumeAuthState:
         assert result.provider_name == "oidc"
         assert result.client_redirect_uri == "http://localhost:10000/login"
         assert result.code_challenge == "challenge-abc"
+        assert result.idp_code_verifier == "upstream-verifier"
         assert result.credential_type == "session"
 
         # Verify atomic get+delete

--- a/services/tests/auth/test_oidc.py
+++ b/services/tests/auth/test_oidc.py
@@ -11,6 +11,11 @@ from terrapod.auth.connectors.oidc import OIDCConnector, _generate_pkce_pair
 from terrapod.config import OIDCProviderConfig
 
 
+class _FakeJwtClaims(dict):
+    def validate(self, leeway: int = 30) -> None:
+        pass
+
+
 class TestGeneratePkcePair:
     def test_challenge_matches_verifier_s256(self):
         verifier, challenge = _generate_pkce_pair()
@@ -91,8 +96,9 @@ class TestOIDCConnectorPkce:
             patch("terrapod.auth.connectors.oidc.authlib_jwt.decode") as mock_decode,
             patch.object(connector, "_fetch_userinfo", new_callable=AsyncMock) as mock_userinfo,
         ):
-            claims = {"sub": "user-1", "email": "user@example.com", "exp": 9999999999}
-            mock_decode.return_value = claims
+            mock_decode.return_value = _FakeJwtClaims(
+                {"sub": "user-1", "email": "user@example.com", "exp": 9999999999}
+            )
             mock_userinfo.return_value = {}
 
             await connector.handle_callback(

--- a/services/tests/auth/test_oidc.py
+++ b/services/tests/auth/test_oidc.py
@@ -2,7 +2,7 @@
 
 import base64
 import hashlib
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -54,9 +54,7 @@ class TestOIDCConnectorPkce:
         params = parse_qs(parsed.query)
         assert params["code_challenge_method"] == ["S256"]
         assert params["code_challenge"] == [
-            base64.urlsafe_b64encode(
-                hashlib.sha256(req.code_verifier.encode("ascii")).digest()
-            )
+            base64.urlsafe_b64encode(hashlib.sha256(req.code_verifier.encode("ascii")).digest())
             .rstrip(b"=")
             .decode("ascii")
         ]
@@ -77,9 +75,8 @@ class TestOIDCConnectorPkce:
             "userinfo_endpoint": "https://idp.example.com/userinfo",
         }
 
-        # Minimal JWT payload whose validation is mocked via jwks + authlib decode.
-        mock_response = AsyncMock()
-        mock_response.raise_for_status = lambda: None
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = {
             "id_token": "header.payload.sig",
             "access_token": "opaque-access",
@@ -88,10 +85,6 @@ class TestOIDCConnectorPkce:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = False
         mock_client.post.return_value = mock_response
-        mock_client.get.return_value = AsyncMock(
-            raise_for_status=lambda: None,
-            json=lambda: {"email": "user@example.com", "groups": []},
-        )
         mock_client_cls.return_value = mock_client
 
         with (
@@ -110,5 +103,5 @@ class TestOIDCConnectorPkce:
 
         posted = mock_client.post.call_args
         assert posted is not None
-        token_data = posted.kwargs.get("data") or posted[1].get("data")
+        token_data = posted.kwargs["data"]
         assert token_data["code_verifier"] == "upstream-verifier-abc"

--- a/services/tests/auth/test_oidc.py
+++ b/services/tests/auth/test_oidc.py
@@ -1,0 +1,114 @@
+"""Tests for the upstream OIDC connector PKCE flow."""
+
+import base64
+import hashlib
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from terrapod.auth.connectors.oidc import OIDCConnector, _generate_pkce_pair
+from terrapod.config import OIDCProviderConfig
+
+
+class TestGeneratePkcePair:
+    def test_challenge_matches_verifier_s256(self):
+        verifier, challenge = _generate_pkce_pair()
+        digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        expected = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        assert challenge == expected
+
+    def test_verifier_is_unique(self):
+        v1, _ = _generate_pkce_pair()
+        v2, _ = _generate_pkce_pair()
+        assert v1 != v2
+
+
+class TestOIDCConnectorPkce:
+    @pytest.fixture
+    def connector(self) -> OIDCConnector:
+        config = OIDCProviderConfig(
+            name="test-idp",
+            issuer_url="https://idp.example.com",
+            client_id="client-123",
+            client_secret="secret",
+            scopes=["openid", "profile"],
+        )
+        return OIDCConnector(config)
+
+    @patch.object(OIDCConnector, "_ensure_discovery", new_callable=AsyncMock)
+    async def test_build_authorization_request_includes_pkce(
+        self, mock_discovery: AsyncMock, connector: OIDCConnector
+    ):
+        mock_discovery.return_value = {
+            "authorization_endpoint": "https://idp.example.com/oauth2/authorize",
+        }
+
+        req = await connector.build_authorization_request(
+            callback_url="https://terrapod.example.com/api/terrapod/v1/auth/callback",
+            state="idp-state-xyz",
+        )
+
+        assert req.code_verifier is not None
+        parsed = urlparse(req.authorize_url)
+        params = parse_qs(parsed.query)
+        assert params["code_challenge_method"] == ["S256"]
+        assert params["code_challenge"] == [
+            base64.urlsafe_b64encode(
+                hashlib.sha256(req.code_verifier.encode("ascii")).digest()
+            )
+            .rstrip(b"=")
+            .decode("ascii")
+        ]
+
+    @patch("terrapod.auth.connectors.oidc.httpx.AsyncClient")
+    @patch.object(OIDCConnector, "_ensure_jwks", new_callable=AsyncMock)
+    @patch.object(OIDCConnector, "_ensure_discovery", new_callable=AsyncMock)
+    async def test_handle_callback_posts_code_verifier(
+        self,
+        mock_discovery: AsyncMock,
+        mock_jwks: AsyncMock,
+        mock_client_cls,
+        connector: OIDCConnector,
+    ):
+        mock_discovery.return_value = {
+            "issuer": "https://idp.example.com",
+            "token_endpoint": "https://idp.example.com/oauth2/token",
+            "userinfo_endpoint": "https://idp.example.com/userinfo",
+        }
+
+        # Minimal JWT payload whose validation is mocked via jwks + authlib decode.
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = lambda: None
+        mock_response.json.return_value = {
+            "id_token": "header.payload.sig",
+            "access_token": "opaque-access",
+        }
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+        mock_client.post.return_value = mock_response
+        mock_client.get.return_value = AsyncMock(
+            raise_for_status=lambda: None,
+            json=lambda: {"email": "user@example.com", "groups": []},
+        )
+        mock_client_cls.return_value = mock_client
+
+        with (
+            patch("terrapod.auth.connectors.oidc.authlib_jwt.decode") as mock_decode,
+            patch.object(connector, "_fetch_userinfo", new_callable=AsyncMock) as mock_userinfo,
+        ):
+            claims = {"sub": "user-1", "email": "user@example.com", "exp": 9999999999}
+            mock_decode.return_value = claims
+            mock_userinfo.return_value = {}
+
+            await connector.handle_callback(
+                callback_url="https://terrapod.example.com/api/terrapod/v1/auth/callback",
+                code="auth-code",
+                code_verifier="upstream-verifier-abc",
+            )
+
+        posted = mock_client.post.call_args
+        assert posted is not None
+        token_data = posted.kwargs.get("data") or posted[1].get("data")
+        assert token_data["code_verifier"] == "upstream-verifier-abc"

--- a/services/tests/auth/test_sso.py
+++ b/services/tests/auth/test_sso.py
@@ -42,6 +42,7 @@ class TestSSOConnectorABC:
             state="state-123",
         )
         assert req.nonce is None
+        assert req.code_verifier is None
 
     def test_connector_display_name_defaults_to_name(self):
         """SSOConnector.display_name falls back to name."""


### PR DESCRIPTION
## Summary

Terrapod already uses PKCE for browser/CLI login to itself, but the upstream OIDC connector did not send `code_challenge` on authorize or `code_verifier` on token exchange. Some IdPs require S256 PKCE for the authorization code flow even when a client secret is configured (e.g. Pinniped Supervisor).

This change:
- Adds S256 PKCE to `OIDCConnector.build_authorization_request`
- Persists the upstream verifier in `AuthState` and sends it on token exchange in `/auth/callback`
- Adds unit tests in `services/tests/auth/test_oidc.py`

Without upstream PKCE, IdPs that enforce PKCE reject the authorize request and redirect back with `error=invalid_request` (missing `code_challenge`). The Terrapod callback then fails because no authorization `code` is present.
