### PR TITLE
fix(db): harden cloud-IAM DB auth — TLS verification, event-loop safety, first-class CA

### DIFF
--- a/docs/cloud-credentials.md
+++ b/docs/cloud-credentials.md
@@ -489,7 +489,37 @@ The auth mode is selected by `api.config.database.auth_mode`. Besides the defaul
 | `gcp_iam` | **GCP Cloud SQL IAM auth** — the service account's OAuth2 access token as the DB password. | Workload Identity Federation |
 | `azure_ad` | **Azure Database for PostgreSQL — Microsoft Entra auth** — an Entra access token as the DB password. | Azure Workload Identity |
 
-In every IAM mode the DB URL carries the **user but no password** (the token is the password), and **TLS is required** (forced to at least `require`; set `ssl_mode: verify-full` for cert verification). The credential libraries cache and refresh tokens near expiry, so the per-connection hook is a fast cached read in steady state. Existing connections persist after a token expires (the token only authenticates the initial handshake), so a fresh token per *new* connection is all that's needed.
+In every IAM mode the DB URL carries the **user but no password** (the token is the password), and **TLS is always on**. The credential libraries cache and refresh tokens near expiry; minting is offloaded to a worker thread so it never blocks the API event loop, and a fresh token is supplied per *new* connection. Existing connections persist after a token expires (the token only authenticates the initial handshake).
+
+#### TLS modes (`ssl_mode` + `ssl_root_cert`)
+
+All IAM modes encrypt the connection. `ssl_mode` controls server-certificate verification:
+
+| `ssl_mode` | Behaviour | Needs `ssl_root_cert`? |
+|---|---|---|
+| `` / `require` (default) | Encrypt, but do **not** verify the server certificate. | No |
+| `verify-ca` | Verify the server cert chains to a trusted CA. | Yes (unless the CA is in the system trust store) |
+| `verify-full` | `verify-ca` **plus** hostname match — recommended. | Yes (unless system-trusted) |
+
+`verify-ca`/`verify-full` need the provider's CA bundle (e.g. the AWS RDS [`global-bundle.pem`](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) or the Cloud SQL server CA). A CA bundle is **public, non-secret** material, so the chart takes it as a ConfigMap via the first-class `api.databaseCA` block — paste it inline (the chart creates the ConfigMap) or reference an existing one. The chart mounts it read-only and wires `database.ssl_root_cert` to the mounted path automatically:
+
+```yaml
+api:
+  databaseCA:
+    # Option 1 — paste the CA inline; the chart creates the ConfigMap:
+    inline: |
+      -----BEGIN CERTIFICATE-----
+      ...the RDS / Cloud SQL CA bundle...
+      -----END CERTIFICATE-----
+    # Option 2 — reference an existing ConfigMap instead of `inline`:
+    #   existingConfigMap: rds-ca-bundle
+    key: ca.pem            # filename to mount (and the ConfigMap key)
+  config:
+    database:
+      ssl_mode: verify-full   # ssl_root_cert is set for you from api.databaseCA
+```
+
+If neither `ssl_root_cert` nor `api.databaseCA` is set, the system CA trust store is used — sufficient for providers whose server cert chains to a public root (e.g. Azure's DigiCert root), but AWS RDS and Cloud SQL use private CAs, so supply the bundle. (Operators with an existing mounting convention can instead set `database.ssl_root_cert` to a path they mount via `api.extraVolumes`; `api.databaseCA` is the recommended path.)
 
 ### AWS RDS IAM auth (`auth_mode: aws_iam`)
 
@@ -515,7 +545,8 @@ Setup:
        database:
          auth_mode: aws_iam
          aws_iam_region: ""        # "" = AWS_REGION env (set by IRSA)
-         ssl_mode: verify-full     # require | verify-ca | verify-full (recommended)
+         ssl_mode: verify-full     # recommended; needs the RDS CA bundle (see TLS modes above)
+         ssl_root_cert: /etc/db-ca/global-bundle.pem
    ```
    ```
    # TERRAPOD_DATABASE_URL — user + host, NO password
@@ -539,7 +570,8 @@ Setup:
      config:
        database:
          auth_mode: gcp_iam
-         ssl_mode: verify-ca        # require | verify-ca | verify-full
+         ssl_mode: verify-ca        # needs the Cloud SQL server CA (see TLS modes above)
+         ssl_root_cert: /etc/db-ca/server-ca.pem
    ```
    ```
    # TERRAPOD_DATABASE_URL — IAM DB user (SA email minus the gserviceaccount suffix), NO password

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -39,6 +39,11 @@ data:
       auth_mode: {{ .Values.api.config.database.auth_mode | default "password" | quote }}
       aws_iam_region: {{ .Values.api.config.database.aws_iam_region | default "" | quote }}
       ssl_mode: {{ .Values.api.config.database.ssl_mode | default "" | quote }}
+      {{- if or .Values.api.databaseCA.inline .Values.api.databaseCA.existingConfigMap }}
+      ssl_root_cert: {{ printf "/etc/terrapod/db-ca/%s" (.Values.api.databaseCA.key | default "ca.pem") | quote }}
+      {{- else }}
+      ssl_root_cert: {{ .Values.api.config.database.ssl_root_cert | default "" | quote }}
+      {{- end }}
     {{- end }}
     storage:
       backend: {{ .Values.api.config.storage.backend | quote }}

--- a/helm/terrapod/templates/configmap-database-ca.yaml
+++ b/helm/terrapod/templates/configmap-database-ca.yaml
@@ -1,0 +1,19 @@
+{{- /*
+Database TLS CA bundle (public, non-secret) for cloud-IAM DB auth verify-ca/
+verify-full. Rendered only when api.databaseCA.inline is provided; an
+existingConfigMap is referenced directly instead. The API Deployment mounts this
+at /etc/terrapod/db-ca and the API ConfigMap derives database.ssl_root_cert from
+the mounted path.
+*/ -}}
+{{- if and .Values.api.enabled .Values.api.databaseCA.inline }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "terrapod.fullname" . }}-database-ca
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+data:
+  {{ .Values.api.databaseCA.key | default "ca.pem" }}: |
+{{ .Values.api.databaseCA.inline | indent 4 }}
+{{- end }}

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -136,6 +136,11 @@ spec:
             - name: storage
               mountPath: {{ .Values.api.config.storage.filesystem.root_dir }}
             {{- end }}
