### PR TITLE
docs: add AGENTS.md + CONTRIBUTING.md and make contributing prominent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,250 @@
+# AGENTS.md
+
+Guidance for contributors and AI coding assistants working in the Terrapod
+repository. If you are using an AI assistant (Claude Code, Cursor, Copilot,
+Aider, etc.), point it at this file — it captures the architecture, the
+contracts, the test tiers, and the conventions that keep changes consistent.
+
+New here? Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup and the
+contribution workflow, then come back here for the deeper architecture and
+contract rules. **Contributions are very welcome — including AI-assisted
+("vibe") contributions** — as long as they follow the contracts below and
+ship with tests.
+
+---
+
+## What Terrapod is
+
+Terrapod is a free, open-source **platform** replacement for Terraform
+Enterprise. It is **not** a fork of Terraform or OpenTofu — it provides the
+collaboration, governance, state management, and UI layer that wraps around
+`terraform` or `tofu` as pluggable execution backends.
+
+Terrapod targets **TFE V2 API compatibility for the surface that
+`terraform`, `tofu`, and `tfci` consume** — service discovery, the
+cloud-block run lifecycle, variable + variable-set management, and the module
++ provider registry CLI download protocols. That subset is mounted at
+`/api/v2/` and is treated as a stable contract for those clients. Everything
+else — workspace/role/registry management, agent pools, notifications, run
+tasks, drift detection, the SSE streams, and the runner protocol — is
+Terrapod-native and lives at `/api/terrapod/v1/`.
+
+The verified CLI-consumed endpoints are catalogued in
+[`docs/tfe-cli-surface.md`](docs/tfe-cli-surface.md). When extending the API:
+if a route is on that list it stays at `/api/v2/`; otherwise it goes under
+`/api/terrapod/v1/`.
+
+## Repository layout
+
+| Path | What it is | Language |
+|---|---|---|
+| `services/terrapod/` | API server (FastAPI) **and** the runner listener — one codebase, different entrypoints. Implicit namespace package (no `__init__.py`). | Python 3.13 |
+| `web/` | Next.js frontend + BFF (the single ingress; proxies `/api/*` to the API). | TypeScript / React |
+| `go-terrapod/` | Public, canonical Go SDK for the Terrapod API. Source of truth for the Go-side view of every endpoint. | Go |
+| `provider/` | `terraform-provider-terrapod` — a thin wrapper over go-terrapod. | Go |
+| `migrate/` | `terrapod-migrate` — TFE/HCP + Atlantis migration CLI. | Go |
+| `publish/` | `terrapod-publish` — registry publish CLI (client-signed provider/module uploads). | Go |
+| `helm/terrapod/` | The Helm chart (the only supported deployment mechanism). | YAML |
+| `alembic/` | Async Alembic migrations (hash-based revision IDs). | Python |
+| `docs/` | User + operator documentation. | Markdown |
+
+The four Go modules at the repo root (`go-terrapod/`, `provider/`,
+`migrate/`, `publish/`) each have their own `go.mod` so their dependency
+surfaces stay independent.
+
+## Build, lint, and test
+
+**Everything runs in Docker via `make` — there is no local Python
+environment to set up.**
+
+```sh
+make test          # pytest in Docker (with a Postgres + Redis + S3-emulator stack)
+make lint          # ruff check + format --check in Docker
+make test-down     # tear down the test containers
+make dev           # local Kubernetes dev stack (Tilt)
+make dev-down      # stop the dev stack
+```
+
+Per-surface verification before you push (lint alone is **not** enough):
+
+- **Python** changes → `make test`
+- **Frontend** changes → `npm run build` from `web/` (the Next.js prerender
+  step catches things `tsc` and ESLint cannot)
+- **Helm** changes → `helm template ./helm/terrapod -f helm/terrapod/values-local.yaml`
+- **Go** changes → `go build ./...` + `go test ./...` in the relevant module
+
+## Architecture principles
+
+1. **API-first** — every UI action is backed by a public API endpoint; the
+   V2 API is the contract.
+2. **OpenTofu-friendly** — support both `terraform` and `tofu` as execution
+   backends. Terrapod is the platform, not the engine.
+3. **Postgres + native object storage** — Postgres for relational data;
+   native cloud object storage (S3, Azure Blob, GCS) with a filesystem
+   fallback for dev.
+4. **Kubernetes-native** — deployed exclusively via the Helm chart.
+5. **ARC-pattern execution** — a runner *listener* is a stateless,
+   event-driven thin launcher. It connects to the API over outbound SSE,
+   receives run notifications, creates Kubernetes Jobs, and reports Job
+   metadata back. The listener holds **zero run state**; the API owns the run
+   lifecycle via a periodic reconciler.
+6. **Bring your own auth** — local accounts, OIDC, SAML; no baked-in IdP.
+7. **Modern UX** — the web UI is a first-class concern.
+8. **BFF (Backend For Frontend) — ALL traffic goes through the BFF (hard
+   requirement)** — the Next.js frontend is the single ingress entry point and
+   proxies `/api/*` to the API. The browser never talks to the API directly.
+   Every feature — including SSE and streaming — must work through the full
+   proxy chain. New SSE endpoints must be added to the `headers()` config in
+   `web/next.config.js` with `Content-Encoding: none`, or SSE silently fails
+   through the BFF.
+9. **Single organization (hard requirement)** — Terrapod does **not** support
+   multiple organizations at any level. There is no `org_name` column
+   anywhere. The literal organization name is always `default` — in code,
+   tests, fixtures, docs, and comments. Never use `{org}`, `<org>`,
+   `test-org`, or any placeholder where the organization is referenced.
+10. **RFC3339 timestamps** — all datetimes are timezone-aware UTC; the API
+    always serialises them as RFC3339 with a trailing `Z` (e.g.
+    `2025-01-01T00:00:00Z`), never `+00:00`. Required for `go-tfe`
+    compatibility.
+11. **Multi-replica safe, no leader election** — the API runs with multiple
+    replicas behind a load balancer. All background work uses the distributed
+    scheduler (`services/scheduler.py`), which coordinates via Redis. Never use
+    in-process state (module globals, `asyncio.Event`, in-memory queues) for
+    cross-replica coordination, and never use raw `asyncio.create_task()` for
+    background work.
+12. **Original implementation only** — Terrapod targets API *compatibility*
+    with the public TFE V2 specification, but all implementation code must be
+    entirely original. Referencing the public API docs to understand the
+    contract is expected; copying implementation logic from any HashiCorp
+    proprietary source is not.
+13. **No sync work in async handlers (hard requirement)** — FastAPI + uvicorn
+    runs a single event loop per worker. Any synchronous CPU-heavy or blocking
+    I/O call inside an `async def` handler starves the whole replica. Wrap such
+    calls in `asyncio.to_thread(...)` / `run_in_executor(...)`, or use an
+    async-native alternative (`httpx.AsyncClient`, `aiofiles`,
+    `asyncio.subprocess`, `asyncpg`, `redis.asyncio`). When a plain `def`
+    endpoint genuinely needs sync libraries, prefer `def` — FastAPI runs it in
+    a threadpool for you; that rescue does **not** apply to `async def`.
+
+## The API ↔ Consumer contract (hard)
+
+Terrapod's API has several classes of consumer, each with its own contract.
+**Every API change must update every consumer it affects.**
+
+- **Web UI** (`web/`) — SSR fetches + client `fetch()` calls.
+- **go-terrapod** (`go-terrapod/`) — the canonical Go SDK; the source of
+  truth for the Go-side shape of every resource.
+- **terraform-provider-terrapod** (`provider/`) — imports go-terrapod for
+  every API call; holds only Terraform-plugin-framework code.
+- **terrapod-migrate** (`migrate/`) and **terrapod-publish** (`publish/`) —
+  both import go-terrapod for every Terrapod-side write.
+
+The workflow when extending the API:
+
+1. Add the endpoint to the appropriate router (`/api/v2/` only if it's on the
+   CLI-surface list; otherwise `/api/terrapod/v1/`).
+2. Add a typed method to **go-terrapod** + a test (the shape matches the
+   JSON:API response).
+3. Add the consumer code that needs it (provider resource, frontend page,
+   migration/publish writer).
+
+When a JSON:API attribute name changes, update go-terrapod's struct
+field/tag, the provider's matching attribute, every frontend `fetch` that
+references it, and the migration tool if it touches that field. go-terrapod is
+the single source of truth for the Go-side view; the provider and migration
+tools do not carry their own JSON:API marshaling.
+
+## The Code ↔ Tests contract (hard)
+
+Every code change ships with tests at the right tier(s). **No new endpoint,
+service function, UI surface, SSE event, or hard invariant lands without its
+accompanying tests.**
+
+| Tier | Where | What it exercises | DB / Redis |
+|---|---|---|---|
+| **Unit** | `services/tests/{auth,runner,storage}/`, introspection tests | Pure functions, single-class behaviour, source-introspection invariants | Mocked / none |
+| **Services-API** | `services/tests/{services,api}/` | Handler + service-layer logic with mocked DB/Redis (the bulk of tests) | `AsyncMock` |
+| **Integration** | `services/tests/integration/` | Multi-row workflows needing a real engine (FKs, unique constraints, CASCADE, the run state machine) | Real Postgres |
+| **E2E** | `e2e/tests/*.spec.ts` (Playwright) | Full user flows through the real BFF proxy chain, real DB/Redis, real SSE, real RBAC | Full stack |
+
+Routing rules of thumb:
+
+- A **router** endpoint → a services-API test in `services/tests/api/`
+  (happy path + auth/RBAC + error responses).
+- A **service function** with mockable deps → a services-API test in
+  `services/tests/services/` (`AsyncMock`-driven). Reach for integration only
+  when it depends on Postgres-row-level semantics.
+- A **run state-machine transition** or multi-step lifecycle → an integration
+  test (real DB).
+- A **new SSE event** → (a) a services-API test asserting it's published from
+  the right path, **and** (b) an E2E spec asserting the UI re-renders on
+  receipt without a manual reload.
+- A **new frontend page / RBAC gate / user-facing flow** → an E2E spec. For
+  RBAC, include a **negative-path** spec with a non-admin session asserting the
+  action is blocked. `tsc` + ESLint are necessary but **not** sufficient — the
+  page must actually render in the E2E stack.
+- A **new hard invariant** ("X must never happen") → a source-introspection
+  test that reads the implementation and asserts the absence of the forbidden
+  pattern, so the invariant fails CI loudly if a future change violates it.
+- A **behaviour-changing fix for a reported bug** → a regression test named
+  after the failure mode that fails on the pre-fix code and passes after.
+
+E2E isolation invariants (higher worker/shard counts make violations flaky,
+not deterministic): every test creates its own uniquely-named resources and
+tears them down; never assert global counts or absolute list positions; never
+depend on another spec having run; no fixed `setTimeout` waits — use
+Playwright's auto-waiting.
+
+## Conventions
+
+- **Issue-first** — every change beyond a genuinely trivial tweak (a typo, a
+  one-line comment, a formatting-only change) starts with a GitHub issue, and
+  the PR references it (`closes #N`). The flow is **issue → branch → PR →
+  merge**. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+- **Conventional commits** — `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`,
+  etc.
+- **Branches** — feature branches off `main`; never push directly to `main`;
+  never stack a PR on another open feature branch (always base on `main`).
+- **Namespace package (hard requirement)** — `services/terrapod/__init__.py`
+  must **not** exist. Its absence enables PEP 420 implicit namespace packages
+  so each Docker image can include only the sub-packages it needs.
+- **Migrations** — Alembic with async SQLAlchemy and hash-based revision IDs
+  (generate with `python3 -c "import secrets; print(secrets.token_hex(6))"`),
+  not sequential numbers. Every migration has a real `upgrade()` **and**
+  `downgrade()`.
+- **Substantial API tempfiles go on the attached PVC, not `/tmp`** — on the
+  API pod `/tmp` is RAM-backed. Anything that can hold tens of MB (provider
+  archives, VCS tarballs, state snapshots, config tarballs) must be written to
+  the configured ephemeral PVC dir, not `/tmp`, or it will OOM the pod.
+- **Helm values ↔ schema** — when you add/rename/remove a key in
+  `values.yaml`, update `values.schema.json` to match (it uses
+  `additionalProperties: false`, so `helm lint` fails otherwise), and make
+  sure the template renders it.
+
+## Content hygiene (hard requirements)
+
+These protect the public repository. Git history, PRs, and source are
+world-readable forever.
+
+- **No internal references** — commit messages, PR text, **and source
+  comments / docstrings** must never reference any company, internal
+  hostname, internal repo/project name, internal cluster name, or specific
+  customer/deployment. When describing an issue motivated by a real
+  deployment, anonymise it ("a multi-workspace monorepo with large tarballs"),
+  never name the source. If you catch a leak in your own draft, scrub it
+  before pushing.
+- **Respect peer open-source projects** — peer projects (such as Terrakube)
+  are respected fellow projects, not competitors to disparage. Never denigrate
+  them — not in commits, PRs, comments, docs, issues, release notes, or
+  conversation — and never passive-aggressively. Honest, factual, neutral
+  technical comparison is fine; comparison framed to rank or belittle is not.
+  Position Terrapod on its own merits.
+
+## Where to learn more
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — setup + the contribution workflow.
+- [`docs/`](docs/) — user and operator documentation
+  ([`docs/index.md`](docs/index.md) is the entry point;
+  [`docs/local-development.md`](docs/local-development.md),
+  [`docs/architecture.md`](docs/architecture.md), and
+  [`docs/api-reference.md`](docs/api-reference.md) are good next reads).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contributing to Terrapod
+
+Thanks for your interest in Terrapod! Contributions are genuinely welcome —
+whether you're fixing a typo, filing a well-described bug, or building a whole
+feature. **AI-assisted ("vibe") contributions are welcome too** — if you pair
+with an AI coding assistant, point it at [`AGENTS.md`](AGENTS.md), which
+captures the architecture, contracts, and conventions it needs to produce
+changes that fit.
+
+This guide covers the workflow. For the deeper architecture and the hard
+contract rules, read [`AGENTS.md`](AGENTS.md).
+
+## Start with an issue
+
+**Every change beyond a genuinely trivial tweak starts with a GitHub issue.**
+A trivial tweak is a typo, a one-line comment, or a formatting-only change —
+those can go straight to a PR. Everything else — a feature, a bug fix, a
+refactor, a behaviour change, a new endpoint, a doc set — gets an issue first,
+and the pull request references it (`closes #123`).
+
+Why: it gives every change a searchable, reviewable home, lets us agree on the
+approach before you invest in the code, and keeps the project's history easy
+to follow. We hold ourselves to the same bar — the maintainers open issues for
+their own non-trivial work too.
+
+So the flow is:
+
+```
+issue  →  branch  →  pull request  →  review  →  merge
+```
+
+If you're not sure whether something needs an issue, open one — it costs a
+minute and saves rework.
+
+> Good first contributions: browse issues labelled
+> [`good first issue`](https://github.com/mattrobinsonsre/terrapod/labels/good%20first%20issue)
+> and [`help wanted`](https://github.com/mattrobinsonsre/terrapod/labels/help%20wanted).
+
+## Set up a local environment
+
+Everything builds, lints, and tests **in Docker** — there's no local Python
+environment to install. You'll need Docker and (for the full local stack) a
+local Kubernetes (e.g. Rancher Desktop) plus [Tilt](https://tilt.dev/).
+
+```sh
+make test      # run the test suite in Docker
+make lint      # ruff check + format --check
+make dev       # bring up the full local stack on Kubernetes (Tilt)
+make dev-down   # tear it down
+```
+
+See [`docs/local-development.md`](docs/local-development.md) for the full local
+setup, and [`docs/getting-started.md`](docs/getting-started.md) for a tour of
+the running platform.
+
+## Make your change
+
+The platform core is **Python** (FastAPI + async SQLAlchemy), which keeps the
+contribution barrier low; the consumer ecosystem (the Go SDK, the Terraform
+provider, and the migration/publish CLIs) is **Go**. The repository layout and
+the per-component build commands are in [`AGENTS.md`](AGENTS.md#repository-layout).
+
+Two contracts are worth internalising before you start (both detailed in
+[`AGENTS.md`](AGENTS.md)):
+
+- **API ↔ Consumer** — if you change the API, update every consumer it affects
+  (go-terrapod first, then the provider / frontend / migration tool).
+- **Code ↔ Tests** — every change ships with tests at the right tier (unit /
+  services-api / integration / e2e). A change that alters a user-visible
+  surface or a behaviour the system depends on (state machine, locking, SSE,
+  RBAC) ships its end-to-end coverage in the same PR.
+
+## Verify before you push
+
+Lint passing tells you nothing about whether the build or tests pass. Run the
+check that matches what you changed:
+
+- **Python** → `make test`
+- **Frontend** → `npm run build` from `web/`
+- **Helm** → `helm template ./helm/terrapod -f helm/terrapod/values-local.yaml`
+- **Go** → `go build ./...` and `go test ./...` in the relevant module
+
+## Open the pull request
+
+- Base your branch on `main`; don't stack a PR on another open branch.
+- Reference the issue (`closes #123`).
+- Use [conventional commit](https://www.conventionalcommits.org/) style for the
+  title (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, …).
+- Keep the description honest about what's covered and what isn't (e.g. "UI
+  verified via build, not yet browser-clicked").
+
+CI runs the Python, frontend, Helm, and Go jobs in containers; a gate job
+aggregates the results. A green CI is required to merge.
+
+## A couple of house rules
+
+These keep the public repository clean — please read them, they're firm:
+
+- **No internal references.** The repository is world-readable forever. Don't
+  put company names, private hostnames, internal repo/cluster names, or
+  specific customer/deployment details in commits, PRs, code comments, or docs.
+  Describe real-world motivation in generic shapes ("a multi-workspace
+  monorepo").
+- **Respect peer projects.** Other open-source projects in this space are
+  respected peers, not rivals to put down. Neutral, factual technical
+  comparison is fine; disparagement (even passive-aggressive) is not. Describe
+  what Terrapod does and let it stand on its own merits.
+
+Full detail on both is in [`AGENTS.md`](AGENTS.md#content-hygiene-hard-requirements).
+
+## Maintainers
+
+Terrapod is built and maintained by a small core team with site-reliability
+and platform-engineering backgrounds — it's a platform built by the kind of
+people who operate it. Matt Robinson
+([@mattrobinsonsre](https://github.com/mattrobinsonsre)) currently leads the
+project; [@karl0r](https://github.com/karl0r) and
+[@mhempstock](https://github.com/mhempstock) are maintainers with full access.
+Any maintainer can review and merge; the lead has the final say for now. The
+best way to join the team is to start contributing — we'd love the help.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [GPLv3](LICENSE) license.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 
 > **Policy-as-code with OPA.** Block applies on policy violations using [Open Policy Agent](https://www.openpolicyagent.org/) and the Rego language — the open-source equivalent of TFE's proprietary Sentinel. Policy sets are scoped to workspaces with the same label-based model as roles, evaluated on the runner against the plan JSON, and gated as `advisory` (warn) or `mandatory` (block). See [docs/policies.md](docs/policies.md).
 
+> **Contributions welcome — including AI-assisted ones.** The platform core is **Python** (FastAPI + async SQLAlchemy), which keeps the contribution barrier low; the consumer ecosystem (Go SDK, Terraform provider, migration/publish CLIs) is **Go**. Pairing with an AI coding assistant? Point it at [AGENTS.md](AGENTS.md) — it carries the architecture, contracts, and conventions. Then read [CONTRIBUTING.md](CONTRIBUTING.md) and [open an issue](https://github.com/mattrobinsonsre/terrapod/issues) to get started.
+
 ---
 
 ## Key Features
@@ -294,11 +296,14 @@ make images       # Build production Docker images
 
 ### Conventions
 
+- **Issue-first**: every change beyond a trivial tweak starts with a GitHub issue; the PR references it (`closes #N`)
 - **Commits**: conventional commits (`feat:`, `fix:`, `docs:`, `chore:`)
 - **Branches**: feature branches off `main`; never push directly to `main`
 - **API contract**: JSON:API spec; compatibility tested against `go-tfe` client
 - **Migrations**: Alembic with async SQLAlchemy
 - **Local dev**: Tilt with live_update for Python and Node.js hot reload
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow and [AGENTS.md](AGENTS.md) for the architecture, contracts, and conventions (point your AI assistant at it).
 
 ---
 
@@ -341,16 +346,16 @@ Reports are written to `reports/pentest/`. See [SECURITY.md](SECURITY.md) for th
 **Where Terrakube is ahead of Terrapod:**
 
 - **Multi-organization tenancy** with teams -- Terrapod is single-org by deliberate design.
-- **Maturity**: longer track record, larger community, more permissive (Apache-2.0) license. Terrapod is newer and, today, single-maintainer.
+- **Maturity**: longer track record, larger community, more permissive (Apache-2.0) license. Terrapod is newer and backed by a small core team.
 
 **Where Terrapod is genuinely differentiated** (verified against Terrakube's current docs). The first three share one theme -- Terrapod is built for restricted-network, multi-cluster, low-upstream-dependency topologies:
 
 - **Firewall-friendly cross-cluster execution.** Terrapod runners connect *outbound* to the control plane over SSE and create Jobs locally; the API holds no inbound reach and no Kubernetes access into the execution cluster. Terrakube's API connects *into* the executor (it must be exposed via ingress, with Redis reachable), so isolated / NAT'd / outbound-only execution clusters aren't supported the same way.
 - **Polling-first VCS** -- Terrapod polls VCS over outbound HTTPS (webhooks optional); Terrakube is webhook-only and needs inbound webhook delivery.
-- **Pull-through provider mirror + terraform/tofu binary cache** -- runners have zero direct upstream dependency; Terrakube ships only a local plugin cache.
+- **Pull-through provider mirror + terraform/tofu binary cache** -- runners have zero direct upstream dependency; Terrakube ships a local plugin cache.
 - **Monorepo autodiscovery** -- Atlantis-style auto-creation of workspaces from glob-matched directories on PRs (Terrakube has directory filtering, but not auto-creation).
 - **Run tasks** -- pre/post-plan external webhook validation hooks (not present in Terrakube).
-- **In-platform AI** -- plan summaries, failure analysis, and chat (Terrakube offers only an external MCP server).
+- **In-platform AI** -- plan summaries, failure analysis, and chat (Terrakube integrates AI via an external MCP server).
 - **Native Terragrunt** -- a per-workspace flag wraps agent-mode runs in `terragrunt` (pull-through binary cache, local-backend reconciliation) while Terrapod keeps owning state and the run lifecycle; CLI-driven runs need no config. Something TFE/HCP Terraform never did. See [docs/terragrunt.md](docs/terragrunt.md).
 - Additionally: first-class OPA **policy sets** with mandatory/advisory enforcement, native multi-channel **notifications** (Slack/email/webhook), and cross-workspace **run triggers**.
 
@@ -374,12 +379,26 @@ Terrapod is not affiliated with, endorsed by, or a product of HashiCorp, Inc. or
 
 ## Contributing
 
-Contributions are welcome. Please follow these guidelines:
+Contributions are very welcome — including AI-assisted ("vibe") contributions.
+The platform core is Python, which keeps the contribution barrier low.
 
-1. Fork the repository and create a feature branch from `main`
-2. Follow conventional commit format (`feat:`, `fix:`, `docs:`, `chore:`)
-3. Run tests (`make test`) and linting (`make lint`) before submitting
-4. Ensure all CI checks pass
-5. Open a pull request with a clear description of the change
+The short version: **start with an issue** (every change beyond a trivial tweak
+gets one), branch from `main`, run the checks for what you changed (`make test`
+for Python, `npm run build` for the frontend, `helm template …` for Helm), and
+open a PR that references the issue.
 
-For architecture questions or major changes, open an issue first to discuss the approach.
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — setup, the issue-first workflow, and how to open a PR.
+- **[AGENTS.md](AGENTS.md)** — architecture, the API↔consumer and code↔tests contracts, and conventions. If you use an AI coding assistant, point it here.
+
+Browse [`good first issue`](https://github.com/mattrobinsonsre/terrapod/labels/good%20first%20issue)
+and [`help wanted`](https://github.com/mattrobinsonsre/terrapod/labels/help%20wanted)
+for a place to start.
+
+### Team
+
+Terrapod is built and maintained by a small core team with site-reliability and
+platform-engineering backgrounds — a platform built by the kind of people who
+operate it. [@mattrobinsonsre](https://github.com/mattrobinsonsre) currently
+leads the project; [@karl0r](https://github.com/karl0r) and
+[@mhempstock](https://github.com/mhempstock) are maintainers. We'd welcome more
+hands — start by contributing.


### PR DESCRIPTION
Publishes a committed contributor-onboarding surface to lower the barrier to contribution (including AI-assisted contributions) and to encode the issue-first development discipline publicly.

## What's here

- **`AGENTS.md`** (new) — the public subset of project knowledge for outside contributors and their AI coding assistants: architecture orientation, the API↔consumer and code↔tests contracts, the test tiers + how to run build/lint/test, conventions (issue-first, conventional commits, namespace package, no-sync-in-async, RFC3339-Z, single-org `default`, PVC tempfiles, Helm values↔schema), the hard invariants and "where does X go" routing, and the content-hygiene rules (no internal references; respect peer OSS projects). Authored fresh from public knowledge — no operational/internal content.
- **`CONTRIBUTING.md`** (new) — a welcoming, GitHub-native guide that leads with the **issue-first** workflow (`issue → branch → PR → merge`), local-dev setup, per-surface verify commands, the PR flow, the house rules, and a short Team/Maintainers mention.
- **README** — a prominent hero callout inviting contributions (Python core → low barrier; point your AI assistant at AGENTS.md), an issue-first bullet in Conventions, and a rewritten Contributing + Team section.

## Also in this change

- Corrected a stale **"single-maintainer"** line in the README to "a small core team" (factual accuracy).
- Reworded two peer-comparison bullets in the README to neutral framing (per the peer-respect convention now documented in AGENTS.md): "ships only a local plugin cache" → "ships a local plugin cache"; "offers only an external MCP server" → "integrates AI via an external MCP server".

## Verification

- Docs-only change (no code paths touched).
- Internal-reference scrub run over the staged diff — clean (important, since AGENTS.md is the public counterpart of local guidance).
- All cross-referenced files (`docs/*`, `LICENSE`, `SECURITY.md`) confirmed present.

closes #554

Part of the contribution-accessibility thread in #559.
