### PR TITLE
feat(eval): one-command kind/k3d quickstart + chart-managed dev/eval datastores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,8 +514,8 @@ jobs:
       - name: Install ${{ matrix.tool }}
         run: |
           if [ "${{ matrix.tool }}" = "kind" ]; then
-            curl -fsSLo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
-            chmod +x /usr/local/bin/kind
+            curl -fsSLo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+            sudo install -m 0755 ./kind /usr/local/bin/kind && rm -f ./kind
           else
             curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.9.0/install.sh | TAG=v5.9.0 bash
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,62 @@ jobs:
               --values helm/terrapod/values.yaml \
               --values helm/terrapod/values-local.yaml > /dev/null
           echo "values-local renders OK"
+      - name: Eval values render (embedded Postgres/Redis)
+        run: |
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --values helm/terrapod/values-eval.yaml)
+          echo "$out" | grep -q "component: postgresql" || { echo "FAIL: values-eval did not render embedded Postgres"; exit 1; }
+          echo "$out" | grep -q "component: redis" || { echo "FAIL: values-eval did not render embedded Redis"; exit 1; }
+          echo "$out" | grep -q "kind: PersistentVolumeClaim" || { echo "FAIL: embedded Postgres PVC missing"; exit 1; }
+          echo "values-eval renders embedded datastores OK"
+
+  # ── Eval quickstart boot (kind + k3d) ──────────────────
+  # Proves `make eval` actually stands up a complete stack (embedded
+  # Postgres/Redis + migrations + API + web) on a throwaway cluster, on both
+  # supported cluster tools. Uses released images, so it exercises the eval
+  # mechanism + chart, not the PR's app code (that's covered by the test job).
+  helm-eval-boot:
+    name: Eval Boot (${{ matrix.tool }})
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: [kind, k3d]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install ${{ matrix.tool }}
+        run: |
+          if [ "${{ matrix.tool }}" = "kind" ]; then
+            curl -fsSLo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+            chmod +x /usr/local/bin/kind
+          else
+            curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.9.0/install.sh | TAG=v5.9.0 bash
+          fi
+      - name: make eval (boot the stack)
+        env:
+          CI: "1"
+          EVAL_NO_PORT_FORWARD: "1"
+          TERRAPOD_VERSION: latest
+        run: scripts/eval.sh up
+      - name: Smoke the running stack
+        run: |
+          ctx=$([ "${{ matrix.tool }}" = "kind" ] && echo kind-terrapod-eval || echo k3d-terrapod-eval)
+          ns=terrapod-eval
+          # helm --wait already gated on readiness; assert the data plane is real:
+          kubectl --context "$ctx" -n "$ns" wait --for=condition=available deploy/terrapod-web --timeout=120s
+          kubectl --context "$ctx" -n "$ns" wait --for=condition=available deploy/terrapod-api --timeout=120s
+          kubectl --context "$ctx" -n "$ns" port-forward svc/terrapod-web 18080:3000 >/dev/null 2>&1 &
+          sleep 6
+          code=$(curl -s -o /dev/null -w '%{http_code}' --retry 8 --retry-delay 3 --retry-all-errors http://localhost:18080/login)
+          echo "GET /login -> $code"
+          [ "$code" = "200" ] || { echo "FAIL: UI did not serve /login"; exit 1; }
+          echo "Eval stack booted + UI served on ${{ matrix.tool }}"
+      - name: Teardown
+        if: always()
+        run: scripts/eval.sh down
 
   # ── SAST (Semgrep) ─────────────────────────────────────
   sast:
@@ -1362,6 +1418,7 @@ jobs:
       - dependency-review
       - helm-lint
       - helm-smoke
+      - helm-eval-boot
       - sast
       - build-images-amd64
       - build-images-arm64
@@ -1399,6 +1456,7 @@ jobs:
             "${{ needs.dependency-review.result }}"
             "${{ needs.helm-lint.result }}"
             "${{ needs.helm-smoke.result }}"
+            "${{ needs.helm-eval-boot.result }}"
             "${{ needs.sast.result }}"
             "${{ needs.build-images-amd64.result }}"
             "${{ needs.build-images-arm64.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,10 @@ jobs:
           CI: "1"
           EVAL_NO_PORT_FORWARD: "1"
           TERRAPOD_VERSION: latest
+          # Pin the tool — the runner ships a pre-installed `kind`, so without
+          # this the k3d matrix job would auto-detect kind and the smoke step's
+          # k3d-pinned context lookup would miss.
+          TERRAPOD_EVAL_TOOL: ${{ matrix.tool }}
         run: scripts/eval.sh up
       - name: Smoke the running stack
         run: |
@@ -540,6 +544,8 @@ jobs:
           echo "Eval stack booted + UI served on ${{ matrix.tool }}"
       - name: Teardown
         if: always()
+        env:
+          TERRAPOD_EVAL_TOOL: ${{ matrix.tool }}
         run: scripts/eval.sh down
 
   # ── SAST (Semgrep) ─────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,19 @@ Playwright's auto-waiting.
   `values.yaml`, update `values.schema.json` to match (it uses
   `additionalProperties: false`, so `helm lint` fails otherwise), and make
   sure the template renders it.
+- **The chart has three first-class value profiles — keep all three working.**
+  `values.yaml` (production defaults), `values-local.yaml` (the Tilt dev loop),
+  and `values-eval.yaml` (the `make eval` kind/k3d quickstart). Any chart value /
+  default / schema change must keep **all three** rendering (`helm lint` +
+  `helm template -f <profile>`) **and** the eval stack booting — the eval-boot CI
+  job (kind + k3d matrix) is what enforces the last part. `values-eval.yaml` must
+  stay **batteries-included / zero-external-deps** (it deploys in-cluster
+  Postgres/Redis via `postgresql.deploy`/`redis.deploy`, filesystem storage, a
+  local admin): if a new feature defaults to *requiring* an external dependency,
+  override it OFF in `values-eval.yaml`, or one-command eval breaks. The embedded
+  `postgresql.deploy`/`redis.deploy` datastores are **eval/dev only** (single
+  replica, no HA/backups) and must stay **off by default** so production is
+  unaffected.
 - **Keep [`llms.txt`](llms.txt) current (it's a first-class deliverable, not an
   afterthought)** — `llms.txt` is the machine-friendly map AI assistants land on
   to understand and operate Terrapod. It is only useful if it stays accurate, so

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,13 @@ dev:                ## Start Tilt development environment (port 10352)
 dev-down:           ## Stop Tilt
 	tilt down --port 10352
 
+# ── Evaluation (one-command kind/k3d quickstart) ─────────
+eval:               ## Stand up a throwaway Terrapod for evaluation (kind/k3d)
+	scripts/eval.sh up
+
+eval-down:          ## Delete the evaluation cluster
+	scripts/eval.sh down
+
 # ── Utility ──────────────────────────────────────────────
 clean:              ## Clean build artifacts
 	rm -rf services/.pytest_cache services/.coverage services/htmlcov

--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 
 ---
 
+## ⚡ Quick Evaluation
+
+Try Terrapod end-to-end on your laptop in one command. It spins up a throwaway
+[kind](https://kind.sigs.k8s.io/) or [k3d](https://k3d.io/) cluster and installs
+a complete, self-contained stack — in-cluster PostgreSQL + Redis, filesystem
+storage, a local admin login — with **no cloud account and no external
+dependencies**.
+
+```sh
+make eval          # create a local cluster + install Terrapod, then port-forward
+# → open http://localhost:8080  (login: admin@example.com / terrapod)
+
+make eval-down     # delete the whole thing when you're done
+```
+
+Prerequisites: Docker, `kubectl`, `helm`, and either `kind` or `k3d`. The
+quickstart pulls released images, so the only wait is the image download.
+
+> This is an **evaluation** profile — single-replica in-cluster datastores, a
+> known password, no HA or backups. For a real deployment see
+> [docs/deployment.md](docs/deployment.md); for the design behind the K8s-only
+> stance and how to enable agent execution, see [docs/getting-started.md](docs/getting-started.md).
+
+---
+
 ## Key Features
 
 | Feature | Status | Description |

--- a/Tiltfile
+++ b/Tiltfile
@@ -153,111 +153,15 @@ docker_build(
 #
 # Redis is *deliberately* left ephemeral below — sessions, listener
 # heartbeats, and scheduler locks should reset on Tilt restart.
-k8s_yaml(blob("""
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: terrapod-postgresql-data
-  namespace: terrapod
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 2Gi
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: terrapod-postgresql
-  namespace: terrapod
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: terrapod-postgresql
-  template:
-    metadata:
-      labels:
-        app: terrapod-postgresql
-    spec:
-      containers:
-        - name: postgres
-          image: postgres:16-alpine
-          ports:
-            - containerPort: 5432
-          env:
-            - name: POSTGRES_USER
-              value: terrapod
-            - name: POSTGRES_PASSWORD
-              value: terrapod
-            - name: POSTGRES_DB
-              value: terrapod
-            # PVC's mount point is `/var/lib/postgresql/data`, which
-            # postgres's official entrypoint also wants to populate with
-            # config; point the actual DB cluster into a subdirectory so
-            # the lost+found dir at the PVC root doesn't confuse initdb.
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/postgresql/data
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: terrapod-postgresql-data
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: terrapod-postgresql
-  namespace: terrapod
-spec:
-  selector:
-    app: terrapod-postgresql
-  ports:
-    - port: 5432
-      targetPort: 5432
-"""))
-
-# Redis for local development
-k8s_yaml(blob("""
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: terrapod-redis
-  namespace: terrapod
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: terrapod-redis
-  template:
-    metadata:
-      labels:
-        app: terrapod-redis
-    spec:
-      containers:
-        - name: redis
-          image: redis:7-alpine
-          ports:
-            - containerPort: 6379
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: terrapod-redis
-  namespace: terrapod
-spec:
-  selector:
-    app: terrapod-redis
-  ports:
-    - port: 6379
-      targetPort: 6379
-"""))
-
+# PostgreSQL + Redis are deployed by the Helm chart itself now
+# (postgresql.deploy / redis.deploy = true in values-local.yaml), so the Tilt
+# dev loop and the `make eval` kind/k3d quickstart share ONE batteries-included
+# datastore path instead of maintaining a separate copy here. Postgres keeps a
+# PVC (persists across restarts via embedded.persistence); Redis is ephemeral.
+#
+# These resources come through helm() below. Tilt does NOT execute helm hook
+# ordering, so the migrations→Postgres and api→migrations sequencing is enforced
+# by the resource_deps wired further down (unchanged — same resource names).
 k8s_resource('terrapod-postgresql', labels=['infra'])
 k8s_resource('terrapod-redis', labels=['infra'])
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,29 @@ This guide deploys Terrapod onto a Kubernetes cluster with the Helm chart, then 
 
 ---
 
+## Just kicking the tyres? One-command evaluation
+
+To try Terrapod end-to-end on your laptop without provisioning anything, skip
+the rest of this guide and run the evaluation quickstart. It spins up a
+throwaway [kind](https://kind.sigs.k8s.io/) or [k3d](https://k3d.io/) cluster
+and installs a **complete, self-contained stack** — in-cluster PostgreSQL +
+Redis (deployed by the chart), filesystem storage, and a local admin — with no
+cloud account and no external dependencies:
+
+```sh
+make eval          # create a local cluster + install Terrapod, then port-forward
+# → open http://localhost:8080  (login: admin@example.com / terrapod)
+make eval-down     # delete it all
+```
+
+Prerequisites: Docker, `kubectl`, `helm`, and either `kind` or `k3d`. This is an
+**evaluation** profile (single-replica datastores, a known password, no
+HA/backups) — for a real deployment, continue below. Agent execution (server-side
+plan/apply) is off in the eval to keep it small; create an agent pool and set
+`listener.enabled=true` to try it.
+
+---
+
 ## Prerequisites
 
 | Need | Notes |

--- a/helm/terrapod/templates/NOTES.txt
+++ b/helm/terrapod/templates/NOTES.txt
@@ -1,4 +1,12 @@
 Terrapod has been installed.
+{{- if or .Values.postgresql.deploy .Values.redis.deploy }}
+
+⚠  EVAL/DEV MODE: this release deploys chart-managed
+{{- if and .Values.postgresql.deploy .Values.redis.deploy }} PostgreSQL and Redis{{ else if .Values.postgresql.deploy }} PostgreSQL{{ else }} Redis{{ end }}
+   (single-replica, no HA, no backups). DO NOT use this for production — set
+   postgresql.deploy / redis.deploy to false and provide a managed datastore via
+   url / existingSecret.
+{{- end }}
 
 {{- if .Values.web.enabled }}
 

--- a/helm/terrapod/templates/_helpers.tpl
+++ b/helm/terrapod/templates/_helpers.tpl
@@ -339,3 +339,42 @@ primary `ingress`.
 {{- printf "%s://%s" $scheme .Values.internalIngress.hostname -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Embedded-datastore helpers (eval/dev only — see postgresql.deploy / redis.deploy).
+When the chart deploys its own Postgres/Redis, these resolve the connection
+target so consumers (api, migrations, bootstrap) need no manual url/secret.
+*/}}
+
+{{/*
+Name of the Secret holding the database URL: an operator-provided existingSecret
+if set; otherwise the chart-managed embedded secret when postgresql.deploy=true;
+otherwise empty (the consumer falls back to postgresql.url).
+*/}}
+{{- define "terrapod.postgresql.secretName" -}}
+{{- if .Values.postgresql.existingSecret -}}
+{{- .Values.postgresql.existingSecret -}}
+{{- else if .Values.postgresql.deploy -}}
+{{- printf "%s-postgresql" (include "terrapod.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "terrapod.postgresql.secretKey" -}}
+{{- if .Values.postgresql.existingSecret -}}
+{{- .Values.postgresql.existingSecretKey | default "url" -}}
+{{- else -}}
+url
+{{- end -}}
+{{- end -}}
+
+{{/*
+Effective Redis URL: redis.url if set; otherwise the embedded service when
+redis.deploy=true; otherwise empty.
+*/}}
+{{- define "terrapod.redis.url" -}}
+{{- if .Values.redis.url -}}
+{{- .Values.redis.url -}}
+{{- else if .Values.redis.deploy -}}
+{{- printf "redis://%s-redis:6379" (include "terrapod.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -75,12 +75,13 @@ spec:
                   name: {{ .Values.api.tokenSigningKey.existingSecret }}
                   key: {{ .Values.api.tokenSigningKey.existingSecretKey | default "token_signing_key" }}
             {{- end }}
-            {{- if .Values.postgresql.existingSecret }}
+            {{- $pgSecret := include "terrapod.postgresql.secretName" . }}
+            {{- if $pgSecret }}
             - name: TERRAPOD_DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.postgresql.existingSecret }}
-                  key: {{ .Values.postgresql.existingSecretKey | default "url" }}
+                  name: {{ $pgSecret }}
+                  key: {{ include "terrapod.postgresql.secretKey" . }}
             {{- else if .Values.postgresql.url }}
             - name: TERRAPOD_DATABASE_URL
               value: {{ .Values.postgresql.url | quote }}
@@ -91,9 +92,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.redis.existingSecret }}
                   key: {{ .Values.redis.existingSecretKey | default "url" }}
-            {{- else if .Values.redis.url }}
+            {{- else if (include "terrapod.redis.url" .) }}
             - name: TERRAPOD_REDIS_URL
-              value: {{ .Values.redis.url | quote }}
+              value: {{ include "terrapod.redis.url" . | quote }}
             {{- end }}
             {{- range .Values.api.config.auth.sso.oidc }}
             - name: TERRAPOD_{{ .name | upper }}_CLIENT_SECRET

--- a/helm/terrapod/templates/embedded-postgresql.yaml
+++ b/helm/terrapod/templates/embedded-postgresql.yaml
@@ -1,0 +1,151 @@
+{{- /*
+EMBEDDED POSTGRESQL — EVAL / DEV ONLY (gated on postgresql.deploy).
+
+This deploys a single-replica, in-cluster PostgreSQL so the chart can stand up a
+complete stack with zero external dependencies — for local evaluation (the
+`make eval` kind/k3d quickstart) and the Tilt dev loop. It is intentionally NOT
+production-grade: one replica, no HA, no backups, no connection pooling, no
+tuning. For production, leave postgresql.deploy=false and provide a managed
+database via postgresql.url / postgresql.existingSecret.
+
+ORDERING: the migrations Job is a Helm pre-install hook (weight -5), so it runs
+before normal resources. These datastore resources are therefore themselves
+`pre-install` hooks at a LOWER weight (-20) so Helm creates them — and waits for
+Postgres to be ready — before migrations run. They carry no hook-delete-policy,
+so they persist across `helm upgrade` (the DB is stateful); the pre-install-only
+hook simply isn't re-run on upgrade, and the original keeps serving. Teardown is
+`make eval-down` (deletes the whole cluster).
+*/ -}}
+{{- if .Values.postgresql.deploy }}
+{{- $fullname := include "terrapod.fullname" . }}
+{{- $name := printf "%s-postgresql" $fullname }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- $password := "" }}
+{{- if and $existing $existing.data (hasKey $existing.data "password") }}
+{{- $password = index $existing.data "password" | b64dec }}
+{{- else }}
+{{- $password = .Values.postgresql.embedded.password | default (randAlphaNum 24) }}
+{{- end }}
+{{- $url := printf "postgresql+asyncpg://terrapod:%s@%s:5432/terrapod" $password $name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-20"
+type: Opaque
+stringData:
+  password: {{ $password | quote }}
+  url: {{ $url | quote }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}-data
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-20"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.postgresql.embedded.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.embedded.persistence.size | default "1Gi" }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-20"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "terrapod.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "terrapod.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      # Eval/dev datastore: the official postgres image starts as root then
+      # drops to the postgres user, so it is intentionally not run under the
+      # hardened non-root SecurityContext the application pods use.
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgresql
+          image: {{ .Values.postgresql.embedded.image }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_USER
+              value: terrapod
+            - name: POSTGRES_DB
+              value: terrapod
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $name }}
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "terrapod", "-d", "terrapod"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "terrapod", "-d", "terrapod"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.postgresql.embedded.resources | nindent 12 }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ $name }}-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-20"
+spec:
+  selector:
+    {{- include "terrapod.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
+{{- end }}

--- a/helm/terrapod/templates/embedded-redis.yaml
+++ b/helm/terrapod/templates/embedded-redis.yaml
@@ -1,0 +1,78 @@
+{{- /*
+EMBEDDED REDIS — EVAL / DEV ONLY (gated on redis.deploy).
+
+Single-replica, in-cluster Redis so the chart can run with zero external
+dependencies for local evaluation (`make eval`) and the Tilt dev loop. NOT
+production-grade: one replica, no auth, no persistence, no HA. For production,
+leave redis.deploy=false and provide a managed Redis/Valkey via redis.url /
+redis.existingSecret.
+*/ -}}
+{{- if .Values.redis.deploy }}
+{{- $name := printf "%s-redis" (include "terrapod.fullname" .) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "terrapod.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "terrapod.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: {{ .Values.redis.embedded.image }}
+          imagePullPolicy: IfNotPresent
+          args: ["--save", "", "--appendonly", "no"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.redis.embedded.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  selector:
+    {{- include "terrapod.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+{{- end }}

--- a/helm/terrapod/templates/job-bootstrap.yaml
+++ b/helm/terrapod/templates/job-bootstrap.yaml
@@ -45,12 +45,13 @@ spec:
             - -m
             - terrapod.cli.bootstrap
           env:
-            {{- if .Values.postgresql.existingSecret }}
+            {{- $pgSecret := include "terrapod.postgresql.secretName" . }}
+            {{- if $pgSecret }}
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.postgresql.existingSecret }}
-                  key: {{ .Values.postgresql.existingSecretKey | default "url" }}
+                  name: {{ $pgSecret }}
+                  key: {{ include "terrapod.postgresql.secretKey" . }}
             {{- else if .Values.postgresql.url }}
             - name: DATABASE_URL
               value: {{ .Values.postgresql.url | quote }}

--- a/helm/terrapod/templates/job-migrations.yaml
+++ b/helm/terrapod/templates/job-migrations.yaml
@@ -14,7 +14,11 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 3
+  # Retry generously: when the database is co-deployed in the same release
+  # (eval/dev embedded Postgres), it may still be coming up when this hook
+  # first runs — the Job retries with exponential backoff until the DB is
+  # reachable. Harmless for an already-up managed DB in production.
+  backoffLimit: {{ .Values.migrations.backoffLimit | default 10 }}
   ttlSecondsAfterFinished: 600
   template:
     metadata:
@@ -46,12 +50,13 @@ spec:
             - upgrade
             - head
           env:
-            {{- if .Values.postgresql.existingSecret }}
+            {{- $pgSecret := include "terrapod.postgresql.secretName" . }}
+            {{- if $pgSecret }}
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.postgresql.existingSecret }}
-                  key: {{ .Values.postgresql.existingSecretKey | default "url" }}
+                  name: {{ $pgSecret }}
+                  key: {{ include "terrapod.postgresql.secretKey" . }}
             {{- else if .Values.postgresql.url }}
             - name: DATABASE_URL
               value: {{ .Values.postgresql.url | quote }}

--- a/helm/terrapod/values-eval.yaml
+++ b/helm/terrapod/values-eval.yaml
@@ -1,0 +1,61 @@
+# ── Terrapod evaluation profile — batteries-included, ZERO external deps ──────
+#
+# Used by `make eval` (the kind/k3d quickstart) to stand up a complete, throwaway
+# Terrapod in a local cluster: in-cluster Postgres + Redis (deployed by the chart),
+# filesystem object storage, a local admin login, no cloud credentials, no ingress
+# controller (access is via `kubectl port-forward`).
+#
+# THIS IS NOT A PRODUCTION CONFIG. It trades durability and security for a
+# one-command demo: single-replica datastores, no HA, no backups, a known admin
+# password. For production see helm/terrapod/values.yaml and docs/deployment.md.
+#
+# Contract: this file is a first-class consumer of the chart — any chart value /
+# default / schema change must keep `helm template -f values-eval.yaml` rendering
+# AND the eval stack booting (see AGENTS.md). Keep it zero-external-deps: if a new
+# feature defaults to requiring an external dependency, override it OFF here.
+
+fullnameOverride: terrapod
+
+# Chart-deployed datastores (eval/dev only — see postgresql.deploy / redis.deploy).
+postgresql:
+  deploy: true
+redis:
+  deploy: true
+
+# Filesystem object storage is the chart default (api.config.storage.backend);
+# just shrink the PVC for a throwaway cluster (kind/k3d ship a default StorageClass).
+storage:
+  filesystem:
+    persistence:
+      enabled: true
+      size: 2Gi
+
+api:
+  replicas: 1
+  config:
+    # Browser-facing URL via `kubectl port-forward svc/terrapod-web 8080:3000`.
+    external_url: "http://localhost:8080"
+    auth:
+      local_enabled: true
+  # The hardened ephemeral PVC isn't needed for a local eval.
+  ephemeralStorage:
+    enabled: false
+
+web:
+  replicas: 1
+
+# No ingress controller assumed in a throwaway kind/k3d cluster — the quickstart
+# port-forwards the web service instead. (The BFF Service/Deployment still deploy.)
+ingress:
+  enabled: false
+
+# Agent execution (server-side plan/apply on runner Jobs) is OFF for the quickstart
+# to keep the footprint tiny. To try it, create an agent pool + join token and set
+# listener.enabled=true with a runner image.
+listener:
+  enabled: false
+
+# Seed a local admin so you can log in immediately. Eval-only credentials.
+bootstrap:
+  adminEmail: admin@example.com
+  adminPassword: terrapod

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -215,13 +215,19 @@ bootstrap:
   poolName: dev-pool
   poolToken: "dev-join-token-do-not-use-in-prod"
 
-# Local PostgreSQL (bundled via Tiltfile)
+# Chart-managed PostgreSQL + Redis for local dev (same batteries-included path
+# as the `make eval` quickstart). Postgres keeps a PVC; the chart derives the
+# connection URLs from the in-cluster services, so no url/existingSecret needed.
+# A fixed dev password keeps the embedded DB connectable for dump/restore.
 postgresql:
-  url: "postgresql+asyncpg://terrapod:terrapod@terrapod-postgresql:5432/terrapod"
+  deploy: true
+  embedded:
+    password: terrapod
+    persistence:
+      size: 2Gi
 
-# Local Redis (bundled via Tiltfile)
 redis:
-  url: "redis://terrapod-redis:6379"
+  deploy: true
 
 storage:
   filesystem:

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -251,7 +251,8 @@
       "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
-        "image": { "$ref": "#/$defs/imageSpec" }
+        "image": { "$ref": "#/$defs/imageSpec" },
+        "backoffLimit": { "type": "integer", "minimum": 0 }
       }
     },
 
@@ -276,7 +277,25 @@
       "properties": {
         "url": { "type": "string" },
         "existingSecret": { "type": "string" },
-        "existingSecretKey": { "type": "string" }
+        "existingSecretKey": { "type": "string" },
+        "deploy": { "type": "boolean" },
+        "embedded": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "image": { "type": "string" },
+            "password": { "type": "string" },
+            "persistence": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "size": { "type": "string" },
+                "storageClass": { "type": "string" }
+              }
+            },
+            "resources": { "type": "object" }
+          }
+        }
       }
     },
 
