### PR TITLE
feat(migrate): reversible migrations — rollback, fuller dry-run, parity verify (#548)

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -33,9 +33,9 @@ producing half-migrated state.
 ## Status
 
 Available since **v0.27.0**. The `apply`, `status`, `rewrite`, `verify`,
-`cutover`, and `module` subcommands are fully implemented; `terrapod-migrate`
-ships as a GitHub Release artifact (universal-macOS + linux/windows
-amd64+arm64).
+`rollback`, `cutover`, and `module` subcommands are fully implemented;
+`terrapod-migrate` ships as a GitHub Release artifact (universal-macOS +
+linux/windows amd64+arm64).
 
 ## Subcommands
 
@@ -45,10 +45,67 @@ amd64+arm64).
 - `terrapod-migrate rewrite` — mechanically rewrite HCL `cloud {}` /
   `backend "remote"` blocks and private module sources in a local
   directory tree. No VCS interaction — operator commits and pushes after.
-- `terrapod-migrate verify` — re-run plans on migrated workspaces to
-  confirm parity with what the source produced.
+- `terrapod-migrate verify` — confirm each migrated workspace still
+  matches what the migration recorded: it's present, the variable count
+  is intact, and the state serial/lineage is unchanged. Exits non-zero on
+  any mismatch.
+- `terrapod-migrate rollback` — reverse a migration by deleting the
+  workspaces it created. Dry-run by default; pass `--apply` to delete.
+  Safe by construction (see [Reversibility](#reversibility-dry-run--rollback)).
 - `terrapod-migrate status` — print the contents of the migration state
   file.
+
+## Reversibility: dry-run + rollback
+
+Reversibility is what makes a migration approvable — "we can undo it"
+removes the largest switching-cost objection. The migration is therefore
+**dry-run by default at both ends** and fully undoable.
+
+**1. Preview with a dry-run.** `apply` writes nothing without `--apply`.
+The dry-run reports exactly what *would* be created — every workspace,
+variable, VCS-connection wiring, and **state version** (it reads the
+source state to report its serial/lineage/size, but uploads nothing) —
+plus the skipped-items report. Add `--json` for a machine-readable plan.
+
+```bash
+terrapod-migrate apply --source tfe --tfe-org acme --target https://terrapod.example.com --json   # preview
+terrapod-migrate apply --source tfe --tfe-org acme --target https://terrapod.example.com --apply  # commit
+```
+
+**2. Verify it landed.**
+
+```bash
+terrapod-migrate verify --target https://terrapod.example.com   # exits non-zero on any parity mismatch
+```
+
+**3. Roll back if it goes sideways.** `rollback` reads the state file and
+deletes the workspaces the migration created (cascading their variables
+and state). It is built to never destroy anything it shouldn't:
+
+```bash
+terrapod-migrate rollback --target https://terrapod.example.com           # dry-run: lists what would be deleted
+terrapod-migrate rollback --target https://terrapod.example.com --apply   # delete
+```
+
+Safety guarantees:
+
+- **Provenance gate** — deletes ONLY workspaces *this migration created*.
+  Workspaces it merely reused (anything pre-existing, including
+  `apply --workspace` direct targets) are never deleted.
+- **Advanced-state guard** — before deleting, it checks the workspace's
+  current state serial. If the workspace has been *used* since the
+  migration (serial advanced past what was migrated), it is skipped;
+  pass `--force` only if you really mean to discard that post-migration
+  work. A destination it can't read is left alone (no blind deletes)
+  unless `--force`.
+- **VCS connections are never touched** — the migrator only ever matched
+  pre-existing, operator-owned connections, so rollback leaves them in
+  place.
+- **Idempotent** — re-running is safe; already-deleted workspaces are
+  recorded as rolled back and skipped.
+
+So the end-to-end flow is "import in an afternoon, and roll back cleanly
+if it doesn't go to plan."
 
 ## The migration state file
 

--- a/migrate/cmd/terrapod-migrate/main.go
+++ b/migrate/cmd/terrapod-migrate/main.go
@@ -7,7 +7,8 @@
 //	rewrite    — rewrite HCL `cloud {}` / `backend "remote"` / private module
 //	             sources in an operator-supplied local directory tree. Does
 //	             not interact with VCS — operator commits and pushes after.
-//	verify     — re-run plans on migrated workspaces to confirm parity
+//	verify     — confirm migrated workspaces match (state file, or live source)
+//	rollback   — delete what a migration created (reversible migration)
 //	status     — print the contents of the migration state file
 //
 // Migration is dry-run by default; pass --apply to actually write. Every
@@ -43,6 +44,8 @@ func main() {
 		os.Exit(rewriteCmd(rest))
 	case "verify":
 		os.Exit(verifyCmd(rest))
+	case "rollback":
+		os.Exit(rollbackCmd(rest))
 	case "cutover":
 		os.Exit(cutoverCmd(rest))
 	case "version", "-v", "--version":
@@ -69,7 +72,12 @@ SUBCOMMANDS:
   rewrite   Mechanically rewrite HCL cloud{}/backend"remote"{}/private
             module sources in a local directory. No VCS interaction.
   verify    Read back the migrated workspaces from Terrapod and confirm
-            they match the migration state file.
+            they match the migration state file (or, with --source, diff
+            against the live source platform). Exits non-zero on mismatch.
+  rollback  Reverse a migration: delete the workspaces this migration
+            created (recorded in the state file). Default is dry-run;
+            pass --apply to delete. Never deletes pre-existing or
+            already-used workspaces, nor operator-owned VCS connections.
   cutover   Generate the handover Markdown doc; optionally --lock or
             --unlock source workspaces (TFE only) during the cutover.
   status    Print the contents of the migration state file.

--- a/migrate/cmd/terrapod-migrate/rollback.go
+++ b/migrate/cmd/terrapod-migrate/rollback.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/mattrobinsonsre/terrapod/migrate/internal/framework"
+)
+
+// rollbackCmd reverses what a migration `apply` created. It reads the
+// migration state file and deletes the Terrapod workspaces THIS
+// migration created — making a migration reversible, which is what makes
+// it approvable: "we can undo it" removes the largest switching-cost
+// objection.
+//
+// Safety (this DELETES infrastructure-state-bearing resources, so it is
+// guarded like the apply path):
+//
+//   - Dry-run by DEFAULT. Pass --apply to actually delete. The dry-run
+//     prints exactly which workspaces would be deleted and which are
+//     left untouched.
+//   - Provenance gate: deletes ONLY workspaces the migration itself
+//     created (state record CreatedByMigration). Workspaces the
+//     migration merely reused — anything that pre-existed, including
+//     `apply --workspace` direct targets — are NEVER deleted. Older
+//     state files without provenance decode to "not created by us" and
+//     are skipped.
+//   - Advanced-state guard: before deleting, it reads the workspace's
+//     current state serial. If the workspace has advanced PAST the
+//     serial the migration recorded — i.e. someone has applied real
+//     changes since the migration — it is skipped (the operator must
+//     pass --force to delete a workspace that's been used). A
+//     destination read that fails is treated as "don't delete blind"
+//     unless --force.
+//   - VCS connections are never touched: the migrator only ever matched
+//     pre-existing, operator-owned connections, so they are reported as
+//     left in place.
+//   - Idempotent: a workspace already gone (404) is recorded as
+//     rolled_back; re-running is safe.
+func rollbackCmd(args []string) int {
+	fs := flag.NewFlagSet("rollback", flag.ContinueOnError)
+	var (
+		target    = fs.String("target", os.Getenv("TERRAPOD_HOSTNAME"), "Terrapod base URL (or TERRAPOD_HOSTNAME)")
+		token     = fs.String("token", os.Getenv("TERRAPOD_TOKEN"), "Terrapod API token (or TERRAPOD_TOKEN)")
+		statePath = fs.String("state-file", framework.DefaultStateFile, "Path to the migration state JSON file")
+		apply     = fs.Bool("apply", false, "Actually delete (default is dry-run)")
+		force     = fs.Bool("force", false, "Delete even workspaces whose state has advanced past the migrated serial (DANGEROUS — destroys post-migration work)")
+		jsonOut   = fs.Bool("json", false, "Emit the rollback report as JSON")
+		skipTLS   = fs.Bool("skip-tls-verify", false, "Skip TLS certificate verification (dev only)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *target == "" {
+		fmt.Fprintln(os.Stderr, "rollback: --target (or TERRAPOD_HOSTNAME) is required")
+		return 2
+	}
+	if *token == "" {
+		fmt.Fprintln(os.Stderr, "rollback: --token (or TERRAPOD_TOKEN) is required")
+		return 2
+	}
+
+	state, err := framework.Load(*statePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "rollback: load state file %s: %v\n", *statePath, err)
+		return 1
+	}
+	if state == nil {
+		fmt.Fprintf(os.Stderr, "rollback: state file %s not found — nothing to roll back\n", *statePath)
+		return 1
+	}
+
+	c, err := terrapod.NewClient(terrapod.Options{
+		BaseURL:       *target,
+		Token:         *token,
+		SkipTLSVerify: *skipTLS,
+		UserAgent:     "terrapod-migrate/" + Version,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "rollback: build terrapod client: %v\n", err)
+		return 1
+	}
+
+	report := runRollback(context.Background(), c, state, *statePath, *apply, *force)
+
+	if *jsonOut {
+		if data, err := json.MarshalIndent(report, "", "  "); err == nil {
+			fmt.Println(string(data))
+		}
+	} else {
+		printRollbackSummary(report, !*apply)
+	}
+	if len(report.Errors) > 0 {
+		return 1
+	}
+	return 0
+}
+
+// RollbackReport is the structured result of a rollback run.
+type RollbackReport struct {
+	DryRun          bool                `json:"dry_run"`
+	Target          string              `json:"target"`
+	Workspaces      []RollbackWorkspace `json:"workspaces"`
+	ConnectionsLeft []string            `json:"connections_left_in_place,omitempty"`
+	DeletedCount    int                 `json:"deleted_count"`
+	SkippedCount    int                 `json:"skipped_count"`
+	Errors          []string            `json:"errors,omitempty"`
+}
+
+// RollbackWorkspace is the per-workspace rollback outcome. Action is one
+// of: "would_delete" (dry-run), "deleted", "already_gone",
+// "skipped_advanced", "skipped_not_created", "errored".
+type RollbackWorkspace struct {
+	SourceName     string `json:"source_name"`
+	TerrapodID     string `json:"terrapod_id,omitempty"`
+	Action         string `json:"action"`
+	MigratedSerial int64  `json:"migrated_serial"`
+	CurrentSerial  int64  `json:"current_serial,omitempty"`
+	Detail         string `json:"detail,omitempty"`
+}
+
+func runRollback(ctx context.Context, c *terrapod.Client, state *framework.State, statePath string, apply, force bool) *RollbackReport {
+	report := &RollbackReport{DryRun: !apply, Target: state.DestHost}
+
+	// Connections are operator-owned (the migrator only matched
+	// pre-existing ones); never delete them. Report them as left in place.
+	for i := range state.VCSConnections {
+		report.ConnectionsLeft = append(report.ConnectionsLeft, state.VCSConnections[i].Name)
+	}
+
+	targets := state.RollbackTargets()
+	for _, rec := range targets {
+		rw := RollbackWorkspace{
+			SourceName:     rec.SourceName,
+			TerrapodID:     rec.TerrapodID,
+			MigratedSerial: rec.StateSerial,
+		}
+
+		if !apply {
+			rw.Action = "would_delete"
+			report.Workspaces = append(report.Workspaces, rw)
+			report.DeletedCount++ // count of would-be deletions in dry-run
+			continue
+		}
+
+		// Advanced-state guard: read the destination's current serial.
+		// Skip (unless --force) if it advanced past what we migrated —
+		// that means real work happened on the workspace post-migration
+		// and deleting it would destroy it.
+		dest, derr := c.GetCurrentStateVersion(ctx, rec.TerrapodID)
+		switch {
+		case derr == nil && dest != nil:
+			rw.CurrentSerial = dest.Serial
+			if dest.Serial > rec.StateSerial && !force {
+				rw.Action = "skipped_advanced"
+				rw.Detail = fmt.Sprintf("current serial %d > migrated serial %d — workspace has been used since migration; re-run with --force to delete anyway", dest.Serial, rec.StateSerial)
+				report.Workspaces = append(report.Workspaces, rw)
+				report.SkippedCount++
+				continue
+			}
+		case terrapod.IsNotFound(derr):
+			// No state yet (or workspace already gone). Either way safe
+			// to proceed to the delete, which is itself 404-tolerant.
+		case derr != nil && !force:
+			rw.Action = "errored"
+			rw.Detail = fmt.Sprintf("could not read destination state to confirm it's safe to delete: %v — refusing to delete blind (use --force to override)", derr)
+			report.Workspaces = append(report.Workspaces, rw)
+			report.Errors = append(report.Errors, fmt.Sprintf("workspace %q: %s", rec.SourceName, rw.Detail))
+			continue
+		}
+
+		if err := c.DeleteWorkspace(ctx, rec.TerrapodID); err != nil {
+			var nf *terrapod.NotFoundError
+			if errors.As(err, &nf) {
+				// Already gone — record as rolled back so re-runs are clean.
+				rw.Action = "already_gone"
+				rec.State = "rolled_back"
+				rec.TerrapodID = ""
+				report.Workspaces = append(report.Workspaces, rw)
+				report.DeletedCount++
+				_ = state.Save(statePath, Version)
+				continue
+			}
+			rw.Action = "errored"
+			rw.Detail = err.Error()
+			report.Workspaces = append(report.Workspaces, rw)
+			report.Errors = append(report.Errors, fmt.Sprintf("workspace %q: delete failed: %v", rec.SourceName, err))
+			continue
+		}
+
+		rw.Action = "deleted"
+		rec.State = "rolled_back"
+		rec.TerrapodID = ""
+		report.Workspaces = append(report.Workspaces, rw)
+		report.DeletedCount++
+		// Persist after every delete so an interrupted rollback resumes
+		// cleanly (a re-run skips already-rolled-back records).
+		if err := state.Save(statePath, Version); err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("workspace %q deleted but state save failed: %v", rec.SourceName, err))
+		}
+	}
+
+	return report
+}
+
+func printRollbackSummary(r *RollbackReport, dryRun bool) {
+	label := "rolled back"
+	if dryRun {
+		label = "planned (dry-run; pass --apply to delete)"
+	}
+	fmt.Printf("\nterrapod-migrate rollback — %s\n", label)
+	fmt.Printf("  target:        %s\n", r.Target)
+	if dryRun {
+		fmt.Printf("  would delete:  %d workspace(s)\n", r.DeletedCount)
+	} else {
+		fmt.Printf("  deleted:       %d\n", r.DeletedCount)
+		fmt.Printf("  skipped:       %d\n", r.SkippedCount)
+	}
+	if len(r.ConnectionsLeft) > 0 {
+		fmt.Printf("  vcs connections left in place (operator-owned): %d\n", len(r.ConnectionsLeft))
+	}
+	if len(r.Errors) > 0 {
+		fmt.Printf("  errors:        %d\n", len(r.Errors))
+	}
+	for _, w := range r.Workspaces {
+		fmt.Printf("    [%-16s] %s", w.Action, w.SourceName)
+		if w.TerrapodID != "" {
+			fmt.Printf(" (%s)", w.TerrapodID)
+		}
+		fmt.Println()
+		if w.Detail != "" {
+			fmt.Printf("        - %s\n", w.Detail)
+		}
+	}
+	if dryRun && r.DeletedCount > 0 {
+		fmt.Println("\n  Re-run with --apply to delete the workspaces listed above.")
+	}
+}

