### PR TITLE
feat(deploy): forward proxy + custom CA trust bundle (#592)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,33 @@ jobs:
           echo "$out" | grep -q "component: redis" || { echo "FAIL: values-eval did not render embedded Redis"; exit 1; }
           echo "$out" | grep -q "kind: PersistentVolumeClaim" || { echo "FAIL: embedded Postgres PVC missing"; exit 1; }
           echo "values-eval renders embedded datastores OK"
+      - name: Forward proxy + custom CA bundle render (#592)
+        run: |
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set listener.enabled=true \
+              --set listener.joinToken=tok \
+              --set proxy.enabled=true \
+              --set proxy.httpProxy=http://proxy.example.com:3128 \
+              --set proxy.httpsProxy=http://proxy.example.com:3128 \
+              --set caBundle.enabled=true \
+              --set-string caBundle.inline="dummy-ca-pem")
+          # Proxy env reaches API + listener.
+          echo "$out" | grep -q "HTTPS_PROXY" || { echo "FAIL: HTTPS_PROXY not injected"; exit 1; }
+          # The custom CA ConfigMap is created from inline.
+          echo "$out" | grep -q "name: terrapod-ca-bundle" || { echo "FAIL: CA bundle ConfigMap missing"; exit 1; }
+          # API/listener get the merge init container + merged SSL_CERT_FILE.
+          echo "$out" | grep -q "name: ca-merge" || { echo "FAIL: ca-merge init container missing"; exit 1; }
+          echo "$out" | grep -q "/etc/terrapod-ca/ca-bundle.crt" || { echo "FAIL: SSL_CERT_FILE not pointed at merged bundle"; exit 1; }
+          # Web (Node) trusts the raw source via NODE_EXTRA_CA_CERTS.
+          echo "$out" | grep -q "NODE_EXTRA_CA_CERTS" || { echo "FAIL: web NODE_EXTRA_CA_CERTS missing"; exit 1; }
+          # runners.yaml carries the proxy + CA source path for the listener to
+          # forward into runner Jobs.
+          echo "$out" | grep -q "ca_bundle_source_path" || { echo "FAIL: runners.yaml CA source path missing"; exit 1; }
+          echo "$out" | grep -q "http_proxy: \"http://proxy.example.com:3128\"" || { echo "FAIL: runners.yaml proxy missing"; exit 1; }
+          echo "proxy + CA bundle render OK (#592)"
 
   # ── Eval quickstart boot (kind + k3d) ──────────────────
   # Proves `make eval` actually stands up a complete stack (embedded

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Service Catalog](docs/service-catalog.md) | No-code self-service provisioning over the module registry |
 | [Monitoring](docs/monitoring.md) | Prometheus metrics, scraping, recommended alerts |
 | [Optional Webhook Ingress](docs/deployment-webhook-ingress.md) | Split public webhook ingress so the management plane can stay private |
+| [Forward Proxy & Custom CA](docs/deployment-proxy.md) | Route all outbound HTTP(S) through a corporate proxy and trust a private/MITM CA, across every component including runner Jobs |
 | [Security Hardening](docs/security-hardening.md) | Pod hardening defaults, secrets, network posture |
 | [Production Checklist](docs/production-checklist.md) | Pre-go-live checklist for a production deployment |
 | [Disaster Recovery](docs/disaster-recovery.md) | Break-glass state recovery from object storage |

