### PR TITLE
fix(runner): retry authoritative plan/apply-result POST to avoid false drift

### DIFF
--- a/services/terrapod/runner/phases/uploads.py
+++ b/services/terrapod/runner/phases/uploads.py
@@ -19,6 +19,7 @@ to inline curl flags or JSON bodies.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import httpx
@@ -83,7 +84,19 @@ def _post_json(
     *,
     timeout_seconds: float = 10.0,
     client: httpx.Client | None = None,
+    retries: int = 0,
+    retry_delay_seconds: float = 3.0,
 ) -> tuple[bool, int | None]:
+    """POST JSON to the API; returns (ok, status_code).
+
+    Set ``retries`` > 0 for the authoritative result POSTs (plan-result /
+    apply-result) whose payload drives a state transition. A transient
+    read-timeout or 5xx must not silently drop the result: a lost
+    plan-result left ``has_changes`` unknown, and the workspace was then
+    conservatively flagged drifted (#565). The server-side landing point
+    (`complete_plan`) is idempotent, so re-POSTing is safe. A 4xx is a
+    definitive answer and is never retried.
+    """
     if not cfg.has_api:
         return False, None
     own_client = client is None
@@ -93,15 +106,37 @@ def _post_json(
             headers={"Authorization": f"Bearer {cfg.auth_token}"} if cfg.auth_token else {},
         )
     try:
-        if body is None:
-            resp = client.post(url)
-        else:
-            resp = client.post(url, json=body)
-        ok = 200 <= resp.status_code < 300
-        return ok, resp.status_code
-    except httpx.RequestError as exc:
-        logger.warning("post request failed", url=url, err=str(exc))
-        return False, None
+        attempt = 0
+        while True:
+            try:
+                if body is None:
+                    resp = client.post(url)
+                else:
+                    resp = client.post(url, json=body)
+                ok = 200 <= resp.status_code < 300
+                # Retry only transient server errors (5xx); 2xx/4xx are final.
+                if ok or resp.status_code < 500 or attempt >= retries:
+                    return ok, resp.status_code
+                logger.warning(
+                    "post non-2xx — retrying",
+                    url=url,
+                    status=resp.status_code,
+                    attempt=attempt + 1,
+                    retries=retries,
+                )
+            except httpx.RequestError as exc:
+                if attempt >= retries:
+                    logger.warning("post request failed", url=url, err=str(exc))
+                    return False, None
+                logger.warning(
+                    "post request failed — retrying",
+                    url=url,
+                    err=str(exc),
+                    attempt=attempt + 1,
+                    retries=retries,
+                )
+            attempt += 1
+            time.sleep(retry_delay_seconds)
     finally:
         if own_client:
             client.close()
@@ -290,11 +325,14 @@ def post_plan_result(
     fallback; this just drives the planning→planned transition faster
     when the runner can reach the API directly."""
     url = f"{cfg.api_url}/api/terrapod/v1/runs/{cfg.run_id}/plan-result"
+    # Authoritative has_changes signal — retry so a transient read-timeout
+    # doesn't leave the run's has_changes unknown and falsely flag drift (#565).
     ok, status = _post_json(
         cfg,
         url,
         body={"has_changes": has_changes},
         client=client,
+        retries=3,
     )
     if not ok:
         logger.warning("plan-result POST failed (non-fatal)", status=status)
@@ -309,7 +347,9 @@ def post_apply_result(
     """Apply phase. Best-effort. Drives applying→applied transition
     without the listener round-trip."""
     url = f"{cfg.api_url}/api/terrapod/v1/runs/{cfg.run_id}/apply-result"
-    ok, status = _post_json(cfg, url, body=None, client=client)
+    # Authoritative apply-completion trigger — retry for the same reason as
+    # plan-result (#565); complete_apply is idempotent.
+    ok, status = _post_json(cfg, url, body=None, client=client, retries=3)
     if not ok:
         logger.warning("apply-result POST failed (non-fatal)", status=status)
     return ok

--- a/services/tests/runner/test_phase_uploads.py
+++ b/services/tests/runner/test_phase_uploads.py
@@ -174,6 +174,34 @@ class TestRunResults:
         # Empty body — apply-result is a side-effect-only POST.
         assert seen_bodies[0] in (b"", b"null", b"{}")
 
+    def test_plan_result_retries_on_read_timeout(self, monkeypatch) -> None:
+        # #565: a transient read-timeout must not drop the authoritative
+        # has_changes signal (which would leave the run unknown → false drift).
+        monkeypatch.setattr(uploads.time, "sleep", lambda *_a, **_k: None)
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ReadTimeout("read timed out", request=request)
+            return httpx.Response(204)
+
+        ok = uploads.post_plan_result(_cfg(), has_changes=False, client=_client(handler))
+        assert ok is True
+        assert calls["n"] == 2  # retried once after the timeout, then succeeded
+
+    def test_plan_result_gives_up_after_retries(self, monkeypatch) -> None:
+        monkeypatch.setattr(uploads.time, "sleep", lambda *_a, **_k: None)
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            raise httpx.ReadTimeout("read timed out", request=request)
+
+        ok = uploads.post_plan_result(_cfg(), has_changes=False, client=_client(handler))
+        assert ok is False
+        assert calls["n"] == 4  # 1 initial attempt + 3 retries, then give up
+
 
 # ── CLI entrypoint ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

A VCS-connected workspace whose drift-detection plan found **no changes** was still flagged `drift_status=drifted`. Root-caused from the run's own logs:

1. tofu's drift plan found no drift (`No changes. Your infrastructure matches the configuration`; runner `plan completed has_changes=False`).
2. The runner POSTs that authoritative result to `/runs/{id}/plan-result`, but it **timed out** (`post request failed err='The read operation timed out'`) — `post_plan_result` → `_post_json` did a single attempt with no retry.
3. `has_changes=False` never reached the API. The reconciler's fallback path then drove `planning → planned` via `complete_plan(has_changes=None)`, leaving `run.has_changes = None`.
4. The drift handler's conservative branch (`has_changes unknown → assume drift`) flipped the workspace to `drifted`. False positive; latent across the fleet whenever the API is momentarily slow.

## Fix

Add bounded **retry + backoff** to `_post_json` and use it for the authoritative result POSTs `post_plan_result` / `post_apply_result` (`retries=3`). A transient read-timeout / 5xx must not silently drop the `has_changes` signal. Safe because:

- the payload is <1 KB;
- the server landing point (`complete_plan` / the apply equivalent) is **idempotent** (`if run.status != "planning": return run`), so re-POSTing can't double-process;
- a 4xx is treated as a final answer and is never retried.

## Tests

`test_phase_uploads.py`:
- `test_plan_result_retries_on_read_timeout` — first attempt raises `ReadTimeout`, retry succeeds (2 attempts, `ok`).
- `test_plan_result_gives_up_after_retries` — always times out → `ok=False` after 1 + 3 attempts.

(`time.sleep` is patched out so the tests don't actually back off.)

## Scope / follow-up

This ships in the `terrapod-runner` image. The deeper follow-up noted in #565 — having the reconciler derive `has_changes` from the uploaded plan JSON when no inline result arrives (robust even if the API is unreachable for the whole retry window) — is intentionally **not** in this PR.

closes #565
