### PR TITLE
fix(runs): stale-plan guard on the listener auto-apply path + best-effort discard hook (closes #665)

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1531,16 +1531,20 @@ async def update_run_status(
         run.has_changes = has_changes
 
     try:
-        run = await run_service.transition_run(db, run, target_status, error_message=error_message)
-
-        # No-op short-circuit: a plan with has_changes=False has nothing for an
-        # apply Job to do. Use the shared helper so this path stays in lockstep
-        # with the reconciler's `_handle_succeeded` no-op skip.
-        if target_status == "planned" and not run.plan_only and run.has_changes is False:
-            run = await run_service.complete_planned_as_noop(db, run)
-        # Auto-apply if configured
-        elif target_status == "planned" and run.auto_apply and not run.plan_only:
-            run = await run_service.transition_run(db, run, "confirmed")
+        if target_status == "planned" and not run.plan_only:
+            # Route a plan completion through the shared, guarded path — the
+            # SAME one the plan-result endpoint (report_plan_result) and the
+            # reconciler use — so it applies the post-plan gates, the no-op
+            # short-circuit, AND the #646/#647 auto-apply staleness +
+            # manual-lock guards. A bare transition_run(..., "confirmed") here
+            # bypassed those guards and could auto-apply a plan against state
+            # that moved since it was computed (#665). complete_plan is
+            # idempotent (no-ops unless the run is still `planning`).
+            run = await run_service.complete_plan(db, run, has_changes=has_changes)
+        else:
+            run = await run_service.transition_run(
+                db, run, target_status, error_message=error_message
+            )
 
         # Unlock workspace when plan-only run reaches planned
         # (plan-only runs don't mutate state, so no need to hold the lock)

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -463,9 +463,17 @@ async def discard_stale_plans_for_state_change(
         try:
             await discard_run(db, run, reason=reason)
             discarded += 1
-        except ValueError:
+        except Exception:
+            # Best-effort cleanup: a failure discarding ONE stale plan must never
+            # abort the sweep OR propagate out to the caller — this hook runs
+            # inside a state-version write transaction, and a state write must
+            # not be lost because a stale-plan cleanup hiccupped (#665). Log and
+            # move on to the next stale run.
             logger.warning(
-                "Skipped discarding stale-state run", run_id=str(run.id), status=run.status
+                "Skipped discarding stale-state run",
+                run_id=str(run.id),
+                status=run.status,
+                exc_info=True,
             )
     if discarded:
         logger.info(

--- a/services/tests/integration/test_run_execution.py
+++ b/services/tests/integration/test_run_execution.py
@@ -1043,3 +1043,47 @@ class TestPlanStaleness:
         after = (await _get_run(client, run["id"]))["attributes"]
         assert after["status"] == "discarded"
         assert "state changed" in (after["discard-reason"] or "")
+
+    async def test_listener_status_report_respects_state_drift_guard(self, app, client, setup):
+        """The listener status-report PATCH (update_run_status) must route an
+        auto-apply plan completion through the guarded complete_plan path — it
+        must NOT bare-transition a stale plan straight to confirmed/applying
+        against state that moved since the plan was computed (#665)."""
+        import uuid as _uuid
+
+        from terrapod.db.models import StateVersion
+        from terrapod.db.session import get_db_session
+
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(
+            client, pool_id, "listener-stale-ws", auto_apply=True
+        )
+        ws_uuid = _uuid.UUID(ws_id.removeprefix("ws-"))
+
+        # Baseline serial 1 — the plan is measured stale against it.
+        async with get_db_session() as db:
+            db.add(StateVersion(workspace_id=ws_uuid, serial=1, lineage="x"))
+            await db.commit()
+
+        # Claim the run so it enters `planning` and snapshots plan_state_serial=1.
+        run = await _create_run(client, ws_id)
+        claimed = await _claim_run(client, listener_id)
+        assert claimed is not None
+        assert (await _get_run(client, run["id"]))["attributes"]["status"] == "planning"
+
+        # State advances to serial 2 before the listener reports the plan done.
+        async with get_db_session() as db:
+            db.add(StateVersion(workspace_id=ws_uuid, serial=2, lineage="x"))
+            await db.commit()
+
+        # Listener reports the plan finished via the PATCH status endpoint.
+        resp = await client.patch(
+            f"/api/terrapod/v1/listeners/{listener_id}/runs/{run['id']}",
+            json={"status": "planned", "has_changes": True},
+        )
+        assert resp.status_code == 200, resp.text
+
+        after = (await _get_run(client, run["id"]))["attributes"]
+        # Guarded: discarded as stale — NOT auto-applied (confirmed/applying).
+        assert after["status"] == "discarded", after["status"]
+        assert "state changed" in (after["discard-reason"] or "")

--- a/services/tests/services/test_plan_staleness.py
+++ b/services/tests/services/test_plan_staleness.py
@@ -154,3 +154,35 @@ class TestStateVersionSitesInvalidateStalePlans:
             "router(s) create a StateVersion without invalidating stale plans "
             f"via discard_stale_plans_for_state_change: {offenders}"
         )
+
+
+class TestDiscardHookIsBestEffort:
+    """The state-version discard hook must never propagate — it runs inside a
+    state-version write transaction, and a state write must not be lost because
+    a stale-plan cleanup failed on one run (#665)."""
+
+    async def test_discard_failure_does_not_propagate_and_continues(self):
+        import uuid
+        from unittest.mock import MagicMock, patch
+
+        run_a = SimpleNamespace(id=uuid.uuid4(), status="planned", plan_state_serial=1)
+        run_b = SimpleNamespace(id=uuid.uuid4(), status="planned", plan_state_serial=1)
+
+        db = AsyncMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [run_a, run_b]
+        db.execute.return_value = result
+
+        calls = []
+
+        async def _boom(db_, run, reason):
+            calls.append(run)
+            if run is run_a:
+                raise RuntimeError("transient discard failure")
+
+        with patch.object(run_service, "discard_run", new=_boom):
+            # Must NOT raise even though run_a's discard blows up.
+            discarded = await run_service.discard_stale_plans_for_state_change(db, uuid.uuid4(), 2)
+
+        assert calls == [run_a, run_b]  # kept going past the failure
+        assert discarded == 1  # only the successful discard counted


### PR DESCRIPTION
Fixes **both** items from the v0.52.0 review issue #665.

## Item 1 — auto-apply via the listener status-report bypassed the stale-plan guard
`PATCH /listeners/{id}/runs/{id}` (`update_run_status`) — a **live** path the listener calls (`listener.py`) — bare-transitioned an auto-apply run straight `planned → confirmed`, **bypassing** the #646/#647 staleness guard and the manual-lock guard that live in `run_service.complete_plan`. A plan reported done through this path could **auto-apply against state that had moved since the plan was computed** — exactly what #647 exists to prevent (`complete_plan`, used by the plan-result endpoint and the reconciler, has the guard; this third path had drifted).

**Fix:** route the `planned` (non-plan-only) completion through `complete_plan` — the same guarded path — so the post-plan gates, the no-op short-circuit, and the auto-apply staleness + manual-lock guards all apply. `complete_plan` is idempotent (no-ops unless the run is still `planning`), so double status-reports stay safe.

Regression test (integration, real DB): an auto-apply run whose state serial advances after it enters `planning`, reported done via the PATCH endpoint, is **discarded** (stale) rather than auto-applied. Fails on the pre-fix bare-transition; passes now.

## Item 2 — the state-version discard hook could roll back a legitimate state write
`discard_stale_plans_for_state_change` runs inside the state-version write transaction at all four creation sites, and caught only `ValueError` per run — so any other exception from `discard_run` would propagate and **roll back the state-version write**. Broaden the per-run catch to `Exception` (log + continue) so a cleanup failure on one stale plan never aborts the sweep or sinks the state write.

Unit test: when `discard_run` raises for one run, the hook does not propagate and still processes the rest.

## Verify
`make test` on `tests/integration/test_run_execution.py`, `tests/api/test_runs.py` (78 passed) + `tests/services/test_plan_staleness.py` (14 passed). Ruff clean via pre-commit.

Closes #665.