### PR TITLE
fix(db): cloud-IAM auth for the bootstrap Job + bootstrap.enabled toggle (#577)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 from logging.config import fileConfig
 
-from sqlalchemy import event, pool
+from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
@@ -55,28 +55,14 @@ async def run_async_migrations() -> None:
     )
 
     # Cloud-IAM DB auth (#573) for the migrations Job: mirror the API's
-    # per-connection token + TLS injection so the Job authenticates the same way
-    # as the running app (the DB role is IAM-only / TLS-required). Config comes
-    # via TP_DB_* env vars set by the migrations Job template. Default
-    # auth_mode="password" leaves the engine untouched.
-    auth_mode = os.environ.get("TP_DB_AUTH_MODE", "password")
-    if auth_mode in ("aws_iam", "gcp_iam", "azure_ad"):
-        from terrapod.db import iam_auth
+    # per-connection token + TLS injection (shared with the bootstrap Job) so the
+    # Job authenticates the same way as the running app when an IAM auth_mode is
+    # set via TP_DB_* env. No-op for the default static-password mode.
+    from terrapod.db import iam_auth
 
-        host, port, user = iam_auth.parse_pg_target(config.get_main_option("sqlalchemy.url") or "")
-        event.listen(
-            connectable.sync_engine,
-            "do_connect",
-            iam_auth.make_do_connect_handler(
-                auth_mode=auth_mode,
-                host=host,
-                port=port,
-                user=user,
-                region=os.environ.get("TP_DB_AWS_IAM_REGION", ""),
-                ssl_mode=os.environ.get("TP_DB_SSL_MODE", ""),
-                ssl_root_cert=os.environ.get("TP_DB_SSL_ROOT_CERT", ""),
-            ),
-        )
+    iam_auth.register_engine_iam_auth(
+        connectable.sync_engine, config.get_main_option("sqlalchemy.url") or ""
+    )
 
     async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations)

--- a/helm/terrapod/templates/job-bootstrap.yaml
+++ b/helm/terrapod/templates/job-bootstrap.yaml
@@ -1,6 +1,9 @@
 {{- if ne .Values.api.enabled false }}
-{{- if .Values.bootstrap }}
+{{- if and .Values.bootstrap (ne .Values.bootstrap.enabled false) }}
 {{- if or (and .Values.bootstrap.adminEmail .Values.bootstrap.adminPassword) .Values.bootstrap.existingSecret }}
