### PR TITLE
feat(cache): operator-overridable version-index sources for binary cache (#606 part 1)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | **Drift Detection** | Scheduled plan-only runs to detect out-of-band infrastructure changes |
 | **Workspace Health** | Per-workspace health conditions with status indicators on workspace list |
 | **Cloud Credentials** | Dynamic provider credentials via Kubernetes workload identity (AWS IRSA, GCP WIF, Azure WI) |
-| **Binary Caching** | Pull-through cache for terraform/tofu/terragrunt CLI binaries |
+| **Binary Caching** | Pull-through cache for terraform/tofu/terragrunt CLI binaries; download base + version-index sources are operator-overridable to an internal mirror (restricted-network / air-gapped) and honour the forward proxy/CA |
 | **Supply-chain Verification** | Cached binaries + provider archives verified against the publisher's GPG-signed SHA256SUMS with pinned keys; the runner re-verifies the executable (visible in the run log) before running it |
 | **Terragrunt** | Per-workspace Terragrunt for agent-mode runs (flag + version, pull-through binary cache, local-backend reconciliation); CLI-driven runs work with zero config |
 | **Workspace Autodiscovery** | Atlantis-style monorepo autodiscovery with rule templating; safe-by-default rename/delete/orphan lifecycle (opt-in destroy) |

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -666,8 +666,48 @@ api:
         enabled: true
         terraform_mirror_url: "https://releases.hashicorp.com/terraform"
         tofu_mirror_url: "https://github.com/opentofu/opentofu/releases/download"
+        terragrunt_mirror_url: "https://github.com/gruntwork-io/terragrunt/releases/download"
         allow_prerelease: none    # none | rc | beta | alpha | dev
 ```
+
+### Pointing the cache at an internal mirror (restricted-network / air-gapped)
+
+Every upstream the binary cache reaches is operator-overridable, so a deployment with no direct egress to `releases.hashicorp.com` / GitHub / `get.opentofu.org` can pull from an internal artifact repository (Artifactory, Nexus, an internal HTTP mirror) instead. There are **two distinct sources per tool**, and an internal-mirror deployment must override **both**:
+
+1. **Download base** (`*_mirror_url`) — where the per-platform binary is fetched.
+2. **Version index** (`*_version_index_url`) — the endpoint the cache reads to **list** versions and to resolve a partial version (e.g. `terraform_version = "1.12"` → `1.12.3`). Upstream these live on different hosts from the download base, which is why they are separate keys.
+
+```yaml
+api:
+  config:
+    registry:
+      binary_cache:
+        # Download bases
+        terraform_mirror_url:  "https://artifacts.internal/terraform"
+        tofu_mirror_url:       "https://artifacts.internal/opentofu/releases/download"
+        terragrunt_mirror_url: "https://artifacts.internal/terragrunt/releases/download"
+        # Version-index sources
+        terraform_version_index_url:  "https://artifacts.internal/terraform/index.json"
+        tofu_version_index_url:       "https://artifacts.internal/opentofu/api.json"
+        terragrunt_version_index_url: "https://artifacts.internal/terragrunt/releases"
+```
+
+A mirror **must serve the same response shape** as the upstream it replaces, because the cache parses the upstream JSON format:
+
+| Source | Expected response shape |
+|---|---|
+| `terraform_version_index_url` | HashiCorp releases index JSON: `{"versions": {"1.12.3": {...}, ...}}` |
+| `tofu_version_index_url` | OpenTofu index JSON: `{"versions": [{"id": "1.12.3"}, ...]}` (ids carry no leading `v`) |
+| `terragrunt_version_index_url` | GitHub releases array: `[{"tag_name": "v0.58.0", "prerelease": false}, ...]` |
+| `terraform_mirror_url` | `…/{version}/terraform_{version}_{os}_{arch}.zip` |
+| `tofu_mirror_url` | `…/v{version}/tofu_{version}_{os}_{arch}.zip` |
+| `terragrunt_mirror_url` | `…/v{version}/terragrunt_{os}_{arch}` (a bare binary, not an archive) |
+
+The provider network mirror has the equivalent override: `registry.provider_cache.upstream_registries` (see [Provider Caching](#provider-caching-network-mirror) above) — point it at an internal provider registry that implements the provider network-mirror protocol.
+
+All of these fetches go through the [forward proxy and custom CA](deployment-proxy.md) when configured (the API's HTTP client honours `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` / the mounted CA bundle), so an internal mirror reached only via a corporate egress proxy works without further changes. Integrity verification ([supply-chain verification](supply-chain-verification.md)) still applies to mirror-served artifacts — if the mirror re-signs binaries with its own key, supply the key via `binary_cache.signing_keys`.
+
+> A fully sealed, **no-egress** deployment (cache-miss must never reach upstream at all) plus declarative cache pre-population is tracked as the later parts of air-gapped support (#606). This section covers pointing the pull-through caches at internal sources; the caches still fall through to those configured sources on a miss.
 
 ### Pre-release versions (`allow_prerelease`)
 

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -190,6 +190,12 @@ data:
             arch: {{ .arch | quote }}
           {{- end }}
         {{- end }}
+        {{- if .Values.api.config.registry.provider_cache.verify }}
+        verify: {{ .Values.api.config.registry.provider_cache.verify | quote }}
+        {{- end }}
+        {{- if hasKey .Values.api.config.registry.provider_cache "allow_unsigned" }}
+        allow_unsigned: {{ .Values.api.config.registry.provider_cache.allow_unsigned }}
+        {{- end }}
       {{- end }}
       {{- if .Values.api.config.registry.binary_cache }}
       binary_cache:
@@ -200,8 +206,27 @@ data:
         {{- if .Values.api.config.registry.binary_cache.tofu_mirror_url }}
         tofu_mirror_url: {{ .Values.api.config.registry.binary_cache.tofu_mirror_url | quote }}
         {{- end }}
+        {{- if .Values.api.config.registry.binary_cache.terragrunt_mirror_url }}
+        terragrunt_mirror_url: {{ .Values.api.config.registry.binary_cache.terragrunt_mirror_url | quote }}
+        {{- end }}
+        {{- if .Values.api.config.registry.binary_cache.terraform_version_index_url }}
+        terraform_version_index_url: {{ .Values.api.config.registry.binary_cache.terraform_version_index_url | quote }}
+        {{- end }}
+        {{- if .Values.api.config.registry.binary_cache.tofu_version_index_url }}
+        tofu_version_index_url: {{ .Values.api.config.registry.binary_cache.tofu_version_index_url | quote }}
+        {{- end }}
+        {{- if .Values.api.config.registry.binary_cache.terragrunt_version_index_url }}
+        terragrunt_version_index_url: {{ .Values.api.config.registry.binary_cache.terragrunt_version_index_url | quote }}
+        {{- end }}
         {{- if .Values.api.config.registry.binary_cache.allow_prerelease }}
         allow_prerelease: {{ .Values.api.config.registry.binary_cache.allow_prerelease | quote }}
+        {{- end }}
+        {{- if .Values.api.config.registry.binary_cache.verify }}
+        verify: {{ .Values.api.config.registry.binary_cache.verify | quote }}
+        {{- end }}
+        {{- if .Values.api.config.registry.binary_cache.signing_keys }}
+        signing_keys:
+          {{- toYaml .Values.api.config.registry.binary_cache.signing_keys | nindent 10 }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -687,6 +687,9 @@
                 "terraform_mirror_url": { "type": "string" },
                 "tofu_mirror_url": { "type": "string" },
                 "terragrunt_mirror_url": { "type": "string" },
+                "terraform_version_index_url": { "type": "string" },
+                "tofu_version_index_url": { "type": "string" },
+                "terragrunt_version_index_url": { "type": "string" },
                 "allow_prerelease": {
                   "type": "string",
                   "enum": ["none", "rc", "beta", "alpha", "dev"]

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -288,6 +288,19 @@ api:
         # Upstream download base for terragrunt binaries (bare per-platform
         # binary, not a zip). Only used by workspaces with terragrunt enabled.
         terragrunt_mirror_url: "https://github.com/gruntwork-io/terragrunt/releases/download"
+        # Version-index sources — separate from the *_mirror_url download bases
+        # above. These are the endpoints the cache reads to LIST versions and to
+        # resolve a partial version (e.g. "1.12" -> "1.12.3"). Upstream they live
+        # on different hosts from the download base, so an internal-mirror /
+        # air-gapped deployment must override BOTH the download base AND the
+        # version index for each tool. A mirror MUST serve the same response
+        # shape as the upstream it replaces:
+        #   - terraform: HashiCorp index JSON  {"versions": {"1.12.3": {...}}}
+        #   - tofu:      OpenTofu index JSON    {"versions": [{"id": "1.12.3"}]}
+        #   - terragrunt: GitHub releases array [{"tag_name": "v0.58.0", ...}]
+        terraform_version_index_url: "https://releases.hashicorp.com/terraform/index.json"
+        tofu_version_index_url: "https://get.opentofu.org/tofu/api.json"
+        terragrunt_version_index_url: "https://api.github.com/repos/gruntwork-io/terragrunt/releases"
         # Lowest pre-release tier to accept for terraform/tofu CLI version
         # resolution + caching. One of: none, rc, beta, alpha, dev.
         # 'none' (default) permits only GA releases. 'rc' allows release

--- a/llms.txt
+++ b/llms.txt
@@ -53,7 +53,7 @@ Build/lint/test all run in Docker via `make` (`make test`, `make lint`, `make de
 - [RBAC](docs/rbac.md): label-based roles, hierarchical workspace permissions (read/plan/write/admin); no teams.
 - [Authentication](docs/authentication.md): local, OIDC, SAML, `terraform login`, API tokens, scoped service tokens.
 - [Cloud Credentials](docs/cloud-credentials.md): zero static cloud credentials — runs and the platform use K8s workload identity (AWS IRSA, GCP WIF, Azure WI), plus passwordless **database** and **Redis/Valkey** IAM auth.
-- [Private Module & Provider Registry](docs/registry.md) and [Registry Publishing](docs/registry-publishing.md): GPG-signed registry, provider network-mirror + binary caching, `terrapod-publish` CLI.
+- [Private Module & Provider Registry](docs/registry.md) and [Registry Publishing](docs/registry-publishing.md): GPG-signed registry, provider network-mirror + binary caching (every upstream — terraform/tofu/terragrunt download base AND version index, plus the provider registry — is operator-overridable to an internal mirror for restricted-network deployments, and honours the forward proxy/CA), `terrapod-publish` CLI.
 - [Service Catalog](docs/service-catalog.md): no-code self-service provisioning over the module registry.
 - [Drift Detection](docs/drift-detection.md) and [Drift Ignore Rules](docs/drift-ignore-rules.md): scheduled plan-only drift checks with a per-workspace noise allowlist.
 - [Run Triggers](docs/run-triggers.md): cross-workspace dependency chains.

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -474,6 +474,37 @@ class BinaryCacheConfig(BaseModel):
         "not a zip/tarball — the pull-through cache stores it as-is. Only used by "
         "workspaces with terragrunt enabled.",
     )
