### PR TITLE
feat(preflight): cloud-identity + object-store preflight doctor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,25 @@ jobs:
               --set redis.url=redis://redis:6379)
           echo "$stock" | grep -q "component: backup" && { echo "FAIL: backup CronJob rendered by default (should be opt-in)"; exit 1; }
           echo "backup + DR-drill CronJobs render OK and are off by default (#545)"
+      - name: Preflight identity-doctor Jobs render and are off by default (#571)
+        run: |
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set api.config.storage.backend=s3 --set api.config.storage.s3.bucket=b \
+              --set preflight.enabled=true)
+          echo "$out" | grep -q "terrapod.cli.preflight" || { echo "FAIL: preflight entrypoint missing"; exit 1; }
+          echo "$out" | grep -q "component: preflight" || { echo "FAIL: preflight component label missing"; exit 1; }
+          echo "$out" | grep -q "preflight-runner" || { echo "FAIL: runner-SA preflight Job missing (s3 backend)"; exit 1; }
+          echo "$out" | grep -q 'helm.sh/hook' || { echo "FAIL: preflight not a Helm hook"; exit 1; }
+          # Off by default.
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379)
+          echo "$stock" | grep -q "component: preflight" && { echo "FAIL: preflight rendered by default (should be opt-in)"; exit 1; }
+          echo "preflight Jobs render OK and are off by default (#571)"
 
   # ── Config-channel contract (#617) ────────────────────
   # Renders the chart (every values profile) and parses the rendered ConfigMaps

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 	pentest pentest-sast pentest-images pentest-dast \
 	dev dev-down \
 	ai-eval \
+	preflight-identity \
 	clean test-down \
 	help
 
@@ -30,6 +31,9 @@ test-python:        ## Test Python only (Docker)
 
 helm-config-contract: ## Config-channel contract: render chart + parse via real config models (#617)
 	scripts/helm-config-contract.sh
+
+preflight-identity:  ## Cloud-identity preflight against a running release. e.g. RELEASE=tp NAMESPACE=infra make preflight-identity
+	scripts/preflight-identity.sh
 
 ai-eval:            ## Run the AI-analysis eval harness (live model). e.g. make ai-eval ARGS="run --model bedrock/us.anthropic.claude-sonnet-4-6 -n 3"
 	scripts/ai-eval.sh $(ARGS)

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Audit Logging](docs/audit-logging.md) | Immutable event log, query API, retention |
 | [Artifact Retention](docs/artifact-retention.md) | Retention + purge of run logs, plans, and config tarballs |
 | [Runners](docs/runners.md) | Agent pools, the listener/runner ARC model, custom runner images |
-| [Cloud Credentials](docs/cloud-credentials.md) | AWS IRSA, GCP WIF, Azure WI setup |
+| [Cloud Credentials](docs/cloud-credentials.md) | AWS IRSA, GCP WIF, Azure WI setup + a preflight doctor that verifies SA→role + object-store access before the first run |
 | [Service Catalog](docs/service-catalog.md) | No-code self-service provisioning over the module registry |
 | [Monitoring](docs/monitoring.md) | Prometheus metrics, scraping, shipped Grafana dashboard + alert rules (with per-alert runbooks) |
 | [Optional Webhook Ingress](docs/deployment-webhook-ingress.md) | Split public webhook ingress so the management plane can stay private |

--- a/docs/cloud-credentials.md
+++ b/docs/cloud-credentials.md
@@ -433,6 +433,40 @@ listener:
 
 ---
 
