### PR TITLE
chore(release): v0.51.0 pre-release audit fixes (#585 capability RBAC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ quickstart pulls released images, so the only wait is the image download.
 | Agent Execution | Implemented | Plan/apply runs on the server via K8s Job-based runner infrastructure |
 | VCS Integration | Implemented | GitHub (App) and GitLab (access token); inbound webhooks supported (GitHub HMAC + GitLab token) for instant triggers, with outbound polling as the resilient default so webhooks are optional, never required |
 | Variables & Secrets | Implemented | Per-workspace env and Terraform variables; sensitive values protected by database encryption-at-rest; variable sets |
-| RBAC | Implemented | Label-based role system with hierarchical workspace permissions (read/plan/write/admin) |
+| RBAC | Implemented | Label-based roles with granular capabilities (`resource:verb`, e.g. `run:plan` without `run:apply`); permission levels (read/plan/write/admin) remain as authoring shorthand |
 | Private Module Registry | Implemented | Publish, version, and share modules internally |
 | Private Provider Registry | Implemented | Publish, version, and share providers with GPG signing and network mirror caching |
 | Binary Caching | Implemented | Pull-through cache for terraform/tofu/terragrunt CLI binaries |

--- a/alembic/versions/a7e74cad11d5_drop_role_level_columns.py
+++ b/alembic/versions/a7e74cad11d5_drop_role_level_columns.py
@@ -33,6 +33,10 @@ def downgrade() -> None:
     # Re-add the columns and best-effort backfill from the capability summary
     # (lossy: a granular set with no matching preset restores as the literal
     # "custom", and the exact original preset choice is not recoverable).
+    # ``capabilities`` is left intact here, so a single down/up round-trip at
+    # THIS revision preserves the grant. The genuinely lossy case is downgrading
+    # further past e31a11e302fe (which drops ``capabilities``) and then
+    # re-upgrading — see that revision's downgrade() note.
     op.add_column(
         "roles",
         sa.Column("workspace_permission", sa.String(20), nullable=False, server_default="read"),

--- a/alembic/versions/e31a11e302fe_add_role_capabilities.py
+++ b/alembic/versions/e31a11e302fe_add_role_capabilities.py
@@ -61,4 +61,16 @@ def downgrade() -> None:
     # Lossy by nature (a customised capability set can't be represented as a
     # single level); the role's level columns are untouched, so collapsing back
     # to them is the intended behaviour.
+    #
+    # ROUND-TRIP DATA LOSS (documented, deliberate): if this is run AFTER
+    # a7e74cad11d5 has already been downgraded — which re-adds the level columns
+    # with the literal "custom" for any granular role — then dropping
+    # ``capabilities`` here discards the only faithful record of that role's
+    # grant. A subsequent re-upgrade backfills from levels, and
+    # ``expand_preset("custom")`` contributes nothing, so a granular role comes
+    # back with an EMPTY capability set (a silent privilege reduction). Only a
+    # full down-past-this-revision-then-up sequence is affected; the normal
+    # forward-only path and a single a7e74cad11d5 down/up round-trip preserve
+    # capabilities. Operators rolling the schema back across the #585 boundary
+    # must restore roles from a backup rather than re-upgrading in place.
     op.drop_column("roles", "capabilities")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2050,7 +2050,7 @@ Returns built-in and custom roles.
 POST /api/terrapod/v1/roles
 ```
 
-**Request body:**
+**Request body (capability authoring — recommended):**
 ```json
 {
   "data": {
@@ -2058,10 +2058,7 @@ POST /api/terrapod/v1/roles
     "attributes": {
       "name": "developer",
       "description": "Development workspace access",
-      "workspace-permission": "write",
-      "pool-permission": "read",
-      "registry-permission": "read",
-      "catalog-permission": "use",
+      "capabilities": ["workspace:read", "run:read", "run:plan", "var:read"],
       "allow-labels": {"env": "dev"},
       "allow-names": [],
       "deny-labels": {},
@@ -2071,7 +2068,29 @@ POST /api/terrapod/v1/roles
 }
 ```
 
-A role carries four independent permission scalars: `workspace-permission` (`read`/`plan`/`write`/`admin`), `pool-permission` (`read`/`write`/`admin`), `registry-permission` (`read`/`write`/`admin`, covering both modules and providers), and `catalog-permission` (`none`/`read`/`use`/`admin`, default `none`). The first three default to `read`; `catalog-permission` defaults to `none` (catalog access is opt-in, with no `everyone` floor). All are independent, so a role can grant registry write (e.g. provider-publish CI) or catalog `use` (self-service provisioning) without any workspace access. See [Service Catalog](service-catalog.md#rbac-the-catalog_permission-axis).
+A role's grant is its **`capabilities`** set — a list of `resource:verb` tokens (e.g. `run:plan`, `run:apply`, `run:apply-destroy`, `workspace:delete`, `var:write`, `state:read`) and **the single stored source of truth for enforcement** (#585). Capabilities express grants the old hierarchical levels could not — for example `run:plan` *without* `run:apply` ("plan but not apply"). Only tokens in the grantable set are accepted; `platform:*` and unknown tokens are rejected with `422`.
+
+**Request body (level shorthand — convenience):** you may instead send the four permission-level fields and the server **expands them into capabilities** on write:
+```json
+{
+  "data": {
+    "type": "roles",
+    "attributes": {
+      "name": "developer",
+      "workspace-permission": "write",
+      "pool-permission": "read",
+      "registry-permission": "read",
+      "catalog-permission": "use",
+      "allow-labels": {"env": "dev"}
+    }
+  }
+}
+```
+- `workspace-permission` (`read`/`plan`/`write`/`admin`), `pool-permission` (`read`/`write`/`admin`), `registry-permission` (`read`/`write`/`admin`, modules + providers) default to `read`; `catalog-permission` (`none`/`read`/`use`/`admin`) defaults to `none` (opt-in, no `everyone` floor).
+- The levels are **not persisted**. On a create/update they are expanded into `capabilities`; on a **PATCH**, a level field replaces only that axis's capabilities, preserving granular capabilities on the other axes.
+- If both `capabilities` and level fields are sent, **`capabilities` wins** (the levels are ignored).
+
+**Response:** every roles response includes the stored `capabilities` list **and** a derived, read-only permission-level summary (`workspace-permission`, `pool-permission`, `registry-permission`, `catalog-permission`) computed from the capabilities — each is the matching preset name, or the literal `"custom"` when the capability set matches no preset. Consumers that write levels must tolerate reading back `"custom"`.
 
 **Required permission:** Platform `admin`.
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -133,18 +133,25 @@ When a user accesses a workspace, permissions are resolved in this order. The fi
      a. Check allow rules (labels + names)
      b. Check deny rules (labels + names)
      c. If workspace matches allow AND does NOT match deny:
-        collect that role's workspace_permission
-   Take the HIGHEST collected permission
+        add that role's capabilities (scoped to this axis) to the set
+   Union the capabilities collected across all matching roles
    |
-   v (if any permission found, use it)
+   v (if any capability granted, use the union)
 
 5. "everyone" role:
-   If workspace has label "access: everyone" --> read permission
+   If workspace has label "access: everyone" --> read-floor capabilities
    |
    v (otherwise)
 
 6. Default: no access (403)
 ```
+
+> **Capabilities, not a scalar max.** Since #585 the enforced grant is the
+> **union of capabilities** across every matching role — not the single highest
+> permission *level*. Two roles granting `run:plan` and `run:apply` respectively
+> combine to plan+apply. The permission *levels* (read/plan/write/admin) are
+> authoring shorthand and a derived read-only summary, not the stored/enforced
+> grant. See [Capability-based RBAC](rbac-capabilities.md).
 
 ---
 
@@ -180,8 +187,9 @@ curl -X POST https://terrapod.example.com/api/terrapod/v1/roles \
 |---|---|---|
 | `name` | string | Unique role name (lowercase, alphanumeric + hyphens) |
 | `description` | string | Human-readable description |
-| `workspace-permission` | string | One of: `read`, `plan`, `write`, `admin` |
-| `pool-permission` | string | One of: `read`, `write`, `admin` (default: `read`) |
+| `capabilities` | array | The role's grant — a list of `resource:verb` tokens (e.g. `run:plan`, `run:apply`, `workspace:delete`). The single stored source of truth for enforcement (#585). On write, sending `capabilities` takes precedence over the level fields; on read it is always returned. See [Capability-based RBAC](rbac-capabilities.md). |
+| `workspace-permission` | string | Authoring shorthand + derived summary. One of: `read`, `plan`, `write`, `admin`, or `custom` (read-only, when the capabilities match no preset) |
+| `pool-permission` | string | Authoring shorthand + derived summary. One of: `read`, `write`, `admin` (default: `read`), or `custom` |
 | `allow-labels` | object | Label key-value pairs that grant access |
 | `allow-names` | array | Explicit workspace names that grant access |
 | `deny-labels` | object | Label key-value pairs that deny access (overrides allow) |

--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -79,7 +79,7 @@ When `catalog.enabled` is `false`, every catalog API endpoint returns `404` and 
 
 ## RBAC: the `catalog_permission` axis
 
-Catalog access is a **dedicated, opt-in permission axis** — like `pool_permission` and `registry_permission`, each custom role carries its own `catalog_permission` scalar, independent of the others. It is **label-scoped**: a role's allow/deny labels and names decide which catalog items the permission applies to, exactly as for workspaces, pools, and registry resources.
+Catalog access is a **dedicated, opt-in permission axis** — like the pool and registry axes, it is carried in the role's `capabilities` set as `catalog:*` tokens (#585). The `catalog-permission` level (`none`/`read`/`use`/`admin`) is authoring shorthand for that slice of the capabilities and a derived read-only summary — it is not a stored scalar. Each axis's capabilities are managed independently, so a role can grant catalog `use` without any workspace access. It is **label-scoped**: a role's allow/deny labels and names decide which catalog items the permission applies to, exactly as for workspaces, pools, and registry resources.
 
 | Level | Grants |
 |---|---|

--- a/go-terrapod/roles.go
+++ b/go-terrapod/roles.go
@@ -13,9 +13,11 @@ import (
 // Terrapod-specific quirk — historical from before the role
 // management API was tidied).
 //
-// AllowLabels/AllowNames grant the role's workspace_permission to
-// matching workspaces; DenyLabels/DenyNames override. Resolution
-// rules are documented in the platform CLAUDE.md.
+// AllowLabels/AllowNames scope the role's Capabilities to matching
+// workspaces (and pools/registry/catalog items); DenyLabels/DenyNames
+// override. Capabilities are the grant (see the Capabilities field);
+// resolution rules are documented in docs/rbac.md and
+// docs/rbac-capabilities.md.
 type Role struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`

--- a/services/terrapod/services/labels_service.py
+++ b/services/terrapod/services/labels_service.py
@@ -22,12 +22,12 @@ for mass-mutating workspaces / pools / modules / providers.
 
 RBAC
 ----
-Each entity type has its own permission resolver
-(`resolve_workspace_permission`, `resolve_pool_permission`,
-`resolve_registry_permission`). We only surface labels on entities
-the caller has at least `read` on. The four resolvers each support
-`preloaded_roles=` to avoid an N+1 DB hit when iterating over many
-entities; we pre-load roles once per entity type.
+Each entity type has its own capability resolver
+(`resolve_workspace_capabilities_for`, `resolve_pool_capabilities_for`,
+`resolve_registry_capabilities_for`). We only surface labels on entities
+the caller holds the axis read capability on (`has_capability(caps, *_READ)`).
+The resolvers each support `preloaded_roles=` to avoid an N+1 DB hit when
+iterating over many entities; we pre-load roles once per entity type.
 """
 
 from __future__ import annotations

--- a/services/tests/api/test_roles.py
+++ b/services/tests/api/test_roles.py
@@ -896,3 +896,39 @@ class TestCapabilityAuthoring:
         assert attrs["workspace-permission"] == "admin"
         # The effective caps now reflect admin (a delete cap the old "read" lacked).
         assert cap.WORKSPACE_DELETE in attrs["capabilities"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_partial_level_edit_preserves_granular_caps_on_other_axes(self, *mocks):
+        from terrapod.auth import capabilities as cap
+
+        # The headline authoring behaviour: a role holding a GRANULAR workspace
+        # set (plan-but-not-apply — matches no preset) gets a level edit on a
+        # DIFFERENT axis (pool → admin). The pool axis must be replaced while the
+        # granular workspace capabilities survive untouched.
+        role = _mock_role(name="dev-team")
+        role.capabilities = [cap.WORKSPACE_READ, cap.RUN_READ, cap.RUN_PLAN, cap.VAR_READ]
+        app, mock_db = _make_app(_user())
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = role
+        mock_db.execute.return_value = result
+        mock_db.refresh = AsyncMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                "/api/terrapod/v1/roles/dev-team",
+                json={"data": {"attributes": {"pool-permission": "admin"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        attrs = resp.json()["data"]["attributes"]
+        caps = set(attrs["capabilities"])
+        # Pool axis was replaced with the admin set.
+        assert cap.POOL_MANAGE in caps
+        assert attrs["pool-permission"] == "admin"
+        # The granular workspace capabilities are preserved: plan yes, apply no.
+        assert cap.RUN_PLAN in caps
+        assert cap.RUN_APPLY not in caps
+        assert cap.WORKSPACE_DELETE not in caps
+        # Workspace axis stays non-preset → derived summary is "custom".
+        assert attrs["workspace-permission"] == "custom"

--- a/services/tests/auth/test_capabilities.py
+++ b/services/tests/auth/test_capabilities.py
@@ -232,3 +232,51 @@ def test_builtin_capability_sets():
     # everyone = the read floor.
     assert everyone == _ws("read")
     assert cap.STATE_READ not in everyone
+
+
+def test_caps_for_level_unions_across_axes():
+    # A preset level unions every axis's capability set, so it is a faithful
+    # stand-in for any single-axis resolver at that level (the test-mock oracle).
+    write = cap.caps_for_level("write")
+    assert cap.RUN_APPLY in write  # workspace axis write tier
+    assert cap.VAR_WRITE in write  # workspace axis write tier
+    assert cap.POOL_ASSIGN in write  # pool axis write tier
+    assert cap.REGISTRY_WRITE in write  # registry axis
+    assert cap.CATALOG_USE in write  # catalog axis (write → use)
+    # It equals the union of the four single-axis expansions for that level.
+    expected = set(
+        cap.expand_preset(
+            workspace_permission="write",
+            pool_permission="write",
+            registry_permission="write",
+            catalog_permission="use",
+        )
+    )
+    assert set(write) == expected
+    # Strictly cumulative across the union: read ⊂ write.
+    assert cap.caps_for_level("read") < write
+
+
+def test_caps_for_level_use_is_catalog_only():
+    # "use" is a catalog-only level: it grants catalog caps and nothing else.
+    caps = cap.caps_for_level("use")
+    assert cap.CATALOG_USE in caps
+    assert not (caps & cap.axis_all_caps("workspace"))
+    assert not (caps & cap.axis_all_caps("pool"))
+    assert not (caps & cap.axis_all_caps("registry"))
+
+
+def test_caps_for_level_none_and_unknown_are_empty():
+    assert cap.caps_for_level("none") == frozenset()
+    assert cap.caps_for_level(None) == frozenset()
+    assert cap.caps_for_level("bogus") == frozenset()
+    assert cap.caps_for_level("") == frozenset()
+
+
+def test_capabilities_for_builtin_unknown_is_empty():
+    assert cap.capabilities_for_builtin("nope") == []
+
+
+def test_has_capability_empty_set_grants_nothing():
+    assert cap.has_capability(frozenset(), cap.RUN_READ) is False
+    assert cap.has_capability(frozenset(), cap.WORKSPACE_READ) is False


### PR DESCRIPTION
Pre-release audit fixes for the **v0.51.0** minor (scope = the #585 capability-RBAC arc since v0.50.1). Landed as a dedicated docs/chore PR per the release process.

## Docs — bring every surface onto the capability model
The model changed (capabilities are the single stored grant; levels are authoring shorthand + a derived summary), but several docs still described the old level-persisted model:
- **`docs/api-reference.md`** roles section rewritten to lead with the `capabilities` attribute, document level shorthand + precedence (`capabilities` wins) and the derived read-only level summary (incl. the literal `"custom"`). *(BLOCKER — the API↔UX doc gate.)*
- **`README.md`** RBAC feature row; **`docs/service-catalog.md`** (`catalog_permission` is derived, not a stored scalar); **`docs/rbac.md`** resolution diagram (union of capabilities, not a scalar max) + attribute table.
- Stale docstrings: `labels_service.py` (named the deleted scalar resolvers), `go-terrapod/roles.go` struct prose.
- Both migration docstrings now **document the round-trip data-loss precisely** (downgrading past `e31a11e302fe` then re-upgrading collapses a `custom` role's grant to empty).

## Tests
- **`caps_for_level`** unit tests — the mock oracle ~20 suites rely on had none (axis-union, catalog-only `use`, `none`/`None`/unknown→empty, cumulative).
- `capabilities_for_builtin` unknown-name + `has_capability` empty-set edges.
- **Partial level-edit preservation** — the headline authoring behaviour: a `pool→admin` PATCH leaves granular workspace caps intact (`run:plan` yes, `run:apply` no) and the ws summary stays `"custom"`.

## Clean audit dimensions (verified, no action)
- No internal-reference / peer-respect leaks (hard gate).
- Helm/config untouched → values↔schema sync N/A.
- Enforcement airtight — no escalation/lockout, no dropped-column reads, token attenuation correct.
- Consumer contract wired across all four layers (server/go-terrapod/provider/web); `"custom"` handled everywhere.

`make test` (changed files) + `make lint` green.

Closes #653