### PR TITLE
fix(ai,registry): retry transient AI-summary failures + quiet pgpy/litellm log noise

### DIFF
--- a/services/terrapod/gpg_verify.py
+++ b/services/terrapod/gpg_verify.py
@@ -11,7 +11,24 @@ own fetching; the cryptographic core lives here.
 
 from __future__ import annotations
 
+import warnings
+
 import pgpy
+
+# pgpy prints static `UserWarning` TODO banners on EVERY ``key.verify()`` —
+# "Self-sigs verification is not yet working", "Revocation checks are not yet
+# implemented", "Flags (s.a. `disabled`) checks are not yet implemented". They
+# are not per-verification signals (they print identically on a good or bad
+# signature), so they're pure log noise in the API + runner. Suppress pgpy's
+# UserWarnings here (the one module that touches pgpy). This does NOT weaken
+# verification: a bad/wrong-key signature still fails closed.
+#
+# Caveat worth keeping visible: the *revocation* TODO is a real pgpy limitation
+# — a revoked signing key's signatures would still verify. Terrapod's trust is
+# anchored in the registered/pinned public key (self-sig + disabled-flag gaps
+# don't apply to that model), and the operator mitigation is removing a revoked
+# key from the registered set. Tracked for a proper fix in issue #640.
+warnings.filterwarnings("ignore", category=UserWarning, module=r"pgpy")
 
 
 def parse_sha256sums(text: str) -> dict[str, str]:

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -74,6 +74,26 @@ from terrapod.storage.keys import (
 
 logger = get_logger(__name__)
 
+# ── LiteLLM noise + resilience ────────────────────────────────────────────────
+#
+# LiteLLM is chatty by default (an INFO "LiteLLM completion() model=…" line on
+# every call) and emits provider-debug banners on errors — pure noise in our
+# logs since we wrap every call with our own structured logging. Quiet it.
+import logging as _logging  # noqa: E402
+
+litellm.suppress_debug_info = True
+_logging.getLogger("LiteLLM").setLevel(_logging.WARNING)
+
+# Bounded retry for the model call. Bedrock (and any provider) occasionally
+# fails a connection instantly under concurrency — LiteLLM surfaces these as
+# `litellm.Timeout` with ~0s elapsed even though the model isn't slow. Almost
+# all calls succeed, so a couple of backed-off retries make the intermittent
+# blips self-heal instead of failing the (best-effort) summary and spamming the
+# log. LiteLLM retries its own transient classes (Timeout / APIConnectionError /
+# RateLimitError / InternalServerError / ServiceUnavailable); a 4xx is final and
+# not retried. Matches the "outbound calls use bounded retry" invariant.
+_LLM_NUM_RETRIES = 2  # → up to 3 attempts
+
 
 # --- Input retrieval ---------------------------------------------------------
 
@@ -830,6 +850,10 @@ def _build_litellm_kwargs(
         "max_tokens": max_output_tokens,
         "messages": messages,
         "timeout": cfg.request_timeout_seconds,
+        # Self-heal transient instant-failures (see _LLM_NUM_RETRIES). LiteLLM
+        # backs off between attempts and only retries its transient classes.
+        "num_retries": _LLM_NUM_RETRIES,
+        "retry_strategy": "exponential_backoff_retry",
     }
 
     if use_tools:

--- a/services/tests/services/test_summariser.py
+++ b/services/tests/services/test_summariser.py
@@ -359,6 +359,35 @@ def test_build_litellm_kwargs_omits_role_when_unset():
         assert "aws_external_id" not in kw
 
 
+def test_build_litellm_kwargs_includes_bounded_retry():
+    """The model call must carry a bounded retry so transient instant-failures
+    (Bedrock surfaces these as litellm.Timeout with ~0s elapsed under
+    concurrency) self-heal instead of failing the best-effort summary."""
+    with (
+        patch.object(summariser.settings.ai_summary, "model", "bedrock/anthropic.claude-opus-4-8"),
+        patch.object(summariser.settings.ai_summary, "api_base", ""),
+        patch.object(summariser.settings.ai_summary.auth, "api_key", ""),
+        patch.object(summariser.settings.ai_summary.auth, "aws_role_arn", ""),
+    ):
+        kw = summariser._build_litellm_kwargs(
+            kind="plan_summary",
+            system_message="sys",
+            user_message="usr",
+            max_output_tokens=100,
+        )
+        assert kw["num_retries"] == summariser._LLM_NUM_RETRIES >= 1
+        assert kw["retry_strategy"] == "exponential_backoff_retry"
+
+
+def test_litellm_logging_quieted_at_import():
+    """LiteLLM's chatty INFO logging is turned down so the per-call
+    'LiteLLM completion() model=…' banner stops flooding our logs."""
+    import logging
+
+    assert logging.getLogger("LiteLLM").level >= logging.WARNING
+    assert summariser.litellm.suppress_debug_info is True
+
+
 def test_build_litellm_kwargs_includes_tool_choice_for_plan_summary():
     """Tool-calling is the canonical structured-output path. The kwargs
     must include the submit_plan_summary tool AND force it via

--- a/services/tests/test_gpg_verify.py
+++ b/services/tests/test_gpg_verify.py
@@ -1,0 +1,28 @@
+"""Tests for the shared OpenPGP verification core (gpg_verify)."""
+
+import inspect
+
+from terrapod import gpg_verify
+
+
+def test_gpg_verify_installs_pgpy_warning_filter():
+    """gpg_verify must suppress pgpy's static UserWarning TODO banners
+    (self-sigs / revocation / flags) so they don't flood the API + runner logs
+    on every verify. Source-introspection guard (pytest manages warnings.filters
+    per-test, so a runtime-filter check is unreliable): if the filterwarnings
+    call is removed, this fails. See #640 for the revocation caveat it documents."""
+    src = inspect.getsource(gpg_verify)
+    assert "filterwarnings" in src, "gpg_verify must install a warnings filter for pgpy"
+    assert "category=UserWarning" in src and '"pgpy"' in src, (
+        "the filter must be scoped to pgpy UserWarnings, not a blanket silence"
+    )
+
+
+def test_parse_sha256sums_tolerates_formatting():
+    out = gpg_verify.parse_sha256sums(
+        "ABC123  file.zip\n"  # uppercase digest, two-space sep
+        "def456  *other.bin\n"  # binary-mode marker (*) on the filename
+        "\n"  # blank line
+        "garbage\n"  # short line, skipped
+    )
+    assert out == {"file.zip": "abc123", "other.bin": "def456"}


### PR DESCRIPTION
Two production noise/reliability issues observed in live runner + API logs. Patch-release material.

## 1. AI summaries randomly failing + log spam
Under concurrency, Bedrock occasionally refuses a connection *instantly*; LiteLLM surfaces it as `litellm.Timeout: … time taken=0.001 seconds` — **not a real timeout** (the model isn't slow). Live API logs confirm it's **intermittent** (failures interleaved with successes, including a 202k-token success), so it's not a config/egress problem — and the model call had **no retry**, so every blip failed the best-effort summary and logged a warning.

- **Bounded retry** on the model call (`litellm num_retries=2` + exponential backoff). LiteLLM only retries its transient classes (Timeout / APIConnectionError / RateLimitError / 5xx); a 4xx is final. Matches the "outbound calls use bounded retry" invariant.
- **Quieter LiteLLM** — `suppress_debug_info` + the `LiteLLM` logger set to WARNING (it logged a banner on every call).

Ruled out: no proxy env on the API pod, so v0.50.0's #592 proxy work is **not** involved.

## 2. pgpy log noise on every signature verification
`key.verify()` prints three static `UserWarning` TODO banners (self-sigs / revocation / flags) on **every** provider-signature verification, in both the API and the runner. They're not per-verify signals (identical on a good or bad signature). Suppress pgpy's `UserWarning`s in the shared core `gpg_verify.py`; verification still **fails closed** on a bad signature. The one banner with real weight — revocation-not-checked — is documented in the code and filed as **#640** for a proper fix.

## Tests
- `_build_litellm_kwargs` carries the bounded retry (`num_retries` + `exponential_backoff_retry`).
- LiteLLM logging is quieted at import.
- `gpg_verify` installs the scoped pgpy filter (source-introspection guard — pytest manages `warnings.filters` per-test, so a runtime check is unreliable) + SHA256SUMS parsing tolerates formatting.
- Full `make test` green (2630).