### PR TITLE
fix: honor speculative CVs as plan-only (#661) + add force-unlock endpoint (#662)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -331,6 +331,16 @@ POST /api/v2/workspaces/{id}/actions/unlock
 
 **Required permission:** `plan` on the workspace (own locks only).
 
+### Force-Unlock Workspace
+
+```
+POST /api/v2/workspaces/{id}/actions/force-unlock
+```
+
+**Required permission:** `admin` on the workspace (the `workspace:force-unlock` capability).
+
+Clears the state lock **regardless of the lock ID** — the endpoint `terraform`/`tofu force-unlock` calls. Use it to release a lock held by another user or a lock stranded when a CLI operation crashed mid-run. Idempotent: force-unlocking an already-unlocked workspace returns 200.
+
 ### Drift Detection Attributes
 
 Workspaces support the following drift detection attributes (settable on create and update):

--- a/docs/tfe-cli-surface.md
+++ b/docs/tfe-cli-surface.md
@@ -58,7 +58,7 @@ Terrapod is single-organization with no project concept. Both endpoints return `
 | GET | `/api/v2/workspaces/{id}/effective-tag-bindings` | `Workspaces.ListEffectiveTagBindings` | tag display |
 | POST | `/api/v2/workspaces/{id}/actions/lock` | `Workspaces.Lock` | `remote/backend_state.go:164` |
 | POST | `/api/v2/workspaces/{id}/actions/unlock` | `Workspaces.Unlock` | `remote/backend_state.go:201` |
-| POST | `/api/v2/workspaces/{id}/actions/force-unlock` | `Workspaces.ForceUnlock` | `remote/backend_state.go:222` (gap — see #279) |
+| POST | `/api/v2/workspaces/{id}/actions/force-unlock` | `Workspaces.ForceUnlock` | `remote/backend_state.go:222` |
 | GET | `/api/v2/workspaces/{id}/runs` | `Runs.List` | `cloud/backend_common.go:119`, `remote/backend_common.go:121` |
 | GET | `/api/v2/workspaces/{id}/vars` | `Variables.List` | `cloud/backend_context.go:122`, `remote/backend_context.go:123` (read-only — sensitive-var warnings) |
 

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -406,7 +406,20 @@ async def create_run(
     # Runs without a CV (UI-queued) will fetch code from VCS downstream.
     plan_only = attrs.get("plan-only", False)
     cv_data = relationships.get("configuration-version", {}).get("data", {})
-    has_cv = bool(cv_data.get("id", "") if cv_data else "")
+    cv_id_raw = cv_data.get("id", "") if cv_data else ""
+    has_cv = bool(cv_id_raw)
+    # A run against a speculative configuration version is ALWAYS plan-only
+    # (TFE/HCP parity). The cloud backend uploads a speculative CV for
+    # `tofu plan` and relies on the server to infer plan-only rather than
+    # always setting the run's `plan-only` attribute. Without honoring the CV
+    # flag, a CLI `plan` on a VCS-connected workspace is mis-read as an apply
+    # and rejected by the guard below (#661).
+    if has_cv:
+        from terrapod.db.models import ConfigurationVersion
+
+        _spec_cv = await db.get(ConfigurationVersion, uuid.UUID(cv_id_raw.removeprefix("cv-")))
+        if _spec_cv is not None and _spec_cv.speculative:
+            plan_only = True
     # Config-managed guardrail (#535): a catalog-managed workspace runs only the
     # wrapper config the catalog generated for it. A run that pins a different
     # configuration version would diverge it from its catalog item — reject.

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -2164,3 +2164,39 @@ async def unlock_workspace(
     await publish_workspace_event(str(ws.id), "workspace_lock_change", {"locked": False})
 
     return JSONResponse(content=_workspace_json(ws, caps), headers=_tfe_headers())
+
+
+@router.post("/workspaces/{workspace_id}/actions/force-unlock")
+async def force_unlock_workspace(
+    workspace_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Force-unlock a workspace, clearing the state lock regardless of lock ID.
+
+    TFE parity: `terraform force-unlock` (the cloud/remote backend) calls this
+    endpoint. Unlike `unlock` — which the lock owner uses to release their own
+    lock — force-unlock clears a lock held by anyone (e.g. a lock stranded when
+    a CLI operation crashed mid-run), so it does NOT require the client's lock
+    ID to match and is gated on the workspace:force-unlock capability (#662).
+    """
+    ws = await _get_workspace_by_id(workspace_id, db)
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+
+    if not has_capability(caps, cap.WORKSPACE_FORCE_UNLOCK):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Requires admin permission to force-unlock a workspace",
+        )
+
+    # Idempotent: force-unlocking an already-unlocked workspace is a no-op 200.
+    ws.locked = False
+    ws.lock_id = None
+    await db.commit()
+    await db.refresh(ws)
+
+    from terrapod.redis.client import publish_workspace_event
+
+    await publish_workspace_event(str(ws.id), "workspace_lock_change", {"locked": False})
+
+    return JSONResponse(content=_workspace_json(ws, caps), headers=_tfe_headers())

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -334,6 +334,106 @@ class TestCreateRun:
         assert mock_create_run.await_args.kwargs["configuration_version_id"] == cv.id
 
 
+# ── CLI plan on a VCS-connected workspace (#661) ───────────────────────
+
+
+class TestVCSSpeculativePlan:
+    """CLI `tofu plan` on a VCS-connected agent workspace uploads a
+    *speculative* configuration version and creates a run without explicitly
+    setting `plan-only`. Terrapod must infer plan-only from the CV's
+    `speculative` flag (TFE parity) so the run isn't mis-read as an apply."""
+
+    def _vcs_agent_ws(self):
+        ws = _mock_workspace()
+        ws.execution_mode = "agent"
+        ws.vcs_connection_id = uuid.uuid4()
+        ws.vcs_repo_url = "https://example.com/org/repo"
+        return ws
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.queue_run")
+    @patch("terrapod.api.routers.runs.run_service.create_run")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_speculative_cv_allowed_as_plan_only(
+        self, mock_resolve, mock_create_run, mock_queue, *mocks
+    ):
+        """Speculative CV + no explicit plan-only → allowed (201), created as
+        plan-only — NOT the 422 'apply not allowed' the guard would raise."""
+        mock_resolve.return_value = caps_for_level("write")
+        ws = self._vcs_agent_ws()
+        run = _mock_run(ws_id=ws.id, plan_only=True, status="queued")
+        mock_create_run.return_value = run
+        mock_queue.return_value = run
+
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+        mock_db.refresh = AsyncMock()
+        spec_cv = MagicMock()
+        spec_cv.speculative = True
+        mock_db.get = AsyncMock(return_value=spec_cv)
+
+        cv_id = uuid.uuid4()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/runs",
+                json={
+                    "data": {
+                        # NOTE: no "plan-only" attribute — the cloud backend
+                        # relies on the speculative CV to signal plan-only.
+                        "attributes": {},
+                        "relationships": {
+                            "workspace": {"data": {"id": f"ws-{ws.id}"}},
+                            "configuration-version": {"data": {"id": f"cv-{cv_id}"}},
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 201
+        # Forced plan-only despite the request omitting the attribute.
+        assert mock_create_run.await_args.kwargs["plan_only"] is True
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_nonspeculative_cv_apply_still_blocked(self, mock_resolve, *mocks):
+        """Non-speculative CV + plan-only:false on a VCS workspace = an apply
+        from the CLI — still rejected (422). The #661 fix must not weaken this."""
+        mock_resolve.return_value = caps_for_level("write")
+        ws = self._vcs_agent_ws()
+
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+        real_cv = MagicMock()
+        real_cv.speculative = False
+        mock_db.get = AsyncMock(return_value=real_cv)
+
+        cv_id = uuid.uuid4()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/runs",
+                json={
+                    "data": {
+                        "attributes": {"plan-only": False},
+                        "relationships": {
+                            "workspace": {"data": {"id": f"ws-{ws.id}"}},
+                            "configuration-version": {"data": {"id": f"cv-{cv_id}"}},
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "Apply is not allowed" in resp.json()["detail"]
+
+
 # ── Catalog config-managed guardrail (#535) ────────────────────────────
 
 
@@ -788,6 +888,11 @@ class TestCLIApplyGuard:
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = ws
         mock_db.execute.return_value = mock_result
+        # A real `tofu apply` uploads a NON-speculative CV (#661): the run stays
+        # apply-capable, so the VCS apply guard must still fire.
+        _apply_cv = MagicMock()
+        _apply_cv.speculative = False
+        mock_db.get = AsyncMock(return_value=_apply_cv)
 
         cv_id = uuid.uuid4()
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
@@ -822,6 +927,9 @@ class TestCLIApplyGuard:
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = ws
         mock_db.execute.return_value = mock_result
+        _apply_cv = MagicMock()
+        _apply_cv.speculative = False
+        mock_db.get = AsyncMock(return_value=_apply_cv)
 
         cv_id = uuid.uuid4()
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -506,6 +506,58 @@ class TestUnlockWorkspace:
         assert resp.status_code == 200
 
 
+# ── Force-unlock (TFE `terraform force-unlock`, #662) ──────────────────
+
+
+class TestForceUnlockWorkspace:
+    """The dedicated `actions/force-unlock` endpoint the cloud/remote backend
+    calls. Clears the lock regardless of lock ID; gated on force-unlock."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_force_unlock_clears_lock_regardless_of_id(self, mock_resolve, *mocks):
+        """Admin force-unlocks a lock held under a server-generated lock ID
+        (e.g. the cloud backend's `default/<ws>`), without matching it."""
+        mock_resolve.return_value = caps_for_level("admin")
+        ws = _mock_workspace(locked=True, lock_id="default/some-workspace")
+        app, mock_db = _make_app(_user(roles=["admin"]))
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/v2/workspaces/ws-{ws.id}/actions/force-unlock",
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200
+        assert ws.locked is False
+        assert ws.lock_id is None
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_force_unlock_requires_force_unlock_capability(self, mock_resolve, *mocks):
+        """A plan-level (non-admin) user cannot force-unlock — 403."""
+        mock_resolve.return_value = caps_for_level("plan")
+        ws = _mock_workspace(locked=True, lock_id="default/some-workspace")
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"/api/v2/workspaces/ws-{ws.id}/actions/force-unlock",
+                headers=_AUTH,
+            )
+        assert resp.status_code == 403
+
+
 # ── Permissions block ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Two CLI cloud-backend lifecycle bugs, both reproduced live against a VCS-connected agent workspace.

## #661 — CLI `plan` on a VCS-connected workspace returned 422
`terraform`/`tofu plan` via the cloud backend uploads a **speculative** configuration version and creates a run **without** setting `plan-only: true` — it relies on the server inferring plan-only from the speculative CV (TFE/HCP behaviour). Terrapod read only the run attribute (default `false`), so it treated a plan as an attempted apply and rejected it with:

> 422 Apply is not allowed from the CLI on VCS-connected agent workspaces.

Now `routers/runs.py` forces `plan_only=True` when the linked CV is speculative, **before** the VCS apply guard. Speculative plans are allowed; real applies (non-speculative CV + `plan-only:false`) are still blocked.

## #662 — `terraform force-unlock` failed (missing endpoint)
The cloud/remote backend's `force-unlock` calls `POST /workspaces/{id}/actions/force-unlock`, which Terrapod never implemented (only `lock`/`unlock`) — so a **stranded state lock** (e.g. a CLI op killed mid-run) could not be cleared from the CLI (404 "resource not found"). Added the endpoint with TFE semantics: clears the lock **regardless of lock ID**, gated on `workspace:force-unlock` (admin), idempotent. `docs/tfe-cli-surface.md` already flagged this as a gap; note removed.

## Consumer contract
These are **CLI-only** endpoints (the terraform/tofu cloud backend calls them directly). Consistent with the existing `lock`/`unlock`, they are **not** wrapped in go-terrapod and the UI uses the plain `unlock` (which already clears without an ID match). No SDK/provider/web changes required.

## Tests
- `speculative CV → allowed as plan-only` (not 422) and `plan_only` forced True; `non-speculative CV + plan-only:false → still 422`.
- `force-unlock clears a server-generated lock ID` (200, lock cleared); `403 without the force-unlock capability`.
- Existing CLI-apply-guard tests updated to stub a non-speculative CV (a real apply's CV).
- Verified: `make test` on `tests/api/{test_runs,test_workspaces,test_config_versions_catalog_guard}.py` (104 passed) + `tests/integration/{test_run_execution,test_workspace_state_lifecycle,test_run_state_machine}.py` (54 passed).

Closes #661
Closes #662