### PR TITLE
chore(security): pin codeql-action subpath refs to SHA (follow-up to #657)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -410,7 +410,7 @@ jobs:
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: codeql-${{ matrix.language }}
 
@@ -799,7 +799,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep
@@ -1191,7 +1191,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           sarif_file: trivy-${{ matrix.image }}-${{ matrix.arch }}.sarif
           category: trivy-${{ matrix.image }}-${{ matrix.arch }}


### PR DESCRIPTION
#657 SHA-pinned all actions but its pin regex only matched `owner/repo@ref`, missing **subpath** actions. `github/codeql-action/{init,analyze,upload-sarif}@v4` (4 refs) were left on the mutable `v4` tag. This pins them to the resolved commit SHA.

After this, **every** external `uses:` across the workflows is SHA-pinned (verified: zero bare `@vX` on any `uses:` line, subpaths included). Completes the code-scanning cleanup from #656.

Refs #656