### PR TITLE
feat(redis): cloud-IAM authentication for the Redis/Valkey connection (#579)

### DIFF
--- a/docs/cloud-credentials.md
+++ b/docs/cloud-credentials.md
@@ -610,6 +610,70 @@ Use a **strong static database password**, but keep it out of source and rotate 
 
 ---
 
+## Redis/Valkey authentication
+
+The API connects to Redis/Valkey using the URL in `TERRAPOD_REDIS_URL` (sourced from a K8s Secret). The auth mode is `api.config.redis.auth_mode`; like the database, each cloud's managed Redis/Valkey supports a passwordless token under the API pod's workload identity (the same IRSA / WIF / WI), so no static Redis auth string is needed:
+
+| Mode | What it does | Identity |
+|---|---|---|
+| `password` (default) | The static auth string in `TERRAPOD_REDIS_URL`. Fully supported. | — |
+| `aws_iam` | **AWS ElastiCache IAM auth** — a SigV4-presigned `connect` token, signed locally per connection. | IRSA |
+| `gcp_iam` | **GCP Memorystore IAM auth** — the SA's OAuth2 access token (`cloud-platform` scope). | WIF |
+| `azure_ad` | **Azure Cache for Redis — Microsoft Entra auth** — an Entra token (`redis.azure.com` scope). | Azure WI |
+
+A fresh token is minted per connection via a redis-py credential provider (offloaded to a thread, so the event loop is never blocked), and the token libraries cache + refresh near expiry. **TLS is required** for IAM Redis auth — use a `rediss://` URL. The URL's userinfo is ignored in IAM mode (the token replaces it), so the `TERRAPOD_REDIS_URL` Secret just needs the host/port (and `rediss://`).
+
+### AWS ElastiCache IAM auth (`auth_mode: aws_iam`)
+
+1. **Enable IAM auth on the cache** (Redis OSS 7+ / Valkey, incl. Serverless) and create an [ElastiCache User](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth-iam.html) with **Authentication Mode = IAM**, in a User Group attached to the cache. The user name must match the IAM-authenticated identity.
+2. **Grant the API's IRSA role `elasticache:Connect`** on the cache + user ARNs (in addition to its other permissions).
+3. **Configure the mode** (the username is the ElastiCache User; `aws_cache_name` is the **cache identifier** — the replication-group id or serverless cache name, *not* the endpoint host — used for signing):
+   ```yaml
+   api:
+     config:
+       redis:
+         auth_mode: aws_iam
+         username: terrapod
+         aws_cache_name: terrapod-cache   # replication-group / serverless cache id
+         aws_iam_region: ""               # "" = AWS_REGION env (set by IRSA)
+   ```
+   ```
+   # TERRAPOD_REDIS_URL — TLS, host + port, NO auth string
+   rediss://terrapod-cache-abc123.serverless.us-east-1.cache.amazonaws.com:6379
+   ```
+
+### GCP Memorystore IAM auth (`auth_mode: gcp_iam`)
+
+On Memorystore for Valkey / Redis Cluster with IAM authentication enabled, Terrapod uses the API service account's OAuth2 access token (`cloud-platform` scope) as the Redis password.
+
+1. **Enable IAM authentication** on the instance and grant the API's GCP service account `roles/redis.dbConnectionUser`.
+2. **Bind the API's K8s ServiceAccount to that GCP SA via Workload Identity Federation** (the same binding used for GCS).
+3. **Configure the mode** (the username is the IAM user):
+   ```yaml
+   api:
+     config:
+       redis:
+         auth_mode: gcp_iam
+         username: terrapod-api@my-project.iam.gserviceaccount.com
+   ```
+
+### Azure Cache for Redis — Microsoft Entra auth (`auth_mode: azure_ad`)
+
+On Azure Cache for Redis with Microsoft Entra authentication, Terrapod mints an Entra access token (`https://redis.azure.com/.default`) via `DefaultAzureCredential`, using the pod's Azure Workload Identity.
+
+1. **Enable Entra authentication** on the cache and add the API's managed identity as a Redis user with a data-access policy.
+2. **Bind the API's K8s ServiceAccount to the user-assigned managed identity via Azure Workload Identity** (the same binding used for Blob storage); the pod needs the `azure.workload.identity/use: "true"` label.
+3. **Configure the mode** (the username is the managed identity's **object id**):
+   ```yaml
+   api:
+     config:
+       redis:
+         auth_mode: azure_ad
+         username: 00000000-0000-0000-0000-000000000000   # managed-identity object id
+   ```
+
+---
+
 ## External secret managers (Vault via ESO / Vault Agent)
 
 Terrapod has **no built-in Vault integration** — that is deliberately out of scope. The supported pattern is an **external** secret manager (e.g. HashiCorp Vault) feeding Terrapod's existing Kubernetes Secrets, using either:

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -45,6 +45,13 @@ data:
       ssl_root_cert: {{ .Values.api.config.database.ssl_root_cert | default "" | quote }}
       {{- end }}
     {{- end }}
+    {{- if .Values.api.config.redis }}
+    redis:
+      auth_mode: {{ .Values.api.config.redis.auth_mode | default "password" | quote }}
+      username: {{ .Values.api.config.redis.username | default "" | quote }}
+      aws_iam_region: {{ .Values.api.config.redis.aws_iam_region | default "" | quote }}
+      aws_cache_name: {{ .Values.api.config.redis.aws_cache_name | default "" | quote }}
+    {{- end }}
     storage:
       backend: {{ .Values.api.config.storage.backend | quote }}
       {{- if eq .Values.api.config.storage.backend "s3" }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -464,6 +464,16 @@
             "ssl_root_cert": { "type": "string" }
           }
         },
+        "redis": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "auth_mode": { "type": "string", "enum": ["password", "aws_iam", "gcp_iam", "azure_ad"] },
+            "username": { "type": "string" },
+            "aws_iam_region": { "type": "string" },
+            "aws_cache_name": { "type": "string" }
+          }
+        },
         "default_execution_backend": {
           "type": "string",
           "enum": ["tofu", "terraform"]

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -143,6 +143,19 @@ api:
       ssl_mode: ""             # IAM-auth TLS: "" / require (encrypt) | verify-ca | verify-full
       ssl_root_cert: ""        # CA bundle path for verify-ca/verify-full (mount via api.extraVolumes); "" = system CAs
 
+    # Redis/Valkey auth (#579). "password" (default — static auth string in the
+    # Redis URL) or a cloud-IAM mode that mints a short-lived token per
+    # connection under the API's workload identity (no static Redis secret, TLS
+    # rediss:// required):
+    #   aws_iam   — AWS ElastiCache IAM (IRSA; needs elasticache:Connect + aws_cache_name)
+    #   gcp_iam   — GCP Memorystore IAM (Workload Identity Federation)
+    #   azure_ad  — Azure Cache for Redis Entra auth (Azure Workload Identity)
+    redis:
+      auth_mode: password
+      username: ""             # Redis ACL user for IAM (ElastiCache User / IAM user / Entra object id)
+      aws_iam_region: ""       # AWS region for ElastiCache IAM signing; aws_iam only
+      aws_cache_name: ""       # ElastiCache replication-group / serverless cache id (NOT the endpoint host); aws_iam only
+
     # Default execution backend and version for new workspaces
     default_execution_backend: tofu  # tofu | terraform
     default_terraform_version: "1.12"

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -1043,6 +1043,50 @@ class DatabaseConfig(BaseModel):
     )
 
 
