### PR TITLE
feat(ai-eval): evaluation harness for AI analysis refinement (#602)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
           # the same tables) and the suite is small enough that
           # serial is fine.
           - name: unit
-            paths: tests/auth tests/runner tests/storage tests/test_logging_config.py tests/test_dependency_pins.py
+            paths: tests/auth tests/runner tests/storage tests/ai_eval tests/test_logging_config.py tests/test_dependency_pins.py
             pytest_args: -n auto
           - name: services-api
             paths: tests/services tests/api

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
 	build images \
 	pentest pentest-sast pentest-images pentest-dast \
 	dev dev-down \
+	ai-eval \
 	clean test-down \
 	help
 
@@ -25,6 +26,9 @@ test:               ## Test all (Python) in Docker
 
 test-python:        ## Test Python only (Docker)
 	scripts/test.sh python
+
+ai-eval:            ## Run the AI-analysis eval harness (live model). e.g. make ai-eval ARGS="run --model bedrock/us.anthropic.claude-sonnet-4-6 -n 3"
+	scripts/ai-eval.sh $(ARGS)
 
 test-e2e:           ## Run Playwright E2E tests (Docker Compose stack)
 	scripts/e2e.sh

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -59,6 +59,9 @@ RUN poetry config virtualenvs.create false \
 # Copy application and test code
 COPY services/terrapod ./terrapod
 COPY services/tests ./tests
+# AI-analysis evaluation harness (#602) — committed eval suite. Imported by
+# the offline corpus/rubric tests and run live (model sweep) on demand.
+COPY services/ai_eval ./ai_eval
 
 # Source for the API↔SDK↔provider contract test (tests/test_api_sdk_contract.py).
 # The test reads these files as raw text — no Go build is performed in the

--- a/docs/ai-plan-summary.md
+++ b/docs/ai-plan-summary.md
@@ -232,7 +232,7 @@ Set to `0` for unlimited.
 
 The counter is on output tokens only (cheaper to reason about than
 mixed input/output cost). Input-side cost is bounded by
-`plan_json_max_bytes` (default 500 KB) and `code_context_max_bytes`
+`plan_json_max_bytes` (default 600 KB) and `code_context_max_bytes`
 (default 200 KB).
 
 ## Skipping and overrides
@@ -275,8 +275,12 @@ the bulk of the request):
 - `PLAN_JSON` (for `plan_summary`) — the structured plan JSON
   output by the runner, cleaned (`prior_state` stripped, no-op
   resource_changes pruned, drift partitioned, etc. — see
-  `_clean_plan_json_bytes`). Capped at
-  `ai_summary.plan_json_max_bytes` (default 500 KB).
+  `_clean_plan_json_bytes`). Bounded by
+  `ai_summary.plan_json_max_bytes` (default 600 KB): under the cap the
+  plan is sent unchanged; over it, `_fit_plan_json` reduces structurally
+  — every change keeps its address and actions (destroys → creates →
+  updates → sampled remainder) so a `destroy` is never hidden; only
+  attribute detail is trimmed.
 - `PLAN_LOG` / `APPLY_LOG` (for `failure_analysis`) — the raw text
   of the run log. Tail-truncated when over `plan_json_max_bytes`.
 - `CODE_DIFF` — unified `git diff --no-index` of `*.tf` / `*.tfvars`

--- a/scripts/ai-eval.sh
+++ b/scripts/ai-eval.sh
@@ -23,8 +23,10 @@ IMAGE="${TEST_IMAGE:-terrapod-test:local}"
 REGION="${AI_EVAL_AWS_REGION:-${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}}"
 
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-  echo "test image '$IMAGE' not found — build it once with 'make test' (or 'make images')." >&2
-  exit 1
+  # The test image is Docker-GC'd between runs; rebuild it on demand so the
+  # harness is self-sufficient (same image scripts/test.sh builds).
+  echo "test image '$IMAGE' not found — building it..." >&2
+  docker build -f "$REPO_ROOT/docker/Dockerfile.test" -t "$IMAGE" "$REPO_ROOT" >&2
 fi
 
 mkdir -p "$REPO_ROOT/reports/ai-eval"

--- a/scripts/ai-eval.sh
+++ b/scripts/ai-eval.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Run the AI-analysis evaluation harness (#602) against a LIVE model.
+#
+# Uses the test image (which already has litellm + the app deps), overlays the
+# live `services/terrapod` + `services/ai_eval` source so prompt edits take
+# effect without an image rebuild, and forwards ambient model credentials from
+# the host environment:
+#   - bedrock/*   → AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN
+#                   + a region (AI_EVAL_AWS_REGION | AWS_REGION | AWS_DEFAULT_REGION)
+#   - anthropic/* → ANTHROPIC_API_KEY
+#
+# Reports land in ./reports/ai-eval (gitignored).
+#
+# Usage:
+#   scripts/ai-eval.sh list
+#   scripts/ai-eval.sh run --model bedrock/us.anthropic.claude-sonnet-4-6 -n 3
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${TEST_IMAGE:-terrapod-test:local}"
+REGION="${AI_EVAL_AWS_REGION:-${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}}"
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "test image '$IMAGE' not found — build it once with 'make test' (or 'make images')." >&2
+  exit 1
+fi
+
+mkdir -p "$REPO_ROOT/reports/ai-eval"
+
+exec docker run --rm \
+  -v "$REPO_ROOT/services/terrapod:/app/terrapod" \
+  -v "$REPO_ROOT/services/ai_eval:/app/ai_eval" \
+  -v "$REPO_ROOT/reports/ai-eval:/app/reports/ai-eval" \
+  -w /app \
+  -e ANTHROPIC_API_KEY \
+  -e AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY \
+  -e AWS_SESSION_TOKEN \
+  -e AWS_REGION="$REGION" \
+  -e AWS_DEFAULT_REGION="$REGION" \
+  "$IMAGE" python -m ai_eval "$@"

--- a/services/ai_eval/__init__.py
+++ b/services/ai_eval/__init__.py
@@ -1,0 +1,25 @@
+"""Terrapod AI-analysis evaluation harness (#602).
+
+A committed, CI-runnable suite for iteratively refining the AI analysis
+prompts across the three surfaces — plan summaries, drift detection, and
+apply-failure analysis — by driving the *real* shipping code path
+(``terrapod.services.summariser_prompt.render_prompt`` +
+``terrapod.services.summariser._call_model``) against a labelled corpus of
+synthetic, OSS-safe fixtures.
+
+Modules:
+  - ``cases``     — the Case / Truth schema + corpus loader.
+  - ``prep``      — build the production render_prompt inputs from a Case
+                    (reuses the real plan-JSON cleaning + truncation helpers).
+  - ``rubric``    — deterministic scoring against ground-truth labels
+                    (risk band, must-flag / must-not-flag, churn-not-risk,
+                    key facts, forbidden claims).
+  - ``runner``    — drive a Case through the engine N times (repeatability).
+  - ``judge``     — LLM-judge for description accuracy / utility.
+  - ``report``    — aggregate scorecards + human-readable report + baseline.
+  - ``generator`` — parametric synthesis of labelled plan-JSON fixtures.
+  - ``__main__``  — CLI (``python -m ai_eval ...``).
+
+No real-estate plan data is ever committed here (content hygiene); every
+fixture is synthetic.
+"""

--- a/services/ai_eval/__main__.py
+++ b/services/ai_eval/__main__.py
@@ -75,8 +75,11 @@ def _cmd_run(args: argparse.Namespace) -> int:
         )
         rep = score_model(cases_by_id, runs)
         reports.append(rep)
+        tr, ho = rep.split_counts()
         print(
-            f"  {model}: hard-pass {rep.hard_pass_rate:.0%}  "
+            f"  {model}: hard-pass {rep.hard_pass_rate:.0%} "
+            f"(train {rep.hard_pass_rate_split(False):.0%} n={tr} / "
+            f"holdout {rep.hard_pass_rate_split(True):.0%} n={ho})  "
             f"mean {rep.mean_score:.2f}  risk-repeat {rep.mean_risk_repeatability:.0%}",
             file=sys.stderr,
         )

--- a/services/ai_eval/__main__.py
+++ b/services/ai_eval/__main__.py
@@ -116,8 +116,30 @@ def main(argv: list[str] | None = None) -> int:
     rp.add_argument("--out", type=pathlib.Path, default=pathlib.Path("reports/ai-eval"))
     rp.set_defaults(func=_cmd_run)
 
+    jp = sub.add_parser("judge", help="LLM-judge the descriptions in a saved scorecard")
+    jp.add_argument("--scorecard", type=pathlib.Path, required=True)
+    jp.add_argument("--model", default="bedrock/us.anthropic.claude-sonnet-4-6")
+    jp.add_argument("--concurrency", type=int, default=3)
+    jp.set_defaults(func=_cmd_judge)
+
     args = p.parse_args(argv)
     return args.func(args)
+
+
+def _cmd_judge(args: argparse.Namespace) -> int:
+    from .judge import judge_scorecard, summarise
+
+    judgements = asyncio.run(
+        judge_scorecard(args.scorecard, model=args.model, concurrency=args.concurrency)
+    )
+    s = summarise(judgements)
+    print(f"description quality (n={s.get('n', 0)}, judge={args.model}):", file=sys.stderr)
+    for k in ("accuracy", "utility", "clarity", "mean"):
+        if k in s:
+            print(f"  {k:10s} {s[k]}", file=sys.stderr)
+    for j in s.get("weakest", []):
+        print(f"  weak: {j.case_id} ({j.mean:.1f}) — {j.rationale}", file=sys.stderr)
+    return 0
 
 
 if __name__ == "__main__":

--- a/services/ai_eval/__main__.py
+++ b/services/ai_eval/__main__.py
@@ -1,0 +1,121 @@
+"""CLI for the AI-eval harness (#602).
+
+    python -m ai_eval list [--include all]
+    python -m ai_eval run --model anthropic/claude-sonnet-4-6 [--model ...] \
+        [-n 3] [--surfaces plan,drift] [--tags data_loss,security] \
+        [--include all] [--limit N] [--temperature 0] [--out reports/ai-eval]
+
+Credentials are ambient (ANTHROPIC_API_KEY for anthropic/*, AWS env for
+bedrock/*). The deterministic corpus + rubric need no creds — only ``run``
+calls the model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+
+from .cases import Case, load_corpus
+from .generator import build_generated_cases
+from .report import score_model, write_reports
+from .runner import run_sweep
+
+
+def _collect_cases(args: argparse.Namespace) -> list[Case]:
+    include = args.include
+    cases: list[Case] = []
+    if include in ("all", "curated"):
+        cases += load_corpus()
+    if include in ("all", "generated"):
+        cases += build_generated_cases()
+    if args.surfaces:
+        wanted = set(args.surfaces.split(","))
+        cases = [c for c in cases if c.surface in wanted]
+    if args.tags:
+        wanted = set(args.tags.split(","))
+        cases = [c for c in cases if set(c.tags) & wanted]
+    if args.limit:
+        cases = cases[: args.limit]
+    return cases
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    cases = _collect_cases(args)
+    by_surface: dict[str, int] = {}
+    for c in cases:
+        by_surface[c.surface] = by_surface.get(c.surface, 0) + 1
+    print(f"{len(cases)} cases: " + ", ".join(f"{k}={v}" for k, v in sorted(by_surface.items())))
+    for c in cases:
+        print(f"  {c.id:50s} {c.surface:14s} [{','.join(c.tags)}]")
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    cases = _collect_cases(args)
+    if not cases:
+        print("no cases selected", file=sys.stderr)
+        return 2
+    cases_by_id = {c.id: c for c in cases}
+    models = args.model
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    print(f"running {len(cases)} cases x {len(models)} model(s) x n={args.n} ...", file=sys.stderr)
+
+    reports = []
+    for model in models:
+        runs = asyncio.run(
+            run_sweep(
+                cases,
+                model=model,
+                n=args.n,
+                concurrency=args.concurrency,
+                temperature=args.temperature,
+            )
+        )
+        rep = score_model(cases_by_id, runs)
+        reports.append(rep)
+        print(
+            f"  {model}: hard-pass {rep.hard_pass_rate:.0%}  "
+            f"mean {rep.mean_score:.2f}  risk-repeat {rep.mean_risk_repeatability:.0%}",
+            file=sys.stderr,
+        )
+
+    md_path, json_path = write_reports(reports, args.out, stamp=stamp)
+    print(f"\nwrote {md_path}\n      {json_path}", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    import pathlib
+
+    p = argparse.ArgumentParser(prog="ai_eval")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def add_common(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--include", choices=["all", "curated", "generated"], default="all")
+        sp.add_argument("--surfaces", default="", help="comma list: plan,drift,apply_failure")
+        sp.add_argument("--tags", default="", help="comma list of risk-axis tags")
+        sp.add_argument("--limit", type=int, default=0)
+
+    lp = sub.add_parser("list", help="list selected cases")
+    add_common(lp)
+    lp.set_defaults(func=_cmd_list)
+
+    rp = sub.add_parser("run", help="run the model sweep + score")
+    add_common(rp)
+    rp.add_argument(
+        "--model", action="append", required=True, help="repeatable LiteLLM model string"
+    )
+    rp.add_argument("-n", type=int, default=1, help="repeats per case (repeatability)")
+    rp.add_argument("--temperature", type=float, default=0.0)
+    rp.add_argument("--concurrency", type=int, default=4)
+    rp.add_argument("--out", type=pathlib.Path, default=pathlib.Path("reports/ai-eval"))
+    rp.set_defaults(func=_cmd_run)
+
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/ai_eval/cases.py
+++ b/services/ai_eval/cases.py
@@ -1,0 +1,211 @@
+"""Case + Truth schema and corpus loader for the AI-eval harness (#602).
+
+A *case* is one labelled evaluation example: an input (a terraform plan JSON
+for plan/drift, or an apply log for apply-failure) plus the ground-truth the
+analysis must satisfy. Cases are loaded from YAML files under ``corpus/``;
+generated cases are emitted in the same shape by ``generator.py``.
+
+Surfaces map to the production summariser ``kind`` + flags:
+  - ``plan``          → kind=plan_summary, drift_detection=False
+  - ``drift``         → kind=plan_summary, drift_detection=True
+  - ``apply_failure`` → kind=failure_analysis
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+Surface = Literal["plan", "drift", "apply_failure"]
+
+# Strict ordering of risk levels — used for band comparisons everywhere.
+RISK_ORDER: dict[str, int] = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+
+def risk_rank(level: str) -> int:
+    """Numeric rank of a risk level; unknown → -1 (sorts below 'low')."""
+    return RISK_ORDER.get((level or "").strip().lower(), -1)
+
+
+@dataclass(frozen=True)
+class MustFlag:
+    """A resource the analysis MUST flag as a risk, at >= a minimum severity."""
+
+    address: str
+    min_severity: str = "medium"
+
+
+@dataclass(frozen=True)
+class RiskBand:
+    """Acceptable band for the overall risk_level.
+
+    Any of exact / min / max may be set. ``exact`` pins a single level;
+    ``min``/``max`` bound an inclusive range. Empty band = unconstrained
+    (only the other axes are scored).
+    """
+
+    exact: str | None = None
+    min: str | None = None
+    max: str | None = None
+
+    def contains(self, level: str) -> bool:
+        r = risk_rank(level)
+        if self.exact is not None:
+            return r == risk_rank(self.exact)
+        if self.min is not None and r < risk_rank(self.min):
+            return False
+        if self.max is not None and r > risk_rank(self.max):
+            return False
+        return True
+
+    def describe(self) -> str:
+        if self.exact is not None:
+            return f"=={self.exact}"
+        parts = []
+        if self.min is not None:
+            parts.append(f">={self.min}")
+        if self.max is not None:
+            parts.append(f"<={self.max}")
+        return " & ".join(parts) if parts else "any"
+
+
+@dataclass(frozen=True)
+class Truth:
+    """Ground-truth labels a case's analysis is scored against."""
+
+    risk: RiskBand = field(default_factory=RiskBand)
+    # Resources that MUST appear as risk_factors at >= min_severity.
+    must_flag: tuple[MustFlag, ...] = ()
+    # Resources that MUST NOT appear as risk_factors (false-positive guard).
+    must_not_flag: tuple[str, ...] = ()
+    # Churn addresses (tag-only / known_after_apply / no-op drift). These
+    # must NOT be risk_factors AND should not drive the risk band up. Scored
+    # as the "real-change-vs-churn-noise" axis. A superset relationship with
+    # must_not_flag for scoring, kept separate for reporting clarity.
+    churn_addresses: tuple[str, ...] = ()
+    # Case-insensitive substrings the description MUST contain.
+    key_facts: tuple[str, ...] = ()
+    # Case-insensitive substrings the description MUST NOT contain.
+    forbidden_claims: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Case:
+    """One labelled evaluation example."""
+
+    id: str
+    surface: Surface
+    title: str
+    truth: Truth
+    source: Literal["curated", "generated"] = "curated"
+    tags: tuple[str, ...] = ()
+    # Inputs — exactly one primary per surface.
+    plan_json: dict[str, Any] | None = None  # plan / drift
+    apply_log: str = ""  # apply_failure
+    code_diff: str = ""  # optional context for any surface
+    state_diverged: bool = False
+
+    @property
+    def kind(self) -> str:
+        """Production summariser kind for this surface."""
+        return "failure_analysis" if self.surface == "apply_failure" else "plan_summary"
+
+    @property
+    def drift_detection(self) -> bool:
+        return self.surface == "drift"
+
+
+# --- Loading -----------------------------------------------------------------
+
+
+def _truth_from_dict(d: dict[str, Any]) -> Truth:
+    risk_d = d.get("risk") or {}
+    band = RiskBand(
+        exact=risk_d.get("exact"),
+        min=risk_d.get("min"),
+        max=risk_d.get("max"),
+    )
+    must_flag = tuple(
+        MustFlag(address=mf["address"], min_severity=mf.get("min_severity", "medium"))
+        for mf in (d.get("must_flag") or [])
+    )
+    return Truth(
+        risk=band,
+        must_flag=must_flag,
+        must_not_flag=tuple(d.get("must_not_flag") or []),
+        churn_addresses=tuple(d.get("churn_addresses") or []),
+        key_facts=tuple(d.get("key_facts") or []),
+        forbidden_claims=tuple(d.get("forbidden_claims") or []),
+    )
+
+
+def case_from_dict(d: dict[str, Any], *, base_dir: Path | None = None) -> Case:
+    """Build a Case from a parsed YAML/JSON mapping.
+
+    ``inputs.plan_json`` may be an inline mapping or, via
+    ``inputs.plan_json_file``, a path (relative to ``base_dir``) to a
+    standalone ``*.plan.json``. Same for ``apply_log`` / ``apply_log_file``.
+    """
+    inputs = d.get("inputs") or {}
+    plan_json = inputs.get("plan_json")
+    if plan_json is None and inputs.get("plan_json_file"):
+        path = (base_dir or Path(".")) / inputs["plan_json_file"]
+        plan_json = json.loads(path.read_text(encoding="utf-8"))
+
+    apply_log = inputs.get("apply_log", "")
+    if not apply_log and inputs.get("apply_log_file"):
+        path = (base_dir or Path(".")) / inputs["apply_log_file"]
+        apply_log = path.read_text(encoding="utf-8")
+
+    return Case(
+        id=d["id"],
+        surface=d["surface"],
+        title=d.get("title", d["id"]),
+        truth=_truth_from_dict(d.get("truth") or {}),
+        source=d.get("source", "curated"),
+        tags=tuple(d.get("tags") or []),
+        plan_json=plan_json,
+        apply_log=apply_log,
+        code_diff=inputs.get("code_diff", ""),
+        state_diverged=bool(inputs.get("state_diverged", False)),
+    )
+
+
+def corpus_dir() -> Path:
+    """Absolute path to the bundled corpus directory."""
+    return Path(__file__).resolve().parent / "corpus"
+
+
+def load_corpus(
+    root: Path | None = None,
+    *,
+    surfaces: set[str] | None = None,
+    tags: set[str] | None = None,
+) -> list[Case]:
+    """Load every ``*.case.yaml`` under ``root`` (default: bundled corpus).
+
+    Optional ``surfaces`` / ``tags`` filters narrow the returned set. IDs are
+    asserted unique across the whole corpus so a duplicate is a loud failure,
+    not a silent overwrite.
+    """
+    root = root or corpus_dir()
+    cases: list[Case] = []
+    seen: set[str] = set()
+    for path in sorted(root.rglob("*.case.yaml")):
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not doc:
+            continue
+        case = case_from_dict(doc, base_dir=path.parent)
+        if case.id in seen:
+            raise ValueError(f"duplicate case id {case.id!r} (at {path})")
+        seen.add(case.id)
+        if surfaces and case.surface not in surfaces:
+            continue
+        if tags and not (set(case.tags) & tags):
+            continue
+        cases.append(case)
+    return cases

--- a/services/ai_eval/cases.py
+++ b/services/ai_eval/cases.py
@@ -106,7 +106,15 @@ class Case:
     # Inputs — exactly one primary per surface.
     plan_json: dict[str, Any] | None = None  # plan / drift
     apply_log: str = ""  # apply_failure
-    code_diff: str = ""  # optional context for any surface
+    # Context the production prompt also receives (CODE_DIFF + CODE_CONTEXT
+    # sections). These inform the narrative/"why" but, per the prompt's
+    # grounding rule, must NEVER raise risk above what PLAN_JSON justifies —
+    # which is exactly what the corpus needs to test.
+    code_diff: str = ""  # unified diff of *.tf / *.tfvars vs prior applied config
+    code_context: str = ""  # current .tf source (truncated)
+    # NOT fed to the shipping prompt today; carried here so the corpus can test
+    # a future COMMIT_CONTEXT enhancement (incl. misleading-message resistance).
+    commit_message: str = ""
     state_diverged: bool = False
 
     @property
@@ -143,23 +151,47 @@ def _truth_from_dict(d: dict[str, Any]) -> Truth:
     )
 
 