+            {{- if or .Values.api.databaseCA.inline .Values.api.databaseCA.existingConfigMap }}
+            - name: database-ca
+              mountPath: /etc/terrapod/db-ca
+              readOnly: true
+            {{- end }}
             {{- with .Values.api.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -207,6 +212,11 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
+        {{- if or .Values.api.databaseCA.inline .Values.api.databaseCA.existingConfigMap }}
+        - name: database-ca
+          configMap:
+            name: {{ .Values.api.databaseCA.existingConfigMap | default (printf "%s-database-ca" (include "terrapod.fullname" .)) }}
         {{- end }}
         {{- with .Values.api.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -44,6 +44,15 @@
             "existingSecretKey": { "type": "string" }
           }
         },
+        "databaseCA": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "inline": { "type": "string" },
+            "existingConfigMap": { "type": "string" },
+            "key": { "type": "string" }
+          }
+        },
         "strategy": { "$ref": "#/$defs/strategySpec" },
         "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
         "preStopSleepSeconds": { "type": "integer", "minimum": 0 },
@@ -451,7 +460,8 @@
             "command_timeout": { "type": "integer", "minimum": 1 },
             "auth_mode": { "type": "string", "enum": ["password", "aws_iam", "gcp_iam", "azure_ad"] },
             "aws_iam_region": { "type": "string" },