@@ -286,7 +305,16 @@
       "properties": {
         "url": { "type": "string" },
         "existingSecret": { "type": "string" },
-        "existingSecretKey": { "type": "string" }
+        "existingSecretKey": { "type": "string" },
+        "deploy": { "type": "boolean" },
+        "embedded": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "image": { "type": "string" },
+            "resources": { "type": "object" }
+          }
+        }
       }
     },
 

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -1114,6 +1114,13 @@ migrations:
     tag: ""  # Defaults to appVersion
     pullPolicy: IfNotPresent
 
+  # Job retry budget. The migrations Job is a pre-install/pre-upgrade hook; when
+  # the database is co-deployed in the same release (eval/dev embedded Postgres,
+  # postgresql.deploy=true) it may still be starting when the hook first runs, so
+  # the Job retries with exponential backoff until the DB is reachable. Harmless
+  # for an already-up managed database in production.
+  backoffLimit: 10
+
 # ── Bootstrap (initial admin user + optional pool) ─────────────────────────
 # The bootstrap Job is a post-install hook that idempotently seeds the admin
 # user (+ an optional agent pool). NOTE: ArgoCD runs post-install hooks on
@@ -1136,12 +1143,46 @@ postgresql:
   # existingSecret: "terrapod-db-credentials"
   # existingSecretKey: "url"  # key within the Secret (default: url)
 
