### PR TITLE
feat(db): cloud-IAM database authentication (AWS RDS / GCP Cloud SQL / Azure Entra) (#573)

### DIFF
--- a/docs/cloud-credentials.md
+++ b/docs/cloud-credentials.md
@@ -480,21 +480,101 @@ Workload identity fails closed and the errors are often opaque. The three most c
 
 Terrapod's API connects to PostgreSQL using the connection string in the `TERRAPOD_DATABASE_URL` environment variable (sourced from a K8s Secret — see [External secret managers](#external-secret-managers-vault-via-eso--vault-agent)).
 
-### Cloud IAM database auth is not practical today (honest gap)
+The auth mode is selected by `api.config.database.auth_mode`. Besides the default static password, every major cloud's managed-PostgreSQL IAM auth is supported — Terrapod mints a short-lived token **per connection** under the API pod's workload identity (the same IRSA / WIF / WI used for object storage), so there is **no static database password**:
 
-Cloud-IAM database authentication — **AWS RDS IAM auth**, **GCP Cloud SQL IAM auth**, and **Azure AD authentication for PostgreSQL** — works by using a short-lived (~15-minute) IAM-issued token *as the database password*. That token must be refreshed before it expires, on every new connection.
+| Mode | What it does | Identity |
+|---|---|---|
+| `password` (default) | The static password embedded in `TERRAPOD_DATABASE_URL`. Fully supported; recommended to source the Secret from a manager (below). | — |
+| `aws_iam` | **AWS RDS IAM auth** — a short-lived (~15-min) IAM token, signed locally per connection. | IRSA |
+| `gcp_iam` | **GCP Cloud SQL IAM auth** — the service account's OAuth2 access token as the DB password. | Workload Identity Federation |
+| `azure_ad` | **Azure Database for PostgreSQL — Microsoft Entra auth** — an Entra access token as the DB password. | Azure Workload Identity |
 
-Terrapod does **not** support this today. The API builds its SQLAlchemy engine **once at startup** from a static `database_url` read from the environment, and there is **no in-process token-refresh hook** on the connection pool. An IAM auth token supplied as the DB password would expire after ~15 minutes and the pool could not mint a fresh one without a pod restart — so the connection would break. Do not configure RDS IAM auth / Cloud SQL IAM auth / Azure AD DB auth against the current release; it will fail once the first token expires.
+In every IAM mode the DB URL carries the **user but no password** (the token is the password), and **TLS is required** (forced to at least `require`; set `ssl_mode: verify-full` for cert verification). The credential libraries cache and refresh tokens near expiry, so the per-connection hook is a fast cached read in steady state. Existing connections persist after a token expires (the token only authenticates the initial handshake), so a fresh token per *new* connection is all that's needed.
 
-### Recommended pattern instead
+### AWS RDS IAM auth (`auth_mode: aws_iam`)
+
+Setup:
+
+1. **Enable IAM auth on the RDS instance** and create the database role as an IAM-authenticated user:
+   ```sql
+   CREATE USER terrapod;
+   GRANT rds_iam TO terrapod;
+   ```
+2. **Grant the API's IRSA role `rds-db:connect`** on that DB user (in addition to its object-storage permissions):
+   ```json
+   {
+     "Effect": "Allow",
+     "Action": "rds-db:connect",
+     "Resource": "arn:aws:rds-db:us-east-1:123456789012:dbuser:db-ABCDEFGHIJKL/terrapod"
+   }
+   ```
+3. **Point the DB URL at the user with no password** (the token is the password) and select the mode. TLS is required for IAM auth and is forced on:
+   ```yaml
+   api:
+     config:
+       database:
+         auth_mode: aws_iam
+         aws_iam_region: ""        # "" = AWS_REGION env (set by IRSA)
+         ssl_mode: verify-full     # require | verify-ca | verify-full (recommended)
+   ```
+   ```
+   # TERRAPOD_DATABASE_URL — user + host, NO password
+   postgresql+asyncpg://terrapod@my-db.abcdef.us-east-1.rds.amazonaws.com:5432/terrapod
+   ```
+
+If the API logs `Database auth: cloud IAM (per-connection token)` at startup and a `SELECT 1` succeeds, it's working. A `PAM authentication failed` / `password authentication failed` error usually means the `rds_iam` grant or the `rds-db:connect` IAM policy resource ARN (DBI resource id + user) doesn't match.
+
+### GCP Cloud SQL IAM auth (`auth_mode: gcp_iam`)
+
+On Cloud SQL for PostgreSQL with IAM authentication enabled, Terrapod uses the API service account's OAuth2 access token (scope `https://www.googleapis.com/auth/sqlservice.login`) as the DB password, refreshed per connection via Application Default Credentials.
+
+Setup:
+
+1. **Enable IAM authentication** on the Cloud SQL instance (`cloudsql.iam_authentication = on`) and add the API's GCP service account as an [IAM database user](https://cloud.google.com/sql/docs/postgres/add-manage-iam-users) — the DB user is the SA email **without** the `.gserviceaccount.com` suffix.
+2. **Grant the SA** the role `roles/cloudsql.instanceUser` (the `cloudsql.instances.login` permission) plus `roles/cloudsql.client`.
+3. **Bind the API's K8s ServiceAccount to that GCP SA via Workload Identity Federation** (the same WIF binding used for GCS — see [GCP](#gcp-workload-identity-federation)).
+4. **Configure the mode** (the DB host is the instance's private IP or a Cloud SQL Auth Proxy sidecar; the user is the truncated SA email, no password):
+   ```yaml
+   api:
+     config:
+       database:
+         auth_mode: gcp_iam
+         ssl_mode: verify-ca        # require | verify-ca | verify-full
+   ```
+   ```
+   # TERRAPOD_DATABASE_URL — IAM DB user (SA email minus the gserviceaccount suffix), NO password
+   postgresql+asyncpg://terrapod-api%40my-project.iam@10.20.0.5:5432/terrapod
+   ```
+
+### Azure Database for PostgreSQL — Microsoft Entra auth (`auth_mode: azure_ad`)
+
+On Azure Database for PostgreSQL (Flexible Server) with Microsoft Entra authentication, Terrapod mints an Entra access token (scope `https://ossrdbms-aad.database.windows.net/.default`) per connection via `DefaultAzureCredential`, using the pod's Azure Workload Identity.
+
+Setup:
+
+1. **Enable Microsoft Entra authentication** on the Flexible Server and set an Entra admin.
+2. **Create a PostgreSQL role for the API's managed identity** — as the Entra admin, run `SELECT * FROM pgaadauth_create_principal('terrapod-api', false, false);` — the DB user is the managed identity's name.
+3. **Bind the API's K8s ServiceAccount to the user-assigned managed identity via Azure Workload Identity** (the same binding used for Blob storage — see [Azure](#azure-workload-identity)); the pod needs the `azure.workload.identity/use: "true"` label.
+4. **Configure the mode** (the user is the managed identity's name; the token is the password):
+   ```yaml
+   api:
+     config:
+       database:
+         auth_mode: azure_ad
+         ssl_mode: require          # Azure requires TLS
+   ```
+   ```
+   # TERRAPOD_DATABASE_URL — Entra DB user, NO password
+   postgresql+asyncpg://terrapod-api@my-server.postgres.database.azure.com:5432/terrapod
+   ```
+
+### Recommended pattern for `auth_mode: password`
 
 Use a **strong static database password**, but keep it out of source and rotate it operationally:
 
 1. Generate a strong password and store it in a K8s Secret (the chart reads `TERRAPOD_DATABASE_URL` via `secretKeyRef` when `postgresql.existingSecret` is set).
 2. Optionally source that Secret from an external secret manager at deploy time — see [External secret managers](#external-secret-managers-vault-via-eso--vault-agent). External Secrets Operator with a Vault backend can render the DB URL Secret from a Vault path, so the password never lives in your Helm values or Git.
 3. Rely on the cloud database's **encryption at rest** (RDS encryption, Cloud SQL encryption, Azure Database encryption) and **network isolation** (private subnets / VPC peering / private endpoints, security groups) so the connection is never exposed publicly.
-
-> **Future enhancement (not available now):** native in-process IAM database auth — a per-connection token provider that mints and refreshes the IAM token on each new pooled connection — is tracked in [#573](https://github.com/mattrobinsonsre/terrapod/issues/573). It is not in the current release. This section will be updated if and when it lands.
 
 ---
 

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -36,6 +36,9 @@ data:
       pool_timeout: {{ .Values.api.config.database.pool_timeout | default 30 }}
       connect_timeout: {{ .Values.api.config.database.connect_timeout | default 10 }}
       command_timeout: {{ .Values.api.config.database.command_timeout | default 30 }}
+      auth_mode: {{ .Values.api.config.database.auth_mode | default "password" | quote }}
+      aws_iam_region: {{ .Values.api.config.database.aws_iam_region | default "" | quote }}
+      ssl_mode: {{ .Values.api.config.database.ssl_mode | default "" | quote }}
     {{- end }}
     storage:
       backend: {{ .Values.api.config.storage.backend | quote }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -448,7 +448,10 @@
             "pool_recycle": { "type": "integer", "minimum": -1 },
             "pool_timeout": { "type": "integer", "minimum": 0 },
             "connect_timeout": { "type": "integer", "minimum": 1 },
-            "command_timeout": { "type": "integer", "minimum": 1 }
+            "command_timeout": { "type": "integer", "minimum": 1 },
+            "auth_mode": { "type": "string", "enum": ["password", "aws_iam", "gcp_iam", "azure_ad"] },
+            "aws_iam_region": { "type": "string" },
+            "ssl_mode": { "type": "string" }
           }
         },
         "default_execution_backend": {

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -120,6 +120,15 @@ api:
       pool_timeout: 30         # Seconds to wait for a pool connection
       connect_timeout: 10      # TCP connect timeout in seconds
       command_timeout: 30      # Query timeout in seconds
+      # DB auth (#573): "password" (default — static creds in the DB URL) or a
+      # cloud-IAM mode that mints a short-lived token per connection under the
+      # API's workload identity (no static DB password, TLS required):
+      #   aws_iam   — AWS RDS IAM (IRSA)
+      #   gcp_iam   — GCP Cloud SQL IAM (Workload Identity Federation)
+      #   azure_ad  — Azure Database for PostgreSQL Entra auth (Azure Workload Identity)
+      auth_mode: password
+      aws_iam_region: ""       # AWS region for RDS IAM signing ("" = AWS_REGION env); aws_iam only
+      ssl_mode: ""             # asyncpg TLS mode; forced to >= "require" for any IAM mode
 
     # Default execution backend and version for new workspaces
     default_execution_backend: tofu  # tofu | terraform

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -1001,6 +1001,33 @@ class DatabaseConfig(BaseModel):
         default=30,
         description="Seconds to wait for a query to complete",
     )
+    # --- Authentication mode (#573) ---
+    auth_mode: Literal["password", "aws_iam", "gcp_iam", "azure_ad"] = Field(
+        default="password",
+        description=(
+            "Database authentication. 'password' (default) uses the static "
+            "password in database_url — the existing, fully-supported behaviour. "
+            "The cloud-IAM modes mint a short-lived token per connection under the "
+            "API pod's workload identity — no static DB password, TLS required: "
+            "'aws_iam' (AWS RDS IAM, IRSA), 'gcp_iam' (GCP Cloud SQL IAM, WIF), "
+            "'azure_ad' (Azure Database for PostgreSQL Entra auth, Azure WI)."
+        ),
+    )
+    aws_iam_region: str = Field(
+        default="",
+        description=(
+            "AWS region used to sign RDS IAM auth tokens. Empty = botocore default "
+            "resolution (AWS_REGION / AWS_DEFAULT_REGION, set by IRSA). Only used "
+            "when auth_mode='aws_iam'."
+        ),
+    )
+    ssl_mode: str = Field(
+        default="",
+        description=(
+            "asyncpg TLS mode (e.g. 'require', 'verify-full'). Empty = driver "
+            "default. Forced to at least 'require' when auth_mode='aws_iam'."
+        ),
+    )
 
 
 # --- Main Settings ---

--- a/services/terrapod/db/iam_auth.py
+++ b/services/terrapod/db/iam_auth.py
@@ -1,0 +1,152 @@
+"""Cloud-IAM database authentication (#573).
+
+Opt-in via ``database.auth_mode`` in ``{aws_iam, gcp_iam, azure_ad}``. Each new
+pooled connection authenticates with a freshly-minted, short-lived token instead
+of a static password, under the API pod's **workload identity** (AWS IRSA / GCP
+WIF / Azure WI) — so there is no static database password and no static cloud
+credential anywhere:
+
+- ``aws_iam``  — AWS RDS IAM auth token (botocore ``generate_db_auth_token``,
+  local SigV4 signing).
+- ``gcp_iam``  — GCP Cloud SQL IAM: the service account's OAuth2 access token
+  (google-auth Application Default Credentials / Workload Identity Federation).
+- ``azure_ad`` — Azure Database for PostgreSQL Microsoft Entra auth: an Entra
+  access token for the ``ossrdbms`` scope (azure-identity
+  ``DefaultAzureCredential``).
+
+In every case the token is the database **password**, supplied per connection
+via a SQLAlchemy ``do_connect`` event (which also forces TLS). RDS/Cloud SQL/Entra
+tokens authenticate at connect time and existing connections persist after the
+token expires, so a fresh token per *new* connection is sufficient — no
+pool-recycle clamp is needed.
+
+The credential libraries cache tokens and refresh only near expiry, so the
+handler is a fast cached read in steady state (the periodic refresh is the only
+network call, ~hourly). The default ``auth_mode = "password"`` (static
+credentials from ``database_url``) is unchanged and remains fully supported;
+nothing in this module runs unless an IAM mode is explicitly selected.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from urllib.parse import urlsplit
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# All cloud IAM DB auth mandates TLS; this is the minimum if none was configured.
+_DEFAULT_SSL_MODE = "require"
+
+# GCP OAuth2 scope for Cloud SQL IAM login; Azure Entra scope for OSS RDBMS.
+_GCP_LOGIN_SCOPE = "https://www.googleapis.com/auth/sqlservice.login"
+_AZURE_PG_SCOPE = "https://ossrdbms-aad.database.windows.net/.default"
+
+_lock = threading.Lock()
+_aws_clients: dict[str, object] = {}
+_gcp_state: dict[str, object] = {}
+_azure_state: dict[str, object] = {}
+
+
+def parse_pg_target(database_url: str) -> tuple[str, int, str]:
+    """Extract ``(host, port, user)`` from a ``postgresql[+asyncpg]://`` URL."""
+    parts = urlsplit(str(database_url))
+    return (parts.hostname or ""), (parts.port or 5432), (parts.username or "")
+
+
+# ── AWS RDS IAM ───────────────────────────────────────────────────────
+
+
+def _aws_rds_client(region: str):
+    key = region or "default"
+    client = _aws_clients.get(key)
+    if client is None:
+        with _lock:
+            client = _aws_clients.get(key)
+            if client is None:
+                import botocore.session
+
+                client = botocore.session.get_session().create_client(
+                    "rds", region_name=region or None
+                )
+                _aws_clients[key] = client
+    return client
+
+
+def mint_aws_rds_token(*, host: str, port: int, user: str, region: str) -> str:
+    """Short-lived AWS RDS IAM auth token (local SigV4 signing, no I/O)."""
+    return _aws_rds_client(region).generate_db_auth_token(  # type: ignore[attr-defined]
+        DBHostname=host, Port=port, DBUsername=user, Region=region or None
+    )
+
+
+# ── GCP Cloud SQL IAM ─────────────────────────────────────────────────
+
+
+def mint_gcp_access_token() -> str:
+    """OAuth2 access token for the SA (Cloud SQL IAM login); cached + refreshed."""
+    import google.auth
+    import google.auth.transport.requests
+
+    creds = _gcp_state.get("creds")
+    if creds is None:
+        with _lock:
+            creds = _gcp_state.get("creds")
+            if creds is None:
+                creds, _ = google.auth.default(scopes=[_GCP_LOGIN_SCOPE])
+                _gcp_state["creds"] = creds
+                _gcp_state["request"] = google.auth.transport.requests.Request()
+    if not creds.valid:  # type: ignore[union-attr]
+        creds.refresh(_gcp_state["request"])  # type: ignore[union-attr]
+    return creds.token  # type: ignore[union-attr]
+
+
+# ── Azure Database for PostgreSQL (Entra) ─────────────────────────────
+
+
+def mint_azure_ad_token() -> str:
+    """Microsoft Entra access token for Azure Database for PostgreSQL."""
+    cred = _azure_state.get("cred")
+    if cred is None:
+        with _lock:
+            cred = _azure_state.get("cred")
+            if cred is None:
+                from azure.identity import DefaultAzureCredential
+
+                cred = DefaultAzureCredential()
+                _azure_state["cred"] = cred
+    return cred.get_token(_AZURE_PG_SCOPE).token  # type: ignore[union-attr]
+
+
+# ── do_connect dispatch ───────────────────────────────────────────────
+
+
+def make_do_connect_handler(
+    *, auth_mode: str, host: str, port: int, user: str, region: str, ssl_mode: str
+) -> Callable[..., None]:
+    """Build the SQLAlchemy ``do_connect`` listener for the chosen IAM mode.
+
+    The handler mints a fresh token and sets it as the asyncpg ``password``
+    (overriding whatever the URL had), and forces TLS.
+    """
+    ssl_value = ssl_mode or _DEFAULT_SSL_MODE
+
+    if auth_mode == "aws_iam":
+
+        def _mint() -> str:
+            return mint_aws_rds_token(host=host, port=port, user=user, region=region)
+
+    elif auth_mode == "gcp_iam":
+        _mint = mint_gcp_access_token
+    elif auth_mode == "azure_ad":
+        _mint = mint_azure_ad_token
+    else:
+        raise ValueError(f"unsupported IAM database auth_mode: {auth_mode!r}")
+
+    def _do_connect(_dialect, _conn_rec, _cargs, cparams: dict) -> None:
+        cparams["password"] = _mint()
+        cparams["ssl"] = ssl_value
+
+    return _do_connect

--- a/services/terrapod/db/session.py
+++ b/services/terrapod/db/session.py
@@ -8,7 +8,7 @@ Single engine (no read replica for MVP).
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from terrapod.config import settings
@@ -40,6 +40,32 @@ async def init_db() -> None:
             "command_timeout": db_cfg.command_timeout,
         },
     )
+
+    # Cloud-IAM DB auth (#573, opt-in): mint a fresh short-lived token per new
+    # connection via a do_connect listener, overriding the (absent) static
+    # password and forcing TLS. Default auth_mode="password" leaves this untouched.
+    if db_cfg.auth_mode in ("aws_iam", "gcp_iam", "azure_ad"):
+        from terrapod.db import iam_auth
+
+        host, port, user = iam_auth.parse_pg_target(settings.database_url)
+        event.listen(
+            _engine.sync_engine,
+            "do_connect",
+            iam_auth.make_do_connect_handler(
+                auth_mode=db_cfg.auth_mode,
+                host=host,
+                port=port,
+                user=user,
+                region=db_cfg.aws_iam_region,
+                ssl_mode=db_cfg.ssl_mode,
+            ),
+        )
+        logger.info(
+            "Database auth: cloud IAM (per-connection token)",
+            mode=db_cfg.auth_mode,
+            host=host,
+            user=user,
+        )
 
     _async_session_factory = async_sessionmaker(
         _engine,

--- a/services/tests/test_db_iam_auth.py
+++ b/services/tests/test_db_iam_auth.py
@@ -1,0 +1,113 @@
+"""Tests for cloud-IAM database auth (#573) — AWS RDS IAM, GCP Cloud SQL IAM,
+Azure Entra.
+
+The live connection path per cloud can only be validated against a real
+IAM-enabled database (a staging smoke); these tests cover the unit logic — token
+minting per cloud, target parsing, and the do_connect handler that injects the
+token + TLS and dispatches by mode — and guard that the default stays
+static-password auth.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from terrapod.config import DatabaseConfig
+from terrapod.db import iam_auth
+
+
+def test_auth_mode_defaults_to_password_static():
+    # Static-password auth must remain the default + fully supported.
+    assert DatabaseConfig().auth_mode == "password"
+
+
+def test_parse_pg_target():
+    h, p, u = iam_auth.parse_pg_target("postgresql+asyncpg://terrapod@db.example.com:5432/terrapod")
+    assert (h, p, u) == ("db.example.com", 5432, "terrapod")
+
+
+def test_parse_pg_target_defaults_port_5432():
+    h, p, u = iam_auth.parse_pg_target("postgresql+asyncpg://u@host/db")
+    assert (h, p, u) == ("host", 5432, "u")
+
+
+def test_mint_aws_rds_token_calls_botocore(monkeypatch):
+    mock_client = MagicMock()
+    mock_client.generate_db_auth_token.return_value = "AWS_TOKEN"
+    monkeypatch.setattr(iam_auth, "_aws_rds_client", lambda region: mock_client)
+
+    tok = iam_auth.mint_aws_rds_token(host="h", port=5432, user="u", region="us-east-1")
+
+    assert tok == "AWS_TOKEN"
+    mock_client.generate_db_auth_token.assert_called_once_with(
+        DBHostname="h", Port=5432, DBUsername="u", Region="us-east-1"
+    )
+
+
+# ── do_connect dispatch per mode ──────────────────────────────────────
+
+
+def test_do_connect_aws_injects_token_and_tls(monkeypatch):
+    monkeypatch.setattr(iam_auth, "mint_aws_rds_token", lambda **_kw: "AWS")
+    handler = iam_auth.make_do_connect_handler(
+        auth_mode="aws_iam", host="h", port=5432, user="u", region="r", ssl_mode=""
+    )
+    cparams = {"password": "dummy"}
+    handler(None, None, None, cparams)
+    assert cparams["password"] == "AWS"  # overrides the URL value
+    assert cparams["ssl"] == "require"  # TLS forced
+
+
+def test_do_connect_gcp_uses_access_token(monkeypatch):
+    monkeypatch.setattr(iam_auth, "mint_gcp_access_token", lambda: "GCP")
+    handler = iam_auth.make_do_connect_handler(
+        auth_mode="gcp_iam", host="h", port=5432, user="u", region="", ssl_mode="verify-ca"
+    )
+    cparams: dict = {}
+    handler(None, None, None, cparams)
+    assert cparams["password"] == "GCP"
+    assert cparams["ssl"] == "verify-ca"
+
+
+def test_do_connect_azure_uses_entra_token(monkeypatch):
+    monkeypatch.setattr(iam_auth, "mint_azure_ad_token", lambda: "AZURE")
+    handler = iam_auth.make_do_connect_handler(
+        auth_mode="azure_ad", host="h", port=5432, user="u", region="", ssl_mode=""
+    )
+    cparams: dict = {}
+    handler(None, None, None, cparams)
+    assert cparams["password"] == "AZURE"
+    assert cparams["ssl"] == "require"
+
+
+def test_do_connect_honors_explicit_ssl_mode(monkeypatch):
+    monkeypatch.setattr(iam_auth, "mint_aws_rds_token", lambda **_kw: "T")
+    handler = iam_auth.make_do_connect_handler(
+        auth_mode="aws_iam", host="h", port=5432, user="u", region="r", ssl_mode="verify-full"
+    )
+    cparams: dict = {}
+    handler(None, None, None, cparams)
+    assert cparams["ssl"] == "verify-full"
+
+
+def test_do_connect_mints_fresh_token_each_connection(monkeypatch):
+    tokens = iter(["t1", "t2"])
+    monkeypatch.setattr(iam_auth, "mint_aws_rds_token", lambda **_kw: next(tokens))
+    handler = iam_auth.make_do_connect_handler(
+        auth_mode="aws_iam", host="h", port=5432, user="u", region="r", ssl_mode=""
+    )
+    c1: dict = {}
+    c2: dict = {}
+    handler(None, None, None, c1)
+    handler(None, None, None, c2)
+    assert c1["password"] == "t1"
+    assert c2["password"] == "t2"
+
+
+def test_unsupported_mode_raises():
+    with pytest.raises(ValueError, match="unsupported IAM"):
+        iam_auth.make_do_connect_handler(
+            auth_mode="nope", host="h", port=5432, user="u", region="", ssl_mode=""
+        )


### PR DESCRIPTION
Closes #573.

Adds opt-in **passwordless database authentication** for the platform Postgres connection, using the API pod's existing cloud workload identity — so no static DB password lives anywhere. Static-password auth stays the default and is fully unchanged.

## What

A new `api.config.database.auth_mode` selects the mode:

| Mode | What it does | Identity |
|---|---|---|
| `password` (default) | Static password from `TERRAPOD_DATABASE_URL` — unchanged | — |
| `aws_iam` | AWS RDS IAM auth token (botocore `generate_db_auth_token`, local SigV4 signing) | IRSA |
| `gcp_iam` | GCP Cloud SQL IAM — the SA's OAuth2 access token (`sqlservice.login` scope) | WIF |
| `azure_ad` | Azure Database for PostgreSQL Microsoft Entra token (`ossrdbms` scope) | Azure WI |

In every IAM mode a freshly-minted, short-lived token is injected as the asyncpg `password` per **new** connection via a SQLAlchemy `do_connect` event, which also **forces TLS** (`ssl_mode`, minimum `require`). The DB URL carries the user but no password.

## Why per-connection is sufficient

IAM/Entra tokens authenticate only at connect time; existing connections persist after the token expires. So a fresh token per *new* connection covers it — no `pool_recycle` clamp needed. The credential libraries cache tokens and refresh near expiry, so steady-state is a cached read (the periodic refresh is the only network call). The token-minting libs are already transitive deps (botocore via aioboto3, google-auth via google-cloud-storage, azure-identity).

## Testing

- Unit tests cover token minting per cloud, target parsing, the `do_connect` dispatch per mode + TLS forcing, the unsupported-mode guard, and a guard that the default stays `password`.
- **CI cannot exercise real cloud IAM DB auth** — the live RDS / Cloud SQL / Azure-DB connection is a staging smoke (validated against a real IAM-enabled instance before relying on it in production).

## Scope note

This covers the three managed-Postgres **IAM** mechanisms. Other passwordless approaches (Vault dynamic DB credentials, mTLS client certs) remain reachable today via the existing Secret-sourced `password` mode (see `docs/cloud-credentials.md` → external secret managers) and are out of scope here.

## Files

- New: `services/terrapod/db/iam_auth.py`, `services/tests/test_db_iam_auth.py`
- `config.py`: `DatabaseConfig.auth_mode` / `aws_iam_region` / `ssl_mode`
- `db/session.py`: register the `do_connect` listener when an IAM mode is selected
- Helm: `database.auth_mode` / `aws_iam_region` / `ssl_mode` (values + schema + configmap)
- Docs: per-CSP setup in `cloud-credentials.md`