### PR TITLE
fix(encryption): v0.50.0 pre-release audit fixes (multi-replica DEK + boot safety + docs)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2402,6 +2402,51 @@ DELETE /api/terrapod/v1/admin/binary-cache/{tool}/{version}
 
 ---
 
+## Encryption at Rest (Admin)
+
+Optional application-layer BYOK envelope encryption — off by default. See
+[Encryption at Rest](encryption-at-rest.md) for the full operator guide. Both
+endpoints require platform `admin`.
+
+### Status
+
+```
+GET /api/terrapod/v1/admin/encryption
+```
+
+Reports encryption-at-rest health. `decryptable` is the headline durability
+signal — `false` means the platform is running but cannot read its encrypted data
+back (page on it). Always returns 200 (even when encryption is disabled).
+
+**Response attributes** (`data.type` = `encryption-status`):
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `enabled` | bool | Whether new writes are encrypted |
+| `provider` | string | KEK provider in use (`static` / `vault_transit` / `awskms` / empty when off) |
+| `active_version` | int \| null | DEK version new writes use |
+| `dek_versions` | array<int> | All DEK versions loaded (older ones decrypt existing data) |
+| `canary_ok` | bool | The boot decryptability canary verified |
+| `decryptable` | bool | Can currently decrypt — the alarm signal |
+
+### Rotate DEK
+
+```
+POST /api/terrapod/v1/admin/encryption/rotate-dek
+```
+
+Mints a new active data-encryption key. Prior DEK versions are **retained** so
+existing ciphertext stays decryptable; run `encryption_migrate encrypt` afterwards
+to re-key old rows. The new key is wrapped **and** unwrapped (round-trip verified)
+before activation — a broken provider aborts with nothing changed. Returns the
+same status shape as above. **409** when encryption is disabled.
+
+> Rotation propagates to all API replicas within ~30s via the
+> `encryption_key_refresh` background task (no restart needed); see the
+> [rotation notes](encryption-at-rest.md#key-rotation).
+
+---
+
 ## Agent Pool Events (SSE)
 
 ```

--- a/docs/encryption-at-rest.md
+++ b/docs/encryption-at-rest.md
@@ -127,6 +127,11 @@ the DEK (canary fail-closed).
 - **Back up the KEK first** (`static` especially) — see the footgun box above.
 - The DB backup CronJob and your object store are unaffected: encrypted columns
   are ciphertext in the dump, which is the point.
+- **Break-glass DR** — when state encryption is on, the state objects in your
+  bucket (and the `state/index.yaml` break-glass index points at them) are
+  `TPENC1` ciphertext. Recovering state out-of-band therefore needs the KEK and
+  the envelope format, not just the bucket — factor the KEK into your DR runbook
+  exactly as you would the database.
 - **Disabling** stops new encryption immediately; existing ciphertext stays
   readable as long as the provider + key remain configured. To fully revert,
   run the decrypt migration **before** removing the key (see below).
@@ -160,6 +165,13 @@ the key is gone, encrypted rows can't be converted back.
   `encryption_migrate encrypt` afterwards. The new key is wrapped **and unwrapped
   (round-trip verified)** before it's activated — a broken provider aborts with
   nothing changed.
+  - **Multi-replica propagation** — the new DEK is minted on whichever replica
+    served the request; the others pick it up automatically within ~30s via the
+    `encryption_key_refresh` background task (no leader election, no restart). In
+    that short window a replica that hasn't refreshed yet may transiently fail to
+    read data just written under the new key. It's harmless (fail-loud, no data
+    loss) but if you want zero-window propagation, do a rolling restart after
+    rotating, or rotate during low traffic.
 - **KEK rotation** — for `awskms` / `vault_transit`, the provider manages its own
   key versions transparently; Terrapod's wrapped DEKs keep working across the
   CSP/Vault key rotation as long as the old version remains decryptable. For

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -286,6 +286,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             description="Clean up old artifacts from object storage",
         )
 
+    # Encryption DEK refresh — multi-replica DEK propagation (no leader election).
+    # Lets a DEK rotated on one replica become usable on all replicas without a
+    # restart. Cheap no-op when nothing changed. Only when encryption is enabled.
+    if settings.encryption.enabled:
+
+        async def _encryption_key_refresh() -> None:
+            from terrapod.crypto.service import refresh_keys
+
+            async with get_db_session() as db:
+                await refresh_keys(db)
+
+        register_periodic_task(
+            "encryption_key_refresh",
+            interval_seconds=30,
+            handler=_encryption_key_refresh,
+            description="Propagate rotated DEKs to all replicas (multi-replica safe)",
+        )
+
     await start_scheduler()
     logger.info("Distributed scheduler started")
 

--- a/services/terrapod/crypto/service.py
+++ b/services/terrapod/crypto/service.py
@@ -136,8 +136,47 @@ async def init_encryption(db: AsyncSession) -> None:
         logger.info("Encryption at rest disabled")
         return
 
-    provider = build_provider()
+    # If the provider can't be built/used but encryption is DISABLED while DEK
+    # rows still exist (e.g. an operator turned encryption off AND removed the
+    # KEK before running the `decrypt` migration), do NOT boot a clean passthrough
+    # that then 500s on every encrypted read with no signal. Surface a degraded
+    # service whose status() reports decryptable:false so monitoring/the doctor
+    # catch it. When encryption is ENABLED we still fail closed (re-raise) — a
+    # wrong/missing key must crash, never serve.
+    try:
+        provider = build_provider()
+        await _load_keys_into(svc, provider, db, rows)
+    except Exception:
+        if settings.encryption.enabled:
+            raise
+        if rows:
+            svc.enabled = False
+            svc._canary_ok = False  # can't prove decryptability → not decryptable
+            _service = svc
+            logger.error(
+                "Encryption is disabled but DEK rows exist and the KEK is unusable — "
+                "existing ciphertext is UNREADABLE. Restore the key, or run "
+                "`encryption_migrate decrypt` while the key is available, before removing it.",
+            )
+            return
+        raise
 
+    _service = svc
+    logger.info(
+        "Encryption at rest initialised",
+        enabled=svc.enabled,
+        provider=svc._provider_id,
+        dek_versions=sorted(svc._deks),
+        active_version=svc._active_version,
+    )
+
+
+async def _load_keys_into(svc: "EncryptionService", provider, db: AsyncSession, rows: list) -> None:  # type: ignore[no-untyped-def]
+    """Mint-on-first-enable, unwrap every DEK into ``svc``, verify the canary.
+
+    Shared by init_encryption and refresh_keys. Raises on any provider failure so
+    the caller decides fail-closed vs degrade.
+    """
     if not rows and settings.encryption.enabled:
         # First enable: mint a DEK and wrap it. DEATH-BY-ENCRYPTION GUARD — before
         # we persist the key or let a single byte of data get encrypted, PROVE the
@@ -174,21 +213,16 @@ async def init_encryption(db: AsyncSession) -> None:
 
     svc.enabled = settings.encryption.enabled
 
-    # Decryptability canary on the active key — fail closed on mismatch.
+    # Decryptability canary on the active key — fail closed on mismatch. An ACTIVE
+    # row with no canary cannot prove decryptability, so don't claim it (a normal
+    # mint/rotate always writes a canary, so this only guards hand-edited rows).
     active = next((r for r in rows if r.version == svc._active_version), None)
     if active is not None and active.canary:
         if svc.decrypt(active.canary) != _CANARY:
             raise RuntimeError("encryption canary mismatch — refusing to start (wrong key?)")
         svc._canary_ok = True
-
-    _service = svc
-    logger.info(
-        "Encryption at rest initialised",
-        enabled=svc.enabled,
-        provider=provider.id,
-        dek_versions=sorted(svc._deks),
-        active_version=svc._active_version,
-    )
+    elif rows:
+        svc._canary_ok = False
 
 
 async def rotate_dek(db: AsyncSession) -> int:
@@ -234,6 +268,53 @@ async def rotate_dek(db: AsyncSession) -> int:
     svc._active_version = new_version
     logger.info("Rotated DEK", new_version=new_version, retained=sorted(svc._deks))
     return new_version
+
+
+async def refresh_keys(db: AsyncSession) -> None:
+    """Periodic multi-replica DEK propagation (no leader election).
+
+    rotate_dek only updates the in-memory cache of the replica that served the
+    request; every OTHER replica would 500 when it reads data written under the
+    new DEK until it learned the new key. This task — run on every replica via the
+    distributed scheduler — re-reads ``crypto_keys`` and tops up the local cache so
+    a DEK minted anywhere becomes usable everywhere within the refresh interval,
+    with no restart. Prior versions are never dropped.
+
+    Best-effort and non-destructive: on a transient provider/DB error we keep the
+    existing working cache (never tear down a usable cache because a refresh
+    blipped). No-ops cheaply when there's nothing new (so steady state makes no KEK
+    calls).
+    """
+    global _service  # noqa: PLW0603
+    if not settings.encryption.enabled:
+        return
+    rows = (await db.execute(select(CryptoKey))).scalars().all()
+    if not rows:
+        return
+
+    current = get_encryption()
+    active_ver = next((r.version for r in rows if r.active), None)
+    have = set(current._deks)
+    # Fast path: every persisted version is cached and the active version matches.
+    if have.issuperset(r.version for r in rows) and (
+        active_ver is None or current._active_version == active_ver
+    ):
+        return
+
+    svc = EncryptionService()
+    try:
+        provider = build_provider()
+        await _load_keys_into(svc, provider, db, list(rows))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("encryption key refresh failed; keeping existing cache", error=str(exc))
+        return
+
+    _service = svc
+    logger.info(
+        "encryption keys refreshed (new DEK picked up)",
+        dek_versions=sorted(svc._deks),
+        active_version=svc._active_version,
+    )
 
 
 async def verify_live(db: AsyncSession) -> dict:

--- a/services/tests/crypto/test_crypto.py
+++ b/services/tests/crypto/test_crypto.py
@@ -308,6 +308,128 @@ async def test_rotate_dek_refused_when_disabled(monkeypatch):
         await svc_mod.rotate_dek(_FakeDB(rows=[]))
 
 
+# ── Multi-replica DEK propagation: refresh_keys (#553 audit) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_keys_picks_up_dek_rotated_on_another_replica(monkeypatch):
+    """A DEK minted by rotate_dek on replica A must become usable on replica B
+    after refresh_keys — without a restart. Otherwise B 500s on v2-written data."""
+    from terrapod.crypto import service as svc_mod
+    from terrapod.db.models import CryptoKey
+
+    monkeypatch.setattr(svc_mod.settings.encryption, "enabled", True)
+    # This replica only knows v1.
+    svc = _enabled_service()
+    dek = svc._deks[1]
+    svc_mod._service = svc
+
+    # Another replica rotated to v2 (active); the provider unwraps both to `dek`.
+    good = _GoodProvider()
+    good._dek = dek
+    monkeypatch.setattr(svc_mod, "build_provider", lambda: good)
+    rows = [
+        CryptoKey(version=1, wrapped_dek="w1", provider="static", canary="", active=False),
+        CryptoKey(
+            version=2,
+            wrapped_dek="w2",
+            provider="static",
+            canary=envelope.encrypt(svc_mod._CANARY, dek, 2),
+            active=True,
+        ),
+    ]
+    await svc_mod.refresh_keys(_FakeDB(rows=rows))
+
+    refreshed = svc_mod.get_encryption()
+    assert refreshed._active_version == 2
+    assert {1, 2}.issubset(refreshed._deks)
+    svc_mod.reset_encryption_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_refresh_keys_noop_makes_no_kek_calls_when_nothing_new(monkeypatch):
+    """Steady state: nothing changed → fast path returns before build_provider,
+    so we don't hammer the KEM/KMS every interval."""
+    from terrapod.crypto import service as svc_mod
+    from terrapod.db.models import CryptoKey
+
+    monkeypatch.setattr(svc_mod.settings.encryption, "enabled", True)
+    svc = _enabled_service()  # has v1, active v1
+    svc_mod._service = svc
+
+    def _boom():
+        raise AssertionError("build_provider must not be called on the no-op fast path")
+
+    monkeypatch.setattr(svc_mod, "build_provider", _boom)
+    rows = [CryptoKey(version=1, wrapped_dek="w", provider="static", canary="", active=True)]
+    await svc_mod.refresh_keys(_FakeDB(rows=rows))  # must not raise
+    svc_mod.reset_encryption_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_refresh_keys_keeps_cache_on_provider_error(monkeypatch):
+    """A blipped refresh must NOT tear down a working cache."""
+    from terrapod.crypto import service as svc_mod
+    from terrapod.db.models import CryptoKey
+
+    monkeypatch.setattr(svc_mod.settings.encryption, "enabled", True)
+    svc = _enabled_service()
+    svc_mod._service = svc
+    monkeypatch.setattr(svc_mod, "build_provider", lambda: _BrokenUnwrapProvider())
+    # A new v2 row exists, so the fast path won't short-circuit; the broken
+    # provider then fails the rebuild — but the existing cache must survive.
+    rows = [
+        CryptoKey(version=1, wrapped_dek="w1", provider="static", canary="", active=False),
+        CryptoKey(version=2, wrapped_dek="w2", provider="static", canary="x", active=True),
+    ]
+    await svc_mod.refresh_keys(_FakeDB(rows=rows))
+    assert svc_mod.get_encryption() is svc  # unchanged
+    assert 1 in svc_mod.get_encryption()._deks
+    svc_mod.reset_encryption_for_tests()
+
+
+# ── Boot safety: disabled-but-keys-exist with an unusable KEK (#553 audit) ─────
+
+
+@pytest.mark.asyncio
+async def test_init_degraded_when_disabled_with_rows_and_broken_kek(monkeypatch):
+    """Turning encryption off AND removing the KEK before the decrypt migration
+    must NOT boot a clean passthrough that silently 500s on every encrypted read —
+    it must surface decryptable:false so monitoring/the doctor catch it."""
+    from terrapod.crypto import service as svc_mod
+    from terrapod.db.models import CryptoKey
+
+    monkeypatch.setattr(svc_mod.settings.encryption, "enabled", False)
+
+    def _boom():
+        raise RuntimeError("KEK unreachable")
+
+    monkeypatch.setattr(svc_mod, "build_provider", _boom)
+    rows = [CryptoKey(version=1, wrapped_dek="w", provider="static", canary="c", active=True)]
+    await svc_mod.init_encryption(_FakeDB(rows=rows))  # must NOT raise (disabled)
+
+    st = svc_mod.get_encryption().status()
+    assert st["enabled"] is False
+    assert st["decryptable"] is False  # the durability alarm fires
+    svc_mod.reset_encryption_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_init_active_row_empty_canary_is_not_decryptable(monkeypatch):
+    """An active DEK row with no canary can't prove decryptability — status must
+    not claim decryptable:true on an unverified key."""
+    from terrapod.crypto import service as svc_mod
+    from terrapod.db.models import CryptoKey
+
+    monkeypatch.setattr(svc_mod.settings.encryption, "enabled", True)
+    good = _GoodProvider()
+    monkeypatch.setattr(svc_mod, "build_provider", lambda: good)
+    rows = [CryptoKey(version=1, wrapped_dek="w", provider="static", canary="", active=True)]
+    await svc_mod.init_encryption(_FakeDB(rows=rows))
+    assert svc_mod.get_encryption().status()["decryptable"] is False
+    svc_mod.reset_encryption_for_tests()
+
+
 # ── Migration per-row planner (#553 Phase 4) ──────────────────────────────────
 
 

--- a/services/tests/crypto/test_encryption_doctor.py
+++ b/services/tests/crypto/test_encryption_doctor.py
@@ -1,0 +1,46 @@
+"""Tests for the encryption_doctor CLI exit-code contract (#553 audit).
+
+The doctor is the operator's "are we still recoverable?" drill — its value is the
+non-zero exit on failure (so a CronJob/CI gate can act on it). verify_live itself
+is unit-tested in test_crypto.py; here we assert the CLI wrapper honours the
+exit-code contract.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+
+from terrapod.cli import encryption_doctor as doc
+
+
+def _patch_db(monkeypatch):
+    monkeypatch.setattr(doc, "init_db", AsyncMock())
+    monkeypatch.setattr(doc, "close_db", AsyncMock())
+
+    @asynccontextmanager
+    async def _session():
+        yield AsyncMock()
+
+    monkeypatch.setattr(doc, "get_db_session", _session)
+
+
+@pytest.mark.asyncio
+async def test_doctor_exits_nonzero_on_undecryptable(monkeypatch):
+    _patch_db(monkeypatch)
+    monkeypatch.setattr(
+        doc, "verify_live", AsyncMock(return_value={"ok": False, "failures": ["v1: unwrap failed"]})
+    )
+    with pytest.raises(SystemExit) as exc:
+        await doc.doctor()
+    assert exc.value.code == 1
+
+
+@pytest.mark.asyncio
+async def test_doctor_passes_when_all_decryptable(monkeypatch):
+    _patch_db(monkeypatch)
+    monkeypatch.setattr(
+        doc, "verify_live", AsyncMock(return_value={"ok": True, "checked_versions": [1, 2]})
+    )
+    # No SystemExit on success.
+    await doc.doctor()

--- a/services/tests/integration/test_workspace_state_lifecycle.py
+++ b/services/tests/integration/test_workspace_state_lifecycle.py
@@ -261,3 +261,72 @@ class TestStateVersions:
 
         resp = await client.get(f"/api/v2/workspaces/{ws_id}/current-state-version", headers=AUTH)
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# State encryption at rest (#635) — real DB + filesystem storage round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestStateEncryptionRoundTrip:
+    """Proves the load-bearing #635 invariants against real storage: the stored
+    object is ciphertext (TPENC1), the download decrypts back to the exact
+    plaintext, and the recorded md5 is over the PLAINTEXT (not the ciphertext)."""
+
+    async def test_state_is_ciphertext_at_rest_and_decrypts_on_download(self, app, client):
+        from terrapod.crypto import envelope
+        from terrapod.crypto import service as enc
+        from terrapod.storage import get_storage
+        from terrapod.storage.keys import state_key
+
+        # Turn on encryption with an in-memory DEK (no KEK provider needed).
+        svc = enc.EncryptionService()
+        svc.enabled = True
+        svc._deks = {1: envelope.new_dek()}
+        svc._active_version = 1
+        enc._service = svc
+        try:
+            set_auth(app, admin_user())
+            create = await client.post(WS_ENDPOINT, json=_ws_body("enc-state-ws"), headers=AUTH)
+            ws_id = create.json()["data"]["id"]
+
+            state_bytes = b'{"serial": 1, "lineage": "test-lineage", "secret": "s3cr3t"}'
+            plaintext_md5 = hashlib.md5(state_bytes).hexdigest()
+            sv_resp = await client.post(
+                f"/api/v2/workspaces/{ws_id}/state-versions",
+                json={
+                    "data": {
+                        "type": "state-versions",
+                        "attributes": {
+                            "serial": 1,
+                            "lineage": "test-lineage",
+                            "md5": plaintext_md5,
+                        },
+                    }
+                },
+                headers=AUTH,
+            )
+            assert sv_resp.status_code == 201
+            sv_id = sv_resp.json()["data"]["id"]
+
+            up = await client.put(f"/api/v2/state-versions/{sv_id}/content", content=state_bytes)
+            assert up.status_code == 200
+
+            # At rest: the object is TPENC1 ciphertext, NOT the plaintext.
+            # Storage keys use the bare UUIDs (the JSON:API ids carry ws-/sv- prefixes).
+            stored = await get_storage().get(
+                state_key(ws_id.removeprefix("ws-"), sv_id.removeprefix("sv-"))
+            )
+            assert envelope.is_encrypted_blob(stored)
+            assert state_bytes not in stored
+
+            # md5 recorded is over the PLAINTEXT (TFE-protocol consistency).
+            meta = await client.get(f"/api/v2/state-versions/{sv_id}", headers=AUTH)
+            assert meta.json()["data"]["attributes"]["md5"] == plaintext_md5
+
+            # Download decrypts back to the exact plaintext.
+            dl = await client.get(f"/api/v2/state-versions/{sv_id}/download", headers=AUTH)
+            assert dl.status_code == 200
+            assert dl.content == state_bytes
+        finally:
+            enc.reset_encryption_for_tests()


### PR DESCRIPTION
v0.50.0 pre-release audit + independent adversarial review of the BYOK encryption feature (#553 Phases 1–4 + #635 state-file encryption) surfaced these fixes to land before tagging. No new feature surface — hardening + docs + tests on code already merged for this release.

## Multi-replica DEK propagation (HIGH)

`rotate_dek` only updated the in-memory DEK cache of the replica that served the request. Other replicas would then 500 on any read of data written under the new DEK until restarted — a real availability incident triggered by a documented admin action, and a violation of the multi-replica / no-leader-election architecture principle.

Fix: a 30s `encryption_key_refresh` periodic task (`service.refresh_keys`) that, on every replica, tops up the local DEK cache from `crypto_keys`. A rotation now propagates everywhere within ~30s with no restart. It's a cheap no-op (makes **no** KEK calls) when nothing changed, and non-destructive on a transient provider/DB error (keeps the existing working cache rather than tearing it down). Registered only when encryption is enabled. Documented the ~30s window (harmless/fail-loud) + the rolling-restart option for zero-window propagation.

## Boot safety (MED)

If encryption is disabled but DEK rows still exist **and** the KEK is unusable (operator removed the key before running the `decrypt` migration), init no longer boots a clean passthrough that silently 500s on every encrypted read — it surfaces a **degraded** service so `status()` / the doctor report `decryptable: false` (the durability alarm). Encryption-enabled still fails closed (crashes), unchanged.

## Canary honesty (LOW)

An active DEK row with an empty canary no longer reports `decryptable: true` — we can't prove decryptability on an unverified key.

## Docs (BLOCKER)

- `api-reference.md`: document the two admin endpoints (`GET /admin/encryption`, `POST /admin/encryption/rotate-dek`) — the contract requires it (go-terrapod + the docs already reference them).
- `encryption-at-rest.md`: multi-replica rotation-propagation note + break-glass-index-is-ciphertext DR note.

## Tests

- `refresh_keys`: picks up a DEK rotated on another replica; no-op fast path makes no KEK calls; keeps cache on provider error.
- Degraded boot (disabled + rows + broken KEK → `decryptable:false`); empty-canary → not decryptable.
- `encryption_doctor` exit-code contract (non-zero on undecryptable).
- **Integration (real Postgres + filesystem storage):** uploads state through the real endpoints with encryption on, asserts the stored object is `TPENC1` ciphertext, the recorded md5 is over the **plaintext**, and the download decrypts back to the exact bytes — the death-by-encryption round-trip proven through the stack, not just source introspection.

Full `make test` green (2626 passed).