### PR TITLE
fix(ci): publish SBOM as OCI referrer, not legacy .att tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1282,7 +1282,7 @@ jobs:
       # attestations on every release image and the Helm chart, anchored to
       # this workflow's GitHub OIDC identity and logged in Rekor. Signing is
       # done by immutable digest so it's independent of the retag above.
-      - name: Sign images + Helm chart + attest SBOMs (cosign keyless)
+      - name: Sign images + Helm chart (cosign keyless)
         id: digests
         env:
           COSIGN_YES: "true"
@@ -1294,9 +1294,9 @@ jobs:
             digest=$(docker buildx imagetools inspect "$REGISTRY/$image:$version" --format '{{.Manifest.Digest}}')
             echo "Signing $image@$digest"
             cosign sign "$REGISTRY/$image@$digest"
-            cosign attest --type spdxjson --predicate "dist/sbom-${image}.spdx.json" "$REGISTRY/$image@$digest"
             # Expose the digest (hyphens → underscores for the output key) so the
-            # SLSA provenance steps below can attest the same immutable subject.
+            # SBOM + SLSA provenance steps below can attest the same immutable
+            # subject as OCI 1.1 referrers.
             echo "${image//-/_}_digest=$digest" >> "$GITHUB_OUTPUT"
           done
 
@@ -1335,6 +1335,47 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/terrapod-migrations
           subject-digest: ${{ steps.digests.outputs.terrapod_migrations_digest }}
+          push-to-registry: true
+
+      # SBOM (SPDX) per image, published as an OCI 1.1 referrer next to the image
+      # — same discovery path as the provenance above. (Previously attached via
+      # `cosign attest`, which writes the legacy `.att` tag that
+      # `cosign verify-attestation`/`gh attestation verify` don't read as a
+      # referrer; #549 follow-up.)
+      - name: SBOM — terrapod-api
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/terrapod-api
+          subject-digest: ${{ steps.digests.outputs.terrapod_api_digest }}
+          sbom-path: dist/sbom-terrapod-api.spdx.json
+          push-to-registry: true
+      - name: SBOM — terrapod-web
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/terrapod-web
+          subject-digest: ${{ steps.digests.outputs.terrapod_web_digest }}
+          sbom-path: dist/sbom-terrapod-web.spdx.json
+          push-to-registry: true
+      - name: SBOM — terrapod-runner
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/terrapod-runner
+          subject-digest: ${{ steps.digests.outputs.terrapod_runner_digest }}
+          sbom-path: dist/sbom-terrapod-runner.spdx.json
+          push-to-registry: true
+      - name: SBOM — terrapod-listener
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/terrapod-listener
+          subject-digest: ${{ steps.digests.outputs.terrapod_listener_digest }}
+          sbom-path: dist/sbom-terrapod-listener.spdx.json
+          push-to-registry: true
+      - name: SBOM — terrapod-migrations
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/terrapod-migrations
+          subject-digest: ${{ steps.digests.outputs.terrapod_migrations_digest }}
+          sbom-path: dist/sbom-terrapod-migrations.spdx.json
           push-to-registry: true
 
       - name: Generate checksums

--- a/docs/supply-chain-verification.md
+++ b/docs/supply-chain-verification.md
@@ -47,6 +47,15 @@ Repeat for `terrapod-web`, `terrapod-runner`, `terrapod-listener`,
 
 ### Verify the SBOM attestation
 
+The SBOM (SPDX) is attached to each image as an OCI 1.1 referrer:
+
+```sh
+gh attestation verify oci://"$IMAGE" --repo mattrobinsonsre/terrapod \
+  --predicate-type https://spdx.dev/Document
+```
+
+…or with cosign (reads the same referrer):
+
 ```sh
 cosign verify-attestation "$IMAGE" --type spdxjson \
   --certificate-identity-regexp '^https://github.com/mattrobinsonsre/terrapod/.github/workflows/ci.yml@refs/tags/v.*$' \
@@ -54,10 +63,14 @@ cosign verify-attestation "$IMAGE" --type spdxjson \
   | jq -r '.payload | @base64d | fromjson | .predicate' > sbom.spdx.json
 ```
 
+(The SPDX SBOMs are also attached to each GitHub Release as files, if you'd
+rather download them directly.)
+
 ### Verify build provenance (SLSA)
 
 ```sh
-gh attestation verify oci://"$IMAGE" --repo mattrobinsonsre/terrapod
+gh attestation verify oci://"$IMAGE" --repo mattrobinsonsre/terrapod \
+  --predicate-type https://slsa.dev/provenance/v1
 ```
 
 A deployment can enforce these at admission time (e.g. a Kyverno / Sigstore


### PR DESCRIPTION
## What

The release pipeline's SBOM attestation was attached with `cosign attest --type spdxjson`, which writes to the **legacy `.att` tag**. Neither `cosign verify-attestation` nor `gh attestation verify` reads that as an OCI 1.1 referrer, so the documented SBOM verification fails even though image/chart signatures and SLSA provenance all verify cleanly (provenance already used `actions/attest-build-provenance`, which publishes a referrer).

Found by the v0.49.1 test release.

## Change

- Drop the per-image `cosign attest --type spdxjson` line from the cosign signing loop.
- Add five `actions/attest-sbom@v2` steps (`push-to-registry: true`), one per image, mirroring the existing provenance steps — SBOM is now an OCI referrer on the same discovery path.
- Update `docs/supply-chain-verification.md` to verify SBOM + provenance via `gh attestation verify --predicate-type` (cosign command kept as an alternative since it reads the referrer too).

## Verification

- actionlint clean on the changed region (pre-existing shellcheck style warnings on unrelated lines only).
- Will be exercised end-to-end by the v0.49.2 test release: confirm all four — image signature, chart signature, SBOM (referrer), SLSA provenance.

Closes #626. Part of #549.