### PR TITLE
feat(backup): logical DB backup CronJob + restore-verification DR drill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,28 @@ jobs:
               --set redis.url=redis://redis:6379)
           echo "$stock" | grep -q "kind: PrometheusRule" && { echo "FAIL: PrometheusRule rendered by default (should be opt-in)"; exit 1; }
           echo "observability bundle renders OK and is off by default (#546)"
+      - name: Backup + DR-drill CronJobs render and are off by default (#545)
+        run: |
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set backup.enabled=true \
+              --set backup.restoreVerify.enabled=true)
+          echo "$out" | grep -q "kind: CronJob" || { echo "FAIL: backup CronJob not rendered"; exit 1; }
+          echo "$out" | grep -q "terrapod.cli.backup" || { echo "FAIL: backup entrypoint missing"; exit 1; }
+          echo "$out" | grep -q "terrapod.cli.restore_verify" || { echo "FAIL: restore-verify entrypoint missing"; exit 1; }
+          echo "$out" | grep -q "restartPolicy: Always" || { echo "FAIL: throwaway-postgres native sidecar missing"; exit 1; }
+          echo "$out" | grep -q "component: backup" || { echo "FAIL: backup component label missing"; exit 1; }
+          # config.yaml carries the backup settings (config-channel contract).
+          echo "$out" | grep -q "retention_keep:" || { echo "FAIL: backup config not rendered into config.yaml"; exit 1; }
+          # Off by default.
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379)
+          echo "$stock" | grep -q "component: backup" && { echo "FAIL: backup CronJob rendered by default (should be opt-in)"; exit 1; }
+          echo "backup + DR-drill CronJobs render OK and are off by default (#545)"
 
   # ── Config-channel contract (#617) ────────────────────
   # Renders the chart (every values profile) and parses the rendered ConfigMaps

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Forward Proxy & Custom CA](docs/deployment-proxy.md) | Route all outbound HTTP(S) through a corporate proxy and trust a private/MITM CA, across every component including runner Jobs |
 | [Security Hardening](docs/security-hardening.md) | Pod hardening defaults, secrets, network posture |
 | [Production Checklist](docs/production-checklist.md) | Pre-go-live checklist for a production deployment |
-| [Disaster Recovery](docs/disaster-recovery.md) | Break-glass state recovery from object storage |
+| [Disaster Recovery](docs/disaster-recovery.md) | Break-glass state recovery, shipped DB backup CronJob + restore-verification DR drill, per-backend object-storage protection |
 
 ---
 

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -62,6 +62,7 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     git \
+    postgresql-client \
     xmlsec1 \
     libxmlsec1-openssl \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -182,3 +182,89 @@ state is self-consistent (extra orphaned objects are harmless). Keep the two
 backups loosely time-aligned to minimise orphans. The CA keypair lives in
 PostgreSQL, so a DB restore re-establishes listener trust without re-issuing
 certificates.
+
+### Shipped backup automation (the baseline floor)
+
+If you don't already run RDS snapshots / WAL-G / pgBackRest, the chart ships an
+**optional, off-by-default** logical-backup CronJob. A standard deployment
+already has both halves it needs — a Postgres URL and an object-storage backend
+— so enabling it needs no new infrastructure or credentials:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 2 * * *"     # daily at 02:00 (cluster TZ)
+  prefix: "backups/"        # written under this key in the app object store
+  retention:
+    keep: 14                # keep the 14 most-recent dumps (0 = keep all)
+    days: 30                # and/or delete dumps older than 30 days (0 = off)
+```
+
+The CronJob runs `pg_dump` (custom format) and streams the dump to
+`<prefix><timestamp>.dump` in the configured object store, inheriting the
+bucket's at-rest encryption and the API ServiceAccount's cloud workload
+identity. It works across S3 / Azure / GCS / filesystem and across
+static-password **and** cloud-IAM database auth (it mints the same short-lived
+token the API uses).
+
+This is a **logical** dump: RPO is the dump interval, not point-in-time. Treat
+it as the floor — for tighter RPO keep using RDS snapshots / WAL-G / pgBackRest
+(set `backup.enabled: false` and rely on those instead).
+
+**Keep the backup out of the app data's blast radius.** Rather than dual-writing
+app-side, enable object-store **cross-region/account replication** on the bucket
+so the dumps (and all state) land in a second location automatically — see the
+per-backend toggles below.
+
+### Object-storage protection per backend
+
+Object storage holds state, config tarballs, logs, registry artifacts **and**
+(when enabled) the DB dumps above. Turn on the provider's native protections:
+
+| Backend | Versioning (undo overwrite/delete) | Off-site copy |
+|---|---|---|
+| **AWS S3** | `aws s3api put-bucket-versioning --versioning-configuration Status=Enabled` | S3 Cross-Region Replication (CRR) to a bucket in another account/region |
+| **Azure Blob** | enable Blob versioning + soft-delete on the storage account | Object replication to a second account |
+| **GCS** | `gcloud storage buckets update gs://BUCKET --versioning` | Bucket cross-region/dual-region or `gcloud storage rsync` to a second bucket |
+
+Versioning protects against accidental overwrite/delete; replication protects
+against losing the whole bucket/region. Both are operator-managed (Terrapod
+never needs delete-then-recreate semantics on these objects).
+
+### Restore-verification drill (DR drill)
+
+A tested restore beats a documented one. The chart ships an optional
+**restore-verify** CronJob that restores the latest backup into a **throwaway
+sidecar Postgres** (never the live database) and asserts core invariants — the
+schema + CA load, workspaces resolve, and a state object downloads from the
+store. It exits non-zero on any failure, so it's a real green check:
+
+```yaml
+backup:
+  enabled: true
+  restoreVerify:
+    enabled: true
+    schedule: "0 4 * * 0"   # weekly DR drill, Sundays 04:00
+```
+
+Run it **on demand** any time:
+
+```bash
+kubectl create job --from=cronjob/<release>-terrapod-restore-verify drill-now -n <ns>
+kubectl logs -f job/drill-now -n <ns>
+```
+
+A failing drill is paged via the shipped alert path (the CronJob's Job failure
+surfaces through kube-state-metrics / your Job-failure alerts). See the
+[restore-failed runbook](runbooks.md#dr-restore-drill-failed).
+
+### Full restore (production)
+
+1. **Restore PostgreSQL first.** From an RDS/Azure snapshot, or from a logical
+   dump: `pg_restore --clean --if-exists -d "$DATABASE_URL" <dump>` (the dump
+   the CronJob wrote, fetched from `backups/` in object storage).
+2. **Point the new deployment at the restored object-storage bucket** via Helm
+   values (same bucket, or the replication target).
+3. **Bring up Terrapod.** The CA keypair came back with the DB, so listeners
+   re-establish trust on reconnect; Redis starts fresh. Confirm with the
+   on-demand drill above before declaring recovery complete.

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,7 +130,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Forward proxy & custom CA trust](deployment-proxy.md) | Route all outbound HTTP(S) through a corporate proxy and trust a private/MITM CA, across every component including runner Jobs |
 | [Security Hardening](security-hardening.md) | TLS, secrets management, network policies, rate limiting |
 | [Production Checklist](production-checklist.md) | Step-by-step checklist for go-live readiness |