+class RedisConfig(BaseModel):
+    """Redis/Valkey authentication settings (#579).
+
+    The connection URL itself stays in the top-level ``redis_url``; this block
+    only carries the cloud-IAM auth knobs. Default ``auth_mode='password'`` uses
+    the static auth string in ``redis_url`` and is fully supported.
+    """
+
+    auth_mode: Literal["password", "aws_iam", "gcp_iam", "azure_ad"] = Field(
+        default="password",
+        description=(
+            "Redis authentication. 'password' (default) uses the static auth "
+            "string in redis_url. The cloud-IAM modes mint a short-lived token "
+            "per connection under the API pod's workload identity — no static "
+            "Redis secret, TLS (rediss://) required: 'aws_iam' (AWS ElastiCache "
+            "IAM, IRSA), 'gcp_iam' (GCP Memorystore IAM, WIF), 'azure_ad' (Azure "
+            "Cache for Redis Entra auth, Azure WI)."
+        ),
+    )
+    username: str = Field(
+        default="",
+        description=(
+            "Redis ACL username for IAM auth — the ElastiCache User (AWS), the "
+            "IAM user (GCP), or the Entra principal object id (Azure). Required "
+            "for the cloud-IAM modes; ignored for 'password'."
+        ),
+    )
+    aws_iam_region: str = Field(
+        default="",
+        description=(
+            "AWS region used to sign ElastiCache IAM tokens. Empty = botocore "
+            "default resolution. Only used when auth_mode='aws_iam'."
+        ),
+    )
+    aws_cache_name: str = Field(
+        default="",
+        description=(
+            "ElastiCache cache identifier used for SigV4 signing — the "
+            "replication-group id or serverless cache name (NOT the endpoint "
+            "host). Required when auth_mode='aws_iam'."
+        ),
+    )
+
+
 # --- Main Settings ---
 
 
