### PR TITLE
fix(redis): pre-release hardening of cloud-IAM Redis auth (#579)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Audit Logging](audit-logging.md) | Immutable event log, query API, retention |
 | [Artifact Retention](artifact-retention.md) | Automated cleanup of old state versions, run logs, cache entries |
 | [Runners](runners.md) | Custom runner images, private registries, Job configuration |
-| [Cloud Credentials](cloud-credentials.md) | Zero static cloud credentials, end to end — runs and the platform reach cloud APIs via Kubernetes workload identity (AWS IRSA, GCP WIF, Azure WI). Beginner primer, decision tree, troubleshooting, DB-auth + Vault/ESO patterns |
+| [Cloud Credentials](cloud-credentials.md) | Zero static cloud credentials, end to end — runs and the platform reach cloud APIs via Kubernetes workload identity (AWS IRSA, GCP WIF, Azure WI). Beginner primer, decision tree, troubleshooting, passwordless **database** + **Redis/Valkey** IAM auth (AWS/GCP/Azure), and Vault/ESO patterns |
 | [Registry](registry.md) | Private module/provider registry, caching layers |
 | [Registry Publishing](registry-publishing.md) | Publishing providers/modules with the `terrapod-publish` CLI and the client-signed publish protocol |
 | [Service Catalog](service-catalog.md) | No-code self-service provisioning over the private module registry: blessed catalog items, provider templates, a `catalog_permission` RBAC axis, and a full provision → reconfigure → destroy lifecycle |

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, PostgresDsn, RedisDsn
+from pydantic import BaseModel, Field, PostgresDsn, RedisDsn, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -1085,6 +1085,15 @@ class RedisConfig(BaseModel):
             "host). Required when auth_mode='aws_iam'."
         ),
     )
+
+    @model_validator(mode="after")
+    def _require_iam_fields(self) -> "RedisConfig":
+        """Fail fast on misconfigured IAM auth instead of an opaque connect error."""
+        if self.auth_mode in ("aws_iam", "gcp_iam", "azure_ad") and not self.username:
+            raise ValueError(f"redis.username is required for auth_mode={self.auth_mode!r}")
+        if self.auth_mode == "aws_iam" and not self.aws_cache_name:
+            raise ValueError("redis.aws_cache_name is required for auth_mode='aws_iam'")
+        return self
 
 
 # --- Main Settings ---

--- a/services/terrapod/redis/client.py
+++ b/services/terrapod/redis/client.py
@@ -32,8 +32,16 @@ async def init_redis() -> None:
         # this untouched. TLS (rediss://) is required for IAM Redis auth.
         from terrapod.redis import iam_auth
 