+{{- $dbAuthMode := (.Values.api.config.database).auth_mode | default "password" }}
+{{- $dbIam := or (eq $dbAuthMode "aws_iam") (eq $dbAuthMode "gcp_iam") (eq $dbAuthMode "azure_ad") }}
+{{- $dbCa := or .Values.api.databaseCA.inline .Values.api.databaseCA.existingConfigMap }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -23,6 +26,11 @@ spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $dbIam }}
+      # Cloud-IAM DB auth: run under the API's IRSA/workload-identity SA so the
+      # Job can mint a DB token (the cloud identity webhook projects its own token).
+      serviceAccountName: {{ include "terrapod.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: false
       restartPolicy: OnFailure
@@ -72,6 +80,26 @@ spec:
             - name: TERRAPOD_BOOTSTRAP_POOL_TOKEN
               value: {{ .Values.bootstrap.poolToken | quote }}
             {{- end }}
+            {{- if $dbIam }}
+            - name: TP_DB_AUTH_MODE
+              value: {{ $dbAuthMode | quote }}
+            - name: TP_DB_AWS_IAM_REGION
+              value: {{ (.Values.api.config.database).aws_iam_region | default "" | quote }}
+            - name: TP_DB_SSL_MODE
+              value: {{ (.Values.api.config.database).ssl_mode | default "" | quote }}
+            - name: TP_DB_SSL_ROOT_CERT
+              {{- if $dbCa }}
+              value: {{ printf "/etc/terrapod/db-ca/%s" (.Values.api.databaseCA.key | default "ca.pem") | quote }}
+              {{- else }}
+              value: {{ (.Values.api.config.database).ssl_root_cert | default "" | quote }}
+              {{- end }}
+            {{- end }}
+          {{- if and $dbIam $dbCa }}
+          volumeMounts:
+            - name: database-ca
+              mountPath: /etc/terrapod/db-ca
+              readOnly: true
+          {{- end }}
           resources:
             requests:
               cpu: 250m
@@ -81,6 +109,12 @@ spec:
               memory: 512Mi
           securityContext:
             {{- toYaml .Values.api.containerSecurityContext | nindent 12 }}
+      {{- if and $dbIam $dbCa }}
+      volumes:
+        - name: database-ca
+          configMap:
+            name: {{ .Values.api.databaseCA.existingConfigMap | default (printf "%s-database-ca" (include "terrapod.fullname" .)) }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -259,6 +259,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": { "type": "boolean" },
         "adminEmail": { "type": "string" },
         "adminPassword": { "type": "string" },
         "existingSecret": { "type": "string" },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -1108,7 +1108,12 @@ migrations:
     pullPolicy: IfNotPresent
 
 # ── Bootstrap (initial admin user + optional pool) ─────────────────────────
+# The bootstrap Job is a post-install hook that idempotently seeds the admin
+# user (+ an optional agent pool). NOTE: ArgoCD runs post-install hooks on
+# every Sync, so on an established deployment (admin already exists) it just
+# re-runs as a no-op — set `enabled: false` to stop it once seeded.
 # bootstrap:
+#   enabled: true      # set false to skip the bootstrap Job (admin already seeded)
 #   adminEmail: admin@example.com
 #   adminPassword: ""  # Required when enabled
 #   existingSecret: ""  # Alternative: reference an existing K8s Secret

--- a/services/terrapod/cli/bootstrap.py
+++ b/services/terrapod/cli/bootstrap.py
@@ -54,6 +54,14 @@ async def bootstrap() -> None:
 
     engine = create_async_engine(database_url, echo=False)
 
+    # Cloud-IAM DB auth (#573): authenticate the same way as the API when an IAM
+    # mode is selected (TP_DB_* env from the Job template). No-op for the default
+    # static-password mode. Without this the Job fails on an IAM-only / password-
+    # less database (the API and migrations Job already do this).
+    from terrapod.db import iam_auth
+
+    iam_auth.register_engine_iam_auth(engine.sync_engine, database_url)
+
     async with engine.begin() as conn:
         await conn.execute(text("SELECT 1"))
         logger.info("Connected to database")

--- a/services/terrapod/db/iam_auth.py
+++ b/services/terrapod/db/iam_auth.py
@@ -220,3 +220,39 @@ def make_do_connect_handler(
         cparams["ssl"] = ssl_ctx
 
     return _do_connect
+
+
+def register_engine_iam_auth(sync_engine, database_url: str) -> bool:
+    """Register cloud-IAM ``do_connect`` on an engine from ``TP_DB_*`` env vars.
+
+    Shared by the side jobs that build their own engine outside the API's
+    ``init_db`` — the migrations Job (``alembic/env.py``) and the bootstrap Job
+    (``cli/bootstrap.py``) — so they authenticate the same way as the running
+    app (per-connection token + TLS) when an IAM ``auth_mode`` is selected.
+    Reads ``TP_DB_AUTH_MODE`` / ``TP_DB_AWS_IAM_REGION`` / ``TP_DB_SSL_MODE`` /
+    ``TP_DB_SSL_ROOT_CERT``. Returns ``True`` if a handler was registered;
+    ``False`` (no-op) for the default static-password mode.
+    """
+    import os
+
+    auth_mode = os.environ.get("TP_DB_AUTH_MODE", "password")
+    if auth_mode not in ("aws_iam", "gcp_iam", "azure_ad"):
+        return False
+
+    from sqlalchemy import event
+
+    host, port, user = parse_pg_target(database_url)
+    event.listen(
+        sync_engine,
+        "do_connect",
+        make_do_connect_handler(
+            auth_mode=auth_mode,
+            host=host,
+            port=port,
+            user=user,
+            region=os.environ.get("TP_DB_AWS_IAM_REGION", ""),
+            ssl_mode=os.environ.get("TP_DB_SSL_MODE", ""),
+            ssl_root_cert=os.environ.get("TP_DB_SSL_ROOT_CERT", ""),
+        ),
+    )
+    return True

--- a/services/tests/test_db_iam_auth.py
+++ b/services/tests/test_db_iam_auth.py
@@ -198,3 +198,24 @@ async def test_init_db_registers_listener_only_for_iam_mode():
 
     await _check("password", expect_listener=False)
     await _check("aws_iam", expect_listener=True)
+
+
+def test_register_engine_iam_auth_env_gated(monkeypatch):
+    """The shared helper (migrations + bootstrap Jobs) registers do_connect only
+    for an IAM TP_DB_AUTH_MODE, and is a no-op for the default password mode."""
+    import sqlalchemy
+
+    calls = []
+    monkeypatch.setattr(sqlalchemy.event, "listen", lambda *a, **_k: calls.append(a))
+    engine = MagicMock()
+    url = "postgresql+asyncpg://terrapod@db.example.com:5432/terrapod"
+
+    monkeypatch.delenv("TP_DB_AUTH_MODE", raising=False)
+    assert iam_auth.register_engine_iam_auth(engine, url) is False
+    assert calls == []
+
+    monkeypatch.setenv("TP_DB_AUTH_MODE", "aws_iam")
+    assert iam_auth.register_engine_iam_auth(engine, url) is True
+    assert len(calls) == 1
+    assert calls[0][0] is engine  # the sync_engine we passed
+    assert calls[0][1] == "do_connect"


### PR DESCRIPTION
Completes the "every DB consumer is IAM-aware" coverage from #577. The **bootstrap Job** (a Helm `post-install` hook — which **ArgoCD re-runs on every Sync**) builds its own engine and still used static-password auth, so on an **IAM-only / password-less** database it CrashLoops every sync (`asyncpg: 'NoneType' object has no attribute 'encode'`). The API and migrations Job were already IAM-aware; bootstrap was the deferred sibling.

## Fix
- **`iam_auth.register_engine_iam_auth(sync_engine, url)`** — new shared helper that registers the per-connection token + TLS `do_connect` from `TP_DB_*` env (no-op for `password`). **`alembic/env.py` now uses it too** (DRY — one tested path for both side-jobs).
- **`cli/bootstrap.py`** — registers IAM auth on its engine before connecting.
- **`job-bootstrap.yaml`** — when `database.auth_mode` is an IAM mode: run under the API IRSA SA, pass `TP_DB_*`, mount the DB CA bundle for `verify-full`.
- **New `bootstrap.enabled` chart toggle** (default `true`) — lets operators stop the redundant every-sync re-seed once the admin exists (since ArgoCD runs `post-install` hooks every sync). Values + schema.

## Verify
- `make lint` ✅, `make test` ✅ (2440 passed; new `register_engine_iam_auth` env-gated test)
- `helm lint`/`template` ✅ — bootstrap Job renders SA + `TP_DB_*` + CA mount in IAM mode, nothing in password mode, and `bootstrap.enabled=false` renders no Job.

Default static-password mode is unchanged.