### PR TITLE
chore: v0.52.0 pre-release audit fixes (422 on bad CV id + stale-plan invariant + runbook)

### DIFF
--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -221,6 +221,36 @@ For detailed state recovery procedures, see [disaster-recovery.md](disaster-reco
 
 ---
 
+## Planned Run Auto-Discarded (Stale Plan)
+
+A run sitting in `planned` (waiting for a confirm) was automatically moved to `discarded` — this is **expected behaviour**, not a fault. Terrapod invalidates a saved plan once it can no longer be applied safely, so a stale plan can never apply outdated config.
+
+### Symptoms
+
+- A `planned` run flips to `discarded` without anyone clicking Discard.
+- The run carries a `discard-reason`, e.g. `state changed since plan (serial 6 → 7)` or `plan expired (older than 3600s)`.
+- A confirm attempt (`POST /api/v2/runs/{id}/actions/apply`) returns **409** with the same reason.
+
+### Diagnosis
+
+Two guards discard stale plans:
+
+1. **State drift (always on, #647)** — the workspace's state version advanced (a newer apply, a rollback, or a manual/CLI state upload) *after* this run was planned, so the plan was computed against an older state. Reason: `state changed since plan (serial N → M)`.
+2. **Plan expiry (opt-in, #646)** — the workspace sets `plan-expiry-seconds` and the plan is older than that TTL. Reason: `plan expired (older than <N>s)`. Off unless configured per workspace.
+
+In-flight `confirmed`/`applying` runs are never discarded; only waiting `planned`/`pending`/`queued` apply-capable runs are. Plan-only/speculative/drift runs are exempt.
+
+### Resolution
+
+- **This is normal** — just **re-plan** (queue a new run) and confirm that one. The new plan reflects current state.
+- If plan expiry is firing too aggressively for a workspace with a slow human approval loop, raise or clear `plan-expiry-seconds` on that workspace (it is per-workspace; unset = no time-based expiry).
+
+### Verification
+
+- The freshly queued run reaches `planned` against the current state serial and applies cleanly.
+
+---
+
 ## Scheduler Stall
 
 All background tasks (reconciler, VCS poller, drift detection, audit retention) are coordinated via the distributed scheduler using Redis. If the scheduler stalls, no periodic tasks run across any replica.

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -408,16 +408,28 @@ async def create_run(
     cv_data = relationships.get("configuration-version", {}).get("data", {})
     cv_id_raw = cv_data.get("id", "") if cv_data else ""
     has_cv = bool(cv_id_raw)
+    # Parse the CV id ONCE, up front, with a guard: a malformed id is a client
+    # error (422), not a 500. Reused below for the speculative check and the
+    # run's configuration_version_id.
+    cv_uuid: uuid.UUID | None = None
+    if has_cv:
+        try:
+            cv_uuid = uuid.UUID(cv_id_raw.removeprefix("cv-"))
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid configuration-version id",
+            ) from exc
     # A run against a speculative configuration version is ALWAYS plan-only
     # (TFE/HCP parity). The cloud backend uploads a speculative CV for
     # `tofu plan` and relies on the server to infer plan-only rather than
     # always setting the run's `plan-only` attribute. Without honoring the CV
     # flag, a CLI `plan` on a VCS-connected workspace is mis-read as an apply
     # and rejected by the guard below (#661).
-    if has_cv:
+    if cv_uuid is not None:
         from terrapod.db.models import ConfigurationVersion
 
-        _spec_cv = await db.get(ConfigurationVersion, uuid.UUID(cv_id_raw.removeprefix("cv-")))
+        _spec_cv = await db.get(ConfigurationVersion, cv_uuid)
         if _spec_cv is not None and _spec_cv.speculative:
             plan_only = True
     # Config-managed guardrail (#535): a catalog-managed workspace runs only the
@@ -456,12 +468,8 @@ async def create_run(
             detail=f"Requires '{required_cap}' capability on workspace",
         )
 
-    # Configuration version (optional — provided by CLI uploads)
-    cv_data = relationships.get("configuration-version", {}).get("data", {})
-    cv_id = cv_data.get("id", "") if cv_data else ""
-    cv_uuid = None
-    if cv_id:
-        cv_uuid = uuid.UUID(cv_id.removeprefix("cv-"))
+    # Configuration version (optional) — cv_uuid was parsed + validated above
+    # from the same relationship (422 on a malformed id).
 
     # VCS ref override: plan against an arbitrary branch/tag (always plan-only)
     vcs_ref = attrs.get("vcs-ref", "")

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -433,6 +433,37 @@ class TestVCSSpeculativePlan:
         assert resp.status_code == 422
         assert "Apply is not allowed" in resp.json()["detail"]
 
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_malformed_cv_id_returns_422_not_500(self, mock_resolve, *mocks):
+        """A non-UUID configuration-version id is a client error (422), not a
+        500 from an unguarded uuid.UUID() parse."""
+        mock_resolve.return_value = caps_for_level("write")
+        ws = _mock_workspace()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/runs",
+                json={
+                    "data": {
+                        "attributes": {"plan-only": True},
+                        "relationships": {
+                            "workspace": {"data": {"id": f"ws-{ws.id}"}},
+                            "configuration-version": {"data": {"id": "cv-not-a-uuid"}},
+                        },
+                    }
+                },
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+        assert "configuration-version id" in resp.json()["detail"]
+
 
 # ── Catalog config-managed guardrail (#535) ────────────────────────────
 

--- a/services/tests/services/test_plan_staleness.py
+++ b/services/tests/services/test_plan_staleness.py
@@ -128,3 +128,29 @@ async def test_staleness_reason_none_when_fresh():
     db.scalar.return_value = 5
     run = _run(plan_state_serial=5, workspace_id="w", plan_finished_at=now_utc())
     assert await run_service._staleness_reason(db, run, _ws(None)) is None
+
+
+class TestStateVersionSitesInvalidateStalePlans:
+    """Source-introspection invariant (#647): EVERY API router that constructs a
+    new StateVersion (which bumps the workspace's serial) MUST also call
+    `discard_stale_plans_for_state_change`, so a state change from any path —
+    CLI state-version create, runner post-apply, rollback, manual upload — kills
+    stale planned runs. A future creation site added without the hook fails here
+    loudly rather than silently letting a stale plan apply outdated config.
+    """
+
+    def test_every_state_version_creation_site_calls_the_discard_hook(self):
+        import pathlib
+
+        routers_dir = pathlib.Path(run_service.__file__).parent.parent / "api" / "routers"
+        offenders = []
+        for path in sorted(routers_dir.glob("*.py")):
+            src = path.read_text()
+            constructs_sv = "StateVersion(" in src
+            calls_hook = "discard_stale_plans_for_state_change" in src
+            if constructs_sv and not calls_hook:
+                offenders.append(path.name)
+        assert offenders == [], (
+            "router(s) create a StateVersion without invalidating stale plans "
+            f"via discard_stale_plans_for_state_change: {offenders}"
+        )


### PR DESCRIPTION
Pre-release audit + independent third-party review for **v0.52.0** (`v0.51.0..HEAD`: #655 stale-plan guards, #663 CLI plan/force-unlock, security hardening) found **no blockers** — content hygiene, consumer contract, docs, values↔schema, migration, async-safety, and multi-replica all verified clean. These are the two MEDIUM items worth landing before the tag:

- **422 on a malformed configuration-version id** (was an unguarded `uuid.UUID()` → 500). `create_run` now parses the `cv-` id **once, up front, guarded**, and reuses it for the speculative-CV check and the run's `configuration_version_id`. #663 had added a second unguarded parse; this consolidates both. Test added.
- **Stale-plan hook invariant test**: a source-introspection test asserting every API router that constructs a `StateVersion` also calls `discard_stale_plans_for_state_change` (#647) — so a future state-version creation site added without the invalidation hook fails CI loudly.
- **Runbook**: an operator note explaining the always-on state-drift auto-discard (and opt-in `plan-expiry-seconds`), so an auto-discarded `planned` run reads as expected behaviour rather than a fault.

Verified: `make test` on `tests/api/test_runs.py` + `tests/services/test_plan_staleness.py` (63 passed). Ruff clean via pre-commit.

Two LOW follow-ups from the review are tracked separately (listener `report_run_status` auto-apply bypasses the staleness guard; discard-hook failure could roll back a state-version write) — neither blocks the release.