### PR TITLE
feat(crypto): app-layer encryption at rest — framework + CA-key slice (#553 Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,26 @@ jobs:
               --set redis.url=redis://redis:6379)
           echo "$stock" | grep -q "component: preflight" && { echo "FAIL: preflight rendered by default (should be opt-in)"; exit 1; }
           echo "preflight Jobs render OK and are off by default (#571)"
+      - name: Encryption-at-rest config + secret wiring (#553)
+        run: |
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set api.config.encryption.enabled=true \
+              --set api.config.encryption.existingSecret=tp-enc)
+          echo "$out" | grep -q "encryption:" || { echo "FAIL: encryption block not in config.yaml"; exit 1; }
+          echo "$out" | grep -q "TERRAPOD_ENCRYPTION__STATIC_KEY" || { echo "FAIL: static-key secretKeyRef missing"; exit 1; }
+          echo "$out" | grep -q "TERRAPOD_ENCRYPTION__VAULT_TOKEN" || { echo "FAIL: vault-token secretKeyRef missing"; exit 1; }
+          # Secret values never rendered into a ConfigMap.
+          echo "$out" | awk '/kind: ConfigMap/,/^---/' | grep -q "static_key\|vault_token" && { echo "FAIL: secret key leaked into ConfigMap"; exit 1; }
+          # Off by default — no encryption block enabled.
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379)
+          echo "$stock" | grep -A1 "encryption:" | grep -q "enabled: true" && { echo "FAIL: encryption enabled by default"; exit 1; }
+          echo "encryption-at-rest config + secret wiring OK and off by default (#553)"
 
   # ── Config-channel contract (#617) ────────────────────
   # Renders the chart (every values profile) and parses the rendered ConfigMaps

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Security Hardening](docs/security-hardening.md) | Pod hardening defaults, secrets, network posture |
 | [Production Checklist](docs/production-checklist.md) | Pre-go-live checklist for a production deployment |
 | [Disaster Recovery](docs/disaster-recovery.md) | Break-glass state recovery, shipped DB backup CronJob + restore-verification DR drill, per-backend object-storage protection |
+| [Encryption at Rest](docs/encryption-at-rest.md) | Optional off-by-default app-layer (BYOK) envelope encryption of DB secrets — for no-/niche-CSP, bare-metal, or air-gapped deployments (static / Vault Transit / AWS KMS) |
 
 ---
 