-| [Disaster Recovery](disaster-recovery.md) | Break-glass state recovery from object storage |
+| [Disaster Recovery](disaster-recovery.md) | Break-glass state recovery, shipped DB backup CronJob + restore-verification DR drill, per-backend object-storage protection |
 | [API Reference](api-reference.md) | All API endpoints with examples |
 
 ---

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1198,3 +1198,42 @@ Fires from `TerrapodHighBinaryCacheMissRate` (info): the terraform/tofu binary c
 
 - The hit ratio recovers above 50% as warmed/again-cached versions are served.
 - Per-tool: `sum by (tool) (rate(terrapod_binary_cache_requests_total{result="hit"}[1h]))` rises.
+
+---
+
+## DR restore drill failed
+
+The shipped restore-verify CronJob (`<release>-terrapod-restore-verify`) restores the latest backup into a throwaway sidecar Postgres and asserts core invariants. A failed Job means **the latest backup did not restore cleanly** — treat it as urgent: your backups may not be recoverable.
+
+### Symptoms
+
+- The `restore-verify` Job is in `Failed` state (surfaced by kube-state-metrics / your Job-failure alerts).
+- Job logs end with `DR drill FAILED:` and one or more `✗` invariant lines, **or** never get that far (download / restore error).
+
+### Diagnosis
+
+```bash
+kubectl logs job/<failed-restore-verify-job> -n <ns>
+```
+
+Read the failure mode:
+- **`TP_RESTORE_TARGET_URL must not equal DATABASE_URL — refusing`** — misconfiguration: the drill was pointed at the live DB. It refuses by design. Fix the chart values (the bundled CronJob always targets the sidecar; this only happens with a hand-edited Job).
+- **`no backups found under 'backups/'`** — the backup CronJob hasn't produced a dump (check `backup.enabled`, its schedule, and that its Jobs are succeeding). Without a backup there is nothing to restore.
+- **`pg_restore exited N`** (warning) followed by invariant failures — the dump is corrupt or partial. Check the **backup** Job's logs for a truncated `pg_dump` (OOM, timeout, storage write error).
+- **`certificate_authority is empty` / `workspaces not queryable`** — the restore ran but the data isn't there: suspect a `pg_dump` that captured an empty/wrong database, or a dump format mismatch (the `pg_dump`/`pg_restore` client major must be ≥ the server major).
+- **`state version(s) in DB but no readable object under state/`** — the DB restored but the object store the drill reads is missing state objects: the DB snapshot and object store are badly time-skewed, or the store/credentials are wrong.
+
+### Resolution
+
+1. Fix the root cause surfaced above (most often: the backup Job itself is failing/truncating — fix that first, then a fresh backup gives the drill something restorable).
+2. If `pg_dump`/`pg_restore` version mismatch: align the API image's `postgresql-client` major with your server major (the client must be ≥ server).
+3. Re-run the drill on demand once a good backup exists:
+   ```bash
+   kubectl create job --from=cronjob/<release>-terrapod-restore-verify drill-now -n <ns>
+   kubectl logs -f job/drill-now -n <ns>
+   ```
+
+### Verification
+
+- A fresh drill logs `DR drill PASSED — backup <key> restored and verified` and the Job completes successfully.
+- The backup CronJob's most recent Job is `Complete` and a new `backups/<ts>.dump` object exists.

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -332,6 +332,12 @@ data:
       binary_cache_retention_days: {{ .Values.api.config.artifact_retention.binary_cache_retention_days | default 30 }}
       module_overrides_retention_days: {{ .Values.api.config.artifact_retention.module_overrides_retention_days | default 14 }}
     {{- end }}
+    {{- if .Values.backup }}
+    backup:
+      prefix: {{ .Values.backup.prefix | default "backups/" | quote }}
+      retention_keep: {{ (.Values.backup.retention).keep | default 0 }}
+      retention_days: {{ (.Values.backup.retention).days | default 0 }}
+    {{- end }}
     {{- if .Values.api.config.ai_summary }}
     ai_summary:
       enabled: {{ .Values.api.config.ai_summary.enabled | default false }}