+## Preflight doctor: catch identity mistakes before the first run
+
+Workload identity fails closed and late — the first plan run errors cryptically
+mid-`init`. The **preflight doctor** catches an OIDC-trust / SA-binding mismatch
+up front by exercising the *same code path* the platform uses, under the real
+ServiceAccounts:
+
+- the **API SA** — initialise the configured storage backend and **list** the
+  bucket (proves read access), resolve the cloud identity (AWS STS
+  `GetCallerIdentity` / GCP SA email / Azure token), and connect to PostgreSQL;
+- the **runner SA** — resolve its cloud identity (runners need it for provider
+  auth).
+
+Each check prints a clear ✓/✗ and the resolved identity, and a failure exits
+non-zero with a pointer back to this troubleshooting section.
+
+**As a Helm hook (opt-in).** Turn it on so a misconfigured trust policy fails
+`helm install/upgrade` loudly instead of the first run failing later:
+
+```yaml
+preflight:
+  enabled: true     # runs as a post-install/upgrade hook; a ✗ fails the release
+```
+
+**On demand against a running release** (no chart change):
+
+```bash
+make preflight-identity                          # RELEASE=terrapod NAMESPACE=terrapod
+RELEASE=tp NAMESPACE=infra make preflight-identity
+```
+
+It renders the preflight Jobs from the same chart, runs them under the real SAs,
+and streams the report. A ✗ maps directly to the failure modes below.
+
 ## Troubleshooting: top failure modes
 
 Workload identity fails closed and the errors are often opaque. The three most common causes, with how to diagnose each:

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,7 +119,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Audit Logging](audit-logging.md) | Immutable event log, query API, retention |
 | [Artifact Retention](artifact-retention.md) | Automated cleanup of old state versions, run logs, cache entries |
 | [Runners](runners.md) | Custom runner images, private registries, Job configuration |
-| [Cloud Credentials](cloud-credentials.md) | Zero static cloud credentials, end to end — runs and the platform reach cloud APIs via Kubernetes workload identity (AWS IRSA, GCP WIF, Azure WI). Beginner primer, decision tree, troubleshooting, passwordless **database** + **Redis/Valkey** IAM auth (AWS/GCP/Azure), and Vault/ESO patterns |
+| [Cloud Credentials](cloud-credentials.md) | Zero static cloud credentials, end to end — runs and the platform reach cloud APIs via Kubernetes workload identity (AWS IRSA, GCP WIF, Azure WI). Beginner primer, decision tree, a preflight doctor (`make preflight-identity` / opt-in Helm hook) that verifies SA→role + object-store access before the first run, troubleshooting, passwordless **database** + **Redis/Valkey** IAM auth (AWS/GCP/Azure), and Vault/ESO patterns |
 | [Registry](registry.md) | Private module/provider registry, caching layers |
 | [Registry Publishing](registry-publishing.md) | Publishing providers/modules with the `terrapod-publish` CLI and the client-signed publish protocol |
 | [Service Catalog](service-catalog.md) | No-code self-service provisioning over the private module registry: blessed catalog items, provider templates, a `catalog_permission` RBAC axis, and a full provision → reconfigure → destroy lifecycle |

