### PR TITLE
chore(security): clear HIGH CVEs (libssh2 deb13u1 + OPA 1.18.0)

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -57,7 +57,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # CVE-2026-27135). Without this the apt-upgrade layer is reused from
 # before the patch was published — same cache-staleness issue the
 # runner image's APK_REFRESH solves.
-ARG APT_REFRESH=2026-06-04
+ARG APT_REFRESH=2026-06-26
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
@@ -72,7 +72,7 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 # OPA version via the image tag — see docs/policies.md). TARGETARCH is set
 # by buildx; fall back to dpkg for a plain `docker build`.
 ARG TARGETARCH
-ARG OPA_VERSION=1.17.1
+ARG OPA_VERSION=1.18.0
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -21,7 +21,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 
 # Bump APT_REFRESH to bust the cached apt layer and re-pull Debian
 # security patches (CVE-2026-27135 etc.) — see Dockerfile.api.
-ARG APT_REFRESH=2026-06-04
+ARG APT_REFRESH=2026-06-26
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-ARG OPA_VERSION=1.17.1
+ARG OPA_VERSION=1.18.0
 # GitHub Releases intermittently 5xx; --retry-all-errors covers 5xx as
 # well as transport errors. 6 attempts × 4s base = ~25s ceiling.
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
@@ -50,7 +50,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 
 # Bump APT_REFRESH to bust the cached apt layer and re-pull Debian
 # security patches. See Dockerfile.api for the same pattern.
-ARG APT_REFRESH=2026-06-08
+ARG APT_REFRESH=2026-06-26
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
         git \

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pin and verify the same OPA_VERSION + SHA256 so a bump in one without
 # the other can't silently land an unverified binary in either image.
 ARG TARGETARCH
-ARG OPA_VERSION=1.17.1
+ARG OPA_VERSION=1.18.0
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1778,12 +1778,14 @@ POST /api/terrapod/v1/vcs-connections
 }
 ```
 
-> `webhook-secret` (GitHub, optional) is **write-only** — it is never returned;
-> the response carries `has-webhook-secret` (boolean) instead. When set, this
-> connection's inbound webhooks are validated against it, falling back to the
-> global `vcs.github.webhook_secret` when absent. On `PATCH`, supply a
-> non-empty value to rotate, an explicit empty string to clear, or omit the
-> key to leave it untouched.
+> `webhook-secret` (optional, both providers) is **write-only** — it is never
+> returned; the response carries `has-webhook-secret` (boolean) instead. When
+> set, this connection's inbound webhooks are validated against it: GitHub
+> deliveries are HMAC-SHA256 verified, GitLab deliveries are matched against
+> the `X-Gitlab-Token` header (timing-safe). GitHub falls back to the global
+> `vcs.github.webhook_secret` when the per-connection secret is absent. On
+> `PATCH`, supply a non-empty value to rotate, an explicit empty string to
+> clear, or omit the key to leave it untouched.
 
 **GitLab example:**
 ```json
@@ -2018,7 +2020,15 @@ Response: dry-run `{dry_run:true, matched, would_change:[{id,name,diff}], unchan
 POST /api/terrapod/v1/vcs-events/github
 ```
 