--- a/alembic/versions/4ad6441e82b3_add_crypto_keys.py
+++ b/alembic/versions/4ad6441e82b3_add_crypto_keys.py
@@ -1,0 +1,43 @@
+"""add crypto_keys for app-layer encryption at rest (#553)
+
+Revision ID: 4ad6441e82b3
+Revises: e9503007edfc
+Create Date: 2026-06-30
+
+Stores KEK-wrapped data-encryption keys (one row per DEK version) for optional
+application-layer encryption at rest. Off by default — the table stays empty
+until an operator enables encryption. The encrypted columns themselves (e.g.
+``certificate_authority.ca_key_pem``) remain ``TEXT`` and need no migration.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "4ad6441e82b3"
+down_revision = "e9503007edfc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "crypto_keys",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("wrapped_dek", sa.Text(), nullable=False),
+        sa.Column("provider", sa.String(length=50), nullable=False),
+        sa.Column("canary", sa.Text(), nullable=False, server_default=""),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("version", name="uq_crypto_keys_version"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("crypto_keys")

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -31,8 +31,12 @@ WORKDIR /app
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
-# Only the modules needed for migrations: db models + alembic config
+# Only the modules needed for migrations: db models + alembic config.
+# models.py imports terrapod.crypto.types (the EncryptedText column type), so the
+# crypto package must be present; its service/provider deps are import-lazy and
+# are never loaded during a migration run.
 COPY services/terrapod/db/ ./terrapod/db/
+COPY services/terrapod/crypto/ ./terrapod/crypto/
 COPY alembic/ ./alembic/
 COPY alembic.ini ./
 

--- a/docs/encryption-at-rest.md
+++ b/docs/encryption-at-rest.md
@@ -1,0 +1,114 @@
+# Encryption at rest (application-layer, optional)
+
+> **Most deployments do not need this.** If your platform encrypts data at rest
+> natively — RDS / Cloud SQL / Azure Database encryption for Postgres, and S3
+> SSE / Azure Storage / GCS default encryption for the object store — that is the
+> recommended baseline and Terrapod relies on it by default. Turning on
+> application-layer encryption *on top* of that is **belt-and-braces**.
+>
+> **Where it earns its keep:** deployments **without a usable CSP at-rest
+> switch** — bare-metal, on-prem, a niche cloud that doesn't offer it, or
+> air-gapped — where you can't just tick a box in a console. There, this is your
+> path to encryption at rest at all. It's deliberately for the fussy and the
+> fringe; it is **off by default**.
+
+When enabled, sensitive values are envelope-encrypted **before** they hit
+Postgres, so a leaked database dump exposes ciphertext, not plaintext. The key
+that protects them is held by a key manager you choose — "we hold the key, not
+just the platform."
+
+## What's encrypted (Phase 1)
+
+Application-layer encryption currently covers **DB-stored secrets**, starting
+with the **CA private key** (the single most sensitive blob). The remaining
+Phase-1 columns — sensitive variables, variable-set values, catalog inputs, VCS
+tokens/keys, webhook secrets — land in a follow-up. **State files are out of
+scope for now** (they need a decrypting download proxy and chunked streaming;
+keep them protected by object-store at-rest encryption).
+
+The DB columns stay `TEXT`; nothing is re-typed at the database level. Values
+written before you enable encryption stay readable (they're passed through
+untouched until a future migration re-encrypts them), so enabling/disabling is a
+migration, not a hard cutover.
+
+## How it works — envelope encryption
+
+- A random **DEK** (data-encryption key) encrypts the data with AES-256-GCM.
+- A **KEK** (key-encryption key), held by your chosen provider, *wraps* the DEK.
+  The KEK never reaches the data path: the DEK is unwrapped **once at startup**
+  and cached in memory, so per-row crypto is local and fast.
+- Every encrypted value is self-describing (`tpenc:1:<dek_version>:…`) so DEK
+  rotation and mixed state during a migration are well-defined.
+- A **decryptability canary** (a known value encrypted at enable time) is checked
+  on every boot. If the key is wrong or missing, the API **fails to start and
+  refuses writes** — it never stores data it can't read back.
+
+## Choosing a KEK provider
+
+| Provider | Key custody | Best for |
+|---|---|---|
+| `vault_transit` | HashiCorp Vault Transit (key never leaves Vault) | **on-prem / multi-cloud / air-gapped** — the CSP-agnostic KMS, and the recommended choice when you have no cloud KMS |
+| `static` | an operator-held master key (K8s Secret) | bare-metal / dev / the universal fallback when there is **no** key manager at all |
+| `awskms` | AWS KMS | deployments already on AWS (belt-and-braces) |
+
+> **`static` is a footgun — read this.** With `static`, **you** own key
+> durability. If you lose the master key, **all encrypted data is
+> unrecoverable** — there is no recovery path. Back it up out-of-band, in more
+> than one place, under multi-person control, *before* you enable encryption.
+> Prefer `vault_transit` (or a cloud KMS) whenever you have one, because they
+> own durability, rotation, and audit for you.
+
+## Enabling it
+
+The KEK secret (the `static` master key and/or the Vault token) is injected via
+a K8s Secret — never a ConfigMap. Create it first:
+
+```bash
+# static: a strong master key (passphrase or base64 — it's hashed to a 256-bit KEK)
+kubectl -n terrapod create secret generic terrapod-encryption \
+  --from-literal=static_key="$(openssl rand -base64 48)"
+
+# vault_transit: a Vault token with encrypt/decrypt on the transit key
+kubectl -n terrapod create secret generic terrapod-encryption \
+  --from-literal=vault_token="$VAULT_TOKEN"
+```
+
+Then opt in via Helm values:
+
+```yaml
+api:
+  config:
+    encryption:
+      enabled: true
+      provider: vault_transit          # or: static | awskms
+      existingSecret: terrapod-encryption
+      # vault_transit:
+      vault_address: "https://vault.internal:8200"
+      vault_mount: transit
+      vault_key_name: terrapod
+      # awskms:
+      # provider: awskms
+      # aws_kms_key_id: "arn:aws:kms:…:key/…"   # auth via the API pod's IRSA
+```
+
+On first enable the API mints DEK v1, wraps it with your KEK, stores it (wrapped)
+in the `crypto_keys` table, and writes the canary. From then on, new writes to
+covered columns are encrypted; the API refuses to start if the KEK can't unwrap
+the DEK (canary fail-closed).
+
+## Operational notes
+
+- **Back up the KEK first** (`static` especially) — see the footgun box above.
+- The DB backup CronJob and your object store are unaffected: encrypted columns
+  are ciphertext in the dump, which is the point.
+- **Disabling** stops new encryption immediately; existing ciphertext stays
+  readable as long as the provider + key remain configured (a decrypt-everything
+  migration to fully revert lands with the Phase-2 breadth work).
+- Rotation (re-wrap DEKs under a new KEK; roll the DEK) and a resumable
+  encrypt-existing-data pass are Phase-2 follow-ups.
+
+## See also
+
+- [Cloud Credentials](cloud-credentials.md) — the at-rest encryption baseline this sits on top of.
+- [Security Hardening](security-hardening.md) — the broader posture.
+- [Supply-chain verification](supply-chain-verification.md) — signed releases + verified dependencies.

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,6 +109,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Drift Detection](drift-detection.md) | Scheduled plan-only runs to detect infrastructure drift |
 | [Drift Ignore Rules](drift-ignore-rules.md) | Per-workspace allowlist that suppresses known-noisy attributes from the drift signal (e.g. provider-rotated certs, externally co-managed replicas) |
 | [Supply-chain Verification](supply-chain-verification.md) | How cached binaries/providers and runner executables are verified against publisher signatures (pinned keys, `verify` knobs, air-gap) |
+| [Encryption at Rest](encryption-at-rest.md) | Optional, off-by-default app-layer (BYOK) envelope encryption of DB secrets — for no-/niche-CSP / bare-metal / air-gapped deployments; belt-and-braces if your CSP already encrypts at rest. Providers: static / Vault Transit / AWS KMS |
 | [Run Triggers](run-triggers.md) | Cross-workspace dependency chains |
 | [Terragrunt](terragrunt.md) | CLI-driven and agent-mode Terragrunt support, the agent-mode `terragrunt_enabled` flag, and current limitations |
 | [Remote State](remote-state.md) | Cross-workspace `terraform_remote_state` composition with producer-controlled allowlist |

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -338,6 +338,19 @@ data:
       retention_keep: {{ (.Values.backup.retention).keep | default 0 }}
       retention_days: {{ (.Values.backup.retention).days | default 0 }}
     {{- end }}
+    {{- if .Values.api.config.encryption }}
+    # App-layer encryption at rest (#553) — non-secret config only; the static
+    # master key + Vault token arrive via secretKeyRef env, never here.
+    encryption:
+      enabled: {{ .Values.api.config.encryption.enabled | default false }}
+      provider: {{ .Values.api.config.encryption.provider | default "static" | quote }}
+      vault_address: {{ .Values.api.config.encryption.vault_address | default "" | quote }}
+      vault_mount: {{ .Values.api.config.encryption.vault_mount | default "transit" | quote }}
+      vault_key_name: {{ .Values.api.config.encryption.vault_key_name | default "terrapod" | quote }}
+      vault_namespace: {{ .Values.api.config.encryption.vault_namespace | default "" | quote }}
+      aws_kms_key_id: {{ .Values.api.config.encryption.aws_kms_key_id | default "" | quote }}
+      aws_kms_region: {{ .Values.api.config.encryption.aws_kms_region | default "" | quote }}
+    {{- end }}
     {{- if .Values.api.config.ai_summary }}
     ai_summary:
       enabled: {{ .Values.api.config.ai_summary.enabled | default false }}

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -78,6 +78,23 @@ spec:
                   name: {{ .Values.api.tokenSigningKey.existingSecret }}
                   key: {{ .Values.api.tokenSigningKey.existingSecretKey | default "token_signing_key" }}
             {{- end }}
+            {{- if (.Values.api.config.encryption).existingSecret }}
+            # App-layer encryption at rest (#553) — KEK secrets via secretKeyRef.
+            # optional:true so a single Secret can carry only the key the chosen
+            # provider needs (static → static_key, vault_transit → vault_token).
+            - name: TERRAPOD_ENCRYPTION__STATIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.config.encryption.existingSecret }}
+                  key: {{ .Values.api.config.encryption.staticKeyKey | default "static_key" }}
+                  optional: true
+            - name: TERRAPOD_ENCRYPTION__VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.config.encryption.existingSecret }}
+                  key: {{ .Values.api.config.encryption.vaultTokenKey | default "vault_token" }}
+                  optional: true
+            {{- end }}
             {{- $pgSecret := include "terrapod.postgresql.secretName" . }}
             {{- if $pgSecret }}
             - name: TERRAPOD_DATABASE_URL

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -917,6 +917,24 @@
           }
         },
 
+        "encryption": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "provider": { "type": "string", "enum": ["static", "vault_transit", "awskms"] },
+            "vault_address": { "type": "string" },
+            "vault_mount": { "type": "string" },
+            "vault_key_name": { "type": "string" },
+            "vault_namespace": { "type": "string" },
+            "aws_kms_key_id": { "type": "string" },
+            "aws_kms_region": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "staticKeyKey": { "type": "string" },
+            "vaultTokenKey": { "type": "string" }
+          }
+        },
+
         "metrics": {
           "type": "object",
           "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -569,6 +569,36 @@ api:
           grafana_dashboard: "1"
         annotations: {}
 
+    # Optional application-layer encryption at rest (#553). OFF by default.
+    #
+    # WHEN TO USE: for deployments WITHOUT a usable CSP at-rest encryption switch
+    # — bare-metal, on-prem, niche cloud, or air-gapped — where this is your path
+    # to encryption at rest. If your CSP already encrypts at rest (RDS/S3/Azure/
+    # GCS), prefer that; this is then belt-and-braces, not a requirement.
+    #
+    # Phase 1 encrypts DB-stored secrets (starting with the CA private key).
+    # KEK durability is the backend's job — and for `static` it is YOURS: losing
+    # the master key makes encrypted data unrecoverable. See
+    # docs/encryption-at-rest.md before enabling.
+    encryption:
+      enabled: false
+      # static (operator-held key, works anywhere) | vault_transit (CSP-agnostic,
+      # on-prem/air-gapped) | awskms (cloud belt-and-braces)
+      provider: static
+      # Vault Transit (provider: vault_transit)
+      vault_address: ""
+      vault_mount: transit
+      vault_key_name: terrapod
+      vault_namespace: ""
+      # AWS KMS (provider: awskms)
+      aws_kms_key_id: ""
+      aws_kms_region: ""
+      # Secret holding the static master key and/or Vault token, injected via
+      # secretKeyRef (NEVER a ConfigMap). Required for static + vault_transit.
+      existingSecret: ""
+      staticKeyKey: static_key
+      vaultTokenKey: vault_token
+
     # Artifact Retention — periodic cleanup of old artifacts from object storage.
     # When enabled, a background task runs at the configured interval and removes
     # artifacts that exceed their retention thresholds.  Cache entries (provider

--- a/llms.txt
+++ b/llms.txt
@@ -80,6 +80,7 @@ How each capability is turned on. **Platform-level** features are Helm values un
 | Shipped Grafana dashboard | `api.config.metrics.grafanaDashboards.enabled` (sidecar auto-import; off by default) | [monitoring.md](docs/monitoring.md#grafana-dashboards) |
 | Shipped Prometheus alert rules | `api.config.metrics.prometheusRule.enabled` (off by default; each alert links a runbook) | [monitoring.md](docs/monitoring.md#alerting-shipped-prometheusrule) |
 | Logical DB backup CronJob | `backup.enabled` (off by default; `pg_dump` → object store, retention) | [disaster-recovery.md](docs/disaster-recovery.md#shipped-backup-automation-the-baseline-floor) |
+| App-layer encryption at rest (BYOK) | `api.config.encryption.enabled` (off by default; provider `static`\|`vault_transit`\|`awskms`; for no-/niche-CSP / bare-metal / air-gapped — belt-and-braces if your CSP already encrypts at rest) | [encryption-at-rest.md](docs/encryption-at-rest.md) |
 | Restore-verification DR drill | `backup.restoreVerify.enabled` (off by default; restores into a throwaway Postgres + asserts invariants) | [disaster-recovery.md](docs/disaster-recovery.md#restore-verification-drill-dr-drill) |
 | SSO (OIDC/SAML) | `api.config.auth.sso.*` + client secrets via K8s Secret `secretKeyRef` | [authentication.md](docs/authentication.md) |
 | VCS integration | Admin creates a VCS connection, then sets the workspace's `vcs_*` fields | [vcs-integration.md](docs/vcs-integration.md) |

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -45,6 +45,21 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await init_storage()
     logger.info("Storage initialized")
 
+    # Initialize app-layer encryption at rest (#553) BEFORE the CA — the CA
+    # private key column is EncryptedText, so the service must be ready first.
+    # Fail CLOSED when encryption is enabled (a wrong/missing key must crash);
+    # tolerate errors only when disabled (e.g. table missing pre-migration).
+    from terrapod.config import settings as _settings
+    from terrapod.crypto.service import init_encryption
+
+    try:
+        async with get_db_session() as db:
+            await init_encryption(db)
+    except Exception as e:
+        if _settings.encryption.enabled:
+            raise
+        logger.warning("Encryption init skipped (disabled; migration may be pending)", error=str(e))
+
     # Initialize Certificate Authority
     from terrapod.auth.ca import init_ca
 

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -1019,6 +1019,43 @@ class MetricsConfig(BaseModel):
     )
 
 
+class EncryptionConfig(BaseModel):
+    """Optional application-layer encryption at rest (#553).
+
+    OFF by default. For deployments WITHOUT a CSP at-rest encryption switch
+    (bare-metal / on-prem / niche cloud / air-gapped) this is the path to
+    encryption at rest; if your CSP already encrypts at rest (RDS/S3/Azure/GCS),
+    prefer that and treat this as belt-and-braces. Envelope encryption with a
+    pluggable KEK provider — see docs/encryption-at-rest.md.
+
+    Secrets (the static master key, the Vault token) are NOT here — they come
+    from env (`TERRAPOD_ENCRYPTION__STATIC_KEY` / `__VAULT_TOKEN`) via a K8s
+    Secret, never a ConfigMap.
+    """
+
+    enabled: bool = Field(default=False, description="Enable app-layer encryption at rest")
+    provider: str = Field(
+        default="static",
+        description="KEK provider: static | vault_transit | awskms",
+    )
+    # Vault Transit (CSP-agnostic; on-prem / air-gapped)
+    vault_address: str = Field(default="", description="Vault address, e.g. https://vault:8200")
+    vault_mount: str = Field(default="transit", description="Vault transit mount path")
+    vault_key_name: str = Field(default="terrapod", description="Vault transit key name")
+    vault_namespace: str = Field(default="", description="Vault namespace (Enterprise; optional)")
+    # AWS KMS (cloud belt-and-braces)
+    aws_kms_key_id: str = Field(default="", description="AWS KMS key ARN or id")
+    aws_kms_region: str = Field(default="", description="AWS region for KMS (optional)")
+
+    @field_validator("provider")
+    @classmethod
+    def _valid_provider(cls, v: str) -> str:
+        allowed = {"static", "vault_transit", "awskms"}
+        if v not in allowed:
+            raise ValueError(f"encryption.provider must be one of {sorted(allowed)}")
+        return v
+
+
 class BackupConfig(BaseModel):
     """Logical PostgreSQL backup settings (consumed by terrapod.cli.backup).
 
@@ -1515,6 +1552,9 @@ class Settings(BaseSettings):
 
     # Logical PostgreSQL backup (terrapod.cli.backup; CronJob off by default)
     backup: BackupConfig = Field(default_factory=BackupConfig)
+
+    # Optional app-layer encryption at rest (#553; off by default)
+    encryption: EncryptionConfig = Field(default_factory=EncryptionConfig)
 
     # Runner artifact upload limits (API-side enforcement)
     runner_artifacts: RunnerArtifactsConfig = Field(default_factory=RunnerArtifactsConfig)

--- a/services/terrapod/crypto/__init__.py
+++ b/services/terrapod/crypto/__init__.py
@@ -1,0 +1,7 @@
+"""Optional application-layer encryption at rest (envelope encryption).
+
+OFF by default. See ``service.py`` for the encryption service singleton and
+``providers.py`` for the pluggable KEK (key-encryption-key) backends. The data
+path is local AES-256-GCM with a cached DEK; only KEK wrap/unwrap touches the
+network (at startup and rotation). See docs/encryption-at-rest.md.
+"""

--- a/services/terrapod/crypto/envelope.py
+++ b/services/terrapod/crypto/envelope.py
@@ -1,0 +1,79 @@
+"""Envelope format + the local AES-256-GCM data path.
+
+A stored ciphertext is a self-describing, URL-safe string:
+
+    tpenc:1:<dek_version>:<nonce_b64>:<ciphertext_b64>
+
+- ``tpenc`` marks an application-encrypted value (anything without this prefix is
+  treated as legacy plaintext and returned as-is on read — so enabling/disabling
+  is a well-defined migration, not a hard cutover).
+- ``1`` is the envelope format version.
+- ``dek_version`` selects which data-encryption key (DEK) decrypts it — so DEK
+  rotation and mixed-state during a migration are well-defined.
+
+The DEK never appears in the envelope; it is held wrapped by the KEK provider and
+cached (unwrapped) in memory after a one-time startup unwrap. These functions are
+pure, synchronous, and operate on small secrets — safe on the async hot path
+(no network, no large buffers).
+"""
+
+import base64
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+MARKER = "tpenc"
+FORMAT_VERSION = "1"
+_NONCE_LEN = 12  # AES-GCM standard nonce length
+DEK_LEN = 32  # AES-256
+
+
+def _b64e(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64d(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def is_encrypted(value: str) -> bool:
+    """True if ``value`` is an application-encrypted envelope (vs legacy plaintext)."""
+    return value.startswith(MARKER + ":")
+
+
+def encrypt(plaintext: str, dek: bytes, dek_version: int, *, nonce: bytes | None = None) -> str:
+    """Encrypt ``plaintext`` with ``dek`` (AES-256-GCM) into an envelope string."""
+    if len(dek) != DEK_LEN:
+        raise ValueError(f"DEK must be {DEK_LEN} bytes, got {len(dek)}")
+    import os
+
+    n = nonce if nonce is not None else os.urandom(_NONCE_LEN)
+    ct = AESGCM(dek).encrypt(n, plaintext.encode("utf-8"), None)
+    return f"{MARKER}:{FORMAT_VERSION}:{dek_version}:{_b64e(n)}:{_b64e(ct)}"
+
+
+def parse_version(envelope: str) -> int:
+    """Return the DEK version an envelope was encrypted under."""
+    parts = envelope.split(":", 4)
+    if len(parts) != 5 or parts[0] != MARKER:
+        raise ValueError("not a tpenc envelope")
+    return int(parts[2])
+
+
+def decrypt(envelope: str, dek: bytes) -> str:
+    """Decrypt a ``tpenc`` envelope with the matching ``dek``."""
+    parts = envelope.split(":", 4)
+    if len(parts) != 5 or parts[0] != MARKER:
+        raise ValueError("not a tpenc envelope")
+    _, fmt, _ver, nonce_b64, ct_b64 = parts
+    if fmt != FORMAT_VERSION:
+        raise ValueError(f"unsupported envelope format version {fmt!r}")
+    pt = AESGCM(dek).decrypt(_b64d(nonce_b64), _b64d(ct_b64), None)
+    return pt.decode("utf-8")
+
+
+def new_dek() -> bytes:
+    """Generate a fresh 32-byte data-encryption key."""
+    import os
+
+    return os.urandom(DEK_LEN)

--- a/services/terrapod/crypto/providers.py
+++ b/services/terrapod/crypto/providers.py
@@ -1,0 +1,176 @@
+"""Pluggable KEK (key-encryption-key) providers — wrap/unwrap DEKs.
+
+The KEK never appears on the data path: a provider only wraps (encrypts) and
+unwraps (decrypts) the small data-encryption keys, at startup and on rotation.
+Each provider returns its wrapped DEK as an opaque ``str`` (stored in
+``crypto_keys.wrapped_dek``) and accepts that same string back to unwrap.
+
+Backends (chosen for the no-/niche-CSP case first — see docs):
+  - ``static``        operator-held master key (works ANYWHERE: bare-metal,
+                      on-prem, air-gapped). The operator owns key durability.
+  - ``vault_transit`` HashiCorp Vault Transit — CSP-agnostic encrypt/decrypt-as-
+                      a-service; the key never leaves Vault. The on-prem / niche-
+                      cloud / air-gapped KMS.
+  - ``awskms``        AWS KMS — for deployments already on AWS (belt-and-braces
+                      on top of native at-rest encryption).
+
+Wrap/unwrap is async (network for vault/kms); ``static`` is local but async for a
+uniform interface. None of this is on the per-row hot path.
+"""
+
+import base64
+import hashlib
+import os
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+from terrapod.config import settings
+from terrapod.crypto.envelope import _b64d, _b64e
+from terrapod.http_retry import arequest_with_retry
+from terrapod.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_NONCE_LEN = 12
+
+
+@runtime_checkable
+class KEKProvider(Protocol):
+    """Wrap/unwrap a DEK. ``id`` identifies the backend for diagnostics."""
+
+    id: str
+
+    async def wrap(self, dek: bytes) -> str: ...
+
+    async def unwrap(self, wrapped: str) -> bytes: ...
+
+
+class StaticKEKProvider:
+    """Local AES-256-GCM wrap with an operator-supplied master key.
+
+    Key durability is the OPERATOR's responsibility — losing the master key makes
+    all encrypted data unrecoverable. The master secret is read from the
+    ``TERRAPOD_ENCRYPTION__STATIC_KEY`` env (injected from a K8s Secret), and the
+    32-byte KEK is ``sha256(master_secret)`` so any sufficiently-strong passphrase
+    or base64 key works.
+    """
+
+    id = "static"
+
+    def __init__(self, master_secret: str) -> None:
+        if not master_secret:
+            raise ValueError("static encryption provider requires a master key")
+        self._kek = hashlib.sha256(master_secret.encode("utf-8")).digest()
+
+    async def wrap(self, dek: bytes) -> str:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+        nonce = os.urandom(_NONCE_LEN)
+        ct = AESGCM(self._kek).encrypt(nonce, dek, None)
+        return f"{_b64e(nonce)}.{_b64e(ct)}"
+
+    async def unwrap(self, wrapped: str) -> bytes:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+        nonce_b64, ct_b64 = wrapped.split(".", 1)
+        return AESGCM(self._kek).decrypt(_b64d(nonce_b64), _b64d(ct_b64), None)
+
+
+class VaultTransitKEKProvider:
+    """HashiCorp Vault Transit — encrypt/decrypt-as-a-service; key stays in Vault.
+
+    The CSP-agnostic KMS: works on-prem, multi-cloud, and air-gapped. Auth via a
+    Vault token from ``TERRAPOD_ENCRYPTION__VAULT_TOKEN`` (injected from a Secret).
+    """
+
+    id = "vault_transit"
+
+    def __init__(
+        self, address: str, mount: str, key_name: str, token: str, namespace: str = ""
+    ) -> None:
+        if not (address and key_name and token):
+            raise ValueError("vault_transit requires address, key_name, and a token")
+        self._base = address.rstrip("/")
+        self._mount = mount.strip("/") or "transit"
+        self._key = key_name
+        self._headers = {"X-Vault-Token": token}
+        if namespace:
+            self._headers["X-Vault-Namespace"] = namespace
+
+    async def wrap(self, dek: bytes) -> str:
+        async with httpx.AsyncClient(timeout=15.0) as c:
+            resp = await arequest_with_retry(
+                c,
+                "POST",
+                f"{self._base}/v1/{self._mount}/encrypt/{self._key}",
+                headers=self._headers,
+                json={"plaintext": base64.b64encode(dek).decode("ascii")},
+            )
+            if resp.status_code != 200:
+                raise RuntimeError(
+                    f"Vault transit encrypt failed: HTTP {resp.status_code} {resp.text[:200]}"
+                )
+            return resp.json()["data"]["ciphertext"]
+
+    async def unwrap(self, wrapped: str) -> bytes:
+        async with httpx.AsyncClient(timeout=15.0) as c:
+            resp = await arequest_with_retry(
+                c,
+                "POST",
+                f"{self._base}/v1/{self._mount}/decrypt/{self._key}",
+                headers=self._headers,
+                json={"ciphertext": wrapped},
+            )
+            if resp.status_code != 200:
+                raise RuntimeError(
+                    f"Vault transit decrypt failed: HTTP {resp.status_code} {resp.text[:200]}"
+                )
+            return base64.b64decode(resp.json()["data"]["plaintext"])
+
+
+class AwsKmsKEKProvider:
+    """AWS KMS wrap/unwrap. Auth via the API pod's workload identity (IRSA)."""
+
+    id = "awskms"
+
+    def __init__(self, key_id: str, region: str = "") -> None:
+        if not key_id:
+            raise ValueError("awskms requires a key_id (key ARN or id)")
+        self._key_id = key_id
+        self._region = region or None
+
+    async def wrap(self, dek: bytes) -> str:
+        import aioboto3
+
+        session = aioboto3.Session()
+        async with session.client("kms", region_name=self._region) as kms:
+            resp = await kms.encrypt(KeyId=self._key_id, Plaintext=dek)
+            return base64.b64encode(resp["CiphertextBlob"]).decode("ascii")
+
+    async def unwrap(self, wrapped: str) -> bytes:
+        import aioboto3
+
+        session = aioboto3.Session()
+        async with session.client("kms", region_name=self._region) as kms:
+            resp = await kms.decrypt(KeyId=self._key_id, CiphertextBlob=base64.b64decode(wrapped))
+            return resp["Plaintext"]
+
+
+def build_provider() -> KEKProvider:
+    """Construct the configured KEK provider from settings + secret env vars."""
+    cfg = settings.encryption
+    backend = cfg.provider
+    if backend == "static":
+        return StaticKEKProvider(os.environ.get("TERRAPOD_ENCRYPTION__STATIC_KEY", ""))
+    if backend == "vault_transit":
+        return VaultTransitKEKProvider(
+            address=cfg.vault_address,
+            mount=cfg.vault_mount,
+            key_name=cfg.vault_key_name,
+            token=os.environ.get("TERRAPOD_ENCRYPTION__VAULT_TOKEN", ""),
+            namespace=cfg.vault_namespace,
+        )
+    if backend == "awskms":
+        return AwsKmsKEKProvider(key_id=cfg.aws_kms_key_id, region=cfg.aws_kms_region)
+    raise ValueError(f"unsupported encryption provider: {backend!r}")

--- a/services/terrapod/crypto/service.py
+++ b/services/terrapod/crypto/service.py
@@ -1,0 +1,128 @@
+"""Encryption service singleton: DEK cache, canary, encrypt/decrypt.
+
+Lifecycle (in app lifespan, before init_ca which reads an encrypted column):
+  init_encryption(db) → if encryption is enabled (or any DEK rows already exist),
+  build the KEK provider, unwrap every DEK into an in-memory cache, and verify the
+  decryptability **canary**. A wrong/missing key fails loud here — we never serve
+  or write data we cannot read back.
+
+encrypt()/decrypt() are synchronous and local (AES-GCM on small secrets, with the
+cached DEK) — safe on the async hot path; only init/rotation touch the KEK.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.config import settings
+from terrapod.crypto import envelope
+from terrapod.crypto.providers import build_provider
+from terrapod.db.models import CryptoKey
+from terrapod.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Known plaintext encrypted at key-creation; decrypted + compared on every boot.
+_CANARY = "terrapod-encryption-canary-v1"
+
+
+class EncryptionService:
+    """Holds the unwrapped DEK cache and performs the local crypto."""
+
+    def __init__(self) -> None:
+        self.enabled: bool = False
+        self._deks: dict[int, bytes] = {}
+        self._active_version: int | None = None
+
+    def encrypt(self, plaintext: str) -> str:
+        """Encrypt when enabled; otherwise return plaintext unchanged."""
+        if not self.enabled or self._active_version is None:
+            return plaintext
+        return envelope.encrypt(plaintext, self._deks[self._active_version], self._active_version)
+
+    def decrypt(self, stored: str) -> str:
+        """Decrypt a tpenc envelope; pass legacy plaintext through unchanged."""
+        if not envelope.is_encrypted(stored):
+            return stored
+        version = envelope.parse_version(stored)
+        dek = self._deks.get(version)
+        if dek is None:
+            # Fail loud — never hand a caller ciphertext as if it were plaintext.
+            raise RuntimeError(
+                f"cannot decrypt: no DEK for version {version} "
+                "(wrong/rotated-away key, or encryption disabled before a decrypt pass)"
+            )
+        return envelope.decrypt(stored, dek)
+
+
+_service: EncryptionService | None = None
+
+
+def get_encryption() -> EncryptionService:
+    """Return the service, defaulting to a disabled passthrough if uninitialised.
+
+    Uninitialised happens in the migrations Job and in unit tests that never run
+    the app lifespan — there, encryption is simply off (passthrough).
+    """
+    global _service  # noqa: PLW0603
+    if _service is None:
+        _service = EncryptionService()
+    return _service
+
+
+async def init_encryption(db: AsyncSession) -> None:
+    """Build the provider, unwrap DEKs, run the canary. Fail closed on error."""
+    global _service  # noqa: PLW0603
+    svc = EncryptionService()
+
+    rows = (await db.execute(select(CryptoKey))).scalars().all()
+    if not settings.encryption.enabled and not rows:
+        # Off and never enabled — pure passthrough, no provider needed.
+        _service = svc
+        logger.info("Encryption at rest disabled")
+        return
+
+    provider = build_provider()
+
+    if not rows and settings.encryption.enabled:
+        # First enable: mint a DEK, wrap it, stash the canary.
+        dek = envelope.new_dek()
+        wrapped = await provider.wrap(dek)
+        canary = envelope.encrypt(_CANARY, dek, 1)
+        row = CryptoKey(
+            version=1, wrapped_dek=wrapped, provider=provider.id, canary=canary, active=True
+        )
+        db.add(row)
+        await db.commit()
+        rows = [row]
+        logger.info("Encryption at rest enabled — minted DEK v1", provider=provider.id)
+
+    # Unwrap all DEK versions into the cache (older versions needed for reads).
+    for row in rows:
+        svc._deks[row.version] = await provider.unwrap(row.wrapped_dek)
+        if row.active:
+            svc._active_version = row.version
+    if svc._active_version is None and rows:
+        svc._active_version = max(r.version for r in rows)
+
+    svc.enabled = settings.encryption.enabled
+
+    # Decryptability canary on the active key — fail closed on mismatch.
+    active = next((r for r in rows if r.version == svc._active_version), None)
+    if active is not None and active.canary:
+        if svc.decrypt(active.canary) != _CANARY:
+            raise RuntimeError("encryption canary mismatch — refusing to start (wrong key?)")
+
+    _service = svc
+    logger.info(
+        "Encryption at rest initialised",
+        enabled=svc.enabled,
+        provider=provider.id,
+        dek_versions=sorted(svc._deks),
+        active_version=svc._active_version,
+    )
+
+
+def reset_encryption_for_tests() -> None:
+    """Test helper — drop the singleton so the next get_encryption() is fresh."""
+    global _service  # noqa: PLW0603
+    _service = None

--- a/services/terrapod/crypto/types.py
+++ b/services/terrapod/crypto/types.py
@@ -1,0 +1,33 @@
+"""SQLAlchemy column type that transparently encrypts at the DB boundary.
+
+A column declared ``EncryptedText`` is encrypted on write and decrypted on read
+via the process-wide encryption service. When encryption is disabled (the
+default) it is a pure passthrough — and on read it always passes through legacy
+plaintext (un-prefixed values) unchanged, so enabling/disabling is a migration,
+not a hard cutover. The DB column is still ``TEXT`` (no schema migration needed
+to adopt it on an existing column).
+"""
+
+from sqlalchemy import Text
+from sqlalchemy.types import TypeDecorator
+
+
+class EncryptedText(TypeDecorator):
+    """TEXT column encrypted at rest via the app-layer encryption service."""
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value: str | None, dialect) -> str | None:  # type: ignore[no-untyped-def]
+        if value is None:
+            return None
+        from terrapod.crypto.service import get_encryption
+
+        return get_encryption().encrypt(value)
+
+    def process_result_value(self, value: str | None, dialect) -> str | None:  # type: ignore[no-untyped-def]
+        if value is None:
+            return None
+        from terrapod.crypto.service import get_encryption
+
+        return get_encryption().decrypt(value)

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -27,6 +27,8 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
+from terrapod.crypto.types import EncryptedText
+
 
 def generate_uuid7() -> uuid.UUID:
     """Generate a UUIDv7 (time-sortable UUID)."""
@@ -938,11 +940,34 @@ class CertificateAuthorityModel(Base):
         UUID(as_uuid=True), primary_key=True, default=generate_uuid7
     )
     ca_cert: Mapped[str] = mapped_column(Text, nullable=False)
-    # The CA private key as a PKCS8 PEM. This is NOT application-encrypted
-    # (the old column name `ca_key_encrypted` was misleading) — at-rest
-    # protection comes from database encryption (RDS/Azure/GCS-managed),
-    # the same model used for sensitive variables and VCS tokens.
-    ca_key_pem: Mapped[str] = mapped_column(Text, nullable=False)
+    # The CA private key as a PKCS8 PEM. Stored via EncryptedText (#553): when
+    # app-layer encryption at rest is enabled it is envelope-encrypted, otherwise
+    # it is plaintext and at-rest protection comes from the database's own
+    # encryption (RDS/Azure/GCS-managed). The DB column is still TEXT either way.
+    ca_key_pem: Mapped[str] = mapped_column(EncryptedText, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=now_utc, nullable=False
+    )
+
+
+class CryptoKey(Base):
+    """Wrapped data-encryption keys for app-layer encryption at rest (#553).
+
+    Each row is a DEK version, KEK-wrapped by the configured provider. The raw
+    DEK is never stored — it is unwrapped into memory at startup. ``canary`` is a
+    known plaintext encrypted under the DEK, verified on every boot.
+    """
+
+    __tablename__ = "crypto_keys"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=generate_uuid7
+    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False, unique=True)
+    wrapped_dek: Mapped[str] = mapped_column(Text, nullable=False)
+    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    canary: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False
     )

--- a/services/tests/crypto/test_crypto.py
+++ b/services/tests/crypto/test_crypto.py
@@ -1,0 +1,118 @@
+"""Unit tests for app-layer encryption at rest (#553): envelope + static KEK + service."""
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from terrapod.crypto import envelope
+from terrapod.crypto.providers import StaticKEKProvider
+from terrapod.crypto.service import EncryptionService
+
+# ── Envelope (local AES-GCM data path) ────────────────────────────────────────
+
+
+def test_envelope_round_trip():
+    dek = envelope.new_dek()
+    env = envelope.encrypt("s3cr3t-value", dek, 1)
+    assert envelope.is_encrypted(env)
+    assert env.startswith("tpenc:1:1:")
+    assert envelope.parse_version(env) == 1
+    assert envelope.decrypt(env, dek) == "s3cr3t-value"
+
+
+def test_is_encrypted_rejects_plaintext():
+    assert not envelope.is_encrypted("just-a-plain-token")
+    assert not envelope.is_encrypted("")
+
+
+def test_decrypt_wrong_key_fails():
+    dek = envelope.new_dek()
+    env = envelope.encrypt("x", dek, 1)
+    with pytest.raises(InvalidTag):
+        envelope.decrypt(env, envelope.new_dek())  # different DEK → GCM tag fail
+
+
+def test_decrypt_tampered_ciphertext_fails():
+    dek = envelope.new_dek()
+    env = envelope.encrypt("x", dek, 1)
+    tampered = env[:-2] + ("AA" if not env.endswith("AA") else "BB")
+    with pytest.raises(InvalidTag):
+        envelope.decrypt(tampered, dek)
+
+
+def test_new_dek_is_32_bytes():
+    assert len(envelope.new_dek()) == envelope.DEK_LEN == 32
+
+
+# ── Static KEK provider ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_static_provider_wrap_unwrap():
+    p = StaticKEKProvider("a-strong-master-passphrase")
+    dek = envelope.new_dek()
+    wrapped = await p.wrap(dek)
+    assert wrapped != dek.hex()  # opaque, not the raw key
+    assert await p.unwrap(wrapped) == dek
+
+
+@pytest.mark.asyncio
+async def test_static_provider_wrong_master_cannot_unwrap():
+    dek = envelope.new_dek()
+    wrapped = await StaticKEKProvider("master-A").wrap(dek)
+    with pytest.raises(InvalidTag):
+        await StaticKEKProvider("master-B").unwrap(wrapped)
+
+
+def test_static_provider_requires_key():
+    with pytest.raises(ValueError):
+        StaticKEKProvider("")
+
+
+# ── EncryptionService (encrypt/decrypt + passthrough + canary semantics) ──────
+
+
+def _enabled_service() -> EncryptionService:
+    svc = EncryptionService()
+    svc.enabled = True
+    dek = envelope.new_dek()
+    svc._deks = {1: dek}
+    svc._active_version = 1
+    return svc
+
+
+def test_service_disabled_is_passthrough():
+    svc = EncryptionService()  # disabled by default
+    assert svc.encrypt("plain") == "plain"
+    assert svc.decrypt("plain") == "plain"
+
+
+def test_service_enabled_round_trip():
+    svc = _enabled_service()
+    enc = svc.encrypt("token-123")
+    assert envelope.is_encrypted(enc)
+    assert svc.decrypt(enc) == "token-123"
+
+
+def test_service_decrypts_legacy_plaintext_passthrough():
+    # An enabled service must still read un-prefixed legacy rows unchanged.
+    svc = _enabled_service()
+    assert svc.decrypt("legacy-plaintext") == "legacy-plaintext"
+
+
+def test_service_decrypt_unknown_version_fails_loud():
+    svc = _enabled_service()
+    # Envelope says version 9, which isn't in the cache → must raise, never
+    # return ciphertext as if it were plaintext.
+    foreign = envelope.encrypt("x", envelope.new_dek(), 9)
+    with pytest.raises(RuntimeError):
+        svc.decrypt(foreign)
+
+
+def test_service_disabled_can_still_decrypt_loaded_versions():
+    # Disabled-but-keys-loaded (mid disable migration): encrypt passthrough,
+    # but marked values still decrypt.
+    svc = _enabled_service()
+    enc = svc.encrypt("v")
+    svc.enabled = False
+    assert svc.encrypt("new") == "new"  # no longer encrypts
+    assert svc.decrypt(enc) == "v"  # still reads old ciphertext


### PR DESCRIPTION
Part of #553 — **Phase 1, PR 1 of 2.** (Not `Closes` — PR 2 follows.)

## Framing (offer, don't encourage)

Most deployments do **not** need this: if your platform encrypts at rest natively (RDS/Cloud SQL/Azure DB for Postgres; S3 SSE/Azure/GCS for the object store), that's the recommended baseline and this is belt-and-braces. **Where it earns its keep:** deployments *without* a usable CSP at-rest switch — bare-metal, on-prem, a niche cloud that doesn't offer it, or air-gapped — where you can't just tick a box. There this is the path to encryption at rest at all. **Off by default**, and the docs say all of this plainly.

## What's in this PR

Optional application-layer **envelope encryption** of DB-stored secrets, plus a real end-to-end slice (the **CA private key**).

- **`crypto/envelope.py`** — local AES-256-GCM + self-describing `tpenc:<fmt>:<dek_version>:…` envelope. Legacy un-prefixed values pass through on read, so enable/disable is a migration, not a hard cutover.
- **`crypto/providers.py`** — pluggable KEK: **`static`** (operator-held, works anywhere), **`vault_transit`** (CSP-agnostic / air-gapped — via `httpx`, no new dep), **`awskms`** (`aioboto3`). Wrap/unwrap is async and runs only at startup/rotation.
- **`crypto/service.py`** — DEK unwrapped once at boot and cached, so per-row crypto is local/sync (respects the no-sync-work-in-async rule — small secrets, no network). **Decryptability canary** checked on every boot → **fail closed** (the API refuses to start on a wrong/missing key; never stores data it can't read back).
- **`crypto/types.py`** — `EncryptedText` SQLAlchemy column (lazy service import → no import cycle).
- **`CryptoKey`** model + Alembic migration; `certificate_authority.ca_key_pem` flipped to `EncryptedText` (the slice). DB columns stay `TEXT`.
- `EncryptionConfig` on `Settings`; lifespan init **before** `init_ca`.

## Contracts

- **Config-channel**: `api.config.encryption.*` (off by default) ↔ `values.schema.json` ↔ `configmap-api` render ↔ helm-smoke. The static key + Vault token are **secretKeyRef-only**, never a ConfigMap (smoke asserts no secret leaks into the ConfigMap). Renders on all three profiles; config-contract green ×3.
- **Migrations image** gets the `crypto/` package (models imports `EncryptedText`); its deps are import-lazy so no new runtime deps there. **No new dependencies** anywhere (cryptography/aioboto3/httpx already present).
- **Code↔Tests**: unit tests for envelope round-trip/tamper, static wrap/unwrap (+ wrong-master), and service passthrough/canary/version semantics.

## Verification

- `make test` green (2592 passed); ruff clean; import-graph smoke (no cycle, `EncryptedText` applied, disabled passthrough).
- `helm lint` + `helm template` ×3 profiles; config-channel contract ×3; encryption helm-smoke.

## Deferred to PR 2/2 (and out of scope)

- **PR 2**: extend the encrypt boundary to variables / variable-set values / catalog inputs / VCS token+PEM+webhook secret; KEK/DEK **rotation**; a **resumable** encrypt-existing / decrypt-on-disable migration; key-provider **status surface + UI** indicator.
- **Out of scope** (issue): **state-file** encryption (needs a decrypting download proxy + chunked streaming).

> Live note: the `static`/`vault_transit`/`awskms` wrap/unwrap paths are unit-tested with the local `static` backend exercised end-to-end; the Vault/KMS network calls are structurally covered but not live-exercised against a real Vault/KMS in CI — worth a live smoke before a release that turns this on.