+def _concat_tf_sources(base_dir: Path) -> str:
+    """Concatenate the scenario's real *.tf files into a CODE_CONTEXT blob,
+    mirroring the production format (``# === <file> ===`` headers) so the model
+    sees the same shape it would in a real run."""
+    parts: list[str] = []
+    for tf in sorted(base_dir.glob("*.tf")):
+        parts.append(f"# === {tf.name} ===\n{tf.read_text(encoding='utf-8')}")
+    return "\n".join(parts)
+
+
 def case_from_dict(d: dict[str, Any], *, base_dir: Path | None = None) -> Case:
     """Build a Case from a parsed YAML/JSON mapping.
 
-    ``inputs.plan_json`` may be an inline mapping or, via
-    ``inputs.plan_json_file``, a path (relative to ``base_dir``) to a
-    standalone ``*.plan.json``. Same for ``apply_log`` / ``apply_log_file``.
+    ``inputs.plan_json`` may be inline or via ``inputs.plan_json_file`` (a path
+    relative to ``base_dir``). Same for ``apply_log`` / ``apply_log_file`` and
+    ``code_diff`` / ``code_diff_file``. CODE_CONTEXT is either inline
+    (``code_context``), from a file (``code_context_file``), or — the common
+    case for scenario dirs — auto-assembled from the dir's ``*.tf`` when
+    ``code_context_from_tf: true``. ``commit_message`` is carried for the future
+    COMMIT_CONTEXT enhancement (not fed to the shipping prompt yet).
     """
     inputs = d.get("inputs") or {}
+    bd = base_dir or Path(".")
+
     plan_json = inputs.get("plan_json")
     if plan_json is None and inputs.get("plan_json_file"):
-        path = (base_dir or Path(".")) / inputs["plan_json_file"]
-        plan_json = json.loads(path.read_text(encoding="utf-8"))
+        plan_json = json.loads((bd / inputs["plan_json_file"]).read_text(encoding="utf-8"))
 
     apply_log = inputs.get("apply_log", "")
     if not apply_log and inputs.get("apply_log_file"):
-        path = (base_dir or Path(".")) / inputs["apply_log_file"]
-        apply_log = path.read_text(encoding="utf-8")
+        apply_log = (bd / inputs["apply_log_file"]).read_text(encoding="utf-8")
+
+    code_diff = inputs.get("code_diff", "")
+    if not code_diff and inputs.get("code_diff_file"):
+        code_diff = (bd / inputs["code_diff_file"]).read_text(encoding="utf-8")
+
+    code_context = inputs.get("code_context", "")
+    if not code_context and inputs.get("code_context_file"):
+        code_context = (bd / inputs["code_context_file"]).read_text(encoding="utf-8")
+    if not code_context and inputs.get("code_context_from_tf"):
+        code_context = _concat_tf_sources(bd)
 
     return Case(
         id=d["id"],
@@ -170,7 +202,9 @@ def case_from_dict(d: dict[str, Any], *, base_dir: Path | None = None) -> Case:
         tags=tuple(d.get("tags") or []),
         plan_json=plan_json,
         apply_log=apply_log,
-        code_diff=inputs.get("code_diff", ""),
+        code_diff=code_diff,
+        code_context=code_context,
+        commit_message=inputs.get("commit_message", ""),
         state_diverged=bool(inputs.get("state_diverged", False)),
     )
 

--- a/services/ai_eval/cases.py
+++ b/services/ai_eval/cases.py
@@ -13,6 +13,7 @@ Surfaces map to the production summariser ``kind`` + flags:
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -29,6 +30,24 @@ RISK_ORDER: dict[str, int] = {"low": 0, "medium": 1, "high": 2, "critical": 3}
 def risk_rank(level: str) -> int:
     """Numeric rank of a risk level; unknown → -1 (sorts below 'low')."""
     return RISK_ORDER.get((level or "").strip().lower(), -1)
+
+
+# Fraction of the corpus reserved as holdout when not pinned explicitly.
+_HOLDOUT_MODULUS = 4  # ~25%
+
+
+def is_holdout(case: Case) -> bool:
+    """Whether a case is in the held-out validation set.
+
+    Explicit ``case.holdout`` wins; otherwise a deterministic id hash assigns
+    ~1/_HOLDOUT_MODULUS of cases to holdout. Deterministic so the split is
+    stable across runs and across machines — the prompt-tuner can rely on the
+    same cases always being held out.
+    """
+    if case.holdout is not None:
+        return case.holdout
+    digest = hashlib.md5(case.id.encode("utf-8")).hexdigest()
+    return int(digest, 16) % _HOLDOUT_MODULUS == 0
 
 
 @dataclass(frozen=True)
@@ -116,6 +135,12 @@ class Case:
     # a future COMMIT_CONTEXT enhancement (incl. misleading-message resistance).
     commit_message: str = ""
     state_diverged: bool = False
+    # Train/holdout split for honest generalization measurement. None = decide
+    # deterministically by id hash (see is_holdout); an explicit bool pins it.
+    # The prompt is tuned ONLY against train failures; holdout is never read
+    # while editing the prompt, so a gain that doesn't show on holdout is
+    # overfitting (teaching-to-the-test) and must be reverted.
+    holdout: bool | None = None
 
     @property
     def kind(self) -> str:
@@ -206,6 +231,7 @@ def case_from_dict(d: dict[str, Any], *, base_dir: Path | None = None) -> Case:
         code_context=code_context,
         commit_message=inputs.get("commit_message", ""),
         state_diverged=bool(inputs.get("state_diverged", False)),
+        holdout=d.get("holdout"),
     )
 
 

--- a/services/ai_eval/corpus/scenarios/azure-public-sql/main.tf
+++ b/services/ai_eval/corpus/scenarios/azure-public-sql/main.tf
@@ -1,0 +1,44 @@
+resource "azurerm_resource_group" "data" {
+  name     = "${var.environment}-analytics-rg"
+  location = var.location
+
+  tags = {
+    environment = var.environment
+    managed_by  = "opentofu"
+  }
+}
+
+resource "azurerm_mssql_server" "analytics" {
+  name                = "${var.environment}-analytics-sql"
+  resource_group_name = azurerm_resource_group.data.name
+  location            = azurerm_resource_group.data.location
+  version             = "12.0"
+
+  administrator_login          = "sqladmin"
+  administrator_login_password = var.sql_admin_password
+
+  # Reachable from the public internet.
+  public_network_access_enabled = true
+  minimum_tls_version           = "1.0"
+}
+
+# Firewall rule that allows the entire IPv4 internet to reach the SQL server.
+resource "azurerm_mssql_firewall_rule" "allow_all" {
+  name             = "allow-all"
+  server_id        = azurerm_mssql_server.analytics.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "255.255.255.255"
+}
+
+resource "azurerm_mssql_database" "analytics" {
+  name      = "analytics"
+  server_id = azurerm_mssql_server.analytics.id
+  sku_name  = "S1"
+
+  # No long-term retention; storage not customer-managed-key encrypted.
+  storage_account_type = "Local"
+
+  tags = {
+    environment = var.environment
+  }
+}

--- a/services/ai_eval/corpus/scenarios/azure-public-sql/plan.json
+++ b/services/ai_eval/corpus/scenarios/azure-public-sql/plan.json
@@ -1,0 +1,103 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.12.2",
+  "resource_changes": [
+    {
+      "address": "azurerm_resource_group.data",
+      "mode": "managed",
+      "type": "azurerm_resource_group",
+      "name": "data",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "location": "westeurope",
+          "name": "prod-analytics-rg",
+          "tags": {"environment": "prod", "managed_by": "opentofu"}
+        },
+        "after_unknown": {"id": true, "tags": {}},
+        "before_sensitive": false,
+        "after_sensitive": {"tags": {}}
+      }
+    },
+    {
+      "address": "azurerm_mssql_server.analytics",
+      "mode": "managed",
+      "type": "azurerm_mssql_server",
+      "name": "analytics",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "administrator_login": "sqladmin",
+          "administrator_login_password": "P@ssw0rd-change-me",
+          "location": "westeurope",
+          "minimum_tls_version": "1.0",
+          "name": "prod-analytics-sql",
+          "public_network_access_enabled": true,
+          "resource_group_name": "prod-analytics-rg",
+          "version": "12.0"
+        },
+        "after_unknown": {
+          "fully_qualified_domain_name": true, "id": true, "identity": true,
+          "restorable_dropped_database_ids": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {"administrator_login_password": true}
+      }
+    },
+    {
+      "address": "azurerm_mssql_firewall_rule.allow_all",
+      "mode": "managed",
+      "type": "azurerm_mssql_firewall_rule",
+      "name": "allow_all",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "end_ip_address": "255.255.255.255",
+          "name": "allow-all",
+          "start_ip_address": "0.0.0.0"
+        },
+        "after_unknown": {"id": true, "server_id": true},
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "azurerm_mssql_database.analytics",
+      "mode": "managed",
+      "type": "azurerm_mssql_database",
+      "name": "analytics",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "name": "analytics",
+          "sku_name": "S1",
+          "storage_account_type": "Local",
+          "tags": {"environment": "prod"}
+        },
+        "after_unknown": {
+          "id": true, "server_id": true, "collation": true,
+          "transparent_data_encryption_enabled": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {"tags": {}}
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "azurerm": {
+        "name": "azurerm",
+        "full_name": "registry.terraform.io/hashicorp/azurerm",
+        "expressions": {"features": [{}]}
+      }
+    }
+  }
+}

--- a/services/ai_eval/corpus/scenarios/azure-public-sql/scenario.case.yaml
+++ b/services/ai_eval/corpus/scenarios/azure-public-sql/scenario.case.yaml
@@ -1,0 +1,30 @@
+id: azure-public-sql
+surface: plan
+title: "Public Azure SQL with allow-all firewall (create)"
+source: curated
+tags: [security]
+
+inputs:
+  plan_json_file: plan.json
+  code_context_from_tf: true
+  commit_message: |
+    feat(analytics): add managed SQL for the reporting service
+
+    Provision the prod Azure SQL server + analytics DB. Firewall opened so
+    the on-call laptops and the reporting VMs can connect without VPN.
+
+truth:
+  # An internet-reachable managed SQL server (public access + allow-all
+  # firewall + TLS 1.0) is a clear exposure even on create.
+  risk:
+    min: high
+  must_flag:
+    - { address: azurerm_mssql_firewall_rule.allow_all, min_severity: high }
+    - { address: azurerm_mssql_server.analytics, min_severity: high }
+  must_not_flag:
+    - azurerm_resource_group.data
+  key_facts:
+    - "0.0.0.0"
+    - "255.255.255.255"
+  forbidden_claims:
+    - "no changes"

--- a/services/ai_eval/corpus/scenarios/azure-public-sql/variables.tf
+++ b/services/ai_eval/corpus/scenarios/azure-public-sql/variables.tf
@@ -1,0 +1,17 @@
+variable "location" {
+  description = "Azure region."
+  type        = string
+  default     = "westeurope"
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}
+
+variable "sql_admin_password" {
+  description = "SQL Server administrator password."
+  type        = string
+  sensitive   = true
+  default     = "P@ssw0rd-change-me"
+}

--- a/services/ai_eval/corpus/scenarios/azure-public-sql/versions.tf
+++ b/services/ai_eval/corpus/scenarios/azure-public-sql/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.110"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+}

--- a/services/ai_eval/corpus/scenarios/gcp-public-data/main.tf
+++ b/services/ai_eval/corpus/scenarios/gcp-public-data/main.tf
@@ -1,0 +1,44 @@
+resource "google_storage_bucket" "data" {
+  name                        = "acme-analytics-exports"
+  location                    = "EU"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+# Grants the entire internet read access to every object in the bucket.
+resource "google_storage_bucket_iam_member" "public" {
+  bucket = google_storage_bucket.data.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+resource "google_sql_database_instance" "analytics" {
+  name             = "acme-analytics"
+  database_version = "POSTGRES_16"
+  region           = var.region
+
+  deletion_protection = false
+
+  settings {
+    tier = "db-custom-4-16384"
+
+    ip_configuration {
+      ipv4_enabled = true
+
+      authorized_networks {
+        name  = "world"
+        value = "0.0.0.0/0"
+      }
+    }
+
+    backup_configuration {
+      enabled = false
+    }
+  }
+}
+
+resource "google_sql_user" "admin" {
+  name     = "dbadmin"
+  instance = google_sql_database_instance.analytics.name
+  password = var.db_password
+}

--- a/services/ai_eval/corpus/scenarios/gcp-public-data/plan.json
+++ b/services/ai_eval/corpus/scenarios/gcp-public-data/plan.json
@@ -1,0 +1,114 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.12.2",
+  "resource_changes": [
+    {
+      "address": "google_storage_bucket.data",
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "data",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "force_destroy": true,
+          "location": "EU",
+          "name": "acme-analytics-exports",
+          "project": "acme-analytics-prod",
+          "storage_class": "STANDARD",
+          "uniform_bucket_level_access": true
+        },
+        "after_unknown": {"id": true, "self_link": true, "url": true},
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "google_storage_bucket_iam_member.public",
+      "mode": "managed",
+      "type": "google_storage_bucket_iam_member",
+      "name": "public",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "bucket": "acme-analytics-exports",
+          "member": "allUsers",
+          "role": "roles/storage.objectViewer"
+        },
+        "after_unknown": {"etag": true, "id": true},
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "google_sql_database_instance.analytics",
+      "mode": "managed",
+      "type": "google_sql_database_instance",
+      "name": "analytics",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "database_version": "POSTGRES_16",
+          "deletion_protection": false,
+          "name": "acme-analytics",
+          "region": "europe-west1",
+          "settings": [
+            {
+              "tier": "db-custom-4-16384",
+              "backup_configuration": [{"enabled": false}],
+              "ip_configuration": [
+                {
+                  "ipv4_enabled": true,
+                  "authorized_networks": [{"name": "world", "value": "0.0.0.0/0"}]
+                }
+              ]
+            }
+          ]
+        },
+        "after_unknown": {
+          "id": true, "self_link": true, "connection_name": true,
+          "public_ip_address": true, "first_ip_address": true,
+          "server_ca_cert": true, "settings": [{}]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {"settings": [{}], "server_ca_cert": []}
+      }
+    },
+    {
+      "address": "google_sql_user.admin",
+      "mode": "managed",
+      "type": "google_sql_user",
+      "name": "admin",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "instance": "acme-analytics",
+          "name": "dbadmin",
+          "password": "change-me-in-prod"
+        },
+        "after_unknown": {"id": true},
+        "before_sensitive": false,
+        "after_sensitive": {"password": true}
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "full_name": "registry.terraform.io/hashicorp/google",
+        "expressions": {
+          "project": {"references": ["var.project_id"]},
+          "region": {"references": ["var.region"]}
+        }
+      }
+    }
+  }
+}

--- a/services/ai_eval/corpus/scenarios/gcp-public-data/scenario.case.yaml
+++ b/services/ai_eval/corpus/scenarios/gcp-public-data/scenario.case.yaml
@@ -1,0 +1,31 @@
+id: gcp-public-data
+surface: plan
+title: "Public GCS bucket + Cloud SQL with public IP (create)"
+source: curated
+tags: [security]
+
+inputs:
+  plan_json_file: plan.json
+  code_context_from_tf: true
+  commit_message: |
+    feat: analytics exports bucket + managed Postgres
+
+    Bucket holds the nightly CSV exports the partner dashboards read.
+    Cloud SQL with a public IP so the BI tool (no VPC peering yet) can reach it.
+
+truth:
+  # allUsers on a bucket = world-readable data; Cloud SQL with a public IP and a
+  # 0.0.0.0/0 authorized network = internet-exposed database. Both are clear
+  # exposures on create.
+  risk:
+    min: high
+  must_flag:
+    - { address: google_storage_bucket_iam_member.public, min_severity: high }
+    - { address: google_sql_database_instance.analytics, min_severity: high }
+  must_not_flag:
+    - google_storage_bucket.data
+  key_facts:
+    - "allUsers"
+    - "0.0.0.0/0"
+  forbidden_claims:
+    - "no changes"

--- a/services/ai_eval/corpus/scenarios/gcp-public-data/variables.tf
+++ b/services/ai_eval/corpus/scenarios/gcp-public-data/variables.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  type    = string
+  default = "acme-analytics-prod"
+}
+
+variable "region" {
+  type    = string
+  default = "europe-west1"
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+  default   = "change-me-in-prod"
+}