-            "ssl_mode": { "type": "string" }
+            "ssl_mode": { "type": "string", "enum": ["", "require", "verify-ca", "verify-full"] },
+            "ssl_root_cert": { "type": "string" }
           }
         },
         "default_execution_backend": {

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -53,6 +53,18 @@ api:
     existingSecret: ""               # name of a K8s Secret holding the key
     existingSecretKey: "token_signing_key"  # key within that Secret
 
+  # CA bundle for database TLS server-cert verification, used when
+  # config.database.ssl_mode is "verify-ca"/"verify-full" (cloud-IAM DB auth).
+  # A CA bundle is public, non-secret material, so provide it as a ConfigMap —
+  # either inline (the chart creates the ConfigMap for you) or by referencing an
+  # existing one. The chart mounts it read-only and wires
+  # config.database.ssl_root_cert to the mounted path automatically. Leave unset
+  # for ssl_mode require / a system-trusted CA.
+  databaseCA:
+    inline: ""                       # paste the CA bundle PEM here; the chart creates a ConfigMap for it
+    existingConfigMap: ""            # OR reference an existing ConfigMap holding the CA bundle
+    key: ca.pem                      # key within the ConfigMap (also the mounted filename)
+
   # Service configuration
   service:
     type: ClusterIP
@@ -128,7 +140,8 @@ api:
       #   azure_ad  — Azure Database for PostgreSQL Entra auth (Azure Workload Identity)
       auth_mode: password
       aws_iam_region: ""       # AWS region for RDS IAM signing ("" = AWS_REGION env); aws_iam only
-      ssl_mode: ""             # asyncpg TLS mode; forced to >= "require" for any IAM mode
+      ssl_mode: ""             # IAM-auth TLS: "" / require (encrypt) | verify-ca | verify-full
+      ssl_root_cert: ""        # CA bundle path for verify-ca/verify-full (mount via api.extraVolumes); "" = system CAs
 
     # Default execution backend and version for new workspaces
     default_execution_backend: tofu  # tofu | terraform

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -1024,8 +1024,21 @@ class DatabaseConfig(BaseModel):
     ssl_mode: str = Field(
         default="",
         description=(
-            "asyncpg TLS mode (e.g. 'require', 'verify-full'). Empty = driver "
-            "default. Forced to at least 'require' when auth_mode='aws_iam'."
+            "TLS mode for cloud-IAM auth: 'require' (encrypt, no cert check — "
+            "the default when empty), 'verify-ca' (verify the server cert chain) "
+            "or 'verify-full' (verify chain + hostname). 'verify-ca'/'verify-full' "
+            "require ssl_root_cert (or a system-trusted CA). Cloud IAM auth always "
+            "uses at least 'require'. Ignored when auth_mode='password'."
+        ),
+    )
+    ssl_root_cert: str = Field(
+        default="",
+        description=(
+            "Path to a CA bundle (PEM) used to verify the database server "
+            "certificate when ssl_mode is 'verify-ca'/'verify-full' (e.g. the AWS "
+            "RDS global-bundle.pem or the Cloud SQL server CA, mounted via "
+            "api.extraVolumes). Empty = the system trust store. Only used by the "
+            "cloud-IAM auth modes."
         ),
     )
 

--- a/services/terrapod/db/iam_auth.py
+++ b/services/terrapod/db/iam_auth.py
@@ -15,35 +15,50 @@ credential anywhere:
   ``DefaultAzureCredential``).
 
 In every case the token is the database **password**, supplied per connection
-via a SQLAlchemy ``do_connect`` event (which also forces TLS). RDS/Cloud SQL/Entra
-tokens authenticate at connect time and existing connections persist after the
-token expires, so a fresh token per *new* connection is sufficient — no
-pool-recycle clamp is needed.
+via a SQLAlchemy ``do_connect`` event (which also configures TLS). RDS/Cloud
+SQL/Entra tokens authenticate at connect time and existing connections persist
+after the token expires, so a fresh token per *new* connection is sufficient —
+no pool-recycle clamp is needed.
 
