### PR TITLE
feat(runs): stale-plan guards — state drift (#647) + plan expiry (#646)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ quickstart pulls released images, so the only wait is the image download.
 | SSO (OIDC / SAML) | Implemented | Pluggable identity providers (Auth0, Okta, Azure AD, etc.) |
 | Drift Detection | Implemented | Scheduled plan-only runs to detect out-of-band changes |
 | Run Triggers | Implemented | Cross-workspace dependency chains — source apply triggers downstream runs |
+| Stale-plan Guards | Implemented | Auto-discard a plan that no longer reflects reality: state-version drift (always on) + optional per-workspace time-based plan expiry |
 | **AI Plan Summary** | **Implemented** | **LLM-generated change summary + risk assessment on every plan; failure analysis on errored plans. Provider-agnostic via LiteLLM — AWS Bedrock (Claude, Nova, gpt-oss…), OpenAI, Anthropic direct, Google Gemini, Azure OpenAI, vLLM. IAM-native auth for Bedrock (IRSA + optional cross-account `sts:AssumeRole`).** |
 | **Policy-as-Code (OPA)** | **Implemented** | **Rego-based policy enforcement on plan output — the open-source equivalent of Sentinel. Advisory or mandatory sets, label-scoped to workspaces, evaluated on the runner against plan JSON, with admin-override on mandatory blocks. Author Rego, attach to workspaces by label, see pass/fail per policy on every run.** |
 | Notifications | Implemented | Webhook (HMAC-SHA512), Slack (Block Kit), and email alerts on run events |

--- a/alembic/versions/65f5ee3a86be_plan_staleness_guards.py
+++ b/alembic/versions/65f5ee3a86be_plan_staleness_guards.py
@@ -1,0 +1,37 @@
+"""plan staleness guards: state-version snapshot + discard reason + expiry TTL (#646/#647)
+
+Adds the columns for two run-lifecycle staleness guards:
+- ``runs.plan_state_serial`` (#647) — the workspace state-version serial a run
+  planned against, so an apply can be blocked/auto-discarded when state moved.
+- ``runs.discard_reason`` (#646/#647) — human-readable reason a run was discarded
+  (state changed / plan expired / superseded).
+- ``workspaces.plan_expiry_seconds`` (#646) — per-workspace TTL after which an
+  unconfirmed plan is auto-discarded. NULL = disabled (default, current behaviour).
+
+All three are nullable with no backfill: existing runs have no snapshot/reason
+(so the state guard never retroactively fires on them) and existing workspaces
+have expiry disabled — a faithful no-op on upgrade.
+
+Revision ID: 65f5ee3a86be
+Revises: a7e74cad11d5
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "65f5ee3a86be"
+down_revision = "a7e74cad11d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("runs", sa.Column("plan_state_serial", sa.Integer(), nullable=True))
+    op.add_column("runs", sa.Column("discard_reason", sa.String(length=200), nullable=True))
+    op.add_column("workspaces", sa.Column("plan_expiry_seconds", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "plan_expiry_seconds")
+    op.drop_column("runs", "discard_reason")
+    op.drop_column("runs", "plan_state_serial")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -339,6 +339,7 @@ Workspaces support the following drift detection attributes (settable on create 
 |---|---|---|---|
 | `drift-detection-enabled` | boolean | `true` (VCS) / `false` (non-VCS) | Enable or disable automatic drift detection. Auto-enabled when a VCS connection is set |
 | `drift-detection-interval-seconds` | integer | `86400` | How often to run drift detection checks (minimum: 3600 seconds / 1 hour) |
+| `plan-expiry-seconds` | integer / null | `null` | Per-workspace plan-expiry TTL (#646). When set, an apply-capable run that has sat in `planned` longer than this (from plan completion) is auto-discarded and must be re-planned. `null` / `0` = disabled (default) |
 | `drift-ignore-rules` | list[string] | `[]` | Glob-aware patterns silenced by the drift-result classifier (#482). Each rule is a Terraform address optionally suffixed with a dotted attribute path; `*` matches zero or more non-`.` chars (spans `[N]` indices), `[*]` matches any bracketed index. A bare address with no attribute suffix silences any change to that resource — including destroys — so use carefully. Max 50 entries, ≤ 500 chars each. Examples: `aws_iam_role.foo.tags.Environment`, `aws_autoscaling_group.workers[*].desired_capacity`, `module.eks*.argocd_cluster.*.config.tls_client_config.ca_data`. Affects drift-detection runs only — regular plan/apply is untouched. See [drift-ignore-rules.md](drift-ignore-rules.md) for the full grammar and recipes |
 
 ### Terragrunt Attributes
@@ -610,6 +611,15 @@ Apply-capable (plan+apply) runs are **serialized per workspace** — only one ex
 **Plan-only runs are exempt** — speculative PR plans, CLI `plan`, and drift checks never mutate state, so they run concurrently and neither supersede nor are superseded. (Speculative PR runs are still superseded per-PR by the VCS poller on a new commit.)
 
 This is enforced server-side regardless of run source (VCS, CLI/API, UI), so the same guarantees hold for `terraform`/`tofu` CLI-driven runs as for VCS-driven runs.
+
+#### Stale-plan guards: state drift (#647) & expiry (#646)
+
+Beyond supersede (a *newer run* case), two guards protect against applying a plan that no longer reflects reality. Both resolve an apply-capable `planned` run to `discarded`, unlock the workspace, and surface the reason in the run's **`discard-reason`** attribute; confirming a stale plan returns **409** (re-plan required). Plan-only / drift / speculative runs are exempt.
+
+- **State-version drift (#647, always on)** — a plan is snapshotted against the workspace's state serial when it starts. If the current state serial advances before the plan is applied — another apply, a CLI `state push`, a rollback, a manual upload — the plan is stale and is auto-discarded (`discard-reason: state changed since plan (serial N -> M)`). This runs even in agent mode, where the server drives the apply and there is no client to catch it. A first apply (no prior state) has no baseline and is never stale.
+- **Time-based expiry (#646, per-workspace, off by default)** — when a workspace sets `plan-expiry-seconds`, a plan older than that TTL (from completion) is auto-discarded by a periodic sweep and at confirm time (`discard-reason: plan expired after {ttl}s`).
+
+Whichever reason fires first wins, and both compose with supersede.
 
 #### Configuration version resolution
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 | **Agent Pools** | Named groups of runner listeners; join token → certificate exchange for auth |
 | **SSO (OIDC / SAML)** | Pluggable identity providers (Auth0, Okta, Azure AD, etc.) |
 | **Run Triggers** | Cross-workspace dependency chains -- source apply triggers downstream runs |
+| **Stale-plan Guards** | Auto-discard a plan that no longer reflects reality: state-version drift (always on) + optional per-workspace time-based plan expiry |
 | **Audit Logging** | Immutable event log with configurable retention |
 | **Notifications** | Webhook (HMAC-SHA512), Slack (Block Kit), and email alerts on run events |
 | **Run Tasks** | Pre/post-plan webhook hooks for external validation |

--- a/go-terrapod/workspaces.go
+++ b/go-terrapod/workspaces.go
@@ -54,6 +54,10 @@ type Workspace struct {
 	DriftIgnoreRules              []string `json:"drift-ignore-rules,omitempty"`
 	DriftDetectionEnabled         bool     `json:"drift-detection-enabled"`
 	DriftDetectionIntervalSeconds *int64   `json:"drift-detection-interval-seconds,omitempty"`
+	// PlanExpirySeconds is the per-workspace plan-expiry TTL (#646); nil =
+	// disabled (the default). An apply-capable plan older than this is
+	// auto-discarded and must be re-planned.
+	PlanExpirySeconds             *int64   `json:"plan-expiry-seconds,omitempty"`
 	DriftStatus                   string   `json:"drift-status,omitempty"`
 	DriftLastCheckedAt            string   `json:"drift-last-checked-at,omitempty"`
 	// DriftLatestRunID is the ID (prefixed `run-…`) of the drift run that
@@ -129,6 +133,7 @@ type CreateWorkspaceRequest struct {
 	DriftIgnoreRules              []string          `json:"drift-ignore-rules,omitempty"`
 	DriftDetectionEnabled         *bool             `json:"drift-detection-enabled,omitempty"`
 	DriftDetectionIntervalSeconds *int64            `json:"drift-detection-interval-seconds,omitempty"`
+	PlanExpirySeconds             *int64            `json:"plan-expiry-seconds,omitempty"`
 	// AISummaryMode is the three-state per-workspace override (#401):
 	// "default" | "enabled" | "disabled". Empty string omits the field
 	// (server-side default applies — "default").
@@ -171,6 +176,7 @@ type UpdateWorkspaceRequest struct {
 	DriftIgnoreRules              []string          `json:"drift-ignore-rules,omitempty"`
 	DriftDetectionEnabled         *bool             `json:"drift-detection-enabled,omitempty"`
 	DriftDetectionIntervalSeconds *int64            `json:"drift-detection-interval-seconds,omitempty"`
+	PlanExpirySeconds             *int64            `json:"plan-expiry-seconds,omitempty"`
 	// AISummaryMode see CreateWorkspaceRequest. On UPDATE, empty string
 	// leaves the existing value untouched — to explicitly set "follow
 	// deployment default", pass "default".
@@ -392,6 +398,9 @@ func workspaceCreateAttrs(req CreateWorkspaceRequest) map[string]any {
 	if req.DriftDetectionIntervalSeconds != nil {
 		attrs["drift-detection-interval-seconds"] = *req.DriftDetectionIntervalSeconds
 	}
+	if req.PlanExpirySeconds != nil {
+		attrs["plan-expiry-seconds"] = *req.PlanExpirySeconds
+	}
 	if req.AISummaryMode != "" {
 		attrs["ai-summary-mode"] = req.AISummaryMode
 	}
@@ -473,6 +482,9 @@ func workspaceUpdateAttrs(req UpdateWorkspaceRequest) map[string]any {
 	}
 	if req.DriftDetectionIntervalSeconds != nil {
 		attrs["drift-detection-interval-seconds"] = *req.DriftDetectionIntervalSeconds
+	}
+	if req.PlanExpirySeconds != nil {
+		attrs["plan-expiry-seconds"] = *req.PlanExpirySeconds
 	}
 	if req.AISummaryMode != "" {
 		attrs["ai-summary-mode"] = req.AISummaryMode

--- a/llms.txt
+++ b/llms.txt
@@ -85,6 +85,7 @@ How each capability is turned on. **Platform-level** features are Helm values un
 | SSO (OIDC/SAML) | `api.config.auth.sso.*` + client secrets via K8s Secret `secretKeyRef` | [authentication.md](docs/authentication.md) |
 | VCS integration | Admin creates a VCS connection, then sets the workspace's `vcs_*` fields | [vcs-integration.md](docs/vcs-integration.md) |
 | Drift detection | Per-workspace setting (enable + interval) via API/UI/provider | [drift-detection.md](docs/drift-detection.md) |
+| Stale-plan guards | State-drift auto-discard (#647) is always on; time-based plan expiry (#646) is per-workspace `plan_expiry_seconds` (off by default) | [api-reference.md](docs/api-reference.md) |
 | Notifications / Run tasks | Per-workspace config via API/UI/provider | [notifications.md](docs/notifications.md), [run-tasks.md](docs/run-tasks.md) |
 | Policy-as-code | Create a policy set, attach to workspaces by label | [policies.md](docs/policies.md) |
 | Autodiscovery | Per-VCS-connection rules (glob patterns + workspace template) | [autodiscovery.md](docs/autodiscovery.md) |

--- a/provider/internal/datasources/workspace/data_source.go
+++ b/provider/internal/datasources/workspace/data_source.go
@@ -46,6 +46,7 @@ type workspaceDataSourceModel struct {
 	DriftIgnoreRules              types.List   `tfsdk:"drift_ignore_rules"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`
 	DriftDetectionIntervalSeconds types.Int64  `tfsdk:"drift_detection_interval_seconds"`
+	PlanExpirySeconds             types.Int64  `tfsdk:"plan_expiry_seconds"`
 	AISummaryMode                 types.String `tfsdk:"ai_summary_mode"`
 	AISummaryContext              types.String `tfsdk:"ai_summary_context"`
 	OwnerEmail                    types.String `tfsdk:"owner_email"`
@@ -99,6 +100,7 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"drift_ignore_rules":               computedList("Glob-aware patterns suppressed by the drift-result classifier (#482). See the resource attribute docs for syntax."),
 			"drift_detection_enabled":          computedBool("Drift detection enabled."),
 			"drift_detection_interval_seconds": computedInt64("Drift detection interval."),
+			"plan_expiry_seconds":              computedInt64("Per-workspace plan expiry TTL in seconds (#646); null/0 = disabled."),
 			"ai_summary_mode":                  computedString("Per-workspace AI plan-summary mode: 'default' (follow deployment global), 'enabled' (always summarise), or 'disabled' (never summarise)."),
 			"ai_summary_context":               computedString("Workspace-specific context appended to the AI summariser prompt."),
 			"owner_email":                      computedString("Owner email."),
@@ -212,6 +214,12 @@ func readDataSourceModel(ctx context.Context, res *terrapod.Resource, m *workspa
 		m.DriftDetectionIntervalSeconds = types.Int64Value(v)
 	} else {
 		m.DriftDetectionIntervalSeconds = types.Int64Null()
+	}
+
+	if v := terrapod.GetIntAttr(res, "plan-expiry-seconds"); v > 0 {
+		m.PlanExpirySeconds = types.Int64Value(v)
+	} else {
+		m.PlanExpirySeconds = types.Int64Null()
 	}
 
 	if varFiles := terrapod.GetListAttr(res, "var-files"); len(varFiles) > 0 {

--- a/provider/internal/resources/workspace/model.go
+++ b/provider/internal/resources/workspace/model.go
@@ -78,6 +78,7 @@ type workspaceModel struct {
 	DriftIgnoreRules              types.List   `tfsdk:"drift_ignore_rules"`
 	DriftDetectionEnabled         types.Bool   `tfsdk:"drift_detection_enabled"`
 	DriftDetectionIntervalSeconds types.Int64  `tfsdk:"drift_detection_interval_seconds"`
+	PlanExpirySeconds             types.Int64  `tfsdk:"plan_expiry_seconds"`
 	AISummaryMode                 types.String `tfsdk:"ai_summary_mode"`
 	AISummaryContext              types.String `tfsdk:"ai_summary_context"`
 

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -202,6 +202,14 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
+			"plan_expiry_seconds": schema.Int64Attribute{
+				Description: "Per-workspace plan expiry TTL in seconds (#646). An apply-capable planned run older than this is auto-discarded and must be re-planned. Unset / 0 = disabled (the default).",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
 			"ai_summary_mode": schema.StringAttribute{
 				Description: "Per-workspace AI plan-summary opt-in (#401). One of \"default\" (follow the deployment's global `ai_summary.enabled` setting), \"enabled\" (always summarise this workspace's plans), or \"disabled\" (never summarise — overrides global). Defaults to \"default\".",
 				Optional:    true,
@@ -592,6 +600,10 @@ func buildCreateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 		v := m.DriftDetectionIntervalSeconds.ValueInt64()
 		req.DriftDetectionIntervalSeconds = &v
 	}
+	if !m.PlanExpirySeconds.IsNull() && !m.PlanExpirySeconds.IsUnknown() {
+		v := m.PlanExpirySeconds.ValueInt64()
+		req.PlanExpirySeconds = &v
+	}
 	if !m.AISummaryMode.IsNull() && !m.AISummaryMode.IsUnknown() {
 		req.AISummaryMode = m.AISummaryMode.ValueString()
 	}
@@ -700,6 +712,10 @@ func buildUpdateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 		v := m.DriftDetectionIntervalSeconds.ValueInt64()
 		req.DriftDetectionIntervalSeconds = &v
 	}
+	if !m.PlanExpirySeconds.IsNull() && !m.PlanExpirySeconds.IsUnknown() {
+		v := m.PlanExpirySeconds.ValueInt64()
+		req.PlanExpirySeconds = &v
+	}
 	if !m.AISummaryMode.IsNull() && !m.AISummaryMode.IsUnknown() {
 		req.AISummaryMode = m.AISummaryMode.ValueString()
 	}
@@ -772,6 +788,11 @@ func readWorkspaceIntoModel(ctx context.Context, ws *terrapod.Workspace, m *work
 		m.DriftDetectionIntervalSeconds = types.Int64Value(*ws.DriftDetectionIntervalSeconds)
 	} else {
 		m.DriftDetectionIntervalSeconds = types.Int64Null()
+	}
+	if ws.PlanExpirySeconds != nil && *ws.PlanExpirySeconds > 0 {
+		m.PlanExpirySeconds = types.Int64Value(*ws.PlanExpirySeconds)
+	} else {
+		m.PlanExpirySeconds = types.Int64Null()
 	}
 	if ws.DriftStatus != "" {
 		m.DriftStatus = types.StringValue(ws.DriftStatus)

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -257,6 +257,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         description="Retry failed catalog/autodiscovery lifecycle destroy runs",
     )
 
+    # Plan expiry sweep (#646): discard apply-capable planned runs that have aged
+    # past their workspace's plan_expiry_seconds TTL. No-op when no workspace sets
+    # a TTL (the default). Cheap query gated on plan_expiry_seconds > 0.
+    from terrapod.services.run_service import expire_stale_plans_cycle
+
+    register_periodic_task(
+        "plan_expiry_sweep",
+        interval_seconds=60,
+        handler=expire_stale_plans_cycle,
+        description="Discard planned runs past their workspace plan-expiry TTL",
+    )
+
     # Audit log retention (daily)
     async def _audit_retention() -> None:
         from terrapod.services.audit_service import purge_old_entries

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -589,6 +589,15 @@ async def _persist_runner_state(
     if ws and ws.state_diverged:
         ws.state_diverged = False
 
+    # This apply advanced the workspace state → any OTHER apply-capable planned
+    # run now has a stale plan; auto-discard them (#647). The applying run itself
+    # is not `planned`, but exclude it explicitly for clarity.
+    from terrapod.services import run_service
+
+    await run_service.discard_stale_plans_for_state_change(
+        db, run.workspace_id, serial, exclude_run_id=run.id
+    )
+
     await db.commit()
     logger.info(
         "state_version_created_from_runner",

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -125,6 +125,9 @@ def _run_json(
             "attributes": {
                 "status": run.status,
                 "message": run.message,
+                # Why a run was discarded (state changed / plan expired /
+                # superseded), null otherwise (#646/#647).
+                "discard-reason": run.discard_reason,
                 "is-destroy": run.is_destroy,
                 "auto-apply": run.auto_apply,
                 "plan-only": run.plan_only,

--- a/services/terrapod/api/routers/state_management.py
+++ b/services/terrapod/api/routers/state_management.py
@@ -206,6 +206,12 @@ async def rollback_state_version(
     db.add(new_sv)
     await db.flush()
 
+    # A rollback advances the state serial → any apply-capable planned run now has
+    # a stale plan; auto-discard them (#647).
+    from terrapod.services import run_service
+
+    await run_service.discard_stale_plans_for_state_change(db, sv.workspace_id, new_serial)
+
     # Store state bytes at new key (re-encrypted under the active DEK when on)
     new_key = state_key(str(sv.workspace_id), str(new_sv.id))
     await storage.put(new_key, await encrypt_state_bytes(state_bytes))
@@ -308,6 +314,12 @@ async def upload_state_manual(
             await storage.put_stream(
                 key, file_chunks(tmp_path), content_type="application/octet-stream"
             )
+
+        # A manual upload advances the state serial → any apply-capable planned
+        # run now has a stale plan; auto-discard them (#647).
+        from terrapod.services import run_service
+
+        await run_service.discard_stale_plans_for_state_change(db, ws.id, new_serial)
 
         await db.commit()
         await db.refresh(sv)

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -283,6 +283,22 @@ def _clamp_drift_interval(value: int) -> int:
     return max(int(value), settings.drift_detection.min_workspace_interval_seconds)
 
 
+def _parse_plan_expiry(value) -> int | None:
+    """Validate a plan-expiry TTL (#646). None / 0 → disabled (stored NULL); a
+    positive integer is seconds. Rejects negatives / non-ints with 422."""
+    if value is None:
+        return None
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=422, detail="plan-expiry-seconds must be an integer"
+        ) from None
+    if seconds < 0:
+        raise HTTPException(status_code=422, detail="plan-expiry-seconds must not be negative")
+    return seconds or None
+
+
 async def _update_state_index(
     workspace_name: str,
     workspace_id: str,
@@ -662,6 +678,8 @@ def _workspace_json(
                 "ai-summary-context": ws.ai_summary_context,
                 "drift-detection-enabled": ws.drift_detection_enabled,
                 "drift-detection-interval-seconds": ws.drift_detection_interval_seconds,
+                # Per-workspace plan expiry TTL (#646); null = disabled (default).
+                "plan-expiry-seconds": ws.plan_expiry_seconds,
                 "drift-last-checked-at": _rfc3339(ws.drift_last_checked_at),
                 "drift-status": ws.drift_status,
                 "drift-latest-run-id": (
@@ -984,6 +1002,7 @@ async def create_workspace(
         drift_detection_interval_seconds=_clamp_drift_interval(
             attrs.get("drift-detection-interval-seconds", 86400)
         ),
+        plan_expiry_seconds=_parse_plan_expiry(attrs.get("plan-expiry-seconds")),
     )
     db.add(ws)
     await db.commit()
@@ -1492,6 +1511,8 @@ async def update_workspace(
         ws.drift_detection_interval_seconds = _clamp_drift_interval(
             attrs["drift-detection-interval-seconds"]
         )
+    if "plan-expiry-seconds" in attrs:
+        ws.plan_expiry_seconds = _parse_plan_expiry(attrs["plan-expiry-seconds"])
 
     # AI plan summary opt-in (#401). The mode is a three-state enum
     # constrained by a DB CHECK; reject other values up-front rather than
@@ -1898,6 +1919,16 @@ async def create_state_version(
         run_id=run_uuid,
     )
     db.add(sv)
+    await db.flush()
+
+    # A new state version landed → any other apply-capable planned run on this
+    # workspace now has a stale plan; auto-discard them (#647).
+    from terrapod.services import run_service
+
+    await run_service.discard_stale_plans_for_state_change(
+        db, ws.id, serial, exclude_run_id=run_uuid
+    )
+
     await db.commit()
     await db.refresh(sv)
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -359,6 +359,11 @@ class Workspace(Base):
         String(20), nullable=False, server_default="merge", default="merge"
     )  # merge, squash, rebase
 
+    # Plan expiry (#646): an apply-capable run that has sat in `planned` longer than
+    # this TTL (from plan_finished_at) can no longer be applied — it is auto-discarded
+    # and must be re-planned. NULL / 0 = disabled (default) = current behaviour.
+    plan_expiry_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Drift detection
     drift_detection_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     drift_detection_interval_seconds: Mapped[int] = mapped_column(
@@ -1463,6 +1468,14 @@ class Run(Base):
     plan_finished_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # The workspace state-version serial this run planned against, captured when the
+    # run enters `planning` (#647). NULL = no baseline (first apply, or a plan-only
+    # run) → the state-staleness guard never fires. If the workspace's current serial
+    # later advances past this, the plan is stale and the run is auto-discarded.
+    plan_state_serial: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Human-readable reason a run was discarded (state changed / plan expired /
+    # superseded), surfaced as `discard-reason` in the run serializer (#646/#647).
+    discard_reason: Mapped[str | None] = mapped_column(String(200), nullable=True)
     apply_started_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -1222,6 +1222,11 @@ async def confirm_run(db: AsyncSession, run: Run) -> Run:
     stale = await _staleness_reason(db, run, workspace)
     if stale is not None:
         await discard_run(db, run, reason=stale)
+        # Commit the discard before raising: the ValueError below surfaces as a
+        # 409, and the router's error path would otherwise roll back the session,
+        # losing the discard and leaving the run stuck `planned`. Persist it so
+        # the caller both sees the 409 and finds the run correctly discarded.
+        await db.commit()
         raise ValueError(f"{stale} — re-plan required")
     await _check_mergeability_or_block(db, run)
     return await transition_run(db, run, "confirmed")

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -18,6 +18,7 @@ from terrapod.db.models import (
     ConfigurationVersion,
     Run,
     RunTrigger,
+    StateVersion,
     VCSConnection,
     Workspace,
     now_utc,
@@ -352,9 +353,9 @@ async def supersede_stale_runs(db: AsyncSession, newer: Run) -> int:
         old.message = reason
         try:
             if old.status == "planned":
-                await discard_run(db, old)
+                await discard_run(db, old, reason=reason)
             else:  # pending / queued
-                await cancel_run(db, old, force=True)
+                await cancel_run(db, old, force=True, reason=reason)
             superseded += 1
         except ValueError:
             # The run changed state under us (e.g. it just dispatched).
@@ -373,6 +374,143 @@ async def supersede_stale_runs(db: AsyncSession, newer: Run) -> int:
             count=superseded,
         )
     return superseded
+
+
+# ── Plan staleness guards (#646 time-based expiry, #647 state-version drift) ──
+#
+# A plan is computed against one state snapshot. Applying it later is unsafe if
+# either the state has moved (correctness — #647, always on) or the plan has
+# simply aged past a per-workspace TTL (policy — #646, opt-in). Both resolve an
+# apply-capable `planned` run to `discarded` with a reason; whichever fires first
+# wins, and they compose with supersede (the newer-run case).
+
+
+async def current_state_serial(db: AsyncSession, workspace_id) -> int | None:
+    """The latest state-version serial for a workspace, or None when it has no
+    state yet (first apply — no baseline to compare a plan against)."""
+    return await db.scalar(
+        select(StateVersion.serial)
+        .where(StateVersion.workspace_id == workspace_id)
+        .order_by(StateVersion.serial.desc())
+        .limit(1)
+    )
+
+
+async def _state_moved_since_plan(db: AsyncSession, run: Run) -> int | None:
+    """If the workspace's current state serial has advanced past the serial this
+    run planned against, return the current serial (the plan is stale, #647).
+    None when still current — including the no-baseline case (``plan_state_serial``
+    is None ⇒ first apply, never stale)."""
+    if run.plan_state_serial is None:
+        return None
+    current = await current_state_serial(db, run.workspace_id)
+    if current is not None and current > run.plan_state_serial:
+        return current
+    return None
+
+
+def _plan_expired(run: Run, workspace: Workspace | None) -> bool:
+    """Whether an apply-capable planned run has aged past its workspace's plan
+    expiry TTL (#646). Off (never expired) when the TTL is unset/0, when there is
+    no ``plan_finished_at``, or for plan-only runs."""
+    if workspace is None or run.plan_only:
+        return False
+    ttl = workspace.plan_expiry_seconds
+    if not ttl or ttl <= 0 or run.plan_finished_at is None:
+        return False
+    return (now_utc() - run.plan_finished_at).total_seconds() > ttl
+
+
+async def _staleness_reason(db: AsyncSession, run: Run, workspace: Workspace | None) -> str | None:
+    """The reason an apply-capable planned run may no longer be applied, or None
+    if it is still fresh. State drift (#647) is a correctness guard checked first;
+    time-based expiry (#646) second. Plan-only / drift / speculative runs never
+    go stale (they never apply)."""
+    if not _is_supersedeable_kind(run):
+        return None
+    moved_to = await _state_moved_since_plan(db, run)
+    if moved_to is not None:
+        return f"state changed since plan (serial {run.plan_state_serial} -> {moved_to})"
+    if _plan_expired(run, workspace):
+        return f"plan expired after {workspace.plan_expiry_seconds}s"
+    return None
+
+
+async def discard_stale_plans_for_state_change(
+    db: AsyncSession, workspace_id, new_serial: int, *, exclude_run_id=None
+) -> int:
+    """Event-driven counterpart to the confirm-time guard (#647): when a new state
+    version lands for a workspace, auto-discard every *other* apply-capable
+    ``planned`` run whose snapshot predates it (its plan is now stale). Composes
+    with supersede (which handles the newer-run case); this handles the
+    state-moved-underneath case — a CLI local apply pushing state, a rollback, a
+    manual upload, or another run's apply completing."""
+    conditions = [
+        Run.workspace_id == workspace_id,
+        Run.status == "planned",
+        Run.plan_only.is_(False),
+        Run.is_drift_detection.is_(False),
+        Run.vcs_pull_request_number.is_(None),
+        Run.plan_state_serial.isnot(None),
+        Run.plan_state_serial < new_serial,
+    ]
+    if exclude_run_id is not None:
+        conditions.append(Run.id != exclude_run_id)
+    result = await db.execute(select(Run).where(*conditions))
+    discarded = 0
+    for run in result.scalars().all():
+        reason = f"state changed since plan (serial {run.plan_state_serial} -> {new_serial})"
+        try:
+            await discard_run(db, run, reason=reason)
+            discarded += 1
+        except ValueError:
+            logger.warning(
+                "Skipped discarding stale-state run", run_id=str(run.id), status=run.status
+            )
+    if discarded:
+        logger.info(
+            "Discarded plans stale against new state",
+            workspace_id=str(workspace_id),
+            new_serial=new_serial,
+            count=discarded,
+        )
+    return discarded
+
+
+async def expire_stale_plans_cycle() -> None:
+    """Periodic task (#646): discard apply-capable ``planned`` runs that have aged
+    past their workspace's ``plan_expiry_seconds``, so the run list reflects expiry
+    promptly rather than only lazily at confirm time. Multi-replica-safe via the
+    distributed scheduler's claim; opens its own short-lived session."""
+    from terrapod.db.session import get_db_session
+
+    async with get_db_session() as db:
+        result = await db.execute(
+            select(Run, Workspace)
+            .join(Workspace, Run.workspace_id == Workspace.id)
+            .where(
+                Run.status == "planned",
+                Run.plan_only.is_(False),
+                Run.is_drift_detection.is_(False),
+                Run.vcs_pull_request_number.is_(None),
+                Run.plan_finished_at.isnot(None),
+                Workspace.plan_expiry_seconds.isnot(None),
+                Workspace.plan_expiry_seconds > 0,
+            )
+        )
+        discarded = 0
+        for run, ws in result.all():
+            if _plan_expired(run, ws):
+                try:
+                    await discard_run(
+                        db, run, reason=f"plan expired after {ws.plan_expiry_seconds}s"
+                    )
+                    discarded += 1
+                except ValueError:
+                    pass
+        if discarded:
+            await db.commit()
+            logger.info("Expired stale plans", count=discarded)
 
 
 async def create_run(
@@ -507,6 +645,11 @@ async def transition_run(
     # Track phase timestamps
     if target_status == "planning":
         run.plan_started_at = now
+        # Snapshot the state version this plan is computed against (#647): the
+        # runner downloads the current state at plan start, so if the workspace's
+        # serial later advances the plan is stale and the apply is blocked. None =
+        # no baseline yet (first apply) → the state-staleness guard never fires.
+        run.plan_state_serial = await current_state_serial(db, run.workspace_id)
     elif (
         target_status in ("planned", "errored") and run.plan_started_at and not run.plan_finished_at
     ):
@@ -741,10 +884,18 @@ async def complete_plan(
         return run
 
     if run.auto_apply and not run.plan_only:
+        locked_ws = await db.get(Workspace, run.workspace_id)
+        # Defensive staleness guard on the auto-apply path (#646/#647): if the
+        # state moved or the TTL lapsed between plan completion and this
+        # transition, discard rather than auto-apply a stale plan.
+        stale = await _staleness_reason(db, run, locked_ws)
+        if stale is not None:
+            run = await discard_run(db, run, reason=stale)
+            logger.info("Auto-apply plan stale — discarded", run_id=str(run.id), reason=stale)
+            return run
         # Respect a manual workspace lock even on auto-apply: leave the run
         # `planned` for a human to apply after unlocking, rather than
         # auto-applying past the operator's lock.
-        locked_ws = await db.get(Workspace, run.workspace_id)
         if locked_ws is None or not locked_ws.locked:
             run = await transition_run(db, run, "confirmed")
 
@@ -1064,14 +1215,25 @@ async def confirm_run(db: AsyncSession, run: Run) -> Run:
         raise ValueError(
             f'workspace is locked (lock ID: "{workspace.lock_id}") — unlock before applying'
         )
+    # Staleness guards (#646 expiry, #647 state drift): a plan that no longer
+    # reflects the current state, or has aged past the workspace TTL, must not be
+    # applied. Auto-discard it (unlocking the workspace) and surface a 409 so the
+    # caller re-plans. State drift is the always-on correctness guard.
+    stale = await _staleness_reason(db, run, workspace)
+    if stale is not None:
+        await discard_run(db, run, reason=stale)
+        raise ValueError(f"{stale} — re-plan required")
     await _check_mergeability_or_block(db, run)
     return await transition_run(db, run, "confirmed")
 
 
-async def discard_run(db: AsyncSession, run: Run) -> Run:
-    """Discard a planned run."""
+async def discard_run(db: AsyncSession, run: Run, *, reason: str | None = None) -> Run:
+    """Discard a planned run. ``reason`` (state changed / plan expired /
+    superseded) is recorded on the run and surfaced to the UI/SDK."""
     if run.status != "planned":
         raise ValueError(f"Can only discard runs in 'planned' status, got '{run.status}'")
+    if reason:
+        run.discard_reason = reason
     # Unlock workspace
     workspace = await db.get(Workspace, run.workspace_id)
     if workspace and workspace.locked:
@@ -1092,13 +1254,16 @@ async def discard_run(db: AsyncSession, run: Run) -> Run:
 CANCELABLE_STATES = frozenset({"pending", "queued", "planning", "confirmed", "applying"})
 
 
-async def cancel_run(db: AsyncSession, run: Run, *, force: bool = False) -> Run:
+async def cancel_run(
+    db: AsyncSession, run: Run, *, force: bool = False, reason: str | None = None
+) -> Run:
     """Cancel a run.
 
     By default only in-progress states (`CANCELABLE_STATES`) are cancelable.
     Pass `force=True` to bypass that check — only for internal callers
     that need to cancel superseded `planned` runs as part of cleanup.
-    Terminal states are always rejected.
+    Terminal states are always rejected. ``reason`` (e.g. "superseded by …") is
+    recorded on the run and surfaced to the UI/SDK.
 
     Behaviour by source state:
 
@@ -1120,6 +1285,8 @@ async def cancel_run(db: AsyncSession, run: Run, *, force: bool = False) -> Run:
         raise ValueError(f"Cannot cancel run in terminal state '{run.status}'")
     if not force and run.status not in CANCELABLE_STATES:
         raise ValueError(f"Cannot cancel run in state '{run.status}'")
+    if reason:
+        run.discard_reason = reason
 
     # Choose the target status. `applying` is the only state where a
     # Job may already be mutating real infrastructure; everything else

--- a/services/tests/api/test_ai_summary.py
+++ b/services/tests/api/test_ai_summary.py
@@ -71,6 +71,7 @@ def _mock_workspace(ws_id=None, **overrides):
     ws.autodiscovery_pr_number = None
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400
+    ws.plan_expiry_seconds = None
     ws.drift_last_checked_at = None
     ws.drift_status = ""
     ws.state_diverged = False

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -47,6 +47,7 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.owner_email = "test@example.com"
     ws.drift_detection_enabled = overrides.get("drift_detection_enabled", False)
     ws.drift_detection_interval_seconds = overrides.get("drift_detection_interval_seconds", 86400)
+    ws.plan_expiry_seconds = overrides.get("plan_expiry_seconds")
     ws.drift_last_checked_at = overrides.get("drift_last_checked_at", None)
     ws.drift_status = overrides.get("drift_status", "")
     ws.state_diverged = overrides.get("state_diverged", False)
@@ -208,6 +209,8 @@ class TestRunDriftAttributes:
         run.created_at = datetime(2026, 1, 1, tzinfo=UTC)
         run.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
         run.plan_started_at = datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC)
+        run.plan_state_serial = None
+        run.discard_reason = None
         run.plan_finished_at = datetime(2026, 1, 1, 0, 0, 30, tzinfo=UTC)
         run.apply_started_at = None
         run.apply_finished_at = None

--- a/services/tests/api/test_health_conditions.py
+++ b/services/tests/api/test_health_conditions.py
@@ -28,6 +28,7 @@ def _mock_workspace(**overrides):
     ws.drift_ignore_rules = []
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400
+    ws.plan_expiry_seconds = None
     ws.drift_last_checked_at = None
     ws.drift_status = overrides.get("drift_status", "")
     ws.state_diverged = overrides.get("state_diverged", False)

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -114,6 +114,8 @@ def _mock_run(
     run.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     run.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
     run.plan_started_at = None
+    run.plan_state_serial = None
+    run.discard_reason = None
     run.plan_finished_at = None
     run.apply_started_at = None
     run.apply_finished_at = None

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -60,6 +60,10 @@ def _mock_run(
     run.plan_finished_at = None
     run.apply_started_at = None
     run.apply_finished_at = None
+    # #647/#646: no state snapshot / discard reason by default (no baseline →
+    # the staleness guard never fires; None serialises cleanly).
+    run.plan_state_serial = None
+    run.discard_reason = None
     run.listener_id = None
     run.target_addrs = None
     run.replace_addrs = None
@@ -103,6 +107,9 @@ def _mock_workspace(ws_id=None, name="test-ws", catalog_item_id=None):
     # Explicit None so MagicMock doesn't auto-return a truthy attribute and
     # trip the catalog config-managed guardrail (#535).
     ws.catalog_item_id = catalog_item_id
+    # #646: plan expiry disabled by default (None) so the confirm-time TTL guard
+    # doesn't mis-fire on a truthy MagicMock.
+    ws.plan_expiry_seconds = None
     return ws
 
 

--- a/services/tests/api/test_state_management.py
+++ b/services/tests/api/test_state_management.py
@@ -232,9 +232,13 @@ class TestRollbackStateVersion:
         }
 
         mock_db = AsyncMock()
+        # 3rd execute: the #647 discard-stale-plans hook (returns no planned runs).
+        _no_runs = MagicMock()
+        _no_runs.scalars.return_value.all.return_value = []
         mock_db.execute.side_effect = [
             _scalar_result(sv),  # get state version
             _scalar_result(3),  # get max serial
+            _no_runs,  # discard_stale_plans_for_state_change query
         ]
         mock_db.get.return_value = ws
 

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -57,6 +57,7 @@ def _mock_workspace(ws_id=None, pool_id=None):
     ws.drift_ignore_rules = []
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400
+    ws.plan_expiry_seconds = None
     ws.drift_last_checked_at = None
     ws.drift_status = ""
     ws.state_diverged = False

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -69,6 +69,7 @@ def _mock_workspace(
     ws.drift_ignore_rules = []
     ws.drift_detection_enabled = False
     ws.drift_detection_interval_seconds = 86400
+    ws.plan_expiry_seconds = None
     ws.drift_last_checked_at = None
     ws.drift_status = ""
     ws.state_diverged = False

--- a/services/tests/integration/test_run_execution.py
+++ b/services/tests/integration/test_run_execution.py
@@ -1009,3 +1009,37 @@ class TestPlanStaleness:
         after = (await _get_run(client, run["id"]))["attributes"]
         assert after["status"] == "discarded"
         assert "plan expired" in (after["discard-reason"] or "")
+
+    async def test_confirm_time_guard_409s_and_discards(self, app, client, setup):
+        """Confirm-time backstop (#647): if state moved but the event hook did not
+        discard this run (e.g. it was still `planning` when the version landed),
+        confirming returns 409 AND the run is left `discarded` — the discard is
+        committed before the 409 raises, not rolled back with the errored request."""
+        import uuid as _uuid
+
+        from terrapod.db.models import StateVersion
+        from terrapod.db.session import get_db_session
+
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "confirm-stale-ws")
+        ws_uuid = _uuid.UUID(ws_id.removeprefix("ws-"))
+
+        # Baseline serial 1, then plan against it.
+        async with get_db_session() as db:
+            db.add(StateVersion(workspace_id=ws_uuid, serial=1, lineage="x"))
+            await db.commit()
+        run = await _create_run(client, ws_id)
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+
+        # Advance the state serial WITHOUT the discard hook, so the run is still
+        # `planned` when we try to confirm it (simulates the hook-missed race).
+        async with get_db_session() as db:
+            db.add(StateVersion(workspace_id=ws_uuid, serial=2, lineage="x"))
+            await db.commit()
+
+        resp = await client.post(f"/api/v2/runs/{run['id']}/actions/apply", headers=AUTH)
+        assert resp.status_code == 409
+        assert "state changed" in resp.text
+        after = (await _get_run(client, run["id"]))["attributes"]
+        assert after["status"] == "discarded"
+        assert "state changed" in (after["discard-reason"] or "")

--- a/services/tests/integration/test_run_execution.py
+++ b/services/tests/integration/test_run_execution.py
@@ -924,3 +924,88 @@ class TestRunSerializationAndLocking:
         resp = await client.post(f"/api/v2/runs/{run_id}/actions/apply", headers=AUTH)
         assert resp.status_code == 200, resp.text
         assert (await _get_run(client, run_id))["attributes"]["status"] == "confirmed"
+
+
+class TestPlanStaleness:
+    """State-drift (#647, always on) and time-based expiry (#646, per-workspace)
+    auto-discard of stale apply-capable planned runs — against real Postgres
+    through the real state machine, the state-version discard hook, and the
+    expiry sweep. Composes with supersede (a separate reason)."""
+
+    async def test_new_state_version_discards_stale_plan(self, app, client, setup):
+        """A planned run whose plan predates a newly-landed state version is
+        auto-discarded with a state-changed reason (#647)."""
+        import uuid as _uuid
+
+        from terrapod.db.models import StateVersion
+        from terrapod.db.session import get_db_session
+        from terrapod.services import run_service
+
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "stale-state-ws")
+        ws_uuid = _uuid.UUID(ws_id.removeprefix("ws-"))
+
+        # Seed a baseline state version (serial 1) so the plan has something to
+        # be measured stale against. (No auto_apply → B stays `planned`.)
+        async with get_db_session() as db:
+            db.add(StateVersion(workspace_id=ws_uuid, serial=1, lineage="x"))
+            await db.commit()
+
+        # Run B plans against serial 1, then awaits confirmation.
+        run_b = await _create_run(client, ws_id)
+        await _run_plan_lifecycle(client, listener_id, run_b["id"])
+        assert (await _get_run(client, run_b["id"]))["attributes"]["status"] == "planned"
+
+        # A new state version (serial 2) lands → the hook discards B.
+        async with get_db_session() as db:
+            db.add(StateVersion(workspace_id=ws_uuid, serial=2, lineage="x"))
+            await db.flush()
+            await run_service.discard_stale_plans_for_state_change(db, ws_uuid, 2)
+            await db.commit()
+
+        b_after = (await _get_run(client, run_b["id"]))["attributes"]
+        assert b_after["status"] == "discarded"
+        assert "state changed" in (b_after["discard-reason"] or "")
+
+    async def test_plan_with_no_baseline_is_not_stale(self, app, client, setup):
+        """A first apply (no prior state version) has no baseline → the state
+        guard never fires and the plan confirms normally (#647)."""
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "no-baseline-ws")
+
+        run = await _create_run(client, ws_id)
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+        resp = await client.post(f"/api/v2/runs/{run['id']}/actions/apply", headers=AUTH)
+        assert resp.status_code == 200, resp.text
+        assert (await _get_run(client, run["id"]))["attributes"]["status"] == "confirmed"
+
+    async def test_plan_expiry_sweep_discards_aged_plan(self, app, client, setup):
+        """The periodic sweep discards a planned run older than the workspace's
+        plan-expiry TTL (#646)."""
+        import uuid as _uuid
+        from datetime import timedelta
+
+        from terrapod.db.models import Run, Workspace, now_utc
+        from terrapod.db.session import get_db_session
+        from terrapod.services import run_service
+
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "expiry-ws")
+
+        run = await _create_run(client, ws_id)
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+        assert (await _get_run(client, run["id"]))["attributes"]["status"] == "planned"
+
+        # Enable a TTL and age the plan past it, then run the sweep.
+        async with get_db_session() as db:
+            ws = await db.get(Workspace, _uuid.UUID(ws_id.removeprefix("ws-")))
+            ws.plan_expiry_seconds = 3600
+            r = await db.get(Run, _uuid.UUID(run["id"].removeprefix("run-")))
+            r.plan_finished_at = now_utc() - timedelta(seconds=7200)
+            await db.commit()
+
+        await run_service.expire_stale_plans_cycle()
+
+        after = (await _get_run(client, run["id"]))["attributes"]
+        assert after["status"] == "discarded"
+        assert "plan expired" in (after["discard-reason"] or "")

--- a/services/tests/services/test_drift_detection_service.py
+++ b/services/tests/services/test_drift_detection_service.py
@@ -11,6 +11,7 @@ def _mock_workspace(**overrides):
     ws.name = overrides.get("name", "test-ws")
     ws.drift_detection_enabled = overrides.get("drift_detection_enabled", True)
     ws.drift_detection_interval_seconds = overrides.get("drift_detection_interval_seconds", 86400)
+    ws.plan_expiry_seconds = overrides.get("plan_expiry_seconds")
     ws.drift_last_checked_at = overrides.get("drift_last_checked_at", None)
     ws.drift_status = overrides.get("drift_status", "")
     ws.drift_latest_run_id = overrides.get("drift_latest_run_id", None)

--- a/services/tests/services/test_plan_staleness.py
+++ b/services/tests/services/test_plan_staleness.py
@@ -1,0 +1,130 @@
+"""Unit tests for the plan-staleness guard predicates (#646 expiry, #647 state drift).
+
+These cover the pure decision logic in run_service that decides whether an
+apply-capable planned run may still be applied. The multi-row lifecycle (a new
+state version auto-discarding stale plans, the TTL sweep) is exercised against a
+real database in tests/integration/test_run_execution.py.
+"""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from terrapod.db.models import now_utc
+from terrapod.services import run_service
+
+
+def _run(**over):
+    base = {
+        "plan_only": False,
+        "is_drift_detection": False,
+        "vcs_pull_request_number": None,
+        "plan_state_serial": None,
+        "plan_finished_at": None,
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _ws(plan_expiry_seconds=None):
+    return SimpleNamespace(plan_expiry_seconds=plan_expiry_seconds)
+
+
+# ── #646: _plan_expired (pure) ───────────────────────────────────────────────
+
+
+def test_plan_expired_disabled_when_ttl_unset_or_zero():
+    finished = now_utc() - timedelta(hours=10)
+    assert run_service._plan_expired(_run(plan_finished_at=finished), _ws(None)) is False
+    assert run_service._plan_expired(_run(plan_finished_at=finished), _ws(0)) is False
+
+
+def test_plan_expired_false_without_plan_finished_at():
+    assert run_service._plan_expired(_run(plan_finished_at=None), _ws(3600)) is False
+
+
+def test_plan_expired_false_for_plan_only():
+    finished = now_utc() - timedelta(hours=10)
+    assert (
+        run_service._plan_expired(_run(plan_only=True, plan_finished_at=finished), _ws(3600))
+        is False
+    )
+
+
+def test_plan_expired_true_when_aged_past_ttl():
+    finished = now_utc() - timedelta(seconds=7200)
+    assert run_service._plan_expired(_run(plan_finished_at=finished), _ws(3600)) is True
+
+
+def test_plan_expired_false_within_ttl():
+    finished = now_utc() - timedelta(seconds=100)
+    assert run_service._plan_expired(_run(plan_finished_at=finished), _ws(3600)) is False
+
+
+# ── #647: _state_moved_since_plan (needs current serial from db.scalar) ───────
+
+
+@pytest.mark.asyncio
+async def test_state_not_stale_without_baseline():
+    # No snapshot (first apply) → never stale; db not even consulted.
+    db = AsyncMock()
+    assert await run_service._state_moved_since_plan(db, _run(plan_state_serial=None)) is None
+    db.scalar.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_state_not_stale_when_serial_unchanged():
+    db = AsyncMock()
+    db.scalar.return_value = 5
+    run = _run(plan_state_serial=5, workspace_id="w")
+    assert await run_service._state_moved_since_plan(db, run) is None
+
+
+@pytest.mark.asyncio
+async def test_state_stale_when_serial_advanced():
+    db = AsyncMock()
+    db.scalar.return_value = 7
+    run = _run(plan_state_serial=5, workspace_id="w")
+    assert await run_service._state_moved_since_plan(db, run) == 7
+
+
+# ── _staleness_reason (combines both; plan-only never stale) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_staleness_reason_none_for_plan_only():
+    db = AsyncMock()
+    run = _run(plan_only=True, plan_state_serial=5)
+    assert await run_service._staleness_reason(db, run, _ws(1)) is None
+
+
+@pytest.mark.asyncio
+async def test_staleness_reason_reports_state_change_first():
+    db = AsyncMock()
+    db.scalar.return_value = 9
+    run = _run(plan_state_serial=5, workspace_id="w", plan_finished_at=now_utc())
+    reason = await run_service._staleness_reason(db, run, _ws(3600))
+    assert reason is not None and "state changed" in reason and "5 -> 9" in reason
+
+
+@pytest.mark.asyncio
+async def test_staleness_reason_reports_expiry_when_state_fresh():
+    db = AsyncMock()
+    db.scalar.return_value = 5  # unchanged
+    run = _run(
+        plan_state_serial=5,
+        workspace_id="w",
+        plan_finished_at=now_utc() - timedelta(seconds=7200),
+    )
+    reason = await run_service._staleness_reason(db, run, _ws(3600))
+    assert reason is not None and "plan expired after 3600s" == reason
+
+
+@pytest.mark.asyncio
+async def test_staleness_reason_none_when_fresh():
+    db = AsyncMock()
+    db.scalar.return_value = 5
+    run = _run(plan_state_serial=5, workspace_id="w", plan_finished_at=now_utc())
+    assert await run_service._staleness_reason(db, run, _ws(None)) is None

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -25,6 +25,8 @@ def _mock_run(**kwargs):
     run.job_namespace = kwargs.get("job_namespace", "terrapod-runners")
     run.plan_started_at = kwargs.get("plan_started_at", None)
     run.plan_finished_at = kwargs.get("plan_finished_at", None)
+    run.plan_state_serial = kwargs.get("plan_state_serial", None)
+    run.discard_reason = kwargs.get("discard_reason", None)
     run.apply_started_at = kwargs.get("apply_started_at", None)
     run.apply_finished_at = kwargs.get("apply_finished_at", None)
     run.auto_apply = kwargs.get("auto_apply", False)
@@ -170,7 +172,7 @@ class TestHandleSucceeded:
         db = AsyncMock()
         # Auto-apply respects a manual lock — return an unlocked workspace so
         # the auto-confirm proceeds.
-        db.get.return_value = MagicMock(locked=False)
+        db.get.return_value = MagicMock(locked=False, plan_expiry_seconds=None)
         run = _mock_run(status="planning", auto_apply=True)
         mock_stage.return_value = None
         # First call returns planned run, second returns confirmed
@@ -193,7 +195,9 @@ class TestHandleSucceeded:
         """A manually locked workspace must not auto-apply: the run settles in
         `planned` (one transition) and is NOT auto-confirmed."""
         db = AsyncMock()
-        db.get.return_value = MagicMock(locked=True)  # workspace is locked
+        db.get.return_value = MagicMock(
+            locked=True, plan_expiry_seconds=None
+        )  # workspace is locked
         db.scalar.return_value = None  # no newer run (isolate the lock behaviour)
         run = _mock_run(status="planning", auto_apply=True)
         mock_stage.return_value = None
@@ -231,6 +235,7 @@ class TestHandleSucceeded:
         mock_transition.side_effect = [planned_run, applied_run]
         ws = MagicMock()
         ws.locked = True
+        ws.plan_expiry_seconds = None
         db.get.return_value = ws
 
         await _handle_succeeded(db, run)
@@ -263,7 +268,7 @@ class TestHandleSucceeded:
             status="applied", auto_apply=True, plan_only=False, has_changes=False
         )
         mock_transition.side_effect = [planned_run, applied_run]
-        db.get.return_value = MagicMock(locked=False)
+        db.get.return_value = MagicMock(locked=False, plan_expiry_seconds=None)
 
         await _handle_succeeded(db, run)
 
@@ -283,6 +288,7 @@ class TestHandleSucceeded:
         mock_transition.return_value = planned_run
         ws = MagicMock()
         ws.locked = True
+        ws.plan_expiry_seconds = None
         ws.lock_id = "lock-123"
         db.get.return_value = ws
 
@@ -299,6 +305,7 @@ class TestHandleSucceeded:
         mock_transition.return_value = run
         ws = MagicMock()
         ws.locked = True
+        ws.plan_expiry_seconds = None
         db.get.return_value = ws
 
         await _handle_succeeded(db, run)
@@ -341,6 +348,7 @@ class TestHandleFailed:
         mock_transition.return_value = run
         ws = MagicMock()
         ws.locked = True
+        ws.plan_expiry_seconds = None
         db.get.return_value = ws
 
         await _handle_failed(db, run, "Job failed")

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -63,6 +63,7 @@ interface WorkspaceAttrs {
   'ai-summary-context': string
   'drift-detection-enabled': boolean
   'drift-detection-interval-seconds': number
+  'plan-expiry-seconds': number | null
   'drift-last-checked-at': string
   'drift-status': string
   'state-diverged': boolean
@@ -347,6 +348,7 @@ function WorkspaceDetailContent() {
 
   // Drift detection
   const [savingDrift, setSavingDrift] = useState(false)
+  const [savingPlanExpiry, setSavingPlanExpiry] = useState(false)
   const [checkingDrift, setCheckingDrift] = useState(false)
   const [dismissingDrift, setDismissingDrift] = useState(false)
 
@@ -1115,6 +1117,30 @@ function WorkspaceDetailContent() {
     }
   }
 
+  // Plan expiry TTL (#646): 0 / empty disables (sent as null).
+  async function handlePlanExpiryChange(seconds: number) {
+    setSavingPlanExpiry(true)
+    try {
+      const res = await apiFetch(`/api/v2/workspaces/${workspaceId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: JSON.stringify({
+          data: {
+            type: 'workspaces',
+            attributes: { 'plan-expiry-seconds': seconds > 0 ? seconds : null },
+          },
+        }),
+      })
+      if (!res.ok) throw new Error('Failed to update plan expiry')
+      const data = await res.json()
+      setWorkspace(data.data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update plan expiry')
+    } finally {
+      setSavingPlanExpiry(false)
+    }
+  }
+
   async function handleCheckDriftNow() {
     setCheckingDrift(true)
     setError('')
@@ -1503,6 +1529,17 @@ function WorkspaceDetailContent() {
     { label: '12 hours', value: 43200 },
     { label: '24 hours', value: 86400 },
     { label: '48 hours', value: 172800 },
+    { label: '7 days', value: 604800 },
+  ]
+
+  // #646 plan-expiry TTL choices; 0 = disabled (the default).
+  const PLAN_EXPIRY_OPTIONS = [
+    { label: 'Disabled', value: 0 },
+    { label: '1 hour', value: 3600 },
+    { label: '4 hours', value: 14400 },
+    { label: '12 hours', value: 43200 },
+    { label: '24 hours', value: 86400 },
+    { label: '3 days', value: 259200 },
     { label: '7 days', value: 604800 },
   ]
 
@@ -2205,6 +2242,35 @@ function WorkspaceDetailContent() {
                     </button>
                   </div>
                 )}
+              </dl>
+            </div>
+
+            {/* Plan Expiry (#646) */}
+            <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-6">
+              <div className="mb-4">
+                <h3 className="text-sm font-medium text-slate-300">Plan Expiry</h3>
+                <p className="text-xs text-slate-500 mt-1">
+                  Auto-discard an unconfirmed plan once it is older than this, so a stale
+                  plan can&apos;t be applied against a moved world. Off by default; the plan
+                  must then be re-run. (Applies to apply-capable runs only.)
+                </p>
+              </div>
+              <dl>
+                <div>
+                  <dt className="text-xs text-slate-500">Expire after</dt>
+                  <dd className="mt-1">
+                    <select
+                      value={attrs['plan-expiry-seconds'] || 0}
+                      onChange={(e) => handlePlanExpiryChange(Number(e.target.value))}
+                      disabled={savingPlanExpiry}
+                      className="w-full px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                    >
+                      {PLAN_EXPIRY_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                  </dd>
+                </div>
               </dl>
             </div>
 

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -28,6 +28,7 @@ interface RunAttrs {
   status: string
   source: string
   message: string
+  'discard-reason': string | null
   'error-message': string | null
   'execution-backend': string
   'created-at': string
@@ -649,6 +650,14 @@ function RunDetailPageInner() {
           <div className="mb-6 p-4 bg-red-900/20 rounded-lg border border-red-800/50">
             <h3 className="text-sm font-medium text-red-400 mb-1">Error</h3>
             <pre className="text-sm text-red-300 whitespace-pre-wrap font-mono">{attrs['error-message']}</pre>
+          </div>
+        )}
+
+        {/* Discard reason (#646/#647): why a discarded plan can no longer apply. */}
+        {attrs.status === 'discarded' && attrs['discard-reason'] && (
+          <div className="mb-6 p-4 bg-amber-900/20 rounded-lg border border-amber-800/50">
+            <h3 className="text-sm font-medium text-amber-400 mb-1">Discarded — re-plan required</h3>
+            <p className="text-sm text-amber-200">{attrs['discard-reason']}</p>
           </div>
         )}
 


### PR DESCRIPTION
Two guards that stop an apply-capable `planned` run from applying a plan that no longer reflects reality — complementing the existing supersede (newer-run) logic. Both resolve the run to `discarded` with the reason surfaced in the run's **`discard-reason`** attribute; confirming a stale plan returns **409**. Plan-only / drift / speculative runs are exempt.

## #647 — state-version drift (always on)
A run snapshots the workspace's state serial when it enters `planning` (`run.plan_state_serial`). If the current serial advances before apply — another apply, a CLI `state push`, a rollback, a manual upload — the plan is stale. Enforced at:
- `confirm_run` (409 + auto-discard),
- the `complete_plan` auto-apply path,
- an **event hook** fired from all four `StateVersion`-creation sites (TFE-V2 create, runner post-apply, rollback, manual upload).

First apply (no baseline) is never stale. Works in **agent mode**, where the server drives the apply and there is no client to catch it. *(Always on per the issue's correctness rationale — no per-workspace opt-out.)*

## #646 — time-based expiry (per-workspace, off by default)
Workspaces set `plan_expiry_seconds`; a plan older than the TTL (from `plan_finished_at`) is auto-discarded at confirm time and by a **distributed periodic sweep** (`plan_expiry_sweep`, registered in `app.py` lifespan, multi-replica-safe).

## Schema — migration `65f5ee3a86be`
`runs.plan_state_serial`, `runs.discard_reason`, `workspaces.plan_expiry_seconds` — all nullable, no backfill (faithful no-op on upgrade). `supersede`/`cancel` now also record `discard_reason`.

## Consumers (contract)
- Run serializer `discard-reason`; workspace serializer + create/PATCH `plan-expiry-seconds` (validated; 422 on negative).
- go-terrapod `Workspace.PlanExpirySeconds`; provider `terrapod_workspace` resource **and** data source; web workspace settings (Plan Expiry dropdown) + run-detail discard banner.

## Tests
- **Services-tier** unit tests for the guard predicates (`_plan_expired`, `_state_moved_since_plan`, `_staleness_reason`).
- **Integration** (real Postgres, real state machine): event-driven state-change discard, no-baseline-never-stale, TTL expiry sweep.
- Existing run/workspace mocks updated for the new fields. `make test` (2565 passed) + `make lint` green. Go modules build; go-terrapod tests pass. Frontend `tsc` clean (the local `npm run build` can't run — missing `lightningcss` darwin-arm64 native binding, an environment issue reproduced on clean `main`; CI builds in Linux).

## Docs
`api-reference.md` (workspace attr + a stale-plan-guards section), `llms.txt`, and the `README` / `docs/index` feature catalogue.

### Follow-up
A browser-level E2E for the Plan-Expiry settings toggle + the discard banner is a reasonable add; the behaviour itself is proven by the integration tier (real DB + state machine).

Closes #646
Closes #647