### PR TITLE
fix(registry): honor GPG key revocation in signature verification (#640)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1622,14 +1622,25 @@ All provider responses (show and list) include a `permissions` object:
 ```
 GET    /api/terrapod/v1/gpg-keys
 POST   /api/terrapod/v1/gpg-keys
-GET    /api/terrapod/v1/gpg-keys/{namespace}/{key_id}
-DELETE /api/terrapod/v1/gpg-keys/{namespace}/{key_id}
+GET    /api/terrapod/v1/gpg-keys/{id}
+POST   /api/terrapod/v1/gpg-keys/{id}/revoke
+DELETE /api/terrapod/v1/gpg-keys/{id}
 ```
 
 The **public** key registered here is the trust anchor for client-signed
 provider publishing: `PUT .../shasums.sig` is verified against it. Register
 a key before publishing a provider (or use the `terrapod_gpg_key` provider
 resource). See [Publishing to the Private Registry](registry-publishing.md).
+
+**Revoke a key** (`.../gpg-keys/{id}/revoke`) — POST an owner-issued revocation
+certificate (the armored output of `gpg --gen-revoke`) as the
+`revocation-certificate` attribute. Terrapod verifies it is a valid **self**
+key-revocation for the registered key, then stores the revoked key so **all**
+provider and runner signature verification fails closed for it — a revoked
+signing key can no longer verify anything, even already-published artifacts it
+signed. The key stays registered (auditable) rather than being deleted. Returns
+422 if the certificate is not a genuine self-revocation for the key. (Signature
+verification honors revocation without shelling out to `gpg`; #640.)
 
 ---
 

--- a/docs/supply-chain-verification.md
+++ b/docs/supply-chain-verification.md
@@ -122,6 +122,16 @@ signature is always checked against the pinned key baked into the runner image,
 so even a compromised cache cannot forge a valid publisher signature for a
 tampered binary.
 
+### Key revocation
+
+Signature verification honors OpenPGP **key revocation** (pure Python, no `gpg`
+binary): a signing key that carries a valid self-revocation stops verifying
+everything and fails closed. For a **private-registry** provider key, an operator
+applies the owner's revocation certificate (the armored output of
+`gpg --gen-revoke`) via `POST /api/terrapod/v1/gpg-keys/{id}/revoke` — the key
+stays registered but every signature it made now fails, including
+already-published artifacts. See the [API reference](api-reference.md#gpg-keys).
+
 ## Configuration
 
 Both layers share a three-level knob (default `signature`):

--- a/go-terrapod/gpg_keys.go
+++ b/go-terrapod/gpg_keys.go
@@ -89,6 +89,24 @@ func (c *Client) DeleteGPGKey(ctx context.Context, id string) error {
 	return c.Delete(ctx, "/api/terrapod/v1/gpg-keys/"+url.PathEscape(id))
 }
 
+// RevokeGPGKey applies an owner-issued revocation certificate to a
+// registered key (the armored output of `gpg --gen-revoke`). The key
+// stays registered but every provider/runner signature verification
+// fails closed for it afterward. Errors (ValidationError) if the
+// certificate is not a valid self-revocation for the key.
+func (c *Client) RevokeGPGKey(ctx context.Context, id, revocationCertificate string) (*GPGKey, error) {
+	attrs := map[string]any{"revocation-certificate": revocationCertificate}
+	body, err := MarshalResource("gpg-key-revocations", attrs, nil)
+	if err != nil {
+		return nil, fmt.Errorf("marshal revoke gpg-key: %w", err)
+	}
+	data, err := c.Post(ctx, "/api/terrapod/v1/gpg-keys/"+url.PathEscape(id)+"/revoke", body)
+	if err != nil {
+		return nil, err
+	}
+	return parseGPGKey(data)
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────
 
 func parseGPGKey(body []byte) (*GPGKey, error) {

--- a/services/terrapod/api/routers/gpg_keys.py
+++ b/services/terrapod/api/routers/gpg_keys.py
@@ -9,10 +9,11 @@ The historical TFE-shaped path was `/api/registry/private/v2/gpg-keys`;
 it was removed in v0.24.0 (see #278) and is no longer routable.
 
 Endpoints (canonical):
-    POST   /api/terrapod/v1/gpg-keys              — create
-    GET    /api/terrapod/v1/gpg-keys               — list
-    GET    /api/terrapod/v1/gpg-keys/{key_id}      — show
-    DELETE /api/terrapod/v1/gpg-keys/{key_id}      — delete
+    POST   /api/terrapod/v1/gpg-keys                  — create
+    GET    /api/terrapod/v1/gpg-keys                   — list
+    GET    /api/terrapod/v1/gpg-keys/{key_id}          — show
+    POST   /api/terrapod/v1/gpg-keys/{key_id}/revoke   — revoke (#640)
+    DELETE /api/terrapod/v1/gpg-keys/{key_id}          — delete
 """
 
 import uuid
@@ -31,6 +32,7 @@ from terrapod.services.gpg_key_service import (
     delete_gpg_key,
     get_gpg_key,
     list_gpg_keys,
+    revoke_gpg_key,
 )
 
 router = APIRouter(tags=["gpg-keys"])
@@ -58,6 +60,19 @@ class CreateGPGKeyRequest(BaseModel):
             model_config = {"populate_by_name": True}
 
         type: str = "gpg-keys"
+        attributes: Attributes
+
+    data: Data
+
+
+class RevokeGPGKeyRequest(BaseModel):
+    class Data(BaseModel):
+        class Attributes(BaseModel):
+            revocation_certificate: str = Field(..., alias="revocation-certificate")
+
+            model_config = {"populate_by_name": True}
+
+        type: str = "gpg-key-revocations"
         attributes: Attributes
 
     data: Data
@@ -143,6 +158,33 @@ async def show_gpg_key_endpoint(
     if key is None:
         raise HTTPException(status_code=404, detail="GPG key not found")
 
+    return JSONResponse(content={"data": _gpg_key_to_jsonapi(key)})
+
+
+@router.post("/gpg-keys/{key_id}/revoke")
+async def revoke_gpg_key_endpoint(
+    key_id: str,
+    body: RevokeGPGKeyRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Revoke a registered GPG key by applying an owner-issued revocation
+    certificate (#640). The key stays registered but all signature verification
+    fails closed for it. 422 if the certificate is not a valid self-revocation."""
+    try:
+        key_uuid = uuid.UUID(key_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="GPG key not found") from None
+
+    try:
+        key = await revoke_gpg_key(db, key_uuid, body.data.attributes.revocation_certificate)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+
+    if key is None:
+        raise HTTPException(status_code=404, detail="GPG key not found")
+
+    await db.commit()
     return JSONResponse(content={"data": _gpg_key_to_jsonapi(key)})
 
 

--- a/services/terrapod/gpg_verify.py
+++ b/services/terrapod/gpg_verify.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import warnings
 
 import pgpy
+from pgpy.constants import SignatureType
 
 # pgpy prints static `UserWarning` TODO banners on EVERY ``key.verify()`` —
 # "Self-sigs verification is not yet working", "Revocation checks are not yet
@@ -23,12 +24,45 @@ import pgpy
 # UserWarnings here (the one module that touches pgpy). This does NOT weaken
 # verification: a bad/wrong-key signature still fails closed.
 #
-# Caveat worth keeping visible: the *revocation* TODO is a real pgpy limitation
-# — a revoked signing key's signatures would still verify. Terrapod's trust is
-# anchored in the registered/pinned public key (self-sig + disabled-flag gaps
-# don't apply to that model), and the operator mitigation is removing a revoked
-# key from the registered set. Tracked for a proper fix in issue #640.
+# The self-sig and disabled-flag gaps don't apply to Terrapod's trust model
+# (we anchor on the registered/pinned public key, not on self-certs). The
+# *revocation* gap DID have security weight — pgpy parses revocation signatures
+# but does not act on them, so a self-revoked key's signatures would still
+# verify. We close that gap ourselves in ``is_revoked`` below (pure pgpy, no
+# gpg binary / subprocess) and fail closed on a revoked key (#640).
 warnings.filterwarnings("ignore", category=UserWarning, module=r"pgpy")
+
+
+def is_revoked(key: pgpy.PGPKey) -> bool:
+    """Return True if ``key`` carries a valid self-revocation signature.
+
+    pgpy parses key-revocation signatures but does not honor them during
+    ``verify`` (#640). We check them ourselves: a key is revoked if it has at
+    least one ``KeyRevocation`` (0x20) signature that cryptographically
+    verifies as a self-signature by the key itself — i.e. the key's owner
+    revoked it. A forged/cross-key revocation packet does NOT verify as a
+    self-signature and is ignored, so this never false-positives a legitimate
+    key; a genuine self-revocation always trips it.
+
+    Pure pgpy — no gpg binary, no subprocess. Synchronous/CPU-bound; callers in
+    async contexts must dispatch to a thread.
+    """
+    try:
+        for sig in key.revocation_signatures:
+            if getattr(sig, "type", None) != SignatureType.KeyRevocation:
+                continue
+            try:
+                if key.verify(key, sig):
+                    return True
+            except Exception:
+                # A candidate revocation that won't verify as a self-signature
+                # is not a real revocation — skip it, don't block the key.
+                continue
+    except Exception:
+        # Can't enumerate revocations → don't over-reject; the caller's normal
+        # signature verification still fails closed on a bad/wrong-key sig.
+        return False
+    return False
 
 
 def parse_sha256sums(text: str) -> dict[str, str]:
@@ -71,6 +105,8 @@ def verify_detached(manifest: bytes, signature: bytes, key: pgpy.PGPKey) -> bool
     Synchronous/CPU-bound; callers in async contexts must dispatch to a thread.
     """
     try:
+        if is_revoked(key):
+            return False
         sig = pgpy.PGPSignature.from_blob(signature)
         return bool(key.verify(manifest, sig))
     except Exception:

--- a/services/terrapod/services/gpg_key_service.py
+++ b/services/terrapod/services/gpg_key_service.py
@@ -14,12 +14,14 @@ from pgpy.constants import (
     HashAlgorithm,
     KeyFlags,
     PubKeyAlgorithm,
+    SignatureType,
     SymmetricKeyAlgorithm,
 )
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.db.models import GPGKey
+from terrapod.gpg_verify import is_revoked
 from terrapod.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -105,6 +107,10 @@ async def extract_signature_key_id(sig_bytes: bytes) -> str | None:
 def _verify_detached_signature_sync(public_key_armor: str, data: bytes, sig_bytes: bytes) -> bool:
     try:
         pub, _ = pgpy.PGPKey.from_blob(public_key_armor)
+        # Honor key revocation (#640): a self-revoked signing key must not
+        # verify, even though pgpy would otherwise accept its signatures.
+        if is_revoked(pub):
+            return False
         sig = pgpy.PGPSignature.from_blob(sig_bytes)
         return bool(pub.verify(data, sig))
     except Exception:
@@ -157,6 +163,57 @@ async def create_gpg_key(
 
     logger.info("GPG key created", key_id=key_id)
     return gpg_key
+
+
+def _apply_revocation_sync(stored_armor: str, revocation_cert: str) -> str | None:
+    """Merge an armored revocation certificate into the stored public key (#640).
+
+    Accepts a standalone key-revocation certificate (the armored detached
+    signature `gpg --gen-revoke` produces). Returns the new ASCII-armored public
+    key — now carrying the revocation, so ``is_revoked`` and every verify path
+    reject it — only if the certificate is a valid *self* key-revocation for the
+    stored key. Returns None otherwise (wrong key, wrong signature type, or not
+    a genuine self-revocation). Pure pgpy — no gpg binary / subprocess.
+    """
+    try:
+        key, _ = pgpy.PGPKey.from_blob(stored_armor)
+        sig = pgpy.PGPSignature.from_blob(revocation_cert)
+        # Must be a key-revocation signature AND verify as a self-signature by
+        # this exact key — a forged/other-key certificate is rejected here.
+        if getattr(sig, "type", None) != SignatureType.KeyRevocation:
+            return None
+        if not key.verify(key, sig):
+            return None
+        key |= sig
+        pub = key if key.is_public else key.pubkey
+        new_armor = str(pub)
+        # Belt-and-braces: the merged key must now read as revoked.
+        reloaded, _ = pgpy.PGPKey.from_blob(new_armor)
+        return new_armor if is_revoked(reloaded) else None
+    except Exception:
+        return None
+
+
+async def revoke_gpg_key(
+    db: AsyncSession, key_uuid: uuid.UUID, revocation_cert: str
+) -> GPGKey | None:
+    """Revoke a registered GPG key by applying an owner-issued revocation cert.
+
+    The key stays registered (auditable) but its stored armor now carries the
+    revocation, so all provider/runner signature verification fails closed for
+    it. Returns None if no such key; raises ValueError if the certificate is not
+    a valid self-revocation for the key (router maps to 422).
+    """
+    key = await get_gpg_key(db, key_uuid)
+    if key is None:
+        return None
+    new_armor = await asyncio.to_thread(_apply_revocation_sync, key.ascii_armor, revocation_cert)
+    if new_armor is None:
+        raise ValueError("not a valid self-revocation certificate for this key")
+    key.ascii_armor = new_armor
+    await db.flush()
+    logger.info("GPG key revoked", key_id=key.key_id)
+    return key
 
 
 async def import_signing_key(

--- a/services/tests/api/test_gpg_keys.py
+++ b/services/tests/api/test_gpg_keys.py
@@ -164,6 +164,67 @@ class TestShow:
         assert resp.status_code == 404
 
 
+def _revoke_body():
+    return {
+        "data": {
+            "type": "gpg-key-revocations",
+            "attributes": {
+                "revocation-certificate": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END...",
+            },
+        }
+    }
+
+
+class TestRevoke:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.revoke_gpg_key", new_callable=AsyncMock)
+    async def test_revoke_happy_200(self, mock_revoke, *mocks):
+        key = _mock_key()
+        mock_revoke.return_value = key
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(f"{_KEYS}/{key.id}/revoke", json=_revoke_body(), headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attributes"]["key-id"] == "1C11AB2FF1189D6C"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.revoke_gpg_key", new_callable=AsyncMock)
+    async def test_revoke_invalid_cert_422(self, mock_revoke, *mocks):
+        mock_revoke.side_effect = ValueError("not a valid self-revocation certificate for this key")
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"{_KEYS}/{uuid.uuid4()}/revoke", json=_revoke_body(), headers=_AUTH
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.revoke_gpg_key", new_callable=AsyncMock)
+    async def test_revoke_not_found_404(self, mock_revoke, *mocks):
+        mock_revoke.return_value = None
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"{_KEYS}/{uuid.uuid4()}/revoke", json=_revoke_body(), headers=_AUTH
+            )
+        assert resp.status_code == 404
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_revoke_bad_uuid_404(self, *mocks):
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(f"{_KEYS}/xyz/revoke", json=_revoke_body(), headers=_AUTH)
+        assert resp.status_code == 404
+
+
 class TestDelete:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/services/test_gpg_key_service.py
+++ b/services/tests/services/test_gpg_key_service.py
@@ -1,0 +1,102 @@
+"""Tests for GPG key revocation (#640) — real pgpy crypto, no gpg binary."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pgpy
+from pgpy.constants import (
+    CompressionAlgorithm,
+    EllipticCurveOID,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    RevocationReason,
+    SignatureType,
+    SymmetricKeyAlgorithm,
+)
+
+from terrapod.gpg_verify import is_revoked
+from terrapod.services import gpg_key_service
+
+
+def _new_key():
+    """A fresh Ed25519 signing key (private material available)."""
+    key = pgpy.PGPKey.new(PubKeyAlgorithm.EdDSA, EllipticCurveOID.Ed25519)
+    key.add_uid(
+        pgpy.PGPUID.new("Publisher <pub@example.com>"),
+        usage={KeyFlags.Sign},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+def _revocation_cert(key) -> str:
+    """The armored self key-revocation certificate (gpg --gen-revoke output)."""
+    rev = key.revoke(
+        key,
+        sigtype=SignatureType.KeyRevocation,
+        reason=RevocationReason.Compromised,
+        comment="test",
+    )
+    return str(rev)
+
+
+def test_apply_revocation_produces_revoked_armor():
+    key = _new_key()
+    new_armor = gpg_key_service._apply_revocation_sync(str(key.pubkey), _revocation_cert(key))
+    assert new_armor is not None
+    reloaded, _ = pgpy.PGPKey.from_blob(new_armor)
+    assert is_revoked(reloaded) is True
+
+
+def test_apply_revocation_rejects_a_cert_for_a_different_key():
+    stored = _new_key()
+    other = _new_key()  # a revocation cert issued by a DIFFERENT key
+    assert (
+        gpg_key_service._apply_revocation_sync(str(stored.pubkey), _revocation_cert(other)) is None
+    )
+
+
+def test_apply_revocation_rejects_a_plain_signature():
+    key = _new_key()
+    plain_sig = str(key.sign(pgpy.PGPMessage.new("not a revocation")))
+    assert gpg_key_service._apply_revocation_sync(str(key.pubkey), plain_sig) is None
+
+
+async def test_revoke_gpg_key_persists_revoked_armor():
+    """The service updates the stored armor to the revoked one so every verify
+    path (which re-parses ascii_armor) fails closed afterward."""
+    key = _new_key()
+    row = MagicMock()
+    row.ascii_armor = str(key.pubkey)
+    row.key_id = "ABCD1234ABCD1234"
+
+    with patch.object(gpg_key_service, "get_gpg_key", new=AsyncMock(return_value=row)):
+        result = await gpg_key_service.revoke_gpg_key(
+            AsyncMock(), uuid.uuid4(), _revocation_cert(key)
+        )
+
+    assert result is row
+    reloaded, _ = pgpy.PGPKey.from_blob(row.ascii_armor)
+    assert is_revoked(reloaded) is True
+
+
+async def test_revoke_gpg_key_bad_cert_raises():
+    key = _new_key()
+    other = _new_key()
+    row = MagicMock()
+    row.ascii_armor = str(key.pubkey)
+
+    with patch.object(gpg_key_service, "get_gpg_key", new=AsyncMock(return_value=row)):
+        try:
+            await gpg_key_service.revoke_gpg_key(AsyncMock(), uuid.uuid4(), _revocation_cert(other))
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass
+
+
+async def test_revoke_gpg_key_missing_returns_none():
+    with patch.object(gpg_key_service, "get_gpg_key", new=AsyncMock(return_value=None)):
+        assert await gpg_key_service.revoke_gpg_key(AsyncMock(), uuid.uuid4(), "x") is None

--- a/services/tests/test_gpg_verify.py
+++ b/services/tests/test_gpg_verify.py
@@ -26,3 +26,68 @@ def test_parse_sha256sums_tolerates_formatting():
         "garbage\n"  # short line, skipped
     )
     assert out == {"file.zip": "abc123", "other.bin": "def456"}
+
+
+# ── Key revocation (#640) ──────────────────────────────────────────────
+
+
+def _new_signing_key():
+    """A fresh Ed25519 signing key (fast to generate)."""
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        EllipticCurveOID,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    key = pgpy.PGPKey.new(PubKeyAlgorithm.EdDSA, EllipticCurveOID.Ed25519)
+    key.add_uid(
+        pgpy.PGPUID.new("Test <test@example.com>"),
+        usage={KeyFlags.Sign},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+def _self_revoke(key):
+    """Attach a self key-revocation signature and re-parse the public key."""
+    import pgpy
+    from pgpy.constants import RevocationReason, SignatureType
+
+    rev = key.revoke(
+        key,
+        sigtype=SignatureType.KeyRevocation,
+        reason=RevocationReason.Compromised,
+        comment="test",
+    )
+    key |= rev
+    revoked, _ = pgpy.PGPKey.from_blob(str(key.pubkey))
+    return revoked
+
+
+def test_is_revoked_false_for_fresh_key():
+    assert gpg_verify.is_revoked(_new_signing_key().pubkey) is False
+
+
+def test_is_revoked_true_for_self_revoked_key():
+    assert gpg_verify.is_revoked(_self_revoke(_new_signing_key())) is True
+
+
+def test_verify_detached_fails_closed_on_revoked_key():
+    """A signature that verifies under a key must STOP verifying once that key
+    carries a valid self-revocation (#640) — pgpy alone would still accept it."""
+    key = _new_signing_key()
+    msg = b"payload-to-sign"
+    sig_bytes = str(key.sign(msg)).encode()
+
+    # Sanity: verifies under the live key.
+    assert gpg_verify.verify_detached(msg, sig_bytes, key.pubkey) is True
+
+    # After self-revocation, the SAME good signature must fail closed.
+    revoked = _self_revoke(key)
+    assert gpg_verify.verify_detached(msg, sig_bytes, revoked) is False


### PR DESCRIPTION
Closes #640 — the one `pgpy` limitation with real security weight: it parses key-revocation signatures but does not act on them, so a **self-revoked signing key’s signatures would still verify**.

Your steer was right — no shelling out to `gpg`. This closes it **pure-Python**:

## Detection primitive
`gpg_verify.is_revoked(key)` finds any `KeyRevocation` (0x20) signature in `key.revocation_signatures` and confirms it cryptographically verifies as a **self**-signature by the key itself (a forged/cross-key cert is ignored; a genuine self-revocation trips it). Wired into **both** verify paths — `gpg_verify.verify_detached` (runner binary-verify + `artifact_verification`) and `gpg_key_service` (provider registry) — both **fail closed** on a revoked key. The stale "revocation not implemented" caveat is updated.

## Operator path
`POST /api/terrapod/v1/gpg-keys/{id}/revoke` accepts an owner-issued revocation certificate (the armored output of `gpg --gen-revoke`), verifies it is a valid self-revocation for the registered key, and stores the revoked armor so **all** provider/runner verification fails closed — including already-published artifacts the key signed. The key stays **registered** (auditable), not deleted. 422 on a non-matching / non-revocation cert. `go-terrapod` `RevokeGPGKey` added.

## Spike
Confirmed the pgpy API before designing: `revocation_signatures` (empty on a fresh key, one `KeyRevocation` sig on a revoked one), `key.verify(key, rev_sig)` proves a genuine self-revocation, and the pre-fix gap reproduces.

## Tests (real crypto, no gpg binary)
- `is_revoked`: fresh→false, self-revoked→true, and a good signature stops verifying after the key is revoked.
- `_apply_revocation_sync` / `revoke_gpg_key`: revoked round-trip, a cert for a **different** key rejected, a plain (non-revocation) signature rejected, missing-key→None.
- revoke router: 200 / 422 (bad cert) / 404 (bad uuid + not found).
- Verified: `make test` on gpg-verify + gpg-key-service + gpg-keys router + artifact-verification + binary-verify (57 passed); `go build`/`go vet` clean.

Closes #640