### PR TITLE
feat(ui): clickable Health Issues indicator filters to unhealthy workspaces

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -328,6 +328,8 @@ A small set of label keys are reserved as **virtual filter fields** in the works
 | `locked` | `true`/`false` — currently locked | reserved (planned virtual) |
 | `branch` | `vcs_branch` | reserved (planned virtual) |
 
+The `status` field also accepts one **aggregate** value beyond the per-status values above: `status:unhealthy` matches any workspace with at least one active **health condition** (state diverged, no agent pool assigned, VCS polling error, drift detected, or drift-detection errored). It is the roll-up behind the **Health Issues** summary card on the workspace list — clicking the card when the count is non-zero toggles this filter so you can jump straight to the affected workspaces (and click again to clear). Because it rides the already-reserved `status` field, no additional label key is reserved for it. It is deliberately broader than any single status value: a workspace awaiting confirmation shows as `needs-confirm` even when its state has diverged, and the `no_agent_pool`/`drift_errored` conditions have no standalone status value at all — `status:unhealthy` catches all of them.
+
 The set is intentionally aggressive: reserving a key today is near-zero cost (no virtual implementation required), but adding a reservation later — once the key is in customer use as a literal label — is a migration.
 
 If you have an existing label with one of the reserved keys, reads and existing rows continue to work, but the next create or update of that resource that includes the reserved key in its `labels` field will be rejected with a 422 that names the offending key. Migrate by renaming — for example, swap `version: 1.11` for `tf-version: 1.11` (or drop it if the same data is already on `terraform_version`).

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -166,6 +166,7 @@ export async function setRoleAssignments(
 export async function createWorkspace(
   token: string,
   name: string,
+  attrs: Record<string, unknown> = {},
 ): Promise<string> {
   const res = await fetch(
     `${API_URL}/api/v2/organizations/default/workspaces`,
@@ -178,7 +179,7 @@ export async function createWorkspace(
       body: JSON.stringify({
         data: {
           type: 'workspaces',
-          attributes: { name },
+          attributes: { name, ...attrs },
         },
       }),
     },

--- a/e2e/tests/workspaces.spec.ts
+++ b/e2e/tests/workspaces.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api';
 
 test.describe('Workspaces', () => {
   test('workspace list page loads', async ({ page }) => {
@@ -251,5 +252,51 @@ test.describe('Workspaces', () => {
     await expect(page.locator('button:has-text("Edit")')).toBeVisible({ timeout: 10_000 });
     await page.reload();
     await expect(page.locator(`code:has-text("${rule}")`)).not.toBeVisible();
+  });
+
+  test('Health Issues indicator filters the list to unhealthy workspaces', async ({
+    page,
+  }) => {
+    // Create two workspaces via the API so the test is deterministic and
+    // self-isolated (uniquely-named, no reliance on other specs):
+    //   - healthy: default local mode → no health conditions
+    //   - unhealthy: agent mode with no pool → a `no_agent_pool` health
+    //     condition, which `_compute_health_conditions` flags. This is the
+    //     simplest condition to provoke without running anything.
+    const token = getStoredToken();
+    const healthyName = uniqueName('e2e-health-ok');
+    const unhealthyName = uniqueName('e2e-health-bad');
+    await createWorkspace(token, healthyName);
+    await createWorkspace(token, unhealthyName, { 'execution-mode': 'agent' });
+
+    await page.goto('/workspaces');
+    await expect(page.locator('h1:has-text("Workspaces")')).toBeVisible();
+
+    // Both of MY workspaces are present before filtering. (Never assert global
+    // counts/positions — other workers mutate the same org concurrently.)
+    const healthyRow = page.getByRole('link', { name: healthyName });
+    const unhealthyRow = page.getByRole('link', { name: unhealthyName });
+    await expect(unhealthyRow).toBeVisible({ timeout: 10_000 });
+    await expect(healthyRow).toBeVisible();
+
+    // The Health Issues card is a toggle button whenever the count is > 0
+    // (which my unhealthy workspace guarantees). Clicking it applies the
+    // aggregate `status:unhealthy` filter.
+    const healthBtn = page.getByRole('button', { name: /health issues/i });
+    await expect(healthBtn).toBeVisible();
+    await healthBtn.click();
+
+    // Filter now active: the term is in the box, my unhealthy ws stays, my
+    // healthy ws is filtered out. (Assert on MY named resources, not counts —
+    // the unhealthy view also contains other workers' unhealthy workspaces.)
+    await expect(page.locator('input[aria-label="Filter workspaces"]')).toHaveValue(
+      /status:unhealthy/,
+    );
+    await expect(unhealthyRow).toBeVisible();
+    await expect(healthyRow).toBeHidden();
+
+    // Toggling the badge again clears the filter — my healthy ws returns.
+    await healthBtn.click();
+    await expect(healthyRow).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -17,6 +17,7 @@ import { useWorkspaceListEvents } from '@/lib/use-workspace-list-events'
 import {
   hasLabelTerm,
   hasStatusTerm,
+  HEALTH_ISSUE_STATUS,
   matchWorkspace,
   parseFilterQuery,
   removeTerm,
@@ -285,6 +286,10 @@ function WorkspacesPageInner() {
     if (!tok) return []
     const lower = tok.toLowerCase()
     const out: FilterSuggestion[] = []
+    // Aggregate health-issues count for the `status:unhealthy` suggestion.
+    const unhealthyCount = workspaces.filter(
+      ws => (ws.attributes['health-conditions'] || []).length > 0,
+    ).length
     const sepIdx = tok.search(/[:=]/)
     if (sepIdx >= 0) {
       // `key:partial` → suggest values for that key.
@@ -295,6 +300,8 @@ function WorkspacesPageInner() {
           if (!partial || s.filter.toLowerCase().includes(partial) || s.label.toLowerCase().includes(partial))
             out.push({ kind: 'status', insert: `status:${s.filter}`, display: `status:${s.filter}`, hint: 'status', dot: s.dot, count: statusCounts[s.filter] || 0 })
         }
+        if (unhealthyCount > 0 && (!partial || HEALTH_ISSUE_STATUS.includes(partial) || 'health issues'.includes(partial)))
+          out.push({ kind: 'status', insert: `status:${HEALTH_ISSUE_STATUS}`, display: `status:${HEALTH_ISSUE_STATUS}`, hint: 'health', dot: 'bg-red-400', count: unhealthyCount })
       } else {
         const values = labelIndex.get(key)
         if (values) {
@@ -320,6 +327,8 @@ function WorkspacesPageInner() {
         if (s.filter.toLowerCase().includes(lower) || s.label.toLowerCase().includes(lower))
           out.push({ kind: 'status', insert: `status:${s.filter}`, display: `status:${s.filter}`, hint: 'status', dot: s.dot, count: statusCounts[s.filter] || 0 })
       }
+      if (unhealthyCount > 0 && (HEALTH_ISSUE_STATUS.includes(lower) || 'health'.includes(lower) || 'issues'.includes(lower)))
+        out.push({ kind: 'status', insert: `status:${HEALTH_ISSUE_STATUS}`, display: `status:${HEALTH_ISSUE_STATUS}`, hint: 'health', dot: 'bg-red-400', count: unhealthyCount })
       for (const ws of workspaces) {
         const n = ws.attributes.name
         if (n.toLowerCase().includes(lower))
@@ -702,16 +711,41 @@ function WorkspacesPageInner() {
           const total = workspaces.length
           const withConditions = workspaces.filter(ws => (ws.attributes['health-conditions'] || []).length > 0).length
           const locked = workspaces.filter(ws => ws.attributes.locked).length
+          const healthFilterActive = hasStatusTerm(parsedFilter, HEALTH_ISSUE_STATUS)
           return (
             <div className="grid grid-cols-3 gap-4 mb-6">
               <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
                 <p className="text-xs text-slate-500 uppercase tracking-wider">Total</p>
                 <p className="text-2xl font-semibold text-slate-100 mt-1">{total}</p>
               </div>
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
-                <p className="text-xs text-slate-500 uppercase tracking-wider">Health Issues</p>
-                <p className={`text-2xl font-semibold mt-1 ${withConditions > 0 ? 'text-red-400' : 'text-slate-100'}`}>{withConditions}</p>
-              </div>
+              {/* Clicking a non-zero Health Issues count toggles the
+                  `status:unhealthy` filter so the operator can jump straight to
+                  the affected workspaces (and click again to clear). When the
+                  count is zero there's nothing to filter to, so it stays a
+                  plain card. */}
+              {withConditions > 0 ? (
+                <button
+                  type="button"
+                  aria-pressed={healthFilterActive}
+                  aria-label={healthFilterActive ? 'Clear health issues filter' : 'Filter to workspaces with health issues'}
+                  title={healthFilterActive ? 'Clear health issues filter' : 'Filter to workspaces with health issues'}
+                  onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, HEALTH_ISSUE_STATUS)))}
+                  className={
+                    'text-left rounded-lg border p-4 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 ' +
+                    (healthFilterActive
+                      ? 'bg-red-500/10 border-red-500/50'
+                      : 'bg-slate-800/50 border-slate-700/50 hover:bg-slate-700/40 hover:border-slate-600')
+                  }
+                >
+                  <p className="text-xs text-slate-500 uppercase tracking-wider">Health Issues</p>
+                  <p className="text-2xl font-semibold mt-1 text-red-400">{withConditions}</p>
+                </button>
+              ) : (
+                <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
+                  <p className="text-xs text-slate-500 uppercase tracking-wider">Health Issues</p>
+                  <p className="text-2xl font-semibold mt-1 text-slate-100">{withConditions}</p>
+                </div>
+              )}
               <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
                 <p className="text-xs text-slate-500 uppercase tracking-wider">Locked</p>
                 <p className={`text-2xl font-semibold mt-1 ${locked > 0 ? 'text-amber-400' : 'text-slate-100'}`}>{locked}</p>
@@ -721,7 +755,13 @@ function WorkspacesPageInner() {
         })()}
 
         {!loading && workspaces.length > 0 && (() => {
-          const activeStatusCount = parsedFilter.terms.filter(t => t.kind === 'status').length
+          // The aggregate `unhealthy` term is driven by the Health Issues card
+          // + its filter chip, not the Status dropdown, so it doesn't count
+          // toward the dropdown's active badge (which would otherwise show a
+          // count with no matching checked row inside).
+          const activeStatusCount = parsedFilter.terms.filter(
+            t => t.kind === 'status' && t.value !== HEALTH_ISSUE_STATUS,
+          ).length
           return (
             <div className="mb-4">
               <div className="flex items-center gap-2">

--- a/web/src/lib/workspace-filter.ts
+++ b/web/src/lib/workspace-filter.ts
@@ -19,6 +19,20 @@
 // the labels in `resolveStatus` on the workspaces page (see STATUS_FILTER
 // constants below).
 //
+// One `status:` value is an aggregate rather than a single resolved status:
+// `status:unhealthy` (`HEALTH_ISSUE_STATUS`) matches any workspace with at
+// least one entry in its server-computed `health-conditions` array. It rides
+// the already-reserved `status` facet deliberately — so no NEW reserved label
+// key has to be introduced (which would risk trapping operators who already
+// use a real label like `health:` — see the reserved-key chokepoint in
+// `label_validation.py`). It is the roll-up of every health condition
+// (state-diverged, no-agent-pool, vcs-error, drifted, drift-errored), which is
+// strictly broader than any single `status:` value — e.g. a `needs-confirm`
+// run hides an underlying `state_diverged` from the resolved status, and
+// `no_agent_pool` / `drift_errored` have no resolved-status value at all. It
+// is matched on the same `health-conditions` array the "Health Issues"
+// indicator counts, so the filter can never drift from that indicator.
+//
 // `status` (and the other reserved keys — see `RESERVED_LABEL_KEYS` in
 // `services/terrapod/services/label_validation.py`) cannot be used as
 // literal label keys: the API rejects them at create/update time so the
@@ -43,6 +57,11 @@ export interface StatusTerm {
   kind: 'status'
   value: string
 }
+
+/** The aggregate `status:` value matching any workspace with ≥1 health
+ *  condition. Not a real resolved-status value — matched specially in
+ *  `matchWorkspace` against the `health-conditions` array. */
+export const HEALTH_ISSUE_STATUS = 'unhealthy'
 
 export type FilterTerm = NameTerm | LabelTerm | StatusTerm
 
@@ -132,6 +151,9 @@ export interface MatchableWorkspace {
   attributes: {
     name: string
     labels?: Record<string, string> | null
+    // Server-computed health conditions (see `_compute_health_conditions`).
+    // Only consulted by the `status:unhealthy` aggregate term; safe to omit.
+    'health-conditions'?: unknown[] | null
   }
 }
 
@@ -153,7 +175,14 @@ export function matchWorkspace(
     if (term.kind === 'name') {
       if (!name.includes(term.value.toLowerCase())) return false
     } else if (term.kind === 'status') {
-      if (resolvedStatus !== term.value) return false
+      if (term.value === HEALTH_ISSUE_STATUS) {
+        // Aggregate: any active health condition, independent of the single
+        // resolved status (which can mask underlying conditions, e.g.
+        // needs-confirm over state_diverged).
+        if ((ws.attributes['health-conditions'] || []).length === 0) return false
+      } else if (resolvedStatus !== term.value) {
+        return false
+      }
     } else if (term.value === null) {
       if (!Object.prototype.hasOwnProperty.call(labels, term.key)) return false
     } else if (labels[term.key] !== term.value) {


### PR DESCRIPTION
## What

The non-zero **Health Issues** summary card on `/workspaces` is now a toggle button. Clicking it applies a `status:unhealthy` filter so operators can jump straight to the affected workspaces; clicking again clears it. The term is URL-synced (`?q=status:unhealthy`) and shows as a removable chip, exactly like the other filter terms. It's also surfaced in the filter autocomplete.

## Why this shape (no new reserved key)

A `health:issues`-style term would collide with any real label whose key is `health`, and reserving `health` after the fact would trap operators who already use it as a label (the #316 reserved-key chokepoint) — requiring a data migration. Instead this rides the **already-reserved `status` facet** as an aggregate value:

- **No new reserved label key, no migration, no breaking change.**
- `status:unhealthy` matches any workspace with >=1 entry in its server-computed `health-conditions` array (`state_diverged`, `no_agent_pool`, `vcs_error`, `drifted`, `drift_errored`).
- It is deliberately **broader** than any single resolved status — a `needs-confirm` run masks an underlying `state_diverged`, and `no_agent_pool`/`drift_errored` have no standalone status value at all. Matched on the *same* `health-conditions` array the indicator counts, so the filter and the badge can never diverge.

## Verification

- `tsc --noEmit`, `eslint` (0 errors), and `next build` all green.
- New E2E spec in `e2e/tests/workspaces.spec.ts`: creates a healthy + an unhealthy (agent-mode, no-pool -> `no_agent_pool`) workspace, clicks the badge, asserts the unhealthy one stays / healthy one is filtered out / URL carries the term, then toggles off.
- **Live Tilt smoke** (browser): badge renders as a button at count > 0, click -> `?q=status:unhealthy` with the healthy ws hidden and the unhealthy ws shown + `aria-pressed=true` + chip present; click again -> filter cleared, both visible.

Docs: `docs/rbac.md` reserved-keys section documents the `status:unhealthy` aggregate.

Closes #614