### PR TITLE
fix(db): cloud-IAM auth for the migrations Job (#577)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -4,10 +4,10 @@ import asyncio
 import os
 from logging.config import fileConfig
 
-from alembic import context
-from sqlalchemy import pool
+from sqlalchemy import event, pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
+from alembic import context
 from terrapod.db.models import Base
 
 config = context.config
@@ -53,6 +53,30 @@ async def run_async_migrations() -> None:
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
+
+    # Cloud-IAM DB auth (#573) for the migrations Job: mirror the API's
+    # per-connection token + TLS injection so the Job authenticates the same way
+    # as the running app (the DB role is IAM-only / TLS-required). Config comes
+    # via TP_DB_* env vars set by the migrations Job template. Default
+    # auth_mode="password" leaves the engine untouched.
+    auth_mode = os.environ.get("TP_DB_AUTH_MODE", "password")
+    if auth_mode in ("aws_iam", "gcp_iam", "azure_ad"):
+        from terrapod.db import iam_auth
+
+        host, port, user = iam_auth.parse_pg_target(config.get_main_option("sqlalchemy.url") or "")
+        event.listen(
+            connectable.sync_engine,
+            "do_connect",
+            iam_auth.make_do_connect_handler(
+                auth_mode=auth_mode,
+                host=host,
+                port=port,
+                user=user,
+                region=os.environ.get("TP_DB_AWS_IAM_REGION", ""),
+                ssl_mode=os.environ.get("TP_DB_SSL_MODE", ""),
+                ssl_root_cert=os.environ.get("TP_DB_SSL_ROOT_CERT", ""),
+            ),
+        )
 
     async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations)

--- a/helm/terrapod/templates/job-migrations.yaml
+++ b/helm/terrapod/templates/job-migrations.yaml
@@ -1,4 +1,7 @@
 {{- if and (ne .Values.api.enabled false) .Values.migrations.enabled }}
+{{- $dbAuthMode := (.Values.api.config.database).auth_mode | default "password" }}
+{{- $dbIam := or (eq $dbAuthMode "aws_iam") (eq $dbAuthMode "gcp_iam") (eq $dbAuthMode "azure_ad") }}
+{{- $dbCa := or .Values.api.databaseCA.inline .Values.api.databaseCA.existingConfigMap }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -23,6 +26,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $dbIam }}
+      # Cloud-IAM DB auth: run under the API's IRSA/workload-identity SA so the
+      # Job can mint a DB token (the SA carries the rds-db:connect / Cloud SQL /
+      # Entra grant). The cloud identity webhook projects its own token, so the
+      # default SA token stays unmounted.
+      serviceAccountName: {{ include "terrapod.serviceAccountName" . }}
+      {{- end }}
       automountServiceAccountToken: false
       restartPolicy: OnFailure
       securityContext:
@@ -46,6 +56,26 @@ spec:
             - name: DATABASE_URL
               value: {{ .Values.postgresql.url | quote }}
             {{- end }}
+            {{- if $dbIam }}
+            - name: TP_DB_AUTH_MODE
+              value: {{ $dbAuthMode | quote }}
+            - name: TP_DB_AWS_IAM_REGION
+              value: {{ (.Values.api.config.database).aws_iam_region | default "" | quote }}
+            - name: TP_DB_SSL_MODE
+              value: {{ (.Values.api.config.database).ssl_mode | default "" | quote }}
+            - name: TP_DB_SSL_ROOT_CERT
+              {{- if $dbCa }}
+              value: {{ printf "/etc/terrapod/db-ca/%s" (.Values.api.databaseCA.key | default "ca.pem") | quote }}
+              {{- else }}
+              value: {{ (.Values.api.config.database).ssl_root_cert | default "" | quote }}
+              {{- end }}
+            {{- end }}
+          {{- if and $dbIam $dbCa }}
+          volumeMounts:
+            - name: database-ca
+              mountPath: /etc/terrapod/db-ca
+              readOnly: true
+          {{- end }}
           resources:
             requests:
               cpu: 250m
@@ -55,4 +85,10 @@ spec:
               memory: 512Mi
           securityContext:
             {{- toYaml .Values.api.containerSecurityContext | nindent 12 }}
+      {{- if and $dbIam $dbCa }}
+      volumes:
+        - name: database-ca
+          configMap:
+            name: {{ .Values.api.databaseCA.existingConfigMap | default (printf "%s-database-ca" (include "terrapod.fullname" .)) }}
+      {{- end }}
 {{- end }}

--- a/services/pyproject-migrations.toml
+++ b/services/pyproject-migrations.toml
@@ -12,4 +12,12 @@ dependencies = [
     # this is defence-in-depth — Trivy still flags it because the
     # advisory doesn't carry an OS qualifier.
     "Mako>=1.3.12",
+    # Cloud-IAM DB auth (#573): the migrations Job mints a per-connection token
+    # the same way the API does (terrapod.db.iam_auth, already copied into the
+    # image). structlog is imported by that module; the cloud SDKs are lazy
+    # per auth_mode (botocore=AWS RDS, google-auth=Cloud SQL, azure-identity=Entra).
+    "structlog>=24.1",
+    "botocore>=1.34",
+    "google-auth>=2.28",
+    "azure-identity>=1.21",
 ]


### PR DESCRIPTION
Closes #577. Follow-up to v0.45.0 (#574/#575): the migrations Job never got the IAM+TLS DB-auth path, so on an **RDS-IAM-only + TLS-required** database the pre-upgrade migrations hook fails (`pg_hba.conf rejects connection … no encryption`, then `PAM authentication failed`) and blocks the rollout.

## Fix
- **`alembic/env.py`** — when `TP_DB_AUTH_MODE` is an IAM mode, register the shared `terrapod.db.iam_auth` `do_connect` handler (per-connection token + TLS `SSLContext`) on the migrations engine. Default `password` leaves it untouched.
- **`pyproject-migrations.toml`** — add `structlog` + the lazy cloud token SDKs (`botocore` / `google-auth` / `azure-identity`). `terrapod/db/iam_auth.py` is already copied into the migrations image.
- **`job-migrations.yaml`** — when `auth_mode` is an IAM mode: run under the API's **IRSA service account** (so the Job can mint a token), pass `TP_DB_*` config, and mount the **database CA bundle** for `verify-full`. Password mode renders none of this (verified).

## Verify
- `make lint` ✅, `helm lint` ✅
- `helm template` ✅ — IAM mode renders SA + `TP_DB_*` env + CA mount; password mode renders clean (0 IAM refs)
- Live: the real migrations Job will exercise this on the next mgmt sync once `migrations.enabled` is re-enabled in the wrapper.

## Notes
- The **bootstrap** Job has the same code gap but is `post-install`-only (doesn't run on upgrades) — deferred as a fresh-install-only edge case.
- This is the gap from v0.45.0; I'll add "every DB consumer (API + migrations + bootstrap)" to the pre-release checklist so it's not missed again.