-The credential libraries cache tokens and refresh only near expiry, so the
-handler is a fast cached read in steady state (the periodic refresh is the only
-network call, ~hourly). The default ``auth_mode = "password"`` (static
-credentials from ``database_url``) is unchanged and remains fully supported;
-nothing in this module runs unless an IAM mode is explicitly selected.
+**Event-loop safety (HARD REQUIREMENT — rule 13):** ``do_connect`` runs
+synchronously on the asyncio event-loop thread (SQLAlchemy drives the async
+connect via greenlet). The GCP/Azure token mints can do blocking network I/O
+(``creds.refresh`` / ``cred.get_token``). To avoid stalling the loop we never
+mint inline: ``do_connect`` sets the asyncpg ``password`` to an **awaitable
+callable** that offloads the mint with ``asyncio.to_thread`` (asyncpg awaits a
+callable/awaitable password), keeping the loop free while the token is fetched
+in a worker thread. The token libraries cache and refresh only near expiry, so
+steady-state is a cheap cached read in that thread. The mints serialise on a
+module lock so a concurrent refresh can't corrupt shared credential state.
+
+The default ``auth_mode = "password"`` (static credentials from
+``database_url``) is unchanged and remains fully supported; nothing in this
+module runs unless an IAM mode is explicitly selected.
 """
 
 from __future__ import annotations
 
+import asyncio
+import ssl
 import threading
-from collections.abc import Callable
-from urllib.parse import urlsplit
+from collections.abc import Awaitable, Callable
+from urllib.parse import unquote, urlsplit
 
 import structlog
 
 logger = structlog.get_logger(__name__)
 
-# All cloud IAM DB auth mandates TLS; this is the minimum if none was configured.
+# Cloud IAM DB auth always uses TLS; this is the minimum if none was configured.
 _DEFAULT_SSL_MODE = "require"
+_VALID_SSL_MODES = ("require", "verify-ca", "verify-full")
 
 # GCP OAuth2 scope for Cloud SQL IAM login; Azure Entra scope for OSS RDBMS.
 _GCP_LOGIN_SCOPE = "https://www.googleapis.com/auth/sqlservice.login"
 _AZURE_PG_SCOPE = "https://ossrdbms-aad.database.windows.net/.default"
 
+# A single lock serialises every token mint/refresh so concurrent pooled
+# connections can't race a shared credential object (e.g. google-auth
+# Credentials.refresh mutates in place and is not thread-safe).
 _lock = threading.Lock()
 _aws_clients: dict[str, object] = {}
 _gcp_state: dict[str, object] = {}
@@ -51,9 +66,51 @@ _azure_state: dict[str, object] = {}
 
 
 def parse_pg_target(database_url: str) -> tuple[str, int, str]:
-    """Extract ``(host, port, user)`` from a ``postgresql[+asyncpg]://`` URL."""
+    """Extract ``(host, port, user)`` from a ``postgresql[+asyncpg]://`` URL.
+
+    The username is percent-decoded (matching how SQLAlchemy/asyncpg decode the
+    connect user) so a URL-encoded IAM user like ``sa%40project.iam`` signs/binds
+    as ``sa@project.iam``.
+    """
     parts = urlsplit(str(database_url))
-    return (parts.hostname or ""), (parts.port or 5432), (parts.username or "")
+    return (
+        (parts.hostname or ""),
+        (parts.port or 5432),
+        unquote(parts.username or ""),
+    )
+
+
+def build_ssl_context(ssl_mode: str, ssl_root_cert: str) -> ssl.SSLContext:
+    """Build the asyncpg SSL context for a cloud-IAM connection.
+
+    We construct the context ourselves (rather than passing asyncpg a bare
+    sslmode string) so 'verify-ca'/'verify-full' actually have CA material:
+    asyncpg's string path requires ``~/.postgresql/root.crt`` and does NOT fall
+    back to the system trust store. ``ssl_root_cert`` (e.g. the RDS/Cloud SQL CA
+    bundle) is loaded when set; otherwise the system CAs are used.
+    """
+    mode = (ssl_mode or _DEFAULT_SSL_MODE).lower()
+    if mode not in _VALID_SSL_MODES:
+        raise ValueError(f"unsupported ssl_mode {ssl_mode!r}; expected one of {_VALID_SSL_MODES}")
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    if ssl_root_cert:
+        ctx.load_verify_locations(cafile=ssl_root_cert)
+    else:
+        ctx.load_default_certs()
+
+    if mode == "require":
+        # Encrypt without verifying the server cert. check_hostname must be
+        # cleared before lowering verify_mode or SSLContext raises.
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    elif mode == "verify-ca":
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_REQUIRED
+    else:  # verify-full
+        ctx.check_hostname = True
+        ctx.verify_mode = ssl.CERT_REQUIRED
+    return ctx
 
 
 # ── AWS RDS IAM ───────────────────────────────────────────────────────
@@ -63,44 +120,42 @@ def _aws_rds_client(region: str):
     key = region or "default"
     client = _aws_clients.get(key)
     if client is None:
-        with _lock:
-            client = _aws_clients.get(key)
-            if client is None:
-                import botocore.session
+        import botocore.session
 
