### PR TITLE
refactor(auth): shared S256 PKCE helper + document upstream OIDC PKCE

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -91,6 +91,8 @@ Return session token + redirect URL
 
 Terrapod uses [authlib](https://authlib.org/) for OIDC integration. Any standards-compliant OIDC provider works.
 
+Terrapod sends **S256 PKCE** ([RFC 7636](https://www.rfc-editor.org/rfc/rfc7636)) on the upstream authorization request and token exchange, in addition to the client secret. No configuration is required — it is always on, and providers that don't enforce PKCE simply ignore the extra parameters. This makes Terrapod compatible with IdPs that require PKCE on the authorization-code flow even when a client secret is configured (e.g. Pinniped Supervisor).
+
 ### Auth0 Example
 
 ```yaml

--- a/services/terrapod/api/routers/oauth.py
+++ b/services/terrapod/api/routers/oauth.py
@@ -9,8 +9,6 @@ Endpoints:
     POST /oauth/token — exchange auth code for API token
 """
 
-import base64
-import hashlib
 import hmac
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
@@ -24,6 +22,7 @@ from terrapod.auth.auth_state import (
     generate_state,
     store_auth_state,
 )
+from terrapod.auth.pkce import s256_challenge
 from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -198,8 +197,7 @@ def _verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
     if method != "S256":
         return False
 
-    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
-    computed_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    computed_challenge = s256_challenge(code_verifier)
     # Timing-safe — the PKCE challenge is attacker-influenced in the token
     # exchange; match every other secret comparison in the codebase.
     return hmac.compare_digest(computed_challenge, code_challenge)

--- a/services/terrapod/auth/connectors/oidc.py
+++ b/services/terrapod/auth/connectors/oidc.py
@@ -5,8 +5,6 @@ Supports API audience for application-scoped permissions (Auth0, Okta, etc.)
 and /userinfo endpoint for additional claims.
 """
 
-import base64
-import hashlib
 import secrets
 from datetime import UTC, datetime
 from typing import Any
@@ -17,6 +15,7 @@ from authlib.jose import JsonWebKey
 from authlib.jose import jwt as authlib_jwt
 from authlib.jose.errors import JoseError
 
+from terrapod.auth.pkce import s256_challenge
 from terrapod.auth.sso import AuthenticatedIdentity, AuthorizationRequest, SSOConnector
 from terrapod.config import OIDCProviderConfig
 from terrapod.logging_config import get_logger
@@ -27,9 +26,7 @@ logger = get_logger(__name__)
 def _generate_pkce_pair() -> tuple[str, str]:
     """Return (code_verifier, S256 code_challenge) for upstream OIDC PKCE."""
     verifier = secrets.token_urlsafe(64)
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
-    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-    return verifier, challenge
+    return verifier, s256_challenge(verifier)
 
 
 class OIDCConnector(SSOConnector):

--- a/services/terrapod/auth/pkce.py
+++ b/services/terrapod/auth/pkce.py
@@ -1,0 +1,21 @@
+"""Shared PKCE (RFC 7636) S256 helper.
+
+Used on both sides of the auth surface: where Terrapod is the OAuth2 *client*
+(the upstream OIDC connector sending PKCE to the IdP) and where it is the
+*server* (verifying the CLI login's ``code_verifier`` against the stored
+``code_challenge``). Keeping the derivation in one place avoids the two
+implementations drifting.
+"""
+
+import base64
+import hashlib
+
+
+def s256_challenge(verifier: str) -> str:
+    """Return the S256 PKCE ``code_challenge`` for a ``code_verifier``.
+
+    ``base64url(sha256(verifier))`` with trailing ``=`` padding stripped, per
+    RFC 7636 section 4.2.
+    """
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")

--- a/services/tests/auth/test_pkce.py
+++ b/services/tests/auth/test_pkce.py
@@ -1,0 +1,18 @@
+"""Tests for the shared S256 PKCE helper."""
+
+from terrapod.auth.pkce import s256_challenge
+
+
+def test_s256_challenge_rfc7636_vector():
+    # RFC 7636 Appendix B worked example: verifier -> challenge.
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    assert s256_challenge(verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+
+def test_s256_challenge_has_no_padding():
+    # base64url challenge must be sent without '=' padding (RFC 7636 4.2).
+    assert "=" not in s256_challenge("some-verifier-value-12345")
+
+
+def test_s256_challenge_is_deterministic():
+    assert s256_challenge("abc") == s256_challenge("abc")


### PR DESCRIPTION
Follow-up polish on the merged #543 (upstream OIDC PKCE), to land in the same fix release. No behaviour change — same challenge bytes, derived in one place.

## Changes

- **Shared helper** — factor the S256 challenge derivation into `terrapod.auth.pkce.s256_challenge(verifier)`, reused by:
  - `auth/connectors/oidc.py` `_generate_pkce_pair` (Terrapod as OAuth2 *client*, sending PKCE upstream), and
  - `api/routers/oauth.py` `_verify_pkce` (Terrapod as *server*, verifying the CLI login's verifier).
  This removes the duplicated `base64url(sha256(verifier))` logic and the now-unused `base64`/`hashlib` imports in both modules.
- **Test** — `services/tests/auth/test_pkce.py`: RFC 7636 Appendix B worked-example vector + no-padding + determinism.
- **Docs** — `docs/authentication.md` now notes that Terrapod always sends S256 PKCE on the upstream OIDC authorize + token exchange (compatible with PKCE-enforcing IdPs such as Pinniped Supervisor).

## Verification

- No remaining `base64`/`hashlib` references in either module (imports removed cleanly); `py_compile` clean.
- The existing `test_oidc.py` assertions (which recompute the challenge independently) remain valid against the shared helper.

closes #562