--- a/helm/terrapod/templates/cronjob-backup.yaml
+++ b/helm/terrapod/templates/cronjob-backup.yaml
@@ -1,0 +1,145 @@
+{{- if ne .Values.api.enabled false }}
+{{- if and .Values.backup .Values.backup.enabled }}
+{{- $dbAuthMode := (.Values.api.config.database).auth_mode | default "password" }}
+{{- $dbIam := or (eq $dbAuthMode "aws_iam") (eq $dbAuthMode "gcp_iam") (eq $dbAuthMode "azure_ad") }}
+{{- $dbCa := or .Values.api.databaseCA.inline .Values.api.databaseCA.existingConfigMap }}
+{{- $fs := eq .Values.api.config.storage.backend "filesystem" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "terrapod.fullname" . }}-backup
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.backup.schedule | default "0 2 * * *" | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit | default 3 }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit | default 3 }}
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit | default 2 }}
+      template:
+        metadata:
+          labels:
+            {{- include "terrapod.labels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          {{- with .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          # The backup runs under the API's ServiceAccount so it inherits the
+          # same cloud workload identity (IRSA / GKE WI / Azure WI) used to
+          # reach object storage — no separate credentials.
+          serviceAccountName: {{ include "terrapod.serviceAccountName" . }}
+          restartPolicy: Never
+          securityContext:
+            {{- toYaml .Values.api.podSecurityContext | nindent 12 }}
+          {{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+          initContainers:
+            {{- include "terrapod.caBundle.initContainer" (dict "root" . "image" (include "terrapod.api.image" .) "pullPolicy" .Values.api.image.pullPolicy) | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: backup
+              image: {{ include "terrapod.api.image" . }}
+              imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+              command:
+                - python
+                - -m
+                - terrapod.cli.backup
+              env:
+                - name: TERRAPOD_STORAGE__FILESYSTEM__HMAC_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "terrapod.fullname" . }}-storage
+                      key: hmac-secret
+                      optional: true
+                {{- $pgSecret := include "terrapod.postgresql.secretName" . }}
+                {{- if $pgSecret }}
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $pgSecret }}
+                      key: {{ include "terrapod.postgresql.secretKey" . }}
+                {{- else if .Values.postgresql.url }}
+                - name: DATABASE_URL
+                  value: {{ .Values.postgresql.url | quote }}
+                {{- end }}
+                {{- if $dbIam }}
+                - name: TP_DB_AUTH_MODE
+                  value: {{ $dbAuthMode | quote }}
+                - name: TP_DB_AWS_IAM_REGION
+                  value: {{ (.Values.api.config.database).aws_iam_region | default "" | quote }}
+                - name: TP_DB_SSL_MODE
+                  value: {{ (.Values.api.config.database).ssl_mode | default "" | quote }}
+                - name: TP_DB_SSL_ROOT_CERT
+                  {{- if $dbCa }}
+                  value: {{ printf "/etc/terrapod/db-ca/%s" (.Values.api.databaseCA.key | default "ca.pem") | quote }}
+                  {{- else }}
+                  value: {{ (.Values.api.config.database).ssl_root_cert | default "" | quote }}
+                  {{- end }}
+                {{- end }}
+                {{- include "terrapod.proxyEnv" . | nindent 16 }}
+                {{- include "terrapod.caBundle.env" . | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/terrapod
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+                {{- if .Values.api.ephemeralStorage.enabled }}
+                - name: backup-tmpdir
+                  mountPath: {{ .Values.api.ephemeralStorage.mountPath | default "/var/lib/terrapod/tmp" }}
+                {{- end }}
+                {{- if $fs }}
+                - name: storage
+                  mountPath: {{ .Values.api.config.storage.filesystem.root_dir }}
+                {{- end }}
+                {{- if and $dbIam $dbCa }}
+                - name: database-ca
+                  mountPath: /etc/terrapod/db-ca
+                  readOnly: true
+                {{- end }}
+                {{- include "terrapod.caBundle.volumeMounts" . | nindent 16 }}
+              resources:
+                {{- toYaml (.Values.backup.resources | default dict) | nindent 16 }}
+              securityContext:
+                {{- toYaml .Values.api.containerSecurityContext | nindent 16 }}
+          volumes:
+            - name: config
+              configMap:
+                name: {{ include "terrapod.fullname" . }}-api-config
+            - name: tmp
+              emptyDir: {}
+            {{- if .Values.api.ephemeralStorage.enabled }}
+            - name: backup-tmpdir
+              ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes: ["ReadWriteOnce"]
+                    {{- if .Values.api.ephemeralStorage.storageClass }}
+                    storageClassName: {{ .Values.api.ephemeralStorage.storageClass | quote }}
+                    {{- end }}
+                    resources:
+                      requests:
+                        storage: {{ .Values.api.ephemeralStorage.size | default "10Gi" | quote }}
+            {{- end }}
+            {{- if $fs }}
+            - name: storage
+              {{- if .Values.storage.filesystem.persistence.enabled }}
+              persistentVolumeClaim:
+                claimName: {{ include "terrapod.fullname" . }}-storage
+              {{- else }}
+              emptyDir: {}
+              {{- end }}
+            {{- end }}
+            {{- if and $dbIam $dbCa }}
+            - name: database-ca
+              configMap:
+                name: {{ .Values.api.databaseCA.existingConfigMap | default (printf "%s-database-ca" (include "terrapod.fullname" .)) }}
+            {{- end }}
+            {{- include "terrapod.caBundle.volumes" . | nindent 12 }}
+{{- end }}
+{{- end }}

--- a/helm/terrapod/templates/cronjob-restore-verify.yaml
+++ b/helm/terrapod/templates/cronjob-restore-verify.yaml
@@ -1,0 +1,148 @@
+{{- if ne .Values.api.enabled false }}
+{{- if and .Values.backup .Values.backup.enabled .Values.backup.restoreVerify .Values.backup.restoreVerify.enabled }}
+{{- $fs := eq .Values.api.config.storage.backend "filesystem" }}
+{{- $pgImage := .Values.backup.restoreVerify.postgresImage | default "postgres:17-alpine" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "terrapod.fullname" . }}-restore-verify
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: restore-verify
+spec:
+  # DR drill — restores the latest backup into a THROWAWAY sidecar Postgres
+  # (never the live database) and asserts core invariants. Run on demand with:
+  #   kubectl create job --from=cronjob/{{ include "terrapod.fullname" . }}-restore-verify <name>
+  schedule: {{ .Values.backup.restoreVerify.schedule | default "0 4 * * 0" | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.backup.restoreVerify.successfulJobsHistoryLimit | default 3 }}
+  failedJobsHistoryLimit: {{ .Values.backup.restoreVerify.failedJobsHistoryLimit | default 3 }}
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.restoreVerify.backoffLimit | default 1 }}
+      template:
+        metadata:
+          labels:
+            {{- include "terrapod.labels" . | nindent 12 }}
+            app.kubernetes.io/component: restore-verify
+        spec:
+          {{- with .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          # API ServiceAccount → same cloud workload identity to READ object
+          # storage. The drill never writes to the store or touches the live DB.
+          serviceAccountName: {{ include "terrapod.serviceAccountName" . }}
+          restartPolicy: Never
+          securityContext:
+            {{- toYaml .Values.api.podSecurityContext | nindent 12 }}
+          initContainers:
+            {{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+            {{- include "terrapod.caBundle.initContainer" (dict "root" . "image" (include "terrapod.api.image" .) "pullPolicy" .Values.api.image.pullPolicy) | nindent 12 }}
+            {{- end }}
+            # Native sidecar (restartPolicy: Always) — throwaway Postgres the
+            # backup is restored INTO. Auto-terminates when the main container
+            # exits. Trust auth on loopback only; data on an emptyDir.
+            - name: throwaway-postgres
+              image: {{ $pgImage }}
+              imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+              restartPolicy: Always
+              env:
+                - name: POSTGRES_HOST_AUTH_METHOD
+                  value: "trust"
+                - name: PGDATA
+                  value: /var/lib/postgresql/data/pgdata
+              ports:
+                - containerPort: 5432
+              volumeMounts:
+                - name: pgdata
+                  mountPath: /var/lib/postgresql/data
+                - name: pgrun
+                  mountPath: /var/run/postgresql
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 70
+                runAsGroup: 70
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+              resources:
+                {{- toYaml (.Values.backup.restoreVerify.postgresResources | default dict) | nindent 16 }}
+          containers:
+            - name: restore-verify
+              image: {{ include "terrapod.api.image" . }}
+              imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+              command:
+                - python
+                - -m
+                - terrapod.cli.restore_verify
+              env:
+                - name: TP_RESTORE_TARGET_URL
+                  value: "postgresql://postgres@localhost:5432/postgres"
+                - name: TERRAPOD_STORAGE__FILESYSTEM__HMAC_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "terrapod.fullname" . }}-storage
+                      key: hmac-secret
+                      optional: true
+                {{- include "terrapod.proxyEnv" . | nindent 16 }}
+                {{- include "terrapod.caBundle.env" . | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/terrapod
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+                {{- if .Values.api.ephemeralStorage.enabled }}
+                - name: restore-tmpdir
+                  mountPath: {{ .Values.api.ephemeralStorage.mountPath | default "/var/lib/terrapod/tmp" }}
+                {{- end }}
+                {{- if $fs }}
+                - name: storage
+                  mountPath: {{ .Values.api.config.storage.filesystem.root_dir }}
+                  readOnly: true
+                {{- end }}
+                {{- include "terrapod.caBundle.volumeMounts" . | nindent 16 }}
+              resources:
+                {{- toYaml (.Values.backup.restoreVerify.resources | default dict) | nindent 16 }}
+              securityContext:
+                {{- toYaml .Values.api.containerSecurityContext | nindent 16 }}
+          volumes:
+            - name: config
+              configMap:
+                name: {{ include "terrapod.fullname" . }}-api-config
+            - name: tmp
+              emptyDir: {}
+            - name: pgdata
+              emptyDir: {}
+            - name: pgrun
+              emptyDir: {}
+            {{- if .Values.api.ephemeralStorage.enabled }}
+            - name: restore-tmpdir
+              ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes: ["ReadWriteOnce"]
+                    {{- if .Values.api.ephemeralStorage.storageClass }}
+                    storageClassName: {{ .Values.api.ephemeralStorage.storageClass | quote }}
+                    {{- end }}
+                    resources:
+                      requests:
+                        storage: {{ .Values.api.ephemeralStorage.size | default "10Gi" | quote }}
+            {{- end }}
+            {{- if $fs }}
+            - name: storage
+              {{- if .Values.storage.filesystem.persistence.enabled }}
+              persistentVolumeClaim:
+                claimName: {{ include "terrapod.fullname" . }}-storage
+              {{- else }}
+              emptyDir: {}
+              {{- end }}
+            {{- end }}
+            {{- include "terrapod.caBundle.volumes" . | nindent 12 }}
+{{- end }}
+{{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -282,6 +282,42 @@
       }
     },
 
+    "backup": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "schedule": { "type": "string" },
+        "prefix": { "type": "string" },
+        "retention": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keep": { "type": "integer", "minimum": 0 },
+            "days": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "backoffLimit": { "type": "integer", "minimum": 0 },
+        "successfulJobsHistoryLimit": { "type": "integer", "minimum": 0 },
+        "failedJobsHistoryLimit": { "type": "integer", "minimum": 0 },
+        "resources": { "type": "object" },
+        "restoreVerify": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "schedule": { "type": "string" },
+            "postgresImage": { "type": "string" },
+            "backoffLimit": { "type": "integer", "minimum": 0 },
+            "successfulJobsHistoryLimit": { "type": "integer", "minimum": 0 },
+            "failedJobsHistoryLimit": { "type": "integer", "minimum": 0 },
+            "resources": { "type": "object" },
+            "postgresResources": { "type": "object" }
+          }
+        }
+      }
+    },
+
     "postgresql": {
       "type": "object",
       "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -686,6 +686,43 @@ api:
     #   iam.gke.io/gcp-service-account: terrapod@project.iam.gserviceaccount.com
     annotations: {}
 
+# ── Logical PostgreSQL backup + DR drill (#545) ───────────────────────────────
+# OFF by default. A standard deployment already has both halves a backup needs
+# (a Postgres URL + an object-storage backend), so enabling this needs no new
+# infra or credentials: a CronJob runs `pg_dump` and streams the dump to the
+# configured object store under `prefix`, inheriting the bucket's at-rest
+# encryption and the API ServiceAccount's cloud workload identity.
+#
+# This is a LOGICAL dump — RPO is the dump interval, not point-in-time — and is
+# the baseline floor, not a replacement for RDS snapshots / WAL-G / pgBackRest
+# for serious-RPO deployments. To keep the only backup out of the app data's
+# blast radius, enable object-store cross-region replication on the destination
+# bucket (see docs/disaster-recovery.md) rather than dual-writing app-side.
+backup:
+  enabled: false
+  schedule: "0 2 * * *"          # daily at 02:00 (cluster TZ)
+  prefix: "backups/"             # object-store key prefix for dumps
+  retention:
+    keep: 0                      # keep N most-recent backups (0 = keep all)
+    days: 0                      # delete backups older than N days (0 = disabled)
+  backoffLimit: 2
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  resources: {}
+  # DR drill — restore the latest backup into a THROWAWAY sidecar Postgres
+  # (never the live DB) and assert core invariants. A tested restore beats a
+  # documented one. Run on demand with:
+  #   kubectl create job --from=cronjob/<release>-terrapod-restore-verify drill-now
+  restoreVerify:
+    enabled: false
+    schedule: "0 4 * * 0"        # weekly, Sundays at 04:00
+    postgresImage: "postgres:17-alpine"
+    backoffLimit: 1
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    resources: {}
+    postgresResources: {}
+
 # ── Web UI (Next.js) ──────────────────────────────────────────────────────────
 # The web frontend is the BFF (Backend-For-Frontend): all browser, CLI, and
 # listener traffic enters through it and is proxied to the API. The Ingress

--- a/llms.txt
+++ b/llms.txt
@@ -78,6 +78,8 @@ How each capability is turned on. **Platform-level** features are Helm values un
 | Prometheus metrics | `api.config.metrics.enabled` | [monitoring.md](docs/monitoring.md) |
 | Shipped Grafana dashboard | `api.config.metrics.grafanaDashboards.enabled` (sidecar auto-import; off by default) | [monitoring.md](docs/monitoring.md#grafana-dashboards) |
 | Shipped Prometheus alert rules | `api.config.metrics.prometheusRule.enabled` (off by default; each alert links a runbook) | [monitoring.md](docs/monitoring.md#alerting-shipped-prometheusrule) |
+| Logical DB backup CronJob | `backup.enabled` (off by default; `pg_dump` → object store, retention) | [disaster-recovery.md](docs/disaster-recovery.md#shipped-backup-automation-the-baseline-floor) |
+| Restore-verification DR drill | `backup.restoreVerify.enabled` (off by default; restores into a throwaway Postgres + asserts invariants) | [disaster-recovery.md](docs/disaster-recovery.md#restore-verification-drill-dr-drill) |
 | SSO (OIDC/SAML) | `api.config.auth.sso.*` + client secrets via K8s Secret `secretKeyRef` | [authentication.md](docs/authentication.md) |
 | VCS integration | Admin creates a VCS connection, then sets the workspace's `vcs_*` fields | [vcs-integration.md](docs/vcs-integration.md) |
 | Drift detection | Per-workspace setting (enable + interval) via API/UI/provider | [drift-detection.md](docs/drift-detection.md) |

--- a/services/terrapod/cli/backup.py
+++ b/services/terrapod/cli/backup.py
@@ -1,0 +1,197 @@
+"""Logical PostgreSQL backup to object storage.
+
+Run via: ``python -m terrapod.cli.backup``
+
+Runs ``pg_dump`` in custom format and streams the dump to the configured object
+store under ``settings.backup.prefix``, then prunes old backups per the
+retention policy. Reuses the app's storage backend (S3 / Azure / GCS /
+filesystem) and the app's cloud-IAM DB auth, so it needs no new infra or
+credentials — a standard deployment already has both halves configured.
+
+This is a logical dump: RPO is the dump interval, not point-in-time. It is the
+baseline floor, not a replacement for RDS snapshots / WAL-G / pgBackRest for
+serious-RPO deployments. See docs/disaster-recovery.md.
+
+Environment (set by the Helm CronJob):
+  DATABASE_URL          PostgreSQL connection URL (from the chart's PG secret)
+  TP_DB_AUTH_MODE etc.  Cloud-IAM DB auth (optional; same vars as the API Job)
+  TERRAPOD_CONFIG       Path to config.yaml (storage backend + backup settings)
+"""
+
+import asyncio
+import logging
+import os
+import sys
+import tempfile
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+from terrapod.config import settings
+from terrapod.storage import close_storage, get_storage, init_storage
+
+logger = logging.getLogger("terrapod.backup")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+_CHUNK = 1024 * 1024  # 1 MiB stream chunk
+
+
+def _resolve_tmpdir() -> str | None:
+    """Substantial tempfiles land on the CSP-attached PVC, not /tmp (RAM)."""
+    configured = settings.vcs.tmpdir
+    if configured and os.path.isdir(configured):
+        return configured
+    return None
+
+
+def _libpq_dsn(database_url: str) -> str:
+    """Strip the SQLAlchemy ``+asyncpg`` driver suffix for the libpq tools."""
+    return database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _pg_dump_env() -> dict[str, str]:
+    """Build the pg_dump environment, minting a cloud-IAM token if configured.
+
+    In the default static-password mode the password rides in DATABASE_URL and
+    no extra env is needed. For an IAM ``auth_mode`` we mint the same short-lived
+    token the API uses and pass it via ``PGPASSWORD`` (+ TLS via ``PGSSLMODE`` /
+    ``PGSSLROOTCERT``), so backups work on a password-less IAM database too.
+    """
+    env = dict(os.environ)
+    auth_mode = os.environ.get("TP_DB_AUTH_MODE", "password")
+    if auth_mode not in ("aws_iam", "gcp_iam", "azure_ad"):
+        return env
+
+    from terrapod.db.iam_auth import _select_minter, parse_pg_target
+
+    host, port, user = parse_pg_target(os.environ.get("DATABASE_URL", ""))
+    minter = _select_minter(
+        auth_mode,
+        host=host,
+        port=port,
+        user=user,
+        region=os.environ.get("TP_DB_AWS_IAM_REGION", ""),
+    )
+    env["PGPASSWORD"] = minter()
+    ssl_mode = os.environ.get("TP_DB_SSL_MODE", "")
+    if ssl_mode:
+        env["PGSSLMODE"] = ssl_mode
+    ssl_root = os.environ.get("TP_DB_SSL_ROOT_CERT", "")
+    if ssl_root:
+        env["PGSSLROOTCERT"] = ssl_root
+    return env
+
+
+async def _run_pg_dump(dsn: str, out_path: str) -> None:
+    """Run ``pg_dump -Fc`` into ``out_path`` (custom format → pg_restore)."""
+    proc = await asyncio.create_subprocess_exec(
+        "pg_dump",
+        "--format=custom",
+        "--no-owner",
+        "--no-privileges",
+        "--file",
+        out_path,
+        "--dbname",
+        dsn,
+        env=_pg_dump_env(),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        msg = stderr.decode("utf-8", "replace").strip()
+        raise RuntimeError(f"pg_dump failed (exit {proc.returncode}): {msg}")
+
+
+async def _file_chunks(path: str) -> AsyncIterator[bytes]:
+    """Yield a file's bytes in chunks without blocking the event loop."""
+    fh = await asyncio.to_thread(open, path, "rb")
+    try:
+        while True:
+            chunk = await asyncio.to_thread(fh.read, _CHUNK)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        await asyncio.to_thread(fh.close)
+
+
+def _backup_ts() -> str:
+    """UTC timestamp for the backup key (sortable, filename-safe)."""
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+async def _prune(prefix: str, keep: int, days: int) -> None:
+    """Delete old backups beyond ``keep`` newest and older than ``days``."""
+    if keep <= 0 and days <= 0:
+        return
+    store = get_storage()
+    entries = [m for m in await store.list_prefix(prefix) if m.key.endswith(".dump")]
+    # Keys embed a sortable ISO-ish timestamp → lexical sort == chronological.
+    entries.sort(key=lambda m: m.key, reverse=True)
+
+    to_delete: set[str] = set()
+    if keep > 0:
+        for m in entries[keep:]:
+            to_delete.add(m.key)
+    if days > 0:
+        cutoff = datetime.now(UTC).timestamp() - days * 86400
+        for m in entries:
+            ts = _parse_key_ts(m.key, prefix)
+            if ts is not None and ts < cutoff:
+                to_delete.add(m.key)
+    for key in sorted(to_delete):
+        await store.delete(key)
+        logger.info("Pruned old backup: %s", key)
+
+
+def _parse_key_ts(key: str, prefix: str) -> float | None:
+    """Recover the epoch seconds from a ``<prefix><ts>.dump`` key."""
+    name = key[len(prefix) :] if key.startswith(prefix) else key
+    name = name.rsplit("/", 1)[-1].removesuffix(".dump")
+    try:
+        return datetime.strptime(name, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC).timestamp()
+    except ValueError:
+        return None
+
+
+async def backup() -> None:
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    if not database_url:
+        logger.error("DATABASE_URL is required")
+        sys.exit(1)
+
+    cfg = settings.backup
+    prefix = cfg.prefix if cfg.prefix.endswith("/") else cfg.prefix + "/"
+    key = f"{prefix}{_backup_ts()}.dump"
+    dsn = _libpq_dsn(database_url)
+
+    fd, tmp_path = tempfile.mkstemp(suffix=".dump", dir=_resolve_tmpdir())
+    os.close(fd)
+    try:
+        logger.info("Starting pg_dump → %s", tmp_path)
+        await _run_pg_dump(dsn, tmp_path)
+        size = os.path.getsize(tmp_path)
+        logger.info("pg_dump complete (%d bytes); uploading to %s", size, key)
+
+        await init_storage()
+        try:
+            await get_storage().put_stream(
+                key, _file_chunks(tmp_path), content_type="application/octet-stream"
+            )
+            logger.info("Backup uploaded: %s", key)
+            await _prune(prefix, cfg.retention_keep, cfg.retention_days)
+        finally:
+            await close_storage()
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def main() -> None:
+    asyncio.run(backup())
+
+
+if __name__ == "__main__":
+    main()

--- a/services/terrapod/cli/restore_verify.py
+++ b/services/terrapod/cli/restore_verify.py
@@ -1,0 +1,229 @@
+"""Disaster-recovery drill: restore the latest backup and verify it.
+
+Run via: ``python -m terrapod.cli.restore_verify``
+
+A tested restore beats a documented one. This restores the most recent
+``pg_dump`` backup into a **throwaway** Postgres (never the live database) and
+asserts core invariants against the restored data + the (read-only) object
+store:
+
+  1. the schema + CA load (``certificate_authority`` is queryable and populated),
+  2. workspaces resolve (the ``workspaces`` table is queryable),
+  3. if any state versions exist, a state object is downloadable from the store.
+
+Exit code is non-zero if the restore or any invariant fails, so it doubles as a
+CI/cron gate ("here's the green check"). It reads the object store **read-only**;
+UUID-addressed artifacts mean a same-or-later object store is self-consistent
+with an earlier DB dump.
+
+Environment (set by the Helm CronJob):
+  TP_RESTORE_TARGET_URL   throwaway Postgres to restore INTO (required; NOT the
+                          live DATABASE_URL — the drill refuses if they match)
+  TP_RESTORE_KEY          specific backup key to restore (optional; default: latest)
+  TERRAPOD_CONFIG         config.yaml (storage backend + backup settings)
+"""
+
+import asyncio
+import logging
+import os
+import sys
+import tempfile
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from terrapod.config import settings
+from terrapod.storage import close_storage, get_storage, init_storage
+
+logger = logging.getLogger("terrapod.restore_verify")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+_CHUNK = 1024 * 1024
+
+
+def _resolve_tmpdir() -> str | None:
+    configured = settings.vcs.tmpdir
+    if configured and os.path.isdir(configured):
+        return configured
+    return None
+
+
+def _libpq_dsn(url: str) -> str:
+    return url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _async_dsn(url: str) -> str:
+    if url.startswith("postgresql+asyncpg://"):
+        return url
+    return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+
+async def _latest_backup_key() -> str:
+    cfg = settings.backup
+    prefix = cfg.prefix if cfg.prefix.endswith("/") else cfg.prefix + "/"
+    entries = [m for m in await get_storage().list_prefix(prefix) if m.key.endswith(".dump")]
+    if not entries:
+        raise RuntimeError(f"no backups found under {prefix!r}")
+    entries.sort(key=lambda m: m.key, reverse=True)
+    return entries[0].key
+
+
+async def _download(key: str, dest: str) -> None:
+    store = get_storage()
+    fh = await asyncio.to_thread(open, dest, "wb")
+    try:
+        async for chunk in store.get_stream(key, chunk_size=_CHUNK):
+            await asyncio.to_thread(fh.write, chunk)
+    finally:
+        await asyncio.to_thread(fh.close)
+
+
+async def _pg_restore(target_dsn: str, dump_path: str) -> None:
+    proc = await asyncio.create_subprocess_exec(
+        "pg_restore",
+        "--clean",
+        "--if-exists",
+        "--no-owner",
+        "--no-privileges",
+        "--dbname",
+        target_dsn,
+        dump_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await proc.communicate()
+    # pg_restore can exit non-zero on benign "already exists"/"does not exist"
+    # noise from --clean on an empty target; surface stderr but only fail hard
+    # if the subsequent invariant queries fail.
+    if proc.returncode != 0:
+        logger.warning(
+            "pg_restore exited %d (continuing to invariant checks): %s",
+            proc.returncode,
+            stderr.decode("utf-8", "replace").strip()[:2000],
+        )
+
+
+async def _wait_for_db(target_async_dsn: str, attempts: int = 30) -> None:
+    """Wait for the throwaway Postgres (e.g. a native sidecar) to accept conns."""
+    last: Exception | None = None
+    for _ in range(attempts):
+        engine = create_async_engine(target_async_dsn)
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+            await engine.dispose()
+            return
+        except Exception as exc:  # noqa: BLE001 — retry any connect error
+            last = exc
+            await engine.dispose()
+            await asyncio.sleep(2)
+    raise RuntimeError(f"restore target never became ready: {last}")
+
+
+async def _verify_invariants(target_async_dsn: str) -> list[str]:
+    """Return a list of failures (empty == all invariants held)."""
+    failures: list[str] = []
+    engine = create_async_engine(target_async_dsn)
+    try:
+        async with engine.connect() as conn:
+            # 1. Schema + CA load.
+            try:
+                ca = (
+                    await conn.execute(text("SELECT count(*) FROM certificate_authority"))
+                ).scalar_one()
+                if ca < 1:
+                    failures.append("certificate_authority is empty (no CA restored)")
+                else:
+                    logger.info("✓ CA loads (%d row)", ca)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"certificate_authority not queryable: {exc}")
+
+            # 2. Workspaces resolve.
+            try:
+                ws = (await conn.execute(text("SELECT count(*) FROM workspaces"))).scalar_one()
+                logger.info("✓ workspaces resolve (%d row(s))", ws)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"workspaces not queryable: {exc}")
+
+            # 3. State object downloads (only if any state versions exist).
+            try:
+                sv = (await conn.execute(text("SELECT count(*) FROM state_versions"))).scalar_one()
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"state_versions not queryable: {exc}")
+                sv = 0
+            if sv > 0:
+                ok = await _verify_state_object()
+                if ok:
+                    logger.info("✓ state object downloads from object store")
+                else:
+                    failures.append(
+                        f"{sv} state version(s) in DB but no readable object under state/"
+                    )
+            else:
+                logger.info("• no state versions to verify (empty/fresh dataset)")
+    finally:
+        await engine.dispose()
+    return failures
+
+
+async def _verify_state_object() -> bool:
+    """Download one object under ``state/`` to prove the store is readable.
+
+    Decoupled from the exact key scheme: a state version in the DB should have a
+    corresponding object somewhere under ``state/``.
+    """
+    store = get_storage()
+    objs = [m for m in await store.list_prefix("state/") if m.key.endswith(".tfstate")]
+    if not objs:
+        return False
+    data = await store.get(objs[0].key)
+    return bool(data)
+
+
+async def restore_verify() -> None:
+    target = os.environ.get("TP_RESTORE_TARGET_URL", "").strip()
+    if not target:
+        logger.error("TP_RESTORE_TARGET_URL is required (a THROWAWAY Postgres)")
+        sys.exit(1)
+
+    live = os.environ.get("DATABASE_URL", "").strip()
+    if live and _libpq_dsn(live) == _libpq_dsn(target):
+        logger.error("TP_RESTORE_TARGET_URL must not equal DATABASE_URL — refusing")
+        sys.exit(1)
+
+    target_async = _async_dsn(target)
+    target_libpq = _libpq_dsn(target)
+
+    await init_storage()
+    fd, tmp_path = tempfile.mkstemp(suffix=".dump", dir=_resolve_tmpdir())
+    os.close(fd)
+    try:
+        key = os.environ.get("TP_RESTORE_KEY", "").strip() or await _latest_backup_key()
+        logger.info("Restoring backup %s", key)
+        await _download(key, tmp_path)
+
+        await _wait_for_db(target_async)
+        await _pg_restore(target_libpq, tmp_path)
+
+        failures = await _verify_invariants(target_async)
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        await close_storage()
+
+    if failures:
+        logger.error("DR drill FAILED:")
+        for f in failures:
+            logger.error("  ✗ %s", f)
+        sys.exit(1)
+    logger.info("DR drill PASSED — backup %s restored and verified", key)
+
+
+def main() -> None:
+    asyncio.run(restore_verify())
+
+
+if __name__ == "__main__":
+    main()

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -1019,6 +1019,32 @@ class MetricsConfig(BaseModel):
     )
 
 
+class BackupConfig(BaseModel):
+    """Logical PostgreSQL backup settings (consumed by terrapod.cli.backup).
+
+    The backup CronJob (off by default in the chart) runs ``pg_dump`` and
+    streams the dump to the configured object store under ``prefix``. This is a
+    logical dump — RPO is the dump interval, not point-in-time — and is the
+    baseline floor, not a replacement for RDS snapshots / WAL-G / pgBackRest.
+    See docs/disaster-recovery.md.
+    """
+
+    prefix: str = Field(
+        default="backups/",
+        description="Object-store key prefix backups are written under",
+    )
+    retention_keep: int = Field(
+        default=0,
+        ge=0,
+        description="Number of most-recent backups to keep (0 = keep all)",
+    )
+    retention_days: int = Field(
+        default=0,
+        ge=0,
+        description="Delete backups older than this many days (0 = disabled)",
+    )
+
+
 # --- AI Plan Summary Configuration ---
 
 
@@ -1486,6 +1512,9 @@ class Settings(BaseSettings):
 
     # Artifact Retention
     artifact_retention: ArtifactRetentionConfig = Field(default_factory=ArtifactRetentionConfig)
+
+    # Logical PostgreSQL backup (terrapod.cli.backup; CronJob off by default)
+    backup: BackupConfig = Field(default_factory=BackupConfig)
 
     # Runner artifact upload limits (API-side enforcement)
     runner_artifacts: RunnerArtifactsConfig = Field(default_factory=RunnerArtifactsConfig)

--- a/services/tests/services/test_backup.py
+++ b/services/tests/services/test_backup.py
@@ -1,0 +1,98 @@
+"""Unit tests for the logical-backup CLI (terrapod.cli.backup)."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+
+from terrapod.cli import backup as bk
+
+
+@dataclass
+class _Meta:
+    key: str
+
+
+class _FakeStore:
+    """Minimal ObjectStore stand-in for prune tests."""
+
+    def __init__(self, keys: list[str]) -> None:
+        self._keys = list(keys)
+        self.deleted: list[str] = []
+
+    async def list_prefix(self, prefix: str) -> list[_Meta]:
+        return [_Meta(k) for k in self._keys if k.startswith(prefix)]
+
+    async def delete(self, key: str) -> None:
+        self.deleted.append(key)
+
+
+def test_libpq_dsn_strips_asyncpg():
+    assert bk._libpq_dsn("postgresql+asyncpg://u:p@h:5432/db") == "postgresql://u:p@h:5432/db"
+    # Plain libpq URL is unchanged.
+    assert bk._libpq_dsn("postgresql://u@h/db") == "postgresql://u@h/db"
+
+
+def test_backup_ts_is_sortable_and_parseable():
+    ts = bk._backup_ts()
+    # round-trips through the parser used by retention
+    epoch = bk._parse_key_ts(f"backups/{ts}.dump", "backups/")
+    assert epoch is not None
+    # well-formed: parseable as the documented format
+    datetime.strptime(ts, "%Y%m%dT%H%M%SZ")
+
+
+def test_parse_key_ts_handles_bad_names():
+    assert bk._parse_key_ts("backups/not-a-timestamp.dump", "backups/") is None
+    good = bk._parse_key_ts("backups/20260101T000000Z.dump", "backups/")
+    assert good == datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+
+
+def test_pg_dump_env_password_mode_adds_no_pgpassword(monkeypatch):
+    monkeypatch.delenv("TP_DB_AUTH_MODE", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h:5432/db")
+    env = bk._pg_dump_env()
+    assert "PGPASSWORD" not in env
+
+
+@pytest.mark.asyncio
+async def test_prune_keep_count(monkeypatch):
+    keys = [f"backups/2026010{i}T000000Z.dump" for i in range(1, 6)]  # 5 backups
+    store = _FakeStore(keys)
+    monkeypatch.setattr(bk, "get_storage", lambda: store)
+    await bk._prune("backups/", keep=2, days=0)
+    # keeps the 2 newest (…05, …04); deletes the 3 oldest
+    assert sorted(store.deleted) == sorted(keys[:3])
+
+
+@pytest.mark.asyncio
+async def test_prune_by_age(monkeypatch):
+    old = "backups/20000101T000000Z.dump"
+    new = f"backups/{bk._backup_ts()}.dump"
+    store = _FakeStore([old, new])
+    monkeypatch.setattr(bk, "get_storage", lambda: store)
+    await bk._prune("backups/", keep=0, days=30)
+    assert store.deleted == [old]
+
+
+@pytest.mark.asyncio
+async def test_prune_noop_when_disabled(monkeypatch):
+    store = _FakeStore(["backups/20260101T000000Z.dump"])
+    monkeypatch.setattr(bk, "get_storage", lambda: store)
+    await bk._prune("backups/", keep=0, days=0)
+    assert store.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_prune_ignores_non_dump_keys(monkeypatch):
+    store = _FakeStore(["backups/keep.txt", "backups/20260101T000000Z.dump"])
+    monkeypatch.setattr(bk, "get_storage", lambda: store)
+    await bk._prune("backups/", keep=1, days=0)
+    assert store.deleted == []  # only one .dump, kept
+
+
+@pytest.mark.asyncio
+async def test_backup_requires_database_url(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(SystemExit):
+        await bk.backup()

--- a/services/tests/services/test_restore_verify.py
+++ b/services/tests/services/test_restore_verify.py
@@ -1,0 +1,88 @@
+"""Unit tests for the DR-drill CLI (terrapod.cli.restore_verify)."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from terrapod.cli import restore_verify as rv
+
+
+@dataclass
+class _Meta:
+    key: str
+
+
+class _FakeStore:
+    def __init__(self, keys: list[str], data: bytes = b"x") -> None:
+        self._keys = list(keys)
+        self._data = data
+        self.got: list[str] = []
+
+    async def list_prefix(self, prefix: str) -> list[_Meta]:
+        return [_Meta(k) for k in self._keys if k.startswith(prefix)]
+
+    async def get(self, key: str) -> bytes:
+        self.got.append(key)
+        return self._data
+
+
+def test_dsn_helpers():
+    assert rv._libpq_dsn("postgresql+asyncpg://u@h/db") == "postgresql://u@h/db"
+    assert rv._async_dsn("postgresql://u@h/db") == "postgresql+asyncpg://u@h/db"
+    # already-async is left alone
+    assert rv._async_dsn("postgresql+asyncpg://u@h/db") == "postgresql+asyncpg://u@h/db"
+
+
+@pytest.mark.asyncio
+async def test_refuses_when_target_equals_live(monkeypatch):
+    monkeypatch.setenv("TP_RESTORE_TARGET_URL", "postgresql://u@h:5432/db")
+    # Same DB, different driver suffix — must still be detected as equal.
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u@h:5432/db")
+    with pytest.raises(SystemExit) as exc:
+        await rv.restore_verify()
+    assert exc.value.code == 1
+
+
+@pytest.mark.asyncio
+async def test_requires_target(monkeypatch):
+    monkeypatch.delenv("TP_RESTORE_TARGET_URL", raising=False)
+    with pytest.raises(SystemExit):
+        await rv.restore_verify()
+
+
+@pytest.mark.asyncio
+async def test_latest_backup_key_picks_newest(monkeypatch):
+    keys = [
+        "backups/20260101T000000Z.dump",
+        "backups/20260103T000000Z.dump",
+        "backups/20260102T000000Z.dump",
+        "backups/notes.txt",
+    ]
+    store = _FakeStore(keys)
+    monkeypatch.setattr(rv, "get_storage", lambda: store)
+    monkeypatch.setattr(rv.settings, "backup", type("B", (), {"prefix": "backups/"})())
+    assert await rv._latest_backup_key() == "backups/20260103T000000Z.dump"
+
+
+@pytest.mark.asyncio
+async def test_latest_backup_key_errors_when_empty(monkeypatch):
+    store = _FakeStore(["backups/notes.txt"])
+    monkeypatch.setattr(rv, "get_storage", lambda: store)
+    monkeypatch.setattr(rv.settings, "backup", type("B", (), {"prefix": "backups/"})())
+    with pytest.raises(RuntimeError):
+        await rv._latest_backup_key()
+
+
+@pytest.mark.asyncio
+async def test_verify_state_object_true_when_present(monkeypatch):
+    store = _FakeStore(["state/ws/sv.tfstate"], data=b"{}")
+    monkeypatch.setattr(rv, "get_storage", lambda: store)
+    assert await rv._verify_state_object() is True
+    assert store.got == ["state/ws/sv.tfstate"]
+
+
+@pytest.mark.asyncio
+async def test_verify_state_object_false_when_absent(monkeypatch):
+    store = _FakeStore([])
+    monkeypatch.setattr(rv, "get_storage", lambda: store)
+    assert await rv._verify_state_object() is False


### PR DESCRIPTION
Closes #545.

## What

A tested restore beats a documented one. This ships **optional, off-by-default** disaster-recovery tooling — the procurement question every ops reviewer asks — that needs **no new infra or credentials**: a standard deployment already has both halves a backup needs (a Postgres URL + an object-storage backend).

## Deliverables

1. **Logical backup CronJob** (`backup.enabled`, off by default) — `terrapod.cli.backup` runs `pg_dump` (custom format) and streams the dump to the configured object store under `backups/<ts>.dump`, with keep-N + age retention. Reuses the storage protocol (S3/Azure/GCS/filesystem, inherits bucket at-rest encryption) and the app's cloud-IAM DB auth (mints the same token the API uses), so it works across backends and password/IAM auth alike. It's a **logical** dump — RPO = the dump interval — documented as the floor, not a replacement for RDS snapshots / WAL-G / pgBackRest.
2. **Restore-verification DR drill** (`backup.restoreVerify.enabled`, off by default) — `terrapod.cli.restore_verify` restores the latest backup into a **throwaway native-sidecar Postgres** (never the live DB; refuses if target == `DATABASE_URL`) and asserts core invariants: schema + CA load, workspaces resolve, a state object downloads from the store. Exits non-zero on failure → a real green check. Scheduled drill + on-demand via `kubectl create job --from=cronjob/<release>-terrapod-restore-verify drill-now`.
3. **Per-backend object-storage protection** + **tested restore order** documented in `disaster-recovery.md`, plus a restore-drill-failed runbook.

## Image strategy

`postgresql-client` added to the **API image**; both CronJobs run the API image with a different entrypoint (the listener/runner pattern). **No new release artifact** — the build/sign/SBOM pipeline is untouched.

## Contracts honored

- **Config-channel contract**: `Settings.BackupConfig` ↔ top-level `backup:` values ↔ `values.schema.json` ↔ `configmap-api.yaml` render ↔ helm-smoke assertion. config-channel CI passes on all three profiles.
- **Helm value contract**: renders on `values.yaml` / `values-local.yaml` / `values-eval.yaml`; off by default (helm-smoke asserts both render-when-enabled and absent-by-default).
- **Code↔Tests**: unit tests for retention (keep + age), key parsing, the refuse-equal guard, latest-pick, and state-object verify.

## Verification

- `make test` green (2571 passed); ruff check/format clean.
- `helm lint` + `helm template` ×3 profiles; config-channel contract ×3.

## Smoke gap (F-gate honesty)

The restore-verify CronJob's **native-sidecar Postgres** is render-verified and the Python is unit-tested, but the end-to-end drill (sidecar boot → `pg_restore` → invariants) has **not** yet been exercised on a live cluster. This should get a live Tilt/kind smoke before it's included in a tagged release.
