### PR TITLE
docs: make VCS webhook support explicit (not just "optional")

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | Workspaces | Implemented | Isolate state, variables, and runs per workspace |
 | Remote State Management | Implemented | Versioned state storage with locking, rollback, encryption at rest via CSP services |
 | Agent Execution | Implemented | Plan/apply runs on the server via K8s Job-based runner infrastructure |
-| VCS Integration | Implemented | GitHub (App) and GitLab (access token); polling-first with optional webhooks |
+| VCS Integration | Implemented | GitHub (App) and GitLab (access token); inbound webhooks supported (GitHub, HMAC-validated) for instant triggers, with outbound polling as the resilient default so webhooks are optional, never required |
 | Variables & Secrets | Implemented | Per-workspace env and Terraform variables; sensitive values protected by database encryption-at-rest; variable sets |
 | RBAC | Implemented | Label-based role system with hierarchical workspace permissions (read/plan/write/admin) |
 | Private Module Registry | Implemented | Publish, version, and share modules internally |
@@ -356,7 +356,7 @@ Reports are written to `reports/pentest/`. See [SECURITY.md](SECURITY.md) for th
 **Where Terrapod is genuinely differentiated** (verified against Terrakube's current docs). The first three share one theme -- Terrapod is built for restricted-network, multi-cluster, low-upstream-dependency topologies:
 
 - **Firewall-friendly cross-cluster execution.** Terrapod runners connect *outbound* to the control plane over SSE and create Jobs locally; the API holds no inbound reach and no Kubernetes access into the execution cluster. Terrakube's API connects *into* the executor (it must be exposed via ingress, with Redis reachable), so isolated / NAT'd / outbound-only execution clusters aren't supported the same way.
-- **Polling-first VCS** -- Terrapod polls VCS over outbound HTTPS (webhooks optional); Terrakube is webhook-only and needs inbound webhook delivery.
+- **Polling-first VCS** -- Terrapod supports inbound webhooks (GitHub) but does not require them: it also polls VCS over outbound HTTPS, so the integration works behind firewalls/NATs with no inbound delivery. Terrakube uses webhook delivery. Different fits for inbound-restricted networks.
 - **Pull-through provider mirror + terraform/tofu binary cache** -- runners have zero direct upstream dependency; Terrakube ships a local plugin cache.
 - **Monorepo autodiscovery** -- Atlantis-style auto-creation of workspaces from glob-matched directories on PRs (Terrakube has directory filtering, but not auto-creation).
 - **Run tasks** -- pre/post-plan external webhook validation hooks (not present in Terrakube).

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | **Workspaces** | Isolate state, variables, and runs per workspace |
 | **Remote State Management** | Versioned state storage with locking, rollback, encryption at rest via CSP services |
 | **Agent Execution** | Plan/apply runs on the server via K8s Job-based runner infrastructure |
-| **VCS Integration** | GitHub (App) and GitLab (access token); polling-first with optional webhooks |
+| **VCS Integration** | GitHub (App) and GitLab (access token); inbound webhooks supported (GitHub, HMAC-validated) for instant triggers, plus outbound polling so webhooks are optional, never required |
 | **VCS Workflows** | Default merge-then-apply (TFE standard) plus opt-in apply-then-merge mode (Atlantis-style: PR comments drive applies, `terrapod apply` from a PR comment, auto-merge after apply) |
 | **Variables & Secrets** | Per-workspace env and Terraform variables; sensitive values protected by database encryption-at-rest; variable sets |
 | **RBAC** | Label-based role system with hierarchical workspace permissions (read/plan/write/admin) |

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -39,10 +39,13 @@ Terrapod's background poller checks your VCS providers every 60 seconds (configu
 - **Branch push -> full plan/apply run** -- when a new commit lands on the tracked branch, Terrapod downloads the code and queues a normal run (plan, then apply if auto-apply is on or manually confirmed).
 - **Pull request / merge request -> speculative plan** -- when an open PR/MR targets the tracked branch and has a new head commit, Terrapod queues a plan-only run. The plan shows what _would_ change if the PR were merged, but it can never be applied. A new speculative run is created each time the PR/MR is updated with a new commit.
 
-### Polling-First Design
+### Webhooks are supported — and polling means they're never required
 
-- **No inbound connections required** -- Terrapod only makes outbound HTTPS calls to VCS provider APIs, so it works behind firewalls and NATs without any ingress configuration.
-- **Webhooks are optional** (GitHub only, currently) -- if you want faster feedback (sub-second instead of up to 60s), you can configure GitHub webhooks. The webhook tells the poller to check immediately rather than waiting for the next cycle.
+Terrapod **does support inbound VCS webhooks** for instant triggers, *and* it polls, so it works with or without them. The two are complementary, not either/or:
+
+- **Webhooks are supported** (GitHub today, HMAC-validated at `POST /api/terrapod/v1/vcs-events/github`). Configure one and a push or PR triggers a run within ~a second instead of waiting for the next poll cycle. The webhook simply tells the poller to check *now*. Exposing only the webhook path publicly (so the rest of the platform can stay private) is covered in [Optional webhook ingress](deployment-webhook-ingress.md).
+- **Polling is the resilient default, so webhooks are optional.** Terrapod polls each connected repo over **outbound HTTPS** every `poll_interval_seconds` (default 60). This requires **no inbound connections**, so it works behind firewalls and NATs with zero ingress configuration — and it means **nothing is lost without a webhook**: the same runs are created on the next poll cycle, just up to 60s later. A webhook is a latency optimization, never a dependency.
+- **Why polling-first** — many self-hosted deployments sit in networks where a VCS provider cannot deliver an inbound webhook at all. Polling guarantees the integration works everywhere; webhooks make it faster where inbound delivery is available. (GitLab is polling-only today; a GitLab webhook receiver is not yet implemented, and GitLab repos work fully via polling.)
 
 ### Sparse fetch + caching
 

--- a/llms.txt
+++ b/llms.txt
@@ -47,7 +47,7 @@ Build/lint/test all run in Docker via `make` (`make test`, `make lint`, `make de
 
 - [Workspaces, Remote State & CLI-driven runs](docs/remote-state.md): isolated state/variables/runs; versioned state with locking, rollback; `terraform`/`tofu` via the `cloud` block.
 - [Agent execution & Runners](docs/runners.md): server-side plan/apply on ephemeral K8s Jobs (ARC pattern); custom runner images, Job placement, agent pools.
-- [VCS Integration](docs/vcs-integration.md) and [VCS Workflows](docs/vcs-workflows.md): GitHub App + GitLab token; polling-first with optional webhooks; merge-then-apply vs apply-then-merge.
+- [VCS Integration](docs/vcs-integration.md) and [VCS Workflows](docs/vcs-workflows.md): GitHub App + GitLab token. **Inbound webhooks are supported** (GitHub, HMAC-validated at `POST /api/terrapod/v1/vcs-events/github`) for instant triggers, **and** outbound polling runs alongside — so webhooks are an optional latency optimization, **never required** (the integration works behind firewalls/NATs either way; nothing is lost without a webhook, the same runs fire on the next poll cycle). GitLab is polling-only today. merge-then-apply vs apply-then-merge.
 - [Workspace Autodiscovery](docs/autodiscovery.md): Atlantis-style monorepo workspace auto-creation from PRs.
 - [RBAC](docs/rbac.md): label-based roles, hierarchical workspace permissions (read/plan/write/admin); no teams.
 - [Authentication](docs/authentication.md): local, OIDC, SAML, `terraform login`, API tokens, scoped service tokens.


### PR DESCRIPTION
Reframes VCS docs so webhook support is stated affirmatively — an HMAC-validated GitHub webhook receiver triggers immediate runs — while keeping the accurate resilience point (polling means webhooks are an optional latency optimization, never required; nothing is lost without one). Fixes the perception (seen in LLM platform comparisons) that Terrapod doesn't support webhooks.

- `docs/vcs-integration.md`: section leads with "Webhooks are supported — and polling means they're never required"
- `README.md` / `docs/index.md` / `llms.txt`: "optional webhooks" → affirms inbound webhooks supported (GitHub, HMAC) + polling makes them optional
- GitLab noted as polling-only today; peer refs neutral

Docs only. closes #588