+    # --- Version-index (listing / partial-version resolution) sources ---
+    # The *_mirror_url fields above are the per-binary download bases. These are
+    # the separate endpoints the cache reads to LIST available versions and to
+    # resolve a partial version (e.g. "1.12" -> "1.12.3"). Upstream they live on
+    # different hosts from the download base (terraform's index is on
+    # releases.hashicorp.com, tofu's on get.opentofu.org, terragrunt's on the
+    # GitHub API), so an internal-mirror / air-gapped deployment must override
+    # BOTH the download base and the version-index source for each tool. A mirror
+    # MUST serve the same response shape as the upstream it replaces (documented
+    # per field below), since the cache parses the upstream JSON format.
+    terraform_version_index_url: str = Field(
+        default="https://releases.hashicorp.com/terraform/index.json",
+        description="Version-index source for terraform. Must return the HashiCorp "
+        "releases index JSON shape: a top-level object with a `versions` map keyed "
+        'by version string (e.g. {"versions": {"1.12.3": {...}}}). Used for '
+        "version listing and partial-version resolution.",
+    )
+    tofu_version_index_url: str = Field(
+        default="https://get.opentofu.org/tofu/api.json",
+        description="Version-index source for tofu. Must return the OpenTofu index "
+        'JSON shape: {"versions": [{"id": "1.12.3"}, ...]} with ids carrying no '
+        "leading 'v'. (Distinct from tofu_mirror_url, which is the GitHub releases "
+        "download base.) Used for version listing and partial-version resolution.",
+    )
+    terragrunt_version_index_url: str = Field(
+        default="https://api.github.com/repos/gruntwork-io/terragrunt/releases",
+        description="Version-index source for terragrunt. Must return the GitHub "
+        "releases API shape: a JSON array of objects with `tag_name` (e.g. "
+        '"v0.58.0") and `prerelease`. Used for version listing and '
+        "partial-version resolution.",
+    )
     allow_prerelease: Literal["none", "rc", "beta", "alpha", "dev"] = Field(
         default="none",
         description="Lowest pre-release tier to accept for terraform/tofu/terragrunt CLI version "

--- a/services/terrapod/services/binary_cache_service.py
+++ b/services/terrapod/services/binary_cache_service.py
@@ -379,15 +379,18 @@ async def list_available_versions(tool: str) -> list[str]:
 
 
 async def _fetch_terraform_versions() -> list[str]:
-    """Fetch terraform versions from releases.hashicorp.com.
+    """Fetch terraform versions from the configured terraform version index
+    (default releases.hashicorp.com; overridable via
+    `binary_cache.terraform_version_index_url` for internal mirrors).
 
     Filters by the configured allow_prerelease policy: stable-only by default,
     or includes rc/beta/alpha/dev tiers down to the configured floor.
     """
-    url = "https://releases.hashicorp.com/terraform/index.json"
+    url = settings.registry.binary_cache.terraform_version_index_url
     async with httpx.AsyncClient(timeout=30.0) as client:
         # Upstream GET — idempotent by method; retried on flaky-upstream
         # transient failures (connection errors, read-timeouts, 5xx).
+        # trust_env (httpx default) routes via the configured proxy/CA (#592).
         resp = await arequest_with_retry(client, "GET", url)
         resp.raise_for_status()
         data = resp.json()
@@ -403,21 +406,25 @@ async def _fetch_terraform_versions() -> list[str]:
     return versions
 
 
-# Official OpenTofu version index — the same one OpenTofu's own installer uses.
-# We resolve tofu versions from here instead of the GitHub releases API, which is
-# rate-limited (60 req/hr unauthenticated) and routinely 504s from CI/cloud IPs.
-# When that listing failed, the binary cache could not resolve a partial version
-# (e.g. "1.12") and 502'd the runner, which then dead-ended because it had no
-# fully-qualified version to fall back on (#338). This CDN-backed static JSON is
-# not rate-limited. Version ids carry NO leading "v" and include pre-releases as
+# Official OpenTofu version index (the default for tofu_version_index_url) — the
+# same one OpenTofu's own installer uses. We resolve tofu versions from here
+# instead of the GitHub releases API, which is rate-limited (60 req/hr
+# unauthenticated) and routinely 504s from CI/cloud IPs. When that listing
+# failed, the binary cache could not resolve a partial version (e.g. "1.12") and
+# 502'd the runner, which then dead-ended because it had no fully-qualified
+# version to fall back on (#338). This CDN-backed static JSON is not
+# rate-limited. Version ids carry NO leading "v" and include pre-releases as
 # "x.y.z-suffix", so the allow_prerelease policy still applies on the string.
-_TOFU_VERSION_INDEX_URL = "https://get.opentofu.org/tofu/api.json"
+# Operators can override the source via `binary_cache.tofu_version_index_url`
+# (an internal mirror must serve the same `{"versions": [{"id": ...}]}` shape).
 
 
 async def _fetch_tofu_version_ids() -> list[str]:
-    """Return every OpenTofu release version id from the official index."""
+    """Return every OpenTofu release version id from the configured index."""
+    url = settings.registry.binary_cache.tofu_version_index_url
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await arequest_with_retry(client, "GET", _TOFU_VERSION_INDEX_URL)
+        # trust_env (httpx default) routes via the configured proxy/CA (#592).
+        resp = await arequest_with_retry(client, "GET", url)
         resp.raise_for_status()
         data = resp.json()
     return [v["id"] for v in data.get("versions", []) if v.get("id")]
@@ -442,8 +449,9 @@ async def _fetch_terragrunt_versions() -> list[str]:
     Same shape as `_fetch_tofu_versions`: GitHub's `prerelease` flag plus the
     configured allow_prerelease policy gate which versions are offered.
     """
-    url = "https://api.github.com/repos/gruntwork-io/terragrunt/releases"
+    url = settings.registry.binary_cache.terragrunt_version_index_url
     async with httpx.AsyncClient(timeout=30.0) as client:
+        # trust_env (httpx default) routes via the configured proxy/CA (#592).
         resp = await arequest_with_retry(client, "GET", url, params={"per_page": 100})
         resp.raise_for_status()
         releases = resp.json()
@@ -528,16 +536,18 @@ async def resolve_version(tool: str, partial_version: str) -> str:
 
 
 async def _resolve_terraform_version(partial: str) -> str:
-    """Resolve partial terraform version via releases.hashicorp.com index.
+    """Resolve partial terraform version via the configured terraform version
+    index (default releases.hashicorp.com; see terraform_version_index_url).
 
     Honors the allow_prerelease policy: pre-release versions are only
     considered when explicitly permitted.
     """
-    url = "https://releases.hashicorp.com/terraform/index.json"
+    url = settings.registry.binary_cache.terraform_version_index_url
     prefix = f"{partial}."
     policy = settings.registry.binary_cache.allow_prerelease
 
     async with httpx.AsyncClient(timeout=30.0) as client:
+        # trust_env (httpx default) routes via the configured proxy/CA (#592).
         resp = await arequest_with_retry(client, "GET", url)
         resp.raise_for_status()
         data = resp.json()
@@ -590,11 +600,12 @@ async def _resolve_terragrunt_version(partial: str) -> str:
 
     Mirrors `_resolve_tofu_version`; honors the allow_prerelease policy.
     """
-    url = "https://api.github.com/repos/gruntwork-io/terragrunt/releases"
+    url = settings.registry.binary_cache.terragrunt_version_index_url
     prefix = f"v{partial}."
     policy = settings.registry.binary_cache.allow_prerelease
 
     async with httpx.AsyncClient(timeout=30.0) as client:
+        # trust_env (httpx default) routes via the configured proxy/CA (#592).
         resp = await arequest_with_retry(client, "GET", url, params={"per_page": 100})
         resp.raise_for_status()
         releases = resp.json()

--- a/services/tests/services/test_binary_cache_service.py
+++ b/services/tests/services/test_binary_cache_service.py
@@ -297,10 +297,7 @@ class TestTofuVersionResolution:
 
     @patch("terrapod.services.binary_cache_service.arequest_with_retry", new_callable=AsyncMock)
     async def test_fetch_ids_parses_official_index(self, mock_req: AsyncMock) -> None:
-        from terrapod.services.binary_cache_service import (
-            _TOFU_VERSION_INDEX_URL,
-            _fetch_tofu_version_ids,
-        )
+        from terrapod.services.binary_cache_service import _fetch_tofu_version_ids
 
         resp = MagicMock()
         resp.raise_for_status = MagicMock()
@@ -312,9 +309,11 @@ class TestTofuVersionResolution:
         ids = await _fetch_tofu_version_ids()
 
         assert ids == ["1.12.3", "1.12.0-rc1", "1.11.11"]
-        # Must hit the official index, NOT api.github.com.
+        # Defaults to the official OpenTofu index, NOT the rate-limited GitHub
+        # releases API (#338). The source is now operator-overridable via
+        # tofu_version_index_url (#606); unset, it resolves to this default.
         called_url = mock_req.call_args[0][2]
-        assert called_url == _TOFU_VERSION_INDEX_URL
+        assert called_url == "https://get.opentofu.org/tofu/api.json"
         assert "api.github.com" not in called_url
 
     @patch("terrapod.services.binary_cache_service.settings")
@@ -362,3 +361,107 @@ class TestTofuVersionResolution:
         mock_ids.return_value = ["1.13.0-rc1", "1.13.0-rc2"]
 
         assert await _resolve_tofu_version("1.13") == "1.13.0-rc2"
+
+
+class TestConfigurableVersionIndex:
+    """#606 part 1: every version-index / listing source is operator-overridable
+    to an internal mirror (air-gap / egress-restricted), not hardcoded to the
+    public upstream. The download bases (*_mirror_url) were already configurable;
+    these tests cover the version-index sources, which were hardcoded."""
+
+    @patch("terrapod.services.binary_cache_service.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.binary_cache_service.settings")
+    async def test_terraform_fetch_uses_configured_index(
+        self, mock_settings: MagicMock, mock_req: AsyncMock
+    ) -> None:
+        from terrapod.services.binary_cache_service import _fetch_terraform_versions
+
+        mock_settings.registry.binary_cache.terraform_version_index_url = (
+            "https://mirror.internal/terraform/index.json"
+        )
+        mock_settings.registry.binary_cache.allow_prerelease = "none"
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={"versions": {"1.12.3": {}}})
+        mock_req.return_value = resp
+
+        await _fetch_terraform_versions()
+
+        assert mock_req.call_args[0][2] == "https://mirror.internal/terraform/index.json"
+        assert "releases.hashicorp.com" not in mock_req.call_args[0][2]
+
+    @patch("terrapod.services.binary_cache_service.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.binary_cache_service.settings")
+    async def test_terraform_resolve_uses_configured_index(
+        self, mock_settings: MagicMock, mock_req: AsyncMock
+    ) -> None:
+        from terrapod.services.binary_cache_service import _resolve_terraform_version
+
+        mock_settings.registry.binary_cache.terraform_version_index_url = (
+            "https://mirror.internal/terraform/index.json"
+        )
+        mock_settings.registry.binary_cache.allow_prerelease = "none"
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={"versions": {"1.12.0": {}, "1.12.3": {}}})
+        mock_req.return_value = resp
+
+        assert await _resolve_terraform_version("1.12") == "1.12.3"
+        assert mock_req.call_args[0][2] == "https://mirror.internal/terraform/index.json"
+
+    @patch("terrapod.services.binary_cache_service.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.binary_cache_service.settings")
+    async def test_tofu_fetch_uses_configured_index(
+        self, mock_settings: MagicMock, mock_req: AsyncMock
+    ) -> None:
+        from terrapod.services.binary_cache_service import _fetch_tofu_version_ids
+
+        mock_settings.registry.binary_cache.tofu_version_index_url = (
+            "https://mirror.internal/tofu/api.json"
+        )
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={"versions": [{"id": "1.12.3"}]})
+        mock_req.return_value = resp
+
+        assert await _fetch_tofu_version_ids() == ["1.12.3"]
+        assert mock_req.call_args[0][2] == "https://mirror.internal/tofu/api.json"
+        assert "get.opentofu.org" not in mock_req.call_args[0][2]
+
+    @patch("terrapod.services.binary_cache_service.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.binary_cache_service.settings")
+    async def test_terragrunt_fetch_uses_configured_index(
+        self, mock_settings: MagicMock, mock_req: AsyncMock
+    ) -> None:
+        from terrapod.services.binary_cache_service import _fetch_terragrunt_versions
+
+        mock_settings.registry.binary_cache.terragrunt_version_index_url = (
+            "https://mirror.internal/terragrunt/releases"
+        )
+        mock_settings.registry.binary_cache.allow_prerelease = "none"
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value=[{"tag_name": "v0.58.0", "prerelease": False}])
+        mock_req.return_value = resp
+
+        assert await _fetch_terragrunt_versions() == ["0.58.0"]
+        assert mock_req.call_args[0][2] == "https://mirror.internal/terragrunt/releases"
+        assert "api.github.com" not in mock_req.call_args[0][2]
+
+
+class TestVersionIndexConfigDefaults:
+    """The new config fields default to the public upstreams (so behaviour is
+    unchanged unless an operator overrides them)."""
+
+    def test_defaults(self) -> None:
+        from terrapod.config import BinaryCacheConfig
+
+        cfg = BinaryCacheConfig()
+        assert (
+            cfg.terraform_version_index_url == "https://releases.hashicorp.com/terraform/index.json"
+        )
+        assert cfg.tofu_version_index_url == "https://get.opentofu.org/tofu/api.json"
+        assert (
+            cfg.terragrunt_version_index_url
+            == "https://api.github.com/repos/gruntwork-io/terragrunt/releases"
+        )