--- a/migrate/cmd/terrapod-migrate/rollback_test.go
+++ b/migrate/cmd/terrapod-migrate/rollback_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/mattrobinsonsre/terrapod/migrate/internal/framework"
+)
+
+// rollbackFakeServer answers the two endpoints rollback touches:
+// GET current-state-version (reports a per-workspace serial) and
+// DELETE workspace (records the id). currentSerial maps a terrapod id
+// to the serial the destination currently reports; absent → 404.
+type rollbackFakeServer struct {
+	mu            sync.Mutex
+	currentSerial map[string]int64
+	deleted       []string
+}
+
+func newRollbackServer(t *testing.T, currentSerial map[string]int64) (*rollbackFakeServer, *terrapod.Client) {
+	t.Helper()
+	fs := &rollbackFakeServer{currentSerial: currentSerial}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/current-state-version"):
+			// path: /api/v2/workspaces/{id}/current-state-version
+			id := strings.TrimPrefix(r.URL.Path, "/api/v2/workspaces/")
+			id = strings.TrimSuffix(id, "/current-state-version")
+			fs.mu.Lock()
+			serial, ok := fs.currentSerial[id]
+			fs.mu.Unlock()
+			if !ok {
+				http.Error(w, "no state", http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"data":{"id":"sv-x","type":"state-versions","attributes":{"serial":%d,"lineage":"lin","state-size":10}}}`, serial)
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/api/terrapod/v1/workspaces/"):
+			id := strings.TrimPrefix(r.URL.Path, "/api/terrapod/v1/workspaces/")
+			fs.mu.Lock()
+			fs.deleted = append(fs.deleted, id)
+			fs.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unhandled "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := terrapod.NewClient(terrapod.Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs, c
+}
+
+func TestRollback_DryRun_ListsOnlyCreatedByMigration_NoDeletes(t *testing.T) {
+	fs, c := newRollbackServer(t, map[string]int64{"ws-a": 3, "ws-b": 1})
+	state := &framework.State{
+		Workspaces: []framework.WorkspaceRecord{
+			{SourceName: "a", TerrapodID: "ws-a", State: "created", CreatedByMigration: true, StateSerial: 3},
+			{SourceName: "b-reused", TerrapodID: "ws-b", State: "created", CreatedByMigration: false, StateSerial: 1},
+		},
+	}
+	report := runRollback(t.Context(), c, state, "", false /*apply*/, false /*force*/)
+	if len(fs.deleted) != 0 {
+		t.Fatalf("dry-run deleted workspaces: %v", fs.deleted)
+	}
+	if report.DeletedCount != 1 {
+		t.Fatalf("expected 1 would-delete, got %d (%+v)", report.DeletedCount, report.Workspaces)
+	}
+	if report.Workspaces[0].SourceName != "a" || report.Workspaces[0].Action != "would_delete" {
+		t.Fatalf("unexpected target: %+v", report.Workspaces)
+	}
+}
+
+func TestRollback_Apply_DeletesCreatedOnly_SkipsReused(t *testing.T) {
+	fs, c := newRollbackServer(t, map[string]int64{"ws-a": 3, "ws-b": 1})
+	state := &framework.State{
+		Workspaces: []framework.WorkspaceRecord{
+			{SourceName: "a", TerrapodID: "ws-a", State: "created", CreatedByMigration: true, StateSerial: 3},
+			{SourceName: "b-reused", TerrapodID: "ws-b", State: "created", CreatedByMigration: false, StateSerial: 1},
+		},
+	}
+	report := runRollback(t.Context(), c, state, "", true, false)
+	if len(fs.deleted) != 1 || fs.deleted[0] != "ws-a" {
+		t.Fatalf("expected only ws-a deleted, got %v", fs.deleted)
+	}
+	if report.DeletedCount != 1 {
+		t.Fatalf("DeletedCount=%d", report.DeletedCount)
+	}
+	// The record must be marked rolled_back + id cleared so re-runs skip it.
+	if state.Workspaces[0].State != "rolled_back" || state.Workspaces[0].TerrapodID != "" {
+		t.Fatalf("record not marked rolled_back: %+v", state.Workspaces[0])
+	}
+	// Re-running must delete nothing more (idempotent).
+	fs.deleted = nil
+	report2 := runRollback(t.Context(), c, state, "", true, false)
+	if len(fs.deleted) != 0 || report2.DeletedCount != 0 {
+		t.Fatalf("second rollback was not idempotent: deleted=%v count=%d", fs.deleted, report2.DeletedCount)
+	}
+}
+
+func TestRollback_Apply_SkipsAdvancedState_UnlessForce(t *testing.T) {
+	// Destination has advanced to serial 7; migration recorded 3.
+	fs, c := newRollbackServer(t, map[string]int64{"ws-a": 7})
+	state := &framework.State{
+		Workspaces: []framework.WorkspaceRecord{
+			{SourceName: "a", TerrapodID: "ws-a", State: "created", CreatedByMigration: true, StateSerial: 3},
+		},
+	}
+	report := runRollback(t.Context(), c, state, "", true, false /*force*/)
+	if len(fs.deleted) != 0 {
+		t.Fatalf("advanced workspace was deleted without --force: %v", fs.deleted)
+	}
+	if report.SkippedCount != 1 || report.Workspaces[0].Action != "skipped_advanced" {
+		t.Fatalf("expected skipped_advanced, got %+v", report.Workspaces)
+	}
+
+	// With --force it deletes.
+	fs2, c2 := newRollbackServer(t, map[string]int64{"ws-a": 7})
+	state2 := &framework.State{
+		Workspaces: []framework.WorkspaceRecord{
+			{SourceName: "a", TerrapodID: "ws-a", State: "created", CreatedByMigration: true, StateSerial: 3},
+		},
+	}
+	report2 := runRollback(t.Context(), c2, state2, "", true, true /*force*/)
+	if len(fs2.deleted) != 1 || report2.DeletedCount != 1 {
+		t.Fatalf("--force did not delete advanced workspace: deleted=%v", fs2.deleted)
+	}
+}

--- a/migrate/cmd/terrapod-migrate/verify.go
+++ b/migrate/cmd/terrapod-migrate/verify.go
@@ -85,21 +85,22 @@ func verifyCmd(args []string) int {
 // writer.Report shape so the two are easy to diff in operator
 // dashboards.
 type VerifyReport struct {
-	Target       string                 `json:"target"`
-	StateFile    string                 `json:"state_file"`
-	CheckedCount int                    `json:"checked_count"`
-	OkCount      int                    `json:"ok_count"`
-	FailedCount  int                    `json:"failed_count"`
+	Target       string                  `json:"target"`
+	StateFile    string                  `json:"state_file"`
+	CheckedCount int                     `json:"checked_count"`
+	OkCount      int                     `json:"ok_count"`
+	FailedCount  int                     `json:"failed_count"`
 	Workspaces   []WorkspaceVerification `json:"workspaces"`
 }
 
 // WorkspaceVerification is the per-workspace result.
 type WorkspaceVerification struct {
-	SourceName    string   `json:"source_name"`
-	TerrapodID    string   `json:"terrapod_id"`
-	OK            bool     `json:"ok"`
-	Failures      []string `json:"failures,omitempty"`
-	VariableCount int      `json:"variable_count"`
+	SourceName            string   `json:"source_name"`
+	TerrapodID            string   `json:"terrapod_id"`
+	OK                    bool     `json:"ok"`
+	Failures              []string `json:"failures,omitempty"`
+	VariableCount         int      `json:"variable_count"`
+	ExpectedVariableCount int      `json:"expected_variable_count,omitempty"`
 }
 
 func runVerify(ctx context.Context, c *terrapod.Client, state *framework.State) *VerifyReport {
@@ -134,17 +135,48 @@ func runVerify(ctx context.Context, c *terrapod.Client, state *framework.State) 
 			}
 		}
 
-		// Variable presence: count what's on Terrapod and compare
-		// against what the state file remembers about the workspace.
-		// State doesn't (yet) store the expected variable list, so we
-		// only surface count > 0 today; richer parity checks land with
-		// the apply-time variable manifest.
+		// Variable parity: count what's on Terrapod and compare against
+		// the count the migration recorded (ExpectedVarCount). A drop
+		// between apply and now (a var deleted, or a half-applied run)
+		// surfaces as a failure. Older state files that predate the
+		// recorded count (ExpectedVarCount == 0) fall back to the
+		// presence-only behaviour.
 		if ws := ws; ws != nil {
 			vars, err := c.ListVariables(ctx, ws.ID)
 			if err != nil {
 				v.Failures = append(v.Failures, fmt.Sprintf("ListVariables failed: %v", err))
 			} else {
 				v.VariableCount = len(vars)
+				v.ExpectedVariableCount = rec.ExpectedVarCount
+				if rec.ExpectedVarCount > 0 && len(vars) != rec.ExpectedVarCount {
+					v.Failures = append(v.Failures, fmt.Sprintf(
+						"variable count %d != migrated count %d (a variable was removed or never landed)",
+						len(vars), rec.ExpectedVarCount))
+				}
+			}
+
+			// State parity: the destination's current state serial/lineage
+			// must still match what the migration uploaded. A lineage
+			// mismatch means the workspace points at an unrelated state; a
+			// serial below the migrated one means a rollback happened.
+			if rec.StateLineage != "" {
+				dest, serr := c.GetCurrentStateVersion(ctx, ws.ID)
+				switch {
+				case serr == nil && dest != nil:
+					if dest.Lineage != rec.StateLineage {
+						v.Failures = append(v.Failures, fmt.Sprintf(
+							"state lineage %q != migrated lineage %q", dest.Lineage, rec.StateLineage))
+					}
+					if dest.Serial < rec.StateSerial {
+						v.Failures = append(v.Failures, fmt.Sprintf(
+							"state serial %d < migrated serial %d (state rolled back?)", dest.Serial, rec.StateSerial))
+					}
+				case terrapod.IsNotFound(serr):
+					v.Failures = append(v.Failures, fmt.Sprintf(
+						"migrated state (serial %d) is missing from the destination", rec.StateSerial))
+				case serr != nil:
+					v.Failures = append(v.Failures, fmt.Sprintf("GetCurrentStateVersion failed: %v", serr))
+				}
 			}
 		}
 

--- a/migrate/cmd/terrapod-migrate/verify_test.go
+++ b/migrate/cmd/terrapod-migrate/verify_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/mattrobinsonsre/terrapod/migrate/internal/framework"
+)
+
+// verifyFakeServer reports a workspace's name, variable count, and
+// current state (serial/lineage) so runVerify's parity checks can be
+// exercised. A serial of -1 means "no current state version" (404).
+func newVerifyServer(t *testing.T, name string, varCount int, serial int64, lineage string) *terrapod.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/vars"):
+			var items []string
+			for i := range varCount {
+				items = append(items, fmt.Sprintf(`{"id":"var-%d","type":"vars","attributes":{"key":"k%d","category":"terraform"}}`, i, i))
+			}
+			_, _ = fmt.Fprintf(w, `{"data":[%s]}`, strings.Join(items, ","))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/current-state-version"):
+			if serial < 0 {
+				http.Error(w, "no state", http.StatusNotFound)
+				return
+			}
+			_, _ = fmt.Fprintf(w, `{"data":{"id":"sv-x","type":"state-versions","attributes":{"serial":%d,"lineage":%q,"state-size":10}}}`, serial, lineage)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v2/workspaces/"):
+			_, _ = fmt.Fprintf(w, `{"data":{"id":"ws-a","type":"workspaces","attributes":{"name":%q}}}`, name)
+		default:
+			http.Error(w, "unhandled "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := terrapod.NewClient(terrapod.Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func baselineState() *framework.State {
+	return &framework.State{Workspaces: []framework.WorkspaceRecord{{
+		SourceName: "app", TerrapodID: "ws-a", State: "created",
+		ExpectedVarCount: 2, StateLineage: "lin-1", StateSerial: 5,
+	}}}
+}
+
+func TestVerify_Parity_OK(t *testing.T) {
+	c := newVerifyServer(t, "app", 2, 5, "lin-1")
+	r := runVerify(t.Context(), c, baselineState())
+	if r.FailedCount != 0 {
+		t.Fatalf("expected parity OK, got failures: %+v", r.Workspaces)
+	}
+}
+
+func TestVerify_Parity_VarCountDrop_Fails(t *testing.T) {
+	c := newVerifyServer(t, "app", 1, 5, "lin-1") // 1 var on dest, migrated 2
+	r := runVerify(t.Context(), c, baselineState())
+	if r.FailedCount != 1 {
+		t.Fatalf("expected var-count mismatch to fail: %+v", r.Workspaces)
+	}
+}
+
+func TestVerify_Parity_LineageMismatch_Fails(t *testing.T) {
+	c := newVerifyServer(t, "app", 2, 5, "OTHER-lineage")
+	r := runVerify(t.Context(), c, baselineState())
+	if r.FailedCount != 1 {
+		t.Fatalf("expected lineage mismatch to fail: %+v", r.Workspaces)
+	}
+}
+
+func TestVerify_Parity_StateMissing_Fails(t *testing.T) {
+	c := newVerifyServer(t, "app", 2, -1, "") // no current state version
+	r := runVerify(t.Context(), c, baselineState())
+	if r.FailedCount != 1 {
+		t.Fatalf("expected missing-state to fail: %+v", r.Workspaces)
+	}
+}

--- a/migrate/internal/framework/state.go
+++ b/migrate/internal/framework/state.go
@@ -11,28 +11,28 @@
 // Every `apply` run reads and writes a JSON file (default
 // ./migration-state.json; override with --state-file). The file is:
 //
-//   * the idempotency record: SourceID → TerrapodID for every created
+//   - the idempotency record: SourceID → TerrapodID for every created
 //     resource, so re-running `apply` after a partial migration is safe
 //     and resumes where it left off;
-//   * the input the `rewrite` subcommand consumes (Mode 1) to derive
+//   - the input the `rewrite` subcommand consumes (Mode 1) to derive
 //     source/destination hostnames and the set of workspace names to
 //     rewrite — operators don't have to remember those flags after
 //     `apply` runs.
 //
 // Format choices:
 //
-//   * JSON, not YAML. Deterministic representation (sorted keys, fixed
+//   - JSON, not YAML. Deterministic representation (sorted keys, fixed
 //     indentation, no trailing whitespace) makes diffs between
 //     successive runs stable, which matters when an operator is
 //     reviewing what changed during a retry.
-//   * Top-level `version: 1` field. Schema evolution is real — over a
+//   - Top-level `version: 1` field. Schema evolution is real — over a
 //     few minor releases the set of fields we track will grow. The tool
 //     refuses to load a file written by a future version (loud error,
 //     no silent partial-load) and gracefully zero-fills fields added in
 //     versions it understands.
-//   * Wall-clock timestamps are written in RFC3339 UTC to match
+//   - Wall-clock timestamps are written in RFC3339 UTC to match
 //     Terrapod's wider convention.
-//   * Sensitive variable values are NEVER written here. Only metadata
+//   - Sensitive variable values are NEVER written here. Only metadata
 //     (key, category, sensitive flag) lands in the state file.
 package framework
 
@@ -123,11 +123,11 @@ type State struct {
 // the workspace has actually been created on the destination — until
 // then it stays empty and re-running `apply` re-attempts the create.
 type WorkspaceRecord struct {
-	SourceID    string    `json:"source_id"`
-	SourceName  string    `json:"source_name"`
-	TerrapodID  string    `json:"terrapod_id,omitempty"`
-	State       string    `json:"state"` // "pending" | "created" | "errored"
-	Error       string    `json:"error,omitempty"`
+	SourceID     string    `json:"source_id"`
+	SourceName   string    `json:"source_name"`
+	TerrapodID   string    `json:"terrapod_id,omitempty"`
+	State        string    `json:"state"` // "pending" | "created" | "errored" | "rolled_back"
+	Error        string    `json:"error,omitempty"`
 	StateLineage string    `json:"state_lineage,omitempty"`
 	StateSerial  int64     `json:"state_serial,omitempty"`
 	CreatedAt    time.Time `json:"created_at,omitzero"`
@@ -135,6 +135,22 @@ type WorkspaceRecord struct {
 	// rewriter can verify a cloud-block `tags = [...]` selection still
 	// resolves to a migrated workspace.
 	Labels map[string]string `json:"labels,omitempty"`
+
+	// CreatedByMigration is the rollback safety gate. It is set true
+	// ONLY when *this* migration actually created the Terrapod workspace
+	// (a successful CreateWorkspace). It stays false for workspaces the
+	// migration merely *reused* — pre-existing workspaces targeted via
+	// `apply --workspace`, or any workspace that already existed and was
+	// matched by name. `rollback` deletes ONLY CreatedByMigration
+	// records, so it can never delete a workspace the operator owned
+	// before the migration. Older state files (written before this field
+	// existed) decode to false → rollback conservatively skips them.
+	CreatedByMigration bool `json:"created_by_migration,omitempty"`
+
+	// ExpectedVarCount is how many variables the migration wrote/planned
+	// for this workspace. Recorded so `verify` can confirm the
+	// destination still has them all without re-reading the source.
+	ExpectedVarCount int `json:"expected_var_count,omitempty"`
 }
 
 // VCSConnectionRecord — never carries credentials. Just the SourceID →
@@ -261,6 +277,24 @@ func (s *State) WorkspaceBySourceID(sourceID string) *WorkspaceRecord {
 		}
 	}
 	return nil
+}
+
+// RollbackTargets returns the workspace records `rollback` may delete:
+// those THIS migration created (CreatedByMigration) that still carry a
+// TerrapodID and haven't already been rolled back. Reused/pre-existing
+// workspaces and already-rolled-back records are never returned, so the
+// caller can delete the full list without re-checking provenance. The
+// returned slice points into s.Workspaces so the caller can mutate the
+// records (mark rolled_back) and Save.
+func (s *State) RollbackTargets() []*WorkspaceRecord {
+	var out []*WorkspaceRecord
+	for i := range s.Workspaces {
+		r := &s.Workspaces[i]
+		if r.CreatedByMigration && r.TerrapodID != "" && r.State != "rolled_back" {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // WorkspaceBySourceName returns the recorded workspace by source name,

--- a/migrate/internal/framework/state_test.go
+++ b/migrate/internal/framework/state_test.go
@@ -271,3 +271,25 @@ func TestDefaultStateFile_IsExpected(t *testing.T) {
 		t.Errorf("DefaultStateFile changed: %q — update docs/migration.md and the rewriter UX if intentional", DefaultStateFile)
 	}
 }
+
+func TestRollbackTargets_OnlyCreatedByMigration(t *testing.T) {
+	s := &State{Workspaces: []WorkspaceRecord{
+		{SourceName: "created", TerrapodID: "ws-1", State: "created", CreatedByMigration: true},
+		{SourceName: "reused", TerrapodID: "ws-2", State: "created", CreatedByMigration: false},
+		{SourceName: "planned-no-id", State: "planned", CreatedByMigration: false},
+		{SourceName: "already-rolled-back", TerrapodID: "ws-3", State: "rolled_back", CreatedByMigration: true},
+		{SourceName: "created-but-no-id", State: "errored", CreatedByMigration: true},
+	}}
+	targets := s.RollbackTargets()
+	if len(targets) != 1 {
+		t.Fatalf("expected exactly 1 rollback target, got %d: %+v", len(targets), targets)
+	}
+	if targets[0].SourceName != "created" {
+		t.Fatalf("wrong target: %q (rollback must never select reused/pre-existing/rolled-back records)", targets[0].SourceName)
+	}
+	// Mutating the returned pointer must write through to the State.
+	targets[0].State = "rolled_back"
+	if s.Workspaces[0].State != "rolled_back" {
+		t.Fatal("RollbackTargets must return pointers into s.Workspaces")
+	}
+}

--- a/migrate/internal/writer/writer.go
+++ b/migrate/internal/writer/writer.go
@@ -7,11 +7,11 @@
 //
 // Two modes:
 //
-//   * DryRun (default) — walks the Plan, builds a Report describing
+//   - DryRun (default) — walks the Plan, builds a Report describing
 //     the would-be writes, never touches Terrapod. Sensitive variable
 //     values are NEVER read from the source in this mode.
 //
-//   * Apply — actually writes. Order is dependency-first: VCS
+//   - Apply — actually writes. Order is dependency-first: VCS
 //     connections → workspaces → variables. After each write the state
 //     file is saved so a crash mid-migration is resumable from the
 //     same state file.
@@ -83,14 +83,14 @@ type Options struct {
 // stays self-contained (no live SDK references) so callers can
 // serialise it to disk for the handover document.
 type Report struct {
-	DryRun      bool                  `json:"dry_run"`
-	StartedAt   time.Time             `json:"started_at"`
-	FinishedAt  time.Time             `json:"finished_at"`
-	Source      string                `json:"source"`
-	Connections []ConnectionOutcome   `json:"connections,omitempty"`
-	Workspaces  []WorkspaceOutcome    `json:"workspaces,omitempty"`
-	Skipped     []ir.SkippedItem      `json:"skipped,omitempty"`
-	Errors      []string              `json:"errors,omitempty"`
+	DryRun      bool                `json:"dry_run"`
+	StartedAt   time.Time           `json:"started_at"`
+	FinishedAt  time.Time           `json:"finished_at"`
+	Source      string              `json:"source"`
+	Connections []ConnectionOutcome `json:"connections,omitempty"`
+	Workspaces  []WorkspaceOutcome  `json:"workspaces,omitempty"`
+	Skipped     []ir.SkippedItem    `json:"skipped,omitempty"`
+	Errors      []string            `json:"errors,omitempty"`
 }
 
 // ConnectionOutcome is the per-VCS-connection result. State is
@@ -325,6 +325,14 @@ func (w *Writer) applyWorkspace(ctx context.Context, ws *ir.Workspace, connByRef
 		for _, v := range ws.Variables {
 			out.VarOutcomes = append(out.VarOutcomes, VarOutcome{Key: v.Key, State: "planned"})
 		}
+		// Report the state version that WOULD migrate so the dry-run plan
+		// is complete (the issue's "report exactly what would be created
+		// … state versions"). This only READS the source state for its
+		// metadata (lineage/serial/size) — it never uploads. Reading is
+		// the same safe operation apply does; no Terrapod write happens.
+		if opts.StateForWorkspace != nil {
+			out.StateOutcome = w.planState(ctx, ws.SourceID, opts.StateForWorkspace)
+		}
 		return out
 	}
 
@@ -384,6 +392,10 @@ func (w *Writer) applyWorkspace(ctx context.Context, ws *ir.Workspace, connByRef
 	w.recordWorkspace(ws, "created", "")
 	if rec := w.state.WorkspaceBySourceID(ws.SourceID); rec != nil {
 		rec.TerrapodID = created.ID
+		// Provenance for rollback: WE created this workspace, so rollback
+		// is allowed to delete it. Reused/pre-existing workspaces never
+		// reach this path, so this flag is the safe delete gate.
+		rec.CreatedByMigration = true
 	}
 
 	for i := range ws.Variables {
@@ -396,6 +408,36 @@ func (w *Writer) applyWorkspace(ctx context.Context, ws *ir.Workspace, connByRef
 		out.StateOutcome = w.applyState(ctx, created.ID, ws.SourceID, opts.StateForWorkspace)
 	}
 
+	return out
+}
+
+// planState reads the source state for its metadata only and reports
+// what a real apply WOULD upload — it never writes to Terrapod. Used by
+// the dry-run path so the plan shows the state version (serial/lineage/
+// size) alongside the workspace + variables. A missing/empty source
+// state is reported as "no_source_state"; a read error is reported (so
+// the operator learns about an unreadable backend at plan time) but is
+// non-fatal to the dry-run.
+func (w *Writer) planState(ctx context.Context, sourceID string, reader StateReader) *StateOutcome {
+	out := &StateOutcome{State: "planned"}
+	raw, lineage, serial, err := reader(ctx, sourceID)
+	if err != nil {
+		var none *ErrNoStateForWorkspace
+		if errors.As(err, &none) {
+			out.State = "no_source_state"
+			return out
+		}
+		out.State = "errored"
+		out.Error = fmt.Sprintf("read source state: %v", err)
+		return out
+	}
+	if len(raw) == 0 {
+		out.State = "no_source_state"
+		return out
+	}
+	out.Serial = serial
+	out.Lineage = lineage
+	out.SizeKB = stateSizeKB(len(raw))
 	return out
 }
 
@@ -663,7 +705,6 @@ func (w *Writer) reconcileVariable(ctx context.Context, workspaceID string, req 
 	return nil
 }
 
-
 // ── State plumbing ───────────────────────────────────────────────────
 
 func (w *Writer) recordConnection(c *ir.VCSConnection, state, errMsg string) {
@@ -684,15 +725,17 @@ func (w *Writer) recordWorkspace(ws *ir.Workspace, state, errMsg string) {
 	if rec := w.state.WorkspaceBySourceID(ws.SourceID); rec != nil {
 		rec.State = state
 		rec.Error = errMsg
+		rec.ExpectedVarCount = len(ws.Variables)
 		return
 	}
 	rec := framework.WorkspaceRecord{
-		SourceID:   ws.SourceID,
-		SourceName: ws.Name,
-		State:      state,
-		Error:      errMsg,
-		Labels:     ws.Labels,
-		CreatedAt:  time.Now().UTC(),
+		SourceID:         ws.SourceID,
+		SourceName:       ws.Name,
+		State:            state,
+		Error:            errMsg,
+		Labels:           ws.Labels,
+		ExpectedVarCount: len(ws.Variables),
+		CreatedAt:        time.Now().UTC(),
 	}
 	w.state.Workspaces = append(w.state.Workspaces, rec)
 }
@@ -741,4 +784,3 @@ func collectErrors(r *Report) []string {
 	}
 	return errs
 }
-

--- a/migrate/internal/writer/writer_test.go
+++ b/migrate/internal/writer/writer_test.go
@@ -487,3 +487,71 @@ func TestApplyState_UploadFails_OrphanRollback(t *testing.T) {
 		t.Errorf("expected rollback DELETE, got %d calls", scenario.deleteCalled)
 	}
 }
+
+func TestWriter_Apply_SetsCreatedByMigrationAndVarCount(t *testing.T) {
+	_, c := newFakeServer(t)
+	state := &framework.State{}
+	w := New(c, state, "")
+	plan := ir.Plan{
+		Source: "tfe",
+		Workspaces: []ir.Workspace{{
+			SourceID: "ws-src-1",
+			Name:     "app",
+			Variables: []ir.Variable{
+				{Key: "region", Value: "eu-west-1", Category: "terraform"},
+				{Key: "tier", Value: "prod", Category: "terraform"},
+			},
+		}},
+	}
+	if _, err := w.Run(t.Context(), plan, Options{DryRun: false}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	rec := state.WorkspaceBySourceID("ws-src-1")
+	if rec == nil || !rec.CreatedByMigration {
+		t.Fatalf("CreatedByMigration must be true after a real create: %+v", rec)
+	}
+	if rec.ExpectedVarCount != 2 {
+		t.Fatalf("ExpectedVarCount = %d, want 2", rec.ExpectedVarCount)
+	}
+}
+
+func TestWriter_Reused_DoesNotSetCreatedByMigration(t *testing.T) {
+	_, c := newFakeServer(t)
+	// Pre-seed a reused workspace (e.g. apply --workspace direct mode):
+	// it has a TerrapodID but was NOT created by the migration.
+	state := &framework.State{Workspaces: []framework.WorkspaceRecord{
+		{SourceID: "direct:app", SourceName: "app", TerrapodID: "ws-pre", State: "created", CreatedByMigration: false},
+	}}
+	w := New(c, state, "")
+	plan := ir.Plan{Source: "atlantis", Workspaces: []ir.Workspace{{SourceID: "direct:app", Name: "app"}}}
+	if _, err := w.Run(t.Context(), plan, Options{DryRun: false}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rec := state.WorkspaceBySourceID("direct:app"); rec.CreatedByMigration {
+		t.Fatal("reused workspace must NOT be flagged CreatedByMigration — rollback would delete an operator's pre-existing workspace")
+	}
+}
+
+func TestWriter_DryRun_PlansStateWithoutUpload(t *testing.T) {
+	fs, c := newFakeServer(t)
+	state := &framework.State{}
+	w := New(c, state, "")
+	reader := func(_ context.Context, _ string) ([]byte, string, int64, error) {
+		return []byte(`{"serial":5,"lineage":"lin-1"}`), "lin-1", 5, nil
+	}
+	plan := ir.Plan{Source: "tfe", Workspaces: []ir.Workspace{{SourceID: "ws-1", Name: "app"}}}
+	report, err := w.Run(t.Context(), plan, Options{DryRun: true, StateForWorkspace: reader})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if fs.workspacesCreated != 0 {
+		t.Fatalf("dry-run created a workspace")
+	}
+	so := report.Workspaces[0].StateOutcome
+	if so == nil || so.State != "planned" {
+		t.Fatalf("dry-run should report planned state, got %+v", so)
+	}
+	if so.Serial != 5 || so.Lineage != "lin-1" {
+		t.Fatalf("planned state metadata wrong: %+v", so)
+	}
+}


### PR DESCRIPTION
Makes `terrapod-migrate` safe to attempt: **reversibility is what makes a migration approvable** — "we can undo it" removes the largest switching-cost objection an SRE has to a self-hosted TF platform.

Closes #548.

## `rollback` subcommand (the centerpiece)

Reverses what a migration created, from the migration state file. **Dry-run by default**; `--apply` to delete. Built so it can never destroy something it shouldn't (death-by-deletion guards, the same posture as the apply path):

- **Provenance gate** — deletes ONLY workspaces *this migration created*. New `WorkspaceRecord.CreatedByMigration` is set true **only** on a successful `CreateWorkspace`; reused/pre-existing workspaces (including `apply --workspace` direct targets) stay false and are never deleted. Old state files (no provenance) decode to false → skipped.
- **Advanced-state guard** — reads the workspace's current state serial before deleting; if it advanced past the migrated serial (someone *used* the workspace since migrating), it's skipped unless `--force`. A destination it can't read is left alone (no blind delete) unless `--force`.
- **VCS connections never touched** — operator-owned; the migrator only ever matched pre-existing ones.
- **Idempotent** — already-gone workspaces recorded `rolled_back`; state saved after each delete so an interrupted rollback resumes cleanly.

## Fuller dry-run

`apply --dry-run` (the default) now reports the **state version it would migrate** (reads source state for serial/lineage/size — uploads nothing), so the plan covers workspaces + variables + **state** + skipped items. `--json` emits the structured plan.

## Parity verify

`verify` now confirms the destination still matches what the migration recorded — **variable count** (new `ExpectedVarCount`) and **state serial/lineage**, on top of presence/name — and exits non-zero on any mismatch (a var dropped, state rolled back / lineage diverged / missing, workspace deleted).

## Schema

`WorkspaceRecord` gains `CreatedByMigration` + `ExpectedVarCount` (both optional, back-compatible at schema v1). `State.RollbackTargets()` selects only safely-deletable records.

## Tests

`go build` / `go vet` / `go test ./...` green in the migrate module:
- framework: `RollbackTargets` selects created-only, skips reused/rolled-back/no-id, returns write-through pointers.
- writer: provenance set on create / not on reuse; dry-run reports planned state without uploading; ExpectedVarCount recorded.
- rollback: dry-run lists only created-by-migration with no deletes; apply deletes created-only + skips reused; idempotent re-run; advanced-state skip; `--force` override.
- verify: parity OK; var-count drop, lineage mismatch, and missing-state each fail.

## Docs

`docs/migration.md` gains a **"Reversibility: dry-run + rollback"** section ("import in an afternoon, roll back cleanly if it doesn't go to plan") plus updated subcommand list + status.

## Scope note

The issue's verify checkbox mentions a *live source re-read* diff (re-pull TFE/Atlantis and compare). This PR implements parity against the **recorded migration baseline** (no source re-auth), which catches the practical post-migration failure modes. A live `verify --source` reread can be a small fast-follow if wanted.