### PR TITLE
docs: correct cosign SBOM verify command to versioned SPDX predicate type

### DIFF
--- a/docs/supply-chain-verification.md
+++ b/docs/supply-chain-verification.md
@@ -54,10 +54,12 @@ gh attestation verify oci://"$IMAGE" --repo mattrobinsonsre/terrapod \
   --predicate-type https://spdx.dev/Document
 ```
 
-…or with cosign (reads the same referrer):
+…or with cosign (reads the same referrer). Note the SBOM predicate type is the
+**versioned** SPDX URI, so pass it explicitly — cosign's `--type spdxjson` alias
+maps to the unversioned URI and will not match:
 
 ```sh
-cosign verify-attestation "$IMAGE" --type spdxjson \
+cosign verify-attestation "$IMAGE" --type https://spdx.dev/Document/v2.3 \
   --certificate-identity-regexp '^https://github.com/mattrobinsonsre/terrapod/.github/workflows/ci.yml@refs/tags/v.*$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   | jq -r '.payload | @base64d | fromjson | .predicate' > sbom.spdx.json


### PR DESCRIPTION
The cosign SBOM-verification command in `docs/supply-chain-verification.md` used `--type spdxjson`, whose alias maps to the unversioned `https://spdx.dev/Document` URI. `actions/attest-sbom` writes the **versioned** `https://spdx.dev/Document/v2.3`, so cosign reports "none of the attestations matched the predicate type". Pass the versioned URI explicitly.

Verified against the v0.49.2 release artifacts — image signature, chart signature, SBOM (via both `gh attestation verify` and cosign with the versioned type), and SLSA provenance all pass.

Follow-up to #626 / part of #549.