### PR TITLE
chore(security): suppress 4 test-only Semgrep code-scanning false positives

### DIFF
--- a/go-terrapod/state_versions_test.go
+++ b/go-terrapod/state_versions_test.go
@@ -90,6 +90,9 @@ func TestCreateAndUploadState_ComputesMD5WhenEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// MD5 here is the TFE state-version checksum the V2 protocol mandates, not a
+	// security primitive — this test asserts we send the right checksum.
+	// nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
 	sum := md5.Sum(raw) //nolint:gosec
 	wantMD5 := hex.EncodeToString(sum[:])
 	var req struct {

--- a/services/tests/integration/conftest.py
+++ b/services/tests/integration/conftest.py
@@ -260,6 +260,10 @@ async def clean_db(app):
     from terrapod.db.session import get_db_session
 
     async with get_db_session() as session:
+        # _TRUNCATE_SQL is built from a hard-coded table list (see top of file),
+        # not from any request/user input — no injection surface in this test
+        # cleanup fixture.
+        # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
         await session.execute(text(_TRUNCATE_SQL))
 
 

--- a/services/tests/services/test_github_service.py
+++ b/services/tests/services/test_github_service.py
@@ -110,7 +110,10 @@ class TestGenerateAppJwt:
         ).decode()
 
         token = _generate_app_jwt(42, pem)
-        # Decode without verification to inspect claims
+        # Decode without verification to inspect claims — this is a test that
+        # asserts the claims our own signer produced; there is no untrusted
+        # token here and nothing to verify against.
+        # nosemgrep: python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
         claims = jwt.decode(token, options={"verify_signature": False})
 
         assert claims["iss"] == "42"
@@ -130,6 +133,8 @@ class TestGenerateAppJwt:
         ).decode()
 
         token = _generate_app_jwt(1, pem)
+        # Inspect-only decode of a token we just signed (see above).
+        # nosemgrep: python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
         claims = jwt.decode(token, options={"verify_signature": False})
 
         # exp should be ~11 minutes from iat (iat is now-60, exp is now+600)


### PR DESCRIPTION
Resolves the 4 open Semgrep OSS alerts in the code-scanning tab — all in test code, all genuine false positives. Adds targeted `# nosemgrep` / `// nosemgrep` suppressions with a rationale comment at each site, so the rules stay active for real application code while these test-only sites stop alerting.

| Alert | Rule | Site | Why false positive |
|---|---|---|---|
| #223 / #224 | `python.jwt...unverified-jwt-decode` | `test_github_service.py` | `jwt.decode(verify_signature=False)` inspects claims of a token the test just signed itself |
| #222 | `python.sqlalchemy...avoid-sqlalchemy-text` | `integration/conftest.py` | `text(_TRUNCATE_SQL)` is built from a hard-coded table list, no request/user input |
| #221 | `go.lang...use-of-md5` | `state_versions_test.go` | `md5.Sum` is the TFE state-version checksum the V2 protocol mandates (already `//nolint:gosec`) |

Verified by running the exact config set the `sast` CI job uses (`p/python` + `p/owasp-top-ten` + `p/secrets` + custom rules) against the three files: **0 findings** after the suppressions.

The existing open alerts are dismissed as "used in tests"; the suppressions keep them from recurring on the next `main` scan.

Closes #620