### PR TITLE
fix(cache): close sealed-mode upstream leak paths + air-gap docs (v0.49.0 pre-release)

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -707,7 +707,7 @@ The provider network mirror has the equivalent override: `registry.provider_cach
 
 All of these fetches go through the [forward proxy and custom CA](deployment-proxy.md) when configured (the API's HTTP client honours `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` / the mounted CA bundle), so an internal mirror reached only via a corporate egress proxy works without further changes. Integrity verification ([supply-chain verification](supply-chain-verification.md)) still applies to mirror-served artifacts — if the mirror re-signs binaries with its own key, supply the key via `binary_cache.signing_keys`.
 
-> A fully sealed, **no-egress** deployment (cache-miss must never reach upstream at all) plus declarative cache pre-population is tracked as the later parts of air-gapped support (#606). This section covers pointing the pull-through caches at internal sources; the caches still fall through to those configured sources on a miss.
+> This section covers pointing the pull-through caches at internal sources; the caches still fall through to those configured sources on a miss. To pre-fill the caches up front see [Cache pre-population](#cache-pre-population) below, and to forbid any upstream fall-through entirely (cache-miss must never reach upstream) see [Sealed (cache-only) mode](#sealed-cache-only-mode).
 
 ### Pre-release versions (`allow_prerelease`)
 

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1027,3 +1027,32 @@ The catalog provisions **and** destroys real infrastructure on behalf of self-se
 - **Archive is a soft delete** — the workspace row, its state versions, and run history are **retained** (`lifecycle_state = "archived"`), only hidden from the active catalog/workspace lists. State and audit are recoverable.
 - To restore visibility, flip `lifecycle_state` back to `active` on the workspace row (DBA action — there is intentionally no API to "un-destroy", since the infra was torn down). The workspace's last state version is still in object storage under its state key.
 - If you need the **infrastructure** back (not just the record), re-provision the catalog item with the same inputs — the wrapper is regenerated deterministically from the item + inputs.
+
+---
+
+## Sealed (cache-only) mode — runs failing with cache-miss 404
+
+**Symptom**: after enabling `registry.cache_only: true` (air-gap / sealed mode), runner Jobs fail early — `terraform`/`tofu` `init` can't fetch its CLI binary or a provider, and the API logs / run errors show a **404** with a message like *"… is not in the cache and sealed (cache_only) mode is enabled. Pre-populate it … before sealing, or disable registry.cache_only."* Every run that needs an un-cached artifact fails; runs whose binary + providers are all cached keep working.
+
+This is **by design** — sealed mode guarantees no upstream fetch ever happens, so a cache miss is an actionable error rather than a silent (and, with no egress, doomed) upstream attempt. It is not data loss; nothing is destroyed.
+
+### Diagnosis
+
+- Confirm sealed mode is on: `registry.cache_only` in the API ConfigMap (`helm get values` / the rendered `config.yaml`).
+- Identify the missing artifact from the 404 detail (tool+version+os/arch, or provider `host/ns/type@version`).
+- List what IS cached: `GET /api/terrapod/v1/admin/binary-cache` and `GET /api/terrapod/v1/admin/provider-cache` (admin), or the `/admin/binary-cache` UI.
+- Remember partial versions resolve **only against the cache** when sealed — a workspace pinned to `terraform_version = "1.12"` needs a cached `1.12.x`; if none is cached the resolve itself 404s.
+- The **platform Terrapod provider** (`<host>/default/terrapod`) and the **SHA256SUMS** used for runner re-verification are subject to the same gate — they must be cached too (SHA256SUMS are persisted when the binary is warmed under `verify=signature`).
+
+### Resolution
+
+1. **Preferred — warm the missing artifacts, keep sealed.** Sealed mode refuses to fetch, so warm from a path that *can* reach the source:
+   - Temporarily set `registry.cache_only: false` (optionally with the upstream overrides pointing at an internal mirror), bulk-warm the needed entries via `POST /api/terrapod/v1/admin/binary-cache/warm-bulk` or the **Warm cache** UI panel, confirm they appear in the cache lists, then set `cache_only: true` again. See [Cache pre-population](registry.md#cache-pre-population).
+   - Or warm a staging Terrapod that shares/replicates the same object store + DB, so the sealed instance sees the artifacts.
+2. **Escape hatch — unseal.** Set `registry.cache_only: false` to re-allow upstream fall-through (only viable if the instance actually has egress to upstream or an internal mirror).
+
+### Verification
+
+- Re-list the binary/provider caches and confirm the previously-missing artifact (and the right partial-version match) is present.
+- Re-queue the failed run; `init` now resolves the binary + providers from cache and the run proceeds.
+- Note: the artifact-retention sweeper intentionally **skips** the binary/provider caches while sealed, so warmed artifacts won't be evicted out from under a sealed instance.

--- a/docs/supply-chain-verification.md
+++ b/docs/supply-chain-verification.md
@@ -124,4 +124,4 @@ compare only) until the trust set is updated.
 In a sealed/air-gapped install the runner never reaches upstream: it fetches the
 binary **and** the signed manifest from Terrapod, and verifies both with its
 pinned key. Verification therefore holds end-to-end without any upstream
-connectivity. See [Air-gapped artifact delivery](https://github.com/mattrobinsonsre/terrapod/issues/606).
+connectivity. See [Sealed (cache-only) mode](registry.md#sealed-cache-only-mode) and [Cache pre-population](registry.md#cache-pre-population) for the full air-gapped flow (point at an internal mirror → warm → seal).

--- a/services/terrapod/api/routers/binary_cache.py
+++ b/services/terrapod/api/routers/binary_cache.py
@@ -157,6 +157,8 @@ async def get_binary_sha256sums(
     try:
         resolved = await resolve_version(tool, version)
         manifest, _sig = await get_or_cache_sums(storage, tool, resolved)
+    except CacheOnlyError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except Exception as e:
@@ -182,6 +184,8 @@ async def get_binary_sha256sums_sig(
     try:
         resolved = await resolve_version(tool, version)
         _manifest, sig = await get_or_cache_sums(storage, tool, resolved)
+    except CacheOnlyError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except Exception as e:

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -53,6 +53,7 @@ from terrapod.api.serialization import rfc3339
 from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
+from terrapod.services.cache_errors import CacheOnlyError
 from terrapod.services.platform_provider_service import (
     get_download_info as platform_get_download_info,
 )
@@ -266,6 +267,9 @@ async def download_provider_cli(
         try:
             info = await platform_get_download_info(storage, version, os, arch)
             return JSONResponse(content=info)
+        except CacheOnlyError as e:
+            # Sealed mode + not cached — actionable 404, never fetch upstream.
+            raise HTTPException(status_code=404, detail=str(e)) from e
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
         except RuntimeError as e:

--- a/services/terrapod/services/binary_cache_service.py
+++ b/services/terrapod/services/binary_cache_service.py
@@ -325,6 +325,14 @@ async def get_or_cache_sums(storage: ObjectStore, tool: str, version: str) -> tu
     if await storage.exists(sums_key) and await storage.exists(sig_key):
         return await storage.get(sums_key), await storage.get(sig_key)
 
+    # Sealed (cache-only) mode: never fetch the manifest/sig from upstream.
+    if _sealed():
+        raise CacheOnlyError(
+            f"SHA256SUMS for {tool} {version} are not cached and sealed (cache_only) "
+            f"mode is enabled. They are persisted when the binary is warmed under "
+            f"verify=signature — re-warm it before sealing, or disable registry.cache_only."
+        )
+
     # Not persisted yet — fetch from upstream, verify the signature against the
     # pinned publisher key, persist, and return. Import locally to avoid a
     # module-load cycle (artifact_verification imports config, not this module).
@@ -382,8 +390,13 @@ async def warm_binary(
     os_: str,
     arch: str,
 ) -> str:
-    """Pre-warm a binary into the cache. Returns presigned URL."""
-    return await get_or_cache_binary(db, storage, tool, version, os_, arch)
+    """Pre-warm a binary into the cache. Returns presigned URL.
+
+    Resolves a partial version (e.g. "1.12" → "1.12.3") first, so warm
+    manifests / bulk-warm entries can use major.minor like the CLI does.
+    """
+    resolved = await resolve_version(tool, version)
+    return await get_or_cache_binary(db, storage, tool, resolved, os_, arch)
 
 
 # --- Available Versions ---

--- a/services/terrapod/services/platform_provider_service.py
+++ b/services/terrapod/services/platform_provider_service.py
@@ -27,6 +27,7 @@ import httpx
 from terrapod.config import settings
 from terrapod.http_retry import arequest_with_retry
 from terrapod.logging_config import get_logger
+from terrapod.services.cache_errors import CacheOnlyError
 from terrapod.services.hashing_stream import HashingStream
 from terrapod.storage.keys import (
     platform_provider_binary_key,
@@ -135,6 +136,11 @@ async def get_download_info(
     shasums_sig_key = platform_provider_shasums_sig_key(version)
     filename = f"terraform-provider-terrapod_{version}_{os_}_{arch}.zip"
 
+    # Sealed (cache-only) mode: never fetch the platform provider from GitHub.
+    # The binary + SHA256SUMS must already be cached; otherwise surface an
+    # actionable error rather than reaching upstream (#606).
+    sealed = settings.registry.cache_only
+
     # Check if binary is already cached
     if await storage.exists(binary_key):
         logger.debug(
@@ -142,6 +148,12 @@ async def get_download_info(
             version=version,
             os=os_,
             arch=arch,
+        )
+    elif sealed:
+        raise CacheOnlyError(
+            f"The platform terrapod provider {version} ({os_}/{arch}) is not cached "
+            f"and sealed (cache_only) mode is enabled. Pre-populate it before sealing, "
+            f"or disable registry.cache_only."
         )
     else:
         # Cache miss — fetch from GitHub Release
@@ -155,10 +167,16 @@ async def get_download_info(
 
     # Ensure SHA256SUMS is cached (fetch once per version)
     if not await storage.exists(shasums_key):
+        if sealed:
+            raise CacheOnlyError(
+                f"SHA256SUMS for the platform terrapod provider {version} are not cached "
+                f"and sealed (cache_only) mode is enabled. Pre-populate the provider "
+                f"before sealing, or disable registry.cache_only."
+            )
         await _fetch_and_cache_shasums(storage, version, shasums_key)
 
     # Ensure SHA256SUMS.sig is cached (fetch once per version, optional)
-    if not await storage.exists(shasums_sig_key):
+    if not await storage.exists(shasums_sig_key) and not sealed:
         await _fetch_and_cache_shasums_sig(storage, version, shasums_sig_key)
 
     # Generate presigned URL for the binary

--- a/services/tests/services/test_sealed_mode.py
+++ b/services/tests/services/test_sealed_mode.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from terrapod.config import settings
-from terrapod.services import binary_cache_service, provider_cache_service
+from terrapod.services import (
+    binary_cache_service,
+    platform_provider_service,
+    provider_cache_service,
+)
 from terrapod.services.binary_cache_service import _pick_cached_version
 from terrapod.services.cache_errors import CacheOnlyError
 
@@ -183,6 +187,41 @@ class TestSealedProvider:
             await provider_cache_service.fetch_and_cache_single_platform(
                 db, storage, "registry.terraform.io", "hashicorp", "aws", "5.60.0", "linux", "amd64"
             )
+
+
+# ── Sealed: SHA256SUMS re-verify path + platform provider (no upstream) ──
+
+
+class TestSealedSums:
+    async def test_get_or_cache_sums_miss_raises_no_upstream(self):
+        # Not persisted + sealed → CacheOnlyError, never constructs an httpx client.
+        storage = AsyncMock()
+        storage.exists = AsyncMock(return_value=False)
+        with (
+            _sealed(),
+            patch.object(binary_cache_service.httpx, "AsyncClient") as mock_client,
+        ):
+            with pytest.raises(CacheOnlyError):
+                await binary_cache_service.get_or_cache_sums(storage, "terraform", "1.12.3")
+        mock_client.assert_not_called()
+
+
+class TestSealedPlatformProvider:
+    async def test_get_download_info_miss_raises_no_github(self):
+        # The Terrapod provider itself must not be fetched from GitHub when sealed.
+        storage = AsyncMock()
+        storage.exists = AsyncMock(return_value=False)
+        with (
+            _sealed(),
+            patch.object(
+                platform_provider_service, "_fetch_and_cache_binary", new=AsyncMock()
+            ) as mock_fetch,
+        ):
+            with pytest.raises(CacheOnlyError):
+                await platform_provider_service.get_download_info(
+                    storage, "0.49.0", "linux", "amd64"
+                )
+        mock_fetch.assert_not_called()
 
 
 # ── Artifact retention skips caches when sealed ──────────────────────


### PR DESCRIPTION
Pre-release audit + independent third-party review fixes for **v0.49.0** (the #606 air-gap series). The adversarial review found two real sealed-mode leak paths that green CI + the author self-audit missed — both directly contradict the `registry.cache_only` "no upstream fetch ever" contract.

## Blockers fixed
- **Platform Terrapod-provider download** (`platform_provider_service.get_download_info`) fetched the provider binary + SHA256SUMS from GitHub Releases with **no `cache_only` gate** — a sealed install whose config references `<host>/default/terrapod` (the Terrapod provider itself — common) would hit GitHub on `tofu init`. Now raises `CacheOnlyError` on a sealed cache miss; the CLI-protocol router maps it to **404**.
- **`get_or_cache_sums`** (runner signature re-verify path) lazily fetched SHA256SUMS + `.sig` from upstream with no gate. Now raises `CacheOnlyError` when not already persisted under sealed mode; both `sha256sums`/`sha256sums.sig` endpoints map it to 404.

## Also
- **Bulk-warm resolves partial versions** — `warm_binary` now calls `resolve_version`, so a manifest/bulk entry of `{tool, "1.12"}` warms `1.12.x` instead of 404ing.
- **Tests** — sealed-mode tests for both leak paths (assert no upstream client is constructed) + the existing sealed suite.
- **Docs** — drop the stale `registry.md` blockquote that framed sealed mode / pre-population as future work (both shipped this cycle); point `supply-chain-verification.md` at the in-repo air-gap docs; add a `runbooks.md` entry for the sealed-mode cache-miss-404 failure mode (high-blast-radius operational surface).

## Verification
`make test` (2555 passed), `make lint`, targeted sealed/binary-cache suites all green. This is the gating fix PR before tagging v0.49.0.

Refs #606