@@ -1105,6 +1149,7 @@ class Settings(BaseSettings):
         default="redis://localhost:6379",
         description="Redis connection URL",
     )
+    redis: "RedisConfig" = Field(default_factory=lambda: RedisConfig())
 
     # Storage
     storage: StorageConfig = Field(default_factory=StorageConfig)

--- a/services/terrapod/redis/client.py
+++ b/services/terrapod/redis/client.py
@@ -21,10 +21,37 @@ async def init_redis() -> None:
     """Initialize Redis connection pool."""
     global _redis  # noqa: PLW0603
     logger.info("Initializing Redis connection")
-    _redis = aioredis.from_url(
-        str(settings.redis_url),
-        decode_responses=True,
-    )
+
+    redis_cfg = settings.redis
+    if redis_cfg.auth_mode in ("aws_iam", "gcp_iam", "azure_ad"):
+        # Cloud-IAM Redis auth (#579, opt-in): mint a fresh short-lived token per
+        # connection via a redis-py credential provider (token-as-password under
+        # the API pod's workload identity). The URL's userinfo is stripped — the
+        # provider supplies username + token, and redis-py rejects a URL password
+        # alongside a credential_provider. Default auth_mode="password" leaves
+        # this untouched. TLS (rediss://) is required for IAM Redis auth.
+        from terrapod.redis import iam_auth
+
+        _redis = aioredis.from_url(
+            iam_auth.strip_url_credentials(settings.redis_url),
+            decode_responses=True,
+            credential_provider=iam_auth.make_credential_provider(
+                auth_mode=redis_cfg.auth_mode,
+                username=redis_cfg.username,
+                cache_name=redis_cfg.aws_cache_name,
+                region=redis_cfg.aws_iam_region,
+            ),
+        )
+        logger.info(
+            "Redis auth: cloud IAM (per-connection token)",
+            mode=redis_cfg.auth_mode,
+            user=redis_cfg.username,
+        )
+    else:
+        _redis = aioredis.from_url(
+            str(settings.redis_url),
+            decode_responses=True,
+        )
     # Test connection
     await _redis.ping()
     logger.info("Redis connection established")

