### PR TITLE
test(e2e): capability enforcement — plan-but-not-apply through the BFF (#585)

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -161,6 +161,57 @@ export async function setRoleAssignments(
 }
 
 /**
+ * Create a custom role with a granular capability set (#585). Levels are not
+ * persisted — the role's grant IS its `capabilities`. `allowLabels` scopes the
+ * label RBAC so the role only applies to workspaces carrying those labels.
+ * Idempotent-ish: a 422 "already exists" is swallowed so re-runs don't fail.
+ */
+export async function createRole(
+  adminToken: string,
+  name: string,
+  capabilities: string[],
+  allowLabels: Record<string, string> = {},
+  description = 'E2E capability role',
+): Promise<void> {
+  const res = await fetch(`${API_URL}/api/terrapod/v1/roles`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      Authorization: `Bearer ${adminToken}`,
+    },
+    body: JSON.stringify({
+      data: {
+        name,
+        type: 'roles',
+        attributes: {
+          description,
+          capabilities,
+          'allow-labels': allowLabels,
+        },
+      },
+    }),
+  });
+  if (!res.ok && res.status !== 422) {
+    const body = await res.text();
+    throw new Error(`Create role failed: ${res.status} ${body}`);
+  }
+}
+
+/**
+ * Delete a custom role (teardown helper). A 404 is fine — already gone.
+ */
+export async function deleteRole(adminToken: string, name: string): Promise<void> {
+  const res = await fetch(`${API_URL}/api/terrapod/v1/roles/${name}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${adminToken}` },
+  });
+  if (!res.ok && res.status !== 404) {
+    const body = await res.text();
+    throw new Error(`Delete role failed: ${res.status} ${body}`);
+  }
+}
+
+/**
  * Create a workspace via the admin API. Returns the workspace ID.
  */
 export async function createWorkspace(

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -107,6 +107,14 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
     {
+      // Capability RBAC enforcement drives the API directly with per-principal
+      // tokens (admin for setup, a capability-scoped session for the gates), so
+      // no project-level storageState is needed.
+      name: 'capability-rbac',
+      testMatch: 'capability-rbac.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
       name: 'manual-lock',
       testMatch: 'manual-lock.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },

--- a/e2e/tests/capability-rbac.spec.ts
+++ b/e2e/tests/capability-rbac.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+import { randomBytes } from 'crypto';
+import {
+  getStoredToken,
+  getSessionToken,
+  createUser,
+  createRole,
+  deleteRole,
+  setRoleAssignments,
+  createWorkspace,
+} from '../helpers/api.js';
+
+/**
+ * Capability RBAC enforcement (#585) — the headline of the capability model is
+ * a grant that hierarchical LEVELS could never express: "plan but NOT apply".
+ * This spec proves that granularity is enforced SERVER-SIDE through the full
+ * BFF proxy chain (CDN → ingress → BFF → API), not just that the authoring UI
+ * renders a checkbox.
+ *
+ * A services-tier test with a mocked DB proves the gate *calls* the resolver;
+ * only this end-to-end path proves a real capability-scoped session is actually
+ * blocked at the run endpoint through every real layer — the E2E half of the
+ * RBAC contract.
+ *
+ * Setup uses the admin token (from storageState) to mint a granular role, a
+ * label-matched workspace, a user, and the assignment. Enforcement is then
+ * asserted with the capability user's OWN session token, driven through the BFF
+ * (BASE_URL), never the direct API port.
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+test.describe('Capability RBAC — plan-but-not-apply enforced through the BFF', () => {
+  // The granular grant: read + plan on the matching workspaces, but NOT apply
+  // and NOT delete. This is not any single level preset — it's the whole point
+  // of capabilities.
+  const CAPS = ['workspace:read', 'run:read', 'run:plan', 'var:read'];
+
+  // Hyphen-free unique token so resource names satisfy strict name patterns and
+  // the URLs need no post-hoc sanitising.
+  const tok = `cap585${randomBytes(5).toString('hex')}`;
+  const roleName = `role${tok}`;
+  const wsName = `ws${tok}`;
+  const labelKey = `cap585key${randomBytes(3).toString('hex')}`;
+  const userEmail = `${tok}@terrapod.local`;
+  const userPassword = 'TestPassword123!';
+  const wsByName = `${BASE_URL}/api/v2/organizations/default/workspaces/${wsName}`;
+
+  let adminToken = '';
+  let wsId = '';
+  let userToken = '';
+  // Workspace delete is a Terrapod-native, by-ID route (`workspace:delete`
+  // capability) — NOT the org-scoped TFE-V2 GET-by-name path, which has no
+  // DELETE verb (405). Built once wsId is known.
+  let wsDeleteUrl = '';
+
+  test.beforeAll(async () => {
+    adminToken = getStoredToken('admin.json');
+
+    // Granular role scoped by a unique label so it only applies to our workspace.
+    await createRole(adminToken, roleName, CAPS, { [labelKey]: 'yes' });
+
+    // Label-matched workspace (agent mode so a run can be queued at all).
+    wsId = await createWorkspace(adminToken, wsName, {
+      'execution-mode': 'agent',
+      labels: { [labelKey]: 'yes' },
+    });
+    wsDeleteUrl = `${BASE_URL}/api/terrapod/v1/workspaces/${wsId}`;
+
+    // A fresh principal holding ONLY the granular role (plus implicit everyone).
+    await createUser(adminToken, userEmail, userPassword, 'Cap585 User');
+    await setRoleAssignments(adminToken, userEmail, [roleName]);
+
+    const session = await getSessionToken(userEmail, userPassword);
+    userToken = session.token;
+    expect(userToken).toBeTruthy();
+  });
+
+  test.afterAll(async () => {
+    // Best-effort teardown of the resources this spec created (admin deletes via
+    // the by-ID Terrapod-native route, which the capability user was blocked from).
+    if (wsDeleteUrl) {
+      await fetch(wsDeleteUrl, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      }).catch(() => {});
+    }
+    await setRoleAssignments(adminToken, userEmail, []).catch(() => {});
+    await deleteRole(adminToken, roleName).catch(() => {});
+  });
+
+  async function postRun(planOnly: boolean): Promise<Response> {
+    return fetch(`${BASE_URL}/api/v2/runs`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({
+        data: {
+          type: 'runs',
+          attributes: { 'plan-only': planOnly },
+          relationships: {
+            workspace: { data: { type: 'workspaces', id: wsId } },
+          },
+        },
+      }),
+    });
+  }
+
+  test('granular principal CAN read its label-matched workspace', async () => {
+    const res = await fetch(wsByName, {
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('apply run is BLOCKED — lacks run:apply (403)', async () => {
+    const res = await postRun(false);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    // The gate names the missing capability, not a level threshold.
+    expect(JSON.stringify(body)).toContain('run:apply');
+  });
+
+  test('plan-only run is ALLOWED past the RBAC gate — has run:plan (not 403)', async () => {
+    const res = await postRun(true);
+    // The principal HOLDS run:plan, so the capability gate must not block it.
+    // The workspace has no configuration uploaded, so the request fails LATER
+    // (422 "no configuration") or succeeds (201) — either proves the gate was
+    // passed. The one status we must never see here is 403.
+    expect(res.status).not.toBe(403);
+    expect([201, 422]).toContain(res.status);
+  });
+
+  test('workspace delete is BLOCKED — lacks workspace:delete (403)', async () => {
+    // Delete is the by-ID Terrapod-native route (`workspace:delete`); the
+    // org-scoped TFE-V2 name path has no DELETE verb.
+    const res = await fetch(wsDeleteUrl, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(JSON.stringify(body)).toContain('workspace:delete');
+  });
+});


### PR DESCRIPTION
Capability RBAC (#585) landed enforcement, authoring, and the level-column drop across #644/#645/#648/#649/#650. The E2E suite proved capability **authoring** (`roles.spec`) and admin-nav **hiding** (`rbac-negatives`), but not the headline behaviour that levels could never express — a granular grant of **plan but NOT apply** actually enforced server-side through the full BFF proxy chain.

## What this adds

A `capability-rbac.spec.ts` that, for a capability-scoped non-admin principal (custom role `workspace:read, run:read, run:plan, var:read`, label-scoped to its own workspace), asserts through **that principal's own session token via the BFF**:

- **reads** its label-matched workspace → 200 (`workspace:read`)
- **apply run BLOCKED** → 403 naming `run:apply`
- **plan-only run ALLOWED past the RBAC gate** (holds `run:plan`) → not 403 (422 missing-config or 201, never 403)
- **workspace delete BLOCKED** → 403 naming `workspace:delete`

This is the E2E half of the RBAC contract: a mocked-DB services test proves the gate *calls* the resolver; only this end-to-end path proves the *system behaves* correctly through every real layer (ingress → BFF → API → real DB).

## Notes

- Delete targets the by-ID Terrapod-native route `DELETE /api/terrapod/v1/workspaces/{id}` — the org-scoped TFE-V2 name path has no DELETE verb (found live: it 405s, not 403s).
- Adds `createRole`/`deleteRole` helpers to `e2e/helpers/api.ts`; registers the `capability-rbac` project in `playwright.config.ts`.
- Isolation: uniquely-named resources per run, torn down in `afterAll`.
- **Every assertion was validated against the live Tilt stack before committing.**

Closes #651