-                client = botocore.session.get_session().create_client(
-                    "rds", region_name=region or None
-                )
-                _aws_clients[key] = client
+        client = botocore.session.get_session().create_client("rds", region_name=region or None)
+        _aws_clients[key] = client
     return client
 
 
 def mint_aws_rds_token(*, host: str, port: int, user: str, region: str) -> str:
-    """Short-lived AWS RDS IAM auth token (local SigV4 signing, no I/O)."""
-    return _aws_rds_client(region).generate_db_auth_token(  # type: ignore[attr-defined]
-        DBHostname=host, Port=port, DBUsername=user, Region=region or None
-    )
+    """Short-lived AWS RDS IAM auth token (local SigV4 signing, no network I/O)."""
+    with _lock:
+        return _aws_rds_client(region).generate_db_auth_token(  # type: ignore[attr-defined]
+            DBHostname=host, Port=port, DBUsername=user, Region=region or None
+        )
 
 
 # ── GCP Cloud SQL IAM ─────────────────────────────────────────────────
 
 
 def mint_gcp_access_token() -> str:
-    """OAuth2 access token for the SA (Cloud SQL IAM login); cached + refreshed."""
+    """OAuth2 access token for the SA (Cloud SQL IAM login); cached + refreshed.
+
+    The whole get-or-refresh runs under ``_lock`` because google-auth
+    ``Credentials.refresh`` mutates the shared credential in place.
+    """
     import google.auth
     import google.auth.transport.requests
 
-    creds = _gcp_state.get("creds")
-    if creds is None:
-        with _lock:
-            creds = _gcp_state.get("creds")
-            if creds is None:
-                creds, _ = google.auth.default(scopes=[_GCP_LOGIN_SCOPE])
-                _gcp_state["creds"] = creds
-                _gcp_state["request"] = google.auth.transport.requests.Request()
-    if not creds.valid:  # type: ignore[union-attr]
-        creds.refresh(_gcp_state["request"])  # type: ignore[union-attr]
-    return creds.token  # type: ignore[union-attr]
+    with _lock:
+        creds = _gcp_state.get("creds")
+        if creds is None:
+            creds, _ = google.auth.default(scopes=[_GCP_LOGIN_SCOPE])
+            _gcp_state["creds"] = creds
+            _gcp_state["request"] = google.auth.transport.requests.Request()
+        if not creds.valid:  # type: ignore[union-attr]
+            creds.refresh(_gcp_state["request"])  # type: ignore[union-attr]
+        return creds.token  # type: ignore[union-attr]
 
 
 # ── Azure Database for PostgreSQL (Entra) ─────────────────────────────
@@ -108,45 +163,60 @@ def mint_gcp_access_token() -> str:
 
 def mint_azure_ad_token() -> str:
     """Microsoft Entra access token for Azure Database for PostgreSQL."""
-    cred = _azure_state.get("cred")
-    if cred is None:
-        with _lock:
-            cred = _azure_state.get("cred")
-            if cred is None:
-                from azure.identity import DefaultAzureCredential
+    with _lock:
+        cred = _azure_state.get("cred")
+        if cred is None:
+            from azure.identity import DefaultAzureCredential
 
-                cred = DefaultAzureCredential()
-                _azure_state["cred"] = cred
-    return cred.get_token(_AZURE_PG_SCOPE).token  # type: ignore[union-attr]
+            cred = DefaultAzureCredential()
+            _azure_state["cred"] = cred
+        return cred.get_token(_AZURE_PG_SCOPE).token  # type: ignore[union-attr]
 
 
 # ── do_connect dispatch ───────────────────────────────────────────────
 
 
