### PR TITLE
chore(config): config-channel contract — non-sensitive config via ConfigMap, not env (#617)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,22 @@ jobs:
           echo "$out" | grep -q "http_proxy: \"http://proxy.example.com:3128\"" || { echo "FAIL: runners.yaml proxy missing"; exit 1; }
           echo "proxy + CA bundle render OK (#592)"
 
+  # ── Config-channel contract (#617) ────────────────────
+  # Renders the chart (every values profile) and parses the rendered ConfigMaps
+  # THROUGH the real Pydantic config models (Settings / RunnerConfig), asserting
+  # the chart ↔ code ↔ chart-test contract: no drift (every rendered key is a
+  # real model field), contract-spine keys present, and no non-sensitive
+  # TERRAPOD_* env on any Deployment. See AGENTS.md → "The config-channel
+  # contract" and scripts/check_helm_config_contract.py.
+  helm-config-contract:
+    name: Helm Config Contract
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: scripts/helm-config-contract.sh
+
   # ── Eval quickstart boot (kind + k3d) ──────────────────
   # Proves `make eval` actually stands up a complete stack (embedded
   # Postgres/Redis + migrations + API + web) on a throwaway cluster, on both
@@ -1536,6 +1552,7 @@ jobs:
       - dependency-review
       - helm-lint
       - helm-smoke
+      - helm-config-contract
       - helm-eval-boot
       - sast
       - build-images-amd64
@@ -1574,6 +1591,7 @@ jobs:
             "${{ needs.dependency-review.result }}"
             "${{ needs.helm-lint.result }}"
             "${{ needs.helm-smoke.result }}"
+            "${{ needs.helm-config-contract.result }}"
             "${{ needs.helm-eval-boot.result }}"
             "${{ needs.sast.result }}"
             "${{ needs.build-images-amd64.result }}"

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ smoke-*
 
 # Claude Code session-local files (transient — do not commit)
 .claude/
+.helmrender/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,10 +228,49 @@ Playwright's auto-waiting.
   API pod `/tmp` is RAM-backed. Anything that can hold tens of MB (provider
   archives, VCS tarballs, state snapshots, config tarballs) must be written to
   the configured ephemeral PVC dir, not `/tmp`, or it will OOM the pod.
-- **Helm values ↔ schema** — when you add/rename/remove a key in
-  `values.yaml`, update `values.schema.json` to match (it uses
-  `additionalProperties: false`, so `helm lint` fails otherwise), and make
-  sure the template renders it.
+- **The config-channel contract (hard requirement)** — a three-way contract
+  binding the **config code**, the **Helm chart**, and the **chart tests**:
+  the in-code config models (the API's Pydantic `Settings`, the listener's
+  `RunnerConfig`) ↔ the chart that feeds them (`values.yaml` /
+  `values.schema.json` / `configmap-api.yaml` / `configmap-runner.yaml` /
+  the Deployment templates) ↔ the `helm-smoke` CI job that renders the chart
+  and asserts the wiring. Change one leg, update all three in the same PR.
+  `Settings` is rendered into `config.yaml` by `configmap-api.yaml`;
+  `RunnerConfig` into `runners.yaml` by `configmap-runner.yaml`. The rules:
+  - **Non-sensitive settings flow through a ConfigMap, end to end.** Adding one
+    has **three legs that must all land in the same PR**: (1) a `values.yaml`
+    entry with a rationale comment, (2) a matching `values.schema.json`
+    constraint (the schema uses `additionalProperties: false`, so `helm lint`
+    fails if `values.yaml` carries an undeclared key — include template-only
+    `| default` keys too; K8s pass-through objects like `podSecurityContext` /
+    `nodeSelector` / `affinity` / `tolerations` use schema `type: object` with
+    no property restrictions), and (3) a **render line in the ConfigMap
+    template**
+    (`configmap-api.yaml` for `Settings`, `configmap-runner.yaml` for
+    `RunnerConfig`). Miss leg 3 and the value is silently inert: the operator
+    sets it in `values.yaml`, it never reaches the pod, and the code default
+    wins. `helm template -f <profile>` must show the key in the rendered
+    ConfigMap.
+  - **Secrets** (tokens, private keys, passwords, connection strings) go via
+    **`secretKeyRef`** / env on the Deployment, and are **never** rendered into
+    a ConfigMap. Prefer a first-class `existingSecret`/key block in the
+    Deployment template over relying on `extraEnv`.
+  - **The chart never sets a non-sensitive setting via a `TERRAPOD_*` env var.**
+    Deployment `env:` is reserved for secrets (`secretKeyRef`) and unavoidable
+    runtime values (Downward API like `POD_NAME`, and the proxy/TLS env vars
+    `HTTP(S)_PROXY`/`NO_PROXY`/`SSL_CERT_FILE` that libraries only read from
+    env). Everything else is ConfigMap config. (Pydantic's env-var override
+    still exists for an operator in a pinch, but the chart doesn't rely on it.)
+  - **Verification leg — the `helm-smoke` CI job.** Chart behaviour is tested
+    the house way: `helm template` then grep the **rendered** output (not the
+    template text), the same pattern as the existing Ingress / embedded-Postgres
+    smoke checks. A config-channel change must add/keep assertions there: the new
+    key renders into the right ConfigMap (e.g. `grep -q "rate_limit:"` in the
+    rendered `config.yaml`), and the rendered **Deployment** env carries no
+    non-sensitive `TERRAPOD_*` (secrets via `secretKeyRef` and runtime values
+    like `POD_NAME` are the only env). Grepping the rendered YAML — not Python
+    source-introspection of the Go templates — is what catches a missing render
+    line or a smuggled-in env var, and it's where chart invariants live.
 - **The chart has three first-class value profiles — keep all three working.**
   `values.yaml` (production defaults), `values-local.yaml` (the Tilt dev loop),
   and `values-eval.yaml` (the `make eval` kind/k3d quickstart). Any chart value /

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 
 .PHONY: lint lint-python \
 	test test-python test-e2e test-e2e-down \
+	helm-config-contract \
 	build images \
 	pentest pentest-sast pentest-images pentest-dast \
 	dev dev-down \
@@ -26,6 +27,9 @@ test:               ## Test all (Python) in Docker
 
 test-python:        ## Test Python only (Docker)
 	scripts/test.sh python
+
+helm-config-contract: ## Config-channel contract: render chart + parse via real config models (#617)
+	scripts/helm-config-contract.sh
 
 ai-eval:            ## Run the AI-analysis eval harness (live model). e.g. make ai-eval ARGS="run --model bedrock/us.anthropic.claude-sonnet-4-6 -n 3"
 	scripts/ai-eval.sh $(ARGS)

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -10,6 +10,12 @@ metadata:
 data:
   config.yaml: |
     log_level: {{ .Values.api.config.log_level | quote }}
+    {{- if hasKey .Values.api.config "debug" }}
+    debug: {{ .Values.api.config.debug }}
+    {{- end }}
+    {{- if hasKey .Values.api.config "json_logs" }}
+    json_logs: {{ .Values.api.config.json_logs }}
+    {{- end }}
     {{- if .Values.api.config.external_url }}
     external_url: {{ .Values.api.config.external_url | quote }}
     {{- end }}
@@ -147,6 +153,10 @@ data:
               - {{ . | quote }}
               {{- end }}
             {{- end }}
+            {{- if .claims_to_roles }}
+            claims_to_roles:
+              {{- toYaml .claims_to_roles | nindent 14 }}
+            {{- end }}
           {{- end }}
         {{- end }}
         {{- if .Values.api.config.auth.sso.saml }}
@@ -160,11 +170,18 @@ data:
             {{- if .entity_id }}
             entity_id: {{ .entity_id | quote }}
             {{- end }}
+            {{- if .acs_url }}
+            acs_url: {{ .acs_url | quote }}
+            {{- end }}
             {{- if .role_prefixes }}
             role_prefixes:
               {{- range .role_prefixes }}
               - {{ . | quote }}
               {{- end }}
+            {{- end }}
+            {{- if .claims_to_roles }}
+            claims_to_roles:
+              {{- toYaml .claims_to_roles | nindent 14 }}
             {{- end }}
           {{- end }}
         {{- end }}
@@ -229,6 +246,10 @@ data:
           {{- toYaml .Values.api.config.registry.binary_cache.signing_keys | nindent 10 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.api.config.registry.module_interface }}
+      module_interface:
+        enabled: {{ .Values.api.config.registry.module_interface.enabled }}
+      {{- end }}
     {{- end }}
     {{- if .Values.api.config.catalog }}
     catalog:
@@ -244,6 +265,9 @@ data:
       tmpdir: {{ .Values.api.config.vcs.tmpdir | default .Values.api.ephemeralStorage.mountPath | default "/var/lib/terrapod/tmp" | quote }}
       {{- with .Values.api.config.vcs.archive_cache_retention_days }}
       archive_cache_retention_days: {{ . }}
+      {{- end }}
+      {{- with .Values.api.config.vcs.tmpdir_min_free_bytes }}
+      tmpdir_min_free_bytes: {{ . | int64 }}
       {{- end }}
     {{- end }}
     {{- if .Values.api.config.audit }}
@@ -347,11 +371,38 @@ data:
     {{- end }}
     default_execution_backend: {{ .Values.api.config.default_execution_backend | default "tofu" | quote }}
     default_terraform_version: {{ .Values.api.config.default_terraform_version | default "1.12" | quote }}
-    {{- if .Values.api.config.cors.allow_origins }}
+    {{- if .Values.api.config.cors }}
     cors:
+      {{- if .Values.api.config.cors.allow_origins }}
       allow_origins:
         {{- range .Values.api.config.cors.allow_origins }}
         - {{ . | quote }}
         {{- end }}
+      {{- end }}
+      {{- if hasKey .Values.api.config.cors "allow_credentials" }}
+      allow_credentials: {{ .Values.api.config.cors.allow_credentials }}
+      {{- end }}
+      {{- with .Values.api.config.cors.allow_methods }}
+      allow_methods:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.api.config.cors.allow_headers }}
+      allow_headers:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.api.config.rate_limit }}
+    rate_limit:
+      enabled: {{ .Values.api.config.rate_limit.enabled }}
+      {{- /* Rendered directly (no `| default`): 0 means "unlimited" for these
+             rates and Helm's `default` would silently rewrite a configured 0. */}}
+      requests_per_minute: {{ .Values.api.config.rate_limit.requests_per_minute }}
+      authenticated_requests_per_minute: {{ .Values.api.config.rate_limit.authenticated_requests_per_minute }}
+      runner_requests_per_minute: {{ .Values.api.config.rate_limit.runner_requests_per_minute }}
+      auth_requests_per_minute: {{ .Values.api.config.rate_limit.auth_requests_per_minute }}
     {{- end }}
 {{- end }}

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -371,29 +371,35 @@ data:
     {{- end }}
     default_execution_backend: {{ .Values.api.config.default_execution_backend | default "tofu" | quote }}
     default_terraform_version: {{ .Values.api.config.default_terraform_version | default "1.12" | quote }}
