### PR TITLE
fix(eval): a WORKING runner listener in the kind/k3d quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,13 +502,17 @@ jobs:
   # mechanism + chart, not the PR's app code (that's covered by the test job).
   helm-eval-boot:
     name: Eval Boot (${{ matrix.tool }})
-    needs: prepare
+    # Depend on the amd64 build so the eval boots the images BUILT FROM THIS PR
+    # (loaded into the cluster), not published `:latest`. That's what makes the
+    # plan-through-listener smoke test the PR's actual code (e.g. the binary-cache
+    # version-resolution path), and keeps it from depending on whatever is live.
+    needs: [prepare, build-images-amd64]
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     # `helm --wait` blocks on the full stack (incl. the listener joining the
-    # bootstrapped pool) and the plan-smoke launches a runner Job that pulls the
-    # runner image + a tofu binary — so cap the job at a sensible ceiling rather
-    # than the 6h default, in case an install or the run ever hangs.
+    # bootstrapped pool) and the plan-smoke launches a runner Job — so cap the
+    # job at a sensible ceiling rather than the 6h default, in case an install or
+    # the run ever hangs.
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -524,11 +528,61 @@ jobs:
           else
             curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.9.0/install.sh | TAG=v5.9.0 bash
           fi
-      - name: make eval (boot the stack)
+      # ── Get the amd64 images built by this run ───────────────────────────────
+      # PR builds load them from the build-images-amd64 artifacts (no GHCR push on
+      # PRs); branch/tag builds pull them from GHCR. Either way they end up in the
+      # local docker daemon under their canonical sha-<short>-amd64 tag, which is
+      # what eval.sh resolves below (chart pullPolicy is IfNotPresent, so the
+      # loaded images are used without a registry round-trip).
+      - name: Log in to GHCR (branch/tag)
+        if: needs.prepare.outputs.is_pr != 'true'
+        uses: ./.github/actions/ghcr-login
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+      - name: Pull images (branch/tag)
+        if: needs.prepare.outputs.is_pr != 'true'
+        run: |
+          sha="${{ needs.prepare.outputs.sha_short }}"
+          for i in terrapod-api terrapod-web terrapod-migrations terrapod-listener terrapod-runner; do
+            docker pull "$REGISTRY/$i:sha-${sha}-amd64"
+          done
+      - name: Download image artifacts (PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          pattern: image-*-amd64
+          path: /tmp/images
+          merge-multiple: true
+      - name: Load images into docker (PR)
+        if: needs.prepare.outputs.is_pr == 'true'
+        run: |
+          for i in terrapod-api terrapod-web terrapod-migrations terrapod-listener terrapod-runner; do
+            gunzip -c "/tmp/images/$i-amd64.tar.gz" | docker load
+          done
+      # ── Create the cluster + load the images into it, then install ───────────
+      # eval.sh reuses an existing cluster, so we create it here (kind load /
+      # k3d image import need the cluster to exist first) and let eval.sh install.
+      - name: Create cluster + load images
+        run: |
+          sha="${{ needs.prepare.outputs.sha_short }}"
+          imgs=""
+          for i in terrapod-api terrapod-web terrapod-migrations terrapod-listener terrapod-runner; do
+            imgs="$imgs $REGISTRY/$i:sha-${sha}-amd64"
+          done
+          if [ "${{ matrix.tool }}" = "kind" ]; then
+            kind create cluster --name terrapod-eval --wait 120s
+            for img in $imgs; do kind load docker-image "$img" --name terrapod-eval; done
+          else
+            k3d cluster create terrapod-eval --wait --timeout 120s
+            for img in $imgs; do k3d image import "$img" -c terrapod-eval; done
+          fi
+      - name: make eval (install into the cluster)
         env:
           CI: "1"
           EVAL_NO_PORT_FORWARD: "1"
-          TERRAPOD_VERSION: latest
+          # Use the images built + loaded above (NOT :latest).
+          TERRAPOD_VERSION: sha-${{ needs.prepare.outputs.sha_short }}-amd64
           # Pin the tool — the runner ships a pre-installed `kind`, so without
           # this the k3d matrix job would auto-detect kind and the smoke step's
           # k3d-pinned context lookup would miss.
@@ -566,7 +620,7 @@ jobs:
           ctx=$([ "${{ matrix.tool }}" = "kind" ] && echo kind-terrapod-eval || echo k3d-terrapod-eval)
           kubectl --context "$ctx" -n terrapod-eval get pods,jobs || true
           kubectl --context "$ctx" -n terrapod-eval logs deploy/terrapod-listener --tail=80 || true
-          kubectl --context "$ctx" -n terrapod-eval logs -l app.kubernetes.io/component=runner --tail=120 --prefix || true
+          kubectl --context "$ctx" -n terrapod-eval logs -l app.kubernetes.io/name=terrapod-runner --tail=120 --prefix || true
       - name: Teardown
         if: always()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,7 +575,12 @@ jobs:
             for img in $imgs; do kind load docker-image "$img" --name terrapod-eval; done
           else
             k3d cluster create terrapod-eval --wait --timeout 120s
-            for img in $imgs; do k3d image import "$img" -c terrapod-eval; done
+            # Import ALL images in ONE call. Separate per-image `k3d image import`
+            # calls race on their temp tarball ("ctr: open …tar: no such file or
+            # directory") and k3d masks that with exit 0 — which silently left the
+            # listener image unimported (ImagePullBackOff → run stuck queued). One
+            # call = one tarball = no race.
+            k3d image import $imgs -c terrapod-eval
           fi
       - name: make eval (install into the cluster)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,11 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    # `helm --wait` blocks on the full stack (incl. the listener joining the
+    # bootstrapped pool) and the plan-smoke launches a runner Job that pulls the
+    # runner image + a tofu binary — so cap the job at a sensible ceiling rather
+    # than the 6h default, in case an install or the run ever hangs.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -533,15 +538,35 @@ jobs:
         run: |
           ctx=$([ "${{ matrix.tool }}" = "kind" ] && echo kind-terrapod-eval || echo k3d-terrapod-eval)
           ns=terrapod-eval
-          # helm --wait already gated on readiness; assert the data plane is real:
-          kubectl --context "$ctx" -n "$ns" wait --for=condition=available deploy/terrapod-web --timeout=120s
-          kubectl --context "$ctx" -n "$ns" wait --for=condition=available deploy/terrapod-api --timeout=120s
+          # eval.sh installs with `helm --wait`, so these are already satisfied;
+          # assert them explicitly anyway as the smoke contract.
+          kubectl --context "$ctx" -n "$ns" wait --for=condition=available deploy/terrapod-web --timeout=150s
+          kubectl --context "$ctx" -n "$ns" wait --for=condition=available deploy/terrapod-api --timeout=150s
+          # The listener only reports Available once it has JOINED the bootstrapped
+          # eval-pool — so this proves the agent-execution wiring end-to-end, not
+          # just that a pod started.
+          kubectl --context "$ctx" -n "$ns" wait --for=condition=available deploy/terrapod-listener --timeout=180s
           kubectl --context "$ctx" -n "$ns" port-forward svc/terrapod-web 18080:3000 >/dev/null 2>&1 &
           sleep 6
           code=$(curl -s -o /dev/null -w '%{http_code}' --retry 8 --retry-delay 3 --retry-all-errors http://localhost:18080/login)
           echo "GET /login -> $code"
           [ "$code" = "200" ] || { echo "FAIL: UI did not serve /login"; exit 1; }
           echo "Eval stack booted + UI served on ${{ matrix.tool }}"
+      - name: Plan through the listener
+        # Prove the listener actually EXECUTES runs: create an agent workspace on
+        # the bootstrapped eval-pool, upload a config, queue a plan, and assert it
+        # reaches `planned` on a real Kubernetes Job. This is the difference
+        # between "a listener pod exists" and "server-side runs work".
+        run: |
+          ctx=$([ "${{ matrix.tool }}" = "kind" ] && echo kind-terrapod-eval || echo k3d-terrapod-eval)
+          scripts/eval-smoke-plan.sh "$ctx" terrapod-eval
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          ctx=$([ "${{ matrix.tool }}" = "kind" ] && echo kind-terrapod-eval || echo k3d-terrapod-eval)
+          kubectl --context "$ctx" -n terrapod-eval get pods,jobs || true
+          kubectl --context "$ctx" -n terrapod-eval logs deploy/terrapod-listener --tail=80 || true
+          kubectl --context "$ctx" -n terrapod-eval logs -l app.kubernetes.io/component=runner --tail=120 --prefix || true
       - name: Teardown
         if: always()
         env:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dependencies**.
 
 ```sh
 make eval          # create a local cluster + install Terrapod, then port-forward
-# → open http://localhost:8080  (login: admin@example.com / terrapod)
+# → open http://localhost:8080  (login: admin / terrapod)
 
 make eval-down     # delete the whole thing when you're done
 ```

--- a/Tiltfile
+++ b/Tiltfile
@@ -233,32 +233,16 @@ k8s_resource(
     links=[link('https://terrapod.local', 'Terrapod')],
 )
 
-# Dev pool setup — creates pool + join token via the API pod's bootstrap script.
-# Idempotent: skips if pool already exists.
-local_resource(
-    'setup-dev-pool',
-    cmd='''
-echo "Waiting for API pod to be ready..."
-kubectl -n terrapod wait --for=condition=Ready pod -l app.kubernetes.io/name=terrapod,app.kubernetes.io/component=api --timeout=120s
-
-echo "Creating dev pool + join token..."
-kubectl -n terrapod exec deploy/terrapod-api -- env \
-    DATABASE_URL="postgresql+asyncpg://terrapod:terrapod@terrapod-postgresql:5432/terrapod" \
-    TERRAPOD_BOOTSTRAP_ADMIN_EMAIL=admin \
-    TERRAPOD_BOOTSTRAP_ADMIN_PASSWORD=admin \
-    TERRAPOD_BOOTSTRAP_POOL_NAME=dev \
-    TERRAPOD_BOOTSTRAP_POOL_TOKEN=dev-join-token-do-not-use-in-prod \
-    python -m terrapod.cli.bootstrap
-''',
-    labels=['setup'],
-    resource_deps=['terrapod-api'],
-)
-
-# Runner Listener (uses same image as API, needs dev pool)
+# Runner Listener (uses same image as API). The agent pool + join token are
+# created by the chart's bootstrap Job (terrapod-bootstrap-1), driven by
+# `bootstrap.poolName` / `bootstrap.poolToken` in values-local.yaml — the SAME
+# mechanism the kind/k3d eval profile uses (values-eval.yaml). The listener joins
+# that pool with the matching `listener.joinToken`, so it depends on the bootstrap
+# Job (pool must exist) and the API (the join target). No separate pool-setup step.
 k8s_resource(
     'terrapod-listener',
     labels=['backend'],
-    resource_deps=['setup-dev-pool'],
+    resource_deps=['terrapod-bootstrap-1', 'terrapod-api'],
 )
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ cloud account and no external dependencies:
 
 ```sh
 make eval          # create a local cluster + install Terrapod, then port-forward
-# → open http://localhost:8080  (login: admin@example.com / terrapod)
+# → open http://localhost:8080  (login: admin / terrapod)
 make eval-down     # delete it all
 ```
 

--- a/helm/terrapod/templates/embedded-redis.yaml
+++ b/helm/terrapod/templates/embedded-redis.yaml
@@ -16,6 +16,15 @@ metadata:
   labels:
     {{- include "terrapod.labels" . | nindent 4 }}
     app.kubernetes.io/component: redis
+  annotations:
+    # Pre-install hook (weight -20, same as the embedded Postgres) so Redis is
+    # up BEFORE the API rolls out — the API's lifespan pings Redis and EXITS if
+    # it can't connect, so a main-resource Redis that starts concurrently makes
+    # the API crash-loop on a slow node until Redis is ready. No hook-delete-
+    # policy: the hook isn't re-run on upgrade and the original keeps serving.
+    # Eval/dev only (gated on redis.deploy); production uses external Redis.
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-20"
 spec:
   replicas: 1
   selector:
@@ -67,6 +76,11 @@ metadata:
   labels:
     {{- include "terrapod.labels" . | nindent 4 }}
     app.kubernetes.io/component: redis
+  annotations:
+    # Same pre-install hook as the Deployment so the Service exists when the
+    # API (and its pre-install hooks) resolve terrapod-redis. See above.
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-20"
 spec:
   selector:
     {{- include "terrapod.selectorLabels" . | nindent 4 }}

--- a/helm/terrapod/templates/job-bootstrap.yaml
+++ b/helm/terrapod/templates/job-bootstrap.yaml
@@ -12,8 +12,20 @@ metadata:
     {{- include "terrapod.labels" . | nindent 4 }}
     app.kubernetes.io/component: bootstrap
   annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "10"
+    # Hook phase/weight are configurable, defaulting to the historical
+    # production behavior (post-install, weight 10) so production renders
+    # IDENTICALLY unless explicitly overridden. The eval profile sets
+    # `bootstrap.hook: "pre-install,pre-upgrade"` + `hookWeight: "-3"` so the
+    # admin user AND the bootstrap-created agent pool exist BEFORE the main
+    # resources roll out: with the runner listener enabled, the listener's
+    # readiness probe only passes once it has JOINED the pool, so a post-install
+    # pool would make `helm --wait` block on the listener (waiting for a pool
+    # that doesn't exist yet) and deadlock. The bootstrap is DB-direct (needs
+    # only the migrated schema at weight -5) and idempotent (skips an existing
+    # admin/pool — never resets a changed password), so running it pre-install
+    # at weight -3 is safe for profiles that opt in.
+    "helm.sh/hook": {{ .Values.bootstrap.hook | default "post-install" | quote }}
+    "helm.sh/hook-weight": {{ .Values.bootstrap.hookWeight | default "10" | quote }}
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 300

--- a/helm/terrapod/values-eval.yaml
+++ b/helm/terrapod/values-eval.yaml
@@ -32,11 +32,33 @@ storage:
 
 api:
   replicas: 1
+  # Filesystem storage uses a ReadWriteOnce PVC the API pod mounts. A rolling
+  # update would try to start the new pod while the old one still holds the RWO
+  # volume → the new pod stays Pending and `helm upgrade --wait` deadlocks.
+  # maxSurge: 0 means the old pod is removed before the new one is created, so
+  # the volume hands over cleanly (brief downtime, fine for a single-replica eval).
+  strategy:
+    maxSurge: 0
+    maxUnavailable: 1
   config:
     # Browser-facing URL via `kubectl port-forward svc/terrapod-web 8080:3000`.
     external_url: "http://localhost:8080"
     auth:
       local_enabled: true
+      # Don't expire CLI/automation API tokens after 7 idle days without an
+      # interactive login (#495) — for an eval people poke via curl / `tofu`
+      # with a freshly-minted token and no prior browser login. Matches the
+      # local-dev profile. Production keeps the default (7).
+      bound_token_idle_days: 0
+    storage:
+      backend: filesystem
+      filesystem:
+        # In-cluster runner Jobs fetch config/state/module tarballs from the
+        # filesystem backend via presigned URLs. Those URLs are built from this
+        # base_url; it MUST be the in-cluster API service (not external_url,
+        # which is localhost:8080 and unreachable from a runner pod). Without
+        # this, server-side (agent) runs fail at the config/state download step.
+        base_url: "http://terrapod-api:8000"
   # The hardened ephemeral PVC isn't needed for a local eval.
   ephemeralStorage:
     enabled: false
@@ -49,13 +71,26 @@ web:
 ingress:
   enabled: false
 
-# Agent execution (server-side plan/apply on runner Jobs) is OFF for the quickstart
-# to keep the footprint tiny. To try it, create an agent pool + join token and set
-# listener.enabled=true with a runner image.
+# Agent execution (server-side plan/apply on runner Jobs) is ON so the quickstart
+# is a working platform: queue a plan in the UI and it runs on a Kubernetes Job.
+# The listener joins the `eval-pool` the bootstrap job seeds below using this
+# fixed join token. Eval-only — the cluster is throwaway and this token is never
+# used anywhere real; do NOT copy it into a production config.
 listener:
-  enabled: false
+  enabled: true
+  joinToken: "eval-join-token-not-for-real-use"
 
-# Seed a local admin so you can log in immediately. Eval-only credentials.
+# Seed a local admin (log in immediately) AND an agent pool + matching join token
+# so the listener can join and execute runs. Eval-only credentials.
+#
+# Run the bootstrap as a PRE-install hook (production defaults to post-install,
+# unchanged) so the agent pool exists BEFORE the listener Deployment starts —
+# otherwise `helm --wait` would block on the listener, whose readiness gates on
+# having joined a pool that wouldn't exist yet. See job-bootstrap.yaml.
 bootstrap:
-  adminEmail: admin@example.com
+  hook: "pre-install,pre-upgrade"
+  hookWeight: "-3"
+  adminEmail: admin
   adminPassword: terrapod
+  poolName: eval-pool
+  poolToken: "eval-join-token-not-for-real-use"

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -267,7 +267,9 @@
         "emailKey": { "type": "string" },
         "passwordKey": { "type": "string" },
         "poolName": { "type": "string" },
-        "poolToken": { "type": "string" }
+        "poolToken": { "type": "string" },
+        "hook": { "type": "string" },
+        "hookWeight": { "type": "string" }
       }
     },
 

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -1135,6 +1135,14 @@ migrations:
 #   passwordKey: password
 #   poolName: ""       # Optional: auto-create an agent pool with this name
 #   poolToken: ""      # Optional: auto-create a join token for the pool