--- a/services/ai_eval/corpus/scenarios/gcp-public-data/versions.tf
+++ b/services/ai_eval/corpus/scenarios/gcp-public-data/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.40"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/services/ai_eval/corpus/scenarios/k8s-privileged-workload/main.tf
+++ b/services/ai_eval/corpus/scenarios/k8s-privileged-workload/main.tf
@@ -1,0 +1,54 @@
+resource "kubernetes_namespace" "apps" {
+  metadata {
+    name = "batch"
+  }
+}
+
+resource "kubernetes_deployment" "worker" {
+  metadata {
+    name      = "log-shipper"
+    namespace = kubernetes_namespace.apps.metadata[0].name
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = { app = "log-shipper" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "log-shipper" }
+      }
+
+      spec {
+        # Shares the host network namespace and mounts the host root filesystem.
+        host_network = true
+
+        container {
+          name  = "shipper"
+          image = "acme/log-shipper:1.4.2"
+
+          security_context {
+            privileged                 = true
+            allow_privilege_escalation = true
+            run_as_user                = 0
+          }
+
+          volume_mount {
+            name       = "host-root"
+            mount_path = "/host"
+          }
+        }
+
+        volume {
+          name = "host-root"
+          host_path {
+            path = "/"
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/ai_eval/corpus/scenarios/k8s-privileged-workload/plan.json
+++ b/services/ai_eval/corpus/scenarios/k8s-privileged-workload/plan.json
@@ -1,0 +1,83 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.12.2",
+  "resource_changes": [
+    {
+      "address": "kubernetes_namespace.apps",
+      "mode": "managed",
+      "type": "kubernetes_namespace",
+      "name": "apps",
+      "provider_name": "registry.terraform.io/hashicorp/kubernetes",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "metadata": [{"name": "batch"}]
+        },
+        "after_unknown": {"id": true, "metadata": [{"generation": true, "resource_version": true, "uid": true}]},
+        "before_sensitive": false,
+        "after_sensitive": {"metadata": [{}]}
+      }
+    },
+    {
+      "address": "kubernetes_deployment.worker",
+      "mode": "managed",
+      "type": "kubernetes_deployment",
+      "name": "worker",
+      "provider_name": "registry.terraform.io/hashicorp/kubernetes",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "metadata": [{"name": "log-shipper", "namespace": "batch"}],
+          "spec": [
+            {
+              "replicas": "3",
+              "selector": [{"match_labels": {"app": "log-shipper"}}],
+              "template": [
+                {
+                  "metadata": [{"labels": {"app": "log-shipper"}}],
+                  "spec": [
+                    {
+                      "host_network": true,
+                      "container": [
+                        {
+                          "name": "shipper",
+                          "image": "acme/log-shipper:1.4.2",
+                          "security_context": [
+                            {
+                              "privileged": true,
+                              "allow_privilege_escalation": true,
+                              "run_as_user": "0"
+                            }
+                          ],
+                          "volume_mount": [{"name": "host-root", "mount_path": "/host"}]
+                        }
+                      ],
+                      "volume": [{"name": "host-root", "host_path": [{"path": "/"}]}]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "after_unknown": {
+          "id": true,
+          "metadata": [{"generation": true, "resource_version": true, "uid": true}],
+          "spec": [{}]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {"metadata": [{}], "spec": [{}]}
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "kubernetes": {
+        "name": "kubernetes",
+        "full_name": "registry.terraform.io/hashicorp/kubernetes"
+      }
+    }
+  }
+}

--- a/services/ai_eval/corpus/scenarios/k8s-privileged-workload/scenario.case.yaml
+++ b/services/ai_eval/corpus/scenarios/k8s-privileged-workload/scenario.case.yaml
@@ -1,0 +1,29 @@
+id: k8s-privileged-workload
+surface: plan
+title: "Privileged Deployment with hostNetwork + host root mount (create)"
+source: curated
+tags: [security]
+
+inputs:
+  plan_json_file: plan.json
+  code_context_from_tf: true
+  commit_message: |
+    chore(batch): deploy log-shipper daemon
+
+    Ships node logs to the SIEM. Needs host access to read the journald
+    socket and the container runtime logs under /.
+
+truth:
+  # A privileged container that shares the host network and bind-mounts the
+  # host root filesystem is effectively root on the node — a node-escape /
+  # cluster-compromise surface.
+  risk:
+    min: high
+  must_flag:
+    - { address: kubernetes_deployment.worker, min_severity: high }
+  must_not_flag:
+    - kubernetes_namespace.apps
+  key_facts:
+    - "privileged"
+  forbidden_claims:
+    - "no changes"

--- a/services/ai_eval/corpus/scenarios/k8s-privileged-workload/versions.tf
+++ b/services/ai_eval/corpus/scenarios/k8s-privileged-workload/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.31"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = "prod"
+}

--- a/services/ai_eval/corpus/scenarios/public-data-platform/database.tf
+++ b/services/ai_eval/corpus/scenarios/public-data-platform/database.tf
@@ -1,0 +1,37 @@
+resource "aws_db_subnet_group" "analytics" {
+  name       = "${var.environment}-analytics"
+  subnet_ids = [for s in aws_subnet.public : s.id]
+
+  tags = {
+    Name = "${var.environment}-analytics"
+  }
+}
+
+resource "aws_db_instance" "analytics" {
+  identifier     = "${var.environment}-analytics"
+  engine         = "postgres"
+  engine_version = "16.3"
+  instance_class = "db.r6g.large"
+
+  allocated_storage = 200
+  storage_type      = "gp3"
+
+  db_name  = "analytics"
+  username = "dbadmin"
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.analytics.name
+  vpc_security_group_ids = [aws_security_group.database.id]
+
+  # Risk surface for review: reachable from the internet, unencrypted at rest,
+  # and no deletion protection / final snapshot.
+  publicly_accessible = true
+  storage_encrypted   = false
+  deletion_protection = false
+  skip_final_snapshot = true
+
+  tags = {
+    Name        = "${var.environment}-analytics"
+    Environment = var.environment
+  }
+}

--- a/services/ai_eval/corpus/scenarios/public-data-platform/network.tf
+++ b/services/ai_eval/corpus/scenarios/public-data-platform/network.tf
@@ -1,0 +1,60 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.environment}-data-platform"
+    Environment = var.environment
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.environment}-data-platform"
+  }
+}
+
+resource "aws_subnet" "public" {
+  for_each = {
+    a = { cidr = "10.40.1.0/24", az = "${var.region}a" }
+    b = { cidr = "10.40.2.0/24", az = "${var.region}b" }
+  }
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = each.value.cidr
+  availability_zone       = each.value.az
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.environment}-public-${each.key}"
+    Tier = "public"
+  }
+}
+
+resource "aws_security_group" "database" {
+  name        = "${var.environment}-analytics-db"
+  description = "Analytics database access"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "Postgres from anywhere"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.environment}-analytics-db"
+  }
+}

--- a/services/ai_eval/corpus/scenarios/public-data-platform/plan.json
+++ b/services/ai_eval/corpus/scenarios/public-data-platform/plan.json
@@ -1,0 +1,237 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.12.2",
+  "resource_changes": [
+    {
+      "address": "aws_vpc.main",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "main",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "assign_generated_ipv6_cidr_block": false,
+          "cidr_block": "10.40.0.0/16",
+          "enable_dns_hostnames": true,
+          "enable_dns_support": true,
+          "instance_tenancy": "default",
+          "tags": {
+            "Environment": "prod",
+            "Name": "prod-data-platform"
+          },
+          "tags_all": {
+            "Environment": "prod",
+            "ManagedBy": "opentofu",
+            "Name": "prod-data-platform",
+            "Project": "data-platform"
+          }
+        },
+        "after_unknown": {
+          "arn": true,
+          "default_network_acl_id": true,
+          "default_route_table_id": true,
+          "default_security_group_id": true,
+          "dhcp_options_id": true,
+          "id": true,
+          "main_route_table_id": true,
+          "owner_id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "aws_internet_gateway.main",
+      "mode": "managed",
+      "type": "aws_internet_gateway",
+      "name": "main",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "tags": {"Name": "prod-data-platform"},
+          "tags_all": {
+            "ManagedBy": "opentofu",
+            "Name": "prod-data-platform",
+            "Project": "data-platform"
+          }
+        },
+        "after_unknown": {"arn": true, "id": true, "owner_id": true, "vpc_id": true},
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "aws_subnet.public[\"a\"]",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "index": "a",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "availability_zone": "eu-west-1a",
+          "cidr_block": "10.40.1.0/24",
+          "map_public_ip_on_launch": true,
+          "tags": {"Name": "prod-public-a", "Tier": "public"},
+          "tags_all": {
+            "ManagedBy": "opentofu", "Name": "prod-public-a",
+            "Project": "data-platform", "Tier": "public"
+          }
+        },
+        "after_unknown": {"arn": true, "id": true, "owner_id": true, "vpc_id": true},
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "aws_subnet.public[\"b\"]",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "index": "b",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "availability_zone": "eu-west-1b",
+          "cidr_block": "10.40.2.0/24",
+          "map_public_ip_on_launch": true,
+          "tags": {"Name": "prod-public-b", "Tier": "public"},
+          "tags_all": {
+            "ManagedBy": "opentofu", "Name": "prod-public-b",
+            "Project": "data-platform", "Tier": "public"
+          }
+        },
+        "after_unknown": {"arn": true, "id": true, "owner_id": true, "vpc_id": true},
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "aws_db_subnet_group.analytics",
+      "mode": "managed",
+      "type": "aws_db_subnet_group",
+      "name": "analytics",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "name": "prod-analytics",
+          "tags": {"Name": "prod-analytics"},
+          "tags_all": {"ManagedBy": "opentofu", "Name": "prod-analytics", "Project": "data-platform"}
+        },
+        "after_unknown": {"arn": true, "id": true, "subnet_ids": true, "supported_network_types": true},
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "aws_security_group.database",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "database",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "description": "Analytics database access",
+          "egress": [
+            {
+              "cidr_blocks": ["0.0.0.0/0"],
+              "from_port": 0,
+              "protocol": "-1",
+              "to_port": 0,
+              "description": "",
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": [],
+              "self": false
+            }
+          ],
+          "ingress": [
+            {
+              "cidr_blocks": ["0.0.0.0/0"],
+              "description": "Postgres from anywhere",
+              "from_port": 5432,
+              "protocol": "tcp",
+              "to_port": 5432,
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": [],
+              "self": false
+            }
+          ],
+          "name": "prod-analytics-db",
+          "tags": {"Name": "prod-analytics-db"},
+          "tags_all": {"ManagedBy": "opentofu", "Name": "prod-analytics-db", "Project": "data-platform"}
+        },
+        "after_unknown": {
+          "arn": true, "id": true, "owner_id": true, "vpc_id": true,
+          "egress": [{}], "ingress": [{}]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {"egress": [{}], "ingress": [{}]}
+      }
+    },
+    {
+      "address": "aws_db_instance.analytics",
+      "mode": "managed",
+      "type": "aws_db_instance",
+      "name": "analytics",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "allocated_storage": 200,
+          "auto_minor_version_upgrade": true,
+          "backup_retention_period": 0,
+          "db_name": "analytics",
+          "deletion_protection": false,
+          "engine": "postgres",
+          "engine_version": "16.3",
+          "identifier": "prod-analytics",
+          "instance_class": "db.r6g.large",
+          "iops": 0,
+          "multi_az": false,
+          "password": "change-me-in-prod",
+          "publicly_accessible": true,
+          "skip_final_snapshot": true,
+          "storage_encrypted": false,
+          "storage_type": "gp3",
+          "username": "dbadmin",
+          "tags": {"Environment": "prod", "Name": "prod-analytics"},
+          "tags_all": {
+            "Environment": "prod", "ManagedBy": "opentofu",
+            "Name": "prod-analytics", "Project": "data-platform"
+          }
+        },
+        "after_unknown": {
+          "address": true, "arn": true, "endpoint": true, "hosted_zone_id": true,
+          "id": true, "kms_key_id": true, "port": true, "resource_id": true,
+          "status": true, "db_subnet_group_name": true, "vpc_security_group_ids": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {"password": true, "tags": {}, "tags_all": {}}
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "full_name": "registry.terraform.io/hashicorp/aws",
+        "expressions": {"region": {"references": ["var.region"]}}
+      }
+    }
+  }
+}

--- a/services/ai_eval/corpus/scenarios/public-data-platform/providers.tf
+++ b/services/ai_eval/corpus/scenarios/public-data-platform/providers.tf
@@ -1,0 +1,17 @@
+# Plan-only fixture generation: skip all credential/network validation so a
+# `tofu plan` of resource creates never reaches AWS. No real infrastructure is
+# created — the output is fed to the AI-analysis eval harness.
+provider "aws" {
+  region = var.region
+
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+
+  default_tags {
+    tags = {
+      Project   = "data-platform"
+      ManagedBy = "opentofu"
+    }
+  }
+}

--- a/services/ai_eval/corpus/scenarios/public-data-platform/scenario.case.yaml
+++ b/services/ai_eval/corpus/scenarios/public-data-platform/scenario.case.yaml
@@ -1,0 +1,41 @@
+id: aws-public-data-platform
+surface: plan
+title: "Greenfield public analytics platform (AWS create)"
+source: curated
+tags: [security, data_loss]
+
+inputs:
+  plan_json_file: plan.json
+  # CODE_CONTEXT is auto-assembled from the scenario's real *.tf files.
+  code_context_from_tf: true
+  # Carried for the future COMMIT_CONTEXT enhancement. Note the message frames
+  # the public exposure as a convenience ("so the dashboards box can reach it")
+  # — a misleading-intent probe: the risk rating must come from the plan, not
+  # the commit narrative.
+  commit_message: |
+    feat(data): provision analytics Postgres platform
+
+    Stand up the prod analytics VPC + RDS Postgres for the BI team.
+    Public subnets so the dashboards box can reach it directly.
+
+truth:
+  # A create, but it provisions an internet-reachable, unencrypted production
+  # data store — a genuine security exposure that must elevate above "low
+  # because it's additive".
+  risk:
+    min: high
+  must_flag:
+    - { address: aws_security_group.database, min_severity: high }
+    - { address: aws_db_instance.analytics, min_severity: high }
+  # Plain infra plumbing — must NOT be dressed up as risk factors. (The DB
+  # subnet group is deliberately NOT here: it references the PUBLIC subnets, so
+  # flagging the DB's public-subnet placement is a legitimate risk, not noise.)
+  must_not_flag:
+    - aws_vpc.main
+    - aws_internet_gateway.main
+  key_facts:
+    - "0.0.0.0/0"
+    - "aws_db_instance.analytics"
+    - "encrypt"
+  forbidden_claims:
+    - "no changes"

--- a/services/ai_eval/corpus/scenarios/public-data-platform/variables.tf
+++ b/services/ai_eval/corpus/scenarios/public-data-platform/variables.tf
@@ -1,0 +1,24 @@
+variable "region" {
+  description = "AWS region for the data platform."
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "environment" {
+  description = "Deployment environment."
+  type        = string
+  default     = "prod"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the platform VPC."
+  type        = string
+  default     = "10.40.0.0/16"
+}
+
+variable "db_password" {
+  description = "Master password for the analytics database."
+  type        = string
+  sensitive   = true
+  default     = "change-me-in-prod"
+}

--- a/services/ai_eval/corpus/scenarios/public-data-platform/versions.tf
+++ b/services/ai_eval/corpus/scenarios/public-data-platform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+}

--- a/services/ai_eval/generator.py
+++ b/services/ai_eval/generator.py
@@ -704,6 +704,325 @@ def _apply_failure_cases() -> list[Case]:
     return out
 
 
+def _hard_cases() -> list[Case]:
+    """Discriminating cases — the ones that catch a prompt that over-flags
+    (cry-wolf) or under-flags (misses a buried risk). These are where an
+    already-strong model actually fails, so they're what validate the prompt."""
+    out: list[Case] = []
+
+    # --- cry-wolf traps: scary-looking actions, ~zero real risk -> low -------
+
+    # A null_resource replace: actions [delete, create] but no infrastructure.
+    out.append(
+        Case(
+            id="hard-noop-null-resource-replace",
+            surface="plan",
+            source="generated",
+            tags=("churn", "calibration"),
+            title="Replace null_resource (no blast radius)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        "null_resource.provisioner",
+                        "null_resource",
+                        "provisioner",
+                        ["delete", "create"],
+                        {"triggers": {"v": "1"}},
+                        {"triggers": {"v": "2"}},
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(exact="low"),
+                must_not_flag=("null_resource.provisioner",),
+                forbidden_claims=("data loss", "critical"),
+            ),
+        )
+    )
+    # Rotating a managed password: a replace, routine, not data loss.
+    out.append(
+        Case(
+            id="hard-noop-random-password-rotate",
+            surface="plan",
+            source="generated",
+            tags=("churn", "calibration"),
+            title="Rotate random_password (routine)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        "random_password.db",
+                        "random_password",
+                        "db",
+                        ["delete", "create"],
+                        {"length": 32},
+                        {"length": 32},
+                        after_unknown={"result": True, "bcrypt_hash": True},
+                    )
+                ]
+            ),
+            truth=Truth(risk=RiskBand(max="medium"), must_not_flag=("random_password.db",)),
+        )
+    )
+    # Tightening a security group: 0.0.0.0/0 -> internal CIDR is an IMPROVEMENT.
+    out.append(
+        Case(
+            id="hard-improve-sg-tighten",
+            surface="plan",
+            source="generated",
+            tags=("security", "calibration"),
+            title="Tighten SG from world to internal (improvement)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        "aws_security_group.api",
+                        "aws_security_group",
+                        "api",
+                        ["update"],
+                        {
+                            "ingress": [
+                                {"from_port": 443, "to_port": 443, "cidr_blocks": ["0.0.0.0/0"]}
+                            ]
+                        },
+                        {
+                            "ingress": [
+                                {"from_port": 443, "to_port": 443, "cidr_blocks": ["10.0.0.0/8"]}
+                            ]
+                        },
+                    )
+                ]
+            ),
+            truth=Truth(risk=RiskBand(max="medium"), must_not_flag=("aws_security_group.api",)),
+        )
+    )
+    # Enabling encryption: a security improvement, not a risk.
+    out.append(
+        Case(
+            id="hard-improve-enable-encryption",
+            surface="plan",
+            source="generated",
+            tags=("security", "calibration"),
+            title="Enable S3 bucket encryption (improvement)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        "aws_s3_bucket_server_side_encryption_configuration.data",
+                        "aws_s3_bucket_server_side_encryption_configuration",
+                        "data",
+                        ["create"],
+                        None,
+                        {
+                            "rule": [
+                                {
+                                    "apply_server_side_encryption_by_default": [
+                                        {"sse_algorithm": "aws:kms"}
+                                    ]
+                                }
+                            ]
+                        },
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(exact="low"),
+                must_not_flag=("aws_s3_bucket_server_side_encryption_configuration.data",),
+            ),
+        )
+    )
+    # Deleting an observability resource: low consequence.
+    out.append(
+        Case(
+            id="hard-noop-delete-log-group",
+            surface="plan",
+            source="generated",
+            tags=("churn", "calibration"),
+            title="Delete a CloudWatch log group (low)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        "aws_cloudwatch_log_group.debug",
+                        "aws_cloudwatch_log_group",
+                        "debug",
+                        ["delete"],
+                        {"name": "/acme/debug"},
+                        None,
+                    )
+                ]
+            ),
+            truth=Truth(risk=RiskBand(max="medium"), must_not_flag=()),
+        )
+    )
+    # Large benign greenfield: many creates, all safe -> low (no inflation at scale).
+    greenfield = [
+        _rc(
+            "aws_cloudwatch_log_group.app",
+            "aws_cloudwatch_log_group",
+            "app",
+            ["create"],
+            None,
+            {"name": "/acme/app", "retention_in_days": 30},
+        ),
+        _rc("aws_iam_role.task", "aws_iam_role", "task", ["create"], None, {"name": "acme-task"}),
+        _rc(
+            "aws_lb_target_group.app",
+            "aws_lb_target_group",
+            "app",
+            ["create"],
+            None,
+            {"port": 443, "protocol": "HTTPS"},
+        ),
+        _rc(
+            "aws_ssm_parameter.cfg",
+            "aws_ssm_parameter",
+            "cfg",
+            ["create"],
+            None,
+            {"name": "/acme/cfg", "type": "String"},
+        ),
+    ]
+    out.append(
+        Case(
+            id="hard-noop-benign-greenfield",
+            surface="plan",
+            source="generated",
+            tags=("benign", "calibration"),
+            title="Greenfield of benign resources (low)",
+            plan_json=_plan(greenfield),
+            truth=Truth(
+                risk=RiskBand(exact="low"),
+                must_not_flag=("aws_iam_role.task", "aws_lb_target_group.app"),
+            ),
+        )
+    )
+    # In-place DB resize: medium (brief failover), not high.
+    out.append(
+        Case(
+            id="hard-calib-rds-resize-inplace",
+            surface="plan",
+            source="generated",
+            tags=("calibration",),
+            title="In-place RDS instance_class resize (medium)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        "aws_db_instance.main",
+                        "aws_db_instance",
+                        "main",
+                        ["update"],
+                        {"instance_class": "db.r6g.large", "apply_immediately": True},
+                        {"instance_class": "db.r6g.xlarge", "apply_immediately": True},
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(min="medium", max="high"),
+                must_flag=(MustFlag("aws_db_instance.main", "medium"),),
+            ),
+        )
+    )
+
+    # --- buried needles + subtle exposures: real risk, easy to miss ----------
+
+    # One real DB destroy among many tag-only updates.
+    needle = [
+        _rc(
+            f"aws_ssm_parameter.p{i}",
+            "aws_ssm_parameter",
+            f"p{i}",
+            ["update"],
+            {"tags": {}},
+            {"tags": {"team": "x"}},
+        )
+        for i in range(12)
+    ]
+    needle.insert(
+        7,
+        _rc(
+            "aws_rds_cluster.core",
+            "aws_rds_cluster",
+            "core",
+            ["delete"],
+            {"engine": "aurora-postgresql"},
+            None,
+        ),
+    )
+    out.append(
+        Case(
+            id="hard-needle-db-destroy-in-churn",
+            surface="plan",
+            source="generated",
+            tags=("data_loss", "churn"),
+            title="One RDS destroy buried in 12 tag updates",
+            plan_json=_plan(needle),
+            truth=Truth(
+                risk=RiskBand(min="critical"),
+                must_flag=(MustFlag("aws_rds_cluster.core", "critical"),),
+                churn_addresses=tuple(f"aws_ssm_parameter.p{i}" for i in range(12)),
+                key_facts=("aws_rds_cluster.core",),
+            ),
+        )
+    )
+    # S3 bucket policy that adds a wildcard Principal — public, subtle (in a doc).
+    out.append(
+        Case(
+            id="hard-subtle-s3-policy-wildcard",
+            surface="plan",
+            source="generated",
+            tags=("security",),
+            title="S3 bucket policy adds Principal:* (public)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        "aws_s3_bucket_policy.data",
+                        "aws_s3_bucket_policy",
+                        "data",
+                        ["update"],
+                        {
+                            "policy": '{"Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111111111111:root"},"Action":"s3:GetObject"}]}'
+                        },
+                        {
+                            "policy": '{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject"}]}'
+                        },
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(min="high"),
+                must_flag=(MustFlag("aws_s3_bucket_policy.data", "high"),),
+            ),
+        )
+    )
+    # IAM policy that adds iam:PassRole on * — privilege escalation, subtle.
+    out.append(
+        Case(
+            id="hard-subtle-iam-passrole-wildcard",
+            surface="plan",
+            source="generated",
+            tags=("security",),
+            title="IAM policy adds iam:PassRole on * (priv-esc)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        "aws_iam_role_policy.ci",
+                        "aws_iam_role_policy",
+                        "ci",
+                        ["update"],
+                        {
+                            "policy": '{"Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::acme/*"}]}'
+                        },
+                        {
+                            "policy": '{"Statement":[{"Effect":"Allow","Action":["s3:GetObject","iam:PassRole"],"Resource":"*"}]}'
+                        },
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(min="high"), must_flag=(MustFlag("aws_iam_role_policy.ci", "high"),)
+            ),
+        )
+    )
+    return out
+
+
 def build_generated_cases() -> list[Case]:
     """Return the full deterministic set of generated cases."""
     cases: list[Case] = []