-    {{- if .Values.api.config.cors }}
+    {{- with .Values.api.config.cors }}
+    {{- /* Only emit `cors:` when at least one child renders — a bare `cors:`
+           serialises to null, which Settings (CORSConfig) rejects. The common
+           `cors: { allow_origins: [] }` default therefore renders nothing and
+           the API uses its CORSConfig default. */}}
+    {{- if or .allow_origins (hasKey . "allow_credentials") .allow_methods .allow_headers }}
     cors:
-      {{- if .Values.api.config.cors.allow_origins }}
+      {{- with .allow_origins }}
       allow_origins:
-        {{- range .Values.api.config.cors.allow_origins }}
+        {{- range . }}
         - {{ . | quote }}
         {{- end }}
       {{- end }}
-      {{- if hasKey .Values.api.config.cors "allow_credentials" }}
-      allow_credentials: {{ .Values.api.config.cors.allow_credentials }}
+      {{- if hasKey . "allow_credentials" }}
+      allow_credentials: {{ .allow_credentials }}
       {{- end }}
-      {{- with .Values.api.config.cors.allow_methods }}
+      {{- with .allow_methods }}
       allow_methods:
         {{- range . }}
         - {{ . | quote }}
         {{- end }}
       {{- end }}
-      {{- with .Values.api.config.cors.allow_headers }}
+      {{- with .allow_headers }}
       allow_headers:
         {{- range . }}
         - {{ . | quote }}
         {{- end }}
       {{- end }}
+    {{- end }}
     {{- end }}
     {{- if .Values.api.config.rate_limit }}
     rate_limit:

--- a/helm/terrapod/templates/configmap-runner.yaml
+++ b/helm/terrapod/templates/configmap-runner.yaml
@@ -23,6 +23,28 @@ data:
     drift_max_duration_seconds: {{ .Values.runners.driftMaxDurationSeconds | default 1800 }}
     lifecycle_destroy_retries: {{ .Values.runners.lifecycleDestroyRetries | default 2 }}
     lifecycle_destroy_retry_backoff_seconds: {{ .Values.runners.lifecycleDestroyRetryBackoffSeconds | default 45 }}
+    default_terraform_version: {{ .Values.runners.defaultTerraformVersion | default "1.12" | quote }}
+    default_execution_backend: {{ .Values.runners.defaultExecutionBackend | default "tofu" | quote }}
+    launch_timeout_seconds: {{ .Values.runners.launchTimeoutSeconds | default 300 }}
+    {{- /*
+    Listener operational settings (#617): non-sensitive, so they flow through
+    this ConfigMap instead of TERRAPOD_* env on the listener Deployment. The
+    listener reads them from RunnerConfig (layered defaults → runners.yaml →
+    env). Secrets (join token) + runtime values (POD_NAME) stay Deployment env.
+    */}}
+    listener_name: {{ .Values.listener.name | default "listener" | quote }}
+    runner_namespace: {{ include "terrapod.runnerNamespace" . | quote }}
+    listener_namespace: {{ .Release.Namespace | quote }}
+    credentials_secret_name: {{ include "terrapod.listenerCredentialsSecretName" . | quote }}
+    health_port: {{ .Values.listener.healthPort | default 8081 }}
+    public_api_url: {{ .Values.listener.publicApiUrl | default .Values.api.config.external_url | default "" | quote }}
+    listener_cert_ttl_seconds: {{ .Values.api.config.agent_pools.listener_cert_ttl_seconds | default 3600 }}
+    heartbeat_interval: {{ .Values.listener.heartbeatInterval | default 60 }}
+    max_concurrent: {{ .Values.listener.maxConcurrent | default 3 }}
+    poll_interval: {{ .Values.listener.pollInterval | default 30 }}
+    sse_read_timeout: {{ .Values.listener.sseReadTimeout | default 30 }}
+    sse_max_age: {{ .Values.listener.sseMaxAge | default 600 }}
+    sse_retry_interval: {{ .Values.listener.sseRetryInterval | default 5 }}
     {{- with .Values.runners.imagePullSecrets }}
     image_pull_secrets:
       {{- toYaml . | nindent 6 }}

--- a/helm/terrapod/templates/deployment-listener.yaml
+++ b/helm/terrapod/templates/deployment-listener.yaml
@@ -59,38 +59,17 @@ spec:
               containerPort: {{ .Values.listener.healthPort | default 8081 }}
               protocol: TCP
           env:
-            - name: TERRAPOD_RUNNER_NAMESPACE
-              value: {{ include "terrapod.runnerNamespace" . | quote }}
-            - name: TERRAPOD_LISTENER_NAME
-              value: {{ .Values.listener.name | default "listener" | quote }}
-            # Credentials-Secret name is tied to the listener Deployment, not
-            # to listener.name, so renaming the listener (changing its
-            # API-registered identity) doesn't orphan the Secret.
-            - name: TERRAPOD_CREDENTIALS_SECRET_NAME
-              value: {{ include "terrapod.listenerCredentialsSecretName" . | quote }}
-            - name: TERRAPOD_HEALTH_PORT
-              value: {{ .Values.listener.healthPort | default 8081 | quote }}
+            # Non-sensitive listener settings (name, namespaces, API URLs,
+            # health port, cert TTL, SSE/heartbeat/poll knobs) now come from
+            # the runner ConfigMap (runners.yaml → RunnerConfig), NOT from
+            # TERRAPOD_* Deployment env (#617). Only the runtime POD_NAME
+            # (Downward API — can't be file config) and the join-token secret
+            # remain here. server_url in runners.yaml carries the internal API
+            # URL the listener uses (was TERRAPOD_API_URL).
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: TERRAPOD_API_URL
-              value: {{ .Values.listener.apiUrl | default (printf "http://%s-api:8000" (include "terrapod.fullname" .)) | quote }}
-            # Public/canonical API URL — what users see in their browsers,
-            # the CLI cloud block, and module/provider source URLs. When
-            # different from TERRAPOD_API_URL, the listener forwards it to
-            # runner Jobs as TP_PUBLIC_API_URL so the runner entrypoint can
-            # add a terraform host{} redirect (canonical → internal).
-            # Defaults to api.config.external_url; empty in single-network
-            # deployments where listener.apiUrl == the canonical URL.
-            - name: TERRAPOD_PUBLIC_API_URL
-              value: {{ .Values.listener.publicApiUrl | default .Values.api.config.external_url | default "" | quote }}
-            # Cert TTL drives the renewal threshold (renew at 50% + splay).
-            # Must match `api.config.agent_pools.listener_cert_ttl_seconds` so
-            # pods anticipate renewal correctly. Values-local.yaml lowers
-            # this for fast iteration.
-            - name: TERRAPOD_LISTENER_CERT_TTL_SECONDS
-              value: {{ .Values.api.config.agent_pools.listener_cert_ttl_seconds | default 3600 | quote }}
             {{- if .Values.listener.existingSecret }}
             - name: TERRAPOD_JOIN_TOKEN
               valueFrom:

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -143,6 +143,9 @@
         "tokenTTLSeconds": { "type": "integer", "minimum": 1 },
         "maxTokenTTLSeconds": { "type": "integer", "minimum": 1 },
         "staleTimeoutSeconds": { "type": "integer", "minimum": 60 },
+        "launchTimeoutSeconds": { "type": "integer", "minimum": 0 },
+        "defaultTerraformVersion": { "type": "string" },
+        "defaultExecutionBackend": { "type": "string", "enum": ["tofu", "terraform"] },
         "driftMaxDurationSeconds": { "type": "integer", "minimum": 0 },
         "lifecycleDestroyRetries": { "type": "integer", "minimum": 0 },
         "lifecycleDestroyRetryBackoffSeconds": { "type": "integer", "minimum": 0 },
@@ -163,6 +166,12 @@
         "healthPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "apiUrl": { "type": "string" },
         "publicApiUrl": { "type": "string" },
+        "heartbeatInterval": { "type": "integer", "minimum": 1 },
+        "maxConcurrent": { "type": "integer", "minimum": 1 },
+        "pollInterval": { "type": "integer", "minimum": 1 },
+        "sseReadTimeout": { "type": "integer", "minimum": 1 },
+        "sseMaxAge": { "type": "integer", "minimum": 1 },
+        "sseRetryInterval": { "type": "integer", "minimum": 1 },
         "joinToken": { "type": "string" },
         "existingSecret": { "type": "string" },
         "joinTokenKey": { "type": "string" },
@@ -499,6 +508,8 @@
           "type": "string",
           "enum": ["debug", "info", "warning", "error", "critical"]
         },
+        "debug": { "type": "boolean" },
+        "json_logs": { "type": "boolean" },
         "external_url": { "type": "string" },
         "public_webhook_url": { "type": "string" },
         "database": {
@@ -622,6 +633,7 @@
                       "audience": { "type": "string" },
                       "groups_claim": { "type": "string" },
                       "role_prefixes": { "type": "array", "items": { "type": "string" } },
+                      "claims_to_roles": { "type": "array", "items": { "type": "object" } },
                       "existingSecret": { "type": "string" },
                       "existingSecretKey": { "type": "string" }
                     }