+#   hook: ""           # Helm hook phase (default "post-install"). Set to
+#                      # "pre-install,pre-upgrade" with hookWeight "-3" to create
+#                      # the admin/pool BEFORE the listener rolls out — required if
+#                      # you enable the listener with a bootstrap-created pool AND
+#                      # install with `helm --wait` (otherwise --wait deadlocks on
+#                      # the listener's pool-join readiness). The eval profile does
+#                      # this; production defaults keep the historical post-install.
+#   hookWeight: ""     # Helm hook-weight (default "10")
 
 # ── Database (PostgreSQL) ─────────────────────────────────────────────────────
 # Provide credentials via existingSecret (recommended) or url (dev only).

--- a/scripts/eval-smoke-plan.sh
+++ b/scripts/eval-smoke-plan.sh
@@ -96,7 +96,7 @@ status=""
 while [ "$elapsed" -lt "$DEADLINE" ]; do
   status=$(curl -fsS "${API}/api/v2/runs/${RUN}" "${auth[@]}" \
     | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['attributes'].get('status',''))" 2>/dev/null || echo "")
-  jobs=$(k get pods -l app.kubernetes.io/component=runner 2>/dev/null | grep -c tprun || true)
+  jobs=$(k get pods -l app.kubernetes.io/name=terrapod-runner 2>/dev/null | grep -c tprun || true)
   echo "  [${elapsed}s] status=${status} runner-job-pods=${jobs:-0}"
   case "$status" in
     planned|planned_and_finished) log "PLAN SUCCEEDED through the listener (status=${status})"; exit 0 ;;

