### PR TITLE
fix(ci): syft installer args broke the release SBOM step (v0.52.0 tag failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1360,10 +1360,15 @@ jobs:
 
           # Install syft: fetch the installer pinned to a release tag (not main)
           # to a file, then run it (no curl|sh pipe), installing a pinned version.
+          # NOTE: `-s --` belongs ONLY to the piped `curl | sh -s -- ARGS` idiom
+          # (where `-s` tells sh to read the script from stdin). When running the
+          # installer as a FILE, the args go straight to syft's install.sh, whose
+          # usage is `install.sh [-v] [-b DIR] [-d] [TAG]` — so pass `-b DIR TAG`
+          # directly; `-s` is rejected as an illegal option.
           SYFT_VERSION=v1.46.0
           curl -sSfL -o "$RUNNER_TEMP/syft-install.sh" \
             "https://raw.githubusercontent.com/anchore/syft/${SYFT_VERSION}/install.sh"
-          sh "$RUNNER_TEMP/syft-install.sh" -s -- -b /usr/local/bin "$SYFT_VERSION"
+          sh "$RUNNER_TEMP/syft-install.sh" -b /usr/local/bin "$SYFT_VERSION"
 
           for image in terrapod-api terrapod-web terrapod-runner terrapod-listener terrapod-migrations; do
             echo "Generating SBOM for $image:$version"


### PR DESCRIPTION
The **v0.52.0 release pipeline failed** at *Generate SBOMs* with `Illegal option -s` → `syft: command not found` → exit 127 (tag auto-deleted by Cleanup Tag).

**Root cause:** the #657 `curl|sh` hardening converted `curl … | sh -s -- -b DIR TAG` into a download-then-run form but kept the `-s --`. That prefix only belongs to the **piped** idiom — there `-s` tells `sh` to read the script from stdin and `--` ends `sh`'s options. When the installer is run as a **file** (`sh syft-install.sh …`), `-s -- -b DIR TAG` are passed straight to syft's `install.sh`, whose usage is `install.sh [-v] [-b DIR] [-d] [TAG]` — it rejects `-s`.

**Fix:** `sh "$RUNNER_TEMP/syft-install.sh" -b /usr/local/bin "$SYFT_VERSION"` (drop `-s --`).

This step runs **only in the release (tag) pipeline**, so PR/main CI never exercises it — the fix is verified directly against syft's own usage message in the failure log. Latent since #657; v0.51.0 predates it. Once this merges I re-tag **v0.52.0** on the new main HEAD (the tag never published, so reuse is safe).