### PR TITLE
feat(rbac): capability enforcement switch (#585)

### DIFF
--- a/docs/rbac-capabilities.md
+++ b/docs/rbac-capabilities.md
@@ -57,10 +57,10 @@ grantable or enforced in this feature.
 
 Net-new capabilities that **no preset grants** (so no existing role gains them)
 are also out of scope here and tracked separately: a finer state-read tier
-(`state:read-outputs` / `state:read-sensitive`), separable
+(`state:read-outputs` / `state:read-sensitive`) and separable
 `run:apply-destroy` *enforcement* (the token exists and sits in the `write`
 preset for faithfulness; gating destroy on it independently is the granular
-win, landed with enforcement), and maker-checker (#643).
+win, landed with enforcement).
 
 ---
 

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -40,14 +40,14 @@ from terrapod.api.dependencies import (
     require_admin,
 )
 from terrapod.api.labels import validate_labels as _validate_labels
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service
 from terrapod.services.pool_rbac_service import (
-    POOL_PERMISSION_HIERARCHY,
     fetch_custom_roles,
-    has_pool_permission,
-    resolve_pool_permission_for,
+    resolve_pool_capabilities_for,
 )
 
 router = APIRouter(tags=["agent-pools"])
@@ -230,26 +230,41 @@ async def _get_pool(pool_id: str, db: AsyncSession):
     return pool
 
 
-async def _require_pool_permission(
-    pool, user: AuthenticatedUser, db: AsyncSession, required: str
-) -> str:
-    """Resolve user's pool permission and require at least `required` level.
+def _pool_permission_summary(caps: frozenset[str]) -> str | None:
+    """Derive the legacy pool level (read/write/admin) from a capability set for
+    the JSON:API `permission` field. Returns None when the set grants no pool
+    capability (no access)."""
+    if cap.POOL_MANAGE in caps:
+        return "admin"
+    if cap.POOL_ASSIGN in caps:
+        return "write"
+    if cap.POOL_READ in caps:
+        return "read"
+    return None
 
-    Returns the effective permission. Raises 404 if no access, 403 if
-    insufficient.
+
+async def _require_pool_capability(
+    pool, user: AuthenticatedUser, db: AsyncSession, required_cap: str
+) -> str:
+    """Resolve the user's pool capabilities and require `required_cap`.
+
+    Returns the derived permission-level summary (for the response body). Raises
+    404 if the caller holds no pool capability at all, 403 if they hold some but
+    not the required one.
     """
-    perm = await resolve_pool_permission_for(
+    caps = await resolve_pool_capabilities_for(
         db,
         user,
         pool_name=pool.name,
         pool_labels=pool.labels or {},
         owner_email=pool.owner_email or "",
     )
-    if perm is None:
+    summary = _pool_permission_summary(caps)
+    if summary is None:
         raise HTTPException(status_code=404, detail="Agent pool not found")
-    if not has_pool_permission(perm, required):
-        raise HTTPException(status_code=403, detail=f"Requires {required} permission on pool")
-    return perm
+    if not has_capability(caps, required_cap):
+        raise HTTPException(status_code=403, detail="Insufficient permission on pool")
+    return summary
 
 
 # ── Agent Pools ──────────────────────────────────────────────────────────
@@ -266,7 +281,7 @@ async def list_pools(
     custom_roles = await fetch_custom_roles(db, user.roles)
     result = []
     for p in pools:
-        perm = await resolve_pool_permission_for(
+        caps = await resolve_pool_capabilities_for(
             db,
             user,
             pool_name=p.name,
@@ -274,6 +289,7 @@ async def list_pools(
             owner_email=p.owner_email or "",
             preloaded_roles=custom_roles,
         )
+        perm = _pool_permission_summary(caps)
         if perm is None:
             continue
         listeners = await agent_pool_service.list_listeners(p.id)
@@ -320,7 +336,7 @@ async def show_pool(
 ) -> JSONResponse:
     """Show an agent pool (requires read permission)."""
     pool = await _get_pool(pool_id, db)
-    perm = await _require_pool_permission(pool, user, db, "read")
+    perm = await _require_pool_capability(pool, user, db, cap.POOL_READ)
     listeners = await agent_pool_service.list_listeners(pool.id)
     status = _derive_pool_status(listeners)
     return JSONResponse(content={"data": _pool_json(pool, status=status, permission=perm)})
@@ -335,7 +351,14 @@ async def update_pool(
 ) -> JSONResponse:
     """Update an agent pool (requires admin permission on pool)."""
     pool = await _get_pool(pool_id, db)
-    perm = await _require_pool_permission(pool, user, db, "admin")
+    await _require_pool_capability(pool, user, db, cap.POOL_MANAGE)
+    old_caps = await resolve_pool_capabilities_for(
+        db,
+        user,
+        pool_name=pool.name,
+        pool_labels=pool.labels or {},
+        owner_email=pool.owner_email or "",
+    )
 
     attrs = body.get("data", {}).get("attributes", {})
 
@@ -352,23 +375,23 @@ async def update_pool(
     if "labels" in attrs:
         labels_arg = _validate_labels(attrs["labels"]) if attrs["labels"] else {}
 
-    # Self-lockout check: warn if label/owner change would reduce user's access.
+    # Self-lockout check: warn if label/owner change would remove any capability
+    # the caller currently holds on this pool. Capability sets are a partial
+    # order, so we compare by set difference rather than a total-order level drop.
     # Platform admins are immune (their access doesn't depend on labels/owner).
     if "admin" not in effective_platform_roles(user) and not attrs.get("force"):
         new_labels = labels_arg if labels_arg is not _UNSET else (pool.labels or {})
         new_owner = (owner_arg or None) if owner_arg is not _UNSET else pool.owner_email
         if new_labels != (pool.labels or {}) or new_owner != pool.owner_email:
-            new_perm = await resolve_pool_permission_for(
+            new_caps = await resolve_pool_capabilities_for(
                 db,
                 user,
                 pool_name=attrs.get("name") or pool.name,
                 pool_labels=new_labels,
                 owner_email=new_owner or "",
             )
-            if new_perm is None or POOL_PERMISSION_HIERARCHY.get(
-                new_perm, -1
-            ) < POOL_PERMISSION_HIERARCHY.get(perm, -1):
-                new_level = new_perm or "none"
+            removed = old_caps - new_caps
+            if removed:
                 return JSONResponse(
                     status_code=409,
                     content={
@@ -377,9 +400,9 @@ async def update_pool(
                                 "status": "409",
                                 "title": "Label/owner change would reduce your access",
                                 "detail": (
-                                    f"This change would reduce your access from "
-                                    f"{perm} to {new_level} on this pool. "
-                                    f'Re-submit with "force": true to confirm.'
+                                    "This change would remove capabilities you "
+                                    f"currently hold on this pool ({', '.join(sorted(removed))}). "
+                                    'Re-submit with "force": true to confirm.'
                                 ),
                             }
                         ]
@@ -408,7 +431,7 @@ async def delete_pool(
 ) -> None:
     """Delete an agent pool (requires admin permission on pool)."""
     pool = await _get_pool(pool_id, db)
-    await _require_pool_permission(pool, user, db, "admin")
+    await _require_pool_capability(pool, user, db, cap.POOL_MANAGE)
     # Clean up all listener Redis keys for this pool before DB delete
     await agent_pool_service.delete_pool_listeners(pool.id)
     await agent_pool_service.delete_pool(db, pool)
@@ -426,7 +449,7 @@ async def list_pool_tokens(
 ) -> JSONResponse:
     """List join tokens for an agent pool (requires admin on pool)."""
     pool = await _get_pool(pool_id, db)
-    await _require_pool_permission(pool, user, db, "admin")
+    await _require_pool_capability(pool, user, db, cap.POOL_MANAGE)
     tokens = await agent_pool_service.list_pool_tokens(db, pool.id)
     return JSONResponse(content={"data": [_token_json(t) for t in tokens]})
 
@@ -440,7 +463,7 @@ async def create_pool_token(
 ) -> JSONResponse:
     """Create a join token for an agent pool (requires admin on pool)."""
     pool = await _get_pool(pool_id, db)
-    await _require_pool_permission(pool, user, db, "admin")
+    await _require_pool_capability(pool, user, db, cap.POOL_MANAGE)
 
     attrs = body.get("data", {}).get("attributes", {})
 
@@ -469,7 +492,7 @@ async def delete_pool_token(
 ) -> None:
     """Delete/revoke a join token (requires admin on pool)."""
     pool = await _get_pool(pool_id, db)
-    await _require_pool_permission(pool, user, db, "admin")
+    await _require_pool_capability(pool, user, db, cap.POOL_MANAGE)
     token_uuid = uuid.UUID(token_id.removeprefix("at-"))
 
     from sqlalchemy import select
@@ -594,7 +617,7 @@ async def list_pool_listeners(
     the actual fleet size.
     """
     pool = await _get_pool(pool_id, db)
-    await _require_pool_permission(pool, user, db, "read")
+    await _require_pool_capability(pool, user, db, cap.POOL_READ)
     listeners = await agent_pool_service.list_listeners(pool.id)
     # Only fetch replica counts for listeners that actually track pods. A
     # listener on a pre-0.19.0 image doesn't write per-pod keys, so its SCAN
@@ -640,7 +663,7 @@ async def pool_events(
 
     async with get_db_session() as db:
         pool = await _get_pool(pool_id, db)
-        await _require_pool_permission(pool, user, db, "read")
+        await _require_pool_capability(pool, user, db, cap.POOL_READ)
         pool_uuid = str(pool.id)
 
     channel = f"{POOL_EVENTS_PREFIX}{pool_uuid}"
@@ -695,7 +718,7 @@ async def delete_listener(
             if "admin" not in effective_platform_roles(user):
                 raise HTTPException(status_code=403, detail="Admin access required")
         else:
-            await _require_pool_permission(pool, user, db, "admin")
+            await _require_pool_capability(pool, user, db, cap.POOL_MANAGE)
     await agent_pool_service.delete_listener(listener["id"], listener["name"], pool_id_str)
 
 

--- a/services/terrapod/api/routers/catalog.py
+++ b/services/terrapod/api/routers/catalog.py
@@ -42,6 +42,8 @@ from terrapod.api.dependencies import (
     require_admin_or_audit,
 )
 from terrapod.api.labels import validate_labels
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.config import settings
 from terrapod.db.models import (
     AgentPool,
@@ -55,13 +57,11 @@ from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import catalog_service, run_service
 from terrapod.services.catalog_rbac_service import (
-    has_catalog_permission,
-    resolve_catalog_permission_for,
+    resolve_catalog_capabilities_for,
 )
 from terrapod.services.catalog_service import CatalogError
 from terrapod.services.pool_rbac_service import (
-    has_pool_permission,
-    resolve_pool_permission_for,
+    resolve_pool_capabilities_for,
 )
 
 router = APIRouter(tags=["catalog"])
@@ -401,10 +401,10 @@ async def list_catalog_items(
     items = await catalog_service.list_catalog_items(db)
     visible = []
     for item in items:
-        perm = await resolve_catalog_permission_for(
+        caps = await resolve_catalog_capabilities_for(
             db, user, item.name, item.labels or {}, item.owner_email or ""
         )
-        if has_catalog_permission(perm, "read"):
+        if has_capability(caps, cap.CATALOG_READ):
             visible.append(item)
     return JSONResponse(content={"data": [_item_json(i) for i in visible]})
 
@@ -453,10 +453,10 @@ async def _load_item_for_read(
         raise HTTPException(status_code=404, detail="catalog item not found") from e
     if item is None:
         raise HTTPException(status_code=404, detail="catalog item not found")
-    perm = await resolve_catalog_permission_for(
+    caps = await resolve_catalog_capabilities_for(
         db, user, item.name, item.labels or {}, item.owner_email or ""
     )
-    if not has_catalog_permission(perm, "read"):
+    if not has_capability(caps, cap.CATALOG_READ):
         raise HTTPException(status_code=403, detail="Requires catalog read on this item")
     return item
 
@@ -581,10 +581,10 @@ async def provision_catalog_item(
     if not item.enabled:
         raise HTTPException(status_code=409, detail="catalog item is disabled")
 
-    perm = await resolve_catalog_permission_for(
+    caps = await resolve_catalog_capabilities_for(
         db, user, item.name, item.labels or {}, item.owner_email or ""
     )
-    if not has_catalog_permission(perm, "use"):
+    if not has_capability(caps, cap.CATALOG_USE):
         raise HTTPException(status_code=403, detail="Requires catalog 'use' on this item")
 
     attrs = body.get("data", {}).get("attributes", {})
@@ -613,11 +613,11 @@ async def provision_catalog_item(
                 detail="agent pool is not allowed for this catalog item",
             )
 
-    # User must have write on the pool to assign it (pool RBAC intersection).
-    pool_perm = await resolve_pool_permission_for(
+    # User must have pool:assign to assign the pool (pool RBAC intersection).
+    pool_caps = await resolve_pool_capabilities_for(
         db, user, pool.name, pool.labels or {}, pool.owner_email
     )
-    if not has_pool_permission(pool_perm, "write"):
+    if not has_capability(pool_caps, cap.POOL_ASSIGN):
         raise HTTPException(status_code=403, detail="Requires write permission on the agent pool")
 
     input_values = attrs.get("input-values", {})
@@ -675,11 +675,11 @@ async def _load_instance(
     user: AuthenticatedUser,
     ws_id: str,
     *,
-    required: str,
+    required_cap: str,
     active_only: bool = False,
 ) -> Workspace:
-    """Load a catalog instance workspace and enforce `required` catalog
-    permission on its originating item. Lifecycle actions are gated by catalog
+    """Load a catalog instance workspace and enforce the `required_cap` catalog
+    capability on its originating item. Lifecycle actions are gated by catalog
     'use' on the item — NOT by workspace permission (the clamp gives the
     provisioner read only; the catalog surface is the control plane).
 
@@ -699,11 +699,11 @@ async def _load_instance(
     item = await db.get(CatalogItem, ws.catalog_item_id)
     if item is None:
         raise HTTPException(status_code=409, detail="catalog item no longer exists")
-    perm = await resolve_catalog_permission_for(
+    caps = await resolve_catalog_capabilities_for(
         db, user, item.name, item.labels or {}, item.owner_email or ""
     )
-    if not has_catalog_permission(perm, required):
-        raise HTTPException(status_code=403, detail=f"Requires catalog '{required}' on this item")
+    if not has_capability(caps, required_cap):
+        raise HTTPException(status_code=403, detail=f"Requires '{required_cap}' on this item")
     return ws
 
 
@@ -714,7 +714,7 @@ async def show_catalog_instance(
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    ws = await _load_instance(db, user, ws_id, required="read")
+    ws = await _load_instance(db, user, ws_id, required_cap=cap.CATALOG_READ)
     attrs = _instance_json(ws)["attributes"]
     attrs["input-values"] = dict(ws.catalog_input_values or {})
     return JSONResponse(
@@ -741,7 +741,7 @@ async def reconfigure_catalog_instance(
     Requires catalog 'use' on the originating item. A non-auto-apply run plans
     and waits for a platform-admin confirm (the clamp blocks 'use' holders from
     confirming via the workspace API); pass auto-apply to apply directly."""
-    ws = await _load_instance(db, user, ws_id, required="use", active_only=True)
+    ws = await _load_instance(db, user, ws_id, required_cap=cap.CATALOG_USE, active_only=True)
     attrs = body.get("data", {}).get("attributes", {})
     input_values = attrs.get("input-values")
     if input_values is None:
@@ -785,7 +785,7 @@ async def destroy_catalog_instance(
     originating item. On a successful apply the workspace is archived. As with
     reconfigure, a non-auto-apply destroy plans and waits for an admin confirm;
     pass auto-apply to tear down directly."""
-    ws = await _load_instance(db, user, ws_id, required="use", active_only=True)
+    ws = await _load_instance(db, user, ws_id, required_cap=cap.CATALOG_USE, active_only=True)
     attrs = body.get("data", {}).get("attributes", {}) if body else {}
     auto_apply = bool(attrs.get("auto-apply", False))
     try:
@@ -837,7 +837,7 @@ async def confirm_catalog_instance_run(
     provisioner only `read`, so a non-auto-apply provision/reconfigure/destroy
     is confirmed here rather than via the workspace run API (which would need a
     platform admin)."""
-    ws = await _load_instance(db, user, ws_id, required="use")
+    ws = await _load_instance(db, user, ws_id, required_cap=cap.CATALOG_USE)
     run = await _latest_run(db, ws.id)
     if not _is_confirmable_catalog_run(run):
         raise HTTPException(status_code=409, detail="no planned run awaiting confirmation")
@@ -860,7 +860,7 @@ async def discard_catalog_instance_run(
     """Discard the instance's pending **planned** run. Requires catalog `use`.
     Catalog-surface counterpart of confirm (the clamp blocks the workspace run
     API for the provisioner)."""
-    ws = await _load_instance(db, user, ws_id, required="use")
+    ws = await _load_instance(db, user, ws_id, required_cap=cap.CATALOG_USE)
     run = await _latest_run(db, ws.id)
     if not _is_confirmable_catalog_run(run):
         raise HTTPException(status_code=409, detail="no planned run to discard")
@@ -895,7 +895,7 @@ async def delete_catalog_instance(
     and points at destroy — there is no way to orphan a catalog instance by
     accident.
     """
-    ws = await _load_instance(db, user, ws_id, required="admin")
+    ws = await _load_instance(db, user, ws_id, required_cap=cap.CATALOG_ADMIN)
     if not orphan:
         raise HTTPException(
             status_code=409,

--- a/services/terrapod/api/routers/config_versions.py
+++ b/services/terrapod/api/routers/config_versions.py
@@ -29,14 +29,15 @@ from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth import capabilities as cap
 from terrapod.auth import download_tickets
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import ConfigurationVersion, Run, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import cv_diff_service, run_service
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.keys import config_version_key
@@ -126,8 +127,8 @@ async def create_configuration_version(
                 "uploading configuration versions."
             ),
         )
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "write"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.CONFIG_UPLOAD):
         raise HTTPException(status_code=403, detail="Requires write permission on workspace")
 
     attrs = body.get("data", {}).get("attributes", {})
@@ -173,8 +174,8 @@ async def list_configuration_versions(
     RBAC: requires `read` on the workspace.
     """
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.CONFIG_READ):
         raise HTTPException(status_code=404, detail="Workspace not found")
 
     total = await db.scalar(
@@ -253,8 +254,8 @@ async def download_configuration_version(
     if ws is None:
         # Workspace deleted out from under us — treat as gone.
         raise HTTPException(status_code=404, detail="Configuration version not found")
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.CONFIG_READ):
         raise HTTPException(status_code=404, detail="Configuration version not found")
 
     storage = get_storage()
@@ -310,8 +311,8 @@ async def mint_download_ticket(
     ws = await db.get(Workspace, cv.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Configuration version not found")
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.CONFIG_READ):
         raise HTTPException(status_code=404, detail="Configuration version not found")
 
     attrs = (body or {}).get("data", {}).get("attributes", {}) if body else {}
@@ -456,8 +457,8 @@ async def diff_configuration_versions(
     ws = await db.get(Workspace, from_cv.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Configuration version not found")
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.CONFIG_READ):
         raise HTTPException(status_code=404, detail="Configuration version not found")
 
     if from_cv.status != "uploaded" or to_cv.status != "uploaded":

--- a/services/terrapod/api/routers/notification_configurations.py
+++ b/services/terrapod/api/routers/notification_configurations.py
@@ -24,6 +24,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import NotificationConfiguration, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -34,8 +36,7 @@ from terrapod.services.notification_service import (
     record_delivery_response,
 )
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 
 router = APIRouter(tags=["notification-configurations"])
@@ -87,14 +88,14 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
     return ws
 
 
-async def _require_ws_permission(
+async def _require_ws_capability(
     ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, required):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on workspace",
+            detail=f"Requires {required} capability on workspace",
         )
 
 
@@ -119,7 +120,7 @@ async def create_notification_configuration(
 ) -> JSONResponse:
     """Create a notification configuration. Requires admin on the workspace."""
     ws = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(ws, "admin", user, db)
+    await _require_ws_capability(ws, cap.NOTIFICATION_MANAGE, user, db)
 
     attrs = body.get("data", {}).get("attributes", {})
     name = attrs.get("name", "").strip()
@@ -183,7 +184,7 @@ async def list_notification_configurations(
 ) -> JSONResponse:
     """List notification configs for a workspace. Requires read."""
     ws = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(ws, "read", user, db)
+    await _require_ws_capability(ws, cap.NOTIFICATION_READ, user, db)
 
     result = await db.execute(
         select(NotificationConfiguration)
@@ -218,7 +219,7 @@ async def show_notification_configuration(
 ) -> JSONResponse:
     """Show a notification configuration. Requires read on the workspace."""
     nc = await _get_nc(nc_id, db)
-    await _require_ws_permission(nc.workspace, "read", user, db)
+    await _require_ws_capability(nc.workspace, cap.NOTIFICATION_READ, user, db)
     return JSONResponse(content={"data": _nc_json(nc)})
 
 
@@ -231,7 +232,7 @@ async def update_notification_configuration(
 ) -> JSONResponse:
     """Update a notification configuration. Requires admin on the workspace."""
     nc = await _get_nc(nc_id, db)
-    await _require_ws_permission(nc.workspace, "admin", user, db)
+    await _require_ws_capability(nc.workspace, cap.NOTIFICATION_MANAGE, user, db)
 
     attrs = body.get("data", {}).get("attributes", {})
 
@@ -280,7 +281,7 @@ async def delete_notification_configuration(
 ) -> None:
     """Delete a notification configuration. Requires admin on the workspace."""
     nc = await _get_nc(nc_id, db)
-    await _require_ws_permission(nc.workspace, "admin", user, db)
+    await _require_ws_capability(nc.workspace, cap.NOTIFICATION_MANAGE, user, db)
 
     nc_ws_id = str(nc.workspace_id)
 
@@ -302,7 +303,7 @@ async def verify_notification_configuration(
 ) -> JSONResponse:
     """Send a test notification. Requires admin on the workspace."""
     nc = await _get_nc(nc_id, db)
-    await _require_ws_permission(nc.workspace, "admin", user, db)
+    await _require_ws_capability(nc.workspace, cap.NOTIFICATION_MANAGE, user, db)
 
     payload = build_verification_payload(nc.name)
 

--- a/services/terrapod/api/routers/policy_sets.py
+++ b/services/terrapod/api/routers/policy_sets.py
@@ -47,6 +47,8 @@ from terrapod.api.dependencies import (
     require_admin,
     require_runner_for_run,
 )
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import (
     Policy,
     PolicyEvaluation,
@@ -61,8 +63,7 @@ from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import policy_engine, policy_set_service, run_service
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 
 router = APIRouter(tags=["policy-sets"])
@@ -550,8 +551,8 @@ async def _get_run_for_read(db: AsyncSession, run_id: str, user: AuthenticatedUs
     ws = await db.get(Workspace, run.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.RUN_READ):
         raise HTTPException(status_code=403, detail="Requires read permission on workspace")
     return run
 
@@ -596,8 +597,8 @@ async def override_run_policy(
     ws = await db.get(Workspace, run.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "admin"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.WORKSPACE_SETTINGS):
         raise HTTPException(status_code=403, detail="Requires admin permission on workspace")
 
     count = await policy_set_service.override_run_policies(db, run.id, user.email)

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -43,6 +43,8 @@ from terrapod.api.dependencies import (
 )
 from terrapod.api.labels import validate_labels
 from terrapod.api.serialization import rfc3339
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import ModuleWorkspaceLink, RegistryModuleVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -57,9 +59,7 @@ from terrapod.services.registry_module_service import (
     upload_module_tarball,
 )
 from terrapod.services.registry_rbac_service import (
-    REGISTRY_PERMISSION_HIERARCHY,
-    has_registry_permission,
-    resolve_registry_permission_for,
+    resolve_registry_capabilities_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.protocol import ObjectStore
@@ -131,7 +131,7 @@ def _semver_sort_key(version_str: str) -> tuple[int, ...]:
     return tuple(parts)
 
 
-def _module_to_jsonapi(module, effective_permission: str | None = None) -> dict:  # type: ignore[no-untyped-def]
+def _module_to_jsonapi(module, caps: frozenset[str] | None = None) -> dict:  # type: ignore[no-untyped-def]
     sorted_versions = sorted(
         module.versions or [], key=lambda v: _semver_sort_key(v.version), reverse=True
     )
@@ -144,7 +144,7 @@ def _module_to_jsonapi(module, effective_permission: str | None = None) -> dict:
         }
         for v in sorted_versions
     ]
-    perm = effective_permission
+    caps = caps or frozenset()
     return {
         "id": str(module.id),
         "type": "registry-modules",
@@ -167,9 +167,9 @@ def _module_to_jsonapi(module, effective_permission: str | None = None) -> dict:
             "created-at": rfc3339(module.created_at),
             "updated-at": rfc3339(module.updated_at),
             "permissions": {
-                "can-update": has_registry_permission(perm, "admin"),
-                "can-destroy": has_registry_permission(perm, "admin"),
-                "can-create-version": has_registry_permission(perm, "write"),
+                "can-update": has_capability(caps, cap.REGISTRY_ADMIN),
+                "can-destroy": has_capability(caps, cap.REGISTRY_ADMIN),
+                "can-create-version": has_capability(caps, cap.REGISTRY_WRITE),
             },
         },
     }
@@ -191,14 +191,14 @@ async def list_module_versions_cli(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "read"):
+    if not has_capability(caps, cap.REGISTRY_READ):
         raise HTTPException(status_code=404, detail="Module not found")
 
     versions = sorted(
@@ -226,14 +226,14 @@ async def download_module_cli(
     """Get download URL for a module version (CLI protocol). Requires read."""
     module = await get_module(db, namespace, name, provider)
     if module is not None:
-        perm = await resolve_registry_permission_for(
+        caps = await resolve_registry_capabilities_for(
             db,
             user,
             module.name,
             module.labels or {},
             module.owner_email,
         )
-        if not has_registry_permission(perm, "read"):
+        if not has_capability(caps, cap.REGISTRY_READ):
             raise HTTPException(status_code=404, detail="Module version not found")
 
     url = await get_module_download_url(
@@ -320,15 +320,15 @@ async def list_modules_endpoint(
     modules = await list_modules(db)
     visible = []
     for m in modules:
-        perm = await resolve_registry_permission_for(
+        caps = await resolve_registry_capabilities_for(
             db,
             user,
             m.name,
             m.labels or {},
             m.owner_email,
         )
-        if perm is not None:
-            visible.append(_module_to_jsonapi(m, perm))
+        if has_capability(caps, cap.REGISTRY_READ):
+            visible.append(_module_to_jsonapi(m, caps))
     return JSONResponse(content={"data": visible})
 
 
@@ -344,17 +344,17 @@ async def show_module_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "read"):
+    if not has_capability(caps, cap.REGISTRY_READ):
         raise HTTPException(status_code=404, detail="Module not found")
 
-    return JSONResponse(content={"data": _module_to_jsonapi(module, perm)})
+    return JSONResponse(content={"data": _module_to_jsonapi(module, caps)})
 
 
 @management_router.get("/registry-modules/private/default/{name}/{provider}/{version}/interface")
@@ -375,14 +375,14 @@ async def module_interface_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "read"):
+    if not has_capability(caps, cap.REGISTRY_READ):
         raise HTTPException(status_code=404, detail="Module not found")
 
     result = await db.execute(
@@ -423,14 +423,14 @@ async def delete_module_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "admin"):
+    if not has_capability(caps, cap.REGISTRY_ADMIN):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires admin permission on module",
@@ -457,14 +457,14 @@ async def update_module_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "admin"):
+    if not has_capability(caps, cap.REGISTRY_ADMIN):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires admin permission on module",
@@ -484,24 +484,25 @@ async def update_module_endpoint(
         # Validate up-front (size limits + reserved-key check). Raises 422
         # before any self-lockout logic.
         new_labels = validate_labels(attrs["labels"])
-        # Self-lockout check: warn if label change would reduce user's access
+        # Self-lockout check: warn if label change would remove any capability
+        # the caller currently holds on this module. Capability sets are a
+        # partial order, so the guard is a set-difference ("would the edit
+        # remove any capability I hold?"), not a total-order level comparison.
         if (
             new_labels != (module.labels or {})
             and not attrs.get("force")
             and "admin" not in effective_platform_roles(user)
             and module.owner_email != user.email
         ):
-            new_perm = await resolve_registry_permission_for(
+            new_caps = await resolve_registry_capabilities_for(
                 db,
                 user,
                 module.name,
                 new_labels,
                 module.owner_email,
             )
-            if new_perm is None or REGISTRY_PERMISSION_HIERARCHY.get(
-                new_perm, -1
-            ) < REGISTRY_PERMISSION_HIERARCHY.get(perm, -1):
-                new_level = new_perm or "none"
+            removed = caps - new_caps
+            if removed:
                 return JSONResponse(
                     status_code=409,
                     content={
@@ -510,8 +511,9 @@ async def update_module_endpoint(
                                 "status": "409",
                                 "title": "Label change would reduce your access",
                                 "detail": (
-                                    f"This label change would reduce your access from "
-                                    f"{perm} to {new_level} on this module. "
+                                    f"This label change would remove capabilities you "
+                                    f"currently hold on this module "
+                                    f"({', '.join(sorted(removed))}). "
                                     f'Re-submit with "force": true to confirm.'
                                 ),
                             }
@@ -551,7 +553,7 @@ async def update_module_endpoint(
 
     await db.commit()
     await db.refresh(module)
-    return JSONResponse(content={"data": _module_to_jsonapi(module, perm)})
+    return JSONResponse(content={"data": _module_to_jsonapi(module, caps)})
 
 
 @management_router.post("/registry-modules/private/default/{name}/{provider}/versions")
@@ -568,14 +570,14 @@ async def create_module_version_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "write"):
+    if not has_capability(caps, cap.REGISTRY_WRITE):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires write permission on module",
@@ -648,14 +650,14 @@ async def delete_module_version_endpoint(
     """Delete a specific module version. Requires admin on module."""
     module = await get_module(db, "default", name, provider)
     if module is not None:
-        perm = await resolve_registry_permission_for(
+        caps = await resolve_registry_capabilities_for(
             db,
             user,
             module.name,
             module.labels or {},
             module.owner_email,
         )
-        if not has_registry_permission(perm, "admin"):
+        if not has_capability(caps, cap.REGISTRY_ADMIN):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Requires admin permission on module",
@@ -689,14 +691,14 @@ async def upload_module_version_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "write"):
+    if not has_capability(caps, cap.REGISTRY_WRITE):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires write permission on module",
@@ -778,14 +780,14 @@ async def update_module_vcs_endpoint(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "admin"):
+    if not has_capability(caps, cap.REGISTRY_ADMIN):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires admin permission on module",
@@ -870,14 +872,14 @@ async def list_workspace_links(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "read"):
+    if not has_capability(caps, cap.REGISTRY_READ):
         raise HTTPException(status_code=404, detail="Module not found")
 
     result = await db.execute(
@@ -903,14 +905,14 @@ async def create_workspace_link(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "admin"):
+    if not has_capability(caps, cap.REGISTRY_ADMIN):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires admin permission on module",
@@ -974,14 +976,14 @@ async def delete_workspace_link(
     if module is None:
         raise HTTPException(status_code=404, detail="Module not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         module.name,
         module.labels or {},
         module.owner_email,
     )
-    if not has_registry_permission(perm, "admin"):
+    if not has_capability(caps, cap.REGISTRY_ADMIN):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires admin permission on module",

--- a/services/terrapod/api/routers/registry_providers.py
+++ b/services/terrapod/api/routers/registry_providers.py
@@ -50,6 +50,8 @@ from terrapod.api.dependencies import (
 )
 from terrapod.api.labels import validate_labels
 from terrapod.api.serialization import rfc3339
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.config import settings
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -77,9 +79,7 @@ from terrapod.services.registry_provider_service import (
     store_provider_shasums,
 )
 from terrapod.services.registry_rbac_service import (
-    REGISTRY_PERMISSION_HIERARCHY,
-    has_registry_permission,
-    resolve_registry_permission_for,
+    resolve_registry_capabilities_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.protocol import ObjectStore
@@ -113,8 +113,8 @@ class CreateProviderRequest(BaseModel):
 # --- JSON:API serialization ---
 
 
-def _provider_to_jsonapi(provider, effective_permission: str | None = None) -> dict:  # type: ignore[no-untyped-def]
-    perm = effective_permission
+def _provider_to_jsonapi(provider, caps: frozenset[str] | None = None) -> dict:  # type: ignore[no-untyped-def]
+    caps = caps or frozenset()
     return {
         "id": str(provider.id),
         "type": "registry-providers",
@@ -126,9 +126,9 @@ def _provider_to_jsonapi(provider, effective_permission: str | None = None) -> d
             "created-at": rfc3339(provider.created_at),
             "updated-at": rfc3339(provider.updated_at),
             "permissions": {
-                "can-update": has_registry_permission(perm, "admin"),
-                "can-destroy": has_registry_permission(perm, "admin"),
-                "can-create-version": has_registry_permission(perm, "write"),
+                "can-update": has_capability(caps, cap.REGISTRY_ADMIN),
+                "can-destroy": has_capability(caps, cap.REGISTRY_ADMIN),
+                "can-create-version": has_capability(caps, cap.REGISTRY_WRITE),
             },
         },
     }
@@ -175,24 +175,24 @@ def _platform_to_jsonapi(platform, upload_link: str | None = None) -> dict:  # t
 # --- Helper ---
 
 
-async def _require_provider_permission(
+async def _require_provider_capability(
     db: AsyncSession,
     user: AuthenticatedUser,
     provider,
-    required: str,
+    required_cap: str,
 ) -> None:
-    """Check registry permission on a provider or raise 403."""
-    perm = await resolve_registry_permission_for(
+    """Check the required registry capability on a provider or raise 403."""
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
     )
-    if not has_registry_permission(perm, required):
+    if not has_capability(caps, required_cap):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on provider",
+            detail=f"Requires {required_cap} capability on provider",
         )
 
 
@@ -220,14 +220,14 @@ async def list_provider_versions_cli(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
     )
-    if not has_registry_permission(perm, "read"):
+    if not has_capability(caps, cap.REGISTRY_READ):
         raise HTTPException(status_code=404, detail="Provider not found")
 
     versions = []
@@ -277,14 +277,14 @@ async def download_provider_cli(
 
     provider = await get_provider(db, namespace, name)
     if provider is not None:
-        perm = await resolve_registry_permission_for(
+        caps = await resolve_registry_capabilities_for(
             db,
             user,
             provider.name,
             provider.labels or {},
             provider.owner_email,
         )
-        if not has_registry_permission(perm, "read"):
+        if not has_capability(caps, cap.REGISTRY_READ):
             raise HTTPException(status_code=404, detail="Provider platform not found")
 
     info = await get_provider_download_info(db, storage, namespace, name, version, os, arch)
@@ -330,15 +330,15 @@ async def list_providers_endpoint(
     providers = await list_providers(db)
     visible = []
     for p in providers:
-        perm = await resolve_registry_permission_for(
+        caps = await resolve_registry_capabilities_for(
             db,
             user,
             p.name,
             p.labels or {},
             p.owner_email,
         )
-        if perm is not None:
-            visible.append(_provider_to_jsonapi(p, perm))
+        if caps:
+            visible.append(_provider_to_jsonapi(p, caps))
     return JSONResponse(content={"data": visible})
 
 
@@ -353,17 +353,17 @@ async def show_provider_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
     )
-    if not has_registry_permission(perm, "read"):
+    if not has_capability(caps, cap.REGISTRY_READ):
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    return JSONResponse(content={"data": _provider_to_jsonapi(provider, perm)})
+    return JSONResponse(content={"data": _provider_to_jsonapi(provider, caps)})
 
 
 @management_router.delete(_BASE + "/private/default/{name}")
@@ -378,7 +378,7 @@ async def delete_provider_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    await _require_provider_permission(db, user, provider, "admin")
+    await _require_provider_capability(db, user, provider, cap.REGISTRY_ADMIN)
 
     deleted = await delete_provider(db, storage, "default", name)
     if not deleted:
@@ -400,14 +400,14 @@ async def update_provider_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
     )
-    if not has_registry_permission(perm, "admin"):
+    if not has_capability(caps, cap.REGISTRY_ADMIN):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires admin permission on provider",
@@ -427,24 +427,23 @@ async def update_provider_endpoint(
         # Validate up-front (size limits + reserved-key check). Raises 422
         # before any self-lockout logic.
         new_labels = validate_labels(attrs["labels"])
-        # Self-lockout check: warn if label change would reduce user's access
+        # Self-lockout check: refuse (409) if the label change would remove any
+        # capability the caller currently holds. Capability sets are a partial
+        # order, so the guard is set-difference, not a level comparison.
         if (
             new_labels != (provider.labels or {})
             and not attrs.get("force")
             and "admin" not in effective_platform_roles(user)
             and provider.owner_email != user.email
         ):
-            new_perm = await resolve_registry_permission_for(
+            new_caps = await resolve_registry_capabilities_for(
                 db,
                 user,
                 provider.name,
                 new_labels,
                 provider.owner_email,
             )
-            if new_perm is None or REGISTRY_PERMISSION_HIERARCHY.get(
-                new_perm, -1
-            ) < REGISTRY_PERMISSION_HIERARCHY.get(perm, -1):
-                new_level = new_perm or "none"
+            if caps - new_caps:
                 return JSONResponse(
                     status_code=409,
                     content={
@@ -453,9 +452,9 @@ async def update_provider_endpoint(
                                 "status": "409",
                                 "title": "Label change would reduce your access",
                                 "detail": (
-                                    f"This label change would reduce your access from "
-                                    f"{perm} to {new_level} on this provider. "
-                                    f'Re-submit with "force": true to confirm.'
+                                    "This label change would remove capabilities you "
+                                    "currently hold on this provider. "
+                                    'Re-submit with "force": true to confirm.'
                                 ),
                             }
                         ]
@@ -465,7 +464,7 @@ async def update_provider_endpoint(
 
     await db.commit()
     await db.refresh(provider)
-    return JSONResponse(content={"data": _provider_to_jsonapi(provider, perm)})
+    return JSONResponse(content={"data": _provider_to_jsonapi(provider, caps)})
 
 
 # --- Version Management ---
@@ -508,7 +507,7 @@ async def upload_provider_shasums_endpoint(
     provider = await get_provider(db, "default", name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
-    await _require_provider_permission(db, user, provider, "write")
+    await _require_provider_capability(db, user, provider, cap.REGISTRY_WRITE)
 
     data = await request.body()
     if not data:
@@ -543,7 +542,7 @@ async def upload_provider_shasums_sig_endpoint(
     provider = await get_provider(db, "default", name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
-    await _require_provider_permission(db, user, provider, "write")
+    await _require_provider_capability(db, user, provider, cap.REGISTRY_WRITE)
 
     data = await request.body()
     if not data:
@@ -577,14 +576,14 @@ async def list_provider_versions_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
     )
-    if not has_registry_permission(perm, "read"):
+    if not has_capability(caps, cap.REGISTRY_READ):
         raise HTTPException(status_code=404, detail="Provider not found")
 
     versions = await list_provider_versions(db, provider.id)
@@ -604,7 +603,7 @@ async def delete_provider_version_endpoint(
     """Delete a provider version and its platforms. Requires admin."""
     provider = await get_provider(db, "default", name)
     if provider is not None:
-        await _require_provider_permission(db, user, provider, "admin")
+        await _require_provider_capability(db, user, provider, cap.REGISTRY_ADMIN)
 
     deleted = await delete_provider_version(db, storage, "default", name, version)
     if not deleted:
@@ -629,14 +628,14 @@ async def list_provider_platforms_endpoint(
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
-    perm = await resolve_registry_permission_for(
+    caps = await resolve_registry_capabilities_for(
         db,
         user,
         provider.name,
         provider.labels or {},
         provider.owner_email,
     )
-    if not has_registry_permission(perm, "read"):
+    if not has_capability(caps, cap.REGISTRY_READ):
         raise HTTPException(status_code=404, detail="Provider not found")
 
     prov_version = await get_provider_version(db, provider.id, version)
@@ -671,7 +670,7 @@ async def upload_provider_platform_endpoint(
     provider = await get_provider(db, "default", name)
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
-    await _require_provider_permission(db, user, provider, "write")
+    await _require_provider_capability(db, user, provider, cap.REGISTRY_WRITE)
 
     declared = request.headers.get("content-length")
     if declared is not None:
@@ -757,7 +756,7 @@ async def delete_provider_platform_endpoint(
     """Delete a specific provider platform binary. Requires admin."""
     provider = await get_provider(db, "default", name)
     if provider is not None:
-        await _require_provider_permission(db, user, provider, "admin")
+        await _require_provider_capability(db, user, provider, cap.REGISTRY_ADMIN)
 
     deleted = await delete_provider_platform(db, storage, "default", name, version, os, arch)
     if not deleted:

--- a/services/terrapod/api/routers/remote_state_consumers.py
+++ b/services/terrapod/api/routers/remote_state_consumers.py
@@ -31,12 +31,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import Workspace, WorkspaceRemoteStateConsumer
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 
 router = APIRouter(tags=["remote-state-consumers"])
@@ -97,14 +98,14 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
     return ws
 
 
-async def _require_ws_permission(
+async def _require_ws_capability(
     ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, required):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on workspace",
+            detail=f"Requires {required} capability on workspace",
         )
 
 
@@ -133,7 +134,7 @@ async def create_remote_state_consumer(
     control of the secret-bearing state is the security invariant.
     """
     producer = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(producer, "admin", user, db)
+    await _require_ws_capability(producer, cap.WORKSPACE_SETTINGS, user, db)
 
     consumer = await _get_workspace(_extract_consumer_id(body), db)
 
@@ -207,7 +208,7 @@ async def list_remote_state_consumers(
     read (I'm the consumer). Requires read on the workspace.
     """
     ws = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(ws, "read", user, db)
+    await _require_ws_capability(ws, cap.STATE_READ_METADATA, user, db)
 
     if filter_type is None:
         filter_type = "outbound"
@@ -251,7 +252,7 @@ async def replace_remote_state_consumers(
     Body shape: ``{"data": [{"type": "workspaces", "id": "ws-..."}, ...]}``.
     """
     producer = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(producer, "admin", user, db)
+    await _require_ws_capability(producer, cap.WORKSPACE_SETTINGS, user, db)
 
     items = body.get("data", [])
     if not isinstance(items, list):
@@ -351,7 +352,7 @@ async def show_remote_state_consumer(
     if row is None:
         raise HTTPException(status_code=404, detail="Remote-state consumer not found")
 
-    await _require_ws_permission(row.producer_workspace, "read", user, db)
+    await _require_ws_capability(row.producer_workspace, cap.STATE_READ_METADATA, user, db)
 
     return JSONResponse(content={"data": _consumer_json(row)})
 
@@ -380,7 +381,7 @@ async def delete_remote_state_consumer(
     if row is None:
         raise HTTPException(status_code=404, detail="Remote-state consumer not found")
 
-    await _require_ws_permission(row.producer_workspace, "admin", user, db)
+    await _require_ws_capability(row.producer_workspace, cap.WORKSPACE_SETTINGS, user, db)
 
     producer_id = str(row.producer_workspace_id)
     consumer_id = str(row.consumer_workspace_id)

--- a/services/terrapod/api/routers/run_tasks.py
+++ b/services/terrapod/api/routers/run_tasks.py
@@ -27,6 +27,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import Run, RunTask, TaskStage, TaskStageResult, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
@@ -39,8 +41,7 @@ from terrapod.services.run_task_service import (
     verify_callback_token,
 )
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 
 router = APIRouter(prefix="/api/v2", tags=["run-tasks"])
@@ -153,14 +154,14 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
     return ws
 
 
-async def _require_ws_permission(
+async def _require_ws_capability(
     ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, required):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on workspace",
+            detail=f"Requires {required} capability on workspace",
         )
 
 
@@ -187,7 +188,7 @@ async def create_run_task(
 ) -> JSONResponse:
     """Create a run task. Requires admin on the workspace."""
     ws = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(ws, "admin", user, db)
+    await _require_ws_capability(ws, cap.RUN_TASK_MANAGE, user, db)
 
     attrs = body.get("data", {}).get("attributes", {})
     name = attrs.get("name", "").strip()
@@ -245,7 +246,7 @@ async def list_run_tasks(
 ) -> JSONResponse:
     """List run tasks for a workspace. Requires read."""
     ws = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(ws, "read", user, db)
+    await _require_ws_capability(ws, cap.RUN_TASK_READ, user, db)
 
     result = await db.execute(
         select(RunTask)
@@ -266,7 +267,7 @@ async def show_run_task(
 ) -> JSONResponse:
     """Show a run task. Requires read on the workspace."""
     rt = await _get_run_task(rt_id, db)
-    await _require_ws_permission(rt.workspace, "read", user, db)
+    await _require_ws_capability(rt.workspace, cap.RUN_TASK_READ, user, db)
     return JSONResponse(content={"data": _run_task_json(rt)})
 
 
@@ -279,7 +280,7 @@ async def update_run_task(
 ) -> JSONResponse:
     """Update a run task. Requires admin on the workspace."""
     rt = await _get_run_task(rt_id, db)
-    await _require_ws_permission(rt.workspace, "admin", user, db)
+    await _require_ws_capability(rt.workspace, cap.RUN_TASK_MANAGE, user, db)
 
     attrs = body.get("data", {}).get("attributes", {})
 
@@ -339,7 +340,7 @@ async def delete_run_task(
 ) -> None:
     """Delete a run task. Requires admin on the workspace."""
     rt = await _get_run_task(rt_id, db)
-    await _require_ws_permission(rt.workspace, "admin", user, db)
+    await _require_ws_capability(rt.workspace, cap.RUN_TASK_MANAGE, user, db)
 
     rt_ws_id = str(rt.workspace_id)
 
@@ -374,9 +375,11 @@ async def list_task_stages(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
-        raise HTTPException(status_code=403, detail="Requires read permission on workspace")
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.RUN_TASK_READ):
+        raise HTTPException(
+            status_code=403, detail="Requires run-task:read capability on workspace"
+        )
 
     from terrapod.services.run_task_service import list_run_task_stages
 
@@ -405,9 +408,11 @@ async def show_task_stage(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
-        raise HTTPException(status_code=403, detail="Requires read permission on workspace")
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.RUN_TASK_READ):
+        raise HTTPException(
+            status_code=403, detail="Requires run-task:read capability on workspace"
+        )
 
     return JSONResponse(content={"data": _task_stage_json(ts)})
 
@@ -434,9 +439,11 @@ async def override_task_stage(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "admin"):
-        raise HTTPException(status_code=403, detail="Requires admin permission on workspace")
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.RUN_TASK_MANAGE):
+        raise HTTPException(
+            status_code=403, detail="Requires run-task:manage capability on workspace"
+        )
 
     try:
         ts = await override_stage(db, ts_uuid)

--- a/services/terrapod/api/routers/run_triggers.py
+++ b/services/terrapod/api/routers/run_triggers.py
@@ -22,12 +22,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import RunTrigger, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 
 router = APIRouter(tags=["run-triggers"])
@@ -79,14 +80,14 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
     return ws
 
 
-async def _require_ws_permission(
+async def _require_ws_capability(
     ws: Workspace, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, required):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on workspace",
+            detail=f"Requires {required} capability on workspace",
         )
 
 
@@ -99,7 +100,7 @@ async def create_run_trigger(
 ) -> JSONResponse:
     """Create a run trigger. Requires admin on the destination workspace."""
     ws = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(ws, "admin", user, db)
+    await _require_ws_capability(ws, cap.RUN_TRIGGER_MANAGE, user, db)
 
     # Extract source workspace from relationships
     relationships = body.get("data", {}).get("relationships", {})
@@ -174,7 +175,7 @@ async def list_run_triggers(
 ) -> JSONResponse:
     """List run triggers for a workspace (inbound or outbound). Requires read."""
     ws = await _get_workspace(workspace_id, db)
-    await _require_ws_permission(ws, "read", user, db)
+    await _require_ws_capability(ws, cap.RUN_TRIGGER_READ, user, db)
 
     if filter_type not in ("inbound", "outbound"):
         raise HTTPException(
@@ -221,7 +222,7 @@ async def show_run_trigger(
         raise HTTPException(status_code=404, detail="Run trigger not found")
 
     ws = trigger.workspace
-    await _require_ws_permission(ws, "read", user, db)
+    await _require_ws_capability(ws, cap.RUN_TRIGGER_READ, user, db)
 
     return JSONResponse(content={"data": _trigger_json(trigger)})
 
@@ -244,7 +245,7 @@ async def delete_run_trigger(
         raise HTTPException(status_code=404, detail="Run trigger not found")
 
     ws = trigger.workspace
-    await _require_ws_permission(ws, "admin", user, db)
+    await _require_ws_capability(ws, cap.RUN_TRIGGER_MANAGE, user, db)
 
     # Capture both endpoint ids before the row is gone.
     dest_id = str(trigger.workspace_id)

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -44,6 +44,8 @@ from terrapod.api.dependencies import (
     get_current_user,
     get_listener_identity,
 )
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.config import settings
 from terrapod.db.models import (
     PlanSummary,
@@ -58,8 +60,7 @@ from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service, run_service
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.keys import apply_log_key, plan_json_output_key, plan_log_key
@@ -266,18 +267,18 @@ async def _get_workspace(workspace_id: str, db: AsyncSession) -> Workspace:
     return ws
 
 
-async def _require_run_ws_permission(
+async def _require_run_ws_capability(
     run: Run, required: str, user: AuthenticatedUser, db: AsyncSession
 ) -> None:
-    """Check that user has the required permission on the run's workspace."""
+    """Check that user holds the required capability on the run's workspace."""
     ws = await db.get(Workspace, run.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, required):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on workspace",
+            detail=f"Requires '{required}' capability on workspace",
         )
 
 
@@ -424,13 +425,19 @@ async def create_run(
             )
         plan_only = True
 
-    # Check permission: plan-only requires plan, apply requires write
-    required = "plan" if plan_only else "write"
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, required):
+    # Check capability: plan-only needs run:plan; apply needs run:apply, or
+    # run:apply-destroy when the run is a destroy (is-destroy=true).
+    if plan_only:
+        required_cap = cap.RUN_PLAN
+    elif attrs.get("is-destroy", False):
+        required_cap = cap.RUN_APPLY_DESTROY
+    else:
+        required_cap = cap.RUN_APPLY
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, required_cap):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on workspace",
+            detail=f"Requires '{required_cap}' capability on workspace",
         )
 
     # Configuration version (optional — provided by CLI uploads)
@@ -533,7 +540,7 @@ async def show_run(
 ) -> JSONResponse:
     """Show a run. Requires read on workspace."""
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
     ws = await db.get(Workspace, run.workspace_id)
 
     # Look up state version created by this run (detail endpoint only)
@@ -563,8 +570,8 @@ async def list_workspace_runs(
 ) -> JSONResponse:
     """List runs for a workspace. Requires read."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.RUN_READ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires read permission on workspace",
@@ -589,7 +596,9 @@ async def confirm_run(
 ) -> JSONResponse:
     """Confirm a planned run for apply. Requires write."""
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "write", user, db)
+    await _require_run_ws_capability(
+        run, cap.RUN_APPLY_DESTROY if run.is_destroy else cap.RUN_APPLY, user, db
+    )
 
     # No-op apply guard: a plan with has_changes=False has nothing to apply.
     # The reconciler short-circuits these directly to `applied`, so this
@@ -641,7 +650,7 @@ async def discard_run(
 ) -> JSONResponse:
     """Discard a planned run. Requires plan."""
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "plan", user, db)
+    await _require_run_ws_capability(run, cap.RUN_CANCEL, user, db)
     try:
         run = await run_service.discard_run(db, run)
         await db.commit()
@@ -658,7 +667,7 @@ async def cancel_run(
 ) -> JSONResponse:
     """Cancel a run. Requires plan."""
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "plan", user, db)
+    await _require_run_ws_capability(run, cap.RUN_CANCEL, user, db)
     try:
         run = await run_service.cancel_run(db, run)
         await db.commit()
@@ -681,7 +690,7 @@ async def retry_run(
     Requires plan permission.
     """
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "plan", user, db)
+    await _require_run_ws_capability(run, cap.RUN_CANCEL, user, db)
 
     is_terminal = run.status in run_service.TERMINAL_STATES or (
         run.plan_only and run.status == "planned"
@@ -816,7 +825,7 @@ async def list_run_events(
     We synthesize events from the run's status timestamps.
     """
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
 
     events = []
     event_pairs = [
@@ -900,7 +909,7 @@ async def show_plan_by_id(
     Plan IDs use the same UUID as the run with a 'plan-' prefix.
     """
     run = await _get_run(plan_id.replace("plan-", "run-"), db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
     return JSONResponse(content=_plan_json(run))
 
 
@@ -921,7 +930,7 @@ async def show_plan_summary(
     branches on the ``kind`` attribute.
     """
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
 
     summary = (
         await db.execute(select(PlanSummary).where(PlanSummary.run_id == run.id))
@@ -1000,7 +1009,7 @@ async def regenerate_plan_summary(
         raise HTTPException(status_code=503, detail="AI summary is disabled globally")
 
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
 
     kind = _summary_kind_for_run(run)
     if kind is None:
@@ -1123,7 +1132,7 @@ async def _resolve_plan_summary_for_chat(
     plan that hasn't been summarised), and returns the joined rows.
     """
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
     summary = (
         await db.execute(select(PlanSummary).where(PlanSummary.run_id == run.id))
     ).scalar_one_or_none()
@@ -1269,7 +1278,7 @@ async def show_plan(
 ) -> JSONResponse:
     """Show plan details including log URL."""
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
     return JSONResponse(content=_plan_json(run))
 
 
@@ -1305,7 +1314,7 @@ async def show_apply_by_id(
     Apply IDs use the same UUID as the run with an 'apply-' prefix.
     """
     run = await _get_run(apply_id.replace("apply-", "run-"), db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
     return JSONResponse(content=_apply_json(run))
 
 
@@ -1317,7 +1326,7 @@ async def show_apply(
 ) -> JSONResponse:
     """Show apply details including log URL."""
     run = await _get_run(run_id, db)
-    await _require_run_ws_permission(run, "read", user, db)
+    await _require_run_ws_capability(run, cap.RUN_READ, user, db)
     return JSONResponse(content=_apply_json(run))
 
 
@@ -1343,8 +1352,8 @@ async def run_events_stream(
 
     async with get_db_session() as db:
         ws = await _get_workspace(workspace_id, db)
-        perm = await resolve_workspace_permission_for(db, user, ws)
-        if not has_permission(perm, "read"):
+        caps = await resolve_workspace_capabilities_for(db, user, ws)
+        if not has_capability(caps, cap.RUN_READ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Requires read permission on workspace",

--- a/services/terrapod/api/routers/state_management.py
+++ b/services/terrapod/api/routers/state_management.py
@@ -22,12 +22,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.api.upload_stream import file_chunks, read_file_bytes, stream_to_tempfile
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import StateVersion, Workspace
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.keys import state_key
@@ -65,21 +66,21 @@ def _read_state_lineage_md5(path: str) -> tuple[str, str]:
     return state_data.get("lineage", ""), h.hexdigest()
 
 
-async def _require_sv_workspace_permission(
+async def _require_sv_workspace_capability(
     sv: StateVersion,
     required: str,
     user: AuthenticatedUser,
     db: AsyncSession,
 ) -> Workspace:
-    """Check permission on the state version's workspace. Returns workspace."""
+    """Check a capability on the state version's workspace. Returns workspace."""
     ws = await db.get(Workspace, sv.workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, required):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on workspace",
+            detail=f"Requires {required} capability on workspace",
         )
     return ws
 
@@ -96,7 +97,7 @@ async def delete_state_version(
     protects against accidentally removing the active workspace state.
     """
     sv = await _get_state_version(state_version_id, db)
-    ws = await _require_sv_workspace_permission(sv, "admin", user, db)
+    ws = await _require_sv_workspace_capability(sv, cap.STATE_DELETE, user, db)
 
     # Prevent deleting the current (latest) state version, UNLESS the
     # record is an unuploaded orphan placeholder. We can't gate on
@@ -166,7 +167,7 @@ async def rollback_state_version(
     — no versions are deleted, history is preserved.
     """
     sv = await _get_state_version(state_version_id, db)
-    ws = await _require_sv_workspace_permission(sv, "write", user, db)
+    ws = await _require_sv_workspace_capability(sv, cap.STATE_WRITE, user, db)
 
     # Download the old state bytes (decrypting if app-layer state encryption was
     # on when they were written, #635). Working in plaintext keeps md5/state_size
@@ -252,11 +253,11 @@ async def upload_state_manual(
     from terrapod.api.routers.tfe_v2 import _get_workspace_by_id
 
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "write"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.STATE_WRITE):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Requires write permission on workspace",
+            detail="Requires state:write capability on workspace",
         )
 
     # Stream the state body to a capped tempfile on the ephemeral PVC rather

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -53,6 +53,8 @@ from terrapod.api.dependencies import (
     require_non_runner,
 )
 from terrapod.api.labels import validate_labels
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import (
     AuditLog,
     Run,
@@ -64,11 +66,9 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service as _agent_pool_service
-from terrapod.services.pool_rbac_service import has_pool_permission, resolve_pool_permission_for
+from terrapod.services.pool_rbac_service import resolve_pool_capabilities_for
 from terrapod.services.workspace_rbac_service import (
-    PERMISSION_HIERARCHY,
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 from terrapod.storage import get_storage
 from terrapod.storage.keys import state_index_key, state_key
@@ -613,16 +613,16 @@ def _compute_health_conditions(ws: Workspace) -> list[dict]:
 
 def _workspace_json(
     ws: Workspace,
-    effective_permission: str | None = None,
+    caps: frozenset[str] | None = None,
     latest_run: Run | None = None,
 ) -> dict:
     """Serialize a Workspace to TFE V2 JSON:API format.
 
-    When effective_permission is provided, the permissions block reflects
-    the user's actual permission level. Otherwise defaults to full access
-    (for backwards compat with internal callers).
+    When ``caps`` (the caller's resolved capability set on this workspace)
+    is provided, the permissions block reflects the user's actual
+    capabilities. Otherwise defaults to no access (empty set).
     """
-    perm = effective_permission
+    caps = caps or frozenset()
 
     latest_run_attr = None
     if latest_run is not None:
@@ -695,20 +695,20 @@ def _workspace_json(
                 "created-at": _rfc3339(ws.created_at),
                 "updated-at": _rfc3339(ws.updated_at),
                 "permissions": {
-                    "can-update": has_permission(perm, "admin"),
-                    "can-destroy": has_permission(perm, "admin"),
-                    "can-queue-run": has_permission(perm, "plan"),
-                    "can-read-state-versions": has_permission(perm, "read"),
-                    "can-create-state-versions": has_permission(perm, "write"),
-                    "can-read-variable": has_permission(perm, "read"),
-                    "can-update-variable": has_permission(perm, "write"),
-                    "can-lock": has_permission(perm, "plan"),
-                    "can-unlock": has_permission(perm, "plan"),
-                    "can-force-unlock": has_permission(perm, "admin"),
-                    "can-read-settings": has_permission(perm, "read"),
+                    "can-update": has_capability(caps, cap.WORKSPACE_SETTINGS),
+                    "can-destroy": has_capability(caps, cap.WORKSPACE_DELETE),
+                    "can-queue-run": has_capability(caps, cap.RUN_PLAN),
+                    "can-read-state-versions": has_capability(caps, cap.STATE_READ_METADATA),
+                    "can-create-state-versions": has_capability(caps, cap.STATE_WRITE),
+                    "can-read-variable": has_capability(caps, cap.VAR_READ),
+                    "can-update-variable": has_capability(caps, cap.VAR_WRITE),
+                    "can-lock": has_capability(caps, cap.WORKSPACE_LOCK),
+                    "can-unlock": has_capability(caps, cap.WORKSPACE_LOCK),
+                    "can-force-unlock": has_capability(caps, cap.WORKSPACE_FORCE_UNLOCK),
+                    "can-read-settings": has_capability(caps, cap.WORKSPACE_READ),
                 },
                 "actions": {
-                    "is-destroyable": has_permission(perm, "admin"),
+                    "is-destroyable": has_capability(caps, cap.WORKSPACE_DELETE),
                 },
             },
             "relationships": {
@@ -844,9 +844,9 @@ async def list_workspaces(
     # Filter to workspaces user has at least read access to
     visible = []
     for ws in workspaces:
-        perm = await resolve_workspace_permission_for(db, user, ws)
-        if perm is not None:
-            visible.append(_workspace_json(ws, perm, latest_run=latest_runs.get(ws.id))["data"])
+        caps = await resolve_workspace_capabilities_for(db, user, ws)
+        if caps:
+            visible.append(_workspace_json(ws, caps, latest_run=latest_runs.get(ws.id))["data"])
 
     return JSONResponse(
         content={"data": visible},
@@ -867,8 +867,8 @@ async def show_workspace(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if perm is None:
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not caps:
         # Runner-token consumers can resolve the producer workspace by name
         # so the OpenTofu `remote` backend's first hop (workspace lookup) in
         # `data "terraform_remote_state"` finds it instead of falling through
@@ -876,7 +876,7 @@ async def show_workspace(
         # runner's missing org-write permission). Allowlist check mirrors
         # the state-read endpoints below.
         if await _runner_state_read_allowed(db, user, ws):
-            perm = "read"
+            caps = cap.caps_for_level("read")
         else:
             raise HTTPException(status_code=404, detail="Workspace not found")
 
@@ -890,7 +890,7 @@ async def show_workspace(
     latest_run = run_result.scalar_one_or_none()
 
     return JSONResponse(
-        content=_workspace_json(ws, perm, latest_run=latest_run),
+        content=_workspace_json(ws, caps, latest_run=latest_run),
         headers=_tfe_headers(),
     )
 
@@ -935,16 +935,16 @@ async def create_workspace(
         target_pool = await _agent_pool_service.get_pool(db, agent_pool_id)
         if target_pool is None:
             raise HTTPException(status_code=404, detail="Agent pool not found")
-        pool_perm = await resolve_pool_permission_for(
+        pool_caps = await resolve_pool_capabilities_for(
             db,
             user,
             pool_name=target_pool.name,
             pool_labels=target_pool.labels or {},
             owner_email=target_pool.owner_email or "",
         )
-        if pool_perm is None:
+        if not has_capability(pool_caps, cap.POOL_READ):
             raise HTTPException(status_code=404, detail="Agent pool not found")
-        if not has_pool_permission(pool_perm, "write"):
+        if not has_capability(pool_caps, cap.POOL_ASSIGN):
             raise HTTPException(
                 status_code=403,
                 detail="Requires write permission on agent pool",
@@ -1000,7 +1000,7 @@ async def create_workspace(
     await publish_workspace_event(str(ws.id), "workspace_created")
 
     return JSONResponse(
-        content=_workspace_json(ws, "admin"),
+        content=_workspace_json(ws, cap.caps_for_level("admin")),
         status_code=201,
         headers=_tfe_headers(),
     )
@@ -1022,21 +1022,21 @@ async def _get_workspace_by_id(workspace_id: str, db: AsyncSession) -> Workspace
     return ws
 
 
-async def _require_ws_permission(
+async def _require_ws_capability(
     workspace_id: str,
     required: str,
     user: AuthenticatedUser,
     db: AsyncSession,
-) -> tuple[Workspace, str]:
-    """Load workspace and check permission. Returns (workspace, effective_permission)."""
+) -> tuple[Workspace, frozenset[str]]:
+    """Load workspace and check capability. Returns (workspace, capability set)."""
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, required):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, required):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Requires {required} permission on workspace",
+            detail=f"Requires '{required}' capability on workspace",
         )
-    return ws, perm
+    return ws, caps
 
 
 async def _runner_state_read_allowed(
@@ -1127,10 +1127,10 @@ async def show_workspace_by_id(
     state-read endpoints further down.
     """
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.WORKSPACE_READ):
         if await _runner_state_read_allowed(db, user, ws):
-            perm = "read"
+            caps = cap.caps_for_level("read")
         else:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -1147,7 +1147,7 @@ async def show_workspace_by_id(
     latest_run = run_result.scalar_one_or_none()
 
     return JSONResponse(
-        content=_workspace_json(ws, perm, latest_run=latest_run),
+        content=_workspace_json(ws, caps, latest_run=latest_run),
         headers=_tfe_headers(),
     )
 
@@ -1169,7 +1169,7 @@ async def list_workspace_tag_bindings(
     (also used for label-based RBAC) double as TFE tag bindings. Each label
     key/value pair is returned as one tag-binding entry.
     """
-    ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
+    ws, _ = await _require_ws_capability(workspace_id, cap.WORKSPACE_READ, user, db)
 
     # `id` is required by JSON:API and go-tfe's jsonapi parser silently
     # drops entries that are missing it. Without an id, ListTagBindings
@@ -1206,7 +1206,7 @@ async def list_workspace_effective_tag_bindings(
     Terrapod has no project hierarchy, so this is identical to the
     workspace-level bindings.
     """
-    ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
+    ws, _ = await _require_ws_capability(workspace_id, cap.WORKSPACE_READ, user, db)
 
     # See note on `id` in `list_workspace_tag_bindings` above — required by
     # JSON:API or go-tfe drops the entry on parse.
@@ -1252,7 +1252,7 @@ async def add_workspace_tag_names(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Legacy POST tag-add — no-op."""
-    await _require_ws_permission(workspace_id, "read", user, db)
+    await _require_ws_capability(workspace_id, cap.WORKSPACE_READ, user, db)
     return Response(status_code=204, headers=_tfe_headers())
 
 
@@ -1264,7 +1264,7 @@ async def remove_workspace_tag_names(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Legacy DELETE tag-remove — no-op."""
-    await _require_ws_permission(workspace_id, "read", user, db)
+    await _require_ws_capability(workspace_id, cap.WORKSPACE_READ, user, db)
     return Response(status_code=204, headers=_tfe_headers())
 
 
@@ -1276,7 +1276,7 @@ async def update_workspace(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Update workspace settings. Requires admin on workspace."""
-    ws, perm = await _require_ws_permission(workspace_id, "admin", user, db)
+    ws, old_caps = await _require_ws_capability(workspace_id, cap.WORKSPACE_SETTINGS, user, db)
 
     attrs = body.get("data", {}).get("attributes", {})
 
@@ -1420,12 +1420,13 @@ async def update_workspace(
         ):
             old_labels = ws.labels
             ws.labels = new_labels
-            new_perm = await resolve_workspace_permission_for(db, user, ws)
+            new_caps = await resolve_workspace_capabilities_for(db, user, ws)
             ws.labels = old_labels  # revert before deciding
-            if new_perm is None or PERMISSION_HIERARCHY.get(
-                new_perm, -1
-            ) < PERMISSION_HIERARCHY.get(perm, -1):
-                new_level = new_perm or "none"
+            # Capability sets are a partial order — a "reduction" is any
+            # capability the caller currently holds that the edit would
+            # remove (set difference), not a drop in a total-order level.
+            removed = old_caps - new_caps
+            if removed:
                 return JSONResponse(
                     status_code=409,
                     content={
@@ -1434,9 +1435,10 @@ async def update_workspace(
                                 "status": "409",
                                 "title": "Label change would reduce your access",
                                 "detail": (
-                                    f"This label change would reduce your access from "
-                                    f"{perm} to {new_level} on this workspace. "
-                                    f'Re-submit with "force": true to confirm.'
+                                    "This label change would remove capabilities you "
+                                    "currently hold on this workspace "
+                                    f"({', '.join(sorted(removed))}). "
+                                    'Re-submit with "force": true to confirm.'
                                 ),
                             }
                         ]
@@ -1465,16 +1467,16 @@ async def update_workspace(
             target_pool = await _agent_pool_service.get_pool(db, new_pool_id)
             if target_pool is None:
                 raise HTTPException(status_code=404, detail="Agent pool not found")
-            pool_perm = await resolve_pool_permission_for(
+            pool_caps = await resolve_pool_capabilities_for(
                 db,
                 user,
                 pool_name=target_pool.name,
                 pool_labels=target_pool.labels or {},
                 owner_email=target_pool.owner_email or "",
             )
-            if pool_perm is None:
+            if not has_capability(pool_caps, cap.POOL_READ):
                 raise HTTPException(status_code=404, detail="Agent pool not found")
-            if not has_pool_permission(pool_perm, "write"):
+            if not has_capability(pool_caps, cap.POOL_ASSIGN):
                 raise HTTPException(
                     status_code=403,
                     detail="Requires write permission on agent pool",
@@ -1557,7 +1559,7 @@ async def update_workspace(
             )
         logger.info("Workspace renamed", old_name=old_name, new_name=ws.name)
 
-    return JSONResponse(content=_workspace_json(ws, perm), headers=_tfe_headers())
+    return JSONResponse(content=_workspace_json(ws, old_caps), headers=_tfe_headers())
 
 
 @extensions_router.delete("/workspaces/{workspace_id}")
@@ -1574,7 +1576,7 @@ async def delete_workspace(
     the infrastructure (the recommended path), or the explicit, discouraged
     ``DELETE /catalog-instances/{id}?orphan=true`` to abandon it.
     """
-    ws, _ = await _require_ws_permission(workspace_id, "admin", user, db)
+    ws, _ = await _require_ws_capability(workspace_id, cap.WORKSPACE_DELETE, user, db)
     if ws.catalog_item_id is not None:
         raise HTTPException(
             status_code=409,
@@ -1606,7 +1608,7 @@ async def list_state_versions(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """List all state versions for a workspace, ordered by serial DESC."""
-    ws, _ = await _require_ws_permission(workspace_id, "read", user, db)
+    ws, _ = await _require_ws_capability(workspace_id, cap.STATE_READ_METADATA, user, db)
 
     result = await db.execute(
         select(StateVersion)
@@ -1640,8 +1642,8 @@ async def current_state_version(
     """
     ws = await _get_workspace_by_id(workspace_id, db)
     if not await _runner_state_read_allowed(db, user, ws):
-        perm = await resolve_workspace_permission_for(db, user, ws)
-        if not has_permission(perm, "read"):
+        caps = await resolve_workspace_capabilities_for(db, user, ws)
+        if not has_capability(caps, cap.STATE_READ_METADATA):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Requires read permission on workspace",
@@ -1685,8 +1687,8 @@ async def download_state(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
     if not await _runner_state_read_allowed(db, user, ws):
-        perm = await resolve_workspace_permission_for(db, user, ws)
-        if not has_permission(perm, "plan"):
+        caps = await resolve_workspace_capabilities_for(db, user, ws)
+        if not has_capability(caps, cap.STATE_READ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Requires plan permission on workspace",
@@ -1836,8 +1838,8 @@ async def show_state_version(
     # Check read permission on workspace
     ws = await db.get(Workspace, sv.workspace_id)
     if ws is not None:
-        perm = await resolve_workspace_permission_for(db, user, ws)
-        if perm is None:
+        caps = await resolve_workspace_capabilities_for(db, user, ws)
+        if not has_capability(caps, cap.STATE_READ_METADATA):
             raise HTTPException(status_code=404, detail="State version not found")
 
     return JSONResponse(content=_state_version_json(sv, request), headers=_tfe_headers())
@@ -1851,7 +1853,7 @@ async def create_state_version(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Create a new state version. Requires write permission."""
-    ws, _ = await _require_ws_permission(workspace_id, "write", user, db)
+    ws, _ = await _require_ws_capability(workspace_id, cap.STATE_WRITE, user, db)
 
     body = await request.json()
     attrs = body.get("data", {}).get("attributes", {})
@@ -2063,7 +2065,7 @@ async def lock_workspace(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Lock a workspace. Requires plan permission."""
-    ws, perm = await _require_ws_permission(workspace_id, "plan", user, db)
+    ws, caps = await _require_ws_capability(workspace_id, cap.WORKSPACE_LOCK, user, db)
 
     # Parse lock info from request body
     import json as json_mod
@@ -2093,7 +2095,7 @@ async def lock_workspace(
 
     await publish_workspace_event(str(ws.id), "workspace_lock_change", {"locked": True})
 
-    return JSONResponse(content=_workspace_json(ws, perm), headers=_tfe_headers())
+    return JSONResponse(content=_workspace_json(ws, caps), headers=_tfe_headers())
 
 
 @router.post("/workspaces/{workspace_id}/actions/unlock")
@@ -2104,18 +2106,18 @@ async def unlock_workspace(
 ) -> JSONResponse:
     """Unlock a workspace. Plan for own lock, admin for force-unlock."""
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
 
-    # Check: at minimum plan permission required
-    if not has_permission(perm, "plan"):
+    # Check: at minimum the lock capability is required
+    if not has_capability(caps, cap.WORKSPACE_LOCK):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires plan permission on workspace",
         )
 
-    # If locked by someone else, require admin to force-unlock
+    # If locked by someone else, require the force-unlock capability
     own_lock = ws.lock_id and (ws.lock_id == f"lock-{user.email}")
-    if ws.locked and not own_lock and not has_permission(perm, "admin"):
+    if ws.locked and not own_lock and not has_capability(caps, cap.WORKSPACE_FORCE_UNLOCK):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires admin permission to force-unlock workspace locked by another user",
@@ -2130,4 +2132,4 @@ async def unlock_workspace(
 
     await publish_workspace_event(str(ws.id), "workspace_lock_change", {"locked": False})
 
-    return JSONResponse(content=_workspace_json(ws, perm), headers=_tfe_headers())
+    return JSONResponse(content=_workspace_json(ws, caps), headers=_tfe_headers())

--- a/services/terrapod/api/routers/variables.py
+++ b/services/terrapod/api/routers/variables.py
@@ -27,6 +27,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_admin
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import (
     Variable,
     VariableSet,
@@ -38,8 +40,7 @@ from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import variable_service
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 
 router = APIRouter(prefix="/api/v2", tags=["variables"])
@@ -99,8 +100,8 @@ async def list_workspace_vars(
 ) -> JSONResponse:
     """List all variables for a workspace. Requires read."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.VAR_READ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Requires read permission on workspace"
         )
@@ -117,8 +118,8 @@ async def create_workspace_var(
 ) -> JSONResponse:
     """Create a variable for a workspace. Requires write."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "write"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.VAR_WRITE):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Requires write permission on workspace"
         )
@@ -160,8 +161,8 @@ async def update_workspace_var(
 ) -> JSONResponse:
     """Update a workspace variable. Requires write."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "write"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.VAR_WRITE):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Requires write permission on workspace"
         )
@@ -204,8 +205,8 @@ async def delete_workspace_var(
 ) -> None:
     """Delete a workspace variable. Requires write."""
     ws = await _get_workspace(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "write"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.VAR_WRITE):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Requires write permission on workspace"
         )

--- a/services/terrapod/api/routers/workspace_bulk.py
+++ b/services/terrapod/api/routers/workspace_bulk.py
@@ -31,6 +31,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, effective_platform_roles, require_admin
 from terrapod.api.labels import validate_labels
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import (
     AgentPool,
     AuditLog,
@@ -41,7 +43,7 @@ from terrapod.db.models import (
 )
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services import pool_rbac_service
+from terrapod.services.capability_resolver import resolve_capabilities
 from terrapod.services.notification_service import VALID_TRIGGERS
 from terrapod.services.run_task_service import VALID_ENFORCEMENT_LEVELS, VALID_STAGES
 from terrapod.services.workspace_search_service import (
@@ -218,13 +220,19 @@ async def _validate_update(
                 pool = await db.get(AgentPool, pid)
                 if pool is None:
                     raise HTTPException(status_code=422, detail="agent-pool-id not found")
-                # Assigning a pool requires pool `write` (platform admin bypass) —
-                # mirrors the single-workspace rule.
+                # Assigning a pool requires the pool:assign capability (platform
+                # admin bypass) — mirrors the single-workspace rule (#585).
                 if "admin" not in effective_platform_roles(user):
-                    perm = await pool_rbac_service.resolve_pool_permission(
-                        db, user.email, user.roles, pool.name, pool.labels, pool.owner_email
+                    pool_caps = await resolve_capabilities(
+                        db,
+                        user.email,
+                        user.roles,
+                        pool.name,
+                        pool.labels or {},
+                        pool.owner_email,
+                        axis="pool",
                     )
-                    if not pool_rbac_service.has_pool_permission(perm, "write"):
+                    if not has_capability(pool_caps, cap.POOL_ASSIGN):
                         raise HTTPException(
                             status_code=403,
                             detail=f"write permission on agent pool '{pool.name}' is required",

--- a/services/terrapod/api/routers/workspace_extensions.py
+++ b/services/terrapod/api/routers/workspace_extensions.py
@@ -18,11 +18,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.workspace_rbac_service import (
-    has_permission,
-    resolve_workspace_permission_for,
+    resolve_workspace_capabilities_for,
 )
 
 router = APIRouter(tags=["workspace-extensions"])
@@ -95,11 +96,11 @@ async def list_vcs_refs(
     )
 
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "read"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.WORKSPACE_READ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Requires read permission on workspace",
+            detail="Requires workspace:read capability on workspace",
         )
 
     if not ws.vcs_connection_id or not ws.vcs_repo_url:
@@ -148,11 +149,11 @@ async def dismiss_drift(
     from terrapod.api.routers.tfe_v2 import _get_workspace_by_id
 
     ws = await _get_workspace_by_id(workspace_id, db)
-    perm = await resolve_workspace_permission_for(db, user, ws)
-    if not has_permission(perm, "plan"):
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.DRIFT_DISMISS):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Requires plan permission on workspace",
+            detail="Requires drift:dismiss capability on workspace",
         )
 
     ws.drift_status = ""

--- a/services/terrapod/auth/capabilities.py
+++ b/services/terrapod/auth/capabilities.py
@@ -246,6 +246,28 @@ def has_capability(caps: frozenset[str] | set[str], required: str) -> bool:
     return required in caps
 
 
+# Public per-axis level maps, keyed by short axis name — for the capability
+# resolver (union / read-floor / full-set per axis). Values are the SAME frozen
+# sets as the private maps above.
+AXIS_LEVEL_MAPS: dict[str, dict[str, frozenset[str]]] = {
+    "workspace": _WORKSPACE_LEVELS,
+    "pool": _POOL_LEVELS,
+    "registry": _REGISTRY_LEVELS,
+    "catalog": _CATALOG_LEVELS,
+}
+
+
+def axis_read_caps(axis: str) -> frozenset[str]:
+    """The read-floor capability set for an axis (empty for catalog — no floor)."""
+    return AXIS_LEVEL_MAPS[axis].get("read", frozenset())
+
+
+def axis_all_caps(axis: str) -> frozenset[str]:
+    """Every capability the axis can grant (its top preset)."""
+    levels = AXIS_LEVEL_MAPS[axis]
+    return frozenset().union(*levels.values()) if levels else frozenset()
+
+
 def expand_preset(
     *,
     workspace_permission: str | None,

--- a/services/terrapod/auth/capabilities.py
+++ b/services/terrapod/auth/capabilities.py
@@ -234,6 +234,35 @@ def normalize_capabilities(caps: list[str] | set[str] | frozenset[str]) -> list[
     return sorted(out)
 
 
+_LEVEL_TO_AXES: dict[str, dict[str, str]] = {
+    "read": {"w": "read", "p": "read", "r": "read", "c": "read"},
+    "plan": {"w": "plan", "p": "read", "r": "read", "c": "read"},
+    "write": {"w": "write", "p": "write", "r": "write", "c": "use"},
+    "admin": {"w": "admin", "p": "admin", "r": "admin", "c": "admin"},
+    "use": {"c": "use"},
+    "none": {},
+}
+
+
+def caps_for_level(level: str | None) -> frozenset[str]:
+    """The capability set a legacy permission level maps to, unioned across all
+    four axes. A given axis's gate only checks its own axis's capability, so this
+    union is a faithful stand-in for any single-axis resolver at ``level`` (used
+    by tests that mock a resolver, and by UX that renders a preset's caps).
+    ``None`` / unknown → empty (no access)."""
+    if not level:
+        return frozenset()
+    m = _LEVEL_TO_AXES.get(level, {})
+    return frozenset(
+        expand_preset(
+            workspace_permission=m.get("w"),
+            pool_permission=m.get("p"),
+            registry_permission=m.get("r"),
+            catalog_permission=m.get("c"),
+        )
+    )
+
+
 def has_capability(caps: frozenset[str] | set[str], required: str) -> bool:
     """Canonical capability membership check (the enforcement primitive).
 

--- a/services/terrapod/auth/capabilities.py
+++ b/services/terrapod/auth/capabilities.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 # enumeration; new endpoints map onto an existing capability or add one here
 # deliberately. Net-new capabilities that no legacy preset grants until an admin
 # opts in (state:read-outputs / state:read-sensitive tier; the scoped platform:*
-# split #642; maker-checker #643) are introduced by their own follow-ups.
+# split #642) are introduced by their own follow-ups.
 
 # ── Workspace / runs — read tier ────────────────────────────────────────────
 # Per-resource read caps (each paired with a write/manage cap below, so an

--- a/services/terrapod/services/capability_resolver.py
+++ b/services/terrapod/services/capability_resolver.py
@@ -1,0 +1,191 @@
+"""Capability-set resolution for capability-based RBAC (#585).
+
+Parallel to the scalar level resolvers (``workspace_rbac_service`` etc.): instead
+of the single highest LEVEL a principal has on a resource, this returns the SET
+of capabilities they hold on it, so gates can check one capability
+(``has_capability(caps, RUN_PLAN)``) rather than a level threshold.
+
+A role's contribution is its explicit ``capabilities`` if populated (capability
+authoring), else ``expand_preset(role's levels)`` (migrated / level-authored
+roles) — so create/update need not expand on write. Sliced to the axis being
+resolved. Owner / platform-admin / audit / everyone-floor / runner-floor /
+catalog-managed-clamp / token-attenuation all mirror the scalar resolvers
+exactly; the equivalence test (``test_capability_resolver``) asserts, for every
+preset role shape, that this layer agrees with ``expand_preset(scalar_level)``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.auth import capabilities as cap
+from terrapod.auth.builtin_roles import BUILTIN_ROLE_NAMES
+from terrapod.db.models import Role
+from terrapod.services.rbac_service import matches_labels, merge_labels
+
+if TYPE_CHECKING:
+    from terrapod.api.dependencies import AuthenticatedUser
+
+AXES = ("workspace", "pool", "registry", "catalog")
+
+
+def role_effective_capabilities(role: Role) -> frozenset[str]:
+    """A role's full capability set: stored ``capabilities`` if any, else the
+    expansion of its legacy level fields. Normalised (aliases upgraded)."""
+    caps = role.capabilities or cap.expand_preset(
+        workspace_permission=role.workspace_permission,
+        pool_permission=role.pool_permission,
+        registry_permission=role.registry_permission,
+        catalog_permission=role.catalog_permission,
+    )
+    return frozenset(cap.normalize_capabilities(caps))
+
+
+def _role_matches(role: Role, resource_name: str, resource_labels: dict) -> bool:
+    """Deny-then-allow label/name match (the shared per-role gate)."""
+    deny_labels: dict[str, set[str]] = {}
+    merge_labels(deny_labels, role.deny_labels)
+    if resource_name in set(role.deny_names):
+        return False
+    if matches_labels(resource_labels, deny_labels):
+        return False
+
+    allow_labels: dict[str, set[str]] = {}
+    merge_labels(allow_labels, role.allow_labels)
+    if resource_name in set(role.allow_names):
+        return True
+    return matches_labels(resource_labels, allow_labels)
+
+
+async def resolve_capabilities(
+    db: AsyncSession,
+    user_email: str,
+    user_roles: list[str],
+    resource_name: str,
+    resource_labels: dict,
+    owner_email: str | None,
+    *,
+    axis: str,
+    preloaded_roles: list[Role] | None = None,
+    apply_everyone_floor: bool = True,
+    auth_method: str = "",
+    is_catalog_managed: bool = False,
+) -> frozenset[str]:
+    """The capability set a principal holds on a resource, for one axis.
+
+    Mirrors the scalar resolver's order (platform admin > audit > runner-floor
+    (registry) > owner > label RBAC > everyone-floor) but accumulates capability
+    sets. ``is_catalog_managed`` (workspace axis) clamps every non-platform-admin
+    grant to the read floor, exactly as the scalar catalog clamp does.
+    """
+    all_caps = cap.axis_all_caps(axis)
+    read_caps = cap.axis_read_caps(axis)
+    role_set = set(user_roles)
+
+    # 1. Platform admin → full axis caps, bypassing the catalog clamp (admins
+    #    manage catalog-managed workspaces directly), matching scalar's early
+    #    return of "admin".
+    if "admin" in role_set:
+        return all_caps
+
+    caps: set[str] = set()
+
+    # 2. Platform audit → read floor.
+    if "audit" in role_set:
+        caps |= read_caps
+
+    # 3. Registry runner-token floor (runners download modules/providers).
+    if axis == "registry" and auth_method == "runner_token":
+        caps |= read_caps
+
+    # 4. Owner → full axis caps (the catalog clamp below reduces this to read on
+    #    a catalog-managed workspace, matching scalar's owner→read branch there).
+    if owner_email and owner_email == user_email:
+        caps |= all_caps
+
+    # 5. Label-based RBAC from custom roles.
+    custom_role_names = role_set - BUILTIN_ROLE_NAMES
+    if custom_role_names:
+        if preloaded_roles is not None:
+            roles = [r for r in preloaded_roles if r.name in custom_role_names]
+        else:
+            result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
+            roles = list(result.scalars().all())
+        for role in roles:
+            if _role_matches(role, resource_name, resource_labels):
+                caps |= role_effective_capabilities(role) & all_caps
+
+    # 6. everyone-floor: read on resources labelled access=everyone. Catalog has
+    #    no floor (opt-in axis), matching the scalar catalog resolver.
+    if axis != "catalog" and apply_everyone_floor and resource_labels.get("access") == "everyone":
+        caps |= read_caps
+
+    # 7. catalog-managed workspace clamp → read floor for all non-admin grants.
+    if axis == "workspace" and is_catalog_managed:
+        caps &= read_caps
+
+    return frozenset(caps)
+
+
+async def resolve_capabilities_for(
+    db: AsyncSession,
+    user: AuthenticatedUser,
+    resource_name: str,
+    resource_labels: dict,
+    owner_email: str | None,
+    *,
+    axis: str,
+    preloaded_roles: list[Role] | None = None,
+    token_preloaded_roles: list[Role] | None = None,
+    is_catalog_managed: bool = False,
+) -> frozenset[str]:
+    """Kind-aware capability set (#495): interactive → user roles;
+    service_bound → user ∩ token; service_detached → token only (no owner
+    identity, everyone/runner floors suppressed)."""
+    auth_method = getattr(user, "auth_method", "") or ""
+    if user.kind == "service_detached":
+        return await resolve_capabilities(
+            db,
+            "",
+            user.pinned_roles or [],
+            resource_name,
+            resource_labels,
+            owner_email,
+            axis=axis,
+            preloaded_roles=token_preloaded_roles,
+            apply_everyone_floor=False,
+            auth_method="",
+            is_catalog_managed=is_catalog_managed,
+        )
+
+    user_caps = await resolve_capabilities(
+        db,
+        user.email,
+        user.roles,
+        resource_name,
+        resource_labels,
+        owner_email,
+        axis=axis,
+        preloaded_roles=preloaded_roles,
+        auth_method=auth_method,
+        is_catalog_managed=is_catalog_managed,
+    )
+    if user.kind == "service_bound":
+        token_caps = await resolve_capabilities(
+            db,
+            "",
+            user.pinned_roles or [],
+            resource_name,
+            resource_labels,
+            owner_email,
+            axis=axis,
+            preloaded_roles=token_preloaded_roles,
+            apply_everyone_floor=False,
+            auth_method="",
+            is_catalog_managed=is_catalog_managed,
+        )
+        return user_caps & token_caps
+    return user_caps

--- a/services/terrapod/services/catalog_rbac_service.py
+++ b/services/terrapod/services/catalog_rbac_service.py
@@ -143,6 +143,35 @@ async def resolve_catalog_permission(
     return best
 
 
+async def resolve_catalog_capabilities_for(
+    db: AsyncSession,
+    user: "AuthenticatedUser",
+    resource_name: str,
+    resource_labels: dict,
+    owner_email: str,
+    *,
+    preloaded_roles: list[Role] | None = None,
+    token_preloaded_roles: list[Role] | None = None,
+) -> frozenset[str]:
+    """Capability set a principal holds on a catalog item (#585).
+
+    Catalog-typed wrapper over ``capability_resolver`` (axis="catalog"; no
+    everyone-floor, opt-in). Faithful to :func:`resolve_catalog_permission_for`
+    for every preset role."""
+    from terrapod.services.capability_resolver import resolve_capabilities_for
+
+    return await resolve_capabilities_for(
+        db,
+        user,
+        resource_name,
+        resource_labels or {},
+        owner_email,
+        axis="catalog",
+        preloaded_roles=preloaded_roles,
+        token_preloaded_roles=token_preloaded_roles,
+    )
+
+
 async def resolve_catalog_permission_for(
     db: AsyncSession,
     user: "AuthenticatedUser",

--- a/services/terrapod/services/pool_rbac_service.py
+++ b/services/terrapod/services/pool_rbac_service.py
@@ -147,6 +147,34 @@ def min_pool_permission(a: str | None, b: str | None) -> str | None:
     return a if POOL_PERMISSION_HIERARCHY[a] <= POOL_PERMISSION_HIERARCHY[b] else b
 
 
+async def resolve_pool_capabilities_for(
+    db: AsyncSession,
+    user: AuthenticatedUser,
+    pool_name: str,
+    pool_labels: dict,
+    owner_email: str | None,
+    *,
+    preloaded_roles: list[Role] | None = None,
+    token_preloaded_roles: list[Role] | None = None,
+) -> frozenset[str]:
+    """Capability set a principal holds on an agent pool (#585 enforcement).
+
+    Pool-typed wrapper over ``capability_resolver`` (axis="pool"). Faithful to
+    :func:`resolve_pool_permission_for` for every preset role."""
+    from terrapod.services.capability_resolver import resolve_capabilities_for
+
+    return await resolve_capabilities_for(
+        db,
+        user,
+        pool_name,
+        pool_labels or {},
+        owner_email,
+        axis="pool",
+        preloaded_roles=preloaded_roles,
+        token_preloaded_roles=token_preloaded_roles,
+    )
+
+
 async def resolve_pool_permission_for(
     db: AsyncSession,
     user: AuthenticatedUser,

--- a/services/terrapod/services/registry_rbac_service.py
+++ b/services/terrapod/services/registry_rbac_service.py
@@ -153,6 +153,35 @@ def min_registry_permission(a: str | None, b: str | None) -> str | None:
     return a if REGISTRY_PERMISSION_HIERARCHY[a] <= REGISTRY_PERMISSION_HIERARCHY[b] else b
 
 
+async def resolve_registry_capabilities_for(
+    db: AsyncSession,
+    user: "AuthenticatedUser",
+    resource_name: str,
+    resource_labels: dict,
+    owner_email: str,
+    *,
+    preloaded_roles: list[Role] | None = None,
+    token_preloaded_roles: list[Role] | None = None,
+) -> frozenset[str]:
+    """Capability set a principal holds on a registry resource (#585).
+
+    Registry-typed wrapper over ``capability_resolver`` (axis="registry"; the
+    runner-token read floor is applied inside via ``user.auth_method``). Faithful
+    to :func:`resolve_registry_permission_for` for every preset role."""
+    from terrapod.services.capability_resolver import resolve_capabilities_for
+
+    return await resolve_capabilities_for(
+        db,
+        user,
+        resource_name,
+        resource_labels or {},
+        owner_email,
+        axis="registry",
+        preloaded_roles=preloaded_roles,
+        token_preloaded_roles=token_preloaded_roles,
+    )
+
+
 async def resolve_registry_permission_for(
     db: AsyncSession,
     user: "AuthenticatedUser",

--- a/services/terrapod/services/workspace_rbac_service.py
+++ b/services/terrapod/services/workspace_rbac_service.py
@@ -165,6 +165,35 @@ def min_workspace_permission(a: str | None, b: str | None) -> str | None:
     return a if PERMISSION_HIERARCHY[a] <= PERMISSION_HIERARCHY[b] else b
 
 
+async def resolve_workspace_capabilities_for(
+    db: AsyncSession,
+    user: "AuthenticatedUser",
+    workspace: Workspace,
+    *,
+    preloaded_roles: list[Role] | None = None,
+    token_preloaded_roles: list[Role] | None = None,
+) -> frozenset[str]:
+    """Capability set a principal holds on a workspace (#585 enforcement).
+
+    Workspace-typed wrapper over ``capability_resolver`` — extracts the resource
+    fields and delegates. Gates check ``has_capability(caps, RUN_PLAN)`` instead
+    of a level threshold; faithful to :func:`resolve_workspace_permission_for`
+    for every preset role (``test_capability_resolver``)."""
+    from terrapod.services.capability_resolver import resolve_capabilities_for
+
+    return await resolve_capabilities_for(
+        db,
+        user,
+        workspace.name,
+        workspace.labels or {},
+        workspace.owner_email,
+        axis="workspace",
+        preloaded_roles=preloaded_roles,
+        token_preloaded_roles=token_preloaded_roles,
+        is_catalog_managed=workspace.catalog_item_id is not None,
+    )
+
+
 async def resolve_workspace_permission_for(
     db: AsyncSession,
     user: "AuthenticatedUser",

--- a/services/tests/api/test_agent_pools.py
+++ b/services/tests/api/test_agent_pools.py
@@ -14,6 +14,7 @@ from terrapod.api.dependencies import (
     get_listener_identity,
     require_admin,
 )
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -213,7 +214,7 @@ class TestListPoolsRBAC:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -230,8 +231,8 @@ class TestListPoolsRBAC:
         mock_fetch_roles.return_value = []
         mock_list_listeners.return_value = []
 
-        # First pool: read access; second pool: no access
-        mock_resolve.side_effect = ["read", None]
+        # First pool: read access; second pool: no access (empty cap set)
+        mock_resolve.side_effect = [caps_for_level("read"), frozenset()]
 
         user = _user(roles=["everyone"])
         app, _ = _make_app(user)
@@ -250,7 +251,7 @@ class TestListPoolsRBAC:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -265,7 +266,7 @@ class TestListPoolsRBAC:
         mock_list_pools.return_value = [pool]
         mock_fetch_roles.return_value = []
         mock_list_listeners.return_value = []
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
 
         user = _user(roles=["pool-writer"])
         app, _ = _make_app(user)
@@ -287,7 +288,7 @@ class TestPoolStatus:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -300,7 +301,7 @@ class TestPoolStatus:
         pool = _mock_pool(name="busy-pool")
         mock_list_pools.return_value = [pool]
         mock_fetch_roles.return_value = []
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         mock_list_listeners.return_value = [
             {"id": str(uuid.uuid4()), "name": "lis-1", "status": "online"}
         ]
@@ -321,7 +322,7 @@ class TestPoolStatus:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -334,7 +335,7 @@ class TestPoolStatus:
         pool = _mock_pool(name="quiet-pool")
         mock_list_pools.return_value = [pool]
         mock_fetch_roles.return_value = []
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         mock_list_listeners.return_value = []
 
         app, _ = _make_app(_user())
@@ -349,7 +350,7 @@ class TestPoolStatus:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_show_pool_includes_status(
@@ -357,7 +358,7 @@ class TestPoolStatus:
     ):
         pool = _mock_pool(name="visible")
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         mock_list_listeners.return_value = [
             {"id": str(uuid.uuid4()), "name": "lis", "status": "online"}
         ]
@@ -443,7 +444,7 @@ class TestDerivePoolStatus:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.list_pools", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     @patch(
@@ -457,7 +458,7 @@ class TestDerivePoolStatus:
         pool = _mock_pool(name="dying-pool")
         mock_list_pools.return_value = [pool]
         mock_fetch_roles.return_value = []
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
         mock_list_listeners.return_value = [
             {
@@ -485,7 +486,7 @@ class TestListListenersReplicaCount:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_listeners_carry_replica_count(
@@ -498,7 +499,7 @@ class TestListListenersReplicaCount:
     ):
         pool = _mock_pool()
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         lid_a, lid_b = uuid.uuid4(), uuid.uuid4()
         mock_list_listeners.return_value = [
             {"id": str(lid_a), "name": "lis-a", "status": "online", "tracks_pods": "1"},
@@ -526,7 +527,7 @@ class TestListListenersReplicaCount:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_replica_count_omitted_when_listener_does_not_track_pods(
@@ -541,7 +542,7 @@ class TestListListenersReplicaCount:
         and count_listener_replicas is never called."""
         pool = _mock_pool()
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         lid = uuid.uuid4()
         mock_list_listeners.return_value = [
             {"id": str(lid), "name": "old-listener", "status": "online"},
@@ -565,7 +566,7 @@ class TestListListenersReplicaCount:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_replica_count_included_for_mixed_listeners(
@@ -579,7 +580,7 @@ class TestListListenersReplicaCount:
         """Mixed list: tracking listener gets replica-count, old one doesn't."""
         pool = _mock_pool()
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         lid_new, lid_old = uuid.uuid4(), uuid.uuid4()
         mock_list_listeners.return_value = [
             {"id": str(lid_new), "name": "new", "status": "online", "tracks_pods": "1"},
@@ -608,7 +609,7 @@ class TestShowPoolRBAC:
     @patch("terrapod.services.agent_pool_service.list_listeners", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_show_pool_with_read(
@@ -617,7 +618,7 @@ class TestShowPoolRBAC:
         pool = _mock_pool(name="visible", labels={"env": "dev"}, owner_email="owner@test.com")
         mock_get_pool.return_value = pool
         mock_list_listeners.return_value = []
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
 
         user = _user()
         app, _ = _make_app(user)
@@ -637,14 +638,14 @@ class TestShowPoolRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_show_pool_no_access_returns_404(self, mock_resolve, mock_get_pool, *mocks):
         """Pool invisible to user returns 404 (not 403)."""
         pool = _mock_pool(name="secret")
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = None
+        mock_resolve.return_value = caps_for_level(None)
 
         user = _user()
         app, _ = _make_app(user)
@@ -733,14 +734,14 @@ class TestUpdatePoolRBAC:
     @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_update_pool_with_labels(self, mock_resolve, mock_get_pool, mock_update, *mocks):
         pool = _mock_pool(name="my-pool", labels={"env": "dev"})
         updated_pool = _mock_pool(name="my-pool", labels={"env": "prod"})
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         mock_update.return_value = updated_pool
 
         user = _user(email="owner@example.com")
@@ -768,14 +769,14 @@ class TestUpdatePoolRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_update_pool_write_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
         """Write permission is insufficient for pool update — admin required."""
         pool = _mock_pool(name="restricted")
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
 
         user = _user()
         app, _ = _make_app(user)
@@ -803,7 +804,7 @@ class TestDeletePoolRBAC:
     )
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_delete_pool_with_admin(
@@ -811,7 +812,7 @@ class TestDeletePoolRBAC:
     ):
         pool = _mock_pool()
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
 
         user = _user(email="owner@example.com")
         app, mock_db = _make_app(user)
@@ -829,13 +830,13 @@ class TestDeletePoolRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_delete_pool_no_access_returns_404(self, mock_resolve, mock_get_pool, *mocks):
         pool = _mock_pool()
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = None
+        mock_resolve.return_value = caps_for_level(None)
 
         user = _user()
         app, _ = _make_app(user)
@@ -856,14 +857,14 @@ class TestTokenEndpointRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_list_tokens_read_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
         """User with read permission cannot list pool tokens."""
         pool = _mock_pool()
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
 
         user = _user()
         app, _ = _make_app(user)
@@ -880,14 +881,14 @@ class TestTokenEndpointRBAC:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_create_token_read_only_returns_403(self, mock_resolve, mock_get_pool, *mocks):
         """User with read permission cannot create pool tokens."""
         pool = _mock_pool()
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
 
         user = _user()
         app, _ = _make_app(user)
@@ -910,7 +911,7 @@ class TestUpdatePoolSelfLockout:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_label_change_reducing_access_returns_409(
@@ -919,9 +920,15 @@ class TestUpdatePoolSelfLockout:
         """Changing labels that would reduce user's access returns 409."""
         pool = _mock_pool(name="my-pool", labels={"team": "sre"})
         mock_get_pool.return_value = pool
-        # First call: current permission check → admin
-        # Second call: simulated new permission → None (locked out)
-        mock_resolve.side_effect = ["admin", None]
+        # Three resolver calls in update_pool: (1) the _require_pool_capability
+        # gate, (2) old_caps capture, (3) new_caps after the label change. Start
+        # as pool admin, drop to read (no POOL_MANAGE/POOL_ASSIGN) → removed
+        # capabilities → 409.
+        mock_resolve.side_effect = [
+            caps_for_level("admin"),
+            caps_for_level("admin"),
+            caps_for_level("read"),
+        ]
 
         user = _user(email="user@example.com", roles=["sre-role"])
         app, _ = _make_app(user)
@@ -934,7 +941,9 @@ class TestUpdatePoolSelfLockout:
             )
 
         assert res.status_code == 409
-        assert "reduce your access" in res.json()["errors"][0]["detail"]
+        err = res.json()["errors"][0]
+        assert "reduce your access" in err["title"]
+        assert "remove capabilities you currently hold" in err["detail"]
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -942,7 +951,7 @@ class TestUpdatePoolSelfLockout:
     @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_force_bypasses_lockout_check(
@@ -952,7 +961,7 @@ class TestUpdatePoolSelfLockout:
         pool = _mock_pool(name="my-pool", labels={"team": "sre"})
         updated_pool = _mock_pool(name="my-pool", labels={"team": "other"})
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         mock_update.return_value = updated_pool
 
         user = _user(email="user@example.com", roles=["sre-role"])
@@ -975,7 +984,7 @@ class TestUpdatePoolSelfLockout:
     @patch("terrapod.services.agent_pool_service.update_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_platform_admin_immune_to_lockout(
@@ -985,7 +994,7 @@ class TestUpdatePoolSelfLockout:
         pool = _mock_pool(name="my-pool", labels={"team": "sre"})
         updated_pool = _mock_pool(name="my-pool", labels={})
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         mock_update.return_value = updated_pool
 
         user = _user(email="admin@example.com", roles=["admin"])
@@ -1016,7 +1025,7 @@ class TestDeleteListenerRBAC:
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_listener")
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_delete_listener_with_pool_admin(
@@ -1027,7 +1036,7 @@ class TestDeleteListenerRBAC:
         listener = _mock_listener_dict(listener_id=lid, pool_id=pool.id)
         mock_get_listener.return_value = listener
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
 
         user = _user()
         app, _ = _make_app(user)
@@ -1043,7 +1052,7 @@ class TestDeleteListenerRBAC:
     @patch("terrapod.services.agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch("terrapod.services.agent_pool_service.get_listener")
     @patch(
-        "terrapod.api.routers.agent_pools.resolve_pool_permission_for",
+        "terrapod.api.routers.agent_pools.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_delete_listener_read_only_returns_403(
@@ -1055,7 +1064,7 @@ class TestDeleteListenerRBAC:
         listener = _mock_listener_dict(listener_id=lid, pool_id=pool.id)
         mock_get_listener.return_value = listener
         mock_get_pool.return_value = pool
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
 
         user = _user()
         app, _ = _make_app(user)

--- a/services/tests/api/test_ai_summary.py
+++ b/services/tests/api/test_ai_summary.py
@@ -17,6 +17,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -129,9 +130,9 @@ class TestGetPlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_returns_summary_when_present(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run()
         ws = _mock_workspace(ws_id=run.workspace_id)
         summary = _mock_summary(run.id, risk_level="high")
@@ -161,9 +162,9 @@ class TestGetPlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_returns_404_when_no_summary(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run()
         ws = _mock_workspace(ws_id=run.workspace_id)
 
@@ -184,10 +185,10 @@ class TestGetPlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_plan_response_includes_ai_summary_url(self, mock_resolve, *mocks):
         """GET /plans/{id} advertises the ai-summary-url even when no row exists yet."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run()
         ws = _mock_workspace(ws_id=run.workspace_id)
 
@@ -210,12 +211,12 @@ class TestGetPlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_plan_response_omits_ai_summary_url_when_disabled(self, mock_resolve, *mocks):
         """AI globally disabled → plan response carries no ai-summary-url
         so the UI doesn't fetch /plan-summary and waste a round-trip
         getting back a guaranteed 404 (#463 phase 7)."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run()
         ws = _mock_workspace(ws_id=run.workspace_id)
 
@@ -242,9 +243,9 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_get_includes_ai_summary_fields(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace(ai_summary_mode="enabled", ai_summary_context="vault prod")
 
         app, mock_db = _make_app(_user())
@@ -265,9 +266,9 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_patch_accepts_valid_mode(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -296,9 +297,9 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_patch_rejects_invalid_mode(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -317,9 +318,9 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_patch_rejects_oversize_context(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -338,9 +339,9 @@ class TestWorkspaceAISummaryFields:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_patch_rejects_non_string_context(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -369,12 +370,12 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_planned_run_returns_202_and_enqueues(
         self, mock_enq, mock_resolve, *_mocks
     ):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="planned")
         run.plan_started_at = datetime(2026, 1, 1, tzinfo=UTC)
         run.apply_started_at = None
@@ -419,12 +420,12 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_plan_phase_errored_picks_failure_analysis(
         self, mock_enq, mock_resolve, *_mocks
     ):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="errored")
         run.plan_started_at = datetime(2026, 1, 1, tzinfo=UTC)
         run.apply_started_at = None  # errored during plan, not apply
@@ -458,7 +459,7 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_apply_phase_errored_picks_failure_analysis(
         self, mock_enq, mock_resolve, *_mocks
@@ -467,7 +468,7 @@ class TestRegeneratePlanSummary:
         regenerate; now they're in scope and the regenerate flow
         produces a failure_analysis summary against the apply log.
         """
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="errored")
         run.plan_started_at = datetime(2026, 1, 1, tzinfo=UTC)
         run.apply_started_at = datetime(2026, 1, 1, 0, 5, tzinfo=UTC)  # apply BEGAN
@@ -501,7 +502,7 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_409_when_no_summary_kind_applies(
         self, mock_enq, mock_resolve, *_mocks
@@ -511,7 +512,7 @@ class TestRegeneratePlanSummary:
         phase errored runs ARE in scope post-#419 and tested
         separately below.
         """
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="queued")
         run.plan_started_at = None
         run.apply_started_at = None
@@ -560,11 +561,11 @@ class TestRegeneratePlanSummary:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.services.scheduler.enqueue_trigger", new_callable=AsyncMock)
     async def test_regenerate_403_when_no_workspace_read(self, mock_enq, mock_resolve, *_mocks):
         """No workspace read → 403 (the permission helper raises)."""
-        mock_resolve.return_value = None  # no permission
+        mock_resolve.return_value = caps_for_level(None)  # no permission
         run = _mock_run(status="planned")
         ws = _mock_workspace(ws_id=run.workspace_id)
 

--- a/services/tests/api/test_catalog.py
+++ b/services/tests/api/test_catalog.py
@@ -11,6 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.api.routers import catalog as catalog_router
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.config import settings
 from terrapod.db.session import get_db
 
@@ -170,8 +171,8 @@ class TestCatalogItemRBAC:
 
 class TestProvision:
     @patch("terrapod.api.routers.catalog.catalog_service.provision_instance")
-    @patch("terrapod.api.routers.catalog.resolve_pool_permission_for")
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_pool_capabilities_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.routers.catalog.catalog_service.get_catalog_item")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -189,8 +190,8 @@ class TestProvision:
         item.owner_email = ""
         item.allowed_agent_pool_ids = None
         mock_get.return_value = item
-        mock_cat.return_value = "use"
-        mock_pool.return_value = "write"
+        mock_cat.return_value = caps_for_level("use")
+        mock_pool.return_value = caps_for_level("write")
 
         pool = MagicMock()
         pool.id = pool_uuid
@@ -246,7 +247,7 @@ class TestProvision:
             )
         assert resp.status_code == 409
 
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.routers.catalog.catalog_service.get_catalog_item")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -258,7 +259,7 @@ class TestProvision:
         item.labels = {}
         item.owner_email = ""
         mock_get.return_value = item
-        mock_perm.return_value = "read"  # read, not use
+        mock_perm.return_value = caps_for_level("read")  # read, not use
 
         app, _ = _make_app(_user(roles=["everyone"]))
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
@@ -269,8 +270,8 @@ class TestProvision:
             )
         assert resp.status_code == 403
 
-    @patch("terrapod.api.routers.catalog.resolve_pool_permission_for")
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_pool_capabilities_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.routers.catalog.catalog_service.get_catalog_item")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -287,8 +288,8 @@ class TestProvision:
         item.owner_email = ""
         item.allowed_agent_pool_ids = [str(allowed)]
         mock_get.return_value = item
-        mock_cat_perm.return_value = "use"
-        mock_pool_perm.return_value = "write"
+        mock_cat_perm.return_value = caps_for_level("use")
+        mock_pool_perm.return_value = caps_for_level("write")
 
         pool = MagicMock()
         pool.id = chosen
@@ -308,8 +309,8 @@ class TestProvision:
         assert resp.status_code == 403
         assert "not allowed" in resp.json()["detail"]
 
-    @patch("terrapod.api.routers.catalog.resolve_pool_permission_for")
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_pool_capabilities_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.routers.catalog.catalog_service.get_catalog_item")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -325,8 +326,8 @@ class TestProvision:
         item.owner_email = ""
         item.allowed_agent_pool_ids = None  # any pool allowed
         mock_get.return_value = item
-        mock_cat_perm.return_value = "use"
-        mock_pool_perm.return_value = "read"  # not write
+        mock_cat_perm.return_value = caps_for_level("use")
+        mock_pool_perm.return_value = caps_for_level("read")  # not write
 
         pool = MagicMock()
         pool.id = chosen
@@ -375,7 +376,7 @@ class TestInstanceLifecycle:
             )
         assert resp.status_code == 404
 
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -387,7 +388,7 @@ class TestInstanceLifecycle:
         item.labels = {}
         item.owner_email = ""
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "read"  # read, not use
+        mock_perm.return_value = caps_for_level("read")  # read, not use
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.patch(
@@ -398,7 +399,7 @@ class TestInstanceLifecycle:
         assert resp.status_code == 403
 
     @patch("terrapod.api.routers.catalog.catalog_service.reconfigure_instance")
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -410,7 +411,7 @@ class TestInstanceLifecycle:
         item.labels = {}
         item.owner_email = ""
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "use"
+        mock_perm.return_value = caps_for_level("use")
         run = MagicMock()
         run.id = uuid.uuid4()
         run.status = "queued"
@@ -437,7 +438,7 @@ class TestInstanceLifecycle:
         assert mock_reconfig.await_args.kwargs["auto_apply"] is True
 
     @patch("terrapod.api.routers.catalog.catalog_service.destroy_instance")
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -449,7 +450,7 @@ class TestInstanceLifecycle:
         item.labels = {}
         item.owner_email = ""
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "use"
+        mock_perm.return_value = caps_for_level("use")
         run = MagicMock()
         run.id = uuid.uuid4()
         run.status = "queued"
@@ -466,7 +467,7 @@ class TestInstanceLifecycle:
         assert resp.json()["data"]["attributes"]["is-destroy"] is True
         assert mock_destroy.await_args.kwargs["auto_apply"] is True
 
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -478,7 +479,7 @@ class TestInstanceLifecycle:
         item.labels = {}
         item.owner_email = ""
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "read"
+        mock_perm.return_value = caps_for_level("read")
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
@@ -488,7 +489,7 @@ class TestInstanceLifecycle:
             )
         assert resp.status_code == 403
 
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -500,7 +501,7 @@ class TestInstanceLifecycle:
         item = MagicMock(labels={}, owner_email="")
         item.name = "vpc"
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "admin"
+        mock_perm.return_value = caps_for_level("admin")
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(f"/api/terrapod/v1/catalog-instances/ws-{ws.id}", headers=_AUTH)
@@ -508,7 +509,7 @@ class TestInstanceLifecycle:
         assert "destroy" in resp.json()["detail"].lower()
         mock_db.delete.assert_not_called()
 
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -519,7 +520,7 @@ class TestInstanceLifecycle:
         item = MagicMock(labels={}, owner_email="")
         item.name = "vpc"
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "admin"
+        mock_perm.return_value = caps_for_level("admin")
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(
@@ -528,7 +529,7 @@ class TestInstanceLifecycle:
         assert resp.status_code == 204
         mock_db.delete.assert_awaited_once_with(ws)
 
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -539,7 +540,7 @@ class TestInstanceLifecycle:
         item = MagicMock(labels={}, owner_email="")
         item.name = "vpc"
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "use"  # use is enough to destroy, not to orphan
+        mock_perm.return_value = caps_for_level("use")  # use is enough to destroy, not to orphan
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(
@@ -667,7 +668,7 @@ def _exec_returns(obj):
 
 class TestConfirmDiscard:
     @patch("terrapod.api.routers.catalog.run_service.confirm_run")
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -677,7 +678,7 @@ class TestConfirmDiscard:
         item = MagicMock(labels={}, owner_email="")
         item.name = "vpc"
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "use"
+        mock_perm.return_value = caps_for_level("use")
         planned = _planned_run()
         mock_db.execute = AsyncMock(return_value=_exec_returns(planned))
         mock_confirm.return_value = _planned_run(status="confirmed")
@@ -689,7 +690,7 @@ class TestConfirmDiscard:
         assert resp.status_code == 200
         mock_confirm.assert_awaited_once()
 
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -699,7 +700,7 @@ class TestConfirmDiscard:
         item = MagicMock(labels={}, owner_email="")
         item.name = "vpc"
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "use"
+        mock_perm.return_value = caps_for_level("use")
         mock_db.execute = AsyncMock(return_value=_exec_returns(None))  # no run
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
@@ -708,7 +709,7 @@ class TestConfirmDiscard:
             )
         assert resp.status_code == 409
 
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -777,7 +778,7 @@ class TestConfirmDiscardRunSourceGuard:
     (plan_only, non-catalog source) is rejected 409 by confirm/discard."""
 
     @patch("terrapod.api.routers.catalog.run_service.confirm_run")
-    @patch("terrapod.api.routers.catalog.resolve_catalog_permission_for")
+    @patch("terrapod.api.routers.catalog.resolve_catalog_capabilities_for")
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
@@ -789,7 +790,7 @@ class TestConfirmDiscardRunSourceGuard:
         item = MagicMock(labels={}, owner_email="")
         item.name = "vpc"
         mock_db.get = AsyncMock(side_effect=[ws, item])
-        mock_perm.return_value = "use"
+        mock_perm.return_value = caps_for_level("use")
         speculative = _planned_run(source="module-test", plan_only=True)
         mock_db.execute = AsyncMock(return_value=_exec_returns(speculative))
 

--- a/services/tests/api/test_config_versions_catalog_guard.py
+++ b/services/tests/api/test_config_versions_catalog_guard.py
@@ -13,6 +13,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -66,13 +67,13 @@ async def test_cv_create_rejected_on_catalog_ws(*mocks):
 
 
 @patch("terrapod.api.routers.config_versions.run_service.create_configuration_version")
-@patch("terrapod.api.routers.config_versions.resolve_workspace_permission_for")
+@patch("terrapod.api.routers.config_versions.resolve_workspace_capabilities_for")
 @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
 @patch("terrapod.api.app.init_redis")
 @patch("terrapod.api.app.init_db")
 async def test_cv_create_allowed_on_normal_ws(_db, _redis, _storage, mock_resolve, mock_create):
     ws = _mock_workspace(catalog_item_id=None)
-    mock_resolve.return_value = "write"
+    mock_resolve.return_value = caps_for_level("write")
     cv = MagicMock()
     cv.id = uuid.uuid4()
     cv.workspace_id = ws.id

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -87,10 +88,10 @@ class TestWorkspaceDriftAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_workspace_includes_drift_attributes(self, mock_resolve, *mocks):
         """GET workspace includes drift fields in response."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace(drift_detection_enabled=True, drift_status="no_drift")
 
         app, mock_db = _make_app(_user())
@@ -111,10 +112,10 @@ class TestWorkspaceDriftAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_update_drift_settings(self, mock_resolve, *mocks):
         """PATCH workspace drift-detection-enabled updates model."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -143,10 +144,10 @@ class TestWorkspaceDriftAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_drift_interval_minimum_enforced(self, mock_resolve, *mocks):
         """Interval below minimum is clamped to configured floor."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -179,10 +180,10 @@ class TestRunDriftAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_run_includes_drift_fields(self, mock_resolve, *mocks):
         """GET run includes is-drift-detection and has-changes."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run_id = uuid.uuid4()
         ws_id = uuid.uuid4()
         run = MagicMock()
@@ -257,12 +258,12 @@ class TestDismissDriftAction:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_capabilities_for")
     async def test_dismiss_drift_clears_state_and_keeps_detection_enabled(
         self, mock_resolve, *mocks
     ):
         """drift_status and drift_last_checked_at reset; drift_detection_enabled unchanged."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace(
             drift_detection_enabled=True,
             drift_status="drifted",
@@ -293,10 +294,10 @@ class TestDismissDriftAction:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_capabilities_for")
     async def test_dismiss_drift_requires_plan_permission(self, mock_resolve, *mocks):
         """Read-only users cannot dismiss drift."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace(drift_status="drifted")
 
         app, mock_db = _make_app(_user())
@@ -317,10 +318,10 @@ class TestDismissDriftAction:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.workspace_extensions.resolve_workspace_capabilities_for")
     async def test_dismiss_drift_is_idempotent(self, mock_resolve, *mocks):
         """Dismissing a workspace with no drift reported is a no-op (still 200)."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace(
             drift_detection_enabled=True,
             drift_status="",

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 from terrapod.storage import get_storage
 
@@ -158,12 +159,12 @@ class TestRunJsonModuleOverrides:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.get_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_run_json_includes_module_overrides(self, mock_resolve, mock_get_run, *mocks):
         overrides = {"default/eks/aws": "module_overrides/abc123/default/eks/aws.tar.gz"}
         run = _mock_run(module_overrides=overrides, source="module-test")
         mock_get_run.return_value = run
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
 
         mock_db = AsyncMock()
         mock_db.get.return_value = _mock_workspace(ws_id=run.workspace_id)
@@ -267,7 +268,7 @@ class TestRetryRunCopiesOverrides:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_retry_copies_module_overrides(
         self, mock_resolve, mock_get_run, mock_create_run, mock_queue, *mocks
     ):
@@ -278,7 +279,7 @@ class TestRetryRunCopiesOverrides:
             module_overrides=overrides,
         )
         mock_get_run.return_value = original
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
 
         new_run = _mock_run()
         mock_create_run.return_value = new_run
@@ -306,12 +307,12 @@ class TestWorkspaceLinkCRUD:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission_for")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_capabilities_for")
     @patch("terrapod.api.routers.registry_modules.get_module")
     async def test_list_workspace_links(self, mock_get_module, mock_resolve, *mocks):
         module = _mock_module()
         mock_get_module.return_value = module
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
 
         link = _mock_link(module_id=module.id)
 
@@ -335,14 +336,14 @@ class TestWorkspaceLinkCRUD:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission_for")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_capabilities_for")
     @patch("terrapod.api.routers.registry_modules.get_module")
     async def test_create_workspace_link_requires_admin(
         self, mock_get_module, mock_resolve, *mocks
     ):
         module = _mock_module()
         mock_get_module.return_value = module
-        mock_resolve.return_value = "write"  # Not admin
+        mock_resolve.return_value = caps_for_level("write")  # Not admin
 
         app, _ = _make_app(_admin_user())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:

--- a/services/tests/api/test_notification_configurations.py
+++ b/services/tests/api/test_notification_configurations.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -74,10 +75,10 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_create_generic(self, mock_resolve, *mocks):
         """Create generic webhook → 201."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -108,10 +109,10 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_create_invalid_type(self, mock_resolve, *mocks):
         """Invalid destination-type → 422."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -139,10 +140,10 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_create_invalid_triggers(self, mock_resolve, *mocks):
         """Invalid trigger event → 422."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -172,10 +173,10 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_create_requires_admin(self, mock_resolve, *mocks):
         """Write permission → 403."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -204,10 +205,10 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_create_email_requires_addresses(self, mock_resolve, *mocks):
         """Email type without email-addresses → 422."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -236,10 +237,10 @@ class TestCreateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_create_generic_requires_url(self, mock_resolve, *mocks):
         """Generic without url → 422."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -272,10 +273,10 @@ class TestListNotificationConfigurations:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_list(self, mock_resolve, *mocks):
         """List returns configs. Read permission sufficient."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         nc = _mock_nc(ws=ws)
 
@@ -304,9 +305,9 @@ class TestShowNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_show(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         nc = _mock_nc()
 
         app, mock_db = _make_app(_user())
@@ -350,10 +351,10 @@ class TestUpdateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_update_name(self, mock_resolve, *mocks):
         """PATCH updates name → 200."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         nc = _mock_nc()
 
         app, mock_db = _make_app(_user())
@@ -378,10 +379,10 @@ class TestUpdateNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_update_requires_admin(self, mock_resolve, *mocks):
         """Write permission → 403."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         nc = _mock_nc()
 
         app, mock_db = _make_app(_user())
@@ -405,10 +406,10 @@ class TestDeleteNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     async def test_delete(self, mock_resolve, *mocks):
         """Admin can delete → 204."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         nc = _mock_nc()
 
         app, mock_db = _make_app(_user())
@@ -432,12 +433,12 @@ class TestVerifyNotificationConfiguration:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.notification_configurations.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.notification_configurations.deliver_notification")
     @patch("terrapod.api.routers.notification_configurations.record_delivery_response")
     async def test_verify(self, mock_record, mock_deliver, mock_resolve, *mocks):
         """Verify sends test notification and records response."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         mock_deliver.return_value = {"status": 200, "body": "ok", "success": True}
 
         nc = _mock_nc()

--- a/services/tests/api/test_registry_module_interface.py
+++ b/services/tests/api/test_registry_module_interface.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -125,7 +126,7 @@ class TestCreateModuleVersionDuplicate:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission_for")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_capabilities_for")
     @patch("terrapod.api.routers.registry_modules.get_module")
     async def test_duplicate_version_returns_409(self, mock_get_module, mock_perm, *_mocks):
         """Creating a version that already exists returns a clean 409 (not a
@@ -136,7 +137,7 @@ class TestCreateModuleVersionDuplicate:
         app.dependency_overrides[get_storage] = lambda: AsyncMock()
         module = _mock_module()
         mock_get_module.return_value = module
-        mock_perm.return_value = "admin"
+        mock_perm.return_value = caps_for_level("admin")
         # The pre-check query finds an existing version → 409 before any insert.
         db.execute = AsyncMock(return_value=_scalar_result(_mock_version()))
 
@@ -156,7 +157,7 @@ class TestCreateModuleVersionDuplicate:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.registry_modules.create_module_version", new_callable=AsyncMock)
-    @patch("terrapod.api.routers.registry_modules.resolve_registry_permission_for")
+    @patch("terrapod.api.routers.registry_modules.resolve_registry_capabilities_for")
     @patch("terrapod.api.routers.registry_modules.get_module")
     async def test_concurrent_insert_race_rolls_back_to_409(
         self, mock_get_module, mock_perm, mock_create, *_mocks
@@ -170,7 +171,7 @@ class TestCreateModuleVersionDuplicate:
         app, db = _make_app()
         app.dependency_overrides[get_storage] = lambda: AsyncMock()
         mock_get_module.return_value = _mock_module()
-        mock_perm.return_value = "admin"
+        mock_perm.return_value = caps_for_level("admin")
         # Pre-check finds nothing → we proceed; then the flush races and raises.
         db.execute = AsyncMock(return_value=_scalar_result(None))
         db.rollback = AsyncMock()

--- a/services/tests/api/test_remote_state_consumers.py
+++ b/services/tests/api/test_remote_state_consumers.py
@@ -18,6 +18,7 @@ from httpx import ASGITransport, AsyncClient
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.api.routers.tfe_v2 import _runner_state_read_allowed
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -154,7 +155,7 @@ class TestRunnerAuthzWiring:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id", new_callable=AsyncMock)
     @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
     async def test_current_state_version_grants_when_helper_returns_true(
@@ -192,7 +193,7 @@ class TestRunnerAuthzWiring:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id", new_callable=AsyncMock)
     @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
     async def test_current_state_version_falls_through_and_denies_runner(
@@ -204,7 +205,7 @@ class TestRunnerAuthzWiring:
         producer = _mock_ws(name="producer")
         m_get_ws.return_value = producer
         m_helper.return_value = False
-        m_resolve.return_value = None  # everyone role → no permission
+        m_resolve.return_value = frozenset()  # everyone role → no capabilities
 
         app, _db = _make_app(_user(auth_method="runner_token", run_id=str(uuid.uuid4())))
 
@@ -221,7 +222,7 @@ class TestRunnerAuthzWiring:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.tfe_v2._runner_state_read_allowed", new_callable=AsyncMock)
     async def test_download_state_falls_through_and_denies_runner(self, m_helper, m_resolve, *_):
         """Same wiring guarantee for the download endpoint — helper
@@ -232,7 +233,7 @@ class TestRunnerAuthzWiring:
         wasn't checked, masking a future regression of either kind)."""
         producer = _mock_ws(name="producer")
         m_helper.return_value = False
-        m_resolve.return_value = None
+        m_resolve.return_value = frozenset()
 
         sv = MagicMock()
         sv.id = uuid.uuid4()
@@ -259,13 +260,13 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_capabilities_for")
     @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
     async def test_create_happy_path(self, mock_publish, mock_resolve, *_):
         """Admin on producer → 201, and the response JSON carries the
         producer + consumer names (i.e. the row's relationships actually
         get populated)."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         producer = _mock_ws(name="producer")
         consumer = _mock_ws(name="consumer")
 
@@ -325,10 +326,10 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_capabilities_for")
     async def test_create_requires_producer_admin(self, mock_resolve, *_):
         """Read on producer is not enough — mutation requires admin."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         producer = _mock_ws()
 
         app, db = _make_app(_user())
@@ -349,10 +350,10 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_capabilities_for")
     async def test_create_self_reference_rejected(self, mock_resolve, *_):
         """A workspace listing itself is meaningless (already reads own state)."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_ws()
         app, db = _make_app(_user())
         r = MagicMock()
@@ -370,9 +371,9 @@ class TestCreateConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_capabilities_for")
     async def test_create_duplicate_rejected(self, mock_resolve, *_):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         producer = _mock_ws(name="producer")
         consumer = _mock_ws(name="consumer")
         app, db = _make_app(_user())
@@ -399,10 +400,10 @@ class TestListConsumers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_capabilities_for")
     async def test_list_outbound_default(self, mock_resolve, *_):
         """No filter ⇒ outbound (workspaces I share to)."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         producer = _mock_ws()
         app, db = _make_app(_user())
         ws_lookup = MagicMock()
@@ -422,9 +423,9 @@ class TestListConsumers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_capabilities_for")
     async def test_list_invalid_filter_rejected(self, mock_resolve, *_):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         producer = _mock_ws()
         app, db = _make_app(_user())
         r = MagicMock()
@@ -444,10 +445,10 @@ class TestDeleteConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_capabilities_for")
     async def test_delete_happy(self, mock_resolve, *_):
         """Admin on producer → 204."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         producer = _mock_ws()
         row = MagicMock()
         row.id = uuid.uuid4()
@@ -467,11 +468,11 @@ class TestDeleteConsumer:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.remote_state_consumers.resolve_workspace_capabilities_for")
     async def test_delete_requires_producer_admin(self, mock_resolve, *_):
         """A consumer (or any non-admin) cannot revoke their own grant
         — only the producer's admin may delete an edge."""
-        mock_resolve.return_value = "write"  # not admin
+        mock_resolve.return_value = caps_for_level("write")  # not admin
         producer = _mock_ws()
         row = MagicMock()
         row.id = uuid.uuid4()

--- a/services/tests/api/test_run_tasks.py
+++ b/services/tests/api/test_run_tasks.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -99,10 +100,10 @@ class TestCreateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_create(self, mock_resolve, *mocks):
         """Create run task → 201."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -134,10 +135,10 @@ class TestCreateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_create_invalid_stage(self, mock_resolve, *mocks):
         """Invalid stage → 422."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -166,10 +167,10 @@ class TestCreateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_create_requires_admin(self, mock_resolve, *mocks):
         """Write permission → 403."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -197,10 +198,10 @@ class TestCreateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_create_missing_url(self, mock_resolve, *mocks):
         """Missing url → 422."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -233,10 +234,10 @@ class TestListRunTasks:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_list(self, mock_resolve, *mocks):
         """List returns tasks. Read permission sufficient."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         rt = _mock_run_task(ws=ws)
 
@@ -265,9 +266,9 @@ class TestShowRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_show(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         rt = _mock_run_task()
 
         app, mock_db = _make_app(_user())
@@ -310,10 +311,10 @@ class TestUpdateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_update_name(self, mock_resolve, *mocks):
         """PATCH updates name → 200."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         rt = _mock_run_task()
 
         app, mock_db = _make_app(_user())
@@ -338,10 +339,10 @@ class TestUpdateRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_update_requires_admin(self, mock_resolve, *mocks):
         """Write permission → 403."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         rt = _mock_run_task()
 
         app, mock_db = _make_app(_user())
@@ -365,10 +366,10 @@ class TestDeleteRunTask:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_tasks.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_tasks.resolve_workspace_capabilities_for")
     async def test_delete(self, mock_resolve, *mocks):
         """Admin can delete → 204."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         rt = _mock_run_task()
 
         app, mock_db = _make_app(_user())

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -66,11 +67,11 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
     async def test_create_run_trigger(self, mock_publish, mock_resolve, *mocks):
         """Happy path: create a run trigger → 201."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         dest_ws = _mock_workspace(name="dest")
         source_ws = _mock_workspace(name="source")
 
@@ -122,10 +123,10 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_create_self_referential_rejected(self, mock_resolve, *mocks):
         """Same source and destination workspace → 422."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -151,10 +152,10 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_create_duplicate_rejected(self, mock_resolve, *mocks):
         """Same pair twice → 409."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         dest_ws = _mock_workspace(name="dest")
         source_ws = _mock_workspace(name="source")
 
@@ -191,10 +192,10 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_create_max_20_sources(self, mock_resolve, *mocks):
         """21st source → 422."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         dest_ws = _mock_workspace(name="dest")
         source_ws = _mock_workspace(name="source")
 
@@ -235,10 +236,10 @@ class TestCreateRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_create_requires_admin(self, mock_resolve, *mocks):
         """Non-admin → 403."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -270,9 +271,9 @@ class TestListRunTriggers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_list_inbound(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         trigger = _mock_trigger(ws=ws)
 
@@ -296,9 +297,9 @@ class TestListRunTriggers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_list_outbound(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         trigger = _mock_trigger(source_ws=ws)
 
@@ -322,10 +323,10 @@ class TestListRunTriggers:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_list_requires_filter(self, mock_resolve, *mocks):
         """Missing filter → 422."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
 
         app, mock_db = _make_app(_user())
@@ -348,9 +349,9 @@ class TestShowRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_show_run_trigger(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         trigger = _mock_trigger()
 
         app, mock_db = _make_app(_user())
@@ -385,10 +386,10 @@ class TestDeleteRunTrigger:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.run_triggers.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.run_triggers.resolve_workspace_capabilities_for")
     async def test_delete_run_trigger(self, mock_resolve, *mocks):
         """Happy path → 204."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         trigger = _mock_trigger()
 
         app, mock_db = _make_app(_user())

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth import capabilities as cap
 from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
@@ -1230,3 +1231,70 @@ class TestRetryRun:
 
         assert resp.status_code == 422
         mock_create_run.assert_not_called()
+
+
+class TestGranularCapabilityEnforcement:
+    """A capability set that matches NO preset is enforced per-gate — the
+    granularity capability RBAC exists to enable (levels cannot express
+    'plan but not apply and not cancel'). #585."""
+
+    _GRANULAR = frozenset({cap.RUN_PLAN, cap.RUN_READ})  # no run:apply, no run:cancel
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.queue_run")
+    @patch("terrapod.api.routers.runs.run_service.create_run")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_granular_role_can_plan(self, mock_resolve, mock_create_run, mock_queue, *mocks):
+        mock_resolve.return_value = self._GRANULAR
+        ws = _mock_workspace()
+        run = _mock_run(ws_id=ws.id, plan_only=True, status="queued")
+        mock_create_run.return_value = run
+        mock_queue.return_value = run
+        app, mock_db = _make_app(_user())
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = result
+        mock_db.refresh = AsyncMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/runs",
+                json={
+                    "data": {
+                        "attributes": {"plan-only": True},
+                        "relationships": {"workspace": {"data": {"id": f"ws-{ws.id}"}}},
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 201
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_granular_role_cannot_apply(self, mock_resolve, *mocks):
+        # Same set that passed plan — but an apply run needs run:apply, which
+        # this role lacks. A 'plan' LEVEL would also block apply; the point is
+        # this set is NOT a level (it also lacks lock/state-read/cancel), yet
+        # each gate is enforced on its own capability.
+        mock_resolve.return_value = self._GRANULAR
+        ws = _mock_workspace()
+        app, mock_db = _make_app(_user())
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = result
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/runs",
+                json={
+                    "data": {
+                        "attributes": {},
+                        "relationships": {"workspace": {"data": {"id": f"ws-{ws.id}"}}},
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 403
+        assert "run:apply" in resp.json()["detail"]

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -122,11 +123,11 @@ class TestCreateRun:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_create_plan_only_with_plan_perm(
         self, mock_resolve, mock_create_run, mock_queue, *mocks
     ):
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace()
         run = _mock_run(ws_id=ws.id, plan_only=True, status="queued")
         mock_create_run.return_value = run
@@ -158,10 +159,10 @@ class TestCreateRun:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_create_apply_needs_write_perm(self, mock_resolve, *mocks):
         """Plan-only=false (default) requires write permission."""
-        mock_resolve.return_value = "plan"  # only plan, not write
+        mock_resolve.return_value = caps_for_level("plan")  # only plan, not write
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -200,7 +201,7 @@ class TestCreateRun:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_latest_uploaded_cv")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_non_vcs_no_cv_uses_latest_uploaded_cv(
         self, mock_resolve, mock_get_cv, mock_create_run, mock_queue, *mocks
     ):
@@ -208,7 +209,7 @@ class TestCreateRun:
         configuration-version to the last successful CLI upload so the
         runner has something to download. Without this the run is
         created with cv_id=NULL and the runner 404s on archive fetch."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace()  # vcs_connection_id is None by default
         cv = MagicMock(id=uuid.uuid4())
         mock_get_cv.return_value = cv
@@ -244,14 +245,14 @@ class TestCreateRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.get_latest_uploaded_cv")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_non_vcs_no_cv_no_uploaded_cv_returns_422(
         self, mock_resolve, mock_get_cv, *mocks
     ):
         """#358 counterpart: when no CLI upload has ever succeeded for a
         non-VCS workspace, queueing a plan must fail loudly with an
         actionable 422 rather than create an unrunnable run."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace()
         mock_get_cv.return_value = None
 
@@ -282,7 +283,7 @@ class TestCreateRun:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_latest_uploaded_cv")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_vcs_workspace_with_empty_repo_url_falls_back_to_uploaded_cv(
         self, mock_resolve, mock_get_cv, mock_create_run, mock_queue, *mocks
     ):
@@ -291,7 +292,7 @@ class TestCreateRun:
         create a NULL-CV run. The fallback now covers this case so it
         behaves the same as a non-VCS workspace (use the latest uploaded
         CV or 422)."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace()
         ws.vcs_connection_id = uuid.uuid4()  # connection set
         ws.vcs_repo_url = ""  # but no repo — misconfigured
@@ -335,9 +336,9 @@ class TestCatalogManagedRunGuard:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_run_with_cv_on_catalog_ws_rejected(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace(catalog_item_id=uuid.uuid4())
 
         app, mock_db = _make_app(_user())
@@ -369,12 +370,12 @@ class TestCatalogManagedRunGuard:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_latest_uploaded_cv")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_cvless_rerun_on_catalog_ws_allowed(
         self, mock_resolve, mock_get_cv, mock_create_run, mock_queue, *mocks
     ):
         """CV-less re-plan/re-apply of the generated config stays allowed."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace(catalog_item_id=uuid.uuid4())  # non-VCS by default
         cv = MagicMock(id=uuid.uuid4())
         mock_get_cv.return_value = cv
@@ -411,10 +412,10 @@ class TestShowRun:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_show_with_read(self, mock_get_run, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run()
         mock_get_run.return_value = run
 
@@ -449,10 +450,10 @@ class TestConfirmRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_with_write_perm(self, mock_get_run, mock_resolve, mock_confirm, *mocks):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         run = _mock_run(status="planned")
         mock_get_run.return_value = run
         confirmed = _mock_run(status="confirmed")
@@ -473,12 +474,12 @@ class TestConfirmRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_wrong_state_returns_409(
         self, mock_get_run, mock_resolve, mock_confirm, *mocks
     ):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         run = _mock_run(status="queued")
         mock_get_run.return_value = run
         mock_confirm.side_effect = ValueError("Can only confirm planned")
@@ -498,7 +499,7 @@ class TestConfirmRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_no_changes_returns_422(
         self, mock_get_run, mock_resolve, mock_confirm, *mocks
@@ -510,7 +511,7 @@ class TestConfirmRun:
         Defensive check guards against legacy data and races, and pairs with
         `is-confirmable=false` in the response so UI and API agree.
         """
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         run = _mock_run(status="planned")
         run.has_changes = False
         mock_get_run.return_value = run
@@ -538,10 +539,10 @@ class TestDiscardRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.discard_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_discard_with_plan_perm(self, mock_get_run, mock_resolve, mock_discard, *mocks):
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         run = _mock_run(status="planned")
         mock_get_run.return_value = run
         mock_discard.return_value = _mock_run(status="discarded")
@@ -566,10 +567,10 @@ class TestCancelRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.cancel_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_cancel_with_plan_perm(self, mock_get_run, mock_resolve, mock_cancel, *mocks):
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         run = _mock_run(status="planning")
         mock_get_run.return_value = run
         mock_cancel.return_value = _mock_run(status="canceled")
@@ -589,12 +590,12 @@ class TestCancelRun:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.cancel_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_cancel_terminal_returns_409(
         self, mock_get_run, mock_resolve, mock_cancel, *mocks
     ):
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         run = _mock_run(status="applied")
         mock_get_run.return_value = run
         mock_cancel.side_effect = ValueError("terminal")
@@ -618,11 +619,11 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_actions_block(self, mock_get_run, mock_resolve, *mocks):
         """Verify actions reflect run state."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="planned", auto_apply=False)
         mock_get_run.return_value = run
 
@@ -644,7 +645,7 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_no_changes_hides_confirm_and_discard(self, mock_get_run, mock_resolve, *mocks):
         """Planned run with has_changes=False must not advertise confirm/discard.
@@ -654,7 +655,7 @@ class TestRunJsonSerialization:
         the state-upload 500 cycle. Keep both flags false (and the matching
         permission booleans) so the API and the UI present the same answer.
         """
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="planned", auto_apply=False)
         run.has_changes = False
         mock_get_run.return_value = run
@@ -690,7 +691,7 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_is_cancelable_by_status(
         self,
@@ -703,7 +704,7 @@ class TestRunJsonSerialization:
         expected: bool,
     ):
         """Cancelable flips per run state — only in-progress states allow cancel."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status=status, auto_apply=False)
         mock_get_run.return_value = run
         ws = _mock_workspace(ws_id=run.workspace_id)
@@ -718,10 +719,10 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_timestamps_rfc3339(self, mock_get_run, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run()
         run.created_at = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
         mock_get_run.return_value = run
@@ -739,11 +740,11 @@ class TestRunJsonSerialization:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_auto_apply_not_confirmable(self, mock_get_run, mock_resolve, *mocks):
         """Auto-apply runs in planned state are NOT confirmable."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="planned", auto_apply=True)
         mock_get_run.return_value = run
 
@@ -767,10 +768,10 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_create_apply_blocked_on_vcs_remote_workspace(self, mock_resolve, *mocks):
         """Remote + VCS + plan_only=false → 422."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
         ws.execution_mode = "agent"
         ws.vcs_connection_id = uuid.uuid4()  # VCS-connected
@@ -801,10 +802,10 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_create_apply_blocked_even_with_spoofed_vcs_source(self, mock_resolve, *mocks):
         """Remote + VCS + CLI CV + source='vcs' spoofed → still 422."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
         ws.execution_mode = "agent"
         ws.vcs_connection_id = uuid.uuid4()
@@ -837,12 +838,12 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_create_apply_allowed_on_non_vcs_remote_workspace(
         self, mock_resolve, mock_create_run, mock_queue, *mocks
     ):
         """Remote + no VCS + plan_only=false → 201 (CLI-driven workflow)."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
         ws.execution_mode = "agent"
         ws.vcs_connection_id = None  # No VCS
@@ -880,12 +881,12 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_create_plan_forced_on_vcs_remote_workspace(
         self, mock_resolve, mock_create_run, mock_queue, *mocks
     ):
         """Remote + VCS + plan_only=true → 201 (plan is always allowed)."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace()
         ws.execution_mode = "agent"
         ws.vcs_connection_id = uuid.uuid4()
@@ -921,13 +922,13 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_blocked_on_vcs_remote_workspace(
         self, mock_get_run, mock_resolve, *mocks
     ):
         """Confirm CLI run on VCS-connected remote workspace → 422."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         run = _mock_run(status="planned")
         mock_get_run.return_value = run
 
@@ -950,13 +951,13 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_allowed_for_ui_queued_vcs_run(
         self, mock_get_run, mock_resolve, mock_confirm, *mocks
     ):
         """Confirm UI-queued run on VCS-connected workspace → 200 (code from VCS)."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         run = _mock_run(status="planned")
         run.vcs_commit_sha = "abc123"  # Code was fetched from VCS
         mock_get_run.return_value = run
@@ -981,13 +982,13 @@ class TestCLIApplyGuard:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.confirm_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_confirm_allowed_on_non_vcs_remote_workspace(
         self, mock_get_run, mock_resolve, mock_confirm, *mocks
     ):
         """Confirm CLI run on non-VCS remote workspace → 200."""
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         run = _mock_run(status="planned")
         mock_get_run.return_value = run
         confirmed = _mock_run(status="confirmed")
@@ -1112,10 +1113,10 @@ class TestPlanJsonAttribute:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_attribute_present_when_uploaded(self, mock_get_run, mock_resolve, *_mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="planned")
         run.has_json_output = True
         mock_get_run.return_value = run
@@ -1134,12 +1135,12 @@ class TestPlanJsonAttribute:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_attribute_absent_when_not_uploaded(self, mock_get_run, mock_resolve, *_mocks):
         """Don't advertise a URL we know would 404. Older / errored / failed-upload
         runs must not carry the `json-output` attribute."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         run = _mock_run(status="planned")
         run.has_json_output = False
         mock_get_run.return_value = run
@@ -1162,13 +1163,13 @@ class TestRetryRun:
     @patch("terrapod.api.routers.runs.run_service.queue_run")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_retry_attaches_latest_cv_when_source_has_none(
         self, mock_resolve, mock_get_run, mock_create_run, mock_queue, *mocks
     ):
         """#439: retrying a run whose CV is null falls back to the workspace's
         latest uploaded CV rather than faithfully copying the null forward."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
 
         original = _mock_run(status="errored")
         original.configuration_version_id = None  # The bug
@@ -1201,13 +1202,13 @@ class TestRetryRun:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.run_service.create_run")
     @patch("terrapod.api.routers.runs.run_service.get_run")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_retry_rejects_when_workspace_has_no_cv(
         self, mock_resolve, mock_get_run, mock_create_run, *mocks
     ):
         """If the source run has no CV AND the workspace has never had one
         uploaded, the retry is rejected with 422 (nothing the runner could do)."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
 
         original = _mock_run(status="errored")
         original.configuration_version_id = None

--- a/services/tests/api/test_state_management.py
+++ b/services/tests/api/test_state_management.py
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.models import StateVersion
 from terrapod.db.session import get_db
 
@@ -82,7 +83,7 @@ class TestDeleteStateVersion:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
     @patch("terrapod.api.routers.state_management.get_storage")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_capabilities_for")
     async def test_delete_non_current_state_version(
         self,
         mock_resolve,
@@ -96,7 +97,7 @@ class TestDeleteStateVersion:
         ws = _mock_workspace(ws_id=ws_id, owner_email="test@example.com")
         sv = _mock_state_version(ws_id, serial=1)
 
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
 
         mock_db = AsyncMock()
         # First execute: get state version
@@ -126,7 +127,7 @@ class TestDeleteStateVersion:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_capabilities_for")
     async def test_delete_current_state_version_rejected(
         self,
         mock_resolve,
@@ -138,7 +139,7 @@ class TestDeleteStateVersion:
         ws = _mock_workspace(ws_id=ws_id, owner_email="test@example.com")
         sv = _mock_state_version(ws_id, serial=3)
 
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
 
         mock_db = AsyncMock()
         mock_db.execute.side_effect = [
@@ -162,7 +163,7 @@ class TestDeleteStateVersion:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_capabilities_for")
     async def test_delete_state_requires_admin(
         self,
         mock_resolve,
@@ -174,7 +175,7 @@ class TestDeleteStateVersion:
         ws = _mock_workspace(ws_id=ws_id)
         sv = _mock_state_version(ws_id, serial=1)
 
-        mock_resolve.return_value = "write"  # not admin
+        mock_resolve.return_value = caps_for_level("write")  # not admin
 
         mock_db = AsyncMock()
         mock_db.execute.return_value = _scalar_result(sv)
@@ -203,7 +204,7 @@ class TestRollbackStateVersion:
     @patch("terrapod.api.metrics.STATE_VERSIONS_CREATED")
     @patch("terrapod.api.routers.tfe_v2._state_version_json")
     @patch("terrapod.api.routers.state_management.get_storage")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_capabilities_for")
     async def test_rollback_creates_new_version(
         self,
         mock_resolve,
@@ -219,7 +220,7 @@ class TestRollbackStateVersion:
         ws = _mock_workspace(ws_id=ws_id, owner_email="test@example.com")
         sv = _mock_state_version(ws_id, serial=1)
 
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
 
         state_bytes = b'{"version": 4, "serial": 1, "lineage": "test"}'
         mock_storage = AsyncMock()
@@ -255,7 +256,7 @@ class TestRollbackStateVersion:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.state_management.get_storage")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_capabilities_for")
     async def test_rollback_missing_storage_returns_404(
         self,
         mock_resolve,
@@ -268,7 +269,7 @@ class TestRollbackStateVersion:
         ws = _mock_workspace(ws_id=ws_id, owner_email="test@example.com")
         sv = _mock_state_version(ws_id, serial=1)
 
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
 
         mock_storage = AsyncMock()
         mock_storage.get.side_effect = Exception("Not found")
@@ -301,7 +302,7 @@ class TestUploadState:
     @patch("terrapod.api.metrics.STATE_VERSIONS_CREATED")
     @patch("terrapod.api.routers.tfe_v2._state_version_json")
     @patch("terrapod.api.routers.state_management.get_storage")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id")
     async def test_upload_state_manual(
         self,
@@ -318,7 +319,7 @@ class TestUploadState:
         ws_id = uuid.uuid4()
         ws = _mock_workspace(ws_id=ws_id)
         mock_get_ws.return_value = ws
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
 
         mock_sv_json.return_value = {
             "data": {"id": "sv-new", "type": "state-versions", "attributes": {}}
@@ -353,7 +354,7 @@ class TestUploadState:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id")
     async def test_upload_state_requires_write(
         self,
@@ -365,7 +366,7 @@ class TestUploadState:
     ):
         ws = _mock_workspace()
         mock_get_ws.return_value = ws
-        mock_resolve.return_value = "read"  # not write
+        mock_resolve.return_value = caps_for_level("read")  # not write
 
         mock_db = AsyncMock()
         user = _user(roles=["everyone"])
@@ -384,7 +385,7 @@ class TestUploadState:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.state_management.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.state_management.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.tfe_v2._get_workspace_by_id")
     async def test_upload_invalid_json_returns_400(
         self,
@@ -396,7 +397,7 @@ class TestUploadState:
     ):
         ws = _mock_workspace()
         mock_get_ws.return_value = ws
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
 
         mock_db = AsyncMock()
         user = _user(email="test@example.com")
@@ -481,7 +482,7 @@ class TestRunDetailStateVersion:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.runs.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     @patch("terrapod.api.routers.runs.run_service.get_run")
     async def test_show_run_includes_state_version(
         self,

--- a/services/tests/api/test_variables.py
+++ b/services/tests/api/test_variables.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_admin
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -72,9 +73,9 @@ class TestListVariables:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.list_variables")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_list_with_read_perm(self, mock_resolve, mock_list, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         var = _mock_var(ws_id=ws.id)
         mock_list.return_value = [var]
@@ -96,9 +97,9 @@ class TestListVariables:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.list_variables")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_sensitive_values_masked(self, mock_resolve, mock_list, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         var = _mock_var(key="secret", sensitive=True, ws_id=ws.id)
         mock_list.return_value = [var]
@@ -117,9 +118,9 @@ class TestListVariables:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_list_no_permission_returns_403(self, mock_resolve, *mocks):
-        mock_resolve.return_value = None
+        mock_resolve.return_value = caps_for_level(None)
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -139,9 +140,9 @@ class TestCreateVariable:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.create_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_create_with_write_perm(self, mock_resolve, mock_create, *mocks):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
         var = _mock_var(ws_id=ws.id)
         mock_create.return_value = var
@@ -170,9 +171,9 @@ class TestCreateVariable:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_create_missing_key_returns_422(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -190,9 +191,9 @@ class TestCreateVariable:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_create_read_only_returns_403(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -211,9 +212,9 @@ class TestCreateVariable:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.create_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_create_encryption_error_returns_422(self, mock_resolve, mock_create, *mocks):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         mock_create.side_effect = ValueError("encryption not configured")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
@@ -239,9 +240,9 @@ class TestUpdateVariable:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.update_variable")
     @patch("terrapod.api.routers.variables.variable_service.get_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_update_with_write_perm(self, mock_resolve, mock_get, mock_update, *mocks):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
         var = _mock_var(ws_id=ws.id)
         mock_get.return_value = var
@@ -264,9 +265,9 @@ class TestUpdateVariable:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.get_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_update_not_found_returns_404(self, mock_resolve, mock_get, *mocks):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         mock_get.return_value = None
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
@@ -292,9 +293,9 @@ class TestDeleteVariable:
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.variables.variable_service.delete_variable")
     @patch("terrapod.api.routers.variables.variable_service.get_variable")
-    @patch("terrapod.api.routers.variables.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.variables.resolve_workspace_capabilities_for")
     async def test_delete_with_write_perm(self, mock_resolve, mock_get, mock_delete, *mocks):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
         var = _mock_var(ws_id=ws.id)
         mock_get.return_value = var

--- a/services/tests/api/test_workspace_bulk.py
+++ b/services/tests/api/test_workspace_bulk.py
@@ -15,6 +15,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, require_admin
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -563,15 +564,14 @@ class TestBulkUpdateFailureRollback:
 
 
 class TestBulkUpdatePoolRbac:
-    @patch("terrapod.api.routers.workspace_bulk.pool_rbac_service.has_pool_permission")
     @patch(
-        "terrapod.api.routers.workspace_bulk.pool_rbac_service.resolve_pool_permission",
+        "terrapod.api.routers.workspace_bulk.resolve_capabilities",
         new_callable=AsyncMock,
     )
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    async def test_non_admin_without_pool_write_403(self, _db, _redis, _storage, m_resolve, m_has):
+    async def test_non_admin_without_pool_write_403(self, _db, _redis, _storage, m_resolve):
         """A non-admin assigning an agent pool needs pool `write`; without
         it the update is rejected 403 with zero mutation."""
         pool = MagicMock()
@@ -579,8 +579,8 @@ class TestBulkUpdatePoolRbac:
         pool.name = "aws-prod"
         pool.labels = {}
         pool.owner_email = "someone-else@example.com"
-        m_resolve.return_value = "read"
-        m_has.return_value = False
+        # `read` caps do NOT include pool:assign → the gate rejects.
+        m_resolve.return_value = caps_for_level("read")
 
         app, db = _make_app(_non_admin())
         db.get = AsyncMock(return_value=pool)
@@ -603,22 +603,21 @@ class TestBulkUpdatePoolRbac:
         assert "write permission on agent pool" in resp.json()["detail"]
         db.commit.assert_not_awaited()
 
-    @patch("terrapod.api.routers.workspace_bulk.pool_rbac_service.has_pool_permission")
     @patch(
-        "terrapod.api.routers.workspace_bulk.pool_rbac_service.resolve_pool_permission",
+        "terrapod.api.routers.workspace_bulk.resolve_capabilities",
         new_callable=AsyncMock,
     )
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    async def test_non_admin_with_pool_write_allowed(self, _db, _redis, _storage, m_resolve, m_has):
+    async def test_non_admin_with_pool_write_allowed(self, _db, _redis, _storage, m_resolve):
         pool = MagicMock()
         pool.id = uuid.uuid4()
         pool.name = "aws-prod"
         pool.labels = {}
         pool.owner_email = "someone-else@example.com"
-        m_resolve.return_value = "write"
-        m_has.return_value = True
+        # `write` caps include pool:assign → the gate passes.
+        m_resolve.return_value = caps_for_level("write")
 
         ws = _mock_ws(name="w1", agent_pool_id=None)
         app, db = _make_app(_non_admin())

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -95,12 +96,12 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.api.routers.tfe_v2.resolve_pool_permission_for",
+        "terrapod.api.routers.tfe_v2.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_assign_pool_with_write_permission(
@@ -111,9 +112,9 @@ class TestWorkspacePoolAssignment:
         pool = _mock_pool(name="prod-pool")
         ws = _mock_workspace()
 
-        mock_ws_perm.return_value = "admin"
+        mock_ws_perm.return_value = caps_for_level("admin")
         mock_get_pool.return_value = pool
-        mock_pool_perm.return_value = "write"
+        mock_pool_perm.return_value = caps_for_level("write")
 
         app, mock_db = _make_app(user)
 
@@ -143,25 +144,25 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.api.routers.tfe_v2.resolve_pool_permission_for",
+        "terrapod.api.routers.tfe_v2.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_assign_pool_without_write_permission_403(
         self, mock_ws_perm, mock_get_pool, mock_pool_perm, *mocks
     ):
-        """User without write on pool gets 403."""
+        """User without pool:assign capability gets 403."""
         user = _user(roles=["everyone"])
         pool = _mock_pool(name="restricted-pool")
         ws = _mock_workspace()
 
-        mock_ws_perm.return_value = "admin"
+        mock_ws_perm.return_value = caps_for_level("admin")
         mock_get_pool.return_value = pool
-        mock_pool_perm.return_value = "read"  # Only read, not write
+        mock_pool_perm.return_value = caps_for_level("read")  # Only read, no pool:assign
 
         app, mock_db = _make_app(user)
 
@@ -189,7 +190,7 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_clear_pool_no_permission_check(self, mock_ws_perm, *mocks):
@@ -197,7 +198,7 @@ class TestWorkspacePoolAssignment:
         user = _user(roles=["everyone"])
         ws = _mock_workspace(pool_id=uuid.uuid4())
 
-        mock_ws_perm.return_value = "admin"
+        mock_ws_perm.return_value = caps_for_level("admin")
 
         app, mock_db = _make_app(user)
 
@@ -226,12 +227,12 @@ class TestWorkspacePoolAssignment:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch(
-        "terrapod.api.routers.tfe_v2.resolve_pool_permission_for",
+        "terrapod.api.routers.tfe_v2.resolve_pool_capabilities_for",
         new_callable=AsyncMock,
     )
     @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
     @patch(
-        "terrapod.services.workspace_rbac_service.resolve_workspace_permission",
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
         new_callable=AsyncMock,
     )
     async def test_platform_admin_bypasses_pool_check(
@@ -242,9 +243,9 @@ class TestWorkspacePoolAssignment:
         pool = _mock_pool(name="restricted-pool")
         ws = _mock_workspace()
 
-        mock_ws_perm.return_value = "admin"
+        mock_ws_perm.return_value = caps_for_level("admin")
         mock_get_pool.return_value = pool
-        mock_pool_perm.return_value = "admin"  # admin resolves to admin
+        mock_pool_perm.return_value = caps_for_level("admin")  # admin resolves to admin
 
         app, mock_db = _make_app(user)
 

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from terrapod.api.app import create_application as create_app
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.auth.capabilities import caps_for_level
 from terrapod.db.session import get_db
 
 _BASE = "http://test"
@@ -172,9 +173,9 @@ class TestShowWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_show_by_name(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace(name="test-ws")
         user = _user()
         app, mock_db = _make_app(user)
@@ -195,10 +196,10 @@ class TestShowWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_show_no_permission_returns_404(self, mock_resolve, *mocks):
         """TFE behavior: workspace invisible (404) when no permission, not 403."""
-        mock_resolve.return_value = None
+        mock_resolve.return_value = caps_for_level(None)
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -236,9 +237,9 @@ class TestShowWorkspaceById:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_show_by_id_with_read(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         ws_result = MagicMock()
@@ -257,9 +258,9 @@ class TestShowWorkspaceById:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_show_by_id_no_permission_returns_403(self, mock_resolve, *mocks):
-        mock_resolve.return_value = None
+        mock_resolve.return_value = caps_for_level(None)
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -278,9 +279,9 @@ class TestUpdateWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_update_requires_admin(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "write"  # not admin
+        mock_resolve.return_value = caps_for_level("write")  # not admin
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -298,10 +299,10 @@ class TestUpdateWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_update_owner_requires_platform_admin(self, mock_resolve, *mocks):
         """owner-email change requires platform admin, not just workspace admin."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace(owner_email="old@test.com")
         # User is workspace admin via ownership but NOT platform admin
         user = _user(email="old@test.com", roles=["everyone"])
@@ -326,9 +327,9 @@ class TestDeleteWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_delete_with_admin_returns_204(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user(roles=["admin"]))
         mock_result = MagicMock()
@@ -342,9 +343,9 @@ class TestDeleteWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_delete_without_admin_returns_403(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "write"
+        mock_resolve.return_value = caps_for_level("write")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -358,11 +359,11 @@ class TestDeleteWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_delete_catalog_workspace_blocked_409(self, mock_resolve, *mocks):
         """A catalog-managed workspace can't be deleted via the workspace API —
         that would silently orphan its infra. 409 → use the catalog teardown."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
         ws.catalog_item_id = uuid.uuid4()  # catalog-managed
         app, mock_db = _make_app(_user(roles=["admin"]))
@@ -384,9 +385,9 @@ class TestLockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_lock_with_plan_permission(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace(locked=False)
         user = _user()
         app, mock_db = _make_app(user)
@@ -405,9 +406,9 @@ class TestLockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_lock_already_locked_returns_409(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace(locked=True, lock_id="lock-other@test.com")
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -424,9 +425,9 @@ class TestLockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_lock_read_only_returns_403(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -445,9 +446,9 @@ class TestUnlockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_unlock_own_lock(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace(locked=True, lock_id="lock-test@example.com")
         user = _user(email="test@example.com")
         app, mock_db = _make_app(user)
@@ -466,10 +467,10 @@ class TestUnlockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_force_unlock_requires_admin(self, mock_resolve, *mocks):
         """Non-admin with plan perm can't force-unlock another user's lock."""
-        mock_resolve.return_value = "plan"
+        mock_resolve.return_value = caps_for_level("plan")
         ws = _mock_workspace(locked=True, lock_id="lock-other@test.com")
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -486,9 +487,9 @@ class TestUnlockWorkspace:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_admin_can_force_unlock(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace(locked=True, lock_id="lock-other@test.com")
         app, mock_db = _make_app(_user(roles=["admin"]))
         mock_result = MagicMock()
@@ -511,10 +512,10 @@ class TestPermissionsBlock:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_read_user_permissions(self, mock_resolve, *mocks):
         """Read permission: can read, but not update/destroy/queue."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         ws_result = MagicMock()
@@ -537,9 +538,9 @@ class TestPermissionsBlock:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_admin_user_permissions(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user(roles=["admin"]))
         ws_result = MagicMock()
@@ -597,9 +598,9 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_returns_labels_as_bindings(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace(labels={"repo": "infra-core", "env": "dev"})
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -626,9 +627,9 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_empty_labels_returns_empty_array(self, mock_resolve, *mocks):
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace(labels={})
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -645,9 +646,9 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_no_permission_blocks_access(self, mock_resolve, *mocks):
-        mock_resolve.return_value = None
+        mock_resolve.return_value = caps_for_level(None)
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -663,10 +664,10 @@ class TestWorkspaceTagBindings:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_effective_tag_bindings_mirrors_workspace_bindings(self, mock_resolve, *mocks):
         # Terrapod has no project hierarchy, so effective bindings == workspace bindings
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace(labels={"repo": "infra-core"})
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -825,12 +826,12 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_default_workspace_serializes_default_workflow(self, mock_resolve, *_mocks):
         """Default-mode regression: an existing workspace serializes with the
         new attributes at default values. Frontend / providers must see the
         new fields, but their values are inert."""
-        mock_resolve.return_value = "read"
+        mock_resolve.return_value = caps_for_level("read")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         ws_result = MagicMock()
@@ -851,9 +852,9 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_invalid_workflow_value_rejected(self, mock_resolve, *_mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
         ws.vcs_connection_id = uuid.uuid4()
         app, mock_db = _make_app(_user())
@@ -873,9 +874,9 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_apply_then_merge_requires_vcs_connection(self, mock_resolve, *_mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()  # no VCS connection
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -894,9 +895,9 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_apply_then_merge_incompatible_with_auto_apply(self, mock_resolve, *_mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace(auto_apply=True)
         ws.vcs_connection_id = uuid.uuid4()
         app, mock_db = _make_app(_user())
@@ -916,13 +917,13 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_combined_flip_off_auto_apply_and_into_apply_then_merge_succeeds(
         self, mock_resolve, *_mocks
     ):
         """User may set vcs-workflow=apply_then_merge AND auto-apply=false in
         one request — the validation evaluates the post-update state."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace(auto_apply=True)
         ws.vcs_connection_id = uuid.uuid4()
         app, mock_db = _make_app(_user())
@@ -953,11 +954,11 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_workflow_flip_blocked_by_active_pr_runs(self, mock_resolve, *_mocks):
         """Q4 of the design: cannot flip vcs-workflow with PR runs in flight.
         Operator must cancel/discard them first."""
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
         ws.vcs_workflow = "apply_then_merge"
         ws.vcs_connection_id = uuid.uuid4()
@@ -983,9 +984,9 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_invalid_auto_merge_strategy_rejected(self, mock_resolve, *_mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()
@@ -1004,9 +1005,9 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_permission_for")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_auto_merge_toggle_persists(self, mock_resolve, *_mocks):
-        mock_resolve.return_value = "admin"
+        mock_resolve.return_value = caps_for_level("admin")
         ws = _mock_workspace()
         app, mock_db = _make_app(_user())
         mock_result = MagicMock()

--- a/services/tests/services/test_capability_resolver.py
+++ b/services/tests/services/test_capability_resolver.py
@@ -1,0 +1,267 @@
+"""Faithfulness proof for capability resolution (#585, enforcement slice).
+
+The capability resolver must, for every preset role shape, resolve to EXACTLY
+the capability set that ``expand_preset`` gives for the scalar level the legacy
+resolver returns. This is the "before == after" guarantee: switching gates from
+level thresholds to capability membership changes nothing for existing roles.
+
+No DB — roles are passed via ``preloaded_roles`` (the resolvers skip the query).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from terrapod.auth import capabilities as cap
+from terrapod.services import capability_resolver as cr
+from terrapod.services import (
+    pool_rbac_service,
+    registry_rbac_service,
+    workspace_rbac_service,
+)
+from terrapod.services.catalog_rbac_service import resolve_catalog_permission
+
+pytestmark = pytest.mark.asyncio
+
+
+def _role(name, *, ws="read", pool="read", reg="read", cat="none", caps=None, **kw):
+    return SimpleNamespace(
+        name=name,
+        workspace_permission=ws,
+        pool_permission=pool,
+        registry_permission=reg,
+        catalog_permission=cat,
+        capabilities=caps if caps is not None else [],
+        allow_labels=kw.get("allow_labels", {}),
+        allow_names=kw.get("allow_names", []),
+        deny_labels=kw.get("deny_labels", {}),
+        deny_names=kw.get("deny_names", []),
+    )
+
+
+def _caps_from_level(axis, level):
+    """expand_preset restricted to one axis == the axis' caps for that level."""
+    kwargs = {
+        "workspace_permission": None,
+        "pool_permission": None,
+        "registry_permission": None,
+        "catalog_permission": None,
+    }
+    kwargs[f"{axis}_permission"] = level
+    return frozenset(cap.expand_preset(**kwargs))
+
+
+async def _scalar_workspace(email, roles, ws, preloaded):
+    return await workspace_rbac_service.resolve_workspace_permission(
+        None, email, roles, ws, preloaded_roles=preloaded
+    )
+
+
+async def _scalar_pool(email, roles, name, labels, owner, preloaded):
+    return await pool_rbac_service.resolve_pool_permission(
+        None, email, roles, name, labels, owner, preloaded_roles=preloaded
+    )
+
+
+async def _scalar_registry(email, roles, name, labels, owner, preloaded, auth_method=""):
+    return await registry_rbac_service.resolve_registry_permission(
+        None, email, roles, name, labels, owner, auth_method=auth_method, preloaded_roles=preloaded
+    )
+
+
+async def _scalar_catalog(email, roles, name, labels, owner, preloaded):
+    return await resolve_catalog_permission(
+        None, email, roles, name, labels, owner, preloaded_roles=preloaded
+    )
+
+
+# ── Per-axis, per-level equivalence via a single label-matched custom role ─────
+
+
+@pytest.mark.parametrize("level", ["read", "plan", "write", "admin"])
+async def test_workspace_level_equivalence(level):
+    role = _role("r", ws=level, allow_labels={"team": ["x"]})
+    ws = SimpleNamespace(name="w1", labels={"team": "x"}, owner_email=None, catalog_item_id=None)
+    scalar = await _scalar_workspace("u@x", ["r"], ws, [role])
+    caps = await cr.resolve_capabilities(
+        None, "u@x", ["r"], "w1", {"team": "x"}, None, axis="workspace", preloaded_roles=[role]
+    )
+    assert caps == _caps_from_level("workspace", scalar)
+
+
+@pytest.mark.parametrize("level", ["read", "write", "admin"])
+async def test_pool_level_equivalence(level):
+    role = _role("r", pool=level, allow_labels={"team": ["x"]})
+    scalar = await _scalar_pool("u@x", ["r"], "p1", {"team": "x"}, None, [role])
+    caps = await cr.resolve_capabilities(
+        None, "u@x", ["r"], "p1", {"team": "x"}, None, axis="pool", preloaded_roles=[role]
+    )
+    assert caps == _caps_from_level("pool", scalar)
+
+
+@pytest.mark.parametrize("level", ["read", "write", "admin"])
+async def test_registry_level_equivalence(level):
+    role = _role("r", reg=level, allow_labels={"team": ["x"]})
+    scalar = await _scalar_registry("u@x", ["r"], "m1", {"team": "x"}, "", [role])
+    caps = await cr.resolve_capabilities(
+        None, "u@x", ["r"], "m1", {"team": "x"}, "", axis="registry", preloaded_roles=[role]
+    )
+    assert caps == _caps_from_level("registry", scalar)
+
+
+@pytest.mark.parametrize("level", ["none", "read", "use", "admin"])
+async def test_catalog_level_equivalence(level):
+    role = _role("r", cat=level, allow_labels={"team": ["x"]})
+    scalar = await _scalar_catalog("u@x", ["r"], "c1", {"team": "x"}, None, [role])
+    caps = await cr.resolve_capabilities(
+        None, "u@x", ["r"], "c1", {"team": "x"}, None, axis="catalog", preloaded_roles=[role]
+    )
+    # scalar None -> no caps
+    assert caps == (_caps_from_level("catalog", scalar) if scalar else frozenset())
+
+
+# ── Special principals ────────────────────────────────────────────────────────
+
+
+async def test_admin_gets_full_axis_caps():
+    for axis in cr.AXES:
+        caps = await cr.resolve_capabilities(
+            None, "a@x", ["admin"], "r1", {}, None, axis=axis, preloaded_roles=[]
+        )
+        assert caps == cap.axis_all_caps(axis)
+
+
+async def test_audit_gets_read_floor():
+    for axis in cr.AXES:
+        caps = await cr.resolve_capabilities(
+            None, "a@x", ["audit"], "r1", {}, None, axis=axis, preloaded_roles=[]
+        )
+        assert caps == cap.axis_read_caps(axis)  # catalog read floor is {catalog:read} for audit
+
+
+async def test_owner_gets_admin_equiv_and_catalog_clamp():
+    # Non-catalog workspace owner -> full workspace caps (admin-equivalent).
+    caps = await cr.resolve_capabilities(
+        None, "o@x", [], "w1", {}, "o@x", axis="workspace", preloaded_roles=[]
+    )
+    assert caps == cap.axis_all_caps("workspace")
+    # Catalog-managed workspace owner -> clamped to read.
+    clamped = await cr.resolve_capabilities(
+        None,
+        "o@x",
+        [],
+        "w1",
+        {},
+        "o@x",
+        axis="workspace",
+        preloaded_roles=[],
+        is_catalog_managed=True,
+    )
+    assert clamped == cap.axis_read_caps("workspace")
+
+
+async def test_everyone_floor_and_no_catalog_floor():
+    labels = {"access": "everyone"}
+    ws = await cr.resolve_capabilities(
+        None, "u@x", [], "w1", labels, None, axis="workspace", preloaded_roles=[]
+    )
+    assert ws == cap.axis_read_caps("workspace")
+    # Catalog has no everyone-floor.
+    catalog = await cr.resolve_capabilities(
+        None, "u@x", [], "c1", labels, None, axis="catalog", preloaded_roles=[]
+    )
+    assert catalog == frozenset()
+
+
+async def test_registry_runner_floor():
+    caps = await cr.resolve_capabilities(
+        None,
+        "u@x",
+        [],
+        "m1",
+        {},
+        "",
+        axis="registry",
+        preloaded_roles=[],
+        auth_method="runner_token",
+    )
+    assert caps == frozenset({cap.REGISTRY_READ})
+
+
+async def test_deny_rule_blocks():
+    role = _role("r", ws="admin", allow_labels={"team": ["x"]}, deny_names=["w1"])
+    caps = await cr.resolve_capabilities(
+        None, "u@x", ["r"], "w1", {"team": "x"}, None, axis="workspace", preloaded_roles=[role]
+    )
+    assert caps == frozenset()
+
+
+async def test_multiple_roles_union_equals_max_level():
+    r_plan = _role("plan", ws="plan", allow_labels={"team": ["x"]})
+    r_write = _role("write", ws="write", allow_labels={"team": ["x"]})
+    caps = await cr.resolve_capabilities(
+        None,
+        "u@x",
+        ["plan", "write"],
+        "w1",
+        {"team": "x"},
+        None,
+        axis="workspace",
+        preloaded_roles=[r_plan, r_write],
+    )
+    assert caps == _caps_from_level("workspace", "write")
+
+
+async def test_granular_stored_capabilities_take_precedence():
+    # A role whose stored capabilities are a non-preset subset resolves to that
+    # subset (not its level expansion) — the granularity the feature enables.
+    granular = sorted({cap.RUN_READ, cap.VAR_READ, cap.VAR_WRITE})
+    role = _role("r", ws="admin", caps=granular, allow_labels={"team": ["x"]})
+    caps = await cr.resolve_capabilities(
+        None, "u@x", ["r"], "w1", {"team": "x"}, None, axis="workspace", preloaded_roles=[role]
+    )
+    assert caps == frozenset(granular)
+
+
+# ── Token attenuation (kind-aware _for) ───────────────────────────────────────
+
+
+def _user(kind, roles, pinned, email="u@x"):
+    return SimpleNamespace(
+        kind=kind, email=email, roles=roles, pinned_roles=pinned, auth_method="api_token"
+    )
+
+
+async def test_service_bound_is_intersection():
+    r_write = _role("write", ws="write", allow_labels={"team": ["x"]})
+    r_plan = _role("plan", ws="plan", allow_labels={"team": ["x"]})
+    user = _user("service_bound", ["write"], ["plan"])
+    caps = await cr.resolve_capabilities_for(
+        None,
+        user,
+        "w1",
+        {"team": "x"},
+        None,
+        axis="workspace",
+        preloaded_roles=[r_write],
+        token_preloaded_roles=[r_plan],
+    )
+    # min(write, plan) == plan
+    assert caps == _caps_from_level("workspace", "plan")
+
+
+async def test_service_detached_is_token_only():
+    r_write = _role("write", ws="write", allow_labels={"team": ["x"]})
+    r_plan = _role("plan", ws="plan", allow_labels={"team": ["x"]})
+    user = _user("service_detached", ["write"], ["plan"])
+    caps = await cr.resolve_capabilities_for(
+        None,
+        user,
+        "w1",
+        {"team": "x"},
+        None,
+        axis="workspace",
+        preloaded_roles=[r_write],
+        token_preloaded_roles=[r_plan],
+    )
+    assert caps == _caps_from_level("workspace", "plan")


### PR DESCRIPTION
Second slice of capability-based RBAC (#585): switch enforcement from hierarchical **levels** to explicit **capabilities**, faithfully. Builds on the merged data layer + locked catalog (#644).

## What this does

Every workspace/pool/registry/catalog gate across **all 16 routers** now checks a **specific capability** (`has_capability(caps, cap.RUN_APPLY)`) instead of a level threshold (`has_permission(perm, "write")`). Resolvers return capability **sets** (`resolve_*_capabilities_for`): union across a principal's matching roles ∩ the axis, token attenuation as set intersection, with the catalog-managed clamp, everyone-floor and runner registry-floor all preserved.

A role's contribution is its stored `capabilities` if populated, else `expand_preset(levels)` — so **create/update stay untouched** (no expand-on-write); authoring capabilities directly is the next slice.

## Faithful by construction (proven)

- **`test_capability_resolver`** — for every preset role shape and every special principal (admin/audit/owner/everyone/runner/token/catalog-clamp), the capability set equals `expand_preset(scalar level)`. So **existing roles behave byte-for-byte identically.**
- **`TestGranularCapabilityEnforcement`** — a role with `run:plan` but NOT `run:apply`/`run:cancel` (a set no level can express) can queue a plan yet is blocked from apply. Proves the *new* granularity is reachable and enforced per-gate.

## Also delivered

- **Separable destroy** — run create/confirm gate on `run:apply-destroy` when `is_destroy` (both in the `write` preset, so migrated write roles keep destroy).
- **Self-lockout guards** (workspace / pool / registry module + provider) → capability **set-difference** (partial order), replacing the total-order level-drop; 409 messages list the removed capabilities.
- **`can-*` serializers** (workspace, registry) → capability membership.

## Scope / not in this PR

Platform-admin gates (`require_admin`) stay role-name based — the scoped `platform:*` split is #642. **Capability authoring** (create/update accept `capabilities` directly) + `summarize_capabilities` on read + consumer updates (go-terrapod / provider / web) are the next slice. No release until the whole feature is implemented and tested.

## How it was built + verified

Independent router files were converted in parallel from the locked contract table; the delicate routers (`tfe_v2`, `runs`) and every shared/coupled test file were done by hand, and **every subagent's gate→capability mapping was adversarially verified against the contract** — which caught two faithfulness bugs before they landed (a `remote_state_consumers` read wrongly tightened to plan-tier; a `workspace_bulk` pool gate left unconverted).

**`make test` green (2669 passed). `make lint` clean.**

Refs #585.