### PR TITLE
feat(crypto): encrypt remaining Phase-1 DB secret columns (#553 Phase 3 — breadth)

### DIFF
--- a/alembic/versions/2b369cd58093_widen_webhook_secret_for_encryption.py
+++ b/alembic/versions/2b369cd58093_widen_webhook_secret_for_encryption.py
@@ -1,0 +1,44 @@
+"""widen vcs_connections.webhook_secret VARCHAR(255)->TEXT for encryption (#553)
+
+Revision ID: 2b369cd58093
+Revises: 4ad6441e82b3
+Create Date: 2026-06-30
+
+Phase-1 breadth flips several secret columns to EncryptedText. The only one that
+was length-bounded is ``vcs_connections.webhook_secret`` (VARCHAR(255)) — an
+encryption envelope is longer than the plaintext, so a near-limit secret would
+**overflow and corrupt** the value. Widen it to TEXT (a no-rewrite, instant
+change on Postgres) before any value can be encrypted. The other newly-encrypted
+columns (variables.value, variable_set_variables.value, vcs_connections.token,
+notification_configurations.token) are already TEXT and need no change.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "2b369cd58093"
+down_revision = "4ad6441e82b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "vcs_connections",
+        "webhook_secret",
+        existing_type=sa.String(length=255),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Reverse to VARCHAR(255). NOTE: only safe when encryption has been disabled
+    # and the column decrypted first — an encrypted envelope exceeds 255 chars.
+    op.alter_column(
+        "vcs_connections",
+        "webhook_secret",
+        existing_type=sa.Text(),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )

--- a/docs/encryption-at-rest.md
+++ b/docs/encryption-at-rest.md
@@ -19,17 +19,22 @@ just the platform."
 
 ## What's encrypted (Phase 1)
 
-Application-layer encryption currently covers **DB-stored secrets**, starting
-with the **CA private key** (the single most sensitive blob). The remaining
-Phase-1 columns — sensitive variables, variable-set values, catalog inputs, VCS
-tokens/keys, webhook secrets — land in a follow-up. **State files are out of
-scope for now** (they need a decrypting download proxy and chunked streaming;
-keep them protected by object-store at-rest encryption).
+Application-layer encryption covers **DB-stored secrets**:
 
-The DB columns stay `TEXT`; nothing is re-typed at the database level. Values
-written before you enable encryption stay readable (they're passed through
-untouched until a future migration re-encrypts them), so enabling/disabling is a
-migration, not a hard cutover.
+- the **CA private key** (`certificate_authority.ca_key_pem`) — the single most sensitive blob;
+- **workspace + variable-set variable values** (`variables.value`, `variable_set_variables.value`) — this also covers catalog inputs, which are stored as workspace variables;
+- **VCS connection credentials** (`vcs_connections.token` — GitHub App PEM / GitLab PAT) and the per-connection **webhook secret** (`vcs_connections.webhook_secret`);
+- **notification tokens** (`notification_configurations.token`).
+
+**State files are out of scope** (Phase 2): they need a decrypting download proxy
+and chunked streaming; keep them protected by object-store at-rest encryption.
+
+Encrypted columns are `TEXT` (the one length-bounded column, `webhook_secret`,
+was widened `VARCHAR(255)→TEXT` so an envelope can never overflow it). Values
+written **before** you enable encryption stay readable — they pass through
+untouched until re-written or migrated — so enabling/disabling is a migration,
+not a hard cutover. Encrypted columns are never indexed or unique-constrained
+(ciphertext is non-deterministic).
 
 ## How it works — envelope encryption
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -999,8 +999,8 @@ class VCSConnection(Base):
         String(500), nullable=False, default=""
     )  # e.g. https://gitlab.example.com, https://github.example.com
     token: Mapped[str | None] = mapped_column(
-        Text, nullable=True
-    )  # PAT (GitLab) or PEM private key (GitHub App)
+        EncryptedText, nullable=True
+    )  # PAT (GitLab) or PEM private key (GitHub App) — app-encrypted at rest (#553)
 
     # GitHub-specific
     github_app_id: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
@@ -1012,9 +1012,10 @@ class VCSConnection(Base):
 
     # Per-connection webhook HMAC secret (GitHub). Optional: when set it is
     # used to validate this connection's inbound webhooks, falling back to the
-    # global vcs.github.webhook_secret when null. Write-only via the API and
-    # protected at rest by database encryption (same as `token`).
-    webhook_secret: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # global vcs.github.webhook_secret when null. Write-only via the API.
+    # EncryptedText (#553): the DB column was widened VARCHAR(255)→TEXT so an
+    # encryption envelope never overflows it. App-encrypted at rest when enabled.
+    webhook_secret: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
 
     status: Mapped[str] = mapped_column(
         String(20), nullable=False, default="active"
@@ -1203,7 +1204,7 @@ class Variable(Base):
         nullable=False,
     )
     key: Mapped[str] = mapped_column(String(255), nullable=False)
-    value: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    value: Mapped[str] = mapped_column(EncryptedText, nullable=False, default="")
     description: Mapped[str] = mapped_column(Text, nullable=False, default="")
     category: Mapped[str] = mapped_column(
         String(20), nullable=False, default="terraform"
@@ -1271,7 +1272,7 @@ class VariableSetVariable(Base):
         nullable=False,
     )
     key: Mapped[str] = mapped_column(String(255), nullable=False)
-    value: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    value: Mapped[str] = mapped_column(EncryptedText, nullable=False, default="")
     description: Mapped[str] = mapped_column(Text, nullable=False, default="")
     category: Mapped[str] = mapped_column(String(20), nullable=False, default="terraform")
     hcl: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
@@ -1660,7 +1661,7 @@ class NotificationConfiguration(Base):
         String(20), nullable=False
     )  # generic, slack, email
     url: Mapped[str] = mapped_column(String(2000), nullable=False, default="")
-    token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)  # app-encrypted (#553)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     triggers: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=list)
     email_addresses: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=list)

--- a/services/tests/crypto/test_crypto.py
+++ b/services/tests/crypto/test_crypto.py
@@ -243,3 +243,32 @@ async def test_verify_live_ok_and_failure(monkeypatch):
     res2 = await svc_mod.verify_live(_FakeDB(rows=[row]))
     assert res2["ok"] is False
     assert res2["failures"]
+
+
+# ── Breadth: which columns are encrypted at rest (#553 Phase 3) ────────────────
+
+
+def test_phase1_secret_columns_use_encrypted_text():
+    """Hard invariant: the Phase-1 DB secret columns are EncryptedText, so they
+    are app-encrypted when encryption is enabled. Guards against a future change
+    silently dropping encryption from a secret column."""
+    from terrapod.crypto.types import EncryptedText
+    from terrapod.db.models import (
+        CertificateAuthorityModel,
+        NotificationConfiguration,
+        Variable,
+        VariableSetVariable,
+        VCSConnection,
+    )
+
+    encrypted = [
+        (CertificateAuthorityModel, "ca_key_pem"),
+        (Variable, "value"),
+        (VariableSetVariable, "value"),
+        (VCSConnection, "token"),
+        (VCSConnection, "webhook_secret"),
+        (NotificationConfiguration, "token"),
+    ]
+    for model, col in encrypted:
+        coltype = model.__table__.c[col].type
+        assert isinstance(coltype, EncryptedText), f"{model.__name__}.{col} must be EncryptedText"


### PR DESCRIPTION
Part of #553 — **Phase 3: breadth** (the remaining Phase-1 secret columns).

Extends app-layer encryption at rest beyond the CA private key (PR-1) to the rest of the Phase-1 DB secrets, all through the existing `EncryptedText` boundary — encrypt on write / decrypt on read, passthrough when disabled, legacy plaintext stays readable:

- `variables.value` + `variable_set_variables.value` (also covers **catalog inputs**, which are stored as workspace variables)
- `vcs_connections.token` (GitHub App PEM / GitLab PAT)
- `vcs_connections.webhook_secret`
- `notification_configurations.token`

## Death-by-encryption / corruption safety

- **`webhook_secret` was `VARCHAR(255)`** — an encryption envelope is longer than the plaintext and would **overflow and corrupt** the value. Widened to `TEXT` in a migration (no-rewrite, instant on Postgres) *before* anything can be encrypted. The other four columns are already `TEXT`.
- Only **read-by-id** secret columns are encrypted; **none are indexed or unique-constrained** (ciphertext is non-deterministic, so an index would be meaningless/broken).
- `GPGKey.private_key` is **intentionally not** encrypted (registry GPG keys are public-key material).
- A **source-introspection test** asserts these columns are `EncryptedText`, so a future refactor can't silently drop encryption from a secret column.

## Behavior

Off by default. With encryption enabled, new writes encrypt; rows written before enabling stay readable as plaintext until re-written (the resumable encrypt-existing migration is the next PR). Encrypted columns are still `TEXT` at the DB level.

## Verification

- `make test` green (2600 passed); single Alembic head; ruff clean.
- Docs: `encryption-at-rest.md` "What's encrypted" + `llms.txt`.

## Remaining to finish #553 Phase 1 (next PRs)

- **Rotation** (KEK re-wrap / DEK roll, verify-before-activate, never drop in-use versions).
- **Resumable** encrypt-existing / decrypt-on-disable migration (version-marker keyed, verify-readback).
- (Phase 2 — state-file encryption — remains out of scope.)
