### PR TITLE
feat(rbac): capability data layer + locked catalog (#585)

### DIFF
--- a/alembic/versions/e31a11e302fe_add_role_capabilities.py
+++ b/alembic/versions/e31a11e302fe_add_role_capabilities.py
@@ -1,0 +1,64 @@
+"""add role capabilities column + expand existing roles (#585)
+
+Capability-based RBAC, data layer. Adds ``roles.capabilities`` (JSONB list) and
+**expands every existing role row** into its explicit capability set via the
+shared preset map (``terrapod.auth.capabilities.expand_preset`` — the SAME map
+the roles router uses on create/update, so migration and runtime can't drift).
+
+Faithful expansion: the capability set equals exactly what the role's levels
+granted — no power added, none removed. Resolution does NOT yet read this column
+(that switch is a follow-up), so this migration is a no-op on effective access.
+
+Built-in roles (admin/audit/everyone) are not rows here; their capability sets
+live in ``terrapod.auth.capabilities`` and are applied in code.
+
+Revision ID: e31a11e302fe
+Revises: 2b369cd58093
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+from terrapod.auth.capabilities import expand_preset
+
+revision = "e31a11e302fe"
+down_revision = "2b369cd58093"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "roles",
+        sa.Column("capabilities", JSONB(), nullable=False, server_default="[]"),
+    )
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT name, workspace_permission, pool_permission, "
+            "registry_permission, catalog_permission FROM roles"
+        )
+    ).fetchall()
+    for r in rows:
+        # expand_preset is total (unknown/None values contribute nothing), so an
+        # unexpected legacy value never aborts the migration.
+        caps = expand_preset(
+            workspace_permission=r.workspace_permission,
+            pool_permission=r.pool_permission,
+            registry_permission=r.registry_permission,
+            catalog_permission=r.catalog_permission,
+        )
+        bind.execute(
+            sa.text("UPDATE roles SET capabilities = CAST(:caps AS JSONB) WHERE name = :name"),
+            {"caps": json.dumps(caps), "name": r.name},
+        )
+
+
+def downgrade() -> None:
+    # Lossy by nature (a customised capability set can't be represented as a
+    # single level); the role's level columns are untouched, so collapsing back
+    # to them is the intended behaviour.
+    op.drop_column("roles", "capabilities")

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -37,6 +37,11 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # are never loaded during a migration run.
 COPY services/terrapod/db/ ./terrapod/db/
 COPY services/terrapod/crypto/ ./terrapod/crypto/
+# The role-capabilities migration (#585) imports terrapod.auth.capabilities for
+# the shared preset map (zero-drift with the runtime). That module is
+# dependency-free and auth/__init__.py is empty, so this stays import-light.
+COPY services/terrapod/auth/__init__.py ./terrapod/auth/__init__.py
+COPY services/terrapod/auth/capabilities.py ./terrapod/auth/capabilities.py
 COPY alembic/ ./alembic/
 COPY alembic.ini ./
 

--- a/docs/rbac-capabilities.md
+++ b/docs/rbac-capabilities.md
@@ -1,0 +1,262 @@
+# Capability-based RBAC (#585)
+
+> **Status:** design contract. This document is the source of the gate →
+> capability mapping that `services/terrapod/auth/capabilities.py` encodes and
+> that the enforcement layer (a follow-up slice) checks against. It is the
+> faithfulness proof for the migration that back-fills existing roles.
+
+## Model
+
+A **capability** is a `resource:verb` token — the unit of permission. It is
+deliberately *not* an API endpoint: endpoints over-split multi-call capabilities
+(`state:write` is three endpoints) and under-split payload-polymorphic ones
+(apply vs. apply-destroy is one endpoint with a flag).
+
+A **role** carries an explicit set of capabilities. The legacy hierarchical
+levels (`workspace_permission`, `pool_permission`, `registry_permission`,
+`catalog_permission`) become **presets** over that set:
+
+- **Stored + enforced truth:** a role's `capabilities` list. There is exactly
+  one authoritative grant per role.
+- **Input sugar (write):** you may POST a preset level (`workspace-permission:
+  "plan"`); the server expands it to capabilities once, at write time, and
+  stores only the capabilities. Or you POST `capabilities` directly. Never both
+  as competing truth.
+- **Derived summary (read):** the API reports the closest preset name for a
+  role's stored capabilities (or `"custom"`), purely informational.
+
+Capabilities are strictly more expressive than the four cumulative levels
+(arbitrary subset vs. prefix), so making them the stored truth **loses
+nothing** — it only drops the guarantee that a role is one of four shapes,
+which is the point of granular RBAC.
+
+### What capabilities do and don't change
+
+Capabilities replace **what verbs** a principal may perform. They do **not**
+touch **which resources** a role applies to — that stays the existing
+label/name allow-deny scoping (`allow_labels`/`allow_names`/`deny_labels`/
+`deny_names`), resolved per resource. A role still says "on workspaces matching
+these labels"; capabilities decide what you can do once matched.
+
+The resolution **order** is unchanged (platform admin → audit → owner →
+label-RBAC → everyone-floor → none) and the kind-aware attenuation is unchanged
+(`interactive` = live roles; `service_bound` = `min(user, token)`;
+`service_detached` = token only). Capability resolution = the **union** of
+capabilities from every role that matches a resource, then (for tokens) the
+**intersection** with the token's pinned-role capabilities.
+
+## Scope of #585
+
+Capability enforcement covers the **four label-scoped axes** that custom roles
+carry: **workspace, pool, registry, catalog**. The platform-admin gates
+(`require_admin` / `require_admin_or_audit`) stay role-name based; decomposing
+the monolithic platform admin into the scoped `platform:*` capabilities is a
+deliberate follow-up (**#642**). The `platform:*` tokens are listed below for
+honesty of the built-in `admin` capability set, but are not independently
+grantable or enforced in this feature.
+
+Net-new capabilities that **no preset grants** (so no existing role gains them)
+are also out of scope here and tracked separately: a finer state-read tier
+(`state:read-outputs` / `state:read-sensitive`), separable
+`run:apply-destroy` *enforcement* (the token exists and sits in the `write`
+preset for faithfulness; gating destroy on it independently is the granular
+win, landed with enforcement), and maker-checker (#643).
+
+---
+
+## Workspace axis — gate → capability
+
+Hierarchy today: `read < plan < write < admin`. Catalog-managed workspaces clamp
+every non-platform-admin grant to `read` (unchanged; applies on top of
+capabilities).
+
+### `read` preset
+
+| Capability | Gates (method path — what it does) |
+|---|---|
+| `workspace:read` | GET workspace by id/name; GET org workspaces list (per-row filter); GET tag-bindings / effective-tag-bindings; POST/DELETE relationships/tags (no-op, gated read); GET vcs-refs |
+| `run:read` | GET run; GET workspace runs; GET run-events; GET plan/apply by id; GET plan log / json-output / apply log; GET run plan/apply (terrapod); GET+POST plan-summary, regenerate, chat messages (read-tier by design — no infra mutation); GET workspace runs SSE stream |
+| `state:read-metadata` | GET workspace state-versions list; GET current-state-version; GET state-version metadata (mints upload URL) |
+| `var:read` | GET workspace vars (sensitive values masked) |
+| `config:read` | GET configuration-versions list; GET cv download; POST cv download-ticket; GET cv diff |
+| `run-task:read` | GET workspace run-tasks; GET run-task; GET task-stages; GET task-stage |
+| `notification:read` | GET workspace notification-configurations; GET notification-configuration |
+| `run-trigger:read` | GET workspace run-triggers; GET run-trigger |
+
+### `plan` preset (adds)
+
+| Capability | Gates |
+|---|---|
+| `run:plan` | POST runs (plan-only branch: `plan_only=true`) |
+| `run:cancel` | POST runs/{id}/actions/discard; .../cancel; .../retry |
+| `workspace:lock` | POST workspaces/{id}/actions/lock; .../unlock (own lock) |
+| `state:read` | GET state-versions/{id}/download (**raw** state JSON — contains secrets) |
+| `drift:dismiss` | POST workspaces/{id}/actions/dismiss-drift |
+
+### `write` preset (adds)
+
+| Capability | Gates |
+|---|---|
+| `run:apply` | POST runs (apply branch: not plan-only); POST runs/{id}/actions/apply (confirm) |
+| `run:apply-destroy` | the same two gates **when `is_destroy=true`** (separable enforcement lands with the enforcement slice; in the `write` preset so migrated write roles keep destroy) |
+| `var:write` | POST/PATCH/DELETE workspace vars |
+| `state:write` | POST workspaces/{id}/state-versions; POST state-versions actions/upload; POST state-versions/{id}/actions/rollback |
+| `config:upload` | POST workspaces/{id}/configuration-versions |
+
+### `admin` preset (adds)
+
+| Capability | Gates |
+|---|---|
+| `workspace:settings` | PATCH workspace (settings, VCS, labels, execution mode, pool — pool reassign additionally needs `pool:assign` on the target pool) |
+| `workspace:force-unlock` | POST workspaces/{id}/actions/unlock when the lock is held by another user |
+| `workspace:delete` | DELETE workspace |
+| `state:delete` | DELETE state-versions/{id}/manage (delete a non-current state version) |
+| `notification:manage` | POST/PATCH/DELETE notification-configurations; POST .../actions/verify |
+| `run-task:manage` | POST/PATCH/DELETE run-tasks; POST task-stages/{id}/actions/override |
+| `run-trigger:manage` | POST workspaces/{id}/run-triggers; DELETE run-triggers/{id} |
+
+> **Correction vs. first draft:** variable-**set** management is *not* here — varset
+> CRUD is `require_admin` (platform), so it is a `platform:varset-admin`
+> capability, not a workspace-admin one. Putting it in the workspace-admin preset
+> would have falsely granted it to workspace-admin roles.
+
+---
+
+## Pool axis — gate → capability
+
+Hierarchy `read < write < admin`.
+
+| Preset | Capability | Gates |
+|---|---|---|
+| read | `pool:read` | GET agent-pools (filter); GET pool; GET pool listeners; GET pool events SSE |
+| write | `pool:assign` | assign a pool to a workspace — checked in POST workspace create + PATCH workspace + catalog provision (in addition to workspace admin / catalog use) |
+| admin | `pool:manage` | PATCH pool; DELETE pool; GET/POST/DELETE pool tokens; DELETE listener |
+
+Pool **creation** (POST agent-pools) is `require_admin` → `platform:pool-admin`,
+not a pool-RBAC level. Orphan-listener cleanup also falls back to platform admin.
+
+---
+
+## Registry axis — gate → capability
+
+Hierarchy `read < write < admin`. (Runner tokens get an implicit `read` floor —
+unchanged, lives in `registry_rbac_service`.)
+
+| Preset | Capability | Gates |
+|---|---|---|
+| read | `registry:read` | CLI list/download (modules + providers); GET module/provider show, interface, versions, platforms, workspace-links |
+| write | `registry:write` | POST module versions; PUT module upload; PUT provider shasums / shasums.sig / platform binary |
+| admin | `registry:admin` | DELETE module/provider/version/platform; PATCH module/provider (labels) — **owner reassignment additionally requires platform admin**; PATCH module vcs; POST/DELETE workspace-links |
+
+`platform:registry-admin` (not registry-RBAC) covers: binary-cache + provider-cache
+admin endpoints, and registry resource **owner** reassignment. **Gap flagged:**
+`gpg_keys.py` CRUD is currently authenticated-only (no registry or admin gate) —
+a pre-existing surface noted for follow-up, not changed by the faithful migration.
+
+---
+
+## Catalog axis — gate → capability
+
+Hierarchy `read < use < admin`. No `everyone` floor; `none` grants nothing
+(opt-in). Unchanged here.
+
+| Preset | Capability | Gates |
+|---|---|---|
+| read | `catalog:read` | GET catalog-items (filter); GET item; GET item form; GET item instances; GET instance |
+| use | `catalog:use` | POST item provision (also needs `pool:assign`); PATCH instance reconfigure; POST instance destroy/confirm/discard |
+| admin | `catalog:admin` | DELETE catalog-instance (orphan-delete) |
+
+Catalog **item** authoring (POST/PATCH/DELETE catalog-items) and
+**provider-templates** are `require_admin` → `platform:catalog-admin`, not
+catalog-RBAC.
+
+---
+
+## Platform capabilities (informational; enforced via role-name until #642)
+
+`platform:role-admin`, `platform:vcs-admin`, `platform:pool-admin`,
+`platform:registry-admin`, `platform:varset-admin`, `platform:user-admin`,
+`platform:audit-admin`, `platform:policy-admin`,
+`platform:autodiscovery-admin`, `platform:catalog-admin`,
+`platform:bulk-admin`, `platform:settings-admin`.
+
+These enumerate every `require_admin` / `require_admin_or_audit` surface in the
+API (roles, role-assignments, vcs-connections, pool create, binary/provider
+cache, GPG/owner reassign, variable sets, users, audit log, policy sets,
+autodiscovery rules, catalog items + provider templates, workspace bulk ops,
+encryption settings). They are the target vocabulary for #642.
+
+---
+
+## Built-in roles (code, not DB rows)
+
+| Role | Capabilities |
+|---|---|
+| `admin` | every grantable capability ∪ every `platform:*` (admin bypasses RBAC; this is the honest description) |
+| `audit` | every `*:read` / `*:read-metadata` capability across the four axes + `platform:audit-admin` (read the audit log) |
+| `everyone` | the `read` workspace preset, granted only on resources labelled `access: everyone` |
+
+---
+
+## Enforcement contract (obligations for the resolution-switch slice)
+
+The data layer (this slice) records capabilities and exposes them read-only;
+levels are still enforced, so behaviour is byte-identical. When the enforcement
+slice flips resolution from a scalar level to a capability set, it MUST honour
+the following — these are the holes an independent review flagged that a naive
+"level → preset set" translation would silently re-introduce:
+
+1. **Per-gate capability, never "set ⊇ preset".** Each route gate maps to
+   exactly ONE capability (the verb it performs) and checks
+   `has_capability(caps, THAT_CAP)`. Translating `has_permission(perm, "write")`
+   on `POST /runs` to "holds the whole write preset" would deny a future
+   granular role that legitimately holds only the relevant verb, and re-couple
+   the levels the feature exists to decouple. The faithfulness test asserts
+   **per gate**, not per level.
+2. **`has_permission(effective, required)` → `has_capability(caps, CAP)`.** Keep
+   a single membership primitive (`capabilities.has_capability`); the ~40 gate
+   sites become a mechanical swap of the level string for the gate's capability
+   constant.
+3. **Resolution = union, attenuation = intersection.** A principal's caps on a
+   resource = the union of capabilities from every role that matches it. Token
+   attenuation: `service_bound` = `user_caps ∩ token_caps`; `service_detached` =
+   `token_caps` only; the everyone-floor contributes exactly the workspace
+   `read` preset to the **user** side only (mirroring `apply_everyone_floor`).
+   For migrated (preset-only) roles this is provably identical to today's
+   scalar-max / `min(level)` because the per-axis presets are cumulative.
+4. **Catalog-managed clamp = intersect with the read preset.** Replace
+   `if PERMISSION_HIERARCHY[best] > 0: best = "read"` with
+   `resolved_caps &= _WORKSPACE_LEVELS["read"]`, applied at the same point
+   (after union + everyone-floor, before return). Do **not** reimplement it as a
+   string-suffix heuristic (`endswith(":read")`).
+5. **Self-lockout guard = set difference, not total-order `<`.** Capability sets
+   are a partial order. Replace "would my level drop?"
+   (`PERMISSION_HIERARCHY[new] < PERMISSION_HIERARCHY[old]`) with "would the edit
+   remove any capability I hold?" (`if old_caps - new_caps: 409`). The four 409
+   sites (tfe_v2 workspace label edit, agent_pools, registry module/provider
+   owner-change) also interpolate the old/new level strings into the message —
+   switch those to the derived summary name or the removed-capability list.
+6. **Serialized `can-*` flags become capability-membership.** The 12 workspace
+   `can-*` flags (`tfe_v2.py`), and registry `can-*`, map each to its capability.
+   Note `can-force-unlock` shifts meaning from "is admin" to "has
+   `workspace:force-unlock`" — permissive, acceptable in beta, but documented.
+   Org/account entitlements stay platform-role based (unchanged).
+7. **Levels become a derived summary on read.** Capabilities are the stored
+   truth; the level columns are recomputed from `summarize_capabilities(caps)`
+   on every write (a denormalised cache, not a second source of truth) so
+   consumers that still read the level fields keep working until they migrate.
+8. **Forward-compat.** Load and write-validate stored sets through
+   `normalize_capabilities` (alias-upgrade legacy tokens) so a capability
+   rename/split never silently drops a grant or traps a role uneditable.
+
+## Faithfulness invariant (the test that proves the migration)
+
+For **every** combination of legacy levels a role can hold,
+`expand_preset(...)` must equal *exactly* the set of capabilities for the gates
+that level combination grants today — no capability lost, none gained. The
+enforcement slice ships an **effective-permission before/after** test anchored
+to the real route-gate sites: for each existing role shape, the set of gates it
+passes under level-based resolution must be identical to the set it passes under
+capability resolution. That, plus the no-retroactive-tightening rule (we are in
+beta), is the guarantee that turning capabilities on changes nothing for
+existing roles while making finer grants newly possible.

--- a/go-terrapod/roles.go
+++ b/go-terrapod/roles.go
@@ -30,6 +30,11 @@ type Role struct {
 	RegistryPermission  string `json:"registry-permission,omitempty"` // read | write | admin (modules + providers)
 	CatalogPermission   string `json:"catalog-permission,omitempty"`  // none | read | use | admin
 
+	// Capabilities is the explicit capability set the permission levels above
+	// expand to (#585). Read-only for now (server-derived from the levels);
+	// direct capability authoring is a later slice.
+	Capabilities []string `json:"capabilities,omitempty"`
+
 	BuiltIn   bool   `json:"built-in"`
 	CreatedAt string `json:"created-at,omitempty"`
 	UpdatedAt string `json:"updated-at,omitempty"`

--- a/services/terrapod/api/routers/roles.py
+++ b/services/terrapod/api/routers/roles.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, require_admin, require_admin_or_audit
 from terrapod.auth.builtin_roles import BUILTIN_ROLES, is_builtin_role
+from terrapod.auth.capabilities import capabilities_for_builtin
 from terrapod.db.models import Role
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -57,6 +58,10 @@ def _role_json(role: Role) -> dict:
             "pool-permission": role.pool_permission,
             "registry-permission": role.registry_permission,
             "catalog-permission": role.catalog_permission,
+            # The explicit capability set this role grants (#585). Existing roles
+            # were back-filled from their permission levels by the migration;
+            # going forward new roles are authored with capabilities directly.
+            "capabilities": role.capabilities,
             "built-in": False,
             "created-at": _rfc3339(role.created_at),
             "updated-at": _rfc3339(role.updated_at),
@@ -82,6 +87,7 @@ def _builtin_role_json(name: str, info: dict) -> dict:
             "catalog-permission": (
                 "admin" if name == "admin" else "read" if name == "audit" else "none"
             ),
+            "capabilities": capabilities_for_builtin(name),
             "built-in": True,
             "created-at": "",
             "updated-at": "",

--- a/services/terrapod/auth/capabilities.py
+++ b/services/terrapod/auth/capabilities.py
@@ -1,0 +1,346 @@
+"""Capability catalog + preset expansion for capability-based RBAC (#585).
+
+The capability is the unit of permission (resource × verb), NOT an API endpoint
+(endpoints over-split multi-call capabilities like ``state:write`` and
+under-split payload-polymorphic ones like apply-vs-apply-destroy). Roles carry an
+explicit set of capabilities; the legacy hierarchical levels
+(``workspace_permission`` etc.) become **presets** over this set.
+
+This module is the single source of truth for the legacy-level → capability
+mapping. It is used by BOTH:
+  * the Alembic migration that expands existing role rows, and
+  * the roles router, when a role is written with the legacy level fields
+    (presets are input sugar that expand on write; capabilities are the stored,
+    enforced truth).
+so the two can never drift.
+
+FAITHFULNESS CONTRACT (the reason every token below is pinned to a tier):
+Each capability maps to exactly one real route gate, and every preset level is
+the *union of the capabilities for every gate at or below that level today*. So
+``expand_preset(workspace_permission="plan", ...)`` grants precisely what a
+``plan`` role can do now — no more, no less. The mapping is grounded in the
+actual ``has_permission`` / ``_require_ws_permission`` / ``has_pool_permission``
+/ ``has_registry_permission`` / ``has_catalog_permission`` gate sites; see
+``docs/rbac-capabilities.md`` for the full gate→capability table this is
+derived from.
+
+SCOPE (#585): capability enforcement covers the FOUR label-scoped axes that
+custom roles actually carry — workspace, pool, registry, catalog. The
+platform-admin gates (``require_admin`` / ``require_admin_or_audit``) stay
+role-name based; decomposing the monolithic platform admin into the scoped
+``platform:*`` capabilities below is a deliberate follow-up (#642), so those
+tokens are listed for honesty of the built-in ``admin`` capability set but are
+NOT independently grantable or enforced yet.
+"""
+
+from __future__ import annotations
+
+# ── Catalog ───────────────────────────────────────────────────────────────────
+# A capability is "<resource>:<verb>". Keep this list as the authoritative
+# enumeration; new endpoints map onto an existing capability or add one here
+# deliberately. Net-new capabilities that no legacy preset grants until an admin
+# opts in (state:read-outputs / state:read-sensitive tier; the scoped platform:*
+# split #642; maker-checker #643) are introduced by their own follow-ups.
+
+# ── Workspace / runs — read tier ────────────────────────────────────────────
+# Per-resource read caps (each paired with a write/manage cap below, so an
+# operator can grant read-only on one resource type independently). Today's
+# "read" level grants ALL of them.
+WORKSPACE_READ = "workspace:read"  # show/list workspace, vcs-refs, tag-bindings
+RUN_READ = "run:read"  # runs, plans, applies, run-events, AI summary+chat, SSE
+STATE_READ_METADATA = "state:read-metadata"  # list/show state versions, current
+VAR_READ = "var:read"  # list variables (values masked when sensitive)
+CONFIG_READ = "config:read"  # list/download configuration versions, diff, ticket
+RUN_TASK_READ = "run-task:read"  # list/show run tasks + task stages
+NOTIFICATION_READ = "notification:read"  # list/show notification configs
+RUN_TRIGGER_READ = "run-trigger:read"  # list/show run triggers
+
+# ── Workspace / runs — plan tier ────────────────────────────────────────────
+RUN_PLAN = "run:plan"  # create a plan-only run
+RUN_CANCEL = "run:cancel"  # discard / cancel / retry a run
+WORKSPACE_LOCK = "workspace:lock"  # lock / unlock own lock (state lock)
+STATE_READ = "state:read"  # download RAW state JSON (contains secrets)
+DRIFT_DISMISS = "drift:dismiss"  # dismiss a workspace drift flag
+
+# ── Workspace / runs — write tier ───────────────────────────────────────────
+RUN_APPLY = "run:apply"  # create an apply-capable run + confirm apply
+RUN_APPLY_DESTROY = "run:apply-destroy"  # create/confirm a destroy run (is_destroy)
+VAR_WRITE = "var:write"  # create / update / delete variables
+STATE_WRITE = "state:write"  # create state version, manual upload, rollback
+CONFIG_UPLOAD = "config:upload"  # create a configuration version
+
+# ── Workspace / runs — admin tier ───────────────────────────────────────────
+WORKSPACE_SETTINGS = "workspace:settings"  # PATCH workspace (settings/VCS/labels/pool)
+WORKSPACE_FORCE_UNLOCK = "workspace:force-unlock"  # unlock a lock held by someone else
+WORKSPACE_DELETE = "workspace:delete"  # delete the workspace
+STATE_DELETE = "state:delete"  # delete a non-current state version
+NOTIFICATION_MANAGE = "notification:manage"  # create/update/delete/verify notif configs
+RUN_TASK_MANAGE = "run-task:manage"  # create/update/delete run tasks + stage override
+RUN_TRIGGER_MANAGE = "run-trigger:manage"  # create/delete run triggers
+
+# ── Pool ────────────────────────────────────────────────────────────────────
+POOL_READ = "pool:read"  # show pool, list listeners, pool event stream
+POOL_ASSIGN = "pool:assign"  # assign the pool to a workspace (write tier)
+POOL_MANAGE = "pool:manage"  # update/delete pool, manage join tokens, delete listeners
+
+# ── Registry ────────────────────────────────────────────────────────────────
+REGISTRY_READ = "registry:read"  # list/show/download modules + providers
+REGISTRY_WRITE = "registry:write"  # create versions, upload tarballs/binaries
+REGISTRY_ADMIN = "registry:admin"  # delete modules/providers/versions, VCS, links
+
+# ── Catalog ─────────────────────────────────────────────────────────────────
+CATALOG_READ = "catalog:read"  # browse catalog items + own instances
+CATALOG_USE = "catalog:use"  # provision / reconfigure / destroy an instance
+CATALOG_ADMIN = "catalog:admin"  # orphan-delete an instance (item authoring is platform)
+
+# ── Platform (informational only until #642 — NOT yet enforced/grantable) ────
+# The monolithic platform admin's constituent powers, grouped by the survey of
+# require_admin gates. Listed so capabilities_for_builtin("admin") is honest and
+# the scoped split (#642) has its target vocabulary; platform gates stay
+# role-name based in this feature.
+PLATFORM_ROLE_ADMIN = "platform:role-admin"  # roles + role assignments
+PLATFORM_VCS_ADMIN = "platform:vcs-admin"  # VCS connections
+PLATFORM_POOL_ADMIN = "platform:pool-admin"  # create agent pools, orphan-listener cleanup
+PLATFORM_REGISTRY_ADMIN = (
+    "platform:registry-admin"  # binary/provider cache, GPG keys, owner reassign
+)
+PLATFORM_VARSET_ADMIN = "platform:varset-admin"  # variable sets (org-scoped)
+PLATFORM_USER_ADMIN = "platform:user-admin"  # user CRUD + password reset
+PLATFORM_AUDIT_ADMIN = "platform:audit-admin"  # read the audit log
+PLATFORM_POLICY_ADMIN = "platform:policy-admin"  # OPA policy sets
+PLATFORM_AUTODISCOVERY_ADMIN = "platform:autodiscovery-admin"  # autodiscovery rules
+PLATFORM_CATALOG_ADMIN = "platform:catalog-admin"  # catalog item + provider-template authoring
+PLATFORM_BULK_ADMIN = "platform:bulk-admin"  # bulk workspace operations
+PLATFORM_SETTINGS_ADMIN = "platform:settings-admin"  # platform settings (e.g. state-encryption)
+
+PLATFORM_CAPABILITIES: frozenset[str] = frozenset(
+    {
+        PLATFORM_ROLE_ADMIN,
+        PLATFORM_VCS_ADMIN,
+        PLATFORM_POOL_ADMIN,
+        PLATFORM_REGISTRY_ADMIN,
+        PLATFORM_VARSET_ADMIN,
+        PLATFORM_USER_ADMIN,
+        PLATFORM_AUDIT_ADMIN,
+        PLATFORM_POLICY_ADMIN,
+        PLATFORM_AUTODISCOVERY_ADMIN,
+        PLATFORM_CATALOG_ADMIN,
+        PLATFORM_BULK_ADMIN,
+        PLATFORM_SETTINGS_ADMIN,
+    }
+)
+
+# ── Per-axis level → capability maps (cumulative: each level ⊇ lower) ──────────
+# Faithful to today's enforced gates (verified against the routers' has_permission
+# / _require_ws_permission sites; see docs/rbac-capabilities.md for the full
+# gate→capability table and the #585 before/after proof).
+
+_WORKSPACE_LEVELS: dict[str, frozenset[str]] = {
+    "read": frozenset(
+        {
+            WORKSPACE_READ,
+            RUN_READ,
+            STATE_READ_METADATA,
+            VAR_READ,
+            CONFIG_READ,
+            RUN_TASK_READ,
+            NOTIFICATION_READ,
+            RUN_TRIGGER_READ,
+        }
+    ),
+}
+_WORKSPACE_LEVELS["plan"] = _WORKSPACE_LEVELS["read"] | {
+    RUN_PLAN,
+    RUN_CANCEL,
+    WORKSPACE_LOCK,
+    STATE_READ,
+    DRIFT_DISMISS,
+}
+_WORKSPACE_LEVELS["write"] = _WORKSPACE_LEVELS["plan"] | {
+    RUN_APPLY,
+    RUN_APPLY_DESTROY,
+    VAR_WRITE,
+    STATE_WRITE,
+    CONFIG_UPLOAD,
+}
+_WORKSPACE_LEVELS["admin"] = _WORKSPACE_LEVELS["write"] | {
+    WORKSPACE_SETTINGS,
+    WORKSPACE_FORCE_UNLOCK,
+    WORKSPACE_DELETE,
+    STATE_DELETE,
+    NOTIFICATION_MANAGE,
+    RUN_TASK_MANAGE,
+    RUN_TRIGGER_MANAGE,
+}
+
+_POOL_LEVELS: dict[str, frozenset[str]] = {
+    "read": frozenset({POOL_READ}),
+    "write": frozenset({POOL_READ, POOL_ASSIGN}),
+    "admin": frozenset({POOL_READ, POOL_ASSIGN, POOL_MANAGE}),
+}
+
+_REGISTRY_LEVELS: dict[str, frozenset[str]] = {
+    "read": frozenset({REGISTRY_READ}),
+    "write": frozenset({REGISTRY_READ, REGISTRY_WRITE}),
+    "admin": frozenset({REGISTRY_READ, REGISTRY_WRITE, REGISTRY_ADMIN}),
+}
+
+_CATALOG_LEVELS: dict[str, frozenset[str]] = {
+    "none": frozenset(),
+    "read": frozenset({CATALOG_READ}),
+    "use": frozenset({CATALOG_READ, CATALOG_USE}),
+    "admin": frozenset({CATALOG_READ, CATALOG_USE, CATALOG_ADMIN}),
+}
+
+# Full enumeration of every grantable (label-scoped) capability — the union of
+# all four axes' top levels. Used to validate capability lists on role write
+# (reject unknown / not-yet-grantable tokens like platform:* and the net-new
+# sensitive-state tier) and by tests asserting the catalog is complete.
+GRANTABLE_CAPABILITIES: frozenset[str] = frozenset(
+    _WORKSPACE_LEVELS["admin"]
+    | _POOL_LEVELS["admin"]
+    | _REGISTRY_LEVELS["admin"]
+    | _CATALOG_LEVELS["admin"]
+)
+
+
+# ── Forward-compat: capability aliases ────────────────────────────────────────
+# Roles store a frozen snapshot of capability strings in JSONB. If a future
+# release renames or splits a capability, stored roles still carry the OLD token.
+# To avoid silently dropping it (retroactive tightening — forbidden) or trapping
+# the role uneditable on the next write-path validation (the #316 reserved-label
+# failure mode), every stored set is run through ``normalize_capabilities`` at
+# load AND before write-validation: legacy tokens are upgraded to their current
+# equivalent(s) here. Empty until the first rename; e.g. a future split would be
+#   "state:read": frozenset({"state:read-outputs", "state:read-sensitive"}).
+CAPABILITY_ALIASES: dict[str, frozenset[str]] = {}
+
+
+def normalize_capabilities(caps: list[str] | set[str] | frozenset[str]) -> list[str]:
+    """Upgrade any legacy/aliased capability tokens to their current form.
+
+    Applied at load and before write-validation so a role written under an older
+    catalog keeps working after a capability rename/split. Unknown tokens with no
+    alias are preserved (never silently dropped — that would tighten the role);
+    write-path validation decides whether a still-unknown token is a hard error.
+    Returns a sorted, de-duplicated list.
+    """
+    out: set[str] = set()
+    for c in caps:
+        if c in CAPABILITY_ALIASES:
+            out |= CAPABILITY_ALIASES[c]
+        else:
+            out.add(c)
+    return sorted(out)
+
+
+def has_capability(caps: frozenset[str] | set[str], required: str) -> bool:
+    """Canonical capability membership check (the enforcement primitive).
+
+    ENFORCEMENT CONTRACT: a route gate maps to exactly ONE capability — the verb
+    it performs — and checks membership of THAT capability, e.g.
+    ``has_capability(caps, RUN_PLAN)`` for queue-plan. It does NOT check "holds
+    the whole write preset", which would re-introduce the cumulative coupling
+    this feature removes. The faithfulness test asserts per-gate, not per-level.
+    """
+    return required in caps
+
+
+def expand_preset(
+    *,
+    workspace_permission: str | None,
+    pool_permission: str | None,
+    registry_permission: str | None,
+    catalog_permission: str | None,
+) -> list[str]:
+    """Expand the legacy hierarchical levels into the explicit capability set.
+
+    The union of the per-axis level expansions. Unknown/None values contribute
+    nothing (defensive — the migration must never throw on an unexpected stored
+    value). Returns a sorted list (stable on disk / in JSON).
+    """
+    caps: set[str] = set()
+    caps |= _WORKSPACE_LEVELS.get((workspace_permission or "").strip(), frozenset())
+    caps |= _POOL_LEVELS.get((pool_permission or "").strip(), frozenset())
+    caps |= _REGISTRY_LEVELS.get((registry_permission or "").strip(), frozenset())
+    caps |= _CATALOG_LEVELS.get((catalog_permission or "").strip(), frozenset())
+    return sorted(caps)
+
+
+# ── Inverse: capability set → derived preset summary ──────────────────────────
+# The reverse of expand_preset, for the read side. Capabilities are the stored
+# truth; the legacy level fields become a DERIVED, denormalised summary (the
+# closest preset name per axis, or "custom"). Consumers that still read the level
+# fields (go-terrapod, the provider's terrapod_role, the web roles page) get a
+# faithful summary; granular sets that don't match a preset render "custom".
+
+_AXIS_LEVELS: dict[str, dict[str, frozenset[str]]] = {
+    "workspace_permission": _WORKSPACE_LEVELS,
+    "pool_permission": _POOL_LEVELS,
+    "registry_permission": _REGISTRY_LEVELS,
+    "catalog_permission": _CATALOG_LEVELS,
+}
+# The capabilities owned by each axis (union of that axis' top preset) — used to
+# slice a role's full set down to one axis before matching it to a preset.
+_AXIS_CAPS: dict[str, frozenset[str]] = {
+    axis: frozenset().union(*levels.values()) for axis, levels in _AXIS_LEVELS.items()
+}
+
+
+def summarize_capabilities(caps: list[str] | set[str] | frozenset[str]) -> dict[str, str]:
+    """Derive the legacy per-axis level summary from a capability set.
+
+    For each axis, slice the role's caps to that axis and find the preset whose
+    expansion equals the slice exactly; if none matches, the axis is ``"custom"``.
+    An empty slice maps to the axis' bottom level (``"none"`` for catalog, which
+    is genuinely empty; ``"read"`` for the others is the floor preset — note an
+    empty workspace slice means the role grants NO workspace caps, which is below
+    even ``read``, so it is reported as ``custom`` to avoid implying a read grant).
+    """
+    cap_set = set(caps)
+    summary: dict[str, str] = {}
+    for axis, levels in _AXIS_LEVELS.items():
+        slice_caps = frozenset(cap_set & _AXIS_CAPS[axis])
+        match = next((name for name, exp in levels.items() if exp == slice_caps), None)
+        if match is not None:
+            summary[axis] = match
+        elif not slice_caps:
+            # Empty slice with no "empty preset": only catalog has one ("none").
+            summary[axis] = "none" if "none" in levels else "custom"
+        else:
+            summary[axis] = "custom"
+    return summary
+
+
+# ── Built-in role capability sets (built-ins are code, not DB rows) ────────────
+# Defined here so they get the same catalog. `admin` is the superuser preset =
+# every grantable capability PLUS every platform:* power (admin bypasses RBAC
+# entirely, so this set is the honest description of what it can do).
+
+_AUDIT_CAPS = frozenset(
+    {
+        WORKSPACE_READ,
+        RUN_READ,
+        STATE_READ_METADATA,
+        VAR_READ,
+        CONFIG_READ,
+        RUN_TASK_READ,
+        NOTIFICATION_READ,
+        RUN_TRIGGER_READ,
+        POOL_READ,
+        REGISTRY_READ,
+        CATALOG_READ,
+        PLATFORM_AUDIT_ADMIN,
+    }
+)
+
+_BUILTIN_CAPS: dict[str, list[str]] = {
+    "admin": sorted(GRANTABLE_CAPABILITIES | PLATFORM_CAPABILITIES),
+    "audit": sorted(_AUDIT_CAPS),
+    "everyone": sorted(_WORKSPACE_LEVELS["read"]),  # read floor under access:everyone
+}
+
+
+def capabilities_for_builtin(name: str) -> list[str]:
+    """Capability set for a built-in role (admin / audit / everyone)."""
+    return list(_BUILTIN_CAPS.get(name, []))

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -115,6 +115,18 @@ class Role(Base):
         String(20), nullable=False, default="none", server_default="none"
     )  # none, read, use, admin
 
+    # Explicit capability set (#585). Expanded from the level fields above via
+    # the shared preset map (terrapod.auth.capabilities.expand_preset) at write
+    # time and by the role-expansion migration. Source of truth for capability-
+    # based resolution; the level columns remain as the preset inputs. JSONB list
+    # of "<resource>:<verb>" strings; never indexed/unique.
+    # server_default mirrors the migration so schemas built from metadata
+    # (integration tests, which bypass the ORM Python default on raw inserts)
+    # also default to an empty list instead of violating NOT NULL.
+    capabilities: Mapped[list[str]] = mapped_column(
+        JSONB, default=list, server_default="[]", nullable=False
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False
     )

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -40,6 +40,16 @@ def _mock_role(name="dev-team", ws_perm="read", reg_perm="read", catalog_perm="n
     role.pool_permission = "read"
     role.registry_permission = reg_perm
     role.catalog_permission = catalog_perm
+    # Capabilities are expanded from the levels (#585); set a real list so the
+    # mock serialises (an unset MagicMock attr isn't JSON-serialisable).
+    from terrapod.auth.capabilities import expand_preset
+
+    role.capabilities = expand_preset(
+        workspace_permission=ws_perm,
+        pool_permission="read",
+        registry_permission=reg_perm,
+        catalog_permission=catalog_perm,
+    )
     role.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     role.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     return role

--- a/services/tests/auth/test_capabilities.py
+++ b/services/tests/auth/test_capabilities.py
@@ -1,0 +1,234 @@
+"""Capability catalog + preset-expansion tests (#585, data layer).
+
+The expansion is the migration contract: each level expands to exactly what it
+grants, and is a faithful superset of the level below. (Enforcement still uses
+the levels in this phase; the route-gate-anchored equality test arrives with the
+PR that switches resolution to capabilities.)
+"""
+
+from terrapod.auth import capabilities as cap
+
+
+def _ws(level):
+    return set(
+        cap.expand_preset(
+            workspace_permission=level,
+            pool_permission=None,
+            registry_permission=None,
+            catalog_permission=None,
+        )
+    )
+
+
+def test_workspace_levels_are_cumulative():
+    read, plan, write, admin = _ws("read"), _ws("plan"), _ws("write"), _ws("admin")
+    assert read < plan < write < admin, (
+        "each workspace level must be a strict superset of the one below"
+    )
+
+
+def test_workspace_read_tier_membership():
+    read = _ws("read")
+    # Per-resource read caps (each paired with a write/manage cap), but NOT raw
+    # state read (that is plan-tier) or any verb above read.
+    assert {
+        cap.WORKSPACE_READ,
+        cap.RUN_READ,
+        cap.STATE_READ_METADATA,
+        cap.VAR_READ,
+        cap.CONFIG_READ,
+        cap.RUN_TASK_READ,
+        cap.NOTIFICATION_READ,
+        cap.RUN_TRIGGER_READ,
+    } == read
+    assert cap.STATE_READ not in read and cap.RUN_PLAN not in read
+
+
+def test_workspace_plan_tier_membership():
+    plan = _ws("plan")
+    # plan adds: queue plan-only, cancel/discard/retry, lock, raw state read,
+    # drift dismiss. Raw state download == plan today (it contains secrets).
+    assert {
+        cap.RUN_PLAN,
+        cap.RUN_CANCEL,
+        cap.WORKSPACE_LOCK,
+        cap.STATE_READ,
+        cap.DRIFT_DISMISS,
+    } <= plan
+    assert cap.RUN_APPLY not in plan and cap.STATE_WRITE not in plan
+
+
+def test_workspace_write_tier_membership():
+    write = _ws("write")
+    assert {
+        cap.RUN_APPLY,
+        cap.RUN_APPLY_DESTROY,
+        cap.VAR_WRITE,
+        cap.STATE_WRITE,
+        cap.CONFIG_UPLOAD,
+    } <= write
+    assert cap.WORKSPACE_SETTINGS not in write and cap.WORKSPACE_DELETE not in write
+
+
+def test_workspace_admin_tier_membership():
+    admin = _ws("admin")
+    # admin adds: settings, force-unlock, delete, delete-state-version, and the
+    # three per-workspace resource managers (notification / run-task / run-trigger).
+    assert {
+        cap.WORKSPACE_SETTINGS,
+        cap.WORKSPACE_FORCE_UNLOCK,
+        cap.WORKSPACE_DELETE,
+        cap.STATE_DELETE,
+        cap.NOTIFICATION_MANAGE,
+        cap.RUN_TASK_MANAGE,
+        cap.RUN_TRIGGER_MANAGE,
+    } <= admin
+    # Variable SETS are platform-admin gated, not workspace-admin — they must NOT
+    # leak into the workspace preset (this was a draft bug the gate survey caught).
+    assert cap.PLATFORM_VARSET_ADMIN not in admin
+    # No platform capability is ever in a label-scoped preset.
+    assert not (admin & cap.PLATFORM_CAPABILITIES)
+
+
+def test_other_axes_expand_and_are_cumulative():
+    pool_admin = set(
+        cap.expand_preset(
+            workspace_permission=None,
+            pool_permission="admin",
+            registry_permission=None,
+            catalog_permission=None,
+        )
+    )
+    assert {cap.POOL_READ, cap.POOL_ASSIGN, cap.POOL_MANAGE} == pool_admin
+    reg = set(
+        cap.expand_preset(
+            workspace_permission=None,
+            pool_permission=None,
+            registry_permission="write",
+            catalog_permission=None,
+        )
+    )
+    assert reg == {cap.REGISTRY_READ, cap.REGISTRY_WRITE}
+    # catalog "none" grants nothing (opt-in axis, no floor)
+    assert (
+        cap.expand_preset(
+            workspace_permission=None,
+            pool_permission=None,
+            registry_permission=None,
+            catalog_permission="none",
+        )
+        == []
+    )
+    cat = set(
+        cap.expand_preset(
+            workspace_permission=None,
+            pool_permission=None,
+            registry_permission=None,
+            catalog_permission="admin",
+        )
+    )
+    assert cat == {cap.CATALOG_READ, cap.CATALOG_USE, cap.CATALOG_ADMIN}
+
+
+def test_expand_is_total_and_sorted():
+    # Unknown / None values contribute nothing — the migration must never throw.
+    out = cap.expand_preset(
+        workspace_permission="bogus",
+        pool_permission=None,
+        registry_permission="",
+        catalog_permission="also-bogus",
+    )
+    assert out == []
+    # Deterministic sorted output (stable on disk / in JSON).
+    full = cap.expand_preset(
+        workspace_permission="admin",
+        pool_permission="admin",
+        registry_permission="admin",
+        catalog_permission="admin",
+    )
+    assert full == sorted(full)
+
+
+def test_grantable_is_full_preset_union_and_platform_free():
+    # The grantable set is exactly the union of every axis' top preset...
+    full = set(
+        cap.expand_preset(
+            workspace_permission="admin",
+            pool_permission="admin",
+            registry_permission="admin",
+            catalog_permission="admin",
+        )
+    )
+    assert set(cap.GRANTABLE_CAPABILITIES) == full
+    # ...and contains no platform:* token (those are #642, not yet grantable).
+    assert not (cap.GRANTABLE_CAPABILITIES & cap.PLATFORM_CAPABILITIES)
+
+
+def test_summarize_is_inverse_of_expand_for_every_preset_combo():
+    # expand → summarize must round-trip to the original level tuple for every
+    # combination of presets (the derived-summary read contract).
+    ws_levels = ["read", "plan", "write", "admin"]
+    other_levels = ["read", "write", "admin"]
+    cat_levels = ["none", "read", "use", "admin"]
+    for w in ws_levels:
+        for p in other_levels:
+            for r in other_levels:
+                for c in cat_levels:
+                    caps = cap.expand_preset(
+                        workspace_permission=w,
+                        pool_permission=p,
+                        registry_permission=r,
+                        catalog_permission=c,
+                    )
+                    summary = cap.summarize_capabilities(caps)
+                    assert summary == {
+                        "workspace_permission": w,
+                        "pool_permission": p,
+                        "registry_permission": r,
+                        "catalog_permission": c,
+                    }, f"round-trip failed for {(w, p, r, c)}: {summary}"
+
+
+def test_summarize_reports_custom_for_granular_set():
+    # A genuine subset that matches no preset must render "custom", not a preset.
+    granular = [cap.RUN_READ, cap.VAR_READ]  # workspace read is a strict superset
+    summary = cap.summarize_capabilities(granular)
+    assert summary["workspace_permission"] == "custom"
+    # Empty axes still resolve: catalog → "none", workspace (no empty preset) → custom.
+    assert summary["catalog_permission"] == "none"
+    assert summary["pool_permission"] == "none" or summary["pool_permission"] == "custom"
+
+
+def test_normalize_preserves_unknown_and_dedups():
+    # No aliases registered yet → identity (sorted, deduped).
+    assert cap.normalize_capabilities([cap.RUN_READ, cap.RUN_READ, cap.VAR_READ]) == sorted(
+        {cap.RUN_READ, cap.VAR_READ}
+    )
+    # Unknown tokens are preserved (never silently dropped — that would tighten).
+    assert "future:unknown" in cap.normalize_capabilities([cap.RUN_READ, "future:unknown"])
+
+
+def test_has_capability_is_membership():
+    caps = frozenset(_ws("plan"))
+    assert cap.has_capability(caps, cap.RUN_PLAN)
+    assert not cap.has_capability(caps, cap.RUN_APPLY)
+
+
+def test_builtin_capability_sets():
+    admin = set(cap.capabilities_for_builtin("admin"))
+    audit = set(cap.capabilities_for_builtin("audit"))
+    everyone = set(cap.capabilities_for_builtin("everyone"))
+
+    # admin = superuser: every grantable capability + every platform capability.
+    assert cap.PLATFORM_CAPABILITIES <= admin
+    assert cap.GRANTABLE_CAPABILITIES <= admin
+    # audit = read-only everywhere + the (read-only) audit-log power; no
+    # write/manage caps and no platform capability other than audit-admin.
+    assert {cap.WORKSPACE_READ, cap.POOL_READ, cap.REGISTRY_READ, cap.CATALOG_READ} <= audit
+    assert cap.PLATFORM_AUDIT_ADMIN in audit
+    assert not (audit & {cap.STATE_WRITE, cap.VAR_WRITE, cap.RUN_APPLY, cap.WORKSPACE_DELETE})
+    assert not (audit & (cap.PLATFORM_CAPABILITIES - {cap.PLATFORM_AUDIT_ADMIN}))
+    assert cap.STATE_READ not in audit  # audit never downloads raw state
+    # everyone = the read floor.
+    assert everyone == _ws("read")
+    assert cap.STATE_READ not in everyone


### PR DESCRIPTION
First slice of capability-based RBAC (#585). **Provable no-op:** resolution still uses the legacy permission levels; capabilities are recorded and exposed read-only. Nothing reads the new column yet.

This is the data layer **plus** the locked capability catalog that the rest of the feature builds on. No release until granular RBAC is fully implemented and tested — this lands on `main` as a reviewable increment, not a release.

## What's here

- **`auth/capabilities.py`** — the single source of truth for the model:
  - the capability catalog (`resource:verb` tokens) across the four label-scoped axes (workspace / pool / registry / catalog),
  - per-axis level→capability **preset maps**, faithful to today's gates,
  - `expand_preset` (levels→caps — used by both the migration and the roles router),
  - `summarize_capabilities` (caps→derived level summary, for the read side),
  - `normalize_capabilities` (forward-compat alias upgrade so a future capability rename never silently drops a grant or traps a role),
  - `has_capability` (the enforcement primitive — per-gate membership).
- **`Role.capabilities`** JSONB column (`server_default "[]"`), with Alembic migration `e31a11e302fe` back-filling **every existing role faithfully** via `expand_preset` (no power added, none removed).
- **roles router** serializes `capabilities` read-only for custom + built-in roles.
- **go-terrapod** `Role` gains `Capabilities`.
- **`Dockerfile.migrations`** copies the dependency-free `auth/capabilities` module (the migration imports it).
- **`docs/rbac-capabilities.md`** — the full gate→capability contract table + the enforcement-slice obligations.

## How the catalog was validated

The map is derived from an exhaustive survey of every workspace/pool/registry/catalog gate in the API, then put through an adversarial third-party review against the resolver code. The review confirmed **zero LOSS/GAIN/wrong-tier/dead-token** discrepancies and caught real bugs in the first draft, now fixed:
- `varset:manage` belongs to **platform** admin, not workspace-admin (varset CRUD is `require_admin`),
- missing `run-trigger:manage` and `state:delete` tokens (both real workspace-admin gates),
- missing `summarize_capabilities` inverse (every read consumer needs it),
- no forward-compat path for capability renames.

## Scope

The four label-scoped axes only. Platform-admin gates stay role-name based; the scoped platform split is a follow-up (#642). The resolution switch (levels→capabilities, with a route-gate-anchored before==after faithfulness test) is the **next** slice.

## Tests

- `tests/auth/test_capabilities.py` — cumulative levels, per-tier membership, the **expand→summarize round-trip for every preset combination**, normalize/alias, `has_capability`, built-in sets.
- `make test` green (2643 passed); go-terrapod builds + tests; lint clean.

Refs #585.