+  # ── Embedded PostgreSQL — EVAL / DEV ONLY ──────────────────────────────
+  # When true, the chart deploys a single-replica in-cluster PostgreSQL and
+  # wires the API/migrations/bootstrap to it automatically (no url/existingSecret
+  # needed). This exists so the stack can run with ZERO external dependencies
+  # for local evaluation (`make eval`) and the Tilt dev loop. It is NOT
+  # production-grade — one replica, no HA, no backups, no tuning. For production,
+  # keep this false and provide a managed database via url / existingSecret.
+  deploy: false
+  embedded:
+    image: postgres:16-alpine
+    # A fixed password for the embedded DB (eval only). Leave empty to have the
+    # chart generate one (stable across upgrades via a lookup on the Secret).
+    password: ""
+    persistence:
+      size: 1Gi
+      storageClass: ""   # "" = cluster default StorageClass (kind/k3d ship one)
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
 # ── Redis ─────────────────────────────────────────────────────────────────
 # Provide credentials via existingSecret (recommended) or url (dev only).
 redis:
   url: ""
   # existingSecret: "terrapod-redis-credentials"
   # existingSecretKey: "url"  # key within the Secret (default: url)
+
+  # ── Embedded Redis — EVAL / DEV ONLY ───────────────────────────────────
+  # When true, the chart deploys a single-replica in-cluster Redis and points
+  # the API at it automatically. Same caveat as embedded PostgreSQL above:
+  # eval/dev only (no auth, no persistence, no HA). Production should keep this
+  # false and provide a managed Redis/Valkey via url / existingSecret.
+  deploy: false
+  embedded:
+    image: redis:7-alpine
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
 
 # ── Storage ─────────────────────────────────────────────────────────────────
 # Filesystem PVC — only created when storage.backend=filesystem

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,7 @@ This file is a machine-friendly map for AI assistants and LLMs. If you were poin
 - [README.md](README.md): What Terrapod is, the feature list with status, a quick-start, and architecture overview.
 - [AGENTS.md](AGENTS.md): **The canonical guide for contributors and AI assistants** — architecture orientation, the API↔consumer contract, the code↔tests contract, the test tiers, conventions, and the hard invariants. Read this before changing code.
 - [docs/index.md](docs/index.md): The full documentation index (every doc page with a one-line description).
