### PR TITLE
chore(ci): exclude services/ai_eval from code scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -26,6 +26,11 @@
 paths-ignore:
   - e2e
   - alembic/versions
+  # services/ai_eval is the AI-analysis evaluation harness + its synthetic,
+  # never-applied terraform/HCL corpus fixtures (deliberately "insecure" infra
+  # so the AI risk-analysis prompt has something to flag). Not product code,
+  # never deployed — excluded from code scanning entirely (see also .semgrepignore).
+  - services/ai_eval
 
 query-filters:
   - exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,6 +686,7 @@ jobs:
               --exclude "dist" \
               --exclude "alembic/versions" \
               --exclude "reports" \
+              --exclude "services/ai_eval" \
               --exclude-rule "python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5" \
               --exclude-rule "python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure" \
               --exclude-rule "python.flask.security.audit.directly-returned-format-string.directly-returned-format-string" \

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,8 @@
+# Paths excluded from Semgrep (CI `semgrep scan`, `make pentest-sast`, and any
+# Semgrep app integration all honour this file).
+
+# AI-analysis evaluation harness + its synthetic, never-applied terraform/HCL
+# corpus fixtures. The corpus is deliberately "insecure" infra (public SQL,
+# no TLS, public IPs, no logging) so the AI risk-analysis prompt has something
+# to flag — it is test data, never deployed, and must not raise security alerts.
+services/ai_eval/


### PR DESCRIPTION
The AI-analysis eval harness and its synthetic, **never-applied** terraform/HCL corpus fixtures were raising security alerts — the corpus is deliberately 'insecure' infra so the AI risk-analysis prompt has something to flag. It's test data, never deployed.

- `.semgrepignore` + Semgrep `--exclude services/ai_eval` (CI + `make pentest-sast`)
- CodeQL `paths-ignore: services/ai_eval`

Existing alerts triaged: the 6 Semgrep terraform alerts (#215–#220) dismissed as *used in tests*; the CodeQL empty-password alert (#214) on the eval-only embedded-DB default dismissed as a *false positive* (the chart generates a random 24-char password when the value is empty — `embedded-postgresql.yaml`).