@@ -714,4 +1033,5 @@ def build_generated_cases() -> list[Case]:
     cases += _churn_cases()
     cases += _drift_cases()
     cases += _apply_failure_cases()
+    cases += _hard_cases()
     return cases

--- a/services/ai_eval/generator.py
+++ b/services/ai_eval/generator.py
@@ -236,6 +236,11 @@ def _irreversibility_cases() -> list[Case]:
     out: list[Case] = []
     for spec in IRREVERSIBLE:
         addr = f"{spec['type']}.{spec['name']}"
+        # A single snapshot is ONE recovery point — high (unmitigated destroy),
+        # not critical. Reserve critical for the encryption key (locks out all
+        # data) and the backup vault (holds every backup). The model reasoned
+        # this distinction consistently; the label follows the reasoning.
+        sev = "high" if spec["type"].endswith("snapshot") else "critical"
         out.append(
             Case(
                 id=f"gen-irrev-destroy-{spec['type']}",
@@ -247,8 +252,8 @@ def _irreversibility_cases() -> list[Case]:
                     [_rc(addr, spec["type"], spec["name"], ["delete"], spec["after"], None)]
                 ),
                 truth=Truth(
-                    risk=RiskBand(min="critical"),
-                    must_flag=(MustFlag(addr, "critical"),),
+                    risk=RiskBand(min=sev),
+                    must_flag=(MustFlag(addr, sev),),
                     key_facts=(addr,),
                     forbidden_claims=("no changes",),
                 ),

--- a/services/ai_eval/generator.py
+++ b/services/ai_eval/generator.py
@@ -74,6 +74,48 @@ STATEFUL = [
         "irreversible": False,
         "after": {"engine": "redis"},
     },
+    {
+        "type": "aws_redshift_cluster",
+        "name": "warehouse",
+        "irreversible": True,
+        "after": {"node_type": "ra3.xlplus"},
+    },
+    {
+        "type": "aws_neptune_cluster",
+        "name": "graph",
+        "irreversible": True,
+        "after": {"engine": "neptune"},
+    },
+    {
+        "type": "aws_docdb_cluster",
+        "name": "docs",
+        "irreversible": True,
+        "after": {"engine": "docdb"},
+    },
+    {
+        "type": "aws_msk_cluster",
+        "name": "events",
+        "irreversible": True,
+        "after": {"kafka_version": "3.6.0"},
+    },
+    {
+        "type": "aws_memorydb_cluster",
+        "name": "memdb",
+        "irreversible": True,
+        "after": {"node_type": "db.r6g.large"},
+    },
+    {
+        "type": "aws_fsx_lustre_file_system",
+        "name": "scratch",
+        "irreversible": True,
+        "after": {"storage_capacity": 1200},
+    },
+    {
+        "type": "aws_timestreamwrite_table",
+        "name": "metrics",
+        "irreversible": True,
+        "after": {"table_name": "metrics"},
+    },
 ]
 
 # Irreversible-by-nature security/crypto material.
@@ -538,6 +580,125 @@ def _drift_cases() -> list[Case]:
     return out
 
 
+def _apply_log(addr: str, rtype: str, line: int, error_block: str) -> str:
+    """Render a realistic terraform apply error tail for one resource."""
+    verb = "Creating" if "Creating" not in error_block else "Modifying"
+    return (
+        f"{addr}: {verb}...\n"
+        f"╷\n"
+        f"│ Error: {error_block}\n"
+        f"│\n"
+        f"│   with {addr},\n"
+        f'│   on main.tf line {line}, in resource "{rtype}" "{addr.split(".", 1)[1]}":\n'
+        f'│   {line}: resource "{rtype}" "{addr.split(".", 1)[1]}" {{\n'
+        f"╵\n"
+    )
+
+
+def _apply_failure_cases() -> list[Case]:
+    """Apply-phase failures — failure_analysis must name the failed resource,
+    explain the root cause, and rate how blocking it is. risk_factors are
+    candidate fixes; the rubric's must_flag maps to 'the analysis attaches a
+    fix to the failed resource'."""
+    out: list[Case] = []
+
+    def case(cid, addr, rtype, line, err, *, band, sev, facts, tags=("apply_failure",), forbid=()):
+        out.append(
+            Case(
+                id=cid,
+                surface="apply_failure",
+                source="generated",
+                tags=tags,
+                title=cid.replace("gen-applyfail-", "").replace("-", " "),
+                apply_log=_apply_log(addr, rtype, line, err),
+                truth=Truth(
+                    risk=RiskBand(**band),
+                    must_flag=(MustFlag(addr, sev),),
+                    key_facts=facts,
+                    forbidden_claims=forbid,
+                ),
+            )
+        )
+
+    # Already-exists → fix is import (not recreate).
+    case(
+        "gen-applyfail-iam-already-exists",
+        "aws_iam_role.task",
+        "aws_iam_role",
+        12,
+        "creating IAM Role (acme-task): operation error IAM: CreateRole, "
+        "https response error StatusCode: 409, EntityAlreadyExists: Role with "
+        "name acme-task already exists.",
+        band={"min": "medium"},
+        sev="medium",
+        facts=("aws_iam_role.task", "already exists"),
+    )
+    # AccessDenied → IAM permission gap.
+    case(
+        "gen-applyfail-s3-access-denied",
+        "aws_s3_bucket.data",
+        "aws_s3_bucket",
+        3,
+        "creating S3 Bucket (acme-data): operation error S3: CreateBucket, "
+        "https response error StatusCode: 403, api error AccessDenied: "
+        "User is not authorized to perform: s3:CreateBucket.",
+        band={"min": "medium"},
+        sev="medium",
+        facts=("aws_s3_bucket.data", "AccessDenied"),
+    )
+    # DependencyViolation deleting a SG → detach ENIs first.
+    case(
+        "gen-applyfail-sg-dependency-violation",
+        "aws_security_group.app",
+        "aws_security_group",
+        40,
+        "deleting Security Group (sg-0abc): operation error EC2: "
+        "DeleteSecurityGroup, DependencyViolation: resource sg-0abc has a "
+        "dependent object (a network interface is still attached).",
+        band={"min": "medium"},
+        sev="medium",
+        facts=("aws_security_group.app", "DependencyViolation"),
+    )
+    # InvalidParameterValue — bad engine version.
+    case(
+        "gen-applyfail-rds-invalid-engine-version",
+        "aws_db_instance.main",
+        "aws_db_instance",
+        20,
+        "creating RDS DB Instance (acme-main): InvalidParameterCombination: "
+        "Cannot find version 13.99 for postgres.",
+        band={"min": "medium"},
+        sev="medium",
+        facts=("aws_db_instance.main", "13.99"),
+    )
+    # Throttling — transient, retry. Lower blocking level.
+    case(
+        "gen-applyfail-throttling-transient",
+        "aws_cloudwatch_log_group.app",
+        "aws_cloudwatch_log_group",
+        5,
+        "creating CloudWatch Log Group (/acme/app): ThrottlingException: "
+        "Rate exceeded. (RequestLimitExceeded)",
+        band={"min": "low", "max": "medium"},
+        sev="low",
+        facts=("ThrottlingException",),
+        tags=("apply_failure", "churn"),
+    )
+    # Service quota exceeded — needs a quota increase, not a code fix.
+    case(
+        "gen-applyfail-vpc-quota-exceeded",
+        "aws_vpc.main",
+        "aws_vpc",
+        1,
+        "creating EC2 VPC: operation error EC2: CreateVpc, VpcLimitExceeded: "
+        "The maximum number of VPCs has been reached.",
+        band={"min": "medium"},
+        sev="medium",
+        facts=("aws_vpc.main", "VpcLimitExceeded"),
+    )
+    return out
+
+
 def build_generated_cases() -> list[Case]:
     """Return the full deterministic set of generated cases."""
     cases: list[Case] = []
@@ -547,4 +708,5 @@ def build_generated_cases() -> list[Case]:
     cases += _benign_create_cases()
     cases += _churn_cases()
     cases += _drift_cases()
+    cases += _apply_failure_cases()
     return cases