+- **Evaluate in one command**: `make eval` stands up a throwaway kind/k3d cluster with a complete, self-contained Terrapod (chart-deployed in-cluster Postgres + Redis via `postgresql.deploy`/`redis.deploy`, filesystem storage, local admin) and port-forwards the UI; `make eval-down` deletes it. See [`scripts/eval.sh`](scripts/eval.sh) + [`helm/terrapod/values-eval.yaml`](helm/terrapod/values-eval.yaml). Eval-only — not production.
 - [docs/getting-started.md](docs/getting-started.md): Deploy the Helm chart on Kubernetes, create your first workspace, run your first plan/apply.
 - [docs/architecture.md](docs/architecture.md): System components, storage, the ARC-pattern runner/listener model, and auth flows.
 - [docs/api-reference.md](docs/api-reference.md): Every API endpoint with examples (the authoritative API surface).

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Terrapod local evaluation quickstart.
+#
+#   scripts/eval.sh up      Create a throwaway kind/k3d cluster + install Terrapod
+#                           (in-cluster Postgres/Redis, filesystem storage, local
+#                           admin) and wait until it's ready. Prints the URL + creds.
+#   scripts/eval.sh down    Delete the eval cluster.
+#   scripts/eval.sh status  Show pod status.
+#
+# Auto-detects `kind` (preferred) or `k3d`. Uses released images (tag overridable
+# via TERRAPOD_VERSION, default `latest`). NOT for production — see values-eval.yaml.
+set -euo pipefail
+
+CLUSTER="${TERRAPOD_EVAL_CLUSTER:-terrapod-eval}"
+# Distinct namespace + a throwaway cluster keep the eval fully isolated from any
+# Tilt-deployed Terrapod on your default cluster (which uses the `terrapod` ns).
+NS="${TERRAPOD_EVAL_NAMESPACE:-terrapod-eval}"
+RELEASE="terrapod"
+VERSION="${TERRAPOD_VERSION:-latest}"
+PF_PORT="${TERRAPOD_EVAL_PORT:-8080}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHART_DIR="${REPO_ROOT}/helm/terrapod"
+ADMIN_EMAIL="admin@example.com"
+ADMIN_PASSWORD="terrapod"
+
+c_green=$'\033[0;32m'; c_bold=$'\033[1m'; c_yel=$'\033[0;33m'; c_reset=$'\033[0m'
+log()  { echo "${c_green}==>${c_reset} $*"; }
+warn() { echo "${c_yel}!! ${c_reset} $*"; }
+die()  { echo "ERROR: $*" >&2; exit 1; }
+
+# ── Cluster tool detection ────────────────────────────────────────────────────
+detect_tool() {
+  if command -v kind >/dev/null 2>&1; then echo kind
+  elif command -v k3d >/dev/null 2>&1; then echo k3d
+  else die "neither 'kind' nor 'k3d' found — install one: https://kind.sigs.k8s.io or https://k3d.io"; fi
+}
+
+cluster_exists() {
+  case "$1" in
+    kind) kind get clusters 2>/dev/null | grep -qx "$CLUSTER" ;;
+    k3d)  k3d cluster list -o json 2>/dev/null | grep -q "\"name\":\"$CLUSTER\"" ;;
+  esac
+}
+
+kube_context() {
+  case "$1" in
+    kind) echo "kind-${CLUSTER}" ;;
+    k3d)  echo "k3d-${CLUSTER}" ;;
+  esac
+}
+
+create_cluster() {
+  local tool="$1"
+  if cluster_exists "$tool"; then
+    log "Reusing existing ${tool} cluster '${CLUSTER}'"
+    return
+  fi
+  log "Creating ${tool} cluster '${CLUSTER}' (throwaway)…"
+  case "$tool" in
+    kind) kind create cluster --name "$CLUSTER" --wait 120s ;;
+    k3d)  k3d cluster create "$CLUSTER" --wait --timeout 120s ;;
+  esac
+}
+
+# ── Up ────────────────────────────────────────────────────────────────────────
+up() {
+  command -v helm >/dev/null 2>&1 || die "helm not found"
+  command -v kubectl >/dev/null 2>&1 || die "kubectl not found"
+  local tool ctx; tool="$(detect_tool)"; ctx="$(kube_context "$tool")"
+  # Preserve the caller's current kubectl context — `kind`/`k3d` create switches
+  # it to the new cluster, which would yank your default context (e.g. away from
+  # a Tilt-deployed Terrapod). We pin every command below to --context "$ctx" and
+  # restore the original on exit, so the eval never touches your active context.
+  local prev_ctx; prev_ctx="$(kubectl config current-context 2>/dev/null || true)"
+  restore_ctx() { [ -n "$prev_ctx" ] && kubectl config use-context "$prev_ctx" >/dev/null 2>&1 || true; }
+  trap restore_ctx EXIT
+  create_cluster "$tool"
+  restore_ctx
+
+  log "Installing Terrapod (${RELEASE}) into namespace '${NS}' using image tag '${VERSION}'…"
+  helm --kube-context "$ctx" upgrade --install "$RELEASE" "$CHART_DIR" \
+    --namespace "$NS" --create-namespace \
+    -f "${CHART_DIR}/values-eval.yaml" \
+    --set "api.image.tag=${VERSION}" \
+    --set "web.image.tag=${VERSION}" \
+    --set "migrations.image.tag=${VERSION}" \
+    --set "bootstrap.adminEmail=${ADMIN_EMAIL}" \
+    --set "bootstrap.adminPassword=${ADMIN_PASSWORD}" \
+    --set "api.config.external_url=http://localhost:${PF_PORT}" \
+    --wait --timeout 300s || {
+      warn "helm install did not report ready in time — showing pod status:"
+      kubectl --context "$ctx" -n "$NS" get pods || true
+      die "install failed (see pod status above; 'scripts/eval.sh status' to re-check)"
+    }
+
+  log "Waiting for the web frontend to be ready…"
+  kubectl --context "$ctx" -n "$NS" rollout status deploy/${RELEASE}-web --timeout=180s
+
+  print_banner "$ctx"
+  if [[ -z "${CI:-}" && -z "${EVAL_NO_PORT_FORWARD:-}" ]]; then
+    log "Starting port-forward (Ctrl-C to stop; the cluster keeps running — 'make eval-down' to delete)…"
+    exec kubectl --context "$ctx" -n "$NS" port-forward "svc/${RELEASE}-web" "${PF_PORT}:3000"
+  fi
+}
+
+print_banner() {
+  local ctx="$1"
+  cat <<EOF
+
+${c_bold}${c_green}Terrapod is up.${c_reset}
+
+  URL:       ${c_bold}http://localhost:${PF_PORT}${c_reset}   (after the port-forward below)
+  Username:  ${c_bold}${ADMIN_EMAIL}${c_reset}
+  Password:  ${c_bold}${ADMIN_PASSWORD}${c_reset}
+
+  Port-forward (if not started automatically):
+    kubectl --context ${ctx} -n ${NS} port-forward svc/${RELEASE}-web ${PF_PORT}:3000
+
+  Tear down everything:
+    make eval-down
+
+${c_yel}Evaluation only${c_reset} — single-replica in-cluster Postgres/Redis, filesystem
+storage, a known admin password. Not for production.
+EOF
+}
+
+# ── Down / status ─────────────────────────────────────────────────────────────
+down() {
+  local tool; tool="$(detect_tool)"
+  if cluster_exists "$tool"; then
+    log "Deleting ${tool} cluster '${CLUSTER}'…"
+    case "$tool" in
+      kind) kind delete cluster --name "$CLUSTER" ;;
+      k3d)  k3d cluster delete "$CLUSTER" ;;
+    esac
+  else
+    log "No ${tool} cluster '${CLUSTER}' to delete."
+  fi
+}
+
+status() {
+  local tool ctx; tool="$(detect_tool)"; ctx="$(kube_context "$tool")"
+  kubectl --context "$ctx" -n "$NS" get pods,svc
+}
+
+case "${1:-up}" in
+  up) up ;;
+  down) down ;;
+  status) status ;;
+  *) die "usage: $0 {up|down|status}" ;;
+esac

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -23,6 +23,12 @@ CHART_DIR="${REPO_ROOT}/helm/terrapod"
 ADMIN_EMAIL="admin@example.com"
 ADMIN_PASSWORD="terrapod"
 