+        stripped_url = iam_auth.strip_url_credentials(settings.redis_url)
+        if not stripped_url.startswith("rediss://"):
+            # IAM tokens are bearer credentials — refuse to send them over a
+            # plaintext connection. (Fail fast at startup, don't leak.)
+            raise ValueError(
+                "Redis cloud-IAM auth requires TLS: set a rediss:// URL "
+                f"(auth_mode={redis_cfg.auth_mode!r} with a non-TLS redis_url)"
+            )
         _redis = aioredis.from_url(
-            iam_auth.strip_url_credentials(settings.redis_url),
+            stripped_url,
             decode_responses=True,
             credential_provider=iam_auth.make_credential_provider(
                 auth_mode=redis_cfg.auth_mode,

--- a/services/terrapod/redis/iam_auth.py
+++ b/services/terrapod/redis/iam_auth.py
@@ -57,15 +57,16 @@ _azure_state: dict[str, object] = {}
 def strip_url_credentials(redis_url: str) -> str:
     """Drop any userinfo from a redis URL.
 
-    redis-py rejects passing both a URL password and a ``credential_provider``;
-    in IAM mode the provider supplies the username + token, so we strip the
-    URL's userinfo (host/port/path/query/scheme — incl. ``rediss://`` TLS —
-    are preserved).
+    In IAM mode the credential provider supplies the username + token, so we
+    strip the URL's userinfo to avoid it competing with the provider. The
+    scheme (incl. ``rediss://`` TLS), host, port, db-path, and query are
+    preserved; IPv6 host literals stay bracketed.
     """
     parts = urlsplit(str(redis_url))
-    netloc = parts.hostname or ""
-    if parts.port:
-        netloc = f"{netloc}:{parts.port}"
+    host = parts.hostname or ""
+    if ":" in host:  # IPv6 literal — re-bracket so the port stays parseable
+        host = f"[{host}]"
+    netloc = f"{host}:{parts.port}" if parts.port else host
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
@@ -73,6 +74,10 @@ def strip_url_credentials(redis_url: str) -> str:
 
 
 def _aws_signer(region: str):
+    # The RequestSigner holds the session's *refreshable* credentials object
+    # (botocore freezes them at sign time via get_frozen_credentials), so the
+    # cached per-region signer auto-renews across IRSA credential rotation — do
+    # NOT "fix" this by rebuilding the signer each call.
     key = region or "default"
     signer = _aws_signers.get(key)
     if signer is None:

--- a/services/tests/test_redis_iam_auth.py
+++ b/services/tests/test_redis_iam_auth.py
@@ -34,6 +34,29 @@ def test_strip_url_credentials_removes_userinfo():
         iam_auth.strip_url_credentials("rediss://cache.example.com:6379")
         == "rediss://cache.example.com:6379"
     )
+    # Username-only + db-number preserved.
+    assert (
+        iam_auth.strip_url_credentials("rediss://user@cache.example.com:6379/2")
+        == "rediss://cache.example.com:6379/2"
+    )
+
+
+def test_strip_url_credentials_rebrackets_ipv6():
+    # IPv6 literal must stay bracketed or the port can't be parsed.
+    assert (
+        iam_auth.strip_url_credentials("rediss://u:p@[2001:db8::1]:6379/0")
+        == "rediss://[2001:db8::1]:6379/0"
+    )
+
+
+def test_redis_config_requires_username_for_iam():
+    with pytest.raises(ValueError, match="redis.username is required"):
+        RedisConfig(auth_mode="gcp_iam")
+
+
+def test_redis_config_requires_cache_name_for_aws():
+    with pytest.raises(ValueError, match="aws_cache_name is required"):
+        RedisConfig(auth_mode="aws_iam", username="terrapod")
 
 
 def test_mint_aws_elasticache_token_signs_and_strips_scheme(monkeypatch):
@@ -130,7 +153,26 @@ async def test_init_redis_uses_credential_provider_only_for_iam_mode():
                 assert "@" not in from_url.call_args.args[0]
             else:
                 assert "credential_provider" not in kwargs
+                # password mode passes the URL through untouched (userinfo kept).
+                assert from_url.call_args.args[0] == fake_settings.redis_url
         await redis_client.close_redis()
 
     await _check("password", expect_provider=False)
     await _check("aws_iam", expect_provider=True)
+
+
+@pytest.mark.asyncio
+async def test_init_redis_iam_requires_tls():
+    """IAM modes refuse a non-TLS (redis://) URL — tokens never go plaintext."""
+    from terrapod.redis import client as redis_client
+
+    cfg = RedisConfig(auth_mode="aws_iam", username="terrapod", aws_cache_name="c")
+    with (
+        patch.object(redis_client, "settings") as fake_settings,
+        patch.object(redis_client.aioredis, "from_url") as from_url,
+    ):
+        fake_settings.redis = cfg
+        fake_settings.redis_url = "redis://cache.example.com:6379"  # non-TLS
+        with pytest.raises(ValueError, match="requires TLS"):
+            await redis_client.init_redis()
+        from_url.assert_not_called()


### PR DESCRIPTION
Pre-release audit + third-party review fixes for the Redis cloud-IAM auth feature (#579 / #581), before tagging v0.46.0.

- **TLS enforced (security blocker).** IAM tokens are bearer credentials, but `init_redis` didn't require TLS — a `redis://` URL would have sent the token **in plaintext**. It now fails fast at startup unless the URL is `rediss://`.
- **IPv6 endpoints.** `strip_url_credentials` dropped the IPv6 brackets, yielding an unparseable URL; it now re-brackets IPv6 literals.
- **Fail-fast config validation.** `RedisConfig` now requires `username` for every IAM mode and `aws_cache_name` for `aws_iam` (instead of an opaque connect error).
- Clarifying comment that the cached AWS `RequestSigner` holds *refreshable* credentials (auto-renews across IRSA rotation — verified, not a staleness bug); `docs/index.md` now lists Redis IAM; strip docstring accuracy.

Tests added: IPv6 strip, username-only/db-number preservation, password-mode URL passthrough, TLS-required raise, and both config validators.

`make lint` ✅, `make test` ✅ (2439 passed), `helm lint`/`template` ✅.