### PR TITLE
fix(rbac): always persist capabilities on the role (#585)

### DIFF
--- a/services/terrapod/api/routers/roles.py
+++ b/services/terrapod/api/routers/roles.py
@@ -213,12 +213,20 @@ async def create_role(
         registry_permission=registry_perm,
         catalog_permission=catalog_perm,
     )
-    # Capability-authoring (#585): if the caller supplies an explicit capability
-    # set it becomes the stored truth and the levels above are recomputed as its
-    # derived summary. Otherwise the role is level-authored (capabilities stays
-    # empty; enforcement expands the levels).
+    # Capabilities are always persisted as the role's individual permissions
+    # (#585). An explicit `capabilities` set is stored verbatim (and the levels
+    # become its derived summary); otherwise the chosen levels are a shorthand
+    # that expands into the persisted capability set. Either way enforcement
+    # reads the stored capabilities — the levels are only an authoring aid.
     if "capabilities" in attrs:
         _apply_capabilities(role, attrs["capabilities"])
+    else:
+        role.capabilities = expand_preset(
+            workspace_permission=ws_perm,
+            pool_permission=pool_perm,
+            registry_permission=registry_perm,
+            catalog_permission=catalog_perm,
+        )
     db.add(role)
     await db.commit()
     await db.refresh(role)
@@ -281,12 +289,11 @@ async def update_role(
         "registry-permission",
         "catalog-permission",
     }
-    # A level edit on a role that was capability-authored (or migrated) must take
-    # effect: clear the stored caps so enforcement expands the new levels (no
-    # expand-on-write — the resolver falls back). Applied after the level fields
-    # are updated below. Capability-authoring wins over any level fields sent
-    # alongside it (the caps are the truth).
-    revert_to_levels = "capabilities" not in attrs and bool(_level_keys & attrs.keys())
+    # A level edit (without an explicit capabilities set) re-expands the levels
+    # into the persisted capability set below, so the edit takes effect —
+    # capabilities are always the stored truth; levels are the authoring
+    # shorthand. Capability-authoring wins over any level fields sent alongside.
+    reexpand_levels = "capabilities" not in attrs and bool(_level_keys & attrs.keys())
     if "capabilities" in attrs:
         _apply_capabilities(role, attrs["capabilities"])
     # Level fields are only honoured when not capability-authoring (caps win).
@@ -318,10 +325,14 @@ async def update_role(
                 )
             role.catalog_permission = catalog_perm
 
-    if revert_to_levels:
-        # The role's granular stored caps (if any) no longer reflect the edited
-        # levels — drop them so enforcement expands the new levels.
-        role.capabilities = []
+    if reexpand_levels:
+        # Persist the expansion of the (edited) levels as the role's capabilities.
+        role.capabilities = expand_preset(
+            workspace_permission=role.workspace_permission,
+            pool_permission=role.pool_permission,
+            registry_permission=role.registry_permission,
+            catalog_permission=role.catalog_permission,
+        )
 
     await db.commit()
     await db.refresh(role)

--- a/services/terrapod/services/capability_resolver.py
+++ b/services/terrapod/services/capability_resolver.py
@@ -5,10 +5,10 @@ of the single highest LEVEL a principal has on a resource, this returns the SET
 of capabilities they hold on it, so gates can check one capability
 (``has_capability(caps, RUN_PLAN)``) rather than a level threshold.
 
-A role's contribution is its explicit ``capabilities`` if populated (capability
-authoring), else ``expand_preset(role's levels)`` (migrated / level-authored
-roles) — so create/update need not expand on write. Sliced to the axis being
-resolved. Owner / platform-admin / audit / everyone-floor / runner-floor /
+A role's contribution is its persisted ``capabilities`` (always populated —
+migration back-fills it, create/update expand the level shorthand into it), with
+a defensive ``expand_preset(role's levels)`` fallback for any empty legacy row.
+Sliced to the axis being resolved. Owner / platform-admin / audit / everyone-floor / runner-floor /
 catalog-managed-clamp / token-attenuation all mirror the scalar resolvers
 exactly; the equivalence test (``test_capability_resolver``) asserts, for every
 preset role shape, that this layer agrees with ``expand_preset(scalar_level)``.
@@ -33,8 +33,10 @@ AXES = ("workspace", "pool", "registry", "catalog")
 
 
 def role_effective_capabilities(role: Role) -> frozenset[str]:
-    """A role's full capability set: stored ``capabilities`` if any, else the
-    expansion of its legacy level fields. Normalised (aliases upgraded)."""
+    """A role's full capability set. ``capabilities`` is persisted on every write
+    (the migration back-fills it; create/update expand the level shorthand into
+    it), so it is the source of truth; the ``expand_preset`` fallback is defensive
+    for any legacy row with an empty set. Normalised (aliases upgraded)."""
     caps = role.capabilities or cap.expand_preset(
         workspace_permission=role.workspace_permission,
         pool_permission=role.pool_permission,

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -860,11 +860,12 @@ class TestCapabilityAuthoring:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
-    async def test_update_level_edit_reverts_stored_caps(self, *mocks):
+    async def test_update_level_edit_reexpands_stored_caps(self, *mocks):
         from terrapod.auth import capabilities as cap
 
         # A migrated/cap-authored role whose stored caps are for "read"; editing
-        # the level to "admin" must take effect (caps cleared -> expand new level).
+        # the level to "admin" must take effect (the levels re-expand into the
+        # persisted capability set).
         role = _mock_role(name="dev-team", ws_perm="read")
         app, mock_db = _make_app(_user())
         result = MagicMock()


### PR DESCRIPTION
Follow-up to the #585 authoring slice (#648) correcting the storage model to what was intended.

**Model:** capabilities are the role's individual permissions and are **always persisted**; the permission *levels* are only an authoring shorthand that expands into the stored capability set. Enforcement reads the persisted capabilities.

Before, a level-authored role kept an **empty** `capabilities` and enforcement expanded the levels live (a fallback). Now:
- **create**: an explicit `capabilities` set is stored verbatim; otherwise the chosen levels are expanded and persisted.
- **update**: a level edit **re-expands and persists** (instead of clearing the stored caps); explicit `capabilities` still wins and derives the level summary.

Enforcement is unchanged and faithful — the resolver read the same *effective* set either way. The meaningful difference: a role's grant is now a **persisted snapshot** rather than recomputed from the levels, so a later preset redefinition can't silently change an existing role's grant. The resolver's expand fallback remains only as defence for an empty legacy row; docstrings updated to match.

`make test` green (2673).

Refs #585.