+# Caller's kube-context, captured before we create a cluster (kind/k3d switch it).
+# Script-global so the EXIT trap can restore it after up() returns; default empty
+# keeps `set -u` happy when it was never set.
+prev_ctx=""
+restore_ctx() { [ -n "${prev_ctx:-}" ] && kubectl config use-context "$prev_ctx" >/dev/null 2>&1 || true; }
+
 c_green=$'\033[0;32m'; c_bold=$'\033[1m'; c_yel=$'\033[0;33m'; c_reset=$'\033[0m'
 log()  { echo "${c_green}==>${c_reset} $*"; }
 warn() { echo "${c_yel}!! ${c_reset} $*"; }
@@ -71,8 +77,7 @@ up() {
   # it to the new cluster, which would yank your default context (e.g. away from
   # a Tilt-deployed Terrapod). We pin every command below to --context "$ctx" and
   # restore the original on exit, so the eval never touches your active context.
-  local prev_ctx; prev_ctx="$(kubectl config current-context 2>/dev/null || true)"
-  restore_ctx() { [ -n "$prev_ctx" ] && kubectl config use-context "$prev_ctx" >/dev/null 2>&1 || true; }
+  prev_ctx="$(kubectl config current-context 2>/dev/null || true)"
   trap restore_ctx EXIT
   create_cluster "$tool"
   restore_ctx

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -7,8 +7,9 @@
 #   scripts/eval.sh down    Delete the eval cluster.
 #   scripts/eval.sh status  Show pod status.
 #
-# Auto-detects `kind` (preferred) or `k3d`. Uses released images (tag overridable
-# via TERRAPOD_VERSION, default `latest`). NOT for production — see values-eval.yaml.
+# Auto-detects `kind` (preferred) or `k3d`; pin with TERRAPOD_EVAL_TOOL=kind|k3d
+# when both are installed. Uses released images (tag overridable via
+# TERRAPOD_VERSION, default `latest`). NOT for production — see values-eval.yaml.
 set -euo pipefail
 
 CLUSTER="${TERRAPOD_EVAL_CLUSTER:-terrapod-eval}"
@@ -35,7 +36,22 @@ warn() { echo "${c_yel}!! ${c_reset} $*"; }
 die()  { echo "ERROR: $*" >&2; exit 1; }
 
 # ── Cluster tool detection ────────────────────────────────────────────────────
+# TERRAPOD_EVAL_TOOL pins the tool explicitly (kind|k3d); otherwise prefer kind.
+# The override matters when both are installed and you need a specific one — e.g.
+# CI's k3d matrix job runs on a runner that ALSO ships a pre-installed `kind`, so
+# without the pin auto-detection would silently pick kind and the smoke step's
+# k3d-pinned context lookup would miss.
 detect_tool() {
+  if [ -n "${TERRAPOD_EVAL_TOOL:-}" ]; then
+    case "$TERRAPOD_EVAL_TOOL" in
+      kind|k3d)
+        command -v "$TERRAPOD_EVAL_TOOL" >/dev/null 2>&1 \
+          || die "TERRAPOD_EVAL_TOOL=$TERRAPOD_EVAL_TOOL but '$TERRAPOD_EVAL_TOOL' is not installed"
+        echo "$TERRAPOD_EVAL_TOOL" ;;
+      *) die "TERRAPOD_EVAL_TOOL must be 'kind' or 'k3d', got '$TERRAPOD_EVAL_TOOL'" ;;
+    esac
+    return
+  fi
   if command -v kind >/dev/null 2>&1; then echo kind
   elif command -v k3d >/dev/null 2>&1; then echo k3d
   else die "neither 'kind' nor 'k3d' found — install one: https://kind.sigs.k8s.io or https://k3d.io"; fi