@@ -638,7 +650,9 @@
                       "display_name": { "type": "string" },
                       "metadata_url": { "type": "string" },
                       "entity_id": { "type": "string" },
-                      "role_prefixes": { "type": "array", "items": { "type": "string" } }
+                      "acs_url": { "type": "string" },
+                      "role_prefixes": { "type": "array", "items": { "type": "string" } },
+                      "claims_to_roles": { "type": "array", "items": { "type": "object" } }
                     }
                   }
                 }
@@ -729,6 +743,7 @@
             "enabled": { "type": "boolean" },
             "poll_interval_seconds": { "type": "integer", "minimum": 1 },
             "tmpdir": { "type": "string" },
+            "tmpdir_min_free_bytes": { "type": "integer", "minimum": 0 },
             "archive_cache_retention_days": { "type": "integer", "minimum": 0 },
             "github": {
               "type": "object",
@@ -898,6 +913,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "allow_credentials": { "type": "boolean" },
+            "allow_methods": { "type": "array", "items": { "type": "string" } },
+            "allow_headers": { "type": "array", "items": { "type": "string" } },
             "allow_origins": {
               "type": "array",
               "items": { "type": "string" }

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -833,6 +833,13 @@ runners:
   tokenTTLSeconds: 3600         # Runner token TTL (default 1 hour)
   maxTokenTTLSeconds: 7200      # Runner token max TTL (default 2 hours)
   staleTimeoutSeconds: 3600     # Seconds before a run with no Job status is marked errored
+  # Seconds before a claimed run with no Job launched is errored (listener
+  # claimed it but never created the Job — e.g. runner-token 401, K8s outage).
+  launchTimeoutSeconds: 300
+  # Default terraform/tofu version + backend for runner Jobs when a workspace
+  # doesn't pin one. Runs snapshot the resolved version at creation time.
+  defaultTerraformVersion: "1.12"
+  defaultExecutionBackend: "tofu"  # tofu | terraform
   # Maximum wall-clock seconds a drift-detection run may spend in `planning`
   # before the reconciler errors it out. Independent of staleTimeoutSeconds:
   # that one fires on listeners going dark; this one fires on terraform
@@ -934,6 +941,16 @@ listener:
   #
   # See docs/deployment-network-isolation.md for the full pattern.
   publicApiUrl: ""
+
+  # Listener tuning — non-sensitive, delivered via the runner ConfigMap
+  # (runners.yaml → RunnerConfig), not Deployment env (#617). Defaults are
+  # sane; override per cluster as needed.
+  heartbeatInterval: 60   # Seconds between listener heartbeats (Redis TTL is 300).
+  maxConcurrent: 3        # Max concurrent run launches per listener pod.
+  pollInterval: 30        # Fallback poll interval when SSE is idle (s).
+  sseReadTimeout: 30      # SSE silence beyond this reconnects (keepalive is 1s).
+  sseMaxAge: 600          # Proactive SSE reconnect interval (s).
+  sseRetryInterval: 5     # Backoff between SSE reconnect attempts (s).
 
   # Join token for pool registration.
   # Either set joinToken directly or reference an existing K8s Secret (recommended).

--- a/scripts/check_helm_config_contract.py
+++ b/scripts/check_helm_config_contract.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Config-channel contract check (#617).
+
+Parses the **rendered** Helm output through the real Pydantic config models and
+asserts the chart ↔ code ↔ chart-test contract:
+
+  1. **No drift** — every key the chart renders into the API ConfigMap
+     (config.yaml) is a real field on `Settings`, and every key in the runner
+     ConfigMap (runners.yaml) is a real field on `RunnerConfig`. A chart key the
+     code doesn't know (typo, stale rename) fails here. Because this reads the
+     *rendered YAML* (concrete dicts), there is none of the brittleness of
+     grepping Go-template text.
+  2. **Coverage** — config-channel keys that were historically inert or are
+     central to the contract are present (rate_limit, module_interface, the
+     migrated listener settings).
+  3. **Env channel** — the rendered API + listener Deployments carry no
+     non-sensitive `TERRAPOD_*` env: Deployment env is for secrets
+     (`secretKeyRef`) and unavoidable runtime values (Downward API) only.
+
+Usage:
+    check_helm_config_contract.py <rendered-manifests.yaml> [profile-label]
+
+Reads a `helm template` multi-doc stream and exits non-zero with a precise
+message on any violation. Run once per values profile.
+"""
+
+from __future__ import annotations
+
+import sys
+import typing
+
+import yaml
+from pydantic import BaseModel
+
+from terrapod.config import RunnerConfig, Settings
+
+# TERRAPOD_* env vars allowed on a Deployment: secrets (delivered via
+# secretKeyRef; some carry a documented dev-only literal `value:` fallback) plus
+# build/runtime values that can't be config-file driven. Everything else is a
+# non-sensitive setting that must come from a ConfigMap, not env.
+_ENV_ALLOWLIST = {
+    "TERRAPOD_VERSION",  # Chart.AppVersion, deploy-time
+    "TERRAPOD_DATABASE_URL",
+    "TERRAPOD_REDIS_URL",
+    "TERRAPOD_TOKEN_SIGNING_KEY",
+    "TERRAPOD_STORAGE__FILESYSTEM__HMAC_SECRET",
+    "TERRAPOD_REGISTRY__SIGNING_KEY",
+    "TERRAPOD_NOTIFICATIONS__SMTP__PASSWORD",
+    "TERRAPOD_VCS__GITHUB__WEBHOOK_SECRET",
+    "TERRAPOD_VCS__GITLAB__WEBHOOK_SECRET",
+    "TERRAPOD_AI_SUMMARY__AUTH__API_KEY",
+    "TERRAPOD_JOIN_TOKEN",
+}
+# OIDC client secrets render as TERRAPOD_{NAME}_CLIENT_SECRET (per-provider) —
+# always a secretKeyRef, allowed by suffix.
+_ENV_ALLOWLIST_SUFFIX = ("_CLIENT_SECRET",)
+
+# Dotted key paths that MUST appear in the rendered ConfigMaps (regression /
+# contract spine). rate_limit was wholly inert before #617; registry's
+# module_interface block was omitted from the render entirely.
+_API_REQUIRED = ["rate_limit", "registry.module_interface"]
+_RUNNER_REQUIRED = [
+    "listener_name",
+    "runner_namespace",
+    "max_concurrent",
+    "sse_read_timeout",
+    "listener_cert_ttl_seconds",
+]
+
+
+def _model_in(annotation) -> tuple[type[BaseModel] | None, bool]:
+    """Return (BaseModel subclass inside the annotation, is_list)."""
+    origin = typing.get_origin(annotation)
+    args = typing.get_args(annotation)
+    if origin is typing.Union:
+        non_none = [a for a in args if a is not type(None)]
+        return _model_in(non_none[0]) if len(non_none) == 1 else (None, False)
+    if origin in (list, set, tuple):
+        if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):
+            return (args[0], True)
+        return (None, False)
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return (annotation, False)
+    return (None, False)
+
+
+def _walk(data: dict, model: type[BaseModel], path: str = "") -> list[str]:
+    """Return dotted paths of rendered keys that are NOT fields on `model`."""
+    errs: list[str] = []
+    fields = model.model_fields
+    if not isinstance(data, dict):
+        return errs
+    for key, val in data.items():
+        if key not in fields:
+            errs.append(f"{path}{key}")
+            continue
+        sub, is_list = _model_in(fields[key].annotation)
+        if sub and isinstance(val, dict):
+            errs += _walk(val, sub, f"{path}{key}.")
+        elif sub and is_list and isinstance(val, list):
+            for i, item in enumerate(val):
+                errs += _walk(item, sub, f"{path}{key}[{i}].")
+    return errs
+
+
+def _has_path(data: dict, dotted: str) -> bool:
+    cur = data
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False
+        cur = cur[part]
+    return True
+
+
+def _docs(stream: str) -> list[dict]:
+    return [d for d in yaml.safe_load_all(stream) if isinstance(d, dict)]
+
+
+def _configmap_data(docs: list[dict], name_suffix: str, file_key: str) -> dict | None:
+    for d in docs:
+        if d.get("kind") == "ConfigMap" and d["metadata"]["name"].endswith(name_suffix):
+            raw = d.get("data", {}).get(file_key, "")
+            return yaml.safe_load(raw) or {}
+    return None
+
+
+def _deployment_env_offenders(docs: list[dict]) -> list[str]:
+    """Non-sensitive TERRAPOD_* env (literal `value:`) on any Deployment."""
+    offenders: list[str] = []
+    for d in docs:
+        if d.get("kind") != "Deployment":
+            continue
+        dep = d["metadata"]["name"]
+        for c in d["spec"]["template"]["spec"].get("containers", []):
+            for e in c.get("env", []) or []:
+                name = e.get("name", "")
+                if not name.startswith("TERRAPOD_"):
+                    continue
+                if name in _ENV_ALLOWLIST or name.endswith(_ENV_ALLOWLIST_SUFFIX):
+                    continue
+                # secretKeyRef / fieldRef env are fine; only literal `value:` is a
+                # potential non-sensitive-config-in-env violation.
+                if "value" in e:
+                    offenders.append(f"{dep}: {name}")
+    return offenders
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: check_helm_config_contract.py <rendered.yaml> [profile]", file=sys.stderr)
+        return 2
+    profile = sys.argv[2] if len(sys.argv) > 2 else sys.argv[1]
+    docs = _docs(open(sys.argv[1]).read())
+
+    problems: list[str] = []
+
+    api = _configmap_data(docs, "-api-config", "config.yaml")
+    if api is None:
+        problems.append("API ConfigMap (-api-config) not rendered")
+    else:
+        drift = _walk(api, Settings)
+        if drift:
+            problems.append(f"config.yaml keys not on Settings: {sorted(drift)}")
+        for k in _API_REQUIRED:
+            if not _has_path(api, k):
+                problems.append(f"config.yaml missing required key: {k}")
+
+    runner = _configmap_data(docs, "-runner-config", "runners.yaml")
+    if runner is None:
+        # runner ConfigMap only renders when listener.enabled — tolerate absence.
+        pass
+    else:
+        drift = _walk(runner, RunnerConfig)
+        if drift:
+            problems.append(f"runners.yaml keys not on RunnerConfig: {sorted(drift)}")
+        for k in _RUNNER_REQUIRED:
+            if k not in runner:
+                problems.append(f"runners.yaml missing required key: {k}")
+
+    env_offenders = _deployment_env_offenders(docs)
+    if env_offenders:
+        problems.append(f"non-sensitive TERRAPOD_* Deployment env: {env_offenders}")
+
+    if problems:
+        print(f"[{profile}] config-channel contract FAILED:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+    print(f"[{profile}] config-channel contract OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_helm_config_contract.py
+++ b/scripts/check_helm_config_contract.py
@@ -1,45 +1,44 @@
 #!/usr/bin/env python3
 """Config-channel contract check (#617).
 
-Parses the **rendered** Helm output through the real Pydantic config models and
-asserts the chart ↔ code ↔ chart-test contract:
+Parses the **rendered** Helm output and binds it to the real Pydantic config
+models. Run once per values profile (a fresh process each, so the model
+construction below validates that profile's rendered config). Asserts:
 
-  1. **No drift** — every key the chart renders into the API ConfigMap
-     (config.yaml) is a real field on `Settings`, and every key in the runner
-     ConfigMap (runners.yaml) is a real field on `RunnerConfig`. A chart key the
-     code doesn't know (typo, stale rename) fails here. Because this reads the
-     *rendered YAML* (concrete dicts), there is none of the brittleness of
-     grepping Go-template text.
-  2. **Coverage** — config-channel keys that were historically inert or are
-     central to the contract are present (rate_limit, module_interface, the
-     migrated listener settings).
-  3. **Env channel** — the rendered API + listener Deployments carry no
-     non-sensitive `TERRAPOD_*` env: Deployment env is for secrets
-     (`secretKeyRef`) and unavoidable runtime values (Downward API) only.
+  1. **Validates** — the rendered config.yaml / runners.yaml actually
+     construct `Settings()` / `RunnerConfig()` (full pydantic validation, like
+     the API/listener do at startup). Catches type/null errors a key-walk
+     misses (e.g. a bare `cors:` → null).
+  2. **No drift** — every key the chart renders is a real field on the model.
+  3. **Coverage** — contract-spine keys present (rate_limit,
+     registry.module_interface, the migrated listener settings).
+  4. **Env channel** — rendered Deployments carry no non-sensitive TERRAPOD_*
+     env (secrets via secretKeyRef + runtime values only).
 
 Usage:
     check_helm_config_contract.py <rendered-manifests.yaml> [profile-label]
-
-Reads a `helm template` multi-doc stream and exits non-zero with a precise
-message on any violation. Run once per values profile.
 """
 
 from __future__ import annotations
 
+import os
 import sys
 import typing
 
 import yaml
-from pydantic import BaseModel
 
-from terrapod.config import RunnerConfig, Settings
+# Stub the required secret env so Settings() construction gets past the
+# secret fields to the config we actually want to validate. These are NOT read
+# from the ConfigMap (they're secretKeyRef) — values here are throwaway.
+os.environ.setdefault("TERRAPOD_DATABASE_URL", "postgresql+asyncpg://t:t@db:5432/t")
+os.environ.setdefault("TERRAPOD_REDIS_URL", "redis://r:6379")
+os.environ.setdefault("TERRAPOD_TOKEN_SIGNING_KEY", "contract-check-stub")
 
 # TERRAPOD_* env vars allowed on a Deployment: secrets (delivered via
 # secretKeyRef; some carry a documented dev-only literal `value:` fallback) plus
-# build/runtime values that can't be config-file driven. Everything else is a
-# non-sensitive setting that must come from a ConfigMap, not env.
+# build/runtime values that can't be config-file driven.
 _ENV_ALLOWLIST = {
-    "TERRAPOD_VERSION",  # Chart.AppVersion, deploy-time
+    "TERRAPOD_VERSION",
     "TERRAPOD_DATABASE_URL",
     "TERRAPOD_REDIS_URL",
     "TERRAPOD_TOKEN_SIGNING_KEY",
@@ -51,13 +50,8 @@ _ENV_ALLOWLIST = {
     "TERRAPOD_AI_SUMMARY__AUTH__API_KEY",
     "TERRAPOD_JOIN_TOKEN",
 }
-# OIDC client secrets render as TERRAPOD_{NAME}_CLIENT_SECRET (per-provider) —
-# always a secretKeyRef, allowed by suffix.
 _ENV_ALLOWLIST_SUFFIX = ("_CLIENT_SECRET",)
 
-# Dotted key paths that MUST appear in the rendered ConfigMaps (regression /
-# contract spine). rate_limit was wholly inert before #617; registry's
-# module_interface block was omitted from the render entirely.
 _API_REQUIRED = ["rate_limit", "registry.module_interface"]
 _RUNNER_REQUIRED = [
     "listener_name",
@@ -68,39 +62,15 @@ _RUNNER_REQUIRED = [
 ]
 
 
-def _model_in(annotation) -> tuple[type[BaseModel] | None, bool]:
-    """Return (BaseModel subclass inside the annotation, is_list)."""
-    origin = typing.get_origin(annotation)
-    args = typing.get_args(annotation)
-    if origin is typing.Union:
-        non_none = [a for a in args if a is not type(None)]
-        return _model_in(non_none[0]) if len(non_none) == 1 else (None, False)
-    if origin in (list, set, tuple):
-        if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):
-            return (args[0], True)
-        return (None, False)
-    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
-        return (annotation, False)
-    return (None, False)
+def _docs(stream: str) -> list[dict]:
+    return [d for d in yaml.safe_load_all(stream) if isinstance(d, dict)]
 
 
-def _walk(data: dict, model: type[BaseModel], path: str = "") -> list[str]:
-    """Return dotted paths of rendered keys that are NOT fields on `model`."""
-    errs: list[str] = []
-    fields = model.model_fields
-    if not isinstance(data, dict):
-        return errs
-    for key, val in data.items():
-        if key not in fields:
-            errs.append(f"{path}{key}")
-            continue
-        sub, is_list = _model_in(fields[key].annotation)
-        if sub and isinstance(val, dict):
-            errs += _walk(val, sub, f"{path}{key}.")
-        elif sub and is_list and isinstance(val, list):
-            for i, item in enumerate(val):
-                errs += _walk(item, sub, f"{path}{key}[{i}].")
-    return errs
+def _configmap_raw(docs: list[dict], name_suffix: str, file_key: str) -> str | None:
+    for d in docs:
+        if d.get("kind") == "ConfigMap" and d["metadata"]["name"].endswith(name_suffix):
+            return d.get("data", {}).get(file_key)
+    return None
 
 
 def _has_path(data: dict, dotted: str) -> bool:
@@ -112,20 +82,44 @@ def _has_path(data: dict, dotted: str) -> bool:
     return True
 
 
-def _docs(stream: str) -> list[dict]:
-    return [d for d in yaml.safe_load_all(stream) if isinstance(d, dict)]
+def _model_in(annotation):
+    origin = typing.get_origin(annotation)
+    args = typing.get_args(annotation)
+    if origin is typing.Union:
+        non_none = [a for a in args if a is not type(None)]
+        return _model_in(non_none[0]) if len(non_none) == 1 else (None, False)
+    if origin in (list, set, tuple):
+        from pydantic import BaseModel
+
+        if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):
+            return (args[0], True)
+        return (None, False)
+    from pydantic import BaseModel
+
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return (annotation, False)
+    return (None, False)
 
 
-def _configmap_data(docs: list[dict], name_suffix: str, file_key: str) -> dict | None:
-    for d in docs:
-        if d.get("kind") == "ConfigMap" and d["metadata"]["name"].endswith(name_suffix):
-            raw = d.get("data", {}).get(file_key, "")
-            return yaml.safe_load(raw) or {}
-    return None
+def _walk(data: dict, model, path: str = "") -> list[str]:
+    errs: list[str] = []
+    if not isinstance(data, dict):
+        return errs
+    fields = model.model_fields
+    for key, val in data.items():
+        if key not in fields:
+            errs.append(f"{path}{key}")
+            continue
+        sub, is_list = _model_in(fields[key].annotation)
+        if sub and isinstance(val, dict):
+            errs += _walk(val, sub, f"{path}{key}.")
+        elif sub and is_list and isinstance(val, list):
+            for item in val:
+                errs += _walk(item, sub, f"{path}{key}[].")
+    return errs
 
 
 def _deployment_env_offenders(docs: list[dict]) -> list[str]:
-    """Non-sensitive TERRAPOD_* env (literal `value:`) on any Deployment."""
     offenders: list[str] = []
     for d in docs:
         if d.get("kind") != "Deployment":
@@ -138,8 +132,6 @@ def _deployment_env_offenders(docs: list[dict]) -> list[str]:
                     continue
                 if name in _ENV_ALLOWLIST or name.endswith(_ENV_ALLOWLIST_SUFFIX):
                     continue
-                # secretKeyRef / fieldRef env are fine; only literal `value:` is a
-                # potential non-sensitive-config-in-env violation.
                 if "value" in e:
                     offenders.append(f"{dep}: {name}")
     return offenders
@@ -151,25 +143,44 @@ def main() -> int:
         return 2
     profile = sys.argv[2] if len(sys.argv) > 2 else sys.argv[1]
     docs = _docs(open(sys.argv[1]).read())
-
     problems: list[str] = []
 
-    api = _configmap_data(docs, "-api-config", "config.yaml")
-    if api is None:
-        problems.append("API ConfigMap (-api-config) not rendered")
-    else:
+    api_raw = _configmap_raw(docs, "-api-config", "config.yaml")
+    runner_raw = _configmap_raw(docs, "-runner-config", "runners.yaml")
+
+    # 1) VALIDATE: write the rendered config to where the models read it, then
+    #    construct them (full pydantic validation, exactly like pod startup).
+    #    Importing terrapod.config constructs `settings = Settings()` against the
+    #    written config.yaml; RunnerConfig() reads the written runners.yaml.
+    os.makedirs("/etc/terrapod", exist_ok=True)
+    if api_raw is not None:
+        with open("/etc/terrapod/config.yaml", "w") as f:
+            f.write(api_raw)
+    if runner_raw is not None:
+        with open("/etc/terrapod/runners.yaml", "w") as f:
+            f.write(runner_raw)
+
+    Settings = RunnerConfig = None
+    try:
+        import terrapod.config as cfg  # triggers settings = Settings()
+
+        Settings, RunnerConfig = cfg.Settings, cfg.RunnerConfig
+        if runner_raw is not None:
+            RunnerConfig()  # validate runners.yaml
+    except Exception as e:  # pydantic ValidationError or import-time settings build
+        problems.append(f"rendered config fails model validation: {type(e).__name__}: {str(e)[:600]}")
+
+    # 2) DRIFT + 3) COVERAGE (only if the models imported cleanly).
+    if Settings is not None and api_raw is not None:
+        api = yaml.safe_load(api_raw) or {}
         drift = _walk(api, Settings)
         if drift:
             problems.append(f"config.yaml keys not on Settings: {sorted(drift)}")
         for k in _API_REQUIRED:
             if not _has_path(api, k):
                 problems.append(f"config.yaml missing required key: {k}")
-
-    runner = _configmap_data(docs, "-runner-config", "runners.yaml")
-    if runner is None:
-        # runner ConfigMap only renders when listener.enabled — tolerate absence.
-        pass
-    else:
+    if RunnerConfig is not None and runner_raw is not None:
+        runner = yaml.safe_load(runner_raw) or {}
         drift = _walk(runner, RunnerConfig)
         if drift:
             problems.append(f"runners.yaml keys not on RunnerConfig: {sorted(drift)}")
@@ -177,6 +188,7 @@ def main() -> int:
             if k not in runner:
                 problems.append(f"runners.yaml missing required key: {k}")
 
+    # 4) ENV CHANNEL
     env_offenders = _deployment_env_offenders(docs)
     if env_offenders:
         problems.append(f"non-sensitive TERRAPOD_* Deployment env: {env_offenders}")

--- a/scripts/check_helm_config_contract.py
+++ b/scripts/check_helm_config_contract.py
@@ -142,7 +142,8 @@ def main() -> int:
         print("usage: check_helm_config_contract.py <rendered.yaml> [profile]", file=sys.stderr)
         return 2
     profile = sys.argv[2] if len(sys.argv) > 2 else sys.argv[1]
-    docs = _docs(open(sys.argv[1]).read())
+    with open(sys.argv[1]) as f:
+        docs = _docs(f.read())
     problems: list[str] = []
 
     api_raw = _configmap_raw(docs, "-api-config", "config.yaml")

--- a/scripts/helm-config-contract.sh
+++ b/scripts/helm-config-contract.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Config-channel contract (#617): the chart ↔ code ↔ chart-test contract.
+#
+# Renders the Helm chart (every values profile) and parses the rendered
+# ConfigMaps THROUGH the real Pydantic config models (Settings / RunnerConfig),
+# asserting:
+#   - no drift: every key the chart renders is a real field on the model;
+#   - coverage: contract-spine keys (rate_limit, registry.module_interface,
+#     the migrated listener settings) are present;
+#   - env channel: rendered Deployments carry no non-sensitive TERRAPOD_* env.
+#
+# All in Docker — no local Python/helm needed. Run locally with
+# `scripts/helm-config-contract.sh` or `make helm-config-contract`; CI runs it
+# in the `helm-config-contract` job. The checker logic is
+# scripts/check_helm_config_contract.py.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+HELM_IMAGE="alpine/helm:3.17.2"
+PY_IMAGE="python:3.13-slim"
+RENDER_DIR=".helmrender"
+PROFILES=(values.yaml values-local.yaml values-eval.yaml)
+
+rm -rf "$RENDER_DIR"
+mkdir -p "$RENDER_DIR"
+trap 'rm -rf "$RENDER_DIR"' EXIT
+
+echo "==> Rendering chart for each values profile"
+for f in "${PROFILES[@]}"; do
+  docker run --rm -v "$PWD:/chart" -w /chart "$HELM_IMAGE" \
+    template terrapod helm/terrapod -f "helm/terrapod/$f" > "$RENDER_DIR/$f"
+done
+
+echo "==> Parsing rendered ConfigMaps through the real config models"
+# Pydantic v2 + pyyaml only; the models read `.model_fields` (no instantiation,
+# so no secrets/env needed). PYTHONPATH=services makes `terrapod.config`
+# importable (PEP 420 namespace package).
+docker run --rm -v "$PWD:/w" -w /w "$PY_IMAGE" sh -c '
+  pip install -q "pydantic>=2" "pydantic-settings>=2" pyyaml
+  fail=0
+  for f in '"${PROFILES[*]}"'; do
+    PYTHONPATH=services python scripts/check_helm_config_contract.py ".helmrender/$f" "$f" || fail=1
+  done
+  exit $fail
+'

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -22,6 +22,22 @@ def yaml_config_settings_source() -> dict[str, Any]:
     return {}
 
 
+def runners_yaml_config_settings_source() -> dict[str, Any]:
+    """Load runner/listener configuration from the runner ConfigMap (runners.yaml).
+
+    The listener mounts this ConfigMap at /etc/terrapod/runners.yaml. Mirrors
+    `yaml_config_settings_source` so `RunnerConfig` layers defaults → file → env
+    via pydantic-settings, instead of the listener hand-reading os.environ. The
+    file is absent in the API pod (which only consumes a few runner defaults via
+    `load_runner_config`), so it falls back to defaults + env there.
+    """
+    config_path = Path("/etc/terrapod/runners.yaml")
+    if config_path.exists():
+        with open(config_path) as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
 # --- Storage Configuration Models ---
 
 
@@ -52,21 +68,85 @@ class RunnerProxyConfig(BaseModel):
     no_proxy: str = Field(default="")
 
 
-class RunnerConfig(BaseModel):
-    """Runner configuration, loaded from /etc/terrapod/runners.yaml.
+class RunnerConfig(BaseSettings):
+    """Runner + listener configuration, layered defaults → runners.yaml → env.
 
-    Separate from main Settings because listeners need their own
-    config independent of the API server's config.
+    A pydantic-settings model (like `Settings`) so the listener reads ONE
+    config object instead of hand-reading os.environ: the runner ConfigMap
+    (runners.yaml) is the file source, `TERRAPOD_*` env vars override it, and
+    field defaults backstop both. This carries BOTH the runner-Job settings
+    (image, resources, proxy/CA) AND the listener's own operational settings
+    (name, namespaces, API URLs, health port, cert TTL, SSE/heartbeat/poll
+    knobs) — all non-sensitive, so they flow through the ConfigMap, not via
+    chart-set Deployment env vars. Secrets (the join token) and runtime values
+    (POD_NAME) stay as Deployment env and are NOT fields here.
     """
+
+    model_config = SettingsConfigDict(
+        env_prefix="TERRAPOD_",
+        env_nested_delimiter="__",
+        extra="ignore",
+    )
 
     image: RunnerImageConfig = Field(default_factory=RunnerImageConfig)
     server_url: str = Field(
         default="",
-        description="Internal API URL for runner Jobs (e.g. http://terrapod-api:8000). "
-        "Used as base URL for presigned storage URLs. Falls back to TERRAPOD_API_URL env var.",
+        description="Internal API URL the listener + runner Jobs call "
+        "(e.g. http://terrapod-api:8000). Also the base for presigned storage URLs. "
+        "Env override: TERRAPOD_SERVER_URL.",
     )
     default_terraform_version: str = Field(default="1.12")
     default_execution_backend: str = Field(default="tofu")
+    # --- Listener operational settings (non-sensitive; from runners.yaml) ---
+    # Previously read by the listener directly from os.environ; now layered
+    # through this config object so they are ConfigMap-driven, not chart-env.
+    listener_name: str = Field(
+        default="listener",
+        description="Base listener name; the pod name is appended per replica.",
+    )
+    runner_namespace: str = Field(
+        default="terrapod-runners",
+        description="Namespace the listener creates runner Jobs + per-run Secrets in.",
+    )
+    listener_namespace: str = Field(
+        default="terrapod",
+        description="Fallback namespace for the listener's own resources when the "
+        "in-pod service-account namespace file is unreadable (local/dev).",
+    )
+    credentials_secret_name: str = Field(
+        default="",
+        description="Explicit name for the listener credentials Secret. Empty → "
+        "derived as '{listener_name}-credentials'. Set by the chart to tie the "
+        "Secret to the Deployment lifecycle (a Secret NAME, not a secret value).",
+    )
+    health_port: int = Field(default=8081, description="Listener health/readiness port.")
+    public_api_url: str = Field(
+        default="",
+        description="Public/canonical API URL forwarded to runner Jobs as "
+        "TP_PUBLIC_API_URL when it differs from server_url (canonical→internal "
+        "host redirect). Empty in single-network deployments.",
+    )
+    listener_cert_ttl_seconds: int = Field(
+        default=3600,
+        description="Listener certificate validity; drives the renewal threshold. "
+        "Must match api.config.agent_pools.listener_cert_ttl_seconds.",
+    )
+    heartbeat_interval: int = Field(default=60, description="Listener heartbeat interval (s).")
+    max_concurrent: int = Field(
+        default=3, description="Max concurrent run launches per listener pod."
+    )
+    poll_interval: int = Field(
+        default=30, description="Fallback poll interval when SSE is idle (s)."
+    )
+    sse_read_timeout: int = Field(
+        default=30, description="SSE read timeout — silence beyond this reconnects (s)."
+    )
+    sse_max_age: int = Field(
+        default=600, description="Max SSE connection age before a proactive reconnect (s)."
+    )
+    sse_retry_interval: int = Field(
+        default=5, description="Backoff between SSE reconnect attempts (s)."
+    )
     service_account_name: str = Field(default="")
     azure_workload_identity: bool = Field(default=False)
     ttl_seconds_after_finished: int = Field(default=600)
@@ -160,14 +240,33 @@ class RunnerConfig(BaseModel):
         ),
     )
 
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: Any,
+        env_settings: Any,
+        dotenv_settings: Any,
+        file_secret_settings: Any,
+    ) -> tuple[Any, ...]:
+        """Layer sources: init args > env vars > runners.yaml > defaults."""
+        return (
+            init_settings,
+            env_settings,
+            runners_yaml_config_settings_source,
+            dotenv_settings,
+            file_secret_settings,
+        )
+
 
 def load_runner_config(path: str = "/etc/terrapod/runners.yaml") -> RunnerConfig:
-    """Load runner configuration from YAML file."""
-    config_path = Path(path)
-    if config_path.exists():
-        with open(config_path) as f:
-            data = yaml.safe_load(f) or {}
-        return RunnerConfig(**data)
+    """Construct the runner/listener config (defaults → runners.yaml → env).
+
+    The `path` argument is retained for backward compatibility but ignored: the
+    runners.yaml file is now a pydantic-settings source on `RunnerConfig`
+    (`runners_yaml_config_settings_source`, fixed at /etc/terrapod/runners.yaml),
+    so the layering — and env overrides — happen inside the model.
+    """
     return RunnerConfig()
 
 

--- a/services/terrapod/runner/identity.py
+++ b/services/terrapod/runner/identity.py
@@ -44,6 +44,10 @@ import os
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from terrapod.config import RunnerConfig
 
 from cryptography import x509
 
@@ -77,12 +81,18 @@ class ListenerIdentity:
 # ── Public entry point ──────────────────────────────────────────────
 
 
-async def establish_identity() -> ListenerIdentity:
-    """Establish a listener identity for this pod. See module docstring."""
-    name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
-    api_url = os.environ.get("TERRAPOD_API_URL", "http://localhost:8000")
-    secret_name = _credentials_secret_name(name)
-    namespace = _read_in_pod_namespace()
+async def establish_identity(runner_config: RunnerConfig) -> ListenerIdentity:
+    """Establish a listener identity for this pod. See module docstring.
+
+    Non-sensitive identity inputs (name, API URL, namespace, credentials Secret
+    name) come from the layered `RunnerConfig` (runners.yaml + env), not from
+    os.environ. The join token itself stays an env secret (read in
+    `_bootstrap_via_join_token`).
+    """
+    name = runner_config.listener_name
+    api_url = runner_config.server_url or "http://localhost:8000"
+    secret_name = _credentials_secret_name(name, runner_config.credentials_secret_name)
+    namespace = _read_in_pod_namespace(runner_config.listener_namespace)
 
     secret = _read_secret(secret_name, namespace)
     if secret is not None:
@@ -102,7 +112,7 @@ async def establish_identity() -> ListenerIdentity:
 # ── Secret I/O ──────────────────────────────────────────────────────
 
 
-def clear_credentials_secret() -> None:
+def clear_credentials_secret(runner_config: RunnerConfig) -> None:
     """Delete the credentials Secret so the next establish_identity() bootstraps fresh.
 
     Used by `_rejoin` after persistent 401s — the cert in the Secret has been
@@ -114,9 +124,9 @@ def clear_credentials_secret() -> None:
     """
     from kubernetes.client.rest import ApiException
 
-    name = os.environ.get("TERRAPOD_LISTENER_NAME", "listener")
-    secret_name = _credentials_secret_name(name)
-    namespace = _read_in_pod_namespace()
+    name = runner_config.listener_name
+    secret_name = _credentials_secret_name(name, runner_config.credentials_secret_name)
+    namespace = _read_in_pod_namespace(runner_config.listener_namespace)
     api = _core_api()
     try:
         api.delete_namespaced_secret(name=secret_name, namespace=namespace)
@@ -127,29 +137,31 @@ def clear_credentials_secret() -> None:
         logger.warning("Failed to clear credentials Secret", error=str(e))
 
 
-def _credentials_secret_name(listener_name: str) -> str:
+def _credentials_secret_name(listener_name: str, explicit: str = "") -> str:
     """Resolve the credentials Secret name.
 
-    Helm sets `TERRAPOD_CREDENTIALS_SECRET_NAME` to the Deployment fullname +
-    `-credentials` so the Secret is tied to the Deployment lifecycle. Falls
-    back to `{listener_name}-credentials` for environments without Helm
-    (legacy deployments, local tests).
+    The chart sets `RunnerConfig.credentials_secret_name` (runners.yaml) to the
+    Deployment fullname + `-credentials` so the Secret is tied to the Deployment
+    lifecycle. Falls back to `{listener_name}-credentials` when unset
+    (non-Helm deployments, local tests).
     """
-    explicit = os.environ.get("TERRAPOD_CREDENTIALS_SECRET_NAME")
     if explicit:
         return explicit
     return f"{listener_name}-credentials"
 
 
-def _read_in_pod_namespace() -> str:
-    """Read the pod's own namespace from the projected SA token mount."""
+def _read_in_pod_namespace(fallback: str = "terrapod") -> str:
+    """Read the pod's own namespace from the projected SA token mount.
+
+    Falls back to `RunnerConfig.listener_namespace` (passed in) when the in-pod
+    SA namespace file is unreadable (local dev / tests).
+    """
     path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
     try:
         with open(path) as f:
             return f.read().strip()
     except OSError:
-        # Local dev fallback. Helm tests / Tilt can set TERRAPOD_LISTENER_NAMESPACE.
-        return os.environ.get("TERRAPOD_LISTENER_NAMESPACE", "terrapod")
+        return fallback
 
 
 def _read_secret(name: str, namespace: str):

--- a/services/terrapod/runner/job_manager.py
+++ b/services/terrapod/runner/job_manager.py
@@ -4,7 +4,6 @@ Uses the kubernetes Python client to interact with the K8s API.
 """
 
 import asyncio
-import os
 import re
 from concurrent.futures import ThreadPoolExecutor
 
@@ -62,7 +61,17 @@ def _get_core_api() -> client.CoreV1Api:
 
 
 def _default_namespace() -> str:
-    return os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
+    """Fallback runner namespace for call sites that don't pass one explicitly.
+
+    Sourced from the loaded RunnerConfig (the runners.yaml ConfigMap) — the
+    single source of truth per the config-channel contract. The listener's
+    launch/status/delete paths always pass the namespace explicitly; this is a
+    defensive fallback only. (It deliberately does NOT read an env var: the
+    chart delivers the runner namespace via the ConfigMap, not env.)
+    """
+    from terrapod.config import load_runner_config
+
+    return load_runner_config().runner_namespace
 
 
 async def create_job(job_spec: dict, namespace: str = "") -> str:

--- a/services/terrapod/runner/job_template.py
+++ b/services/terrapod/runner/job_template.py
@@ -1,7 +1,6 @@
 """Build K8s Job specs for terraform/tofu plan and apply phases."""
 
 import json
-import os
 import re
 
 from terrapod.config import RunnerConfig, settings
@@ -103,13 +102,13 @@ def build_job_spec(
         namespace: Target namespace for the Job.
     """
     if not namespace:
-        namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
+        namespace = runner_config.runner_namespace
 
     run_short = run_id[:16]
     job_name = f"tprun-{run_short}-{phase}"
 
     # Build container env vars
-    api_url = os.environ.get("TERRAPOD_API_URL", "http://terrapod-api:8000")
+    api_url = runner_config.server_url or "http://terrapod-api:8000"
     container_env = [
         # HOME defends against tools that consult $HOME without a
         # passwd entry (helm's repository/index cache,
@@ -148,7 +147,7 @@ def build_job_spec(
     # a trailing `/` ("https://x.example/" vs "https://x.example") don't
     # trigger a no-op redirect — the entrypoint's host-extraction re-
     # checks at hostname level either way, this is just a tighter guard.
-    public_api_url = os.environ.get("TERRAPOD_PUBLIC_API_URL", "").strip()
+    public_api_url = (runner_config.public_api_url or "").strip()
     if public_api_url and public_api_url.rstrip("/") != api_url.rstrip("/"):
         container_env.append({"name": "TP_PUBLIC_API_URL", "value": public_api_url})
 

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -685,15 +685,17 @@ class RunnerListener:
         namespace = self.runner_config.runner_namespace
 
         try:
-            job_name = await create_job(spec)
+            job_name = await create_job(spec, namespace=namespace)
         except Exception as e:
             logger.error("Failed to create Job", run_id=run_id, error=str(e))
             await self._report_launch_failed(run_id, f"Failed to create K8s Job: {e}")
             return
 
-        # Create auth Secret with ownerReference to the Job
+        # Create auth Secret with ownerReference to the Job. Pass the namespace
+        # explicitly (from runner_config) — never rely on job_manager's fallback,
+        # which is decoupled from the configured runner namespace.
         try:
-            job_uid = await get_job_uid(job_name)
+            job_uid = await get_job_uid(job_name, namespace=namespace)
             await self._create_auth_secret(
                 auth_secret_name, run_id, runner_token, job_name, job_uid
             )

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -40,18 +40,15 @@ logger = get_logger(__name__)
 # Shutdown flag
 _shutdown = asyncio.Event()
 
-# SSE read watchdog: API sends a keepalive comment every 1s, so any stretch
-# of silence longer than this means the stream has gone silent even though
-# the TCP socket is still open (e.g. API-side Redis pubsub detached, proxy
-# buffering). 30s is generous enough to absorb network jitter without
-# accidentally killing healthy streams.
-_SSE_READ_TIMEOUT = int(os.environ.get("TERRAPOD_SSE_READ_TIMEOUT", "30"))
-
-# Mandatory periodic reconnect — even a healthy connection is torn down
-# and rebuilt at this interval to guarantee no stale subscription state
-# survives forever. 10 minutes balances "cheap to reconnect" against
-# "don't churn unnecessarily."
-_SSE_MAX_AGE = int(os.environ.get("TERRAPOD_SSE_MAX_AGE", "600"))
+# SSE tuning lives on RunnerConfig (sse_read_timeout / sse_max_age), layered
+# from runners.yaml + env. The listener reads them via self._sse_read_timeout /
+# self._sse_max_age (set in __init__) rather than module-level env constants.
+#
+# - read watchdog (sse_read_timeout): the API sends a keepalive comment every
+#   1s, so silence longer than this means the stream has gone quiet even though
+#   the TCP socket is open (API-side Redis pubsub detached, proxy buffering).
+# - mandatory reconnect (sse_max_age): even a healthy connection is rebuilt at
+#   this interval so no stale subscription state survives forever.
 
 
 class RunnerListener:
@@ -59,12 +56,18 @@ class RunnerListener:
 
     def __init__(self):
         self.identity = None
+        # Single layered config object (defaults → runners.yaml → env) — the
+        # listener reads ALL its non-sensitive settings from here, never from
+        # os.environ. Only secrets (join token) + runtime values (POD_NAME)
+        # remain as Deployment env (read at their point of use).
         self.runner_config = load_runner_config()
-        self._heartbeat_interval = int(os.environ.get("TERRAPOD_HEARTBEAT_INTERVAL", "60"))
-        self._max_concurrent = int(os.environ.get("TERRAPOD_MAX_CONCURRENT", "3"))
-        self._health_port = int(os.environ.get("TERRAPOD_HEALTH_PORT", "8081"))
-        self._sse_retry_interval = int(os.environ.get("TERRAPOD_SSE_RETRY_INTERVAL", "5"))
-        self._poll_interval = int(os.environ.get("TERRAPOD_POLL_INTERVAL", "30"))
+        self._heartbeat_interval = self.runner_config.heartbeat_interval
+        self._max_concurrent = self.runner_config.max_concurrent
+        self._health_port = self.runner_config.health_port
+        self._sse_retry_interval = self.runner_config.sse_retry_interval
+        self._poll_interval = self.runner_config.poll_interval
+        self._sse_read_timeout = self.runner_config.sse_read_timeout
+        self._sse_max_age = self.runner_config.sse_max_age
         self._identity_ready = False
         self._last_heartbeat_at: float | None = None
         self._active_launches = 0  # count of concurrent launch operations
@@ -120,7 +123,7 @@ class RunnerListener:
         """Establish or re-establish listener identity."""
         from terrapod.runner.identity import establish_identity
 
-        self.identity = await establish_identity()
+        self.identity = await establish_identity(self.runner_config)
         self._identity_ready = True
         # Drop any cached headers so the next call re-encodes against the new cert.
         self._cached_auth_headers_for_cert = None
@@ -182,9 +185,11 @@ class RunnerListener:
             renew_loop,
         )
 
-        cert_validity_seconds = int(os.environ.get("TERRAPOD_LISTENER_CERT_TTL_SECONDS", "3600"))
-        secret_name = _credentials_secret_name(self.identity.name)
-        namespace = _read_in_pod_namespace()
+        cert_validity_seconds = self.runner_config.listener_cert_ttl_seconds
+        secret_name = _credentials_secret_name(
+            self.identity.name, self.runner_config.credentials_secret_name
+        )
+        namespace = _read_in_pod_namespace(self.runner_config.listener_namespace)
 
         await renew_loop(
             self,
@@ -218,7 +223,7 @@ class RunnerListener:
             listener_id=str(self.identity.listener_id) if self.identity else "<unknown>",
             name=self.identity.name if self.identity else "<unknown>",
         )
-        clear_credentials_secret()
+        clear_credentials_secret(self.runner_config)
         await self._establish_identity()
 
         # Recreate HTTP clients with the new identity base URL
@@ -480,17 +485,21 @@ class RunnerListener:
                 # Mandatory periodic reconnect — return cleanly so the outer
                 # loop reopens a fresh connection (and a fresh Redis pubsub
                 # subscription on the API side).
-                if time.monotonic() - connected_at > _SSE_MAX_AGE:
-                    logger.info("SSE max-age reached, reconnecting", age=_SSE_MAX_AGE)
+                if time.monotonic() - connected_at > self._sse_max_age:
+                    logger.info("SSE max-age reached, reconnecting", age=self._sse_max_age)
                     return
 
                 try:
-                    line = await asyncio.wait_for(line_iter.__anext__(), timeout=_SSE_READ_TIMEOUT)
+                    line = await asyncio.wait_for(
+                        line_iter.__anext__(), timeout=self._sse_read_timeout
+                    )
                 except StopAsyncIteration:
                     return  # Stream closed by server — outer loop reconnects
                 except TimeoutError:
                     # Silent stall — kill the connection, outer loop reconnects.
-                    logger.warning("SSE read timeout — stream stalled", timeout=_SSE_READ_TIMEOUT)
+                    logger.warning(
+                        "SSE read timeout — stream stalled", timeout=self._sse_read_timeout
+                    )
                     return
 
                 if line.startswith("event:"):
@@ -673,7 +682,7 @@ class RunnerListener:
             ca_secret_name=ca_secret_name,
         )
 
-        namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
+        namespace = self.runner_config.runner_namespace
 
         try:
             job_name = await create_job(spec)
@@ -953,7 +962,7 @@ class RunnerListener:
 
         from terrapod.runner.job_manager import _get_core_api
 
-        namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
+        namespace = self.runner_config.runner_namespace
 
         secret = k8s_client.V1Secret(
             metadata=k8s_client.V1ObjectMeta(
@@ -1005,7 +1014,7 @@ class RunnerListener:
 
         from terrapod.runner.job_manager import _get_core_api
 
-        namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
+        namespace = self.runner_config.runner_namespace
 
         string_data: dict[str, str] = {}
         if terraform_vars:
@@ -1087,7 +1096,7 @@ class RunnerListener:
 
         from terrapod.runner.job_manager import _get_core_api
 
-        namespace = os.environ.get("TERRAPOD_RUNNER_NAMESPACE", "terrapod-runners")
+        namespace = self.runner_config.runner_namespace
 
         secret = k8s_client.V1Secret(
             metadata=k8s_client.V1ObjectMeta(

--- a/services/tests/runner/test_identity.py
+++ b/services/tests/runner/test_identity.py
@@ -8,7 +8,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from terrapod.config import RunnerConfig
 from terrapod.runner import identity as identity_mod
+
+# establish_identity()/clear_credentials_secret() now take their non-sensitive
+# inputs from RunnerConfig (runners.yaml + env layering) rather than reading
+# os.environ directly (#617). These tests construct a RunnerConfig with the
+# same name/API URL the env used to provide.
+_RC = RunnerConfig(listener_name="core", server_url="http://api")
 
 # ── pod_splay_seconds ───────────────────────────────────────────────
 
@@ -167,7 +174,7 @@ class TestEstablishIdentity:
             patch.object(identity_mod, "_read_secret", return_value=secret),
             patch.object(identity_mod, "_call_join", new=AsyncMock()) as mock_join,
         ):
-            result = await identity_mod.establish_identity()
+            result = await identity_mod.establish_identity(_RC)
 
         assert result.listener_id == lid
         assert result.pool_id == pid
@@ -201,7 +208,7 @@ class TestEstablishIdentity:
             patch.object(identity_mod, "_call_join", new=AsyncMock(return_value=join_response)),
             patch.object(identity_mod, "_create_secret", return_value=created_secret),
         ):
-            result = await identity_mod.establish_identity()
+            result = await identity_mod.establish_identity(_RC)
 
         assert str(result.listener_id) == lid
         assert str(result.pool_id) == pid
@@ -245,7 +252,7 @@ class TestEstablishIdentity:
                 side_effect=identity_mod._SecretAlreadyExists("409"),
             ),
         ):
-            result = await identity_mod.establish_identity()
+            result = await identity_mod.establish_identity(_RC)
 
         # We adopted the winner's cert, not the one /join handed us
         assert result.listener_id == winner_lid
@@ -279,7 +286,7 @@ class TestEstablishIdentity:
             ),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
-            result = await identity_mod.establish_identity()
+            result = await identity_mod.establish_identity(_RC)
 
         assert result.listener_id == winner_lid
 
@@ -293,4 +300,4 @@ class TestEstablishIdentity:
             patch.object(identity_mod, "_read_secret", return_value=None),
         ):
             with pytest.raises(RuntimeError, match="TERRAPOD_JOIN_TOKEN"):