--- a/scripts/eval-smoke-plan.sh
+++ b/scripts/eval-smoke-plan.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Drive a real plan through the eval stack's runner listener and assert it
+# reaches `planned`. This proves the WHOLE server-side-execution path end to
+# end: the listener claims the run, launches a Kubernetes Job, the runner Job
+# downloads the config from the in-cluster filesystem storage (api base_url),
+# runs `tofu plan`, and reports back. A listener that merely joined a pool
+# wouldn't prove any of that.
+#
+# Usage: scripts/eval-smoke-plan.sh <kube-context> [namespace]
+#   Defaults: namespace=terrapod-eval, API port-forward on :18000.
+set -euo pipefail
+
+CTX="${1:?usage: eval-smoke-plan.sh <kube-context> [namespace]}"
+NS="${2:-terrapod-eval}"
+PORT="${TERRAPOD_SMOKE_API_PORT:-18000}"
+API="http://localhost:${PORT}"
+DEADLINE="${TERRAPOD_SMOKE_DEADLINE_SECONDS:-360}"  # runner pulls image + tofu binary on first run
+
+log() { echo "==> $*"; }
+die() { echo "SMOKE FAIL: $*" >&2; exit 1; }
+
+k() { kubectl --context "$CTX" -n "$NS" "$@"; }
+
+# ── 1. Mint an admin API token directly in the API pod ────────────────────────
+log "Minting an admin API token in the API pod…"
+TOKEN=$(k exec deploy/terrapod-api -- python3 -c "
+import asyncio
+from terrapod.db.session import init_db, get_db_session
+from terrapod.auth import api_tokens
+async def main():
+    await init_db()
+    async with get_db_session() as db:
+        _, raw = await api_tokens.create_api_token(
+            db, bound_to='admin', created_by='admin', kind='interactive', lifespan_hours=2)
+        await db.commit()
+        import sys; sys.stderr.write('TOKEN:'+raw+'\n')
+asyncio.run(main())
+" 2>&1 | grep -oE 'TOKEN:[^[:space:]]+' | sed 's/TOKEN://' | tr -d '\r')
+[ -n "$TOKEN" ] || die "could not mint API token"
+
+# ── 2. Resolve the bootstrapped eval-pool id from the DB (deterministic) ──────
+POOL_UUID=$(k exec deploy/terrapod-api -- python3 -c "
+import asyncio
+from sqlalchemy import select
+from terrapod.db.session import init_db, get_db_session
+from terrapod.db import models
+async def main():
+    await init_db()
+    async with get_db_session() as db:
+        p=(await db.execute(select(models.AgentPool).where(models.AgentPool.name=='eval-pool'))).scalars().first()
+        import sys; sys.stderr.write('POOL:'+(str(p.id) if p else '')+'\n')
+asyncio.run(main())
+" 2>&1 | grep -oE 'POOL:[0-9a-f-]+' | sed 's/POOL://' | tr -d '\r')
+[ -n "$POOL_UUID" ] || die "eval-pool not found (bootstrap pool missing)"
+log "eval-pool id: ${POOL_UUID}"
+
+# ── 3. Port-forward the API ───────────────────────────────────────────────────
+k port-forward svc/terrapod-api "${PORT}:8000" >/tmp/eval-smoke-pf.log 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null || true' EXIT
+sleep 4
+
+auth=(-H "Authorization: Bearer ${TOKEN}")
+jsonapi=(-H "Content-Type: application/vnd.api+json")
+
+# ── 4. Create an agent-mode workspace bound to the eval-pool ──────────────────
+WSNAME="eval-smoke-$$"
+log "Creating agent workspace ${WSNAME}…"
+WS=$(curl -fsS -X POST "${API}/api/v2/organizations/default/workspaces" "${auth[@]}" "${jsonapi[@]}" \
+  -d "{\"data\":{\"type\":\"workspaces\",\"attributes\":{\"name\":\"${WSNAME}\",\"execution-mode\":\"agent\",\"agent-pool-id\":\"apool-${POOL_UUID}\",\"auto-apply\":false}}}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['id'])")
+[ -n "$WS" ] || die "workspace create failed"
+
+# ── 5. Upload a trivial config (output only — no providers to download) ───────
+TMPD=$(mktemp -d)
+printf 'output "ok" {\n  value = "eval-listener-works"\n}\n' > "${TMPD}/main.tf"
+tar -C "$TMPD" -czf "${TMPD}/cfg.tar.gz" main.tf
+log "Creating + uploading configuration version…"
+UPURL=$(curl -fsS -X POST "${API}/api/v2/workspaces/${WS}/configuration-versions" "${auth[@]}" "${jsonapi[@]}" \
+  -d '{"data":{"type":"configuration-versions","attributes":{"auto-queue-runs":false}}}' \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['attributes']['upload-url'])")
+UPURL=$(echo "$UPURL" | sed -E "s#https?://[^/]+#${API}#")
+curl -fsS -o /dev/null -X PUT "$UPURL" --data-binary @"${TMPD}/cfg.tar.gz" -H "Content-Type: application/octet-stream"
+
+# ── 6. Queue a plan-only run ──────────────────────────────────────────────────
+log "Queuing a plan-only run…"
+RUN=$(curl -fsS -X POST "${API}/api/v2/runs" "${auth[@]}" "${jsonapi[@]}" \
+  -d "{\"data\":{\"type\":\"runs\",\"attributes\":{\"plan-only\":true,\"message\":\"eval listener smoke\"},\"relationships\":{\"workspace\":{\"data\":{\"type\":\"workspaces\",\"id\":\"${WS}\"}}}}}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['id'])")
+[ -n "$RUN" ] || die "run create failed"
+log "run ${RUN} — waiting up to ${DEADLINE}s for it to plan on a Job…"
+
+# ── 7. Poll to a terminal status ──────────────────────────────────────────────
+elapsed=0
+status=""
+while [ "$elapsed" -lt "$DEADLINE" ]; do
+  status=$(curl -fsS "${API}/api/v2/runs/${RUN}" "${auth[@]}" \
+    | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['attributes'].get('status',''))" 2>/dev/null || echo "")
+  jobs=$(k get pods -l app.kubernetes.io/component=runner 2>/dev/null | grep -c tprun || true)
+  echo "  [${elapsed}s] status=${status} runner-job-pods=${jobs:-0}"
+  case "$status" in
+    planned|planned_and_finished) log "PLAN SUCCEEDED through the listener (status=${status})"; exit 0 ;;
+    errored|canceled) die "run reached ${status} — server-side execution failed (check runner Job logs)" ;;
+  esac
+  sleep 10; elapsed=$((elapsed + 10))
+done
+k get pods | grep -E "tprun" || true
+die "run did not reach 'planned' within ${DEADLINE}s (last status=${status:-none})"

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -21,7 +21,7 @@ VERSION="${TERRAPOD_VERSION:-latest}"
 PF_PORT="${TERRAPOD_EVAL_PORT:-8080}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHART_DIR="${REPO_ROOT}/helm/terrapod"