-Validates HMAC-SHA256 signature and triggers an immediate poll cycle. The webhook secret must match `TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET`.
+Validates HMAC-SHA256 signature and triggers an immediate poll cycle. The webhook secret must match the connection's own `webhook-secret`, falling back to the global `TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET`.
+
+### GitLab Webhook Receiver
+
+```
+POST /api/terrapod/v1/vcs-events/gitlab
+```
+
+Validates the `X-Gitlab-Token` header (timing-safe comparison against the connection's `webhook-secret`) and triggers an immediate poll cycle. Handles `Push Hook`, `Tag Push Hook`, and `Merge Request Hook` events; other event types are acknowledged and ignored. Like GitHub, webhooks are an **optional accelerator** — the background poller still picks up changes within `vcs.poll_interval_seconds` if no webhook is configured.
 
 ---
 

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -39,33 +39,8 @@ CVE-2026-46680
 # graph; the ignore would just shadow regressions if litellm's hot
 # patch is rolled back. Re-add only if the floor drops below 1.83.11.
 
-# --- OPA-bundled Go module CVEs (golang.org/x/net + golang.org/x/crypto) ---
-# Trivy reads the statically-linked `opa` binary's embedded buildinfo and
-# flags every Go module it vendors, including ones whose code path never
-# runs at OPA's runtime. We bumped OPA to 1.17.1, which is built on go1.26.4
-# (clearing the earlier Go stdlib CVEs — CVE-2026-42504 / CVE-2026-27145 —
-# so those ignores are removed), but 1.17.1 still vendors x/net v0.53.0 and
-# x/crypto v0.51.0; the upstream fixes (x/net 0.55.0, x/crypto 0.52.0) landed
-# after OPA 1.17.1's release and no rebuilt OPA binary exists yet.
-#
-# Not reachable in Terrapod's usage: OPA runs only as `opa eval` / `opa check`
-# over our own in-memory plan JSON — no HTTP/2 server (x/net), no SSH or TLS
-# transport (x/crypto), no bundle/server/controller mode. Drop these when OPA
-# publishes a rebuild on x/net >= 0.55.0 / x/crypto >= 0.52.0.
-#
-# golang.org/x/net  (fixed in 0.55.0):
-CVE-2026-25680
-CVE-2026-25681
-CVE-2026-27136
-CVE-2026-39821
-CVE-2026-42502
-CVE-2026-42506
-# golang.org/x/crypto (fixed in 0.52.0):
-CVE-2026-39827
-CVE-2026-39828
-CVE-2026-39829
-CVE-2026-39830
-CVE-2026-39835
-CVE-2026-42508
-CVE-2026-46595
-CVE-2026-46597
+# (OPA-bundled golang.org/x/net + golang.org/x/crypto CVEs removed: the
+# OPA 1.18.0 bump vendors x/net v0.55.0 + x/crypto v0.52.0 — both carrying
+# the upstream fixes — so Trivy reads clean buildinfo and no longer reports
+# them. Preferring the bump over a standing ignore per the release-audit
+# rule "drop the ignore in the same PR as the bump.")


### PR DESCRIPTION
## What

Clears the new HIGH CVEs Trivy started flagging on `main` (release-blocker for v0.47.0):

- **libssh2-1t64** `CVE-2026-55200` / `CVE-2026-7598` → bump `APT_REFRESH` in Dockerfile.{api,listener,runner} so the cached apt-upgrade layer re-runs and re-pulls Debian `1.11.1-1+deb13u1` (already in the trixie mirror).
- **OPA-vendored x/crypto** (incl. `CVE-2026-39832`) **+ x/net** → bump OPA `1.17.1 → 1.18.0` (Dockerfile.{api,runner,test}). 1.18.0 vendors x/net `v0.55.0` + x/crypto `v0.52.0` (the upstream-fixed versions), so the whole OPA Go-CVE `.trivyignore` block is **deleted** — preferring the bump over a standing ignore per the release-audit rule.

Plus two doc fixes from the v0.47.0 third-party review:
- Document the **GitLab webhook receiver** (`POST /api/terrapod/v1/vcs-events/gitlab`).
- Correct the `webhook-secret` note — it's accepted for **both** providers now (GitLab uses timing-safe `X-Gitlab-Token`), not GitHub-only.

## Why bumps not ignores

OPA 1.18.0 (released 2026-06-25) is the first OPA build vendoring x/crypto ≥0.52.0 + x/net ≥0.55.0, so the previously-ignored OPA Go CVEs are now genuinely fixed in the binary — the ignore would just shadow future regressions.

Closes #595