### PR DESCRIPTION
Closes #547.

## What

`make eval` stands up a complete, self-contained Terrapod on a throwaway **kind**/**k3d** cluster in one command — chart-deployed in-cluster Postgres+Redis, filesystem storage, a local admin — **no cloud account, no external deps**. `make eval-down` deletes it.

```sh
make eval        # → http://localhost:8080  (admin@example.com / terrapod)
make eval-down
```

## How

- **Chart embedded datastores (eval/dev only, OFF by default):** `postgresql.deploy` / `redis.deploy` add a single-replica in-cluster Postgres (PVC-backed) + Redis, with loud "not for production" guardrails in values/schema/NOTES. Helpers derive the DB secret + Redis URL so consumers need no `url`/`existingSecret`.
- **`migrations.backoffLimit` (default 10):** the migrations pre-install hook rides out the datastore cold-start when the DB is co-deployed (it briefly retries until Postgres is reachable, then runs once). Harmless for an external DB.
- **`scripts/eval.sh`:** auto-detects kind→k3d, uses released images (`TERRAPOD_VERSION`, default `latest` — the source chart's appVersion is `0.0.0`, so it must override), and **saves/restores the caller's kube-context** so it never disturbs your default cluster.
- **Tilt refactored** to consume the same chart-managed datastores (its hand-rolled PG/Redis blobs deleted). Ordering is preserved by the existing `resource_deps` (Tilt doesn't execute helm hooks — verified).

## The ordering question (migrations-before-API), resolved across all deploy paths

| Path | Mechanism | Status |
|---|---|---|
| `helm install` (eval) | pre-install hook Job | ✅ proven live via event timeline |
| ArgoCD (prod) | hook → PreSync | ✅ ArgoCD honors helm hooks |
| Tilt (dev) | `resource_deps` | ✅ preserved in the refactor |

## Validation (live)

- **kind:** full eval boot — migrations struggled briefly on cold-start then succeeded; **API scaled up only at the instant migrations `Completed`** (event-timeline proof); api/web `1/1`.
- **Tilt (rancher-desktop):** cutover to chart-managed PG/Redis — full stack healthy, **existing dev data preserved** (73 workspaces) via the shared PVC.
- helm lint + template on all three profiles; `values-eval.yaml` is a first-class third profile (AGENTS.md contract).

## CI

- `helm-smoke` now renders `values-eval.yaml` (asserts embedded PG/Redis + PVC).
- New **`helm-eval-boot`** kind+k3d matrix boots the stack and asserts the UI serves `/login`; wired into the `ci-pass` gate.

## Docs

README **Quick Evaluation**, `docs/getting-started.md` section, `llms.txt` entry, AGENTS.md three-profile contract.