-                await identity_mod.establish_identity()
+                await identity_mod.establish_identity(_RC)

--- a/services/tests/runner/test_job_manager.py
+++ b/services/tests/runner/test_job_manager.py
@@ -108,3 +108,32 @@ class TestGetJobFailureInfo:
         mock_batch.return_value.read_namespaced_job.side_effect = ApiException(404)
 
         assert await get_job_failure_info("tprun-abc-plan", namespace="terrapod") is None
+
+
+class TestDefaultNamespace:
+    """Regression: the runner-namespace fallback must come from the loaded
+    RunnerConfig (the runners.yaml ConfigMap), NOT a removed env var.
+
+    The config-channel refactor moved the runner namespace from the
+    TERRAPOD_RUNNER_NAMESPACE env var onto the ConfigMap. A call site that
+    omitted an explicit namespace (get_job_uid during auth-Secret creation)
+    then fell back to the stale hard-coded default and created the Secret /
+    looked up the Job in the wrong namespace than the one the Job itself was
+    created in — a 403 on every launch when the configured namespace differed
+    from that default."""
+
+    def test_default_namespace_sourced_from_runner_config(self):
+        from terrapod.runner import job_manager
+
+        fake_cfg = SimpleNamespace(runner_namespace="cfg-runner-ns")
+        with patch("terrapod.config.load_runner_config", return_value=fake_cfg):
+            assert job_manager._default_namespace() == "cfg-runner-ns"
+
+    def test_default_namespace_ignores_legacy_env(self, monkeypatch):
+        from terrapod.runner import job_manager
+
+        # The chart no longer sets this; the fallback must not honour it.
+        monkeypatch.setenv("TERRAPOD_RUNNER_NAMESPACE", "should-be-ignored")
+        fake_cfg = SimpleNamespace(runner_namespace="cfg-runner-ns")
+        with patch("terrapod.config.load_runner_config", return_value=fake_cfg):
+            assert job_manager._default_namespace() == "cfg-runner-ns"