### PR DESCRIPTION
First of three PRs for **air-gapped artifact delivery** (#606). This part makes every upstream the binary cache reaches operator-overridable to an internal mirror.

## Background

The per-binary **download bases** (`terraform_mirror_url` / `tofu_mirror_url` / `terragrunt_mirror_url`) were already configurable. But the cache reads a **separate version-index source** to list versions and resolve a partial version (e.g. `terraform_version = "1.12"` → `1.12.3`), and those were hardcoded to `releases.hashicorp.com`, `get.opentofu.org`, and the GitHub releases API — on different hosts from the download base. A fully-internal-mirror / air-gapped deployment must override **both**.

## Changes

- New config keys (default to the current public upstreams, so behaviour is unchanged unless set):
  - `binary_cache.terraform_version_index_url`
  - `binary_cache.tofu_version_index_url`
  - `binary_cache.terragrunt_version_index_url`
- Wired through every list/resolve path (`_fetch_*_versions`, `_fetch_tofu_version_ids`, `_resolve_terraform_version`, `_resolve_terragrunt_version`).
- **Proxy/CA**: these fetches use `httpx` with `trust_env` (default), so they already route through the v0.48.0 forward proxy / custom CA (#592). Documented + noted inline.
- **Pre-existing Helm gap fixed**: `configmap-api.yaml` never rendered `terragrunt_mirror_url`, nor the #607 `binary_cache.verify`/`signing_keys` and `provider_cache.verify`/`allow_unsigned` keys — so those could only be set via env var, not Helm. They're now rendered alongside the new keys.

## Docs

`docs/registry.md` gains an "internal mirror / air-gapped" section documenting the **required response shape** for each version-index source (HashiCorp index map / OpenTofu id array / GitHub releases array) and that proxy/CA is honoured. `docs/index.md` + `llms.txt` feature entries updated.

## Tests

- Configurability tests assert each list/resolve path hits the **configured** URL, not the public upstream, for terraform/tofu/terragrunt; plus new-field defaults.
- Full `make test` green (2522 passed). `helm lint` + `helm template` pass on `values.yaml`, `values-local.yaml`, `values-eval.yaml`; the new + previously-missing keys render into the API configmap; `values.schema.json` updated.

## Scope

Part 1 of 3. Cache pre-population (part 2) and sealed/cache-only mode (part 3) follow as separate PRs.

Part of #606