-ADMIN_EMAIL="admin@example.com"
+ADMIN_EMAIL="admin"
 ADMIN_PASSWORD="terrapod"
 
 # Caller's kube-context, captured before we create a cluster (kind/k3d switch it).
@@ -99,16 +99,24 @@ up() {
   restore_ctx
 
   log "Installing Terrapod (${RELEASE}) into namespace '${NS}' using image tag '${VERSION}'…"
+  # `--wait` blocks until every Deployment — including the runner listener — is
+  # ready. The listener only reports ready once it has JOINED the agent pool, and
+  # the pool is created by the bootstrap job, which is a PRE-install hook (see
+  # job-bootstrap.yaml) so it exists before the listener starts. That ordering is
+  # what makes `--wait` safe here: a working server-side-runs stack the moment the
+  # install returns, not just pods that exist.
   helm --kube-context "$ctx" upgrade --install "$RELEASE" "$CHART_DIR" \
     --namespace "$NS" --create-namespace \
     -f "${CHART_DIR}/values-eval.yaml" \
     --set "api.image.tag=${VERSION}" \
     --set "web.image.tag=${VERSION}" \
     --set "migrations.image.tag=${VERSION}" \
+    --set "listener.image.tag=${VERSION}" \
+    --set "runners.image.tag=${VERSION}" \
     --set "bootstrap.adminEmail=${ADMIN_EMAIL}" \
     --set "bootstrap.adminPassword=${ADMIN_PASSWORD}" \
     --set "api.config.external_url=http://localhost:${PF_PORT}" \
-    --wait --timeout 300s || {
+    --wait --timeout "${TERRAPOD_EVAL_HELM_TIMEOUT:-600s}" || {
       warn "helm install did not report ready in time — showing pod status:"
       kubectl --context "$ctx" -n "$NS" get pods || true
       die "install failed (see pod status above; 'scripts/eval.sh status' to re-check)"
@@ -133,6 +141,10 @@ ${c_bold}${c_green}Terrapod is up.${c_reset}
   URL:       ${c_bold}http://localhost:${PF_PORT}${c_reset}   (after the port-forward below)
   Username:  ${c_bold}${ADMIN_EMAIL}${c_reset}
   Password:  ${c_bold}${ADMIN_PASSWORD}${c_reset}
+
+  Server-side runs are enabled: a runner listener has joined the '${c_bold}eval-pool${c_reset}'
+  agent pool, so you can create a workspace and queue a plan in the UI and it
+  executes on a Kubernetes Job (first run pulls the runner image + a tofu binary).
 
   Port-forward (if not started automatically):
     kubectl --context ${ctx} -n ${NS} port-forward svc/${RELEASE}-web ${PF_PORT}:3000

--- a/services/terrapod/services/binary_cache_service.py
+++ b/services/terrapod/services/binary_cache_service.py
@@ -336,24 +336,31 @@ async def _fetch_terraform_versions() -> list[str]:
     return versions
 
 
-async def _fetch_tofu_versions() -> list[str]:
-    """Fetch tofu versions from GitHub releases.
+# Official OpenTofu version index — the same one OpenTofu's own installer uses.
+# We resolve tofu versions from here instead of the GitHub releases API, which is
+# rate-limited (60 req/hr unauthenticated) and routinely 504s from CI/cloud IPs.
+# When that listing failed, the binary cache could not resolve a partial version
+# (e.g. "1.12") and 502'd the runner, which then dead-ended because it had no
+# fully-qualified version to fall back on (#338). This CDN-backed static JSON is
+# not rate-limited. Version ids carry NO leading "v" and include pre-releases as
+# "x.y.z-suffix", so the allow_prerelease policy still applies on the string.
+_TOFU_VERSION_INDEX_URL = "https://get.opentofu.org/tofu/api.json"
 
-    Filters by the configured allow_prerelease policy. GitHub's
-    `prerelease` flag is the authoritative signal for pre-release status;
-    the policy is applied on top of it.
-    """
-    url = "https://api.github.com/repos/opentofu/opentofu/releases"
+
+async def _fetch_tofu_version_ids() -> list[str]:
+    """Return every OpenTofu release version id from the official index."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await arequest_with_retry(client, "GET", url, params={"per_page": 100})
+        resp = await arequest_with_retry(client, "GET", _TOFU_VERSION_INDEX_URL)
         resp.raise_for_status()
-        releases = resp.json()
+        data = resp.json()
+    return [v["id"] for v in data.get("versions", []) if v.get("id")]
 
+
+async def _fetch_tofu_versions() -> list[str]:
+    """Fetch the list of installable tofu versions (allow_prerelease applied)."""
     policy = settings.registry.binary_cache.allow_prerelease
     versions = []
-    for release in releases:
-        tag = release.get("tag_name", "")
-        version = tag.lstrip("v")
+    for version in await _fetch_tofu_version_ids():
         if not _is_version_allowed(version, policy):
             continue
         parts = version.split("-")[0].split(".")
@@ -486,26 +493,19 @@ async def _resolve_terraform_version(partial: str) -> str:
 
 
 async def _resolve_tofu_version(partial: str) -> str:
-    """Resolve partial tofu version via GitHub releases API.
+    """Resolve a partial tofu version (e.g. "1.12") to the highest matching
+    exact release via the official OpenTofu version index (#338).
 
     Honors the allow_prerelease policy: pre-release versions are only
     considered when explicitly permitted.
     """
-    url = "https://api.github.com/repos/opentofu/opentofu/releases"
-    prefix = f"v{partial}."
+    prefix = f"{partial}."  # index ids carry no leading "v"
     policy = settings.registry.binary_cache.allow_prerelease
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await arequest_with_retry(client, "GET", url, params={"per_page": 100})
-        resp.raise_for_status()
-        releases = resp.json()
-
     matching = []
-    for release in releases:
-        tag = release.get("tag_name", "")
-        if not tag.startswith(prefix):
+    for version in await _fetch_tofu_version_ids():
+        if not version.startswith(prefix):
             continue
-        version = tag.lstrip("v")
         if not _is_version_allowed(version, policy):
             continue
         matching.append(version)

--- a/services/tests/services/test_binary_cache_service.py
+++ b/services/tests/services/test_binary_cache_service.py
@@ -287,3 +287,76 @@ class TestTerragruntBinary:
         added = db.add.call_args[0][0]
         assert added.tool == "terragrunt"
         assert added.version == "0.67.0"
+
+
+class TestTofuVersionResolution:
+    """OpenTofu versions resolve via the official, non-rate-limited index
+    (get.opentofu.org/tofu/api.json), not the GitHub releases API (#338)."""
+
+    @patch("terrapod.services.binary_cache_service.arequest_with_retry", new_callable=AsyncMock)
+    async def test_fetch_ids_parses_official_index(self, mock_req: AsyncMock) -> None:
+        from terrapod.services.binary_cache_service import (
+            _TOFU_VERSION_INDEX_URL,
+            _fetch_tofu_version_ids,
+        )
+
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(
+            return_value={"versions": [{"id": "1.12.3"}, {"id": "1.12.0-rc1"}, {"id": "1.11.11"}]}
+        )
+        mock_req.return_value = resp
+
+        ids = await _fetch_tofu_version_ids()
+
+        assert ids == ["1.12.3", "1.12.0-rc1", "1.11.11"]
+        # Must hit the official index, NOT api.github.com.
+        called_url = mock_req.call_args[0][2]
+        assert called_url == _TOFU_VERSION_INDEX_URL
+        assert "api.github.com" not in called_url
+
+    @patch("terrapod.services.binary_cache_service.settings")
+    @patch(
+        "terrapod.services.binary_cache_service._fetch_tofu_version_ids",
+        new_callable=AsyncMock,
+    )
+    async def test_resolves_partial_to_highest_stable(
+        self, mock_ids: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from terrapod.services.binary_cache_service import _resolve_tofu_version
+
+        mock_settings.registry.binary_cache.allow_prerelease = "none"
+        mock_ids.return_value = ["1.12.0", "1.12.3", "1.12.1", "1.12.0-rc1", "1.11.11"]
+
+        assert await _resolve_tofu_version("1.12") == "1.12.3"
+
+    @patch("terrapod.services.binary_cache_service.settings")
+    @patch(
+        "terrapod.services.binary_cache_service._fetch_tofu_version_ids",
+        new_callable=AsyncMock,
+    )
+    async def test_excludes_prereleases_when_policy_none(
+        self, mock_ids: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from terrapod.services.binary_cache_service import _resolve_tofu_version
+
+        mock_settings.registry.binary_cache.allow_prerelease = "none"
+        # Only pre-releases match → no stable → returns the partial unchanged.
+        mock_ids.return_value = ["1.13.0-rc1", "1.13.0-beta1"]
+
+        assert await _resolve_tofu_version("1.13") == "1.13"
+
+    @patch("terrapod.services.binary_cache_service.settings")
+    @patch(
+        "terrapod.services.binary_cache_service._fetch_tofu_version_ids",
+        new_callable=AsyncMock,
+    )
+    async def test_includes_rc_when_policy_rc(
+        self, mock_ids: AsyncMock, mock_settings: MagicMock
+    ) -> None:
+        from terrapod.services.binary_cache_service import _resolve_tofu_version
+
+        mock_settings.registry.binary_cache.allow_prerelease = "rc"
+        mock_ids.return_value = ["1.13.0-rc1", "1.13.0-rc2"]
+
+        assert await _resolve_tofu_version("1.13") == "1.13.0-rc2"


### PR DESCRIPTION
## What

The kind/k3d eval (#594) brought up the API + UI but disabled the listener and bootstrapped no agent pool — so queuing a plan sat in `pending` forever. This makes the quickstart a **working platform**: queue a plan and it runs on a Kubernetes Job.

## Sequencing — resolved in Helm, not worked around

The listener's readiness probe only passes once it has **joined a pool**, created by the bootstrap job. Post-install pool + `helm --wait` → deadlock (wait blocks on the listener, which waits for a pool that doesn't exist yet). Fix: bootstrap hook phase/weight are now **configurable, defaulting to the exact historical production behaviour** (`post-install`, weight 10). The eval opts into `pre-install,pre-upgrade` (-3) so the pool exists before the listener and `--wait` succeeds natively. Bootstrap is DB-direct + idempotent.

**Production renders identically** (no bootstrap job by default; hook defaults unchanged) — no production behaviour change.

## Eval profile (eval-only)
- `listener.enabled` + bootstrapped `eval-pool` + matching join token.
- **`storage.filesystem.base_url` = in-cluster API** — runner Jobs fetch config/state via this; without it every run fails at download.
- listener/runner image tags pinned; `api.strategy.maxSurge: 0` (clean RWO PVC handover on upgrade); `bound_token_idle_days: 0`; login `admin`.

## CI proves it
kind + k3d eval-boot now asserts the listener becomes Available (= joined) AND runs a **real plan through it** (`scripts/eval-smoke-plan.sh` → `planned` on a Job). `timeout-minutes: 25`; `--wait` timeout 600s.

## Tilt
Unified onto the chart-bootstrap path (drops redundant `setup-dev-pool`; listener depends on the bootstrap Job).

## Verified live on kind
`--wait` completed (no deadlock); listener joined `eval-pool`; plan run reached `planned` on a runner Job. Upgrade path exercised too.

Closes #599