+def _select_minter(
+    auth_mode: str, *, host: str, port: int, user: str, region: str
+) -> Callable[[], str]:
+    """Return the synchronous token-minting callable for the chosen IAM mode."""
+    if auth_mode == "aws_iam":
+        return lambda: mint_aws_rds_token(host=host, port=port, user=user, region=region)
+    if auth_mode == "gcp_iam":
+        return mint_gcp_access_token
+    if auth_mode == "azure_ad":
+        return mint_azure_ad_token
+    raise ValueError(f"unsupported IAM database auth_mode: {auth_mode!r}")
+
+
 def make_do_connect_handler(
-    *, auth_mode: str, host: str, port: int, user: str, region: str, ssl_mode: str
+    *,
+    auth_mode: str,
+    host: str,
+    port: int,
+    user: str,
+    region: str,
+    ssl_mode: str,
+    ssl_root_cert: str = "",
 ) -> Callable[..., None]:
     """Build the SQLAlchemy ``do_connect`` listener for the chosen IAM mode.
 
-    The handler mints a fresh token and sets it as the asyncpg ``password``
-    (overriding whatever the URL had), and forces TLS.
+    The handler sets the asyncpg ``password`` to an awaitable callable that mints
+    a fresh token off the event loop (``asyncio.to_thread``), and attaches a
+    pre-built TLS context. asyncpg invokes the callable and awaits its result on
+    each new connection, so every connection gets a fresh token without blocking
+    the loop.
     """
-    ssl_value = ssl_mode or _DEFAULT_SSL_MODE
+    mint = _select_minter(auth_mode, host=host, port=port, user=user, region=region)
+    ssl_ctx = build_ssl_context(ssl_mode, ssl_root_cert)
 
-    if auth_mode == "aws_iam":
-
-        def _mint() -> str:
-            return mint_aws_rds_token(host=host, port=port, user=user, region=region)
-
-    elif auth_mode == "gcp_iam":
-        _mint = mint_gcp_access_token
-    elif auth_mode == "azure_ad":
-        _mint = mint_azure_ad_token
-    else:
-        raise ValueError(f"unsupported IAM database auth_mode: {auth_mode!r}")
+    def _password() -> Awaitable[str]:
+        # Offload the (possibly blocking) mint to a worker thread; asyncpg awaits
+        # the returned coroutine, keeping the event loop free.
+        return asyncio.to_thread(mint)
 
     def _do_connect(_dialect, _conn_rec, _cargs, cparams: dict) -> None:
-        cparams["password"] = _mint()
-        cparams["ssl"] = ssl_value
+        cparams["password"] = _password
+        cparams["ssl"] = ssl_ctx
 
     return _do_connect

--- a/services/terrapod/db/session.py
+++ b/services/terrapod/db/session.py
@@ -58,6 +58,7 @@ async def init_db() -> None:
                 user=user,
                 region=db_cfg.aws_iam_region,
                 ssl_mode=db_cfg.ssl_mode,
+                ssl_root_cert=db_cfg.ssl_root_cert,
             ),
         )
         logger.info(

--- a/services/tests/test_db_iam_auth.py
+++ b/services/tests/test_db_iam_auth.py
@@ -3,14 +3,16 @@ Azure Entra.
 
 The live connection path per cloud can only be validated against a real
 IAM-enabled database (a staging smoke); these tests cover the unit logic — token
-minting per cloud, target parsing, and the do_connect handler that injects the
-token + TLS and dispatches by mode — and guard that the default stays
-static-password auth.
+minting per cloud, target parsing, the TLS-context builder, and the do_connect
+handler that supplies an awaitable token password + TLS context and dispatches by
+mode — and guard that the default stays static-password auth.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import asyncio
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -20,7 +22,9 @@ from terrapod.db import iam_auth
 
 def test_auth_mode_defaults_to_password_static():
     # Static-password auth must remain the default + fully supported.
-    assert DatabaseConfig().auth_mode == "password"
+    cfg = DatabaseConfig()
+    assert cfg.auth_mode == "password"
+    assert cfg.ssl_root_cert == ""
 
 
 def test_parse_pg_target():
@@ -31,6 +35,12 @@ def test_parse_pg_target():
 def test_parse_pg_target_defaults_port_5432():
     h, p, u = iam_auth.parse_pg_target("postgresql+asyncpg://u@host/db")
     assert (h, p, u) == ("host", 5432, "u")
+
+
+def test_parse_pg_target_percent_decodes_username():
+    # GCP Cloud SQL IAM users are the SA email (contains '@', encoded as %40).
+    _, _, u = iam_auth.parse_pg_target("postgresql+asyncpg://sa%40proj.iam@10.0.0.5:5432/terrapod")
+    assert u == "sa@proj.iam"
 
 
 def test_mint_aws_rds_token_calls_botocore(monkeypatch):
@@ -46,29 +56,81 @@ def test_mint_aws_rds_token_calls_botocore(monkeypatch):
     )
 
 