--- a/docs/deployment-proxy.md
+++ b/docs/deployment-proxy.md
@@ -1,0 +1,126 @@
+# Forward proxy & custom CA trust
+
+Some deployments sit in networks that have **no direct internet egress** —
+outbound traffic must traverse a corporate HTTP(S) **forward proxy**, and TLS is
+often **intercepted** by that proxy (or by an internal registry / VCS / artifact
+store) presenting certificates signed by a **private/corporate CA** the default
+image trust store doesn't know.
+
+Terrapod has two chart-level knobs for this, deliberately separate and
+composable:
+
+- `proxy:` — route every component's outbound HTTP(S) through a forward proxy.
+- `caBundle:` — add a custom CA (or CAs) to every component's **outbound** TLS
+  trust, so a TLS-intercepting proxy or a privately-signed registry/VCS endpoint
+  is trusted.
+
+Both are **off by default** and change nothing unless enabled. They apply to all
+long-lived components (API, web/BFF, listener) **and** to the ephemeral runner
+Jobs that execute `terraform`/`tofu` — so `terraform init` can fetch **public**
+registry and `git::` module sources through the proxy and trust the intercepting
+CA.
+
+## What needs egress (and what doesn't)
+
+| Component | Typical outbound egress | Through proxy? |
+|---|---|---|
+| API | Upstream provider/binary mirrors, VCS APIs, run-task & notification webhooks, the AI provider | Yes, when set |
+| web/BFF (Node) | None outbound (proxies to the API in-cluster) | Honours env if set |
+| listener | The API (in-cluster service in single-cluster; the **public URL** in split-cluster) | Yes, when set |
+| runner Job | The API (binaries/providers/state/config — usually in-cluster), **plus public registry/`git::` module sources** | Yes, when set |
+| migrations / bootstrap Jobs | The in-cluster database only | No — DB is in `no_proxy`; DB server-cert trust is the separate `api.databaseCA` |
+
+## `proxy:`
+
+```yaml
+proxy:
+  enabled: true
+  httpProxy: "http://proxy.internal:3128"
+  httpsProxy: "http://proxy.internal:3128"   # often the same endpoint
+  noProxy: []                                 # extra entries; cluster-internal defaults are appended
+```
+
+When enabled, the chart sets `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (and the
+lowercase variants — Go/terraform read uppercase, many libraries read lowercase)
+on every component, including runner Jobs. `no_proxy` always carries
+cluster-local defaults (`localhost`, `127.0.0.1`, the `*.svc` / `*.cluster.local`
+domains, and the in-cluster Service names) and appends your `noProxy` list.
+
+**Split-cluster note (ARC topology).** When the listener + runner live in a
+**different cluster** from the API, they reach it over the **public URL**, not
+the in-cluster Service name — so that hop legitimately traverses the proxy.
+Terrapod does **not** assume the runner→API hop is proxy-exempt: the public host
+isn't in `no_proxy`, so it follows your normal proxy rules. If you have a direct
+private path to a remote API and want to bypass the proxy for it, add its host to
+`proxy.noProxy`.
+
+All Terrapod HTTP clients honour these env vars (Python `httpx` and Go `net/http`
+both read the standard proxy environment by default).
+
+## `caBundle:`
+
+```yaml
+caBundle:
+  enabled: true
+  inline: |                       # paste the extra CA PEM(s); the chart makes a ConfigMap
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  # existingConfigMap: my-corp-ca # OR reference one you already manage
+  # existingSecret: my-corp-ca    # OR a Secret
+  key: ca-extra.pem               # key within the ConfigMap/Secret
+```
+
+A CA bundle is public, non-secret material — prefer a ConfigMap (`inline` creates
+one; `existingConfigMap`/`existingSecret` reference your own).
+
+### How the trust is wired
+
+The supplied CA must be **added to**, not **replace**, the image's built-in
+public roots — otherwise public endpoints (GitHub, the Terraform registry, your
+cloud APIs) would stop verifying. Terrapod does this per runtime:
+
+- **Python / Go / git / curl components (API, listener, runner)** — an
+  init container concatenates the image's system roots
+  (`/etc/ssl/certs/ca-certificates.crt`) with your CA into a single merged
+  bundle on a shared `emptyDir`, and the app trusts the **merged** file via
+  `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` (covers Python, curl,
+  Go, terraform/tofu) and `GIT_SSL_CAINFO` (git). The merge lands on the writable
+  `emptyDir` because the containers run with `readOnlyRootFilesystem`.
+- **web/BFF (Node)** — Node's `NODE_EXTRA_CA_CERTS` **appends** to the built-in
+  roots, so it trusts the raw source file directly with no merge step.
+
+### Runner Jobs (cross-namespace)
+
+Runner Jobs run in the runner namespace (often distinct from the release
+namespace), so they can't mount the release-namespace CA ConfigMap. Instead the
+**listener** reads its own mounted copy of the raw CA and ships it into a
+**per-run Secret** (owner-referenced to the Job, so it's garbage-collected with
+the Job — same lifecycle as the auth/vars Secrets). The runner Job's init
+container then merges that with the **runner image's** own system roots. Shipping
+the raw source (not the listener's already-merged bundle) means the runner trusts
+the runner image's roots plus your CA, not the listener image's roots.
+
+## Relationship to `api.databaseCA`
+
+`caBundle` is **general outbound trust**. It is **separate** from
+`api.databaseCA`, which verifies the **database server** certificate
+specifically (and is mounted only on the components that talk to the DB). Set
+`api.databaseCA` for a privately-signed Postgres endpoint; set `caBundle` for
+everything else outbound (proxy MITM, internal registries/VCS/artifact stores).
+They can both be set and don't interfere.
+
+## Verifying
+
+After enabling, confirm the env + init container rendered:
+
+```sh
+helm template terrapod helm/terrapod \
+  --set proxy.enabled=true --set proxy.httpsProxy=http://proxy.internal:3128 \
+  --set caBundle.enabled=true --set-string caBundle.inline="$(cat corp-ca.pem)" \
+  | grep -E "HTTPS_PROXY|SSL_CERT_FILE|NODE_EXTRA_CA_CERTS|ca-merge"
+```
+
+On a live cluster, a runner Job for a workspace whose modules come from a public
+registry through the proxy should complete `terraform init` without
+`x509: certificate signed by unknown authority` or proxy-connection errors.

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Deployment](deployment.md) | Production Helm deployment, storage backends, scaling |
 | [Split-networking deployments](deployment-network-isolation.md) | Three-Ingress model: management / webhook / internal agent path, with split-hostname runner config |
 | [Optional split webhook ingress](deployment-webhook-ingress.md) | Optional second Ingress for the public-must-reach surface (VCS webhooks, run-task callbacks) |
+| [Forward proxy & custom CA trust](deployment-proxy.md) | Route all outbound HTTP(S) through a corporate proxy and trust a private/MITM CA, across every component including runner Jobs |
 | [Security Hardening](security-hardening.md) | TLS, secrets management, network policies, rate limiting |
 | [Production Checklist](production-checklist.md) | Step-by-step checklist for go-live readiness |
 | [Disaster Recovery](disaster-recovery.md) | Break-glass state recovery from object storage |

--- a/helm/terrapod/templates/_helpers.tpl
+++ b/helm/terrapod/templates/_helpers.tpl
@@ -378,3 +378,159 @@ redis.deploy=true; otherwise empty.
 {{- printf "redis://%s-redis:6379" (include "terrapod.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+─── Egress: forward proxy + custom CA trust (#592) ──────────────────────────
+Helpers shared by every component that makes outbound calls (api, web, listener,
+migrations/bootstrap Jobs, runner Jobs). All take the ROOT context unless noted.
+*/}}
+
+{{/*
+Forward-proxy env vars. Emits BOTH upper- and lower-case HTTP_PROXY/HTTPS_PROXY/
+NO_PROXY when proxy.enabled. no_proxy = cluster-internal defaults + in-cluster
+service names + the operator's proxy.noProxy list. Include inside a container
+`env:` list.
+*/}}
+{{- define "terrapod.proxyEnv" -}}
+{{- if .Values.proxy.enabled -}}
+{{- $fn := include "terrapod.fullname" . -}}
+{{- $defaults := list "localhost" "127.0.0.1" ".svc" ".svc.cluster.local" ".cluster.local" (printf "%s-api" $fn) (printf "%s-web" $fn) (printf "%s-postgresql" $fn) (printf "%s-redis" $fn) -}}
+{{- $no := join "," (concat $defaults (.Values.proxy.noProxy | default (list))) -}}
+- name: HTTP_PROXY
+  value: {{ .Values.proxy.httpProxy | quote }}
+- name: http_proxy
+  value: {{ .Values.proxy.httpProxy | quote }}
+- name: HTTPS_PROXY
+  value: {{ .Values.proxy.httpsProxy | quote }}
+- name: https_proxy
+  value: {{ .Values.proxy.httpsProxy | quote }}
+- name: NO_PROXY
+  value: {{ $no | quote }}
+- name: no_proxy
+  value: {{ $no | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/* True ("true"/"") when a custom outbound CA bundle is configured. */}}
+{{- define "terrapod.caBundle.enabled" -}}
+{{- if and .Values.caBundle.enabled (or .Values.caBundle.inline .Values.caBundle.existingConfigMap .Values.caBundle.existingSecret) -}}true{{- end -}}
+{{- end -}}
+
+{{/* The custom CA filename (key within the ConfigMap/Secret). */}}
+{{- define "terrapod.caBundle.key" -}}
+{{- .Values.caBundle.key | default "ca-extra.pem" -}}
+{{- end -}}
+
+{{/*
+Volumes for the merge components (Python/Go/git): the raw custom CA source
+(ConfigMap or Secret) + an emptyDir for the init-container-merged bundle.
+*/}}
+{{- define "terrapod.caBundle.volumes" -}}
+{{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+- name: ca-src
+  {{- if .Values.caBundle.existingSecret }}
+  secret:
+    secretName: {{ .Values.caBundle.existingSecret }}
+  {{- else }}
+  configMap:
+    name: {{ .Values.caBundle.existingConfigMap | default (printf "%s-ca-bundle" (include "terrapod.fullname" .)) }}
+  {{- end }}
+- name: ca-merged
+  emptyDir: {}
+{{- end }}
+{{- end -}}
+
+{{/* Volume for web (Node): just the raw custom CA source (no merge). */}}
+{{- define "terrapod.caBundle.volumesNode" -}}
+{{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+- name: ca-src
+  {{- if .Values.caBundle.existingSecret }}
+  secret:
+    secretName: {{ .Values.caBundle.existingSecret }}
+  {{- else }}
+  configMap:
+    name: {{ .Values.caBundle.existingConfigMap | default (printf "%s-ca-bundle" (include "terrapod.fullname" .)) }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Init container that MERGES the image's system roots with the supplied CA(s) into
+one bundle on the ca-merged emptyDir. Arg: dict "root" $ "image" <image string>.
+*/}}
+{{- define "terrapod.caBundle.initContainer" -}}
+{{- $root := .root -}}
+{{- if eq (include "terrapod.caBundle.enabled" $root) "true" }}
+- name: ca-merge
+  image: {{ .image }}
+  imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
+  command: ["/bin/sh", "-c", "cat /etc/ssl/certs/ca-certificates.crt /etc/terrapod-ca-src/{{ include "terrapod.caBundle.key" $root }} > /etc/terrapod-ca/ca-bundle.crt"]
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
+  volumeMounts:
+    - name: ca-src
+      mountPath: /etc/terrapod-ca-src
+      readOnly: true
+    - name: ca-merged
+      mountPath: /etc/terrapod-ca
+{{- end }}
+{{- end -}}
+
+{{/* Main-container volumeMount for the merged bundle (merge components). */}}
+{{- define "terrapod.caBundle.volumeMounts" -}}
+{{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+- name: ca-merged
+  mountPath: /etc/terrapod-ca
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/* Main-container volumeMount for web (Node): the raw CA source. */}}
+{{- define "terrapod.caBundle.volumeMountsNode" -}}
+{{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+- name: ca-src
+  mountPath: /etc/terrapod-ca-src
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/*
+Raw-source CA mount for the LISTENER (#592). The listener needs the raw custom
+CA (not just its own merged bundle) so it can ship it into a per-run Secret in
+the runner namespace, where the runner Job merges it with the runner image's
+roots. Same mount as the Node helper; named distinctly so the intent is clear.
+*/}}
+{{- define "terrapod.caBundle.volumeMountsSource" -}}
+{{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+- name: ca-src
+  mountPath: /etc/terrapod-ca-src
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/* CA trust env for Python/Go/git/curl components → the merged bundle. */}}
+{{- define "terrapod.caBundle.env" -}}
+{{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+- name: SSL_CERT_FILE
+  value: /etc/terrapod-ca/ca-bundle.crt
+- name: REQUESTS_CA_BUNDLE
+  value: /etc/terrapod-ca/ca-bundle.crt
+- name: CURL_CA_BUNDLE
+  value: /etc/terrapod-ca/ca-bundle.crt
+- name: GIT_SSL_CAINFO
+  value: /etc/terrapod-ca/ca-bundle.crt
+{{- end }}
+{{- end -}}
+
+{{/* CA trust env for web (Node): NODE_EXTRA_CA_CERTS appends to built-in roots. */}}
+{{- define "terrapod.caBundle.envNode" -}}
+{{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+- name: NODE_EXTRA_CA_CERTS
+  value: /etc/terrapod-ca-src/{{ include "terrapod.caBundle.key" . }}
+{{- end }}
+{{- end -}}

--- a/helm/terrapod/templates/configmap-ca-bundle.yaml
+++ b/helm/terrapod/templates/configmap-ca-bundle.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Custom outbound CA trust bundle (#592). Created only when caBundle.inline is set;
+operators using existingConfigMap/existingSecret bring their own. A CA bundle is
+public, non-secret material, so a ConfigMap is appropriate. The init container in
+each Python/Go/git component merges this with the image's system roots; the
+web/BFF trusts it directly via NODE_EXTRA_CA_CERTS. See _helpers.tpl.
+*/ -}}
+{{- if and .Values.caBundle.enabled .Values.caBundle.inline }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "terrapod.fullname" . }}-ca-bundle
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+data:
+  {{ include "terrapod.caBundle.key" . }}: |
+{{ .Values.caBundle.inline | indent 4 }}
+{{- end }}

--- a/helm/terrapod/templates/configmap-runner.yaml
+++ b/helm/terrapod/templates/configmap-runner.yaml
@@ -62,4 +62,39 @@ data:
     extra_env_from:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- /*
+    Forward proxy (#592): the runner Job fetches PUBLIC registry/git modules
+    directly, which is the egress the proxy is for. When a proxy is configured
+    the listener injects HTTP(S)_PROXY/NO_PROXY into the Job.
+
+    no_proxy carries the cluster-local defaults (loopback, the *.svc /
+    *.cluster.local domains, and the bare in-cluster Service names). We do NOT
+    assume the runner→API hop is always proxy-exempt: in the ARC split-cluster
+    topology the listener+runner live in a DIFFERENT cluster from the API and
+    reach it over the PUBLIC URL — that hop SHOULD traverse the proxy, and it
+    does because the public host isn't in this list. The bare Service name
+    `<release>-api` only matches (and only needs to bypass) when the API really
+    is in-cluster; in split-cluster it simply never matches. Operators who have
+    a direct path to a remote API can add its host to proxy.noProxy.
+    */}}
+    {{- if .Values.proxy.enabled }}
+    {{- $fn := include "terrapod.fullname" . }}
+    {{- $defaults := list "localhost" "127.0.0.1" ".svc" ".svc.cluster.local" ".cluster.local" (printf "%s-api" $fn) (printf "%s-web" $fn) (printf "%s-postgresql" $fn) (printf "%s-redis" $fn) }}
+    proxy:
+      http_proxy: {{ .Values.proxy.httpProxy | quote }}
+      https_proxy: {{ .Values.proxy.httpsProxy | quote }}
+      no_proxy: {{ join "," (concat $defaults (.Values.proxy.noProxy | default (list))) | quote }}
+    {{- end }}
+    {{- /*
+    Custom CA trust bundle (#592): the listener reads its OWN mounted raw CA
+    source file (path below) and ships it into a per-run Secret in the runner
+    namespace; the runner Job's init container merges it with the runner image's
+    own system roots. We deliver the raw source (not the listener's merged
+    bundle) so the runner trusts runner-system-roots + custom-CA, not the
+    listener image's roots.
+    */}}
+    {{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+    ca_bundle_enabled: true
+    ca_bundle_source_path: {{ printf "/etc/terrapod-ca-src/%s" (include "terrapod.caBundle.key" .) | quote }}
+    {{- end }}
 {{- end }}

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -43,9 +43,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.api.extraInitContainers }}
+      {{- if or (eq (include "terrapod.caBundle.enabled" .) "true") .Values.api.extraInitContainers }}
       initContainers:
+        {{- include "terrapod.caBundle.initContainer" (dict "root" . "image" (include "terrapod.api.image" .) "pullPolicy" .Values.api.image.pullPolicy) | nindent 8 }}
+        {{- with .Values.api.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: api
@@ -117,6 +120,8 @@ spec:
                   name: {{ .Values.api.config.vcs.gitlab.existingSecret }}
                   key: {{ .Values.api.config.vcs.gitlab.existingSecretKey | default "webhook_secret" }}
             {{- end }}
+            {{- include "terrapod.proxyEnv" . | nindent 12 }}
+            {{- include "terrapod.caBundle.env" . | nindent 12 }}
             {{- with .Values.api.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -149,6 +154,7 @@ spec:
               mountPath: /etc/terrapod/db-ca
               readOnly: true
             {{- end }}
+            {{- include "terrapod.caBundle.volumeMounts" . | nindent 12 }}
             {{- with .Values.api.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -226,6 +232,7 @@ spec:
           configMap:
             name: {{ .Values.api.databaseCA.existingConfigMap | default (printf "%s-database-ca" (include "terrapod.fullname" .)) }}
         {{- end }}
+        {{- include "terrapod.caBundle.volumes" . | nindent 8 }}
         {{- with .Values.api.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/terrapod/templates/deployment-listener.yaml
+++ b/helm/terrapod/templates/deployment-listener.yaml
@@ -39,9 +39,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.listener.extraInitContainers }}
+      {{- if or (eq (include "terrapod.caBundle.enabled" .) "true") .Values.listener.extraInitContainers }}
       initContainers:
+        {{- include "terrapod.caBundle.initContainer" (dict "root" . "image" (include "terrapod.listener.image" .) "pullPolicy" .Values.listener.image.pullPolicy) | nindent 8 }}
+        {{- with .Values.listener.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: listener
@@ -98,6 +101,8 @@ spec:
             - name: TERRAPOD_JOIN_TOKEN
               value: {{ .Values.listener.joinToken | quote }}
             {{- end }}
+            {{- include "terrapod.proxyEnv" . | nindent 12 }}
+            {{- include "terrapod.caBundle.env" . | nindent 12 }}
             {{- with .Values.listener.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -111,6 +116,10 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            {{- include "terrapod.caBundle.volumeMounts" . | nindent 12 }}
+            {{- /* Source mount (#592): the listener reads the raw custom CA to
+            ship it into per-run Secrets for runner Jobs (cross-namespace). */}}
+            {{- include "terrapod.caBundle.volumeMountsSource" . | nindent 12 }}
             {{- with .Values.listener.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -154,6 +163,7 @@ spec:
         # by the listener — not via a volume mount.
         - name: tmp
           emptyDir: {}
+        {{- include "terrapod.caBundle.volumes" . | nindent 8 }}
         {{- with .Values.listener.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/terrapod/templates/deployment-web.yaml
+++ b/helm/terrapod/templates/deployment-web.yaml
@@ -72,6 +72,8 @@ spec:
             # Set to "" to disable.
             - name: HSTS
               value: {{ .Values.web.hsts.value | quote }}
+            {{- include "terrapod.proxyEnv" . | nindent 12 }}
+            {{- include "terrapod.caBundle.envNode" . | nindent 12 }}
             {{- with .Values.web.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -104,9 +106,12 @@ spec:
             preStop:
               exec:
                 command: ["sleep", "{{ .Values.web.preStopSleepSeconds | default 30 }}"]
-          {{- with .Values.web.extraVolumeMounts }}
+          {{- if or (eq (include "terrapod.caBundle.enabled" .) "true") .Values.web.extraVolumeMounts }}
           volumeMounts:
+            {{- include "terrapod.caBundle.volumeMountsNode" . | nindent 12 }}
+            {{- with .Values.web.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
@@ -117,9 +122,12 @@ spec:
         {{- with .Values.web.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.web.extraVolumes }}
+      {{- if or (eq (include "terrapod.caBundle.enabled" .) "true") .Values.web.extraVolumes }}
       volumes:
+        {{- include "terrapod.caBundle.volumesNode" . | nindent 8 }}
+        {{- with .Values.web.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.web.nodeSelector }}
       nodeSelector:

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -361,6 +361,29 @@
         "create": { "type": "boolean" },
         "labels": { "type": "object" }
       }
+    },
+
+    "proxy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "httpProxy": { "type": "string" },
+        "httpsProxy": { "type": "string" },
+        "noProxy": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
+    "caBundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "inline": { "type": "string" },
+        "existingConfigMap": { "type": "string" },
+        "existingSecret": { "type": "string" },
+        "key": { "type": "string" }
+      }
     }
   },
 

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -1218,3 +1218,45 @@ networkPolicies:
 namespace:
   create: false
   labels: {}
+
+# ── Egress: forward proxy + custom CA trust (restricted-network deployments) ──
+# proxy.* and caBundle.* are a matched pair for high-security / restricted-egress
+# networks where outbound traffic must egress via a forward proxy and/or TLS
+# terminates against internal/corporate CAs — including a TLS-intercepting "MITM"
+# proxy presenting its OWN CA. They apply to EVERY component that makes outbound
+# calls: the API, web/BFF, listener, the migrations + bootstrap Jobs, and the
+# runner Jobs (so terraform/tofu provider+module fetches egress through the proxy
+# and trust the CA too). See docs/deployment-proxy.md.
+
+# Forward proxy. When enabled, BOTH upper- and lower-case env vars
+# (HTTP_PROXY/http_proxy, HTTPS_PROXY/https_proxy, NO_PROXY/no_proxy) are injected
+# into every component — different runtimes (Python httpx/requests, Go,
+# terraform/tofu, curl, cloud SDKs) read different cases. The chart APPENDS
+# cluster-internal destinations to noProxy automatically (localhost, 127.0.0.1,
+# .svc, .svc.cluster.local, .cluster.local, the in-cluster service names) so
+# internal traffic is never proxied. Add cloud metadata (169.254.169.254) and any
+# object-store/STS endpoints that must bypass the proxy to noProxy yourself.
+proxy:
+  enabled: false
+  httpProxy: ""                   # e.g. http://proxy.internal:3128
+  httpsProxy: ""                  # e.g. http://proxy.internal:3128 (often the same as httpProxy)
+  noProxy: []                     # extra no_proxy entries; cluster-internal defaults are appended
+
+# Custom CA trust bundle for OUTBOUND TLS (corporate roots, internal registries /
+# VCS / artifact stores, and a TLS-intercepting proxy's MITM CA). For the Python/
+# Go/git components an init container MERGES the supplied CA(s) with the image's
+# system roots into one bundle on a shared emptyDir, so the app trusts BOTH public
+# and corporate/proxy CAs (a replacement bundle would drop the public roots and
+# break public endpoints); the merged bundle is wired via SSL_CERT_FILE /
+# REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE (Python, curl, Go, terraform/tofu) and
+# GIT_SSL_CAINFO (git). The web/BFF (Node) trusts it via NODE_EXTRA_CA_CERTS, which
+# APPENDS to Node's built-in roots (no merge needed). A CA bundle is public,
+# non-secret material — prefer a ConfigMap. This is SEPARATE from api.databaseCA,
+# which verifies the database SERVER cert specifically; caBundle is general
+# outbound trust. See docs/deployment-proxy.md for how the two interact.
+caBundle:
+  enabled: false
+  inline: ""                      # paste the extra CA PEM(s) here; the chart creates a ConfigMap
+  existingConfigMap: ""           # OR reference an existing ConfigMap holding the CA bundle
+  existingSecret: ""              # OR an existing Secret holding the CA bundle
+  key: ca-extra.pem               # key within the ConfigMap/Secret (the supplied CA filename)

--- a/llms.txt
+++ b/llms.txt
@@ -91,6 +91,7 @@ How each capability is turned on. **Platform-level** features are Helm values un
 - [docs/tfe-cli-surface.md](docs/tfe-cli-surface.md): the verified subset of the TFE V2 API the CLI consumes (mounted at `/api/v2/`); everything else is Terrapod-native at `/api/terrapod/v1/`.
 - [docs/deployment.md](docs/deployment.md): production Helm deployment, storage backends, scaling.
 - [docs/deployment-network-isolation.md](docs/deployment-network-isolation.md) and [docs/deployment-webhook-ingress.md](docs/deployment-webhook-ingress.md): split-ingress topologies.
+- [docs/deployment-proxy.md](docs/deployment-proxy.md): forward proxy (`proxy.*`) + custom outbound CA trust (`caBundle.*`) across all components incl. runner Jobs; for no-direct-egress / TLS-intercepting networks.
 - [docs/security-hardening.md](docs/security-hardening.md), [docs/production-checklist.md](docs/production-checklist.md), [docs/disaster-recovery.md](docs/disaster-recovery.md): go-live and break-glass.
 - [docs/runbooks.md](docs/runbooks.md): operator runbooks for high-blast-radius surfaces.
 - [docs/local-development.md](docs/local-development.md): run from source with Tilt (contributors).

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -36,6 +36,22 @@ class RunnerImageConfig(BaseModel):
     pull_policy: str = Field(default="IfNotPresent")
 
 
+class RunnerProxyConfig(BaseModel):
+    """Forward-proxy settings forwarded into runner Jobs (#592).
+
+    Rendered into runners.yaml from the chart's top-level .Values.proxy. The
+    listener injects these as HTTP(S)_PROXY/NO_PROXY (upper + lower case) env
+    vars on the runner Job so `terraform init` reaches PUBLIC registry/git
+    module sources through a corporate proxy. no_proxy is pre-resolved by the
+    chart (cluster-local defaults + operator list); we do NOT assume the
+    runner→API hop is proxy-exempt — in split-cluster it traverses the proxy.
+    """
+
+    http_proxy: str = Field(default="")
+    https_proxy: str = Field(default="")
+    no_proxy: str = Field(default="")
+
+
 class RunnerConfig(BaseModel):
     """Runner configuration, loaded from /etc/terrapod/runners.yaml.
 
@@ -70,6 +86,23 @@ class RunnerConfig(BaseModel):
     image_pull_secrets: list[str] = Field(default_factory=list)
     extra_env: list[dict] = Field(default_factory=list)
     extra_env_from: list[dict] = Field(default_factory=list)
+    # Forward proxy + custom CA trust bundle (#592). Rendered into runners.yaml
+    # by the chart from top-level .Values.proxy / .Values.caBundle. The listener
+    # forwards these into every runner Job: proxy env vars (so terraform init can
+    # fetch PUBLIC registry/git modules through a corporate proxy) and the custom
+    # CA (so the runner trusts a TLS-intercepting proxy / private registry).
+    proxy: RunnerProxyConfig | None = Field(default=None)
+    ca_bundle_enabled: bool = Field(default=False)
+    ca_bundle_source_path: str = Field(
+        default="",
+        description=(
+            "Path on the LISTENER pod to the raw custom CA file (mounted from "
+            "the chart's caBundle source). The listener reads it at Job-launch "
+            "time and ships it into a per-run Secret in the runner namespace, "
+            "where the runner Job's init container merges it with the runner "
+            "image's own system roots."
+        ),
+    )
     stale_timeout_seconds: int = Field(
         default=3600,
         description="Seconds before a run with no Job status is marked errored",

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -15,6 +15,16 @@ _TFVARS_SECRET_KEY = "terraform.tfvars.json"
 _TFVARS_FILENAME = "terraform.tfvars.json"
 _TFVARS_MOUNT_DIR = "/var/run/terrapod/vars"
 
+# Custom outbound CA trust bundle (#592). The listener ships the raw custom CA
+# into a per-run Secret under this key; an init container merges it with the
+# runner image's own system roots into an emptyDir, and the runner container
+# trusts the merged file. Paths/key mirror the chart's _helpers.tpl so the
+# deployment and Job machinery stay identical.
+_CA_BUNDLE_KEY = "ca-extra.pem"
+_CA_SRC_DIR = "/etc/terrapod-ca-src"
+_CA_MERGED_DIR = "/etc/terrapod-ca"
+_CA_MERGED_FILE = f"{_CA_MERGED_DIR}/ca-bundle.crt"
+
 
 def _double_resource(value: str) -> str:
     """Double a K8s resource value.
@@ -68,6 +78,7 @@ def build_job_spec(
     allow_empty_apply: bool = False,
     is_destroy: bool = False,
     working_directory: str = "",
+    ca_secret_name: str = "",
 ) -> dict:
     """Build a K8s Job spec for a run phase.
 
@@ -200,6 +211,30 @@ def build_job_spec(
     # added below) and the entrypoint renders terrapod.auto.tfvars from it. This
     # keeps sensitive values off the Job spec env and makes complex/object
     # values round-trip identically on terraform and tofu.
+
+    # Forward proxy (#592) — lets `terraform init` reach PUBLIC registry/git
+    # module sources through a corporate proxy. Both upper and lower case: Go
+    # (terraform/tofu, the AWS SDK) reads the UPPER form, while many libraries
+    # read the lower form. no_proxy is pre-resolved by the chart; we do NOT
+    # force the API host into it — in split-cluster the runner→API hop reaches
+    # the public URL and legitimately traverses the proxy.
+    if runner_config.proxy:
+        p = runner_config.proxy
+        for name, value in (
+            ("HTTP_PROXY", p.http_proxy),
+            ("HTTPS_PROXY", p.https_proxy),
+            ("NO_PROXY", p.no_proxy),
+        ):
+            if value:
+                container_env.append({"name": name, "value": value})
+                container_env.append({"name": name.lower(), "value": value})
+
+    # Custom CA trust bundle (#592) — point the runner's TLS stacks at the
+    # init-container-merged bundle (system roots + custom CA). Volumes + init
+    # container are added to the pod spec further down.
+    if ca_secret_name and runner_config.ca_bundle_enabled:
+        for name in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO"):
+            container_env.append({"name": name, "value": _CA_MERGED_FILE})
 
     # Extra env vars from runner config (Helm values → runners.extraEnv)
     for extra in runner_config.extra_env:
@@ -354,6 +389,55 @@ def build_job_spec(
         )
         pod["containers"][0]["volumeMounts"].append(
             {"name": "tfvars", "mountPath": _TFVARS_MOUNT_DIR, "readOnly": True}
+        )
+
+    # Custom CA trust bundle (#592): mount the per-run CA Secret (raw custom CA,
+    # shipped by the listener from its own mounted source) and an emptyDir for
+    # the merged bundle, plus an init container that concatenates the runner
+    # image's system roots with the custom CA. Runner containers run with
+    # readOnlyRootFilesystem, so the merge MUST land on the writable emptyDir,
+    # not the image's /etc/ssl. Mirrors terrapod.caBundle.initContainer in
+    # _helpers.tpl so deployment and Job behave identically.
+    if ca_secret_name and runner_config.ca_bundle_enabled:
+        pod = job_spec["spec"]["template"]["spec"]
+        pod["volumes"].append(
+            {
+                "name": "ca-src",
+                "secret": {
+                    "secretName": ca_secret_name,
+                    "items": [{"key": _CA_BUNDLE_KEY, "path": _CA_BUNDLE_KEY}],
+                },
+            }
+        )
+        pod["volumes"].append({"name": "ca-merged", "emptyDir": {}})
+        pod["containers"][0]["volumeMounts"].append(
+            {"name": "ca-merged", "mountPath": _CA_MERGED_DIR, "readOnly": True}
+        )
+        pod.setdefault("initContainers", []).append(
+            {
+                "name": "ca-merge",
+                "image": image,
+                "imagePullPolicy": runner_config.image.pull_policy,
+                "command": [
+                    "/bin/sh",
+                    "-c",
+                    f"cat /etc/ssl/certs/ca-certificates.crt {_CA_SRC_DIR}/{_CA_BUNDLE_KEY} "
+                    f"> {_CA_MERGED_FILE}",
+                ],
+                "securityContext": {
+                    "runAsNonRoot": True,
+                    "runAsUser": 1000,
+                    "runAsGroup": 1000,
+                    "readOnlyRootFilesystem": True,
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {"drop": ["ALL"]},
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                },
+                "volumeMounts": [
+                    {"name": "ca-src", "mountPath": _CA_SRC_DIR, "readOnly": True},
+                    {"name": "ca-merged", "mountPath": _CA_MERGED_DIR},
+                ],
+            }
         )
 
     # envFrom — inject all keys from Secrets/ConfigMaps as env vars

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -640,6 +640,12 @@ class RunnerListener:
         # so no variable value is ever plaintext in the Job spec. Per-phase name
         # mirrors the auth Secret; ownerReference GCs it with the Job.
         vars_secret_name = f"tprun-{run_short}-{phase}-vars" if (env_vars or terraform_vars) else ""
+        # Per-run CA Secret (#592): ships the custom outbound CA into the runner
+        # namespace so the Job's init container can merge it with the runner
+        # image's system roots. Only when a CA bundle is configured AND the
+        # listener can actually read its own mounted copy.
+        ca_pem = self._read_ca_bundle_pem()
+        ca_secret_name = f"tprun-{run_short}-{phase}-ca" if ca_pem else ""
 
         spec = build_job_spec(
             run_id=run_id,
@@ -664,6 +670,7 @@ class RunnerListener:
             allow_empty_apply=attrs.get("allow-empty-apply", False),
             is_destroy=attrs.get("is-destroy", False),
             working_directory=attrs.get("working-directory", ""),
+            ca_secret_name=ca_secret_name,
         )
 
         namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
@@ -695,6 +702,17 @@ class RunnerListener:
             except Exception as e:
                 logger.error("Failed to create vars secret", run_id=run_id, error=str(e))
                 await self._report_launch_failed(run_id, f"Failed to create variables Secret: {e}")
+                return
+
+        # Create the per-run CA Secret (#592) — same ownerReference GC as the
+        # auth/vars Secrets. Holds the custom outbound CA the runner's init
+        # container merges with its image roots.
+        if ca_secret_name:
+            try:
+                await self._create_ca_secret(ca_secret_name, run_id, ca_pem, job_name, job_uid)
+            except Exception as e:
+                logger.error("Failed to create CA secret", run_id=run_id, error=str(e))
+                await self._report_launch_failed(run_id, f"Failed to create CA Secret: {e}")
                 return
 
         # Report Job launched to the API
@@ -1026,6 +1044,76 @@ class RunnerListener:
         core_api.create_namespaced_secret(namespace=namespace, body=secret)
         logger.info("Created vars secret", secret=secret_name, job=job_name)
         return secret_name
+
+    def _read_ca_bundle_pem(self) -> str:
+        """Read the listener's own mounted custom CA source file (#592).
+
+        Returns the raw PEM, cached after first read (the mounted file is
+        stable for the pod's lifetime). Empty string when no CA bundle is
+        configured or the file is missing/unreadable — the caller then skips
+        per-run CA delivery rather than failing the run. We ship the raw
+        SOURCE (not the listener's merged bundle) so the runner trusts the
+        RUNNER image's roots + the custom CA, not the listener image's roots.
+        """
+        if not self.runner_config.ca_bundle_enabled:
+            return ""
+        cached = getattr(self, "_ca_bundle_pem_cache", None)
+        if cached is not None:
+            return cached
+        path = self.runner_config.ca_bundle_source_path
+        pem = ""
+        if path and os.path.isfile(path):
+            try:
+                with open(path, encoding="utf-8") as f:
+                    pem = f.read().strip()
+            except OSError as e:
+                logger.warning("Could not read CA bundle source", path=path, error=str(e))
+        else:
+            logger.warning("CA bundle enabled but source file missing", path=path)
+        self._ca_bundle_pem_cache = pem
+        return pem
+
+    async def _create_ca_secret(
+        self, secret_name: str, run_id: str, ca_pem: str, job_name: str, job_uid: str
+    ) -> None:
+        """Create a K8s Secret holding the custom outbound CA (#592), with an
+        ownerReference to the Job (cascade-GC'd with it, like the auth Secret).
+
+        The CA is public material, but a Secret avoids needing `configmaps:
+        create` RBAC the listener doesn't have. The runner Job mounts it and
+        merges it with the image's system roots in an init container.
+        """
+        from kubernetes import client as k8s_client
+
+        from terrapod.runner.job_manager import _get_core_api
+
+        namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
+
+        secret = k8s_client.V1Secret(
+            metadata=k8s_client.V1ObjectMeta(
+                name=secret_name,
+                namespace=namespace,
+                labels={
+                    "app.kubernetes.io/name": "terrapod-runner",
+                    "terrapod.io/run-id": run_id,
+                },
+                owner_references=[
+                    k8s_client.V1OwnerReference(
+                        api_version="batch/v1",
+                        kind="Job",
+                        name=job_name,
+                        uid=job_uid,
+                        block_owner_deletion=True,
+                    )
+                ],
+            ),
+            type="Opaque",
+            string_data={"ca-extra.pem": ca_pem},
+        )
+
+        core_api = _get_core_api()
+        core_api.create_namespaced_secret(namespace=namespace, body=secret)
+        logger.info("Created CA secret", secret=secret_name, job=job_name)
 
 
 def _handle_signals() -> None:

--- a/services/tests/runner/test_job_template.py
+++ b/services/tests/runner/test_job_template.py
@@ -22,6 +22,10 @@ def _runner_config():
     cfg.topology_spread_constraints = []
     cfg.pod_security_context = {}
     cfg.pod_annotations = {}
+    # Proxy + CA off by default (#592) — explicit None/False so the truthy
+    # MagicMock defaults don't inject phantom proxy env into every test.
+    cfg.proxy = None
+    cfg.ca_bundle_enabled = False
 
     default_def = MagicMock()
     default_def.name = "default"
@@ -349,3 +353,119 @@ class TestVarsSecretDelivery:
         )
         pod = spec["spec"]["template"]["spec"]
         assert not any(v["name"] == "tfvars" for v in pod["volumes"])
+
+
+class TestProxyInjection:
+    """#592 — forward-proxy env injected into runner Jobs."""
+
+    def _spec(self, proxy):
+        from terrapod.runner.job_template import build_job_spec
+
+        cfg = _runner_config()
+        cfg.proxy = proxy
+        return build_job_spec(
+            run_id="abc123def456",
+            phase="plan",
+            runner_config=cfg,
+            auth_secret_name="tprun-abc123def456-plan-auth",
+            env_vars=[],
+            terraform_vars=[],
+        )
+
+    def test_proxy_env_upper_and_lower(self):
+        proxy = MagicMock()
+        proxy.http_proxy = "http://proxy:3128"
+        proxy.https_proxy = "http://proxy:3128"
+        proxy.no_proxy = "localhost,terrapod-api"
+        spec = self._spec(proxy)
+        env = {
+            e["name"]: e.get("value")
+            for e in spec["spec"]["template"]["spec"]["containers"][0]["env"]
+        }
+        # Both upper (Go/terraform) and lower (libs) forms.
+        for name in (
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            assert name in env, name
+        assert env["HTTP_PROXY"] == "http://proxy:3128"
+        assert env["no_proxy"] == "localhost,terrapod-api"
+
+    def test_no_proxy_env_when_disabled(self):
+        spec = self._spec(None)
+        env_names = {e["name"] for e in spec["spec"]["template"]["spec"]["containers"][0]["env"]}
+        assert "HTTP_PROXY" not in env_names
+        assert "http_proxy" not in env_names
+
+    def test_blank_proxy_values_skipped(self):
+        proxy = MagicMock()
+        proxy.http_proxy = ""
+        proxy.https_proxy = "http://proxy:3128"
+        proxy.no_proxy = ""
+        spec = self._spec(proxy)
+        env_names = {e["name"] for e in spec["spec"]["template"]["spec"]["containers"][0]["env"]}
+        assert "HTTP_PROXY" not in env_names  # empty → skipped
+        assert "HTTPS_PROXY" in env_names
+        assert "NO_PROXY" not in env_names
+
+
+class TestCABundleInjection:
+    """#592 — custom CA trust bundle delivered to runner Jobs."""
+
+    def _spec(self, ca_secret_name, ca_enabled=True):
+        from terrapod.runner.job_template import build_job_spec
+
+        cfg = _runner_config()
+        cfg.ca_bundle_enabled = ca_enabled
+        return build_job_spec(
+            run_id="abc123def456",
+            phase="plan",
+            runner_config=cfg,
+            auth_secret_name="tprun-abc123def456-plan-auth",
+            env_vars=[],
+            terraform_vars=[],
+            ca_secret_name=ca_secret_name,
+        )
+
+    def test_ca_env_volumes_and_init_container(self):
+        spec = self._spec("tprun-abc123def456-plan-ca")
+        pod = spec["spec"]["template"]["spec"]
+        container = pod["containers"][0]
+        env = {e["name"]: e.get("value") for e in container["env"]}
+        # TLS env all point at the merged bundle.
+        for name in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO"):
+            assert env[name] == "/etc/terrapod-ca/ca-bundle.crt"
+        # Source Secret + merged emptyDir volumes present.
+        vols = {v["name"]: v for v in pod["volumes"]}
+        assert vols["ca-src"]["secret"]["secretName"] == "tprun-abc123def456-plan-ca"
+        assert "emptyDir" in vols["ca-merged"]
+        # Runner mounts the MERGED bundle read-only.
+        mounts = {m["name"]: m for m in container["volumeMounts"]}
+        assert mounts["ca-merged"]["mountPath"] == "/etc/terrapod-ca"
+        assert mounts["ca-merged"]["readOnly"] is True
+        # Init container merges system roots + custom CA into the writable emptyDir.
+        init = next(c for c in pod["initContainers"] if c["name"] == "ca-merge")
+        assert "/etc/ssl/certs/ca-certificates.crt" in init["command"][2]
+        assert init["command"][2].endswith("> /etc/terrapod-ca/ca-bundle.crt")
+        assert init["securityContext"]["readOnlyRootFilesystem"] is True
+        assert init["securityContext"]["runAsNonRoot"] is True
+
+    def test_no_ca_when_secret_unset(self):
+        spec = self._spec("")  # listener provided no CA (none configured)
+        pod = spec["spec"]["template"]["spec"]
+        env_names = {e["name"] for e in pod["containers"][0]["env"]}
+        assert "SSL_CERT_FILE" not in env_names
+        assert not any(v["name"] == "ca-src" for v in pod["volumes"])
+        assert "initContainers" not in pod or not any(
+            c["name"] == "ca-merge" for c in pod.get("initContainers", [])
+        )
+
+    def test_no_ca_when_bundle_disabled(self):
+        # ca_secret_name set but bundle disabled in config → still skipped.
+        spec = self._spec("tprun-abc-ca", ca_enabled=False)
+        pod = spec["spec"]["template"]["spec"]
+        assert not any(v["name"] == "ca-src" for v in pod["volumes"])

--- a/services/tests/runner/test_proxy_ca_trust_env.py
+++ b/services/tests/runner/test_proxy_ca_trust_env.py
@@ -1,0 +1,41 @@
+"""#592 — source-introspection invariant: no httpx client opts out of env trust.
+
+httpx defaults `trust_env=True`, so every client already honours the standard
+proxy + CA env vars (HTTP_PROXY/HTTPS_PROXY/NO_PROXY and
+SSL_CERT_FILE/REQUESTS_CA_BUNDLE) that the chart injects for the forward-proxy +
+custom-CA feature. The one way to silently break that feature is to construct a
+client with `trust_env=False`. This test reads the implementation and fails
+loudly if any source file does so, so the invariant can't regress unnoticed.
+
+If a specific client genuinely must bypass env (rare — e.g. a localhost-only
+health probe that must never be proxied), add it to ALLOWED with a rationale.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+# (file_suffix, reason) pairs explicitly permitted to set trust_env=False.
+ALLOWED: set[str] = set()
+
+
+def _src_root() -> pathlib.Path:
+    # services/tests/runner/<this> → services/terrapod
+    return pathlib.Path(__file__).resolve().parents[2] / "terrapod"
+
+
+def test_no_httpx_client_disables_trust_env() -> None:
+    root = _src_root()
+    offenders: list[str] = []
+    for path in root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if "trust_env" not in text:
+            continue
+        # Tolerate whitespace variants: trust_env = False / trust_env=False.
+        normalised = text.replace(" ", "")
+        if "trust_env=False" in normalised and str(path) not in ALLOWED:
+            offenders.append(str(path.relative_to(root)))
+    assert not offenders, (
+        "httpx clients must not set trust_env=False — it disables the #592 "
+        f"forward-proxy + custom-CA env vars. Offenders: {offenders}"
+    )

--- a/services/tests/runner/test_runner_proxy_ca_config.py
+++ b/services/tests/runner/test_runner_proxy_ca_config.py
@@ -1,0 +1,49 @@
+"""#592 — listener-side RunnerConfig parses proxy + CA-bundle from runners.yaml.
+
+These fields are rendered into runners.yaml by the chart and forwarded by the
+listener into runner Jobs (proxy env + a per-run CA Secret). This asserts the
+YAML→model coercion the listener relies on.
+"""
+
+from __future__ import annotations
+
+from terrapod.config import RunnerConfig, RunnerProxyConfig
+
+
+def test_defaults_proxy_none_ca_off() -> None:
+    cfg = RunnerConfig()
+    assert cfg.proxy is None
+    assert cfg.ca_bundle_enabled is False
+    assert cfg.ca_bundle_source_path == ""
+
+
+def test_proxy_dict_coerced_to_model() -> None:
+    cfg = RunnerConfig(
+        proxy={
+            "http_proxy": "http://proxy:3128",
+            "https_proxy": "http://proxy:3128",
+            "no_proxy": "localhost,terrapod-api,.svc",
+        }
+    )
+    assert isinstance(cfg.proxy, RunnerProxyConfig)
+    assert cfg.proxy.http_proxy == "http://proxy:3128"
+    assert cfg.proxy.no_proxy == "localhost,terrapod-api,.svc"
+
+
+def test_ca_bundle_fields() -> None:
+    cfg = RunnerConfig(
+        ca_bundle_enabled=True,
+        ca_bundle_source_path="/etc/terrapod-ca-src/ca-extra.pem",
+    )
+    assert cfg.ca_bundle_enabled is True
+    assert cfg.ca_bundle_source_path == "/etc/terrapod-ca-src/ca-extra.pem"
+
+
+def test_partial_proxy_model_defaults_blank() -> None:
+    # Only https set — the others default to "" (the listener/job_template
+    # skip empty values).
+    cfg = RunnerConfig(proxy={"https_proxy": "http://proxy:3128"})
+    assert cfg.proxy is not None
+    assert cfg.proxy.https_proxy == "http://proxy:3128"
+    assert cfg.proxy.http_proxy == ""
+    assert cfg.proxy.no_proxy == ""


### PR DESCRIPTION
Closes #592.

For deployments with **no direct internet egress** (a corporate forward proxy) and/or **TLS interception** by a private CA, this adds two off-by-default, composable chart knobs that apply across **every** component — API, web/BFF, listener, and the ephemeral runner Jobs that execute `terraform`/`tofu`.

## `proxy.*`
Injects `HTTP(S)_PROXY` / `NO_PROXY` (upper + lower case) so `terraform init` can reach **public** registry and `git::` module sources through the proxy. `no_proxy` carries cluster-local defaults (loopback, `*.svc`/`*.cluster.local`, in-cluster Service names) plus the operator list.

**Split-cluster aware:** the runner/listener→API hop is *not* assumed proxy-exempt. In the ARC topology the listener+runner live in a different cluster and reach the API over its public URL — that hop traverses the proxy (the public host isn't in `no_proxy`). Operators with a direct private path can add it to `proxy.noProxy`.

## `caBundle.*`
Adds a custom CA to **outbound** TLS trust (added to, never replacing, the image's public roots):
- **Python/Go/git/curl** (API, listener, runner) — an init container merges the supplied CA with the image's system roots into an emptyDir (readOnlyRootFS-safe), wired via `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`/`GIT_SSL_CAINFO`.
- **web/BFF (Node)** — `NODE_EXTRA_CA_CERTS` appends to built-in roots (no merge).

Kept **separate** from `api.databaseCA` (which verifies the DB *server* cert specifically).

### Runner Jobs (cross-namespace)
Runner Jobs run in the runner namespace and can't mount the release-namespace CA ConfigMap. The **listener** reads its own mounted raw CA and ships it into a **per-run Secret** (owner-referenced to the Job → GC'd with it, like the auth/vars Secrets); the runner's init container merges it with the **runner image's** own roots.

The migrations/bootstrap Jobs talk only to the in-cluster DB, so they're deliberately left unwired.

## Tests
- `job_template` proxy + CA injection (env, volumes, init container, readOnlyRootFS securityContext).
- `RunnerConfig` proxy/CA YAML→model parse.
- Source-introspection invariant: no httpx client sets `trust_env=False` (would defeat the feature).
- helm-smoke render assertion (`#592` step): proxy env + CA ConfigMap + merge init + `NODE_EXTRA_CA_CERTS` + runners.yaml proxy/CA source path.

## Docs
`docs/deployment-proxy.md` (new) + README / `llms.txt` / `docs/index.md` entries. `values.schema.json` updated for `proxy` + `caBundle`.

## Verification
- `make test` green (1354 passed); targeted runner/config tests added pass.
- `make lint` clean.
- `helm lint` + `helm template` on values.yaml / values-local.yaml / values-eval.yaml all render (proxy+CA off by default and on).

## Not in this PR
No release — rolling into the next minor per maintainer direction. Local mitmproxy smoke to follow before the release that ships it.