### PR TITLE
docs: surface eval quickstart + embedded datastores (index/deployment)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,8 +10,7 @@ Terrapod is deployed exclusively via Helm chart on Kubernetes. This guide covers
 
 - Kubernetes 1.27+
 - Helm 3.x
-- PostgreSQL 14+ (external, managed)
-- Redis 7+ (external, managed)
+- PostgreSQL 14+ and Redis 7+ — **external, managed** for production. For evaluation/dev the chart can run both in-cluster (`postgresql.deploy=true` / `redis.deploy=true`, single-replica, no HA or backups — **not** for production); see [Database Setup](#database-setup).
 - Object storage (S3, Azure Blob, GCS) or PVC-backed filesystem
 - TLS certificate for the ingress hostname
 - DNS record pointing to the ingress
@@ -653,6 +652,8 @@ Note: Filesystem storage uses a PVC with `ReadWriteOnce` access mode, which limi
 ## Database Setup
 
 Terrapod requires PostgreSQL 14+. Use a managed service (RDS, Cloud SQL, Azure Database) for production.
+
+> **Evaluation/dev shortcut:** set `postgresql.deploy=true` (and `redis.deploy=true`) to have the chart run a single in-cluster PostgreSQL (PVC-backed) and Redis instead of providing connection URLs. This is what the [`make eval`](../README.md#quick-evaluation) quickstart uses. It is single-replica with no HA and no backups — **never** use it for production; provide a managed datastore via `postgresql.url` / `redis.url` (or `existingSecret`) there.
 
 ### Connection URL
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,15 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 
 ## Quick Start
 
-Deploy onto any Kubernetes cluster (or a single-node [k3s](https://k3s.io/) VM) with the Helm chart:
+**Just want to try it?** One command spins up a throwaway [kind](https://kind.sigs.k8s.io/) or [k3d](https://k3d.io/) cluster, batteries-included — chart-managed PostgreSQL + Redis, filesystem storage, a local admin — and prints the URL + login:
+
+```zsh
+make eval        # boots the stack; `make eval-down` tears it down
+```
+
+See the [README's Quick Evaluation section](https://github.com/mattrobinsonsre/terrapod#quick-evaluation) for details. The eval profile is for kicking the tyres only — not production.
+
+For a real deployment onto any Kubernetes cluster (or a single-node [k3s](https://k3s.io/) VM) with the Helm chart:
 
 ```zsh
 helm install terrapod oci://ghcr.io/mattrobinsonsre/terrapod \
@@ -57,7 +65,7 @@ helm install terrapod oci://ghcr.io/mattrobinsonsre/terrapod \
   --set bootstrap.adminPassword="change-me-now"
 ```
 
-PostgreSQL and Redis are external (not bundled). See [Getting Started](getting-started.md) for the full walkthrough, or [Local Development](local-development.md) if you want to run Terrapod from source.
+For production, PostgreSQL and Redis are external (managed) services — the chart can run them in-cluster (`postgresql.deploy=true` / `redis.deploy=true`) but that single-replica, no-backup mode is for evaluation/dev only. See [Getting Started](getting-started.md) for the full walkthrough, [Deployment](deployment.md) for the datastore options, or [Local Development](local-development.md) if you want to run Terrapod from source.
 
 ---
 


### PR DESCRIPTION
Pre-release audit for v0.47.0 (the only should-fix items; no blockers) — the kind/k3d eval quickstart (#594) and chart-managed Postgres/Redis option were discoverable from `README.md` + `llms.txt` but missing from two secondary doc pages, and `docs/index.md`'s "external (not bundled)" line was now factually stale.

- **docs/index.md** — lead Quick Start with `make eval`; correct the datastore line to note the in-cluster eval option.
- **docs/deployment.md** — note `postgresql.deploy`/`redis.deploy` in prerequisites + an eval-shortcut callout in Database Setup.

Closes #597