+# ── TLS context builder ───────────────────────────────────────────────
+
+
+def test_build_ssl_context_require_disables_verification():
+    ctx = iam_auth.build_ssl_context("require", "")
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_build_ssl_context_empty_defaults_to_require():
+    ctx = iam_auth.build_ssl_context("", "")
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_build_ssl_context_verify_ca_requires_cert_not_hostname():
+    ctx = iam_auth.build_ssl_context("verify-ca", "")
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_build_ssl_context_verify_full_checks_hostname():
+    ctx = iam_auth.build_ssl_context("verify-full", "")
+    assert ctx.check_hostname is True
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_build_ssl_context_loads_root_cert(tmp_path):
+    bogus = tmp_path / "ca.pem"
+    bogus.write_text("not a real cert\n")
+    # load_verify_locations on a non-PEM file raises — proves the cert path is used.
+    with pytest.raises(ssl.SSLError):
+        iam_auth.build_ssl_context("verify-full", str(bogus))
+
+
+def test_build_ssl_context_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="unsupported ssl_mode"):
+        iam_auth.build_ssl_context("bogus", "")
+
+
 # ── do_connect dispatch per mode ──────────────────────────────────────
 
 
-def test_do_connect_aws_injects_token_and_tls(monkeypatch):
+def _run_password(cparams: dict) -> str:
+    """asyncpg invokes the callable password and awaits its result."""
+    pw = cparams["password"]
+    assert callable(pw)
+    return asyncio.run(pw())
+
+
+def test_do_connect_aws_sets_awaitable_token_and_ssl(monkeypatch):
     monkeypatch.setattr(iam_auth, "mint_aws_rds_token", lambda **_kw: "AWS")
     handler = iam_auth.make_do_connect_handler(
         auth_mode="aws_iam", host="h", port=5432, user="u", region="r", ssl_mode=""
     )
     cparams = {"password": "dummy"}
     handler(None, None, None, cparams)
-    assert cparams["password"] == "AWS"  # overrides the URL value
-    assert cparams["ssl"] == "require"  # TLS forced
+    assert isinstance(cparams["ssl"], ssl.SSLContext)
+    assert _run_password(cparams) == "AWS"  # overrides the URL value
 
 
 def test_do_connect_gcp_uses_access_token(monkeypatch):
     monkeypatch.setattr(iam_auth, "mint_gcp_access_token", lambda: "GCP")
     handler = iam_auth.make_do_connect_handler(
-        auth_mode="gcp_iam", host="h", port=5432, user="u", region="", ssl_mode="verify-ca"
+        auth_mode="gcp_iam",
+        host="h",
+        port=5432,
+        user="u",
+        region="",
+        ssl_mode="verify-ca",
     )
     cparams: dict = {}
     handler(None, None, None, cparams)
-    assert cparams["password"] == "GCP"
-    assert cparams["ssl"] == "verify-ca"
+    assert _run_password(cparams) == "GCP"
+    assert cparams["ssl"].verify_mode == ssl.CERT_REQUIRED
 
 
 def test_do_connect_azure_uses_entra_token(monkeypatch):
@@ -78,21 +140,10 @@ def test_do_connect_azure_uses_entra_token(monkeypatch):
     )
     cparams: dict = {}
     handler(None, None, None, cparams)