--- a/services/tests/runner/test_job_template.py
+++ b/services/tests/runner/test_job_template.py
@@ -26,6 +26,11 @@ def _runner_config():
     # MagicMock defaults don't inject phantom proxy env into every test.
     cfg.proxy = None
     cfg.ca_bundle_enabled = False
+    # Listener/runner settings the job template reads off RunnerConfig (#617),
+    # not os.environ. Real string defaults so `or`/`.strip()` behave.
+    cfg.server_url = "http://terrapod-api:8000"
+    cfg.public_api_url = ""
+    cfg.runner_namespace = "terrapod-runners"
 
     default_def = MagicMock()
     default_def.name = "default"
@@ -226,15 +231,14 @@ class TestPublicApiUrl:
     def _build(self, monkeypatch, api_url, public_api_url):
         from terrapod.runner.job_template import build_job_spec
 
-        monkeypatch.setenv("TERRAPOD_API_URL", api_url)
-        if public_api_url is None:
-            monkeypatch.delenv("TERRAPOD_PUBLIC_API_URL", raising=False)
-        else:
-            monkeypatch.setenv("TERRAPOD_PUBLIC_API_URL", public_api_url)
+        # server_url / public_api_url come off RunnerConfig (#617), not env.
+        cfg = _runner_config()
+        cfg.server_url = api_url
+        cfg.public_api_url = "" if public_api_url is None else public_api_url
         spec = build_job_spec(
             run_id="abc123",
             phase="plan",
-            runner_config=_runner_config(),
+            runner_config=cfg,
             auth_secret_name="tprun-abc12345-auth",
             env_vars=[],
             terraform_vars=[],

--- a/services/tests/services/test_listener.py
+++ b/services/tests/services/test_listener.py
@@ -394,3 +394,47 @@ class TestCreateVarsSecret:
         sd = core_api.create_namespaced_secret.call_args.kwargs["body"].string_data
         assert "terraform.tfvars.json" not in sd
         assert sd["FOO"] == "bar"
+
+
+# ── Launch namespace propagation (regression) ────────────────────────
+
+
+class TestLaunchNamespace:
+    """Regression: the launch path must create the Job AND look up its UID (for
+    the auth-Secret ownerReference) in the *configured* runner namespace.
+
+    get_job_uid() previously omitted the namespace and fell back to a stale
+    default decoupled from the configured runner namespace, so the auth-Secret
+    step did a `get jobs` in the wrong namespace than the Job was created in —
+    a 403 on every launch when the two differed (e.g. single-namespace eval)."""
+
+    async def test_launch_uses_configured_runner_namespace(self, fresh_shutdown_event):
+        listener = _make_listener(fresh_shutdown_event)
+        listener.runner_config.runner_namespace = "custom-runner-ns"
+
+        listener._get_runner_token = AsyncMock(return_value="runtok:abc")
+        listener._create_auth_secret = AsyncMock()
+        listener._read_ca_bundle_pem = MagicMock(return_value="")
+        listener._report_launch_failed = AsyncMock()
+        listener._auth_headers = MagicMock(return_value={})
+
+        spec = {"metadata": {"name": "tprun-r1-plan", "namespace": "custom-runner-ns"}}
+        with (
+            patch("terrapod.runner.job_template.build_job_spec", return_value=spec),
+            patch(
+                "terrapod.runner.job_manager.create_job",
+                new=AsyncMock(return_value="tprun-r1-plan"),
+            ) as mock_create,
+            patch(
+                "terrapod.runner.job_manager.get_job_uid",
+                new=AsyncMock(return_value="uid-1"),
+            ) as mock_uid,
+            patch("terrapod.runner.listener.arequest_with_retry", new=AsyncMock()),
+        ):
+            await listener._launch_run("r1", {"phase": "plan"})
+
+        listener._report_launch_failed.assert_not_called()
+        mock_create.assert_awaited_once()
+        assert mock_create.await_args.kwargs["namespace"] == "custom-runner-ns"
+        mock_uid.assert_awaited_once()
+        assert mock_uid.await_args.kwargs["namespace"] == "custom-runner-ns"

--- a/services/tests/services/test_listener.py
+++ b/services/tests/services/test_listener.py
@@ -24,7 +24,18 @@ def fresh_shutdown_event():
 def _make_listener(shutdown_event: asyncio.Event, **overrides) -> RunnerListener:
     """Create a listener with mocked identity and config."""
     with patch("terrapod.runner.listener.load_runner_config") as mock_cfg:
-        mock_cfg.return_value = MagicMock(definitions=[])
+        # __init__ now reads listener knobs off RunnerConfig (#617) — give the
+        # mock real int defaults so comparisons (active >= max_concurrent) work.
+        mock_cfg.return_value = MagicMock(
+            definitions=[],
+            heartbeat_interval=60,
+            max_concurrent=3,
+            health_port=8081,
+            sse_retry_interval=5,
+            poll_interval=30,
+            sse_read_timeout=30,
+            sse_max_age=600,
+        )
         listener = RunnerListener()
 
     listener.identity = MagicMock()


### PR DESCRIPTION
Establishes the **config-channel contract**: non-sensitive config flows through a ConfigMap (Helm-configurable end to end), secrets via `secretKeyRef`, and the chart never sets a non-sensitive setting via a `TERRAPOD_*` env var. Binds three legs — the config code, the chart, and a render-and-parse CI check.

Closes #617.

## API config (Settings → `configmap-api.yaml`)
Render the settings that were silently **inert** because the ConfigMap omitted them — an operator set them in `values.yaml`, they never reached the pod, and the code default won:
- **`rate_limit`** (entire block — rate limiting was completely unreachable via Helm despite being in values+schema and consumed by `app.py`)
- `registry.module_interface`, `cors.allow_credentials/allow_methods/allow_headers`, OIDC/SAML `claims_to_roles` + SAML `acs_url`, `vcs.tmpdir_min_free_bytes`, `debug`, `json_logs`

`0`-means-unlimited rates render directly (no `| default` trap). `values.schema.json` updated to allow the new operator-settable keys.

## Listener config (`RunnerConfig` → `runners.yaml`)
`RunnerConfig` is now a **pydantic-settings `BaseSettings`** layering defaults → `runners.yaml` → env (mirroring `Settings`), so the listener reads ONE config object instead of scattered `os.environ` calls. It now carries the listener's own operational settings (name, namespaces, API URLs, health port, cert TTL, SSE/heartbeat/poll knobs).
- `listener.py` / `identity.py` / `job_template.py` read them off the config object; `os.environ` is reduced to `POD_NAME`/`HOSTNAME`/`LOG_LEVEL` + the `JOIN_TOKEN` secret.
- `configmap-runner.yaml` renders them; `deployment-listener.yaml` env stripped to **just `POD_NAME` + the join-token secret**.
- Chart and image ship together → no back-compat env shim needed.

## Verification leg — `helm-config-contract` CI job + `scripts/helm-config-contract.sh`
Renders **every** values profile and parses the rendered ConfigMaps **through the real `Settings`/`RunnerConfig` models**, asserting:
1. **No drift** — every key the chart renders is a real field on the model (catches a typo'd/stale chart key).
2. **Coverage** — contract-spine keys present (`rate_limit`, `registry.module_interface`, the migrated listener settings).
3. **Env channel** — no non-sensitive `TERRAPOD_*` env on any rendered Deployment.

Parsing rendered YAML (not grepping Go-template text) is robust — no false positives. Wired into `ci-pass`; runs locally via `make helm-config-contract`. This substantially extends helm CI coverage (previously just an Ingress + embedded-Postgres grep) and ties it to the config models so the contract can't silently drift.

## Docs
AGENTS.md gains the **"config-channel contract"** convention (three legs, in the same PR); the duplicate bullet was removed from the local guide (it imports AGENTS.md).

## Verification
- Full `make test` green (2522). `make lint` clean.
- `helm lint` + `helm template` render on `values.yaml` / `values-local.yaml` / `values-eval.yaml`.
- `scripts/helm-config-contract.sh` green on all three profiles.
- **Live listener join+run smoke on Tilt is pending before merge** (the listener now reads its config purely from `runners.yaml` — proving join + Job launch end-to-end is the F-gate; I'll run it once CI is green).

## Follow-ups (tracked, out of scope here)
First-class `secretKeyRef` blocks for `registry.signing_key` / `smtp.password` / `ai_summary.auth.api_key` + a `secretKeyRef` path for the bootstrap pool token (today reachable only via `extraEnv` / values literal — not a config-channel violation, just a usability/secret-handling improvement).

---

### Follow-up fix (eval-boot regression)

The config-channel refactor (removing `TERRAPOD_RUNNER_NAMESPACE` env in favour of the runners.yaml ConfigMap) left `job_manager._default_namespace()` reading the now-unset env and falling back to a hard-coded `terrapod-runners`. The Job was created in the configured namespace but `get_job_uid()` (auth-Secret step) hit the stale fallback → `403 cannot get jobs in namespace terrapod-runners` on every launch in the **eval profile** (single-namespace: runner namespace == release namespace). Tilt did not reproduce it because its runner namespace equals the old default.

Fixed: the launch path passes `runner_config.runner_namespace` explicitly to `create_job`/`get_job_uid`; `_default_namespace()` now sources from the loaded `RunnerConfig`. Regression tests added. (Also closed an unclosed file handle in `check_helm_config_contract.py` flagged by GitHub Advanced Security.)
