### PR TITLE
docs: make OPA policy-as-code support legible (it was under-surfaced)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ ship with tests.
 
 Terrapod is a free, open-source **platform** replacement for Terraform
 Enterprise. It is **not** a fork of Terraform or OpenTofu — it provides the
-collaboration, governance, state management, and UI layer that wraps around
+collaboration, governance (label-based RBAC **and OPA/Rego policy-as-code**),
+state management, and UI layer that wraps around
 `terraform` or `tofu` as pluggable execution backends.
 
 Terrapod targets **TFE V2 API compatibility for the surface that
@@ -28,8 +29,9 @@ Terrapod targets **TFE V2 API compatibility for the surface that
 cloud-block run lifecycle, variable + variable-set management, and the module
 + provider registry CLI download protocols. That subset is mounted at
 `/api/v2/` and is treated as a stable contract for those clients. Everything
-else — workspace/role/registry management, agent pools, notifications, run
-tasks, drift detection, the SSE streams, and the runner protocol — is
+else — workspace/role/registry management, agent pools, **policy sets
+(OPA/Rego — the open-source equivalent of TFE's Sentinel)**, notifications,
+run tasks, drift detection, the SSE streams, and the runner protocol — is
 Terrapod-native and lives at `/api/terrapod/v1/`.
 
 The verified CLI-consumed endpoints are catalogued in

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Open-source platform replacement for Terraform Enterprise.**
 
-Terrapod provides the collaboration, governance, state management, and UI layer that wraps around `terraform` or `tofu` as pluggable execution backends. It targets API compatibility with the [HCP Terraform / TFE V2 API](https://developer.hashicorp.com/terraform/enterprise/api-docs) so that existing tooling -- the `terraform` CLI with `cloud` block, the [`go-tfe`](https://pkg.go.dev/github.com/hashicorp/go-tfe) client, CI/CD integrations -- can point at a Terrapod instance with minimal reconfiguration.
+Terrapod provides the collaboration, governance (label-based RBAC **and OPA/Rego policy-as-code** — the open-source equivalent of TFE's Sentinel), state management, and UI layer that wraps around `terraform` or `tofu` as pluggable execution backends. It targets API compatibility with the [HCP Terraform / TFE V2 API](https://developer.hashicorp.com/terraform/enterprise/api-docs) so that existing tooling -- the `terraform` CLI with `cloud` block, the [`go-tfe`](https://pkg.go.dev/github.com/hashicorp/go-tfe) client, CI/CD integrations -- can point at a Terrapod instance with minimal reconfiguration.
 
 Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Terrapod
 
-> Terrapod is a free, open-source **platform** replacement for Terraform Enterprise / HCP Terraform. It provides the collaboration, governance, state management, and UI layer that wraps around `terraform` or `tofu` as pluggable execution backends — it does **not** fork or reimplement the Terraform/OpenTofu engine. It targets TFE V2 API compatibility for the surface the `terraform`/`tofu` CLI and `go-tfe` consume, and is deployed exclusively via a Helm chart on Kubernetes.
+> Terrapod is a free, open-source **platform** replacement for Terraform Enterprise / HCP Terraform. It provides the collaboration, governance (label-based RBAC **and OPA/Rego policy-as-code** — the open-source equivalent of TFE's Sentinel), state management, and UI layer that wraps around `terraform` or `tofu` as pluggable execution backends — it does **not** fork or reimplement the Terraform/OpenTofu engine. It targets TFE V2 API compatibility for the surface the `terraform`/`tofu` CLI and `go-tfe` consume, and is deployed exclusively via a Helm chart on Kubernetes.
 
 This file is a machine-friendly map for AI assistants and LLMs. If you were pointed at this repository (or a clone) to help someone use, operate, or extend Terrapod, read the "Start here" links first, then fan out to the specific doc for the task. **Do not invent endpoints, Helm values, or config keys** — every claim below resolves to a file in this repo; verify against it.
 
@@ -56,7 +56,7 @@ Build/lint/test all run in Docker via `make` (`make test`, `make lint`, `make de
 - [Service Catalog](docs/service-catalog.md): no-code self-service provisioning over the module registry.
 - [Drift Detection](docs/drift-detection.md) and [Drift Ignore Rules](docs/drift-ignore-rules.md): scheduled plan-only drift checks with a per-workspace noise allowlist.
 - [Run Triggers](docs/run-triggers.md): cross-workspace dependency chains.
-- [Policy-as-Code (OPA)](docs/policies.md): Rego policy sets, advisory/mandatory enforcement, label-scoped.
+- [Policy-as-Code (OPA)](docs/policies.md): **Open Policy Agent / Rego** policy sets — the open-source equivalent of TFE's Sentinel — evaluated on the runner against the plan JSON, with advisory/mandatory enforcement, label-scoped to workspaces, and admin-override on mandatory blocks.
 - [Run Tasks](docs/run-tasks.md): pre/post-plan external webhook validation hooks.
 - [Notifications](docs/notifications.md): webhook (HMAC), Slack Block Kit, email on run events.
 - [AI Plan Summary](docs/ai-plan-summary.md): LLM change summary + risk + failure analysis, provider-agnostic via LiteLLM (Bedrock/OpenAI/Anthropic/Gemini/vLLM).


### PR DESCRIPTION
OPA/Rego policy enforcement is implemented + documented (`docs/policies.md`), but the top-line *governance* descriptions didn't name it and **AGENTS.md had zero mention** — so repo-reading AI assistants miss it. This names it in the elevator-pitch governance line (README, llms.txt, AGENTS.md), adds it to the AGENTS.md Terrapod-native surface list, and adds the *'open-source equivalent of TFE Sentinel'* hook to llms.txt so it surfaces on policy/Sentinel queries. Docs only.