-    assert cparams["password"] == "AZURE"
-    assert cparams["ssl"] == "require"
+    assert _run_password(cparams) == "AZURE"
 
 
-def test_do_connect_honors_explicit_ssl_mode(monkeypatch):
-    monkeypatch.setattr(iam_auth, "mint_aws_rds_token", lambda **_kw: "T")
-    handler = iam_auth.make_do_connect_handler(
-        auth_mode="aws_iam", host="h", port=5432, user="u", region="r", ssl_mode="verify-full"
-    )
-    cparams: dict = {}
-    handler(None, None, None, cparams)
-    assert cparams["ssl"] == "verify-full"
-
-
-def test_do_connect_mints_fresh_token_each_connection(monkeypatch):
+def test_do_connect_mints_fresh_token_each_call(monkeypatch):
     tokens = iter(["t1", "t2"])
     monkeypatch.setattr(iam_auth, "mint_aws_rds_token", lambda **_kw: next(tokens))
     handler = iam_auth.make_do_connect_handler(
@@ -102,8 +153,8 @@ def test_do_connect_mints_fresh_token_each_connection(monkeypatch):
     c2: dict = {}
     handler(None, None, None, c1)
     handler(None, None, None, c2)
-    assert c1["password"] == "t1"
-    assert c2["password"] == "t2"
+    assert _run_password(c1) == "t1"
+    assert _run_password(c2) == "t2"
 
 
 def test_unsupported_mode_raises():
@@ -111,3 +162,39 @@ def test_unsupported_mode_raises():
         iam_auth.make_do_connect_handler(
             auth_mode="nope", host="h", port=5432, user="u", region="", ssl_mode=""
         )
+
+
+# ── session wiring ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_db_registers_listener_only_for_iam_mode():
+    """The do_connect listener is attached for IAM modes, not for 'password'."""
+    from terrapod.db import session as db_session
+
+    async def _check(auth_mode: str, *, expect_listener: bool):
+        cfg = DatabaseConfig(auth_mode=auth_mode)
+        fake_engine = MagicMock()
+        with (
+            patch.object(db_session, "settings") as fake_settings,
+            patch.object(db_session, "create_async_engine", return_value=fake_engine),
+            patch.object(db_session, "async_sessionmaker"),
+            patch.object(db_session, "event") as fake_event,
+        ):
+            fake_settings.database = cfg
+            fake_settings.debug = False
+            fake_settings.database_url = (
+                "postgresql+asyncpg://terrapod@db.example.com:5432/terrapod"
+            )
+            # The startup SELECT 1 uses an async context manager on the engine.
+            fake_engine.begin.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            fake_engine.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+            await db_session.init_db()
+            if expect_listener:
+                fake_event.listen.assert_called_once()
+                assert fake_event.listen.call_args.args[1] == "do_connect"
+            else:
+                fake_event.listen.assert_not_called()
+
+    await _check("password", expect_listener=False)
+    await _check("aws_iam", expect_listener=True)


### PR DESCRIPTION
Closes #575. Pre-release hardening of the cloud-IAM DB auth feature (#573/#574) — fixes the correctness gaps the v0.45.0 audit + third-party review found before it ships.

## Fixes

- **TLS verify modes now work.** asyncpg's bare-string `ssl="verify-ca"/"verify-full"` requires `~/.postgresql/root.crt` and does **not** fall back to the system trust store — so the documented `verify-full` examples failed at startup (verified against asyncpg 0.31.0). We now build the `ssl.SSLContext` ourselves (load `ssl_root_cert` or the system store) and pass that object.
- **Event-loop safety (rule 13).** `do_connect` runs on the loop thread; GCP/Azure token mints do blocking network I/O. The asyncpg password is now an **awaitable callable** that offloads minting via `asyncio.to_thread`, keeping the loop free. (asyncpg awaits a callable/awaitable password.)
- **No credential race.** The whole mint/refresh runs under the module lock (google-auth `Credentials.refresh` mutates a shared object in place).
- **Username percent-decoded** in `parse_pg_target` (`sa%40proj.iam` → `sa@proj.iam`).

## First-class CA bundle

A CA bundle is **public, non-secret** material, so the new `api.databaseCA` chart block takes it as a ConfigMap — paste it `inline` (the chart creates the ConfigMap) or reference an `existingConfigMap`. The chart mounts it read-only and wires `database.ssl_root_cert` to the mounted path automatically. `extraVolumes` remains only as an escape hatch.

```yaml
api:
  databaseCA:
    inline: |
      -----BEGIN CERTIFICATE-----
      ...RDS / Cloud SQL CA bundle...
      -----END CERTIFICATE-----
    key: ca.pem
  config:
    database:
      ssl_mode: verify-full   # ssl_root_cert wired for you
```

## Verification

- `make lint` ✅, `make test` ✅ (2426 passed; new TLS-context / percent-decode / session-wiring tests)
- `helm lint` + `helm template` ✅ across default / inline-CA / existingConfigMap scenarios
- Static-password auth (default) unchanged.

Live RDS/Cloud SQL/Azure-DB IAM connection remains a staging smoke (CI can't exercise real cloud IAM DB auth).