--- a/helm/terrapod/templates/job-preflight.yaml
+++ b/helm/terrapod/templates/job-preflight.yaml
@@ -1,0 +1,182 @@
+{{- if ne .Values.api.enabled false }}
+{{- if and .Values.preflight .Values.preflight.enabled }}
+{{- $dbAuthMode := (.Values.api.config.database).auth_mode | default "password" }}
+{{- $dbIam := or (eq $dbAuthMode "aws_iam") (eq $dbAuthMode "gcp_iam") (eq $dbAuthMode "azure_ad") }}
+{{- $dbCa := or .Values.api.databaseCA.inline .Values.api.databaseCA.existingConfigMap }}
+{{- $fs := eq .Values.api.config.storage.backend "filesystem" }}
+{{- $hook := .Values.preflight.hook | default "post-install,post-upgrade" }}
+{{- $weight := .Values.preflight.hookWeight | default "5" }}
+# Cloud-identity + object-store preflight (#571). OFF by default. When enabled
+# it runs as a Helm hook so a misconfigured OIDC trust policy / SA binding fails
+# the install/upgrade loudly INSTEAD of the first run failing cryptically. Two
+# Jobs: the API SA (storage + identity + DB) and the runner SA (identity only).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "terrapod.fullname" . }}-preflight-api-{{ .Release.Revision }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: preflight
+  annotations:
+    "helm.sh/hook": {{ $hook | quote }}
+    "helm.sh/hook-weight": {{ $weight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.preflight.backoffLimit | default 0 }}
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "terrapod.labels" . | nindent 8 }}
+        app.kubernetes.io/component: preflight
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "terrapod.serviceAccountName" . }}
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+      {{- if eq (include "terrapod.caBundle.enabled" .) "true" }}
+      initContainers:
+        {{- include "terrapod.caBundle.initContainer" (dict "root" . "image" (include "terrapod.api.image" .) "pullPolicy" .Values.api.image.pullPolicy) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: preflight
+          image: {{ include "terrapod.api.image" . }}
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          command: ["python", "-m", "terrapod.cli.preflight"]
+          env:
+            - name: TP_PREFLIGHT_MODE
+              value: "full"
+            - name: TERRAPOD_STORAGE__FILESYSTEM__HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "terrapod.fullname" . }}-storage
+                  key: hmac-secret
+                  optional: true
+            {{- $pgSecret := include "terrapod.postgresql.secretName" . }}
+            {{- if $pgSecret }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $pgSecret }}
+                  key: {{ include "terrapod.postgresql.secretKey" . }}
+            {{- else if .Values.postgresql.url }}
+            - name: DATABASE_URL
+              value: {{ .Values.postgresql.url | quote }}
+            {{- end }}
+            {{- if $dbIam }}
+            - name: TP_DB_AUTH_MODE
+              value: {{ $dbAuthMode | quote }}
+            - name: TP_DB_AWS_IAM_REGION
+              value: {{ (.Values.api.config.database).aws_iam_region | default "" | quote }}
+            - name: TP_DB_SSL_MODE
+              value: {{ (.Values.api.config.database).ssl_mode | default "" | quote }}
+            - name: TP_DB_SSL_ROOT_CERT
+              {{- if $dbCa }}
+              value: {{ printf "/etc/terrapod/db-ca/%s" (.Values.api.databaseCA.key | default "ca.pem") | quote }}
+              {{- else }}
+              value: {{ (.Values.api.config.database).ssl_root_cert | default "" | quote }}
+              {{- end }}
+            {{- end }}
+            {{- include "terrapod.proxyEnv" . | nindent 12 }}
+            {{- include "terrapod.caBundle.env" . | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/terrapod
+              readOnly: true
+            {{- if $fs }}
+            - name: storage
+              mountPath: {{ .Values.api.config.storage.filesystem.root_dir }}
+              readOnly: true
+            {{- end }}
+            {{- if and $dbIam $dbCa }}
+            - name: database-ca
+              mountPath: /etc/terrapod/db-ca
+              readOnly: true
+            {{- end }}
+            {{- include "terrapod.caBundle.volumeMounts" . | nindent 12 }}
+          resources:
+            {{- toYaml (.Values.preflight.resources | default dict) | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.api.containerSecurityContext | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "terrapod.fullname" . }}-api-config
+        {{- if $fs }}
+        - name: storage
+          {{- if .Values.storage.filesystem.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "terrapod.fullname" . }}-storage
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if and $dbIam $dbCa }}
+        - name: database-ca
+          configMap:
+            name: {{ .Values.api.databaseCA.existingConfigMap | default (printf "%s-database-ca" (include "terrapod.fullname" .)) }}
+        {{- end }}
+        {{- include "terrapod.caBundle.volumes" . | nindent 8 }}
+{{- if and (ne .Values.preflight.checkRunner false) (not $fs) }}
+---
+# Runner SA identity probe — confirms the runner ServiceAccount's cloud
+# workload-identity binding resolves (runners need it for provider auth).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "terrapod.fullname" . }}-preflight-runner-{{ .Release.Revision }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+    app.kubernetes.io/component: preflight
+  annotations:
+    "helm.sh/hook": {{ $hook | quote }}
+    "helm.sh/hook-weight": {{ $weight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.preflight.backoffLimit | default 0 }}
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "terrapod.labels" . | nindent 8 }}
+        app.kubernetes.io/component: preflight
+      {{- if .Values.runners.azureWorkloadIdentity }}
+        azure.workload.identity/use: "true"
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "terrapod.runnerServiceAccountName" . }}
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+      containers:
+        - name: preflight-runner
+          image: {{ include "terrapod.api.image" . }}
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          command: ["python", "-m", "terrapod.cli.preflight"]
+          env:
+            - name: TP_PREFLIGHT_MODE
+              value: "identity"
+            {{- include "terrapod.proxyEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/terrapod
+              readOnly: true
+          resources:
+            {{- toYaml (.Values.preflight.resources | default dict) | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.api.containerSecurityContext | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "terrapod.fullname" . }}-api-config
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -318,6 +318,19 @@
       }
     },
 
+    "preflight": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "checkRunner": { "type": "boolean" },
+        "hook": { "type": "string" },
+        "hookWeight": { "type": "string" },
+        "backoffLimit": { "type": "integer", "minimum": 0 },
+        "resources": { "type": "object" }
+      }
+    },
+
     "postgresql": {
       "type": "object",
       "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -723,6 +723,21 @@ backup:
     resources: {}
     postgresResources: {}
 
+# ── Cloud-identity preflight doctor (#571) ────────────────────────────────────
+# OFF by default. When enabled, runs as a Helm post-install/upgrade hook so a
+# misconfigured OIDC trust policy / SA binding fails the install LOUDLY instead
+# of the first run failing cryptically. Two Jobs: the API ServiceAccount
+# (storage read + cloud identity + DB connect) and the runner ServiceAccount
+# (cloud identity only). A failing hook fails `helm install/upgrade` — that's the
+# point. Also runnable on demand via `make preflight-identity`.
+preflight:
+  enabled: false
+  checkRunner: true              # also probe the runner SA's cloud identity
+  hook: "post-install,post-upgrade"
+  hookWeight: "5"
+  backoffLimit: 0
+  resources: {}
+
 # ── Web UI (Next.js) ──────────────────────────────────────────────────────────
 # The web frontend is the BFF (Backend-For-Frontend): all browser, CLI, and
 # listener traffic enters through it and is proxied to the API. The Ingress

--- a/llms.txt
+++ b/llms.txt
@@ -71,6 +71,7 @@ How each capability is turned on. **Platform-level** features are Helm values un
 
 | Capability | How to enable | Doc |
 |---|---|---|
+| Cloud-identity preflight doctor | `preflight.enabled` (off by default; Helm hook) or `make preflight-identity` — verifies SA→cloud role + object-store read + DB before first run | [cloud-credentials.md](docs/cloud-credentials.md#preflight-doctor-catch-identity-mistakes-before-the-first-run) |
 | Cloud-IAM **database** auth | `api.config.database.auth_mode` = `aws_iam` \| `gcp_iam` \| `azure_ad` (default `password`) | [cloud-credentials.md](docs/cloud-credentials.md) |
 | Cloud-IAM **Redis/Valkey** auth | `api.config.redis.auth_mode` = `aws_iam` \| `gcp_iam` \| `azure_ad` (default `password`); requires a `rediss://` URL | [cloud-credentials.md](docs/cloud-credentials.md) |
 | AI plan summary | `api.config.ai_summary.enabled` + provider/model config | [ai-plan-summary.md](docs/ai-plan-summary.md) |

--- a/scripts/preflight-identity.sh
+++ b/scripts/preflight-identity.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Run the cloud-identity preflight doctor (#571) against an EXISTING Terrapod
+# release in the current kube context — verifies the API + runner ServiceAccounts
+# can assume their cloud role and read the object store, BEFORE a real run fails.
+#
+# Usage:
+#   make preflight-identity                      # release=terrapod ns=terrapod
+#   RELEASE=tp NAMESPACE=infra make preflight-identity
+#   VALUES=helm/terrapod/values-prod.yaml make preflight-identity
+#
+# It renders only the preflight Jobs (with preflight.enabled=true) from the same
+# chart, applies them to the running namespace so they run under the real SAs,
+# waits, and streams the pass/fail report. This is the on-demand counterpart to
+# the opt-in Helm hook (`preflight.enabled: true` in values).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RELEASE="${RELEASE:-terrapod}"
+NAMESPACE="${NAMESPACE:-terrapod}"
+HELM_IMAGE="alpine/helm:3.17.2"
+
+extra=()
+[ -n "${VALUES:-}" ] && extra+=(-f "$VALUES")
+
+echo "==> Rendering preflight Jobs for release '$RELEASE' in namespace '$NAMESPACE'"
+manifest="$(docker run --rm -v "$PWD:/chart" -w /chart "$HELM_IMAGE" \
+  template "$RELEASE" helm/terrapod \
+    --namespace "$NAMESPACE" \
+    "${extra[@]}" \
+    --set preflight.enabled=true \
+    --show-only templates/job-preflight.yaml)"
+
+if [ -z "$manifest" ]; then
+  echo "FAIL: nothing rendered — check RELEASE/VALUES" >&2
+  exit 1
+fi
+
+# Clear any prior preflight Jobs (fixed names → re-run safe), then apply.
+kubectl delete job -n "$NAMESPACE" -l app.kubernetes.io/component=preflight --ignore-not-found
+echo "$manifest" | kubectl apply -n "$NAMESPACE" -f -
+
+echo "==> Waiting for preflight Jobs to complete…"
+rc=0
+kubectl wait -n "$NAMESPACE" --for=condition=complete --timeout=180s \
+  job -l app.kubernetes.io/component=preflight || rc=$?
+
+echo "==> Preflight output:"
+kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/component=preflight --tail=-1 --prefix || true
+
+if [ "$rc" -ne 0 ]; then
+  echo "==> Preflight did NOT pass (see output above + docs/cloud-credentials.md#troubleshooting)" >&2
+  exit 1
+fi
+echo "==> Preflight PASSED"

--- a/services/terrapod/cli/preflight.py
+++ b/services/terrapod/cli/preflight.py
@@ -1,0 +1,183 @@
+"""Cloud-identity + object-store preflight doctor.
+
+Run via: ``python -m terrapod.cli.preflight``
+
+A one-shot check that the ServiceAccount it runs under can actually assume its
+cloud role and reach the configured object store — surfacing an OIDC
+trust-policy / SA-binding mismatch *before* the first run fails cryptically.
+
+It exercises the **same code path** the platform uses (the real storage backend
+init + a list on the bucket) and resolves the cloud identity (AWS STS
+GetCallerIdentity / GCP SA email / Azure token claims), printing a clear
+pass/fail. Failure hints map to the Troubleshooting section of
+``docs/cloud-credentials.md``.
+
+Modes (``TP_PREFLIGHT_MODE``):
+  full      (default) storage read + cloud identity + a DB connect — run under
+            the API ServiceAccount.
+  identity  cloud identity only — run under the runner ServiceAccount (runners
+            don't read the app object store; they need a working cloud identity
+            for provider auth).
+
+Environment (set by the Helm hook):
+  DATABASE_URL          PostgreSQL URL (full mode; from the chart's PG secret)
+  TP_DB_AUTH_MODE etc.  Cloud-IAM DB auth (optional; same vars as the API)
+  TERRAPOD_CONFIG       config.yaml (storage backend selection)
+"""
+
+import asyncio
+import logging
+import os
+import sys
+
+from terrapod.config import StorageBackend, settings
+from terrapod.storage import close_storage, get_storage, init_storage
+
+logger = logging.getLogger("terrapod.preflight")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+_DOCS = "https://github.com/mattrobinsonsre/terrapod/blob/main/docs/cloud-credentials.md#troubleshooting"
+_PROBE_PREFIX = "__terrapod_preflight_probe__/"
+
+
+class _Check:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.ok: bool | None = None
+        self.detail = ""
+
+    def passed(self, detail: str) -> "_Check":
+        self.ok, self.detail = True, detail
+        return self
+
+    def failed(self, detail: str) -> "_Check":
+        self.ok, self.detail = False, detail
+        return self
+
+    def skipped(self, detail: str) -> "_Check":
+        self.ok, self.detail = None, detail
+        return self
+
+
+def _backend_cloud() -> str | None:
+    """Map the configured storage backend to its cloud, or None (filesystem)."""
+    return {
+        StorageBackend.S3: "aws",
+        StorageBackend.GCS: "gcp",
+        StorageBackend.AZURE: "azure",
+    }.get(settings.storage.backend)
+
+
+async def _check_storage() -> _Check:
+    """Init the real storage backend and list a prefix — proves read access."""
+    chk = _Check("object store reachable")
+    try:
+        await init_storage()
+    except Exception as exc:  # noqa: BLE001
+        return chk.failed(f"storage init failed: {exc}")
+    try:
+        # A list on a nonsense prefix returns [] when credentials are valid and
+        # raises (e.g. 403 AccessDenied) when they are not — the cheapest probe
+        # that exercises the SA's bucket permission without mutating anything.
+        await get_storage().list_prefix(_PROBE_PREFIX)
+        return chk.passed(f"{settings.storage.backend.value}: list succeeded")
+    except Exception as exc:  # noqa: BLE001
+        return chk.failed(f"{settings.storage.backend.value}: {exc}")
+    finally:
+        await close_storage()
+
+
+def _resolve_identity() -> _Check:
+    """Best-effort: report the resolved cloud identity for the running SA."""
+    chk = _Check("cloud identity resolves")
+    cloud = _backend_cloud()
+    if cloud is None:
+        return chk.skipped("filesystem backend — no cloud identity to resolve")
+    try:
+        if cloud == "aws":
+            import botocore.session
+
+            sts = botocore.session.get_session().create_client("sts")
+            ident = sts.get_caller_identity()
+            return chk.passed(f"AWS: {ident.get('Arn', ident.get('UserId', '?'))}")
+        if cloud == "gcp":
+            import google.auth
+
+            creds, project = google.auth.default()
+            who = getattr(creds, "service_account_email", None) or "(token-based)"
+            return chk.passed(f"GCP: {who} (project {project})")
+        if cloud == "azure":
+            from azure.identity import DefaultAzureCredential
+
+            token = DefaultAzureCredential().get_token("https://storage.azure.com/.default")
+            return chk.passed(f"Azure: token acquired (expires {token.expires_on})")
+    except Exception as exc:  # noqa: BLE001
+        return chk.failed(f"{cloud}: {exc}")
+    return chk.skipped(f"no identity probe for {cloud}")
+
+
+async def _check_database() -> _Check:
+    """Connect to PostgreSQL the same way the API does (incl. cloud-IAM auth)."""
+    chk = _Check("database reachable")
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    if not database_url:
+        return chk.skipped("DATABASE_URL not set")
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(database_url)
+    try:
+        from terrapod.db.iam_auth import register_engine_iam_auth
+
+        register_engine_iam_auth(engine.sync_engine, database_url)
+    except Exception:  # noqa: BLE001 — IAM wiring is best-effort
+        pass
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return chk.passed("SELECT 1 succeeded")
+    except Exception as exc:  # noqa: BLE001
+        return chk.failed(str(exc))
+    finally:
+        await engine.dispose()
+
+
+async def preflight() -> None:
+    mode = os.environ.get("TP_PREFLIGHT_MODE", "full").strip() or "full"
+    logger.info("Terrapod preflight doctor (mode=%s)", mode)
+
+    checks: list[_Check] = []
+    if mode == "identity":
+        # Runner SA: only the cloud-identity binding matters.
+        checks.append(_resolve_identity())
+    else:
+        checks.append(await _check_storage())
+        checks.append(_resolve_identity())
+        checks.append(await _check_database())
+
+    logger.info("")
+    hard_fail = False
+    for c in checks:
+        if c.ok is True:
+            logger.info("  ✓ %s — %s", c.name, c.detail)
+        elif c.ok is None:
+            logger.info("  • %s — %s", c.name, c.detail)
+        else:
+            logger.info("  ✗ %s — %s", c.name, c.detail)
+            hard_fail = True
+
+    if hard_fail:
+        logger.error("\nPreflight FAILED. See %s", _DOCS)
+        sys.exit(1)
+    logger.info("\nPreflight PASSED.")
+
+
+def main() -> None:
+    asyncio.run(preflight())
+
+
+if __name__ == "__main__":
+    main()

--- a/services/tests/services/test_preflight.py
+++ b/services/tests/services/test_preflight.py
@@ -1,0 +1,97 @@
+"""Unit tests for the cloud-identity preflight doctor (terrapod.cli.preflight)."""
+
+import pytest
+
+from terrapod.cli import preflight as pf
+from terrapod.config import StorageBackend
+
+
+class _FakeStore:
+    def __init__(self, raise_on_list: Exception | None = None) -> None:
+        self._raise = raise_on_list
+
+    async def list_prefix(self, prefix: str):
+        if self._raise:
+            raise self._raise
+        return []
+
+
+def _patch_storage(monkeypatch, store=None, init_exc=None):
+    async def _init():
+        if init_exc:
+            raise init_exc
+
+    async def _close():
+        pass
+
+    monkeypatch.setattr(pf, "init_storage", _init)
+    monkeypatch.setattr(pf, "close_storage", _close)
+    monkeypatch.setattr(pf, "get_storage", lambda: store)
+
+
+def test_backend_cloud_mapping(monkeypatch):
+    for backend, cloud in [
+        (StorageBackend.S3, "aws"),
+        (StorageBackend.GCS, "gcp"),
+        (StorageBackend.AZURE, "azure"),
+        (StorageBackend.FILESYSTEM, None),
+    ]:
+        monkeypatch.setattr(pf.settings.storage, "backend", backend)
+        assert pf._backend_cloud() == cloud
+
+
+@pytest.mark.asyncio
+async def test_check_storage_passes(monkeypatch):
+    monkeypatch.setattr(pf.settings.storage, "backend", StorageBackend.FILESYSTEM)
+    _patch_storage(monkeypatch, store=_FakeStore())
+    chk = await pf._check_storage()
+    assert chk.ok is True
+
+
+@pytest.mark.asyncio
+async def test_check_storage_fails_on_list_error(monkeypatch):
+    monkeypatch.setattr(pf.settings.storage, "backend", StorageBackend.S3)
+    _patch_storage(monkeypatch, store=_FakeStore(raise_on_list=PermissionError("403 AccessDenied")))
+    chk = await pf._check_storage()
+    assert chk.ok is False
+    assert "AccessDenied" in chk.detail
+
+
+@pytest.mark.asyncio
+async def test_check_storage_fails_on_init_error(monkeypatch):
+    monkeypatch.setattr(pf.settings.storage, "backend", StorageBackend.S3)
+    _patch_storage(monkeypatch, store=_FakeStore(), init_exc=RuntimeError("bad config"))
+    chk = await pf._check_storage()
+    assert chk.ok is False
+
+
+def test_resolve_identity_filesystem_skips(monkeypatch):
+    monkeypatch.setattr(pf.settings.storage, "backend", StorageBackend.FILESYSTEM)
+    chk = pf._resolve_identity()
+    assert chk.ok is None  # skipped, not a failure
+
+
+@pytest.mark.asyncio
+async def test_check_database_skipped_without_url(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    chk = await pf._check_database()
+    assert chk.ok is None
+
+
+@pytest.mark.asyncio
+async def test_identity_mode_filesystem_passes(monkeypatch):
+    # Runner identity probe on a filesystem backend: nothing to resolve → pass.
+    monkeypatch.setattr(pf.settings.storage, "backend", StorageBackend.FILESYSTEM)
+    monkeypatch.setenv("TP_PREFLIGHT_MODE", "identity")
+    await pf.preflight()  # must not SystemExit
+
+
+@pytest.mark.asyncio
+async def test_full_mode_hard_fails_on_storage(monkeypatch):
+    monkeypatch.setattr(pf.settings.storage, "backend", StorageBackend.S3)
+    monkeypatch.setenv("TP_PREFLIGHT_MODE", "full")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _patch_storage(monkeypatch, store=_FakeStore(raise_on_list=PermissionError("403")))
+    with pytest.raises(SystemExit) as exc:
+        await pf.preflight()
+    assert exc.value.code == 1


### PR DESCRIPTION
Closes #571.

## What

Workload identity fails closed and **late** — the first plan run errors cryptically mid-`init`. The **preflight doctor** catches an OIDC-trust / SA-binding mismatch up front by exercising the **same code path** the platform uses, under the real ServiceAccounts. (Deferred ergonomic from #552; part of #551.)

## Deliverables

- **`terrapod.cli.preflight`** — `full` mode (API SA): storage backend init + bucket **list** (proves read access), cloud identity (AWS STS `GetCallerIdentity` / GCP SA email / Azure token), and a DB connect. `identity` mode (runner SA): cloud identity only. Each check prints ✓/✗ + the resolved identity; a failure exits non-zero with a pointer to `cloud-credentials.md#troubleshooting`.
- **Opt-in Helm hook** (`preflight.enabled`, default off): a post-install/upgrade hook rendering two Jobs (API SA full + runner SA identity, the latter gated to cloud backends). A ✗ **fails `helm install/upgrade`** — fail fast.
- **`make preflight-identity`** (`scripts/preflight-identity.sh`): run the checks on demand against a running release (`RELEASE=`/`NAMESPACE=`/`VALUES=`).

## Image strategy

Both Jobs run the **API image** with a different entrypoint (listener/runner pattern) — no new release artifact; the build/sign pipeline is untouched.

## Contracts honored

- Helm value contract: `preflight.*` values + `values.schema.json` + renders on all three profiles; off by default (helm-smoke asserts render-when-enabled + absent-by-default + the runner Job appears only on cloud backends).
- No config-channel change (no new `config.yaml` keys — the doctor reads the existing storage config + a mode env var).
- Code↔Tests: unit tests for the backend→cloud mapping, the storage probe (pass / list-403 / init-error), identity skip on filesystem, DB skip without URL, and the full-mode hard-fail + identity-mode pass paths.

## Verification

- `make test` green (2579 passed); ruff check/format clean.
- `helm lint` + `helm template` ×3 profiles; actionlint + shellcheck clean.
- Fully CI-verifiable — no live-only gap (the checks are unit-tested with mocked storage/DB; the Jobs are render-tested).