--- a/services/ai_eval/generator.py
+++ b/services/ai_eval/generator.py
@@ -1,0 +1,550 @@
+"""Parametric generator for labelled plan-JSON cases (#602).
+
+Because *we* synthesize each plan, the ground-truth labels fall out of the
+generation parameters for free — no manual labelling. This is how the corpus
+gets to "substantial" (hundreds of cases) without hand-writing each one.
+
+The generator is deterministic (no randomness): the same code always yields
+the same cases in the same order, so a run is reproducible and the offline
+integrity test can assert on it. Cases are produced in memory as :class:`Case`
+objects (combined with the curated YAML corpus by the CLI); nothing is written
+to disk, keeping the repo clean while the corpus stays large and regenerable.
+
+Coverage spans the five risk axes the refinement targets:
+  - data_loss        — destroy / replace of stateful resources
+  - security         — public exposure, IAM/policy broadening, encryption off
+  - irreversibility  — KMS key / snapshot / backup deletion
+  - blast_radius     — mass replace, region/provider change
+  - churn            — tag-only / known_after_apply / no-op drift (NOT risk)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .cases import Case, MustFlag, RiskBand, Truth
+
+# --- resource archetypes -----------------------------------------------------
+
+
+# A stateful resource holds data that a destroy/replace would lose.
+# ``irreversible`` ones have no practical recovery (KMS key, final-snapshot-
+# skipped DB) → critical on destroy. ``name`` is the local name used in the
+# terraform address.
+STATEFUL = [
+    {
+        "type": "aws_db_instance",
+        "name": "main",
+        "irreversible": True,
+        "after": {"engine": "postgres", "instance_class": "db.r6g.large"},
+    },
+    {
+        "type": "aws_rds_cluster",
+        "name": "core",
+        "irreversible": True,
+        "after": {"engine": "aurora-postgresql"},
+    },
+    {
+        "type": "aws_dynamodb_table",
+        "name": "sessions",
+        "irreversible": True,
+        "after": {"billing_mode": "PAY_PER_REQUEST"},
+    },
+    {
+        "type": "aws_s3_bucket",
+        "name": "data",
+        "irreversible": False,
+        "after": {"bucket": "acme-data"},
+    },
+    {
+        "type": "aws_ebs_volume",
+        "name": "data",
+        "irreversible": True,
+        "after": {"size": 500, "type": "gp3"},
+    },
+    {
+        "type": "aws_efs_file_system",
+        "name": "shared",
+        "irreversible": True,
+        "after": {"encrypted": True},
+    },
+    {
+        "type": "aws_elasticache_cluster",
+        "name": "cache",
+        "irreversible": False,
+        "after": {"engine": "redis"},
+    },
+]
+
+# Irreversible-by-nature security/crypto material.
+IRREVERSIBLE = [
+    {
+        "type": "aws_kms_key",
+        "name": "primary",
+        "after": {"description": "primary CMK", "enable_key_rotation": True},
+    },
+    {
+        "type": "aws_db_snapshot",
+        "name": "preupgrade",
+        "after": {"db_snapshot_identifier": "preupgrade"},
+    },
+    {"type": "aws_backup_vault", "name": "prod", "after": {"name": "prod-vault"}},
+]
+
+# Benign, stateless, additive resources — create is low risk, churn updates
+# are noise.
+BENIGN = [
+    {
+        "type": "aws_cloudwatch_log_group",
+        "name": "app",
+        "after": {"name": "/acme/app", "retention_in_days": 30},
+    },
+    {"type": "aws_iam_role", "name": "task", "after": {"name": "acme-task"}},
+    {
+        "type": "aws_ssm_parameter",
+        "name": "config",
+        "after": {"name": "/acme/config", "type": "String"},
+    },
+    {"type": "aws_lb_target_group", "name": "app", "after": {"port": 443, "protocol": "HTTPS"}},
+]
+
+
+def _plan(resource_changes: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "format_version": "1.2",
+        "terraform_version": "1.12.0",
+        "resource_changes": resource_changes,
+    }
+
+
+def _rc(
+    address: str,
+    rtype: str,
+    name: str,
+    actions: list[str],
+    before: Any,
+    after: Any,
+    after_unknown: dict | None = None,
+) -> dict[str, Any]:
+    change: dict[str, Any] = {"actions": actions, "before": before, "after": after}
+    if after_unknown is not None:
+        change["after_unknown"] = after_unknown
+    return {"address": address, "type": rtype, "name": name, "change": change}
+
+
+# --- per-axis generators -----------------------------------------------------
+
+
+def _data_loss_cases() -> list[Case]:
+    out: list[Case] = []
+    for spec in STATEFUL:
+        addr = f"{spec['type']}.{spec['name']}"
+        # destroy
+        crit = spec["irreversible"]
+        out.append(
+            Case(
+                id=f"gen-dataloss-destroy-{spec['type']}",
+                surface="plan",
+                source="generated",
+                tags=("data_loss",),
+                title=f"Destroy stateful {spec['type']}",
+                plan_json=_plan(
+                    [_rc(addr, spec["type"], spec["name"], ["delete"], spec["after"], None)]
+                ),
+                truth=Truth(
+                    risk=RiskBand(min="critical" if crit else "high"),
+                    must_flag=(MustFlag(addr, "critical" if crit else "high"),),
+                    key_facts=(addr, "destroy"),
+                    forbidden_claims=("no changes", "no-op"),
+                ),
+            )
+        )
+        # replace (delete+create) — still destructive on a stateful resource
+        out.append(
+            Case(
+                id=f"gen-dataloss-replace-{spec['type']}",
+                surface="plan",
+                source="generated",
+                tags=("data_loss", "blast_radius"),
+                title=f"Force-replace stateful {spec['type']}",
+                plan_json=_plan(
+                    [
+                        _rc(
+                            addr,
+                            spec["type"],
+                            spec["name"],
+                            ["delete", "create"],
+                            spec["after"],
+                            spec["after"],
+                        )
+                    ]
+                ),
+                truth=Truth(
+                    risk=RiskBand(min="high"),
+                    must_flag=(MustFlag(addr, "high"),),
+                    key_facts=(addr,),
+                    forbidden_claims=("no changes",),
+                ),
+            )
+        )
+    return out
+
+
+def _irreversibility_cases() -> list[Case]:
+    out: list[Case] = []
+    for spec in IRREVERSIBLE:
+        addr = f"{spec['type']}.{spec['name']}"
+        out.append(
+            Case(
+                id=f"gen-irrev-destroy-{spec['type']}",
+                surface="plan",
+                source="generated",
+                tags=("irreversibility",),
+                title=f"Destroy irreversible {spec['type']}",
+                plan_json=_plan(
+                    [_rc(addr, spec["type"], spec["name"], ["delete"], spec["after"], None)]
+                ),
+                truth=Truth(
+                    risk=RiskBand(min="critical"),
+                    must_flag=(MustFlag(addr, "critical"),),
+                    key_facts=(addr,),
+                    forbidden_claims=("no changes",),
+                ),
+            )
+        )
+    return out
+
+
+def _security_cases() -> list[Case]:
+    out: list[Case] = []
+
+    # Security group opening 0.0.0.0/0 to a sensitive port.
+    for port, label in [(22, "ssh"), (3389, "rdp"), (5432, "postgres")]:
+        addr = f"aws_security_group.{label}"
+        before = {"ingress": [{"from_port": port, "to_port": port, "cidr_blocks": ["10.0.0.0/8"]}]}
+        after = {"ingress": [{"from_port": port, "to_port": port, "cidr_blocks": ["0.0.0.0/0"]}]}
+        out.append(
+            Case(
+                id=f"gen-sec-sg-open-{label}",
+                surface="plan",
+                source="generated",
+                tags=("security",),
+                title=f"Open {label} ({port}) to 0.0.0.0/0",
+                plan_json=_plan(
+                    [_rc(addr, "aws_security_group", label, ["update"], before, after)]
+                ),
+                truth=Truth(
+                    risk=RiskBand(min="high"),
+                    must_flag=(MustFlag(addr, "high"),),
+                    key_facts=("0.0.0.0/0",),
+                ),
+            )
+        )
+
+    # S3 public-access-block disabled.
+    addr = "aws_s3_bucket_public_access_block.data"
+    out.append(
+        Case(
+            id="gen-sec-s3-public",
+            surface="plan",
+            source="generated",
+            tags=("security",),
+            title="Disable S3 public access block",
+            plan_json=_plan(
+                [
+                    _rc(
+                        addr,
+                        "aws_s3_bucket_public_access_block",
+                        "data",
+                        ["update"],
+                        {"block_public_acls": True, "block_public_policy": True},
+                        {"block_public_acls": False, "block_public_policy": False},
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(min="high"),
+                must_flag=(MustFlag(addr, "high"),),
+            ),
+        )
+    )
+
+    # Encryption turned off on an EBS volume (in-place update).
+    addr = "aws_ebs_volume.data"
+    out.append(
+        Case(
+            id="gen-sec-ebs-encryption-off",
+            surface="plan",
+            source="generated",
+            tags=("security",),
+            title="Disable EBS encryption",
+            plan_json=_plan(
+                [
+                    _rc(
+                        addr,
+                        "aws_ebs_volume",
+                        "data",
+                        ["update"],
+                        {"encrypted": True},
+                        {"encrypted": False},
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(min="high"),
+                must_flag=(MustFlag(addr, "high"),),
+            ),
+        )
+    )
+
+    # IAM policy broadened to Action:* Resource:*.
+    addr = "aws_iam_role_policy.task"
+    out.append(
+        Case(
+            id="gen-sec-iam-broaden",
+            surface="plan",
+            source="generated",
+            tags=("security",),
+            title="Broaden IAM policy to *:*",
+            plan_json=_plan(
+                [
+                    _rc(
+                        addr,
+                        "aws_iam_role_policy",
+                        "task",
+                        ["update"],
+                        {
+                            "policy": '{"Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::acme/*"}]}'
+                        },
+                        {
+                            "policy": '{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}'
+                        },
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(min="high"),
+                must_flag=(MustFlag(addr, "high"),),
+            ),
+        )
+    )
+    return out
+
+
+def _benign_create_cases() -> list[Case]:
+    out: list[Case] = []
+    for spec in BENIGN:
+        addr = f"{spec['type']}.{spec['name']}"
+        out.append(
+            Case(
+                id=f"gen-benign-create-{spec['type']}",
+                surface="plan",
+                source="generated",
+                tags=("benign",),
+                title=f"Create {spec['type']}",
+                plan_json=_plan(
+                    [_rc(addr, spec["type"], spec["name"], ["create"], None, spec["after"])]
+                ),
+                truth=Truth(
+                    risk=RiskBand(exact="low"),
+                    must_not_flag=(addr,),
+                    key_facts=(addr,),
+                ),
+            )
+        )
+    return out
+
+
+def _churn_cases() -> list[Case]:
+    """Changes that look like changes but carry no real risk — the model must
+    not inflate risk on them, and must not list them as risk factors."""
+    out: list[Case] = []
+
+    # Tag-only update on a stateful resource — NOT a data-loss event.
+    addr = "aws_db_instance.main"
+    out.append(
+        Case(
+            id="gen-churn-tags-only",
+            surface="plan",
+            source="generated",
+            tags=("churn",),
+            title="Tag-only update on RDS (no data risk)",
+            plan_json=_plan(
+                [
+                    _rc(
+                        addr,
+                        "aws_db_instance",
+                        "main",
+                        ["update"],
+                        {"tags": {"env": "prod"}, "instance_class": "db.r6g.large"},
+                        {"tags": {"env": "prod", "team": "data"}, "instance_class": "db.r6g.large"},
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(exact="low"),
+                churn_addresses=(addr,),
+                forbidden_claims=("destroy", "data loss", "replace"),
+            ),
+        )
+    )
+
+    # known_after_apply churn — an ARN that will be computed; not a risk.
+    addr = "aws_lb_target_group.app"
+    out.append(
+        Case(
+            id="gen-churn-known-after-apply",
+            surface="plan",
+            source="generated",
+            tags=("churn",),
+            title="known_after_apply attribute churn",
+            plan_json=_plan(
+                [
+                    _rc(
+                        addr,
+                        "aws_lb_target_group",
+                        "app",
+                        ["update"],
+                        {"port": 443},
+                        {"port": 443},
+                        after_unknown={"arn": True},
+                    )
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(max="low"),
+                churn_addresses=(addr,),
+            ),
+        )
+    )
+
+    # A real high-risk destroy BURIED among benign churn — must surface the
+    # one real risk and not be distracted by the churn.
+    real = "aws_db_instance.main"
+    churn1 = "aws_cloudwatch_log_group.app"
+    churn2 = "aws_ssm_parameter.config"
+    out.append(
+        Case(
+            id="gen-churn-needle-in-haystack",
+            surface="plan",
+            source="generated",
+            tags=("churn", "data_loss"),
+            title="One real DB destroy among tag churn",
+            plan_json=_plan(
+                [
+                    _rc(
+                        churn1,
+                        "aws_cloudwatch_log_group",
+                        "app",
+                        ["update"],
+                        {"tags": {}},
+                        {"tags": {"team": "x"}},
+                    ),
+                    _rc(real, "aws_db_instance", "main", ["delete"], {"engine": "postgres"}, None),
+                    _rc(
+                        churn2,
+                        "aws_ssm_parameter",
+                        "config",
+                        ["update"],
+                        {"tags": {}},
+                        {"tags": {"team": "x"}},
+                    ),
+                ]
+            ),
+            truth=Truth(
+                risk=RiskBand(min="high"),
+                must_flag=(MustFlag(real, "high"),),
+                churn_addresses=(churn1, churn2),
+                key_facts=(real,),
+            ),
+        )
+    )
+    return out
+
+
+def _drift_cases() -> list[Case]:
+    """Drift-detection runs — framed as detection reports, not proposals."""
+    out: list[Case] = []
+
+    # Drift the apply WOULD revert (manual change to live infra) — elevated.
+    addr = "aws_s3_bucket_versioning.logs"
+    plan = _plan(
+        [
+            _rc(
+                addr,
+                "aws_s3_bucket_versioning",
+                "logs",
+                ["update"],
+                {"versioning_configuration": [{"status": "Disabled"}]},
+                {"versioning_configuration": [{"status": "Enabled"}]},
+            )
+        ]
+    )
+    plan["resource_drift"] = [
+        _rc(
+            addr,
+            "aws_s3_bucket_versioning",
+            "logs",
+            ["update"],
+            {"versioning_configuration": [{"status": "Enabled"}]},
+            {"versioning_configuration": [{"status": "Disabled"}]},
+        )
+    ]
+    out.append(
+        Case(
+            id="gen-drift-reverting-manual-change",
+            surface="drift",
+            source="generated",
+            tags=("churn", "security"),
+            title="Drift detected: versioning disabled out-of-band",
+            plan_json=plan,
+            truth=Truth(
+                risk=RiskBand(min="medium"),
+                must_flag=(MustFlag(addr, "medium"),),
+                key_facts=("drift",),
+                forbidden_claims=("this plan will disable",),
+            ),
+        )
+    )
+
+    # No-op drift only — informational, low.
+    addr = "aws_instance.web"
+    plan = _plan([])
+    plan["resource_drift"] = [
+        _rc(
+            addr,
+            "aws_instance",
+            "web",
+            ["update"],
+            {"tags": {"patched": "no"}},
+            {"tags": {"patched": "yes"}},
+        )
+    ]
+    out.append(
+        Case(
+            id="gen-drift-noop-informational",
+            surface="drift",
+            source="generated",
+            tags=("churn",),
+            title="No-op drift (no apply action)",
+            plan_json=plan,
+            truth=Truth(
+                risk=RiskBand(max="low"),
+                churn_addresses=(addr,),
+                key_facts=("drift",),
+            ),
+        )
+    )
+    return out
+
+
+def build_generated_cases() -> list[Case]:
+    """Return the full deterministic set of generated cases."""
+    cases: list[Case] = []
+    cases += _data_loss_cases()
+    cases += _irreversibility_cases()
+    cases += _security_cases()
+    cases += _benign_create_cases()
+    cases += _churn_cases()
+    cases += _drift_cases()
+    return cases

--- a/services/ai_eval/judge.py
+++ b/services/ai_eval/judge.py
@@ -1,0 +1,180 @@
+"""LLM-judge for description quality (#602).
+
+The deterministic rubric scores risk-correctness (band / must-flag / churn),
+but it is blind to the thing prompt framing most affects: how good the prose
+`description` actually is for an on-call engineer. This judge fills that gap.
+
+It runs POST-HOC over a saved scorecard JSON: for each case it re-loads the
+plan facts (by id, from the corpus), pairs them with the model's stored
+`description`, and asks a judge model to score three axes 1–5:
+
+  • accuracy  — factually correct about what the plan does; no fabrication;
+                doesn't miss the headline change.
+  • utility   — actionable for an on-call SRE; surfaces what matters at the
+                right altitude; not a restatement of the JSON.
+  • clarity   — concise, well-structured operator prose.
+
+Because both prompts are judged by the SAME judge model, the comparison is
+fair for A/B (relative), even though absolute scores carry the usual
+self-grading caveat. Use a different judge model for an unbiased absolute read.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import litellm
+
+from .cases import Case, load_corpus
+from .generator import build_generated_cases
+
+_JUDGE_SYSTEM = """\
+You are a pragmatic, hard-to-impress senior site reliability engineer. You are
+grading an AI-generated SUMMARY of a terraform/tofu plan that one of your
+on-call engineers would read before approving the change. You are given the
+plan's machine facts (PLAN_JSON or the failure log) and the candidate SUMMARY.
+
+Score the SUMMARY on three axes, each an integer 1–5 (5 = excellent, 3 =
+adequate, 1 = poor). Be critical and discriminating — most real summaries are
+a 3 or 4; reserve 5 for genuinely excellent, 1–2 for misleading or useless.
+
+  • accuracy — Is every claim about what the plan does correct and supported by
+    the facts? No fabricated resources, no invented attributes, no missed
+    headline change (e.g. a destroy of a stateful resource not mentioned).
+  • utility — Would an on-call SRE find this actionable? Does it lead with what
+    matters (risk, blast radius, exposure), at the right altitude — not a
+    line-by-line restatement of the JSON, not vague hand-waving?
+  • clarity — Concise, well-structured operator prose. Easy to skim under
+    pressure. No filler, no format noise.
+
+Call `submit_judgement` exactly once with the three integer scores and one
+sentence of rationale naming the single biggest strength or weakness.
+"""
+
+_JUDGE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "submit_judgement",
+        "description": "Submit the 1-5 scores for the candidate summary.",
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["accuracy", "utility", "clarity", "rationale"],
+            "properties": {
+                "accuracy": {"type": "integer", "minimum": 1, "maximum": 5},
+                "utility": {"type": "integer", "minimum": 1, "maximum": 5},
+                "clarity": {"type": "integer", "minimum": 1, "maximum": 5},
+                "rationale": {"type": "string", "maxLength": 300},
+            },
+        },
+    },
+}
+
+
+@dataclass
+class Judgement:
+    case_id: str
+    accuracy: int = 0
+    utility: int = 0
+    clarity: int = 0
+    rationale: str = ""
+    error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return not self.error
+
+    @property
+    def mean(self) -> float:
+        return (self.accuracy + self.utility + self.clarity) / 3.0
+
+
+def _facts(case: Case) -> str:
+    if case.surface == "apply_failure":
+        return f"APPLY_LOG:\n{case.apply_log[:8000]}"
+    return f"PLAN_JSON:\n{json.dumps(case.plan_json)[:12000]}"
+
+
+def _all_cases_by_id() -> dict[str, Case]:
+    cases = load_corpus() + build_generated_cases()
+    return {c.id: c for c in cases}
+
+
+async def _judge_one(case: Case, description: str, model: str) -> Judgement:
+    user = (
+        f"{_facts(case)}\n\nCANDIDATE SUMMARY:\n{description}\n\n"
+        "Call submit_judgement with your scores."
+    )
+    kwargs: dict = {
+        "model": model,
+        "max_tokens": 500,
+        "temperature": 0.0,
+        "num_retries": 5,
+        "messages": [
+            {"role": "system", "content": _JUDGE_SYSTEM},
+            {"role": "user", "content": user},
+        ],
+        "tools": [_JUDGE_TOOL],
+        "tool_choice": {"type": "function", "function": {"name": "submit_judgement"}},
+    }
+    if model.startswith("bedrock/"):
+        region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+        if region:
+            kwargs["aws_region_name"] = region
+    try:
+        resp = await litellm.acompletion(**kwargs)
+        tc = (resp.choices[0].message.tool_calls or [None])[0]
+        if tc is None:
+            return Judgement(case.id, error="no tool_call")
+        args = json.loads(tc.function.arguments)
+        return Judgement(
+            case.id,
+            accuracy=int(args.get("accuracy", 0)),
+            utility=int(args.get("utility", 0)),
+            clarity=int(args.get("clarity", 0)),
+            rationale=str(args.get("rationale", "")),
+        )
+    except Exception as e:  # noqa: BLE001
+        return Judgement(case.id, error=str(e)[:300])
+
+
+async def judge_scorecard(path: Path, *, model: str, concurrency: int = 3) -> list[Judgement]:
+    """Judge every case's representative description in a saved scorecard JSON."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    report = data[0] if isinstance(data, list) else data
+    by_id = _all_cases_by_id()
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _guard(case_entry: dict) -> Judgement | None:
+        cid = case_entry["case_id"]
+        desc = case_entry.get("description", "")
+        case = by_id.get(cid)
+        if case is None or not desc:
+            return None
+        async with sem:
+            return await _judge_one(case, desc, model)
+
+    results = await asyncio.gather(*(_guard(c) for c in report["cases"]))
+    return [r for r in results if r is not None]
+
+
+def summarise(judgements: list[Judgement]) -> dict:
+    ok = [j for j in judgements if j.ok]
+    if not ok:
+        return {"n": 0}
+
+    def _avg(attr: str) -> float:
+        return round(sum(getattr(j, attr) for j in ok) / len(ok), 2)
+
+    return {
+        "n": len(ok),
+        "accuracy": _avg("accuracy"),
+        "utility": _avg("utility"),
+        "clarity": _avg("clarity"),
+        "mean": round(sum(j.mean for j in ok) / len(ok), 2),
+        "weakest": sorted(ok, key=lambda j: j.mean)[:5],
+    }

--- a/services/ai_eval/prep.py
+++ b/services/ai_eval/prep.py
@@ -16,7 +16,7 @@ import json
 from terrapod.config import settings
 from terrapod.services.summariser import (
     _clean_plan_json_bytes,
-    _truncate_head,
+    _fit_plan_json,
     _truncate_tail,
 )
 from terrapod.services.summariser_prompt import render_prompt
@@ -44,7 +44,7 @@ def build_messages(
     if case.surface in ("plan", "drift"):
         raw = json.dumps(case.plan_json or {}).encode("utf-8")
         cleaned = _clean_plan_json_bytes(raw)
-        primary = _truncate_head(cleaned, max_bytes)
+        primary = _fit_plan_json(cleaned, max_bytes)
         label, lang = "PLAN_JSON", "json"
     elif case.surface == "apply_failure":
         primary = _truncate_tail(case.apply_log.encode("utf-8"), max_bytes)

--- a/services/ai_eval/prep.py
+++ b/services/ai_eval/prep.py
@@ -59,7 +59,7 @@ def build_messages(
         primary_input=primary,
         primary_input_label=label,
         primary_input_lang=lang,
-        code_context_truncated="",
+        code_context_truncated=case.code_context,
         code_diff=case.code_diff,
         prompt_prefix="",
         prompt_suffix="",

--- a/services/ai_eval/prep.py
+++ b/services/ai_eval/prep.py
@@ -1,0 +1,68 @@
+"""Build production render_prompt inputs from a Case (#602).
+
+This deliberately reuses the *real* shipping helpers from
+``terrapod.services.summariser`` (plan-JSON cleaning, head/tail truncation)
+and the real ``render_prompt`` so the harness scores exactly what ships — not
+a parallel re-implementation. The only things held empty are the operator
+context layers (``fleet_context`` / per-workspace context / prefix / suffix):
+the eval targets the in-code *skill prompt*, which is the part we refine and
+which every deployment shares.
+"""
+
+from __future__ import annotations
+
+import json
+
+from terrapod.config import settings
+from terrapod.services.summariser import (
+    _clean_plan_json_bytes,
+    _truncate_head,
+    _truncate_tail,
+)
+from terrapod.services.summariser_prompt import render_prompt
+
+from .cases import Case
+
+
+def build_messages(
+    case: Case,
+    *,
+    fleet_context: str = "",
+    workspace_context: str = "",
+) -> tuple[str, str]:
+    """Return ``(system_message, user_message)`` for a Case via the prod path.
+
+    Mirrors ``summariser._handle_ai_plan_summary`` lines that assemble inputs:
+      - plan / drift: primary = ``_truncate_head(_clean_plan_json_bytes(raw))``,
+        label ``PLAN_JSON``, lang ``json``.
+      - apply_failure: primary = ``_truncate_tail(raw)``, label ``APPLY_LOG``,
+        lang ``text``.
+    """
+    cfg = settings.ai_summary
+    max_bytes = cfg.plan_json_max_bytes
+
+    if case.surface in ("plan", "drift"):
+        raw = json.dumps(case.plan_json or {}).encode("utf-8")
+        cleaned = _clean_plan_json_bytes(raw)
+        primary = _truncate_head(cleaned, max_bytes)
+        label, lang = "PLAN_JSON", "json"
+    elif case.surface == "apply_failure":
+        primary = _truncate_tail(case.apply_log.encode("utf-8"), max_bytes)
+        label, lang = "APPLY_LOG", "text"
+    else:  # pragma: no cover - guarded by the Surface literal
+        raise ValueError(f"unknown surface {case.surface!r}")
+
+    return render_prompt(
+        kind=case.kind,
+        fleet_context=fleet_context,
+        workspace_context=workspace_context,
+        primary_input=primary,
+        primary_input_label=label,
+        primary_input_lang=lang,
+        code_context_truncated="",
+        code_diff=case.code_diff,
+        prompt_prefix="",
+        prompt_suffix="",
+        state_diverged=case.state_diverged,
+        drift_detection=case.drift_detection,
+    )

--- a/services/ai_eval/report.py
+++ b/services/ai_eval/report.py
@@ -1,0 +1,218 @@
+"""Aggregate CaseRun outputs into scorecards + a human report (#602).
+
+For each case we score every successful repeat with the deterministic rubric,
+then derive:
+  - a headline pass/score from the representative (first successful) output;
+  - a repeatability metric: how stable the risk_level + hard_pass are across
+    the N repeats (1.0 = identical every time).
+
+Across the corpus we report overall hard-pass rate, mean score, per-axis pass
+rates, and breakdowns by surface and by risk-axis tag — plus, when several
+models are swept, a side-by-side leaderboard so we can pick the cheapest model
+that clears the bar.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from . import rubric
+from .cases import Case
+from .runner import CaseRun
+
+
+@dataclass
+class CaseScore:
+    case_id: str
+    surface: str
+    tags: list[str]
+    title: str
+    n_runs: int
+    n_ok: int
+    hard_pass: bool  # representative run
+    overall_score: float  # representative run
+    axis_pass: dict[str, bool]
+    risk_repeatability: float  # fraction of runs sharing the modal risk_level
+    hard_pass_repeatability: float  # fraction of runs that hard-pass
+    failures: list[str]
+    error: str = ""
+
+
+@dataclass
+class ModelReport:
+    model: str
+    case_scores: list[CaseScore] = field(default_factory=list)
+
+    # --- aggregates ----------------------------------------------------------
+    @property
+    def n(self) -> int:
+        return len(self.case_scores)
+
+    @property
+    def hard_pass_rate(self) -> float:
+        return _mean([1.0 if c.hard_pass else 0.0 for c in self.case_scores])
+
+    @property
+    def mean_score(self) -> float:
+        return _mean([c.overall_score for c in self.case_scores])
+
+    @property
+    def mean_risk_repeatability(self) -> float:
+        return _mean([c.risk_repeatability for c in self.case_scores])
+
+    def axis_pass_rates(self) -> dict[str, float]:
+        names = ["risk_band", "must_flag", "no_false_risk", "key_facts", "no_forbidden"]
+        return {
+            ax: _mean([1.0 if c.axis_pass.get(ax) else 0.0 for c in self.case_scores])
+            for ax in names
+        }
+
+    def by_surface(self) -> dict[str, float]:
+        out: dict[str, list[float]] = {}
+        for c in self.case_scores:
+            out.setdefault(c.surface, []).append(1.0 if c.hard_pass else 0.0)
+        return {k: _mean(v) for k, v in sorted(out.items())}
+
+    def by_tag(self) -> dict[str, float]:
+        out: dict[str, list[float]] = {}
+        for c in self.case_scores:
+            for t in c.tags:
+                out.setdefault(t, []).append(1.0 if c.hard_pass else 0.0)
+        return {k: _mean(v) for k, v in sorted(out.items())}
+
+    def failing_cases(self) -> list[CaseScore]:
+        return [c for c in self.case_scores if not c.hard_pass]
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def score_model(cases_by_id: dict[str, Case], runs: list[CaseRun]) -> ModelReport:
+    """Score one model's sweep into a ModelReport."""
+    model = runs[0].model if runs else "?"
+    rep = ModelReport(model=model)
+    for run in runs:
+        case = cases_by_id[run.case_id]
+        oks = run.successes
+        if not oks:
+            err = run.outputs[0].error if run.outputs else "no output"
+            rep.case_scores.append(
+                CaseScore(
+                    case_id=case.id,
+                    surface=case.surface,
+                    tags=list(case.tags),
+                    title=case.title,
+                    n_runs=len(run.outputs),
+                    n_ok=0,
+                    hard_pass=False,
+                    overall_score=0.0,
+                    axis_pass={},
+                    risk_repeatability=0.0,
+                    hard_pass_repeatability=0.0,
+                    failures=[f"call_error: {err}"],
+                    error=err,
+                )
+            )
+            continue
+
+        scored = [rubric.score(case, o.parsed) for o in oks]
+        rep_score = scored[0]  # representative = first successful run
+        risk_levels = [str(o.parsed.get("risk_level", "")).lower() for o in oks]
+        modal = Counter(risk_levels).most_common(1)[0][1]
+        risk_rep = modal / len(risk_levels)
+        hp_rep = _mean([1.0 if s.hard_pass else 0.0 for s in scored])
+
+        rep.case_scores.append(
+            CaseScore(
+                case_id=case.id,
+                surface=case.surface,
+                tags=list(case.tags),
+                title=case.title,
+                n_runs=len(run.outputs),
+                n_ok=len(oks),
+                hard_pass=rep_score.hard_pass,
+                overall_score=round(rep_score.overall_score, 3),
+                axis_pass={a.name: a.passed for a in rep_score.axes},
+                risk_repeatability=round(risk_rep, 3),
+                hard_pass_repeatability=round(hp_rep, 3),
+                failures=rep_score.failures,
+            )
+        )
+    return rep
+
+
+# --- rendering ---------------------------------------------------------------
+
+
+def render_markdown(reports: list[ModelReport]) -> str:
+    lines: list[str] = ["# AI-eval scorecard", ""]
+
+    if len(reports) > 1:
+        lines += [
+            "## Model leaderboard",
+            "",
+            "| Model | Hard-pass | Mean score | Risk repeatability |",
+            "|---|---|---|---|",
+        ]
+        for r in sorted(reports, key=lambda r: r.hard_pass_rate, reverse=True):
+            lines.append(
+                f"| `{r.model}` | {r.hard_pass_rate:.0%} | {r.mean_score:.2f} | "
+                f"{r.mean_risk_repeatability:.0%} |"
+            )
+        lines.append("")
+
+    for r in reports:
+        lines += [
+            f"## `{r.model}`",
+            "",
+            f"- cases: **{r.n}**",
+            f"- hard-pass (risk-correctness): **{r.hard_pass_rate:.0%}**",
+            f"- mean score: **{r.mean_score:.2f}**",
+            f"- risk repeatability: **{r.mean_risk_repeatability:.0%}**",
+            "",
+        ]
+        lines += ["**Per-axis pass rate**", ""]
+        for ax, v in r.axis_pass_rates().items():
+            lines.append(f"- {ax}: {v:.0%}")
+        lines += ["", "**By surface**", ""]
+        for s, v in r.by_surface().items():
+            lines.append(f"- {s}: {v:.0%}")
+        lines += ["", "**By risk axis (tag)**", ""]
+        for t, v in r.by_tag().items():
+            lines.append(f"- {t}: {v:.0%}")
+        fails = r.failing_cases()
+        lines += ["", f"**Failing cases ({len(fails)})**", ""]
+        for c in fails:
+            lines.append(f"- `{c.case_id}` ({c.surface}) — {'; '.join(c.failures) or 'n/a'}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write_reports(reports: list[ModelReport], out_dir: Path, *, stamp: str) -> tuple[Path, Path]:
+    """Write the markdown report + a machine JSON. ``stamp`` is supplied by the
+    caller (the harness can't call Date.now()/time in a way that breaks
+    reproducibility for the journal; the CLI passes an explicit stamp)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    md_path = out_dir / f"scorecard-{stamp}.md"
+    json_path = out_dir / f"scorecard-{stamp}.json"
+    md_path.write_text(render_markdown(reports), encoding="utf-8")
+    json_path.write_text(json.dumps([_report_json(r) for r in reports], indent=2), encoding="utf-8")
+    return md_path, json_path
+
+
+def _report_json(r: ModelReport) -> dict:
+    return {
+        "model": r.model,
+        "n": r.n,
+        "hard_pass_rate": round(r.hard_pass_rate, 4),
+        "mean_score": round(r.mean_score, 4),
+        "mean_risk_repeatability": round(r.mean_risk_repeatability, 4),
+        "axis_pass_rates": {k: round(v, 4) for k, v in r.axis_pass_rates().items()},
+        "by_surface": {k: round(v, 4) for k, v in r.by_surface().items()},
+        "by_tag": {k: round(v, 4) for k, v in r.by_tag().items()},
+        "cases": [asdict(c) for c in r.case_scores],
+    }

--- a/services/ai_eval/report.py
+++ b/services/ai_eval/report.py
@@ -20,7 +20,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from . import rubric
-from .cases import Case
+from .cases import Case, is_holdout
 from .runner import CaseRun
 
 
@@ -45,6 +45,7 @@ class CaseScore:
     risk_level: str = ""
     description: str = ""
     risk_factors: list[dict] = field(default_factory=list)
+    holdout: bool = False
 
 
 @dataclass
@@ -68,6 +69,19 @@ class ModelReport:
     @property
     def mean_risk_repeatability(self) -> float:
         return _mean([c.risk_repeatability for c in self.case_scores])
+
+    def hard_pass_rate_split(self, holdout: bool) -> float:
+        """Hard-pass rate over just the train (holdout=False) or holdout subset.
+
+        The prompt is tuned against train only; holdout is the honest
+        generalization signal. A train gain that doesn't carry to holdout is
+        overfitting and must be reverted."""
+        xs = [1.0 if c.hard_pass else 0.0 for c in self.case_scores if c.holdout == holdout]
+        return _mean(xs)
+
+    def split_counts(self) -> tuple[int, int]:
+        train = sum(1 for c in self.case_scores if not c.holdout)
+        return train, len(self.case_scores) - train
 
     def axis_pass_rates(self) -> dict[str, float]:
         names = ["risk_band", "must_flag", "no_false_risk", "key_facts", "no_forbidden"]
@@ -121,6 +135,7 @@ def score_model(cases_by_id: dict[str, Case], runs: list[CaseRun]) -> ModelRepor
                     hard_pass_repeatability=0.0,
                     failures=[f"call_error: {err}"],
                     error=err,
+                    holdout=is_holdout(case),
                 )
             )
             continue
@@ -151,6 +166,7 @@ def score_model(cases_by_id: dict[str, Case], runs: list[CaseRun]) -> ModelRepor
                 risk_factors=[
                     f for f in (oks[0].parsed.get("risk_factors") or []) if isinstance(f, dict)
                 ],
+                holdout=is_holdout(case),
             )
         )
     return rep
@@ -182,6 +198,9 @@ def render_markdown(reports: list[ModelReport]) -> str:
             "",
             f"- cases: **{r.n}**",
             f"- hard-pass (risk-correctness): **{r.hard_pass_rate:.0%}**",
+            f"- hard-pass train / **holdout**: "
+            f"{r.hard_pass_rate_split(False):.0%} / **{r.hard_pass_rate_split(True):.0%}** "
+            f"(n={r.split_counts()[0]}/{r.split_counts()[1]})",
             f"- mean score: **{r.mean_score:.2f}**",
             f"- risk repeatability: **{r.mean_risk_repeatability:.0%}**",
             "",

--- a/services/ai_eval/report.py
+++ b/services/ai_eval/report.py
@@ -39,6 +39,12 @@ class CaseScore:
     hard_pass_repeatability: float  # fraction of runs that hard-pass
     failures: list[str]
     error: str = ""
+    # Representative model output (first successful run) — so a failure can be
+    # diagnosed (real miss vs scoring-matcher gap vs label problem) without a
+    # re-run. This is what makes the iterate loop tractable.
+    risk_level: str = ""
+    description: str = ""
+    risk_factors: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -140,6 +146,11 @@ def score_model(cases_by_id: dict[str, Case], runs: list[CaseRun]) -> ModelRepor
                 risk_repeatability=round(risk_rep, 3),
                 hard_pass_repeatability=round(hp_rep, 3),
                 failures=rep_score.failures,
+                risk_level=str(oks[0].parsed.get("risk_level", "")),
+                description=str(oks[0].parsed.get("description", "")),
+                risk_factors=[
+                    f for f in (oks[0].parsed.get("risk_factors") or []) if isinstance(f, dict)
+                ],
             )
         )
     return rep

--- a/services/ai_eval/rubric.py
+++ b/services/ai_eval/rubric.py
@@ -1,0 +1,192 @@
+"""Deterministic scoring of an analysis output against a Case's ground truth.
+
+Engine-free and fully objective: given the parsed model output
+(``{description, risk_level, risk_factors}``) and a :class:`Truth`, it scores
+the axes that don't need a judge. The LLM-judge (``judge.py``) scores the
+softer description-quality axes on top of this.
+
+Axes (priority order — risk-calling first):
+  1. ``risk_band``     — overall risk_level falls in the expected band.
+  2. ``must_flag``     — every must-flag resource appears at >= min severity.
+  3. ``no_false_risk`` — no must-not-flag / churn address is flagged as a risk
+                         (the real-change-vs-churn-noise axis).
+  4. ``key_facts``     — description contains the required substrings.
+  5. ``no_forbidden``  — description omits the forbidden claims.
+
+``hard_pass`` is True only when axes 1–3 all pass — those are the
+risk-correctness guarantees the user prioritised.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .cases import Case, risk_rank
+
+# Axes 1–3 are the risk-correctness core; a regression in any is a hard fail.
+HARD_AXES = ("risk_band", "must_flag", "no_false_risk")
+
+# Relative weights for the graded overall score.
+AXIS_WEIGHTS = {
+    "risk_band": 0.30,
+    "must_flag": 0.30,
+    "no_false_risk": 0.20,
+    "key_facts": 0.12,
+    "no_forbidden": 0.08,
+}
+
+
+@dataclass
+class AxisResult:
+    name: str
+    passed: bool
+    score: float  # 0..1
+    detail: str = ""
+
+
+@dataclass
+class RubricResult:
+    case_id: str
+    axes: list[AxisResult] = field(default_factory=list)
+
+    @property
+    def by_name(self) -> dict[str, AxisResult]:
+        return {a.name: a for a in self.axes}
+
+    @property
+    def hard_pass(self) -> bool:
+        bn = self.by_name
+        return all(bn[a].passed for a in HARD_AXES if a in bn)
+
+    @property
+    def overall_score(self) -> float:
+        total = sum(AXIS_WEIGHTS.get(a.name, 0.0) for a in self.axes)
+        if total == 0:
+            return 0.0
+        got = sum(AXIS_WEIGHTS.get(a.name, 0.0) * a.score for a in self.axes)
+        return got / total
+
+    @property
+    def failures(self) -> list[str]:
+        return [f"{a.name}: {a.detail}" for a in self.axes if not a.passed]
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _factors(parsed: dict[str, Any]) -> list[dict[str, Any]]:
+    rf = parsed.get("risk_factors") or []
+    return [f for f in rf if isinstance(f, dict)]
+
+
+def _factor_matches_address(factor: dict[str, Any], address: str) -> bool:
+    """A factor is *about* an address when its resource_address equals it, or
+    (fallback for models that leave resource_address empty) the address appears
+    verbatim in the title."""
+    ra = (factor.get("resource_address") or "").strip()
+    if ra == address:
+        return True
+    title = factor.get("title") or ""
+    return address in title
+
+
+def _flagged_as_risk(parsed: dict[str, Any], address: str) -> bool:
+    """Whether the output presents ``address`` as a risk factor at all."""
+    return any(_factor_matches_address(f, address) for f in _factors(parsed))
+
+
+# --- axis scorers ------------------------------------------------------------
+
+
+def _score_risk_band(case: Case, parsed: dict[str, Any]) -> AxisResult:
+    level = str(parsed.get("risk_level", "")).lower()
+    band = case.truth.risk
+    ok = band.contains(level)
+    return AxisResult(
+        "risk_band",
+        ok,
+        1.0 if ok else 0.0,
+        f"got {level!r}, expected {band.describe()}",
+    )
+
+
+def _score_must_flag(case: Case, parsed: dict[str, Any]) -> AxisResult:
+    expected = case.truth.must_flag
+    if not expected:
+        return AxisResult("must_flag", True, 1.0, "no must-flag resources")
+    hits = 0
+    misses: list[str] = []
+    for mf in expected:
+        matched = [f for f in _factors(parsed) if _factor_matches_address(f, mf.address)]
+        ok = any(risk_rank(f.get("severity", "")) >= risk_rank(mf.min_severity) for f in matched)
+        if ok:
+            hits += 1
+        else:
+            why = "absent" if not matched else "severity too low"
+            misses.append(f"{mf.address} (>= {mf.min_severity}: {why})")
+    score = hits / len(expected)
+    return AxisResult(
+        "must_flag",
+        hits == len(expected),
+        score,
+        "all flagged" if not misses else "missed: " + "; ".join(misses),
+    )
+
+
+def _score_no_false_risk(case: Case, parsed: dict[str, Any]) -> AxisResult:
+    forbidden = set(case.truth.must_not_flag) | set(case.truth.churn_addresses)
+    if not forbidden:
+        return AxisResult("no_false_risk", True, 1.0, "no false-risk guards")
+    violations = [addr for addr in sorted(forbidden) if _flagged_as_risk(parsed, addr)]
+    score = 1.0 - (len(violations) / len(forbidden))
+    return AxisResult(
+        "no_false_risk",
+        not violations,
+        score,
+        "clean" if not violations else "falsely flagged: " + ", ".join(violations),
+    )
+
+
+def _score_key_facts(case: Case, parsed: dict[str, Any]) -> AxisResult:
+    facts = case.truth.key_facts
+    if not facts:
+        return AxisResult("key_facts", True, 1.0, "no required facts")
+    desc = str(parsed.get("description", "")).lower()
+    missing = [f for f in facts if f.lower() not in desc]
+    score = (len(facts) - len(missing)) / len(facts)
+    return AxisResult(
+        "key_facts",
+        not missing,
+        score,
+        "all present" if not missing else "missing: " + ", ".join(missing),
+    )
+
+
+def _score_no_forbidden(case: Case, parsed: dict[str, Any]) -> AxisResult:
+    forbidden = case.truth.forbidden_claims
+    if not forbidden:
+        return AxisResult("no_forbidden", True, 1.0, "no forbidden claims")
+    desc = str(parsed.get("description", "")).lower()
+    present = [f for f in forbidden if f.lower() in desc]
+    score = 1.0 - (len(present) / len(forbidden))
+    return AxisResult(
+        "no_forbidden",
+        not present,
+        score,
+        "clean" if not present else "contains: " + ", ".join(present),
+    )
+
+
+def score(case: Case, parsed: dict[str, Any]) -> RubricResult:
+    """Score one parsed analysis output against a Case's ground truth."""
+    return RubricResult(
+        case_id=case.id,
+        axes=[
+            _score_risk_band(case, parsed),
+            _score_must_flag(case, parsed),
+            _score_no_false_risk(case, parsed),
+            _score_key_facts(case, parsed),
+            _score_no_forbidden(case, parsed),
+        ],
+    )

--- a/services/ai_eval/runner.py
+++ b/services/ai_eval/runner.py
@@ -1,0 +1,128 @@
+"""Drive a Case through the real engine, N times, for repeatability (#602).
+
+Reuses the production ``_build_litellm_kwargs`` (tools + tool_choice + messages
++ provider auth passthrough) and ``_parse_tool_call_arguments`` so the harness
+exercises exactly the shipping request shape. The only overrides are the
+**model** (so we can sweep candidates) and **temperature=0** (so repeatability
+is a measurable property, not left to the provider default).
+
+Credentials are ambient: for ``anthropic/<model>`` LiteLLM reads
+``ANTHROPIC_API_KEY`` from the environment; for ``bedrock/<id>`` it uses the
+pod/host AWS credentials. The harness passes neither in code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+
+import litellm
+
+from terrapod.config import settings
+from terrapod.services.summariser import _build_litellm_kwargs, _parse_tool_call_arguments
+
+from .cases import Case
+from .prep import build_messages
+
+
+@dataclass
+class RunOutput:
+    """One model call's result (or its error)."""
+
+    parsed: dict | None = None
+    error: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return self.parsed is not None and not self.error
+
+
+@dataclass
+class CaseRun:
+    """All N repeats of one case against one model."""
+
+    case_id: str
+    model: str
+    outputs: list[RunOutput] = field(default_factory=list)
+
+    @property
+    def successes(self) -> list[RunOutput]:
+        return [o for o in self.outputs if o.ok]
+
+
+async def _one_call(
+    case: Case, model: str, max_output_tokens: int, temperature: float
+) -> RunOutput:
+    system_message, user_message = build_messages(case)
+    kwargs = _build_litellm_kwargs(
+        kind=case.kind,
+        system_message=system_message,
+        user_message=user_message,
+        max_output_tokens=max_output_tokens,
+    )
+    kwargs["model"] = model
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    # Bedrock: ensure LiteLLM/boto3 has a region even when the summariser
+    # settings don't carry one (the harness reads ambient AWS_* env creds).
+    if model.startswith("bedrock/") and "aws_region_name" not in kwargs:
+        region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+        if region:
+            kwargs["aws_region_name"] = region
+    try:
+        resp = await litellm.acompletion(**kwargs)
+        choice = resp.choices[0]
+        tool_calls = getattr(choice.message, "tool_calls", None) or []
+        if not tool_calls:
+            return RunOutput(error="model returned no tool_calls")
+        parsed = _parse_tool_call_arguments(tool_calls[0])
+        usage = getattr(resp, "usage", None)
+        return RunOutput(
+            parsed=parsed,
+            input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
+            output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+        )
+    except Exception as e:  # noqa: BLE001 - record any provider/parse failure
+        return RunOutput(error=str(e)[:500])
+
+
+async def run_case(
+    case: Case,
+    *,
+    model: str,
+    n: int = 1,
+    max_output_tokens: int | None = None,
+    temperature: float = 0.0,
+) -> CaseRun:
+    """Run ``case`` ``n`` times against ``model``; collect every output."""
+    max_tokens = max_output_tokens or settings.ai_summary.max_output_tokens
+    outputs = [await _one_call(case, model, max_tokens, temperature) for _ in range(n)]
+    return CaseRun(case_id=case.id, model=model, outputs=outputs)
+
+
+async def run_sweep(
+    cases: list[Case],
+    *,
+    model: str,
+    n: int = 1,
+    concurrency: int = 4,
+    temperature: float = 0.0,
+    max_output_tokens: int | None = None,
+) -> list[CaseRun]:
+    """Run every case against one model with bounded concurrency."""
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _guarded(case: Case) -> CaseRun:
+        async with sem:
+            return await run_case(
+                case,
+                model=model,
+                n=n,
+                temperature=temperature,
+                max_output_tokens=max_output_tokens,
+            )
+
+    return await asyncio.gather(*(_guarded(c) for c in cases))

--- a/services/ai_eval/runner.py
+++ b/services/ai_eval/runner.py
@@ -66,6 +66,10 @@ async def _one_call(
     kwargs["model"] = model
     if temperature is not None:
         kwargs["temperature"] = temperature
+    # Bounded retry with backoff so Bedrock/anthropic throttling on a large
+    # sweep degrades to slower, not to spurious call errors that corrupt the
+    # scorecard. LiteLLM retries RateLimitError / transient 5xx internally.
+    kwargs["num_retries"] = 5
     # Bedrock: ensure LiteLLM/boto3 has a region even when the summariser
     # settings don't carry one (the harness reads ambient AWS_* env creds).
     if model.startswith("bedrock/") and "aws_region_name" not in kwargs:

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -937,12 +937,19 @@ class AISummaryConfig(BaseModel):
         ),
     )
     plan_json_max_bytes: int = Field(
-        default=500_000,
+        default=600_000,
         description=(
-            "Max bytes of plan JSON attached. The runner-uploaded "
-            "plan JSON is truncated to this cap (keeping resource_changes "
-            "intact via best-effort structural truncation). Defends "
-            "against pathological monorepos producing 50MB plan files."
+            "Max bytes of plan JSON attached to the model request. This is a "
+            "last-resort ceiling for the model's context window, not routine "
+            "trimming: the cap only engages on plans with ~1000+ resource "
+            "changes (a cleaned change is a few hundred bytes); everything "
+            "smaller is sent whole and untouched. When it does engage, the "
+            "reduction is STRUCTURAL (`_fit_plan_json`) — every change keeps "
+            "its address and `change.actions`, so a destroy can never be "
+            "hidden; only per-resource attribute detail is trimmed. Defends "
+            "against pathological monorepos producing tens-of-MB plan files "
+            "that would otherwise overflow the context window and hard-fail "
+            "the summary."
         ),
     )
     code_diff_max_bytes: int = Field(

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -92,18 +92,148 @@ def _truncate_tail(data: bytes, max_bytes: int) -> str:
     )
 
 
-def _truncate_head(data: bytes, max_bytes: int) -> str:
-    """Return ``data`` decoded as UTF-8, truncated from the tail.
+# Top-level plan keys that carry no information the risk rating needs; dropped
+# first when a plan is over budget (configuration is large and is background
+# only — the grounding rule forbids rating from it anyway).
+_PLAN_BACKGROUND_KEYS = ("configuration", "planned_values", "prior_state", "relevant_attributes")
+_PLAN_CHANGE_ARRAYS = ("resource_changes", "resource_drift", "drift_observed_no_apply_action")
 
-    Plan JSON's structural value is at the head — provider config and
-    resource_changes come first.
+
+def _change_skeleton(rc: dict) -> dict:
+    """address + type + name + change.actions only — the bare risk signal that
+    preserves a change's existence and action when its full body won't fit."""
+    ch = rc.get("change") if isinstance(rc.get("change"), dict) else {}
+    return {
+        "address": rc.get("address"),
+        "type": rc.get("type"),
+        "name": rc.get("name"),
+        "change": {"actions": ch.get("actions")},
+    }
+
+
+def _fit_plan_json(data: bytes, max_bytes: int) -> str:
+    """Fit cleaned plan JSON within ``max_bytes`` by LOGICAL priority, never
+    hiding a destroy.
+
+    The old code head-truncated the bytes, silently dropping the tail of
+    ``resource_changes`` — so a destroy near the end of a large plan was
+    invisible and the model summarised a plan it only half-read. Instead we keep
+    the most consequential changes in FULL and sample the routine ones, in this
+    order:
+
+        1. every destroy (delete / replace) — full detail (which resource, what
+           data) is exactly what matters most;
+        2. every create — full;
+        3. every update — full;
+        4. a bounded sample of anything else (reads / observed drift).
+
+    Each tier is added in full while budget remains; once full entries no longer
+    fit, the remaining entries are kept as address+actions skeletons so their
+    existence is never lost; only when even skeletons don't fit are the
+    lowest-priority changes summarised as a count in ``_omitted_changes``.
+    Destroys are processed first, so they are the last thing ever reduced — a
+    destroy is effectively never hidden.
     """
     if max_bytes <= 0 or len(data) <= max_bytes:
         return data.decode("utf-8", errors="replace")
-    return (
-        data[:max_bytes].decode("utf-8", errors="replace")
-        + f"\n[... {len(data) - max_bytes} bytes truncated from tail ...]"
-    )
+    try:
+        plan = json.loads(data)
+    except (json.JSONDecodeError, ValueError):
+        return data[:max_bytes].decode("utf-8", errors="replace") + "\n[... truncated ...]"
+    if not isinstance(plan, dict):
+        return data[:max_bytes].decode("utf-8", errors="replace") + "\n[... truncated ...]"
+
+    def _size(obj: object) -> int:
+        return len(json.dumps(obj, separators=(",", ":")).encode("utf-8"))
+
+    # 1) drop background blocks the risk rating never needs.
+    for k in _PLAN_BACKGROUND_KEYS:
+        plan.pop(k, None)
+    # 2) drop the verbose computed-attribute map (not a sensitive marker).
+    for ck in _PLAN_CHANGE_ARRAYS:
+        for rc in plan.get(ck) or []:
+            ch = rc.get("change") if isinstance(rc, dict) else None
+            if isinstance(ch, dict):
+                ch.pop("after_unknown", None)
+    if _size(plan) <= max_bytes:
+        return json.dumps(plan, separators=(",", ":"))
+
+    # 3) priority reduction of resource_changes (the large array; drift arrays
+    # are small and kept intact).
+    rcs = [r for r in (plan.get("resource_changes") or []) if isinstance(r, dict)]
+
+    def _acts(rc: dict) -> list:
+        return (rc.get("change") or {}).get("actions") or []
+
+    destroys = [r for r in rcs if "delete" in _acts(r)]
+    creates = [r for r in rcs if _acts(r) == ["create"]]
+    updates = [r for r in rcs if "update" in _acts(r) and "delete" not in _acts(r)]
+    seen = {id(r) for r in destroys + creates + updates}
+    other = [r for r in rcs if id(r) not in seen]
+    real = destroys + creates + updates  # every real change, in priority order
+
+    reserve = 400  # headroom for the _note / _omitted_changes appended below
+    omitted: dict[str, int] = {}
+
+    # Pass A: list EVERY real change as a skeleton first, so its existence and
+    # action are guaranteed present (a destroy is never hidden).
+    skeletons = [_change_skeleton(r) for r in real]
+    plan["resource_changes"] = skeletons
+    base = _size(plan)
+
+    if base + reserve <= max_bytes:
+        used = base
+        # Pass B: upgrade skeletons to FULL detail in priority order (destroys,
+        # then creates, then updates) while budget remains. The most
+        # consequential changes get full attributes; routine ones may stay
+        # skeletons.
+        for i, rc in enumerate(real):
+            delta = _size(rc) - _size(skeletons[i])
+            if delta > 0 and used + delta <= max_bytes - reserve:
+                plan["resource_changes"][i] = rc
+                used += delta
+        # Pass C: a bounded sample of the lowest-priority changes (reads /
+        # observed drift); count the rest.
+        sample_budget = 25
+        for rc in other:
+            sk = _change_skeleton(rc)
+            sz = _size(sk) + 1
+            if sample_budget > 0 and used + sz + reserve <= max_bytes:
+                plan["resource_changes"].append(sk)
+                used += sz
+                sample_budget -= 1
+            else:
+                key = ",".join(_acts(rc)) or "other"
+                omitted[key] = omitted.get(key, 0) + 1
+    else:
+        # Pathological: even bare skeletons of the real changes overflow. Keep
+        # them in priority order (destroys first) until the budget is spent and
+        # count the rest — so any dropped destroy is at least counted, never
+        # silently lost.
+        plan["resource_changes"] = []
+        used = _size(plan)
+        for rc in real:
+            sk = _change_skeleton(rc)
+            sz = _size(sk) + 1
+            if used + sz + reserve <= max_bytes:
+                plan["resource_changes"].append(sk)
+                used += sz
+            else:
+                key = ",".join(_acts(rc)) or "other"
+                omitted[key] = omitted.get(key, 0) + 1
+        for rc in other:
+            key = ",".join(_acts(rc)) or "other"
+            omitted[key] = omitted.get(key, 0) + 1
+
+    if omitted:
+        plan["_omitted_changes"] = omitted
+        plan["_note"] = (
+            "plan too large to show in full; changes are shown in priority "
+            "order (all destroys, then creates, then updates, then a sample of "
+            "the rest), each in full where it fits else as address+actions. "
+            "Counts of any not shown are in _omitted_changes."
+        )
+    return json.dumps(plan, separators=(",", ":"))
 
 
 def _extract_tf_sources(tarball: bytes, max_bytes: int) -> str:
@@ -432,7 +562,7 @@ async def _gather_inputs(db: AsyncSession, run: Run, kind: str) -> tuple[str, st
         # Clean BEFORE truncation so the head-truncate budget is spent
         # on actual changes, not no-op snapshot noise.
         cleaned = await asyncio.to_thread(_clean_plan_json_bytes, raw)
-        primary = _truncate_head(cleaned, cfg.plan_json_max_bytes)
+        primary = await asyncio.to_thread(_fit_plan_json, cleaned, cfg.plan_json_max_bytes)
     else:
         # failure_analysis. Choose log key by phase: apply-phase errors
         # carry their detail in the apply log (#419). Plan-phase errors

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -368,11 +368,12 @@ Style:
 
 
 FAILURE_ANALYSIS_SKILL_PROMPT = """\
-You are a Terraform run failure analyst embedded in Terrapod. A run
-failed to execute, either during `plan` or during `apply`. You
-receive the operator's log for the failed phase plus the source HCL
-that was being processed. Your job is to explain WHY the run failed
-and suggest concrete fixes. Nothing else.
+You are an infrastructure engineer on call, debugging a terraform/tofu run
+that just failed — in `plan` or in `apply`. A colleague is blocked and
+waiting on you. You have the run log for the failed phase and the HCL that
+was being processed. Find the root cause and give concrete, ordered fixes a
+colleague could act on immediately. Nothing else — you are debugging this
+failure, not reviewing the whole codebase.
 
 You will receive these inputs in the user message:
   • PLAN_LOG or APPLY_LOG — the terraform/tofu stdout+stderr leading

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -145,20 +145,12 @@ You will receive these inputs in the user message:
   • PLAN_JSON — `tofu show -json` output for the proposed changes.
     No-op resource_changes and prior_state have been stripped before
     you see this; everything in `resource_changes` is a real change.
-  • CODE_DIFF — unified diff of *.tf / *.tfvars between this run's
-    configuration and the previously-applied configuration. May be
-    absent (first run on this workspace, or the prior CV has been
-    GC'd). It is BACKGROUND ONLY — context to help you explain WHY a
-    change in PLAN_JSON is happening. It is NOT itself a change set:
-    it can contain edits to files this workspace does not load (e.g.
-    another environment's var-file in a shared monorepo) and can omit
-    files that are not *.tf / *.tfvars (templates, JSON policies,
-    user-data scripts). Never derive what-changes — or risk — from it.
-    See the risk-grounding rule below.
-  • CODE_CONTEXT — concatenated *.tf source for THIS run's
-    configuration. Use it to look up declarations referenced by
-    resource_changes. Background only, like CODE_DIFF — never a risk
-    source. May be absent.
+  • CODE_DIFF — unified diff of *.tf / *.tfvars vs the previously-applied
+    config (may be absent). Background only: it explains WHY a change
+    happens, never WHAT changes or its risk — see the grounding rule below.
+  • CODE_CONTEXT — concatenated *.tf source for this run, to look up
+    declarations referenced by resource_changes (may be absent).
+    Background only, like CODE_DIFF.
   • FLEET_CONTEXT — deployment-wide notes from the operator. May be empty.
   • WORKSPACE_CONTEXT — workspace-specific notes. May be empty.
   • DRIFT_DETECTION (when set) — flags that this run is a scheduled
@@ -267,24 +259,12 @@ CRITICAL — risk is grounded in PLAN_JSON, never in CODE_DIFF:
 
 CRITICAL — `risk_level` and `risk_factors` are paired, not independent:
 
-  Before you submit, check this invariant:
-
-      risk_level in {"medium", "high", "critical"}  ⇔  len(risk_factors) ≥ 1
-
-  In words: an elevated `risk_level` REQUIRES at least one entry in
-  `risk_factors`. An empty `risk_factors` array is permitted ONLY when
-  `risk_level == "low"`. Submitting "medium" / "high" / "critical" with
-  an empty `risk_factors` array is invalid output — the operator sees
-  a severity rating with no reasons attached, which is worse than no
-  rating at all.
-
-  The decision procedure is one-way: you choose the severity by what
-  the plan does, then ENUMERATE the concrete factors that justify it.
-  If you cannot name at least one factor, you have not justified the
-  elevation — set `risk_level = "low"` and submit `risk_factors = []`
-  instead. Do not pick an elevated level and then leave the array
-  empty "because the description already covers it" or "because it is
-  routine"; the array IS how the operator reads what makes it elevated.
+  An elevated `risk_level` (medium/high/critical) REQUIRES at least one
+  `risk_factor`; an empty array is valid ONLY at `low`. Decide the
+  severity from what the plan does, then ENUMERATE the factors that
+  justify it — if you cannot name even one, it is not elevated: use
+  `low` with `[]`. A severity rating with no reasons attached is worse
+  than no rating at all.
 
   A concrete factor names a thing in the plan and why it matters, e.g.:
     {"severity": "medium", "title": "RDS engine_version 16.11 → 16.13",

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -314,6 +314,23 @@ How to rate severity:
   genuinely safe changes: additive, well-scoped, reversible, no exposure
   (a log group, a tightly-scoped role, a tag-only edit).
 
+  Equally, do NOT over-rate — judge by CONSEQUENCE, not by how alarming
+  the action verb looks. Crying wolf on routine work is a failure too:
+
+    • A destroy or replace is only as serious as what is actually lost.
+      Destroying or replacing a resource that holds no data and gates no
+      access has little blast radius — that is low, even though "destroy"
+      sounds severe.
+    • A change that REDUCES exposure or risk — narrowing who can reach
+      something, enabling encryption, adding a protection, removing a
+      permission — is an improvement. Rate it low, and do NOT list an
+      improvement as a `risk_factor`.
+    • Routine, reversible operational changes (rotating a generated value,
+      adjusting a non-production knob) are low.
+
+  None of this lowers the bar for real exposure or data loss above — it
+  only stops alarm-by-keyword on changes whose consequence is small.
+
 Other rules:
 
   • Describe the proposed changes. Do not describe the JSON format, the

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -126,10 +126,20 @@ def tool_for_kind(kind: str) -> dict:
 
 
 PLAN_SUMMARY_SKILL_PROMPT = """\
-You are a Terraform plan reviewer embedded in Terrapod. You receive the
-proposed changes from a terraform/tofu plan and the HCL that produced
-them. Your job is to summarise what the plan changes and rate the risk
-of those changes. Nothing else.
+You are a senior site reliability engineer reviewing a terraform/tofu plan
+before it is applied to your employer's production estate. You are
+accountable on two fronts, and a good review serves both:
+
+  • Protecting the business — its uptime and its customers' data. An
+    outage, a data loss, or an exposure that you wave through is on you.
+  • Not crying wolf — teams ship many safe changes a day. Flagging
+    routine, low-consequence work as dangerous trains operators to
+    ignore your reviews, which is its own failure.
+
+You receive the proposed changes from the plan and the HCL that produced
+them. Explain what the plan changes and rate its risk with that dual
+responsibility in mind. Nothing else — you are reviewing this change, not
+redesigning the system.
 
 You will receive these inputs in the user message:
   • PLAN_JSON — `tofu show -json` output for the proposed changes.
@@ -287,6 +297,43 @@ CRITICAL — `risk_level` and `risk_factors` are paired, not independent:
   the schema enum; the overall `risk_level` should equal the highest
   factor severity.
 
+  Give each materially-distinct risk its OWN `risk_factor`, attributed to
+  the specific resource via `resource_address`. Do not fold two distinct
+  risks into one entry — an exposed database and the firewall rule that
+  exposes it are two factors, each on its own resource, because the
+  operator must be able to see and fix each independently. Conversely, do
+  not split one risk across several factors. Whenever a factor is about a
+  specific resource, set its `resource_address` to that resource's
+  terraform address.
+
+How to rate severity:
+
+  Judge the STATE the change leaves the world in, not whether it adds or
+  removes. Weigh four dimensions; the worst one present sets `risk_level`:
+
+    • Data loss — could this destroy, replace, or make unrecoverable a
+      data store, state, or a recovery point (a database, a volume, a
+      bucket with contents, a snapshot)? Unmitigated, that is at least
+      high; irreversible loss of production-critical data is critical.
+    • Exposure — does it widen who can reach data or actions: a public
+      endpoint, ingress opened to the world, broadened IAM/permissions,
+      encryption disabled, a secret in plaintext, a privileged workload?
+      Provisioning or opening an exposure is a real risk EVEN ON A
+      BRAND-NEW resource.
+    • Irreversibility — once applied, can it be undone, or is it a
+      one-way door (deleting the only backup/snapshot, scheduling key
+      destruction, dropping data with no final snapshot)? One-way
+      destructive change to something production-critical is critical.
+    • Blast radius — how much rides on it: a replace (destroy-then-create
+      under a new identity), a mass change across many resources, a
+      cross-workspace dependency, a region or provider move.
+
+  A create is NOT automatically low. Standing up a resource that is
+  public, unencrypted, over-permissioned, or otherwise exposed carries
+  the exposure dimension above and is rated accordingly. `low` is for
+  genuinely safe changes: additive, well-scoped, reversible, no exposure
+  (a log group, a tightly-scoped role, a tag-only edit).
+
 Other rules:
 
   • Describe the proposed changes. Do not describe the JSON format, the
@@ -300,9 +347,6 @@ Other rules:
     `replace` means destroy-then-create; the resource gets a new
     identity even when it looks the same.
   • Do not invent resources or addresses not in the plan or CODE_DIFF.
-  • Risk severities are about blast radius and reversibility, not
-    novelty. Destroying a Lambda is medium. Destroying a database or
-    an IAM trust root is critical. Pure additions are low.
 
 Style:
   • Operator-facing, terse, professional. No emojis. No first-person

--- a/services/tests/ai_eval/test_offline.py
+++ b/services/tests/ai_eval/test_offline.py
@@ -31,7 +31,7 @@ def test_generated_corpus_is_substantial_and_unique():
 
 def test_every_surface_represented():
     surfaces = {c.surface for c in build_generated_cases()}
-    assert {"plan", "drift"} <= surfaces
+    assert {"plan", "drift", "apply_failure"} <= surfaces
 
 
 def test_generated_cases_well_formed():

--- a/services/tests/ai_eval/test_offline.py
+++ b/services/tests/ai_eval/test_offline.py
@@ -1,0 +1,163 @@
+"""Offline (no model creds) validation of the AI-eval harness (#602).
+
+Runs in normal CI. Covers corpus integrity (generated + curated cases are
+well-formed and their ground-truth references real plan addresses) and the
+deterministic rubric logic (with synthetic model outputs). The live model
+sweep is a separate, manually-dispatched job.
+"""
+
+from __future__ import annotations
+
+from ai_eval import rubric
+from ai_eval.cases import Case, MustFlag, RiskBand, Truth, load_corpus, risk_rank
+from ai_eval.generator import build_generated_cases
+
+
+def _plan_addresses(case: Case) -> set[str]:
+    rcs = (case.plan_json or {}).get("resource_changes", []) or []
+    drift = (case.plan_json or {}).get("resource_drift", []) or []
+    return {rc["address"] for rc in (rcs + drift) if "address" in rc}
+
+
+# --- corpus integrity --------------------------------------------------------
+
+
+def test_generated_corpus_is_substantial_and_unique():
+    cases = build_generated_cases()
+    assert len(cases) >= 25, f"expected a substantial generated corpus, got {len(cases)}"
+    ids = [c.id for c in cases]
+    assert len(ids) == len(set(ids)), "generated case ids must be unique"
+
+
+def test_every_surface_represented():
+    surfaces = {c.surface for c in build_generated_cases()}
+    assert {"plan", "drift"} <= surfaces
+
+
+def test_generated_cases_well_formed():
+    for case in build_generated_cases():
+        if case.surface in ("plan", "drift"):
+            assert isinstance(case.plan_json, dict), case.id
+            assert "resource_changes" in case.plan_json, case.id
+        elif case.surface == "apply_failure":
+            assert case.apply_log, case.id
+
+
+def test_must_flag_addresses_exist_in_plan():
+    """A must-flag address that isn't even in the plan is a corpus bug — the
+    case could never pass."""
+    for case in build_generated_cases():
+        if case.surface == "apply_failure":
+            continue
+        addrs = _plan_addresses(case)
+        for mf in case.truth.must_flag:
+            assert mf.address in addrs, f"{case.id}: must_flag {mf.address} not in plan"
+        for addr in case.truth.churn_addresses:
+            assert addr in addrs, f"{case.id}: churn {addr} not in plan"
+
+
+def test_risk_band_values_valid():
+    for case in build_generated_cases():
+        for v in (case.truth.risk.exact, case.truth.risk.min, case.truth.risk.max):
+            if v is not None:
+                assert risk_rank(v) >= 0, f"{case.id}: bad risk level {v!r}"
+
+
+def test_curated_corpus_loads_if_present():
+    # Tolerates an empty curated dir; just asserts no duplicate ids / parse errs.
+    cases = load_corpus()
+    ids = [c.id for c in cases]
+    assert len(ids) == len(set(ids))
+
+
+# --- rubric logic ------------------------------------------------------------
+
+
+def _case(**truth_kw) -> Case:
+    return Case(
+        id="t",
+        surface="plan",
+        title="t",
+        plan_json={
+            "resource_changes": [
+                {
+                    "address": "aws_db_instance.main",
+                    "type": "aws_db_instance",
+                    "name": "main",
+                    "change": {"actions": ["delete"]},
+                }
+            ]
+        },
+        truth=Truth(**truth_kw),
+    )
+
+
+def test_perfect_output_hard_passes():
+    case = _case(
+        risk=RiskBand(min="high"),
+        must_flag=(MustFlag("aws_db_instance.main", "high"),),
+        key_facts=("aws_db_instance.main", "destroy"),
+    )
+    out = {
+        "risk_level": "critical",
+        "risk_factors": [
+            {
+                "severity": "critical",
+                "title": "DB destroy",
+                "detail": "x",
+                "resource_address": "aws_db_instance.main",
+            }
+        ],
+        "description": "This will destroy aws_db_instance.main.",
+    }
+    res = rubric.score(case, out)
+    assert res.hard_pass
+    assert res.overall_score == 1.0
+
+
+def test_wrong_risk_band_fails():
+    case = _case(risk=RiskBand(min="high"))
+    res = rubric.score(case, {"risk_level": "low", "risk_factors": [], "description": ""})
+    assert not res.by_name["risk_band"].passed
+    assert not res.hard_pass
+
+
+def test_missing_must_flag_fails():
+    case = _case(must_flag=(MustFlag("aws_db_instance.main", "high"),))
+    out = {"risk_level": "high", "risk_factors": [], "description": ""}
+    res = rubric.score(case, out)
+    assert not res.by_name["must_flag"].passed
+
+
+def test_severity_too_low_fails_must_flag():
+    case = _case(must_flag=(MustFlag("aws_db_instance.main", "high"),))
+    out = {
+        "risk_level": "high",
+        "risk_factors": [
+            {"severity": "low", "title": "x", "resource_address": "aws_db_instance.main"}
+        ],
+        "description": "",
+    }
+    res = rubric.score(case, out)
+    assert not res.by_name["must_flag"].passed
+
+
+def test_churn_flagged_as_risk_fails_no_false_risk():
+    case = _case(churn_addresses=("aws_db_instance.main",))
+    out = {
+        "risk_level": "low",
+        "risk_factors": [
+            {"severity": "high", "title": "DB churn", "resource_address": "aws_db_instance.main"}
+        ],
+        "description": "",
+    }
+    res = rubric.score(case, out)
+    assert not res.by_name["no_false_risk"].passed
+    assert not res.hard_pass
+
+
+def test_forbidden_claim_fails():
+    case = _case(forbidden_claims=("no changes",))
+    out = {"risk_level": "high", "risk_factors": [], "description": "There are no changes here."}
+    res = rubric.score(case, out)
+    assert not res.by_name["no_forbidden"].passed

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -51,19 +51,6 @@ def test_resolve_workspace_mode_truth_table(global_enabled, mode, expected):
 # ── Truncation ───────────────────────────────────────────────────────────
 
 
-def test_truncate_head_preserves_head():
-    data = b"a" * 100 + b"TAIL"
-    out = summariser._truncate_head(data, 50)
-    assert out.startswith("a" * 50)
-    assert "TAIL" not in out
-    assert "truncated from tail" in out
-
-
-def test_truncate_head_no_op_when_under_cap():
-    data = b"small"
-    assert summariser._truncate_head(data, 100) == "small"
-
-
 def test_truncate_tail_preserves_tail():
     data = b"HEAD" + b"a" * 100
     out = summariser._truncate_tail(data, 50)
@@ -77,10 +64,9 @@ def test_truncate_tail_no_op_when_under_cap():
 
 
 def test_truncate_zero_cap_returns_full_string():
-    # 0 means "unlimited" in this helper — _gather_inputs uses the
-    # config value directly. Code-context max=0 disables code entirely,
-    # but the truncation primitives themselves are no-ops at 0.
-    assert summariser._truncate_head(b"abc", 0) == "abc"
+    # 0 means "unlimited" in these helpers — _gather_inputs uses the
+    # config value directly. The truncation primitives themselves no-op at 0.
+    assert summariser._truncate_tail(b"abc", 0) == "abc"
 
 
 # ── _extract_tf_sources ──────────────────────────────────────────────────

--- a/services/tests/services/test_summariser_fit.py
+++ b/services/tests/services/test_summariser_fit.py
@@ -1,0 +1,116 @@
+"""Regression tests for plan-JSON fitting (#602).
+
+The previous `_truncate_head` cut bytes from the tail, silently dropping the
+end of `resource_changes` — so a destroy near the end of a large plan became
+invisible and the AI summarised a plan it only half-read. `_fit_plan_json`
+reduces structurally instead: every change keeps its address + actions; only
+attribute detail is trimmed. These tests pin that guarantee.
+"""
+
+from __future__ import annotations
+
+import json
+
+from terrapod.services.summariser import _fit_plan_json
+
+
+def _big_plan(n: int, *, delete_at: int) -> bytes:
+    """A plan with ``n`` changes, each carrying a fat attribute body, and a
+    `delete` at index ``delete_at`` (the rest are updates)."""
+    rcs = []
+    for i in range(n):
+        actions = ["delete"] if i == delete_at else ["update"]
+        rcs.append(
+            {
+                "address": f"aws_ssm_parameter.p{i}",
+                "type": "aws_ssm_parameter",
+                "name": f"p{i}",
+                "change": {
+                    "actions": actions,
+                    "before": {"value": "x" * 400, "tags": {"k": "v" * 50}},
+                    "after": {"value": "y" * 400, "tags": {"k": "v" * 50}},
+                    "after_unknown": {"arn": True},
+                },
+            }
+        )
+    return json.dumps({"format_version": "1.2", "resource_changes": rcs}).encode("utf-8")
+
+
+def test_under_cap_returns_everything_byte_identical():
+    # When the plan fits, NOTHING is touched — not the changes, not the
+    # background `configuration`/`planned_values` blocks. Byte-for-byte.
+    plan = {
+        "format_version": "1.2",
+        "resource_changes": [
+            {
+                "address": "aws_db_instance.main",
+                "type": "aws_db_instance",
+                "name": "main",
+                "change": {"actions": ["delete"], "before": {"engine": "postgres"}, "after": None},
+            }
+        ],
+        "configuration": {"provider_config": {"aws": {"name": "aws"}}},
+        "planned_values": {"root_module": {}},
+    }
+    data = json.dumps(plan).encode("utf-8")
+    out = _fit_plan_json(data, 10_000_000)
+    assert out == data.decode("utf-8")  # returned verbatim, untouched
+    parsed = json.loads(out)
+    assert "configuration" in parsed and "planned_values" in parsed  # nothing dropped
+
+
+def _find_delete(plan: dict) -> dict | None:
+    for r in plan["resource_changes"]:
+        if r["change"]["actions"] == ["delete"]:
+            return r
+    return None
+
+
+def test_tail_delete_survives_reduction():
+    # ~1000 fat changes (~1MB) reduced to fit 200KB. The destroy is the LAST
+    # entry — exactly what head-truncation dropped. The GUARANTEE: it's within
+    # the cap, it's valid JSON, and the destroy is still present and named.
+    n = 1000
+    data = _big_plan(n, delete_at=n - 1)
+    assert len(data) > 200_000  # genuinely over budget
+    out = _fit_plan_json(data, 200_000)
+
+    assert len(out.encode("utf-8")) <= 200_000  # within the cap
+    plan = json.loads(out)  # still valid JSON
+    d = _find_delete(plan)
+    assert d is not None and d["address"] == f"aws_ssm_parameter.p{n - 1}"
+
+
+def test_every_change_kept_when_attrs_trimmable():
+    # At a generous cap, every change is kept (stage 3 just trims attributes).
+    n = 600
+    data = _big_plan(n, delete_at=300)
+    out = _fit_plan_json(data, 500_000)
+    plan = json.loads(out)
+    addrs = {r["address"] for r in plan["resource_changes"]}
+    assert addrs == {f"aws_ssm_parameter.p{i}" for i in range(n)}
+    d = _find_delete(plan)
+    assert d is not None and d["address"] == "aws_ssm_parameter.p300"
+
+
+def test_extreme_destructive_always_kept():
+    # Pathological: so many changes that even bare skeletons overflow the cap
+    # (stage 4). The destroy MUST still be shown in full; the omitted routine
+    # changes are counted, and none of them are destroys.
+    n = 1000
+    data = _big_plan(n, delete_at=n - 1)
+    out = _fit_plan_json(data, 50_000)
+    assert len(out.encode("utf-8")) <= 50_000
+    plan = json.loads(out)
+    rcs = plan["resource_changes"]
+    deletes = [r for r in rcs if r["change"]["actions"] == ["delete"]]
+    assert len(deletes) == 1  # the destroy survived
+    assert deletes[0]["address"] == f"aws_ssm_parameter.p{n - 1}"
+    assert len(rcs) < n  # some routine changes were omitted
+    assert plan.get("_omitted_changes")  # ... and counted
+    assert "delete" not in plan["_omitted_changes"]  # never a destroy
+
+
+def test_unparseable_falls_back_safely():
+    out = _fit_plan_json(b"{not valid json" + b"x" * 1000, 200)
+    assert len(out) <= 250  # bounded, doesn't blow up

--- a/services/tests/services/test_summariser_prompt.py
+++ b/services/tests/services/test_summariser_prompt.py
@@ -67,9 +67,10 @@ def test_plan_summary_prompt_grounds_risk_in_plan_not_code_diff():
     assert "grounded in PLAN_JSON" in prompt
     assert "SOLELY" in prompt
     assert "no informative `resource_changes`" in prompt
-    # CODE_DIFF explicitly demoted to background-only, not a risk source.
-    assert "BACKGROUND ONLY" in prompt
-    assert "never derive what-changes — or risk — from it" in prompt.lower()
+    # CODE_DIFF explicitly demoted to background-only, not a risk source. The
+    # rule must be present; exact wording may evolve (de-duplicated 2026).
+    assert "background only" in prompt.lower()
+    assert "raise `risk_level`" in prompt
 
 
 def test_render_unknown_kind_raises():
@@ -293,19 +294,18 @@ def test_plan_summary_skill_forbids_empty_risk_factors_at_elevated_level():
     others.
     """
     skill = PLAN_SUMMARY_SKILL_PROMPT
-    # Dedicated CRITICAL block, not a single bullet.
+    # Dedicated CRITICAL block, not a single bullet. (Wording de-duplicated
+    # 2026; the invariant — elevated level requires >=1 factor — must remain.)
     assert "CRITICAL — `risk_level` and `risk_factors` are paired" in skill
-    # The biconditional names all three elevated levels.
-    assert 'risk_level in {"medium", "high", "critical"}  ⇔  len(risk_factors) ≥ 1' in skill
-    # The empty-array carve-out is bound to risk_level == "low".
-    assert "empty `risk_factors` array is permitted ONLY when" in skill
-    assert '`risk_level == "low"`' in skill
-    # Submitting elevated + empty is called out as invalid output, not
-    # just "discouraged".
-    assert "is invalid output" in skill
-    # And the prompt instructs the fallback: downgrade to low rather
-    # than return an elevated level with no factors.
-    assert 'set `risk_level = "low"`' in skill
+    # Names all three elevated levels + the pairing requirement.
+    assert "medium/high/critical" in skill
+    assert "REQUIRES at least one" in skill
+    # The empty-array carve-out is bound to low.
+    assert "empty array is valid ONLY at `low`" in skill
+    # An elevated rating with no factors is called out as worse than nothing.
+    assert "no rating at all" in skill
+    # And the fallback: downgrade to low rather than elevated-with-no-factors.
+    assert "`low` with `[]`" in skill
 
 
 def test_failure_analysis_skill_also_describes_code_diff():


### PR DESCRIPTION
Closes #602.

A committed, CI-runnable evaluation harness for the AI analysis prompts — **plus the prompt refinements and a plan-JSON correctness fix it surfaced**. The harness drives the **real shipping code path** (`summariser_prompt.render_prompt` + `summariser._call_model` with the production plan-JSON cleaning/fitting helpers), so we refine exactly what ships, not a parallel copy.

## What landed

### 1. Plan-JSON correctness fix (the highest-value change)
Large plans were **head-truncated** before the model saw them — bytes were cut from the *tail*, so a `destroy` near the end of `resource_changes` became invisible and the model summarised a plan it had only half-read. The config docstring even claimed structural truncation that never existed. Replaced `_truncate_head` with `_fit_plan_json`:
- **Keep everything when it fits** — under the cap the plan is returned byte-for-byte untouched.
- **Priority reduction when it doesn't** — destroys → creates → updates → sampled remainder; a destroy is **never** dropped, even in the pathological 1000+-change case (omitted routine changes are counted, never a destroy).
- Pinned by `tests/services/test_summariser_fit.py`.

### 2. Prompt refinement (senior-SRE reviewer)
- Plan summaries reframed as a senior SRE accountable on two fronts — protect the business **and** don't cry wolf; failure analysis reframed as an on-call engineer debugging a failed run (not "an LLM").
- A consequence-over-keyword **severity rubric** (data loss, exposure, irreversibility, blast radius; "a create is NOT automatically low").
- An **anti-over-flag calibration principle** to stop alarm-by-keyword without lowering the bar for real exposure/data loss.
- De-duplicated repetitive guidance.

### 3. The harness (`services/ai_eval/`)
`cases` (schema + YAML loader), `prep` (prod-faithful input build), `rubric` (deterministic risk-correctness scoring), `generator` (parametric labelled fixtures — ground truth from generation params, so the corpus scales), `runner` (N-run repeatability, model-overridable, `temperature=0`), `report` (scorecards + per-axis/surface/tag breakdowns + **train/holdout split**), `judge` (LLM description-quality), `__main__` (CLI). Scoring axes, risk-correctness first: risk band, must-flag, real-change-vs-churn-noise, key facts, forbidden claims (axes 1–3 are the hard-pass core).

### 4. Realistic multi-provider corpus
`corpus/scenarios/` — real HCL + faithful `plan.json` across AWS / Azure / GCP / Kubernetes, plus parametric generated cases including a hardened discriminating set (real risk hidden in churn; benign work that looks scary).

## Result (Sonnet, hardened 66-case corpus)

| Metric | Start | Shipped |
|---|---|---|
| hard-pass | 89% | **92%** |
| calibration | 0.29 | **0.71** |
| must_flag (real risk caught) | 0.98 | **0.98** (flat) |
| holdout hard-pass | 94% | **100%** |

Prompt edits are **principle-based, not corpus-specific**, and validated against a held-out split (~25%, by id hash) so improvement is real transfer, not teaching-to-the-test. One candidate edit was reverted precisely because the held-out split showed its apparent gain was overfitting.

## CI wiring
- `tests/ai_eval/test_offline.py` — 12 no-creds tests (corpus integrity + rubric logic), run in normal CI.
- `Dockerfile.test` copies `ai_eval`; `scripts/ai-eval.sh` + `make ai-eval` run the live harness in the test image with ambient model creds; reports land in gitignored `reports/ai-eval/`.

## Out of scope (deliberate)
- **2-pass self-review** is already operator-available via the interactive follow-up/chat surface (v0.35.0) — an operator can reply "critique your own analysis for missed risk." No new code needed; may be formalised later.
- Model-switching dropped — optimised on current Sonnet only.