--- a/services/terrapod/redis/iam_auth.py
+++ b/services/terrapod/redis/iam_auth.py
@@ -1,0 +1,183 @@
+"""Cloud-IAM authentication for the Redis/Valkey connection (#579).
+
+The Redis analogue of ``db/iam_auth.py``. Opt-in via ``redis.auth_mode`` in
+``{aws_iam, gcp_iam, azure_ad}``: each new connection authenticates with a
+freshly-minted, short-lived token (used as the Redis ``AUTH`` password) under
+the API pod's **workload identity** — so there is no static Redis auth string:
+
+- ``aws_iam``  — AWS ElastiCache (Redis OSS 7+/Valkey) IAM auth. The token is a
+  SigV4-presigned ``connect`` request (botocore ``RequestSigner``, local
+  signing). The signing identifier is the **cache name** (replication-group /
+  serverless cache id), not the endpoint host; the Redis user must be an
+  ElastiCache User in IAM mode and the IRSA role needs ``elasticache:Connect``.
+- ``gcp_iam``  — GCP Memorystore (Valkey / Redis Cluster) IAM auth: the service
+  account's OAuth2 access token (google-auth ADC / Workload Identity Federation,
+  ``cloud-platform`` scope).
+- ``azure_ad`` — Azure Cache for Redis Microsoft Entra auth: an Entra access
+  token for the ``https://redis.azure.com`` scope (azure-identity
+  ``DefaultAzureCredential``); the username is the Entra principal's object id.
+
+The token is supplied per connection via a redis-py ``CredentialProvider``.
+redis-py awaits ``get_credentials_async`` on (re)connect, so we offload the
+(possibly blocking) mint with ``asyncio.to_thread`` — the event loop is never
+blocked (rule 13). The credential libraries cache + refresh tokens near expiry,
+so steady-state is a cheap cached read. TLS is required for IAM Redis auth (use a
+``rediss://`` URL).
+
+The default ``auth_mode = "password"`` (static auth string from ``redis_url``)
+is unchanged and remains fully supported; nothing here runs unless an IAM mode
+is explicitly selected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+import structlog
+
+from redis.credentials import CredentialProvider
+
+logger = structlog.get_logger(__name__)
+
+_TOKEN_TTL_SECONDS = 900  # ElastiCache presigned-token validity (15 min)
+_GCP_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+_AZURE_REDIS_SCOPE = "https://redis.azure.com/.default"
+
+# One lock serialises every token mint/refresh so concurrent (re)connects can't
+# race a shared credential object (google-auth Credentials.refresh mutates in
+# place and is not thread-safe).
+_lock = threading.Lock()
+_aws_signers: dict[str, object] = {}
+_gcp_state: dict[str, object] = {}
+_azure_state: dict[str, object] = {}
+
+
+def strip_url_credentials(redis_url: str) -> str:
+    """Drop any userinfo from a redis URL.
+
+    redis-py rejects passing both a URL password and a ``credential_provider``;
+    in IAM mode the provider supplies the username + token, so we strip the
+    URL's userinfo (host/port/path/query/scheme — incl. ``rediss://`` TLS —
+    are preserved).
+    """
+    parts = urlsplit(str(redis_url))
+    netloc = parts.hostname or ""
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+# ── AWS ElastiCache IAM ───────────────────────────────────────────────
+
+
+def _aws_signer(region: str):
+    key = region or "default"
+    signer = _aws_signers.get(key)
+    if signer is None:
+        import botocore.session
+        from botocore.model import ServiceId
+        from botocore.signers import RequestSigner
+
+        session = botocore.session.get_session()
+        signer = RequestSigner(
+            ServiceId("elasticache"),
+            region or session.get_config_variable("region"),
+            "elasticache",
+            "v4",
+            session.get_credentials(),
+            session.get_component("event_emitter"),
+        )
+        _aws_signers[key] = signer
+    return signer
+
+
+def mint_aws_elasticache_token(*, cache_name: str, user: str, region: str) -> str:
+    """SigV4-presigned ElastiCache ``connect`` token (local signing, no I/O)."""
+    with _lock:
+        signer = _aws_signer(region)
+        url = f"https://{cache_name}/?{urlencode({'Action': 'connect', 'User': user})}"
+        signed = signer.generate_presigned_url(  # type: ignore[attr-defined]
+            {"method": "GET", "url": url, "body": {}, "headers": {}, "context": {}},
+            operation_name="connect",
+            expires_in=_TOKEN_TTL_SECONDS,
+            region_name=region or None,
+        )
+        # The IAM auth token is the presigned URL without the scheme.
+        return signed.removeprefix("https://")
+
+
+# ── GCP Memorystore IAM ───────────────────────────────────────────────
+
+
+def mint_gcp_access_token() -> str:
+    """OAuth2 access token for Memorystore IAM auth; cached + refreshed."""
+    import google.auth
+    import google.auth.transport.requests
+
+    with _lock:
+        creds = _gcp_state.get("creds")
+        if creds is None:
+            creds, _ = google.auth.default(scopes=[_GCP_SCOPE])
+            _gcp_state["creds"] = creds
+            _gcp_state["request"] = google.auth.transport.requests.Request()
+        if not creds.valid:  # type: ignore[union-attr]
+            creds.refresh(_gcp_state["request"])  # type: ignore[union-attr]
+        return creds.token  # type: ignore[union-attr]
+
+
+# ── Azure Cache for Redis (Entra) ─────────────────────────────────────
+
+
+def mint_azure_redis_token() -> str:
+    """Microsoft Entra access token for Azure Cache for Redis."""
+    with _lock:
+        cred = _azure_state.get("cred")
+        if cred is None:
+            from azure.identity import DefaultAzureCredential
+
+            cred = DefaultAzureCredential()
+            _azure_state["cred"] = cred
+        return cred.get_token(_AZURE_REDIS_SCOPE).token  # type: ignore[union-attr]
+
+
+# ── Credential provider ───────────────────────────────────────────────
+
+
+class _IAMCredentialProvider(CredentialProvider):
+    """redis-py credential provider that mints a per-connection IAM token.
+
+    ``get_credentials_async`` offloads the mint to a worker thread so it never
+    blocks the event loop; ``get_credentials`` (sync) is provided for the rare
+    sync code path.
+    """
+
+    def __init__(self, username: str, mint) -> None:  # type: ignore[no-untyped-def]
+        self._username = username
+        self._mint = mint
+
+    def get_credentials(self) -> tuple[str, str]:
+        return (self._username, self._mint())
+
+    async def get_credentials_async(self) -> tuple[str, str]:
+        return (self._username, await asyncio.to_thread(self._mint))
+
+
+def make_credential_provider(
+    *, auth_mode: str, username: str, cache_name: str, region: str
+) -> CredentialProvider:
+    """Build the redis-py credential provider for the chosen IAM mode."""
+    if auth_mode == "aws_iam":
+
+        def _mint() -> str:
+            return mint_aws_elasticache_token(cache_name=cache_name, user=username, region=region)
+
+    elif auth_mode == "gcp_iam":
+        _mint = mint_gcp_access_token
+    elif auth_mode == "azure_ad":
+        _mint = mint_azure_redis_token
+    else:
+        raise ValueError(f"unsupported IAM redis auth_mode: {auth_mode!r}")
+
+    return _IAMCredentialProvider(username, _mint)

--- a/services/tests/test_redis_iam_auth.py
+++ b/services/tests/test_redis_iam_auth.py
@@ -1,0 +1,136 @@
+"""Tests for cloud-IAM Redis/Valkey auth (#579) — AWS ElastiCache, GCP
+Memorystore, Azure Cache for Redis.
+
+The live connection per cloud can only be validated against a real IAM-enabled
+cache (a staging smoke); these tests cover the unit logic — per-cloud token
+minting, URL-credential stripping, the credential provider (sync + async)
+dispatch, and the redis client wiring — and guard that the default stays the
+static auth string.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.config import RedisConfig
+from terrapod.redis import iam_auth
+
+
+def test_auth_mode_defaults_to_password():
+    # Static auth-string Redis auth must remain the default.
+    assert RedisConfig().auth_mode == "password"
+
+
+def test_strip_url_credentials_removes_userinfo():
+    assert (
+        iam_auth.strip_url_credentials("rediss://user:pass@cache.example.com:6379/0")
+        == "rediss://cache.example.com:6379/0"
+    )
+    # No userinfo → unchanged (scheme/host/port preserved).
+    assert (
+        iam_auth.strip_url_credentials("rediss://cache.example.com:6379")
+        == "rediss://cache.example.com:6379"
+    )
+
+
+def test_mint_aws_elasticache_token_signs_and_strips_scheme(monkeypatch):
+    mock_signer = MagicMock()
+    mock_signer.generate_presigned_url.return_value = (
+        "https://my-cache/?Action=connect&User=terrapod&X-Amz-Signature=abc"
+    )
+    monkeypatch.setattr(iam_auth, "_aws_signer", lambda region: mock_signer)
+
+    tok = iam_auth.mint_aws_elasticache_token(
+        cache_name="my-cache", user="terrapod", region="us-east-1"
+    )
+
+    # Token is the presigned URL without the scheme.
+    assert tok == "my-cache/?Action=connect&User=terrapod&X-Amz-Signature=abc"
+    args = mock_signer.generate_presigned_url.call_args
+    assert args.kwargs["operation_name"] == "connect"
+    assert "Action=connect" in args.args[0]["url"]
+    assert "User=terrapod" in args.args[0]["url"]
+
+
+# ── credential provider dispatch ──────────────────────────────────────
+
+
+def _creds(provider):
+    return (provider.get_credentials(), asyncio.run(provider.get_credentials_async()))
+
+
+def test_provider_aws_returns_username_and_token(monkeypatch):
+    monkeypatch.setattr(iam_auth, "mint_aws_elasticache_token", lambda **_kw: "AWS")
+    p = iam_auth.make_credential_provider(
+        auth_mode="aws_iam", username="terrapod", cache_name="c", region="r"
+    )
+    sync, asyncc = _creds(p)
+    assert sync == ("terrapod", "AWS")
+    assert asyncc == ("terrapod", "AWS")
+
+
+def test_provider_gcp_uses_access_token(monkeypatch):
+    monkeypatch.setattr(iam_auth, "mint_gcp_access_token", lambda: "GCP")
+    p = iam_auth.make_credential_provider(
+        auth_mode="gcp_iam", username="sa@proj.iam", cache_name="", region=""
+    )
+    assert asyncio.run(p.get_credentials_async()) == ("sa@proj.iam", "GCP")
+
+
+def test_provider_azure_uses_entra_token(monkeypatch):
+    monkeypatch.setattr(iam_auth, "mint_azure_redis_token", lambda: "AZURE")
+    p = iam_auth.make_credential_provider(
+        auth_mode="azure_ad", username="obj-id", cache_name="", region=""
+    )
+    assert asyncio.run(p.get_credentials_async()) == ("obj-id", "AZURE")
+
+
+def test_provider_mints_fresh_token_each_call(monkeypatch):
+    tokens = iter(["t1", "t2"])
+    monkeypatch.setattr(iam_auth, "mint_aws_elasticache_token", lambda **_kw: next(tokens))
+    p = iam_auth.make_credential_provider(
+        auth_mode="aws_iam", username="u", cache_name="c", region="r"
+    )
+    assert p.get_credentials()[1] == "t1"
+    assert p.get_credentials()[1] == "t2"
+
+
+def test_provider_unsupported_mode_raises():
+    with pytest.raises(ValueError, match="unsupported IAM redis"):
+        iam_auth.make_credential_provider(auth_mode="nope", username="u", cache_name="", region="")
+
+
+# ── redis client wiring ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_redis_uses_credential_provider_only_for_iam_mode():
+    """init_redis passes a credential_provider for IAM modes, not for password."""
+    from terrapod.redis import client as redis_client
+
+    async def _check(auth_mode: str, *, expect_provider: bool):
+        cfg = RedisConfig(auth_mode=auth_mode, username="terrapod", aws_cache_name="c")
+        fake_redis = MagicMock()
+        fake_redis.ping = AsyncMock()
+        fake_redis.aclose = AsyncMock()
+        with (
+            patch.object(redis_client, "settings") as fake_settings,
+            patch.object(redis_client.aioredis, "from_url", return_value=fake_redis) as from_url,
+        ):
+            fake_settings.redis = cfg
+            fake_settings.redis_url = "rediss://user:pw@cache.example.com:6379"
+            await redis_client.init_redis()
+            kwargs = from_url.call_args.kwargs
+            if expect_provider:
+                assert "credential_provider" in kwargs
+                # URL userinfo stripped (provider supplies username + token).
+                assert "@" not in from_url.call_args.args[0]
+            else:
+                assert "credential_provider" not in kwargs
+        await redis_client.close_redis()
+
+    await _check("password", expect_provider=False)
+    await _check("aws_iam", expect_provider=True)


### PR DESCRIPTION
Closes #579. The Redis/Valkey analogue of the database cloud-IAM auth (#573, v0.45.x) — passwordless Redis under the API pod's workload identity, no static auth string.

## What
Opt in via `api.config.redis.auth_mode`:

| Mode | What it does | Identity |
|---|---|---|
| `password` (default) | Static auth string in the Redis URL — unchanged | — |
| `aws_iam` | AWS ElastiCache (Redis 7+/Valkey, incl. Serverless) — SigV4-presigned `connect` token (botocore, local signing) | IRSA |
| `gcp_iam` | GCP Memorystore — SA OAuth2 token (`cloud-platform` scope) | WIF |
| `azure_ad` | Azure Cache for Redis — Entra token (`redis.azure.com` scope) | Azure WI |

A fresh token is supplied per (re)connect via a redis-py `CredentialProvider`; `get_credentials_async` offloads the mint with `asyncio.to_thread`, so the event loop is never blocked (**rule 13**). **TLS (`rediss://`) is required**; the URL's userinfo is stripped in IAM mode (the provider supplies username + token). The API image already carries the token SDKs (botocore / google-auth / azure-identity) — no new deps.

## Notes
- **AWS specifics:** the Redis user must be an ElastiCache User in IAM mode, and the IRSA role needs **`elasticache:Connect`**. The signing identifier is the **cache name** (`aws_cache_name` — replication-group / serverless cache id), *not* the endpoint host.
- Cluster-mode safe — no change to the `transaction=False` cross-slot invariant.

## Verify
- `make lint` ✅, `make test` ✅ (9 new tests: per-cloud minters, URL-strip, sync+async provider dispatch, the client wiring; plus the default-password guard)
- `helm lint` + `helm template` ✅ — `api.config.redis.*` renders in IAM mode and clean in password mode

## Out of scope
- Wrapper IRSA `elasticache:Connect` grant (internal repo).
- Live ElastiCache / Memorystore / Azure-Redis connection — staging smoke (CI can't exercise real cloud IAM).