### PR TITLE
feat(observability): ship Grafana dashboard + PrometheusRule + per-alert runbooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,31 @@ jobs:
           echo "$out" | grep -q "ca_bundle_source_path" || { echo "FAIL: runners.yaml CA source path missing"; exit 1; }
           echo "$out" | grep -q "http_proxy: \"http://proxy.example.com:3128\"" || { echo "FAIL: runners.yaml proxy missing"; exit 1; }
           echo "proxy + CA bundle render OK (#592)"
+      - name: Observability bundle render — PrometheusRule + Grafana dashboards (#546)
+        run: |
+          # Every bundled dashboard JSON is valid JSON before it's embedded.
+          # (jq is preinstalled on GitHub ubuntu-latest runners.)
+          for f in helm/terrapod/dashboards/*.json; do
+            jq -e . "$f" > /dev/null || { echo "FAIL: invalid dashboard JSON: $f"; exit 1; }
+          done
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set api.config.metrics.prometheusRule.enabled=true \
+              --set api.config.metrics.grafanaDashboards.enabled=true)
+          echo "$out" | grep -q "kind: PrometheusRule" || { echo "FAIL: PrometheusRule not rendered"; exit 1; }
+          echo "$out" | grep -q "alert: TerrapodAPIDown" || { echo "FAIL: bundled alert rules missing"; exit 1; }
+          echo "$out" | grep -q "runbook_url:" || { echo "FAIL: alerts missing runbook_url annotation"; exit 1; }
+          echo "$out" | grep -q "grafana_dashboard:" || { echo "FAIL: Grafana dashboard sidecar label missing"; exit 1; }
+          echo "$out" | grep -q "terrapod-overview.json:" || { echo "FAIL: dashboard ConfigMap key missing"; exit 1; }
+          # Off by default: a stock render emits neither.
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379)
+          echo "$stock" | grep -q "kind: PrometheusRule" && { echo "FAIL: PrometheusRule rendered by default (should be opt-in)"; exit 1; }
+          echo "observability bundle renders OK and is off by default (#546)"
 
   # ── Config-channel contract (#617) ────────────────────
   # Renders the chart (every values profile) and parses the rendered ConfigMaps

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Runners](docs/runners.md) | Agent pools, the listener/runner ARC model, custom runner images |
 | [Cloud Credentials](docs/cloud-credentials.md) | AWS IRSA, GCP WIF, Azure WI setup |
 | [Service Catalog](docs/service-catalog.md) | No-code self-service provisioning over the module registry |
-| [Monitoring](docs/monitoring.md) | Prometheus metrics, scraping, recommended alerts |
+| [Monitoring](docs/monitoring.md) | Prometheus metrics, scraping, shipped Grafana dashboard + alert rules (with per-alert runbooks) |
 | [Optional Webhook Ingress](docs/deployment-webhook-ingress.md) | Split public webhook ingress so the management plane can stay private |
 | [Forward Proxy & Custom CA](docs/deployment-proxy.md) | Route all outbound HTTP(S) through a corporate proxy and trust a private/MITM CA, across every component including runner Jobs |
 | [Security Hardening](docs/security-hardening.md) | Pod hardening defaults, secrets, network posture |

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,7 +123,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Registry](registry.md) | Private module/provider registry, caching layers |
 | [Registry Publishing](registry-publishing.md) | Publishing providers/modules with the `terrapod-publish` CLI and the client-signed publish protocol |
 | [Service Catalog](service-catalog.md) | No-code self-service provisioning over the private module registry: blessed catalog items, provider templates, a `catalog_permission` RBAC axis, and a full provision → reconfigure → destroy lifecycle |
-| [Monitoring](monitoring.md) | Prometheus metrics, scraping, recommended alerts |
+| [Monitoring](monitoring.md) | Prometheus metrics, scraping, shipped Grafana dashboard + alert rules (with per-alert runbooks) |
 | [Deployment](deployment.md) | Production Helm deployment, storage backends, scaling |
 | [Split-networking deployments](deployment-network-isolation.md) | Three-Ingress model: management / webhook / internal agent path, with split-hostname runner config |
 | [Optional split webhook ingress](deployment-webhook-ingress.md) | Optional second Ingress for the public-must-reach surface (VCS webhooks, run-task callbacks) |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -217,84 +217,68 @@ The listener process itself exposes metrics on its health port (`8081` at `GET /
 
 ---
 
-## Recommended Alerts
+## Grafana dashboards
 
-### High Error Rate
+Terrapod ships an opinionated **Grafana dashboard** (`Terrapod — Overview`) covering API throughput/latency, run lifecycle, scheduler/reconciler health, listeners, VCS polling, caches, and infrastructure dependencies. The source JSON lives in the chart at [`helm/terrapod/dashboards/`](../helm/terrapod/dashboards/).
 
-```yaml
-- alert: TerrapodHighErrorRate
-  expr: |
-    sum(rate(terrapod_http_requests_total{status=~"5.."}[5m]))
-    / sum(rate(terrapod_http_requests_total[5m])) > 0.05
-  for: 5m
-  annotations:
-    summary: "Terrapod API error rate above 5%"
-```
+Two ways to get it into Grafana:
 
-### Stuck Runs
+**Auto-import via the Grafana sidecar** (kube-prometheus-stack, bitnami Grafana). Enable the bundled ConfigMap — it's labeled `grafana_dashboard: "1"` so the sidecar picks it up automatically:
 
 ```yaml
-- alert: TerrapodStuckRuns
-  expr: |
-    increase(terrapod_runs_transitioned_total{to_status=~"planning|applying"}[30m]) > 0
-    unless increase(terrapod_runs_terminal_total[30m]) > 0
-  for: 30m
-  annotations:
-    summary: "Runs entering planning/applying but none reaching terminal state"
+api:
+  config:
+    metrics:
+      enabled: true
+      grafanaDashboards:
+        enabled: true
+        labels:
+          grafana_dashboard: "1"   # match your sidecar's watch label
 ```
 
-### Scheduler Stalls
+**Manual import.** In Grafana → *Dashboards → New → Import*, upload `helm/terrapod/dashboards/terrapod-overview.json` and pick your Prometheus data source.
+
+The dashboard uses a templated `datasource` variable, so it works with any Prometheus data source — no hard-coded UID.
+
+---
+
+## Alerting (shipped PrometheusRule)
+
+Terrapod ships a curated **`PrometheusRule`** (Prometheus Operator) so you don't have to author alerts from scratch. It's **off by default**; enable it and label it so your Prometheus's `ruleSelector` picks it up:
 
 ```yaml
-- alert: TerrapodSchedulerStall
-  expr: |
-    increase(terrapod_scheduler_task_executions_total{task="run_reconciler"}[5m]) == 0
-  for: 5m
-  annotations:
-    summary: "Run reconciler has not executed in 5 minutes"
+api:
+  config:
+    metrics:
+      enabled: true
+      prometheusRule:
+        enabled: true
+        labels:
+          release: kube-prometheus-stack   # match your ruleSelector
+        # Optional: pin runbook links to a tag or an internal mirror.
+        runbookBaseUrl: "https://github.com/mattrobinsonsre/terrapod/blob/main/docs/runbooks.md"
+        # Optional: append your own spec.groups entries.
+        extraGroups: []
 ```
 
-### Storage Errors
+Every alert carries a `runbook_url` annotation linking to the matching [operational runbook](runbooks.md). The bundled rules:
 
-```yaml
-- alert: TerrapodStorageErrors
-  expr: rate(terrapod_storage_errors_total[5m]) > 0
-  for: 5m
-  annotations:
-    summary: "Storage backend errors detected"
-```
+| Alert | Severity | Fires when | Runbook |
+|---|---|---|---|
+| `TerrapodAPIDown` | critical | No `terrapod-api` scrape target healthy for 2m | [API Down](runbooks.md#api-down--not-ready) |
+| `TerrapodHighErrorRate` | warning | 5xx ratio > 5% over 5m | [High API Error Rate](runbooks.md#high-api-error-rate) |
+| `TerrapodHighRequestLatency` | warning | p99 latency > 5s for 10m | [High API Latency](runbooks.md#high-api-latency) |
+| `TerrapodRunsStuck` | warning | Runs enter planning/applying but none reach terminal in 30m | [Stale Run](runbooks.md#stale-run-errored-after-timeout) |
+| `TerrapodListenerLaunchFailures` | warning | Listener claimed a run but couldn't launch its Job | [Listener Offline](runbooks.md#listener-offline) |
+| `TerrapodListenerPrelaunchTimeouts` | warning | Reconciler timed out a claimed-but-never-launched run | [Listener Offline](runbooks.md#listener-offline) |
+| `TerrapodReconcilerStalled` | critical | Run reconciler hasn't executed in 5m | [Scheduler Stall](runbooks.md#scheduler-stall) |
+| `TerrapodSchedulerTaskFailing` | warning | A periodic task errors repeatedly over 15m | [Scheduler Stall](runbooks.md#scheduler-stall) |
+| `TerrapodDatabaseErrors` | critical | DB error rate > 0.1/s for 5m | [DB Pool Exhaustion](runbooks.md#db-pool-exhaustion) |
+| `TerrapodRedisErrors` | critical | Redis error rate > 0.1/s for 5m | [Redis Connection Loss](runbooks.md#redis-connection-loss) |
+| `TerrapodStorageErrors` | warning | Object-storage errors for 5m | [Storage Errors](runbooks.md#storage-errors) |
+| `TerrapodHighBinaryCacheMissRate` | info | Binary cache miss rate > 50% over 1h | [High Cache Miss Rate](runbooks.md#high-cache-miss-rate) |
+| `TerrapodRetentionErrors` | warning | > 10 retention deletion errors in a day | [Storage Errors](runbooks.md#storage-errors) |
 
-### Database/Redis Errors
+Thresholds are sensible defaults; to tune them, disable the bundled rule and copy the [template](../helm/terrapod/templates/prometheusrule-api.yaml), or add overriding rules via `extraGroups`.
 
-```yaml
-- alert: TerrapodInfraErrors
-  expr: |
-    rate(terrapod_db_errors_total[5m]) > 0.1
-    or rate(terrapod_redis_errors_total[5m]) > 0.1
-  for: 5m
-  annotations:
-    summary: "Database or Redis errors detected"
-```
-
-### Cache Miss Rate
-
-```yaml
-- alert: TerrapodHighCacheMissRate
-  expr: |
-    sum(rate(terrapod_binary_cache_requests_total{result="miss"}[1h]))
-    / sum(rate(terrapod_binary_cache_requests_total[1h])) > 0.5
-  for: 1h
-  annotations:
-    summary: "Binary cache miss rate above 50% over the last hour"
-```
-
-### Retention Errors
-
-```yaml
-- alert: TerrapodRetentionErrors
-  expr: increase(terrapod_retention_errors_total[1d]) > 10
-  for: 1h
-  annotations:
-    summary: "Artifact retention encountering persistent errors"
-    description: "More than 10 retention deletion errors in the last day. Check storage backend health."
-```
+> **`up{job=...}`** — the `TerrapodAPIDown` rule matches `job=~".*terrapod-api.*"`. The `job` label is derived by the Prometheus Operator from the scraped Service; if your relabeling produces a different value, adjust the matcher.

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1056,3 +1056,145 @@ This is **by design** — sealed mode guarantees no upstream fetch ever happens,
 - Re-list the binary/provider caches and confirm the previously-missing artifact (and the right partial-version match) is present.
 - Re-queue the failed run; `init` now resolves the binary + providers from cache and the run proceeds.
 - Note: the artifact-retention sweeper intentionally **skips** the binary/provider caches while sealed, so warmed artifacts won't be evicted out from under a sealed instance.
+
+---
+
+## API Down / Not Ready
+
+Fires from the bundled `TerrapodAPIDown` alert: no `terrapod-api` scrape target has been healthy for 2 minutes. The platform is unavailable to the UI, CLI, runners, and listeners.
+
+### Symptoms
+
+- `max(up{job=~".*terrapod-api.*"}) == 0`
+- The UI returns 502/503 through the ingress; `terraform`/`tofu` against the cloud backend hang or error.
+- `/ready` failing on the API pods.
+
+### Diagnosis
+
+1. **Pod state:**
+   ```bash
+   kubectl get pods -n <ns> -l app.kubernetes.io/component=api
+   kubectl describe pod <api-pod> -n <ns>
+   ```
+   Look for `CrashLoopBackOff`, `OOMKilled`, failing readiness probes, or `Pending` (unschedulable).
+2. **Readiness detail** — `/ready` checks DB + Redis. Hit it from inside the cluster:
+   ```bash
+   kubectl exec -n <ns> deploy/terrapod-api -- python -c "import urllib.request;print(urllib.request.urlopen('http://localhost:8000/ready').read())" 2>&1 || true
+   ```
+   A failing `/ready` with healthy pods almost always means a dependency is down — see [DB Pool Exhaustion](#db-pool-exhaustion) / [Redis Connection Loss](#redis-connection-loss).
+3. **Recent rollout:**
+   ```bash
+   kubectl rollout history deploy/terrapod-api -n <ns>
+   ```
+   A bad image/config (e.g. a migration that didn't run) often correlates with the outage start.
+4. **Migrations** — a schema/app skew makes the API refuse to start. Confirm the migration Job for the current version succeeded.
+
+### Resolution
+
+- **Dependency down** → restore Postgres/Redis (their runbooks above); the API recovers on the next readiness probe.
+- **Bad rollout** → `kubectl rollout undo deploy/terrapod-api -n <ns>`.
+- **OOM/crash** → check `kubectl logs --previous`; raise `api.resources` if genuinely under-provisioned (confirm with the OOM `reason` field, don't assume).
+- **Unschedulable** → free capacity or fix nodeSelector/taints.
+
+### Verification
+
+- `max(up{job=~".*terrapod-api.*"}) == 1` and `/ready` returns 200.
+- The UI loads and a `terraform plan` against the cloud backend succeeds.
+
+---
+
+## High API Error Rate
+
+Fires from `TerrapodHighErrorRate`: more than 5% of API requests returned 5xx over 5 minutes.
+
+### Symptoms
+
+- `sum(rate(terrapod_http_requests_total{status=~"5.."}[5m])) / sum(rate(terrapod_http_requests_total[5m])) > 0.05`
+- Intermittent UI/CLI failures rather than a hard outage.
+
+### Diagnosis
+
+1. **Which routes?**
+   ```promql
+   topk(10, sum by (path_template, status) (rate(terrapod_http_requests_total{status=~"5.."}[5m])))
+   ```
+2. **Dependency errors** correlate with most 5xx spikes:
+   ```promql
+   rate(terrapod_db_errors_total[5m]) ; rate(terrapod_redis_errors_total[5m]) ; rate(terrapod_storage_errors_total[5m])
+   ```
+   Follow the matching runbook ([DB](#db-pool-exhaustion) / [Redis](#redis-connection-loss) / [Storage](#storage-errors)).
+3. **Logs** for the offending route:
+   ```logql
+   {namespace="<ns>", pod=~"terrapod-api.*"} | json | status >= 500
+   ```
+
+### Resolution
+
+- Fix the underlying dependency error surfaced above (the common case).
+- If 5xx is concentrated on one route after a deploy, roll back (`kubectl rollout undo`) and open a bug.
+- If it's load-driven (paired with [High API Latency](#high-api-latency)), scale the API (`api.replicas` / HPA) and check DB pool size.
+
+### Verification
+
+- The 5xx ratio drops back below 5% and stays there.
+- `topk` over `{status=~"5.."}` is empty for the previously-failing route.
+
+---
+
+## High API Latency
+
+Fires from `TerrapodHighRequestLatency`: p99 request latency above 5s for 10 minutes.
+
+### Symptoms
+
+- `histogram_quantile(0.99, sum(rate(terrapod_http_request_duration_seconds_bucket[5m])) by (le)) > 5`
+- The UI feels slow; SSE reconnects; CLI operations time out.
+
+### Diagnosis
+
+1. **Slow routes:**
+   ```promql
+   topk(10, histogram_quantile(0.95, sum by (le, path_template) (rate(terrapod_http_request_duration_seconds_bucket[5m]))))
+   ```
+2. **DB/Redis pressure** — latency usually tracks a saturated dependency. Check connection-pool saturation (see [DB Pool Exhaustion](#db-pool-exhaustion)) and Redis latency.
+3. **Event-loop starvation** — a sync call in an async handler stalls the whole worker (see the no-sync-work-in-async invariant). Check for a recent change on the slow route; look for liveness-probe restarts in `kubectl get pods`.
+4. **Run load** — a burst of concurrent runs/log-streaming can saturate the API.
+
+### Resolution
+
+- Relieve the saturated dependency (scale Postgres connections / Redis, or the API replicas).
+- If a specific route regressed, roll back and fix the blocking call (wrap in `asyncio.to_thread` or make the endpoint `def`).
+- Scale API replicas / enable the HPA for sustained load.
+
+### Verification
+
+- p99 latency returns under threshold.
+- No API pods are being restarted by the liveness probe.
+
+---
+
+## High Cache Miss Rate
+
+Fires from `TerrapodHighBinaryCacheMissRate` (info): the terraform/tofu binary cache hit rate fell below 50% over the last hour. Not an outage — runs still work by falling back upstream — but slower, and a problem in restricted-network/air-gapped installs.
+
+### Symptoms
+
+- `sum(rate(terrapod_binary_cache_requests_total{result="miss"}[1h])) / sum(rate(terrapod_binary_cache_requests_total[1h])) > 0.5`
+- `terraform init` slower than usual; runner egress to `releases.hashicorp.com` / GitHub increasing.
+
+### Diagnosis
+
+1. **Version spread** — many distinct tool versions in use means each is a legitimate first-time miss. Check the workspace `terraform_version` distribution.
+2. **Eviction too aggressive** — `registry.cache_ttl_days` (default 30, evicted on last-access) may be reclaiming entries between uses on a low-traffic instance.
+3. **Sealed mode** — if `registry.cache_only` is on, a miss is a hard 404, not a slow fall-through; see [Sealed (cache-only) mode](#sealed-cache-only-mode--runs-failing-with-cache-miss-404) instead.
+
+### Resolution
+
+- **Pre-warm** the versions your fleet pins via `POST /api/terrapod/v1/admin/binary-cache/warm-bulk` or the **Warm cache** UI panel ([Cache pre-population](registry.md#cache-pre-population)).
+- **Raise** `registry.cache_ttl_days` if eviction is the cause.
+- **Consolidate** on fewer tool versions where practical.
+
+### Verification
+
+- The hit ratio recovers above 50% as warmed/again-cached versions are served.
+- Per-tool: `sum by (tool) (rate(terrapod_binary_cache_requests_total{result="hit"}[1h]))` rises.

--- a/helm/terrapod/dashboards/terrapod-overview.json
+++ b/helm/terrapod/dashboards/terrapod-overview.json
@@ -1,0 +1,307 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Terrapod platform overview: API throughput/latency, run lifecycle, scheduler health, listeners, VCS polling, caches, and infrastructure dependencies. Ships with Terrapod (issue #546).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["terrapod"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Terrapod — Overview",
+  "uid": "terrapod-overview",
+  "version": 1,
+  "weekStart": "",
+  "panels": [
+    {
+      "type": "row",
+      "title": "API",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "API availability",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max(up{job=~\".*terrapod-api.*\"})" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate by status",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 6, "y": 1 },
+      "id": 3,
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "lastNotNull"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (status) (rate(terrapod_http_requests_total[5m]))", "legendFormat": "{{status}}" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "5xx error ratio (5m)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 0.01 }, { "color": "red", "value": 0.05 } ] }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_http_requests_total{status=~\"5..\"}[5m])) / clamp_min(sum(rate(terrapod_http_requests_total[5m])), 1)" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request latency (quantiles)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "id": 5,
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 5 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.50, sum(rate(terrapod_http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p50" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.95, sum(rate(terrapod_http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p95" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.99, sum(rate(terrapod_http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Auth failures by reason",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "id": 6,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 40 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (reason) (rate(terrapod_auth_failures_total[5m]))", "legendFormat": "{{reason}}" }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Runs",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "id": 10,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Runs created by source",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "id": 11,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (source) (rate(terrapod_runs_created_total[15m]))", "legendFormat": "{{source}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Run terminal outcomes",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "id": 12,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 40, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (status) (increase(terrapod_runs_terminal_total[1h]))", "legendFormat": "{{status}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Plan / apply duration (p95)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "id": 13,
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 5 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.95, sum(rate(terrapod_run_plan_duration_seconds_bucket[30m])) by (le))", "legendFormat": "plan p95" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.95, sum(rate(terrapod_run_apply_duration_seconds_bucket[30m])) by (le))", "legendFormat": "apply p95" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Run state transitions",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "id": 14,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (to_status) (rate(terrapod_runs_transitioned_total[15m]))", "legendFormat": "→ {{to_status}}" }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Scheduler & Listeners",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 20,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Scheduler task executions",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "id": 21,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 5 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (task, status) (rate(terrapod_scheduler_task_executions_total[15m]))", "legendFormat": "{{task}} ({{status}})" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Reconciler executions (5m)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 35 },
+      "id": 22,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "increase(terrapod_scheduler_task_executions_total{task=\"run_reconciler\"}[5m])" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Listener heartbeats & launch failures",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 35 },
+      "id": 23,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 5 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_listener_heartbeats_total[5m]))", "legendFormat": "heartbeats/s" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(increase(terrapod_listener_launch_failures_total[15m]))", "legendFormat": "launch failures (15m)" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(increase(terrapod_listener_prelaunch_timeouts_total[15m]))", "legendFormat": "prelaunch timeouts (15m)" }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "VCS, Caches & Infrastructure",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 43 },
+      "id": 30,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "VCS poll duration (p95) & detections",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 44 },
+      "id": 31,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 5 } }, "overrides": [ { "matcher": { "id": "byName", "options": "poll p95" }, "properties": [ { "id": "unit", "value": "s" } ] } ] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.95, sum(rate(terrapod_vcs_poll_duration_seconds_bucket[15m])) by (le))", "legendFormat": "poll p95" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_vcs_commits_detected_total[15m]))", "legendFormat": "commits/s" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_vcs_prs_detected_total[15m]))", "legendFormat": "PRs/s" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache hit ratio (1h)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 44 },
+      "id": 32,
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_binary_cache_requests_total{result=\"hit\"}[1h])) / clamp_min(sum(rate(terrapod_binary_cache_requests_total[1h])), 1)", "legendFormat": "binary cache" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_provider_cache_requests_total{result=\"hit\"}[1h])) / clamp_min(sum(rate(terrapod_provider_cache_requests_total[1h])), 1)", "legendFormat": "provider cache" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Infrastructure errors",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 52 },
+      "id": 33,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_db_errors_total[5m]))", "legendFormat": "db" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_redis_errors_total[5m]))", "legendFormat": "redis" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_storage_errors_total[5m]))", "legendFormat": "storage" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "State versions & lock conflicts",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 52 },
+      "id": 34,
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_state_versions_created_total[15m]))", "legendFormat": "state versions/s" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(terrapod_state_lock_conflicts_total[15m]))", "legendFormat": "lock conflicts/s" }
+      ]
+    }
+  ]
+}

--- a/helm/terrapod/templates/configmap-dashboards.yaml
+++ b/helm/terrapod/templates/configmap-dashboards.yaml
@@ -1,0 +1,32 @@
+{{- if ne .Values.api.enabled false }}
+{{- if and .Values.api.config.metrics.enabled .Values.api.config.metrics.grafanaDashboards.enabled }}
+{{- /*
+  Ship the bundled Grafana dashboard JSON as a ConfigMap labeled for the
+  Grafana sidecar (kiwigrid/k8s-sidecar, as used by the kube-prometheus-stack
+  and bitnami Grafana charts). The sidecar watches for ConfigMaps carrying the
+  configured label (default `grafana_dashboard: "1"`) and imports them
+  automatically — no manual upload. Operators not using the sidecar can import
+  the same JSON from helm/terrapod/dashboards/ by hand.
+  Each file in dashboards/*.json becomes one key in the ConfigMap.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "terrapod.fullname" . }}-dashboards
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    {{- range $k, $v := .Values.api.config.metrics.grafanaDashboards.labels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  {{- with .Values.api.config.metrics.grafanaDashboards.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+  {{ base $path }}: |
+    {{- $.Files.Get $path | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/terrapod/templates/prometheusrule-api.yaml
+++ b/helm/terrapod/templates/prometheusrule-api.yaml
@@ -1,0 +1,183 @@
+{{- if ne .Values.api.enabled false }}
+{{- if and .Values.api.config.metrics.enabled .Values.api.config.metrics.prometheusRule.enabled }}
+{{- $rb := .Values.api.config.metrics.prometheusRule.runbookBaseUrl | default "https://github.com/mattrobinsonsre/terrapod/blob/main/docs/runbooks.md" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "terrapod.fullname" . }}-api
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    {{- with .Values.api.config.metrics.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    # ── Availability ───────────────────────────────────────────────────────
+    - name: terrapod.availability
+      rules:
+        - alert: TerrapodAPIDown
+          # `job` is derived by the Prometheus Operator from the scraped
+          # Service; the matcher is intentionally loose so it survives common
+          # relabeling. Tighten it to your environment if needed.
+          expr: |
+            max(up{job=~".*terrapod-api.*"}) == 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Terrapod API is down (no healthy scrape targets)"
+            description: "No terrapod-api target has been scrapeable for 2m. The platform is unavailable."
+            runbook_url: "{{ $rb }}#api-down--not-ready"
+        - alert: TerrapodHighErrorRate
+          expr: |
+            sum(rate(terrapod_http_requests_total{status=~"5.."}[5m]))
+            / sum(rate(terrapod_http_requests_total[5m])) > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Terrapod API 5xx error rate above 5%"
+            description: "More than 5% of API requests have returned 5xx over the last 5m."
+            runbook_url: "{{ $rb }}#high-api-error-rate"
+        - alert: TerrapodHighRequestLatency
+          expr: |
+            histogram_quantile(0.99,
+              sum(rate(terrapod_http_request_duration_seconds_bucket[5m])) by (le)
+            ) > 5
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Terrapod API p99 latency above 5s"
+            description: "p99 request latency has exceeded 5s for 10m. Check DB/Redis health and run load."
+            runbook_url: "{{ $rb }}#high-api-latency"
+
+    # ── Run lifecycle ──────────────────────────────────────────────────────
+    - name: terrapod.runs
+      rules:
+        - alert: TerrapodRunsStuck
+          # Runs entered planning/applying but none reached a terminal state in
+          # the same window — the reconciler or listeners are not draining work.
+          expr: |
+            increase(terrapod_runs_transitioned_total{to_status=~"planning|applying"}[30m]) > 0
+            unless increase(terrapod_runs_terminal_total[30m]) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Runs entering planning/applying but none reaching terminal state"
+            description: "Runs have started executing but none have finished in 30m. Suspect a stalled reconciler or no healthy listeners."
+            runbook_url: "{{ $rb }}#stale-run-errored-after-timeout"
+        - alert: TerrapodListenerLaunchFailures
+          expr: |
+            increase(terrapod_listener_launch_failures_total[15m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Listener pre-Job launch failures detected"
+            description: "A listener claimed a run but could not launch its Kubernetes Job (runner-token, Job create, or auth Secret failure)."
+            runbook_url: "{{ $rb }}#listener-offline"
+        - alert: TerrapodListenerPrelaunchTimeouts
+          expr: |
+            increase(terrapod_listener_prelaunch_timeouts_total[15m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Reconciler timed out runs that were claimed but never launched"
+            description: "Backstop signal for silent listener failures — a run was claimed but no Job was ever launched and the listener never reported the failure."
+            runbook_url: "{{ $rb }}#listener-offline"
+
+    # ── Scheduler / background tasks ───────────────────────────────────────
+    - name: terrapod.scheduler
+      rules:
+        - alert: TerrapodReconcilerStalled
+          expr: |
+            increase(terrapod_scheduler_task_executions_total{task="run_reconciler"}[5m]) == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Run reconciler has not executed in 5 minutes"
+            description: "The run reconciler drives all run state transitions. If it stops, runs hang. Check scheduler health and Redis."
+            runbook_url: "{{ $rb }}#scheduler-stall"
+        - alert: TerrapodSchedulerTaskFailing
+          expr: |
+            increase(terrapod_scheduler_task_executions_total{status="error"}[15m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "A periodic scheduler task is failing"
+            description: "One or more periodic tasks ({{ "{{ $labels.task }}" }}) have errored repeatedly over 15m."
+            runbook_url: "{{ $rb }}#scheduler-stall"
+
+    # ── Infrastructure dependencies ────────────────────────────────────────
+    - name: terrapod.infra
+      rules:
+        - alert: TerrapodDatabaseErrors
+          expr: |
+            rate(terrapod_db_errors_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Terrapod database errors detected"
+            description: "The API is logging database errors. Suspect connection-pool exhaustion or a Postgres outage."
+            runbook_url: "{{ $rb }}#db-pool-exhaustion"
+        - alert: TerrapodRedisErrors
+          expr: |
+            rate(terrapod_redis_errors_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Terrapod Redis errors detected"
+            description: "The API is logging Redis errors. Sessions, the scheduler, and SSE all depend on Redis."
+            runbook_url: "{{ $rb }}#redis-connection-loss"
+        - alert: TerrapodStorageErrors
+          expr: |
+            rate(terrapod_storage_errors_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Terrapod object-storage errors detected"
+            description: "Storage operations ({{ "{{ $labels.operation }}" }}) are failing. State, plans, and artifacts depend on object storage."
+            runbook_url: "{{ $rb }}#storage-errors"
+
+    # ── Caches (warning only) ──────────────────────────────────────────────
+    - name: terrapod.cache
+      rules:
+        - alert: TerrapodHighBinaryCacheMissRate
+          expr: |
+            sum(rate(terrapod_binary_cache_requests_total{result="miss"}[1h]))
+            / clamp_min(sum(rate(terrapod_binary_cache_requests_total[1h])), 1) > 0.5
+          for: 1h
+          labels:
+            severity: info
+          annotations:
+            summary: "Binary cache miss rate above 50% over the last hour"
+            description: "Runners are repeatedly missing the terraform/tofu binary cache and falling back upstream. Check cache eviction and upstream reachability."
+            runbook_url: "{{ $rb }}#high-cache-miss-rate"
+
+    # ── Retention ──────────────────────────────────────────────────────────
+    - name: terrapod.retention
+      rules:
+        - alert: TerrapodRetentionErrors
+          expr: |
+            increase(terrapod_retention_errors_total[1d]) > 10
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Artifact retention encountering persistent errors"
+            description: "More than 10 retention deletion errors in the last day. Check object-storage health."
+            runbook_url: "{{ $rb }}#storage-errors"
+    {{- with .Values.api.config.metrics.prometheusRule.extraGroups }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -890,6 +890,25 @@
                 "interval": { "type": "string" },
                 "labels": { "type": "object" }
               }
+            },
+            "prometheusRule": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "labels": { "type": "object" },
+                "runbookBaseUrl": { "type": "string" },
+                "extraGroups": { "type": "array" }
+              }
+            },
+            "grafanaDashboards": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "labels": { "type": "object" },
+                "annotations": { "type": "object" }
+              }
             }
           }
         },

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -542,6 +542,32 @@ api:
         enabled: false
         interval: 30s
         labels: {}
+      # Shipped PrometheusRule (alert rules) — off by default; enable when you
+      # run the Prometheus Operator. The bundled rules cover API availability /
+      # error-rate / latency, stuck runs, listener launch failures, reconciler
+      # stalls, DB/Redis/storage errors, cache miss rate, and retention errors.
+      # Each alert carries a runbook_url annotation pointing at docs/runbooks.md.
+      prometheusRule:
+        enabled: false
+        # Extra labels so your Prometheus's ruleSelector picks the rule up
+        # (e.g. {release: kube-prometheus-stack}).
+        labels: {}
+        # Base URL the runbook_url annotations point at. Override to pin a tag
+        # or mirror the runbooks internally.
+        runbookBaseUrl: "https://github.com/mattrobinsonsre/terrapod/blob/main/docs/runbooks.md"
+        # Append your own rule groups (raw PrometheusRule spec.groups entries).
+        extraGroups: []
+      # Bundled Grafana dashboard(s), shipped as a ConfigMap labeled for the
+      # Grafana sidecar (kiwigrid/k8s-sidecar — used by kube-prometheus-stack
+      # and the bitnami Grafana chart) so they auto-import. Off by default.
+      # Operators without the sidecar can import helm/terrapod/dashboards/*.json
+      # by hand.
+      grafanaDashboards:
+        enabled: false
+        # Label the sidecar watches for. Match your Grafana sidecar config.
+        labels:
+          grafana_dashboard: "1"
+        annotations: {}
 
     # Artifact Retention — periodic cleanup of old artifacts from object storage.
     # When enabled, a background task runs at the configured interval and removes

--- a/llms.txt
+++ b/llms.txt
@@ -61,7 +61,7 @@ Build/lint/test all run in Docker via `make` (`make test`, `make lint`, `make de
 - [Run Tasks](docs/run-tasks.md): pre/post-plan external webhook validation hooks.
 - [Notifications](docs/notifications.md): webhook (HMAC), Slack Block Kit, email on run events.
 - [AI Plan Summary](docs/ai-plan-summary.md): LLM change summary + risk + failure analysis, provider-agnostic via LiteLLM (Bedrock/OpenAI/Anthropic/Gemini/vLLM).
-- [Audit Logging](docs/audit-logging.md), [Monitoring](docs/monitoring.md), [Artifact Retention](docs/artifact-retention.md): immutable event log, Prometheus metrics, automated cleanup.
+- [Audit Logging](docs/audit-logging.md), [Monitoring](docs/monitoring.md), [Artifact Retention](docs/artifact-retention.md): immutable event log, Prometheus metrics + shipped Grafana dashboard + alert rules with per-alert runbooks, automated cleanup.
 - [Terragrunt](docs/terragrunt.md): per-workspace Terragrunt support for agent-mode and CLI-driven runs.
 - [Migration](docs/migration.md): move TFE/HCP and Atlantis platforms onto Terrapod with `terrapod-migrate`.
 
@@ -76,6 +76,8 @@ How each capability is turned on. **Platform-level** features are Helm values un
 | AI plan summary | `api.config.ai_summary.enabled` + provider/model config | [ai-plan-summary.md](docs/ai-plan-summary.md) |
 | Service catalog | `api.config.catalog.enabled` (on by default; the `catalog_permission` RBAC axis is opt-in) | [service-catalog.md](docs/service-catalog.md) |
 | Prometheus metrics | `api.config.metrics.enabled` | [monitoring.md](docs/monitoring.md) |
+| Shipped Grafana dashboard | `api.config.metrics.grafanaDashboards.enabled` (sidecar auto-import; off by default) | [monitoring.md](docs/monitoring.md#grafana-dashboards) |
+| Shipped Prometheus alert rules | `api.config.metrics.prometheusRule.enabled` (off by default; each alert links a runbook) | [monitoring.md](docs/monitoring.md#alerting-shipped-prometheusrule) |
 | SSO (OIDC/SAML) | `api.config.auth.sso.*` + client secrets via K8s Secret `secretKeyRef` | [authentication.md](docs/authentication.md) |
 | VCS integration | Admin creates a VCS connection, then sets the workspace's `vcs_*` fields | [vcs-integration.md](docs/vcs-integration.md) |
 | Drift detection | Per-workspace setting (enable + interval) via API/UI/provider | [drift-detection.md](docs/drift-detection.md) |


### PR DESCRIPTION
Closes #546.

## What

Terrapod already emits Prometheus metrics, but operators had to invent their own dashboards, alerts, and incident playbooks. This ships all three out of the box — an SRE-grade "can I see it, and will it page me correctly?" answer without reverse-engineering the metrics surface.

## Deliverables

1. **Grafana dashboard** — `helm/terrapod/dashboards/terrapod-overview.json` (`Terrapod — Overview`): API throughput/latency, run lifecycle, scheduler/reconciler health, listeners (heartbeats/launch failures), VCS poll health, cache hit rate, infra (DB/Redis/storage) errors, state versions/lock conflicts. Uses a templated `datasource` variable (no hard-coded UID).
   - Auto-import via the Grafana sidecar: `api.config.metrics.grafanaDashboards.enabled` (ConfigMap labeled `grafana_dashboard: "1"`), **off by default**. Or import the JSON by hand.
2. **PrometheusRule** — `api.config.metrics.prometheusRule.enabled` (chart-gated like ServiceMonitor, **off by default**). 13 curated alerts across availability / runs / scheduler / infra / cache / retention, each with a `runbook_url` annotation. `runbookBaseUrl` + `extraGroups` are tunable.
3. **Runbook-per-alert** — 4 new runbooks (API down, high error rate, high latency, high cache miss rate); the rest link to existing runbooks. Every `runbook_url` anchor resolves.

## Contracts honored

- **All metric names grounded in `api/metrics.py`** — no invented metrics (the `llms.txt` no-hallucination rule).
- **Helm value contract**: `values.yaml` (with rationale comments) + `values.schema.json` + renders on all three profiles (`values.yaml` / `values-local.yaml` / `values-eval.yaml`); config-channel contract passes (new keys are template-gating only, never rendered into `config.yaml`).
- **helm-smoke CI** extended: asserts PrometheusRule + dashboard ConfigMap render with the toggles on, are **off by default**, alerts carry `runbook_url`, and every dashboard JSON is valid.
- Discoverability updated: `monitoring.md` (dashboards + shipped-alerts table), `llms.txt`, `README.md`, `docs/index.md`.

## Verification

- `helm lint` + `helm template` on all three profiles ✅
- config-channel contract ✅ (all three profiles)
- dashboard JSON valid (jq) ✅; PrometheusRule structure validated (6 groups, 13 alerts, all with runbook_url) ✅
- actionlint clean on the changed region ✅