### PR TITLE
feat(ops): migration smoke CI + runtime app/schema skew guard on /ready (#544)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,45 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/test.sh python -- ${{ matrix.slice.pytest_args }} ${{ matrix.slice.paths }}
 
+  # ── Migration smoke (#544) ────────────────────────────
+  # The Python test tiers build the schema with `Base.metadata.create_all`, so
+  # the migration files are never executed by any test. This one-shot job runs
+  # the REAL `alembic upgrade head` against a Postgres, then seeds + queries
+  # representative rows — catching a bad backfill / NOT-NULL-without-default on a
+  # populated table that create_all would never exercise. Always-on (cheap,
+  # ~2 min) rather than path-gated, so a models.py change that needs a migration
+  # can't slip through by touching a file the filter missed.
+  migration-check:
+    name: Migration Smoke
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: terrapod
+          POSTGRES_PASSWORD: terrapod
+          POSTGRES_DB: terrapod
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U terrapod"
+          --health-interval 3s --health-timeout 3s --health-retries 20
+    env:
+      DATABASE_URL: postgresql+asyncpg://terrapod:terrapod@localhost:5432/terrapod
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Build migrations image
+        run: docker build -f docker/Dockerfile.migrations -t tp-migrations:ci .
+      - name: Run migrations (alembic upgrade head — the real migration files)
+        run: docker run --rm --network host -e DATABASE_URL="$DATABASE_URL" tp-migrations:ci
+      - name: Seed representative rows + query the migrated schema
+        run: |
+          docker run --rm --network host -e DATABASE_URL="$DATABASE_URL" \
+            -v "$PWD/scripts/migration_smoke.py:/app/scripts/migration_smoke.py:ro" \
+            --entrypoint python tp-migrations:ci scripts/migration_smoke.py
+
   # ── Dependency Audit (Python) ─────────────────────────
   python-audit:
     name: Python Audit
@@ -1747,6 +1786,7 @@ jobs:
       - publish-lint
       - publish-test
       - python-test
+      - migration-check
       - python-audit
       - npm-audit
       - secret-scan
@@ -1786,6 +1826,7 @@ jobs:
             "${{ needs.publish-lint.result }}"
             "${{ needs.publish-test.result }}"
             "${{ needs.python-test.result }}"
+            "${{ needs.migration-check.result }}"
             "${{ needs.python-audit.result }}"
             "${{ needs.npm-audit.result }}"
             "${{ needs.secret-scan.result }}"

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1107,21 +1107,22 @@ Fires from the bundled `TerrapodAPIDown` alert: no `terrapod-api` scrape target 
    kubectl describe pod <api-pod> -n <ns>
    ```
    Look for `CrashLoopBackOff`, `OOMKilled`, failing readiness probes, or `Pending` (unschedulable).
-2. **Readiness detail** — `/ready` checks DB + Redis. Hit it from inside the cluster:
+2. **Readiness detail** — `/ready` checks DB + Redis + storage + **migrations** and reports each in a `checks` map. Hit it from inside the cluster:
    ```bash
    kubectl exec -n <ns> deploy/terrapod-api -- python -c "import urllib.request;print(urllib.request.urlopen('http://localhost:8000/ready').read())" 2>&1 || true
    ```
-   A failing `/ready` with healthy pods almost always means a dependency is down — see [DB Pool Exhaustion](#db-pool-exhaustion) / [Redis Connection Loss](#redis-connection-loss).
+   Read the `checks` map: a `database`/`redis` down almost always means a dependency is down — see [DB Pool Exhaustion](#db-pool-exhaustion) / [Redis Connection Loss](#redis-connection-loss). A `"migrations": "behind: ..."` means **app ↔ schema skew** (#544) — this pod's code expects a migration the DB hasn't got, so it deliberately reports NOT READY (and is pulled from the LB) instead of 500-ing every request against the missing column. Startup also logs a loud `SCHEMA SKEW` warning.
 3. **Recent rollout:**
    ```bash
    kubectl rollout history deploy/terrapod-api -n <ns>
    ```
    A bad image/config (e.g. a migration that didn't run) often correlates with the outage start.
-4. **Migrations** — a schema/app skew makes the API refuse to start. Confirm the migration Job for the current version succeeded.
+4. **Migrations** — if `checks.migrations` is `behind`, the migration Job for the current version did not apply (failed pre-upgrade hook that let the rollout proceed, a bare `kubectl set image`, or ArgoCD sync ordering). The `detail` names the DB revision vs the code head.
 
 ### Resolution
 
 - **Dependency down** → restore Postgres/Redis (their runbooks above); the API recovers on the next readiness probe.
+- **Schema skew (`checks.migrations` behind)** → run the Alembic migration Job (`helm upgrade` re-runs the pre-upgrade hook, or trigger the migration Job directly). Once the DB reaches the code head, the pods flip to ready on the next probe with no restart needed.
 - **Bad rollout** → `kubectl rollout undo deploy/terrapod-api -n <ns>`.
 - **OOM/crash** → check `kubectl logs --previous`; raise `api.resources` if genuinely under-provisioned (confirm with the OOM `reason` field, don't assume).
 - **Unschedulable** → free capacity or fix nodeSelector/taints.

--- a/scripts/migration_smoke.py
+++ b/scripts/migration_smoke.py
@@ -1,0 +1,90 @@
+"""Migration smoke: seed + query the ALEMBIC-built schema (#544).
+
+The integration test tier builds the schema with ``Base.metadata.create_all``, so
+the migration files are never executed by any test. Alembic guarantees the
+*upgrade path* works; it does not guarantee a given ``upgrade()`` is correct
+against **non-empty** data — a bad backfill, a NOT-NULL-without-default added to a
+populated table, or a rename that drops a column would pass CI and only fail in
+prod.
+
+This script runs AFTER ``alembic upgrade head`` against a real Postgres: it seeds
+representative, FK-linked rows using the ORM models and reads them back. Because
+it inserts minimal rows and relies on column defaults for the rest, a migration
+that adds a required column without a default (the classic footgun) makes this
+fail loudly — which is the point.
+
+Usage (DB already migrated to head):
+    DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/db \
+        python scripts/migration_smoke.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import uuid
+
+
+async def _main() -> int:
+    from sqlalchemy import func, select, text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import terrapod.db.models as m
+
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 2
+
+    engine = create_async_engine(url)
+    session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session() as db:
+            # The DB must already be at an Alembic head — the migration Job/step
+            # runs before this script.
+            current = (
+                await db.execute(text("SELECT version_num FROM alembic_version"))
+            ).scalar_one_or_none()
+            if not current:
+                print(
+                    "alembic_version empty — migrations were not applied",
+                    file=sys.stderr,
+                )
+                return 1
+
+            suffix = uuid.uuid4().hex[:10]
+            user = m.User(
+                email=f"smoke-{suffix}@example.com", display_name="Migration Smoke"
+            )
+            db.add(user)
+            ws = m.Workspace(name=f"smoke-ws-{suffix}", owner_email=user.email)
+            db.add(ws)
+            await db.commit()
+
+            # Read the seeded rows back through the ORM — proves the model's
+            # column definitions match the migrated schema (a dropped/renamed
+            # column would 500 here, exactly as the app would in prod).
+            got = (
+                await db.execute(select(m.Workspace).where(m.Workspace.name == ws.name))
+            ).scalar_one()
+            assert got.owner_email == user.email, (
+                "workspace owner_email round-trip mismatch"
+            )
+            assert got.terraform_version, "expected a defaulted terraform_version"
+            n_users = (
+                await db.execute(select(func.count()).select_from(m.User))
+            ).scalar_one()
+            assert n_users >= 1
+    finally:
+        await engine.dispose()
+
+    print(
+        f"migration smoke OK — schema at {current}; seeded + queried a user + workspace "
+        f"against the migrated schema"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -36,6 +36,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await init_db()
     logger.info("Database initialized")
 
+    # App ↔ schema skew guard (#544): warm the code-head cache and loudly warn
+    # if the DB schema is behind this app's expected migration head. Doesn't
+    # raise — a schema-behind pod boots and reports NOT READY via /ready.
+    from terrapod.db.schema_version import check_schema_at_startup
+
+    await check_schema_at_startup()
+
     await init_redis()
     logger.info("Redis initialized")
 

--- a/services/terrapod/api/health.py
+++ b/services/terrapod/api/health.py
@@ -6,6 +6,7 @@ Provides /health (liveness) and /ready (readiness) endpoints.
 
 from fastapi import APIRouter, Response, status
 
+from terrapod.db.schema_version import schema_is_current
 from terrapod.db.session import get_db_health
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_health
@@ -37,6 +38,14 @@ async def ready(response: Response) -> dict[str, str | dict[str, str]]:
 
     storage = get_storage_or_none()
     checks["storage"] = "healthy" if storage is not None else "unhealthy"
+
+    # App ↔ schema skew guard (#544): a pod whose code expects a migration the
+    # DB hasn't got must report NOT READY (and get pulled from the LB) rather
+    # than 500 every request against the missing column. Only meaningful once
+    # the DB is reachable — a DB-down failure already fails readiness above.
+    if checks["database"] == "healthy":
+        schema_ok, schema_detail = await schema_is_current()
+        checks["migrations"] = "healthy" if schema_ok else f"behind: {schema_detail}"
 
     all_healthy = all(v == "healthy" for v in checks.values())
 

--- a/services/terrapod/db/schema_version.py
+++ b/services/terrapod/db/schema_version.py
@@ -1,0 +1,118 @@
+"""Runtime app ↔ schema skew guard (#544).
+
+A new API pod can start before/without its migration applied — a failed Helm
+pre-upgrade hook that let the rollout proceed, a bare `kubectl set image`, or
+ArgoCD sync ordering. The new code then queries a not-yet-existing column and
+500s **every** request against that table. This module lets `/ready` report a
+schema-behind pod as *not ready* (so it's pulled from the load balancer) instead
+of silently erroring, and lets startup log a loud warning.
+
+It compares the revision recorded in the DB's ``alembic_version`` table against
+the head revision the shipped ``alembic/`` scripts declare. Alembic's revision
+chain is linear, so a single head is expected; a DB revision that is not the
+code head means the schema and the code are out of step.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from sqlalchemy import text
+
+import terrapod
+from terrapod.db.session import get_db_session
+from terrapod.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _find_alembic_base() -> Path | None:
+    """Locate the directory holding ``alembic.ini`` + ``alembic/``.
+
+    Robust across the API image (``/app``) and the repo/tests layout (repo root)
+    by walking up from the installed ``terrapod`` package.
+    """
+    # `terrapod` is a PEP 420 namespace package (no __init__.py), so __file__
+    # is None — use __path__ for the package directory instead.
+    pkg_paths = list(getattr(terrapod, "__path__", []))
+    if not pkg_paths:
+        return None
+    start = Path(pkg_paths[0]).resolve().parent
+    for base in (start, *start.parents):
+        if (base / "alembic.ini").is_file() and (base / "alembic").is_dir():
+            return base
+    return None
+
+
+@lru_cache(maxsize=1)
+def code_head_revisions() -> frozenset[str]:
+    """The head revision(s) the shipped alembic scripts declare (cached).
+
+    Empty frozenset if the scripts can't be located — callers treat that as
+    "can't tell, don't block". Reads the filesystem; warm it once at startup
+    (see ``check_schema_at_startup``) so the async ``/ready`` path never does
+    this sync I/O in the event loop.
+    """
+    base = _find_alembic_base()
+    if base is None:
+        return frozenset()
+    try:
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        cfg = Config(str(base / "alembic.ini"))
+        cfg.set_main_option("script_location", str(base / "alembic"))
+        return frozenset(ScriptDirectory.from_config(cfg).get_heads())
+    except Exception:
+        logger.warning("Could not read alembic head revision", exc_info=True)
+        return frozenset()
+
+
+async def db_current_revision() -> str | None:
+    """The revision recorded in the DB's ``alembic_version`` table, or None if
+    the table is absent/empty (fresh DB, migrations never run)."""
+    try:
+        async with get_db_session() as db:
+            row = (await db.execute(text("SELECT version_num FROM alembic_version"))).first()
+            return row[0] if row else None
+    except Exception:
+        return None
+
+
+async def schema_is_current() -> tuple[bool, str]:
+    """Return (ok, detail): does the applied DB revision match the code head?
+
+    ok=True when they match — or when the code head can't be determined (we
+    don't block a pod on our own inability to read the scripts; the DB/Redis
+    checks still gate readiness). ok=False when the DB revision is missing or
+    differs from the code head (the schema-skew signal)."""
+    heads = code_head_revisions()
+    if not heads:
+        return True, "unknown (alembic scripts not found; not gating readiness)"
+    current = await db_current_revision()
+    if current is None:
+        return False, "no alembic_version row — migrations not applied"
+    if current in heads:
+        return True, current
+    return False, f"schema at {current}, code head {'/'.join(sorted(heads))}"
+
+
+async def check_schema_at_startup() -> None:
+    """Warm the code-head cache and log a loud warning if the schema is behind.
+
+    Called once from the app lifespan. Does not raise — a schema-behind pod
+    boots (so it can serve `/ready` = not-ready) rather than crash-looping."""
+    import asyncio
+
+    await asyncio.to_thread(code_head_revisions)  # warm cache off the event loop
+    ok, detail = await schema_is_current()
+    if ok:
+        logger.info("Schema version check passed", detail=detail)
+    else:
+        logger.warning(
+            "SCHEMA SKEW: the database schema does not match this app's expected "
+            "migration head — this pod will report NOT READY until the migration "
+            "is applied. Run the Alembic migration Job / helm upgrade hook.",
+            detail=detail,
+        )

--- a/services/tests/api/test_health.py
+++ b/services/tests/api/test_health.py
@@ -1,0 +1,92 @@
+"""Tests for /health + /ready, including the schema-skew guard (#544)."""
+
+from unittest.mock import AsyncMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+
+_BASE = "http://test"
+
+
+def _app():
+    return create_app()
+
+
+class TestReady:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.health.schema_is_current", new_callable=AsyncMock)
+    @patch("terrapod.api.health.get_storage_or_none")
+    @patch("terrapod.api.health.get_redis_health", new_callable=AsyncMock)
+    @patch("terrapod.api.health.get_db_health", new_callable=AsyncMock)
+    async def test_ready_all_healthy_200(
+        self, mock_db, mock_redis, mock_storage, mock_schema, *app_mocks
+    ):
+        mock_db.return_value = True
+        mock_redis.return_value = True
+        mock_storage.return_value = object()
+        mock_schema.return_value = (True, "abc123")
+
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.get("/ready")
+        assert resp.status_code == 200
+        assert resp.json()["checks"]["migrations"] == "healthy"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.health.schema_is_current", new_callable=AsyncMock)
+    @patch("terrapod.api.health.get_storage_or_none")
+    @patch("terrapod.api.health.get_redis_health", new_callable=AsyncMock)
+    @patch("terrapod.api.health.get_db_health", new_callable=AsyncMock)
+    async def test_ready_schema_behind_503(
+        self, mock_db, mock_redis, mock_storage, mock_schema, *app_mocks
+    ):
+        """Everything else healthy, but the schema is behind the code head — the
+        pod must report NOT READY so the LB pulls it (#544)."""
+        mock_db.return_value = True
+        mock_redis.return_value = True
+        mock_storage.return_value = object()
+        mock_schema.return_value = (False, "schema at old000, code head new999")
+
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.get("/ready")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["status"] == "not ready"
+        assert body["checks"]["migrations"].startswith("behind:")
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.health.schema_is_current", new_callable=AsyncMock)
+    @patch("terrapod.api.health.get_storage_or_none")
+    @patch("terrapod.api.health.get_redis_health", new_callable=AsyncMock)
+    @patch("terrapod.api.health.get_db_health", new_callable=AsyncMock)
+    async def test_ready_db_down_skips_schema_check(
+        self, mock_db, mock_redis, mock_storage, mock_schema, *app_mocks
+    ):
+        """When the DB is down, readiness already fails — and the schema check is
+        skipped (it can't query alembic_version) rather than mislabelled."""
+        mock_db.return_value = False
+        mock_redis.return_value = True
+        mock_storage.return_value = object()
+
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.get("/ready")
+        assert resp.status_code == 503
+        assert "migrations" not in resp.json()["checks"]
+        mock_schema.assert_not_called()
+
+
+class TestHealth:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_health_liveness_200(self, *app_mocks):
+        async with AsyncClient(transport=ASGITransport(app=_app()), base_url=_BASE) as c:
+            resp = await c.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "healthy"

--- a/services/tests/test_schema_version.py
+++ b/services/tests/test_schema_version.py
@@ -1,0 +1,44 @@
+"""Unit tests for the app <-> schema skew guard (#544)."""
+
+from unittest.mock import AsyncMock, patch
+
+from terrapod.db import schema_version
+
+
+async def _check(heads, current):
+    with (
+        patch.object(schema_version, "code_head_revisions", return_value=frozenset(heads)),
+        patch.object(schema_version, "db_current_revision", new=AsyncMock(return_value=current)),
+    ):
+        return await schema_version.schema_is_current()
+
+
+async def test_current_matches_head_is_ok():
+    ok, detail = await _check({"abc123"}, "abc123")
+    assert ok is True
+    assert detail == "abc123"
+
+
+async def test_schema_behind_is_not_ok():
+    ok, detail = await _check({"newhead"}, "oldrev")
+    assert ok is False
+    assert "oldrev" in detail and "newhead" in detail
+
+
+async def test_missing_alembic_version_row_is_not_ok():
+    ok, detail = await _check({"abc"}, None)
+    assert ok is False
+    assert "not applied" in detail
+
+
+async def test_unknown_head_does_not_gate_readiness():
+    # Scripts unreadable -> we don't block a pod on our own inability to tell.
+    ok, detail = await _check(set(), "whatever")
+    assert ok is True
+    assert "unknown" in detail
+
+
+def test_code_head_revisions_never_raises():
+    # In the test image alembic/ isn't shipped, so this returns empty — but it
+    # must always return a frozenset and never raise, whatever the layout.
+    assert isinstance(schema_version.code_head_revisions(), frozenset)


### PR DESCRIPTION
Closes #544 — two orthogonal migration gaps (neither about Alembic's by-design roll-forward, which is guaranteed).

## 1. CI never actually ran a migration
The test tiers build the schema with `Base.metadata.create_all`, so the migration files are **never executed** by any test — Alembic guarantees the *path*, not that a given `upgrade()` is correct against **non-empty** data (a bad backfill, a NOT-NULL-without-default on a populated table, a rename that drops a column).

New one-shot **`migration-check`** CI job: start Postgres → build the migrations image → run the **real `alembic upgrade head`** → seed representative FK-linked rows (user + workspace) and query them back through the ORM (`scripts/migration_smoke.py`). It seeds minimal rows and **relies on column defaults**, so a future NOT-NULL-without-default addition (or a dropped/renamed column the ORM expects) makes it fail loudly. Wired into the `ci-pass` gate. **Verified end-to-end locally** against the migrations image + Postgres (`alembic upgrade head` ran the real chain; the seed inserted + queried against the migrated schema).

## 2. Runtime app ↔ schema skew guard on `/ready`
A new API pod can start before/without its migration applied (failed pre-upgrade hook that let the rollout proceed, a bare `kubectl set image`, ArgoCD sync ordering) and then **500 every request** against the missing column — the failure class behind the v0.44.0 `webhook_secret` concern.

New `db/schema_version.py` compares the DB's applied Alembic revision against the code's shipped head. `/ready` now reports a `checks.migrations` entry and returns **NOT READY (503)** on skew, so the pod is pulled from the LB instead of silently erroring; startup logs a loud `SCHEMA SKEW` warning. **Fail-safe:** if the alembic scripts can't be located it does *not* gate readiness (the DB/Redis checks still do). Reads the head once (cached, warmed off the event loop) — no sync I/O in the async `/ready` path.

## Tests
- `schema_is_current` logic: match / behind / missing `alembic_version` row / unknown-head (fail-safe).
- `/ready` wiring: all-healthy 200 with `migrations: healthy`; schema-behind 503 with `migrations: behind: ...`; DB-down skips the schema check.
- `make test` on the affected + app-creating suites (70 passed, no regressions); ruff clean; ci.yml validates + `migration-check` is in the `ci-pass` gate.
- Runbook: the "API Down / Not Ready" entry now covers the `checks.migrations: behind` case + resolution.

Closes #544 (part of #551).