### PR TITLE
feat(autodiscovery): execution-hook templates on rules (#672)

### DIFF
--- a/alembic/versions/1429df8c538a_autodiscovery_execution_hook_templates.py
+++ b/alembic/versions/1429df8c538a_autodiscovery_execution_hook_templates.py
@@ -1,0 +1,38 @@
+"""autodiscovery execution_hook_templates (#672)
+
+Adds a list of execution-hook ids that an autodiscovery rule associates with
+every workspace it materialises, so discovered workspaces inherit their hooks
+automatically (mirrors run_task_templates / notification_templates). Additive,
+defaults to empty — no behaviour change for existing rules.
+
+Revision ID: 1429df8c538a
+Revises: 6cede1508fb7
+Create Date: 2026-07-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "1429df8c538a"
+down_revision: str | None = "6cede1508fb7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "autodiscovery_rules",
+        sa.Column(
+            "execution_hook_templates",
+            JSONB(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("autodiscovery_rules", "execution_hook_templates")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1971,6 +1971,7 @@ Runs the same walk as Preview but actually creates the workspaces (idempotent, c
 - `var-files` — list of var-file paths.
 - `run-task-templates` — list of run-task specs (same shape as the bulk-update `run-tasks`, below): `{name, url, hmac-key?, stage, enforcement-level?, enabled?}`.
 - `notification-templates` — list of notification specs: `{name, destination-type, url?, token?, triggers?, email-addresses?, enabled?}`.
+- `execution-hook-templates` — list of [execution hook](execution-hooks.md) ids (`hook-<uuid>`) associated with every created workspace (#672).
 
 These use the **identical spec shape** as the bulk-update endpoint, so a run task defined once can be applied to existing workspaces (bulk-update) *and* auto-applied to future ones (this template).
 

--- a/docs/autodiscovery.md
+++ b/docs/autodiscovery.md
@@ -64,6 +64,7 @@ Rules are scoped to a single VCS connection + repo. A rule has:
 | `var-files` | list | no | Var-file paths set on every created workspace. |
 | `run-task-templates` | list | no | Run-task specs (`{name, url, hmac-key?, stage, enforcement-level?, enabled?}`) materialised onto every created workspace — same shape as the bulk-update `run-tasks`. Define a policy gate once; it auto-applies to all future workspaces (#318). |
 | `notification-templates` | list | no | Notification specs (`{name, destination-type, url?, token?, triggers?, email-addresses?, enabled?}`) materialised onto every created workspace. |
+| `execution-hook-templates` | list | no | [Execution hook](execution-hooks.md) ids (`hook-<uuid>`) associated with every created workspace, so discovered workspaces inherit their hooks automatically (#672). Ids that no longer exist are skipped at creation. |
 
 ## Pattern syntax
 

--- a/provider/internal/resources/autodiscovery_rule/resource.go
+++ b/provider/internal/resources/autodiscovery_rule/resource.go
@@ -101,9 +101,10 @@ type autodiscoveryRuleModel struct {
 	OwnerEmail        types.String `tfsdk:"owner_email"`
 	OnDirectoryDelete types.String `tfsdk:"on_directory_delete"`
 
-	VarFiles              types.List `tfsdk:"var_files"`
-	RunTaskTemplates      types.List `tfsdk:"run_task_templates"`
-	NotificationTemplates types.List `tfsdk:"notification_templates"`
+	VarFiles               types.List `tfsdk:"var_files"`
+	RunTaskTemplates       types.List `tfsdk:"run_task_templates"`
+	NotificationTemplates  types.List `tfsdk:"notification_templates"`
+	ExecutionHookTemplates types.List `tfsdk:"execution_hook_templates"`
 
 	CreatedAt types.String `tfsdk:"created_at"`
 	UpdatedAt types.String `tfsdk:"updated_at"`
@@ -278,6 +279,11 @@ func (r *autodiscoveryRuleResource) Schema(_ context.Context, _ resource.SchemaR
 
 			"var_files": schema.ListAttribute{
 				Description: "List of .tfvars file paths inherited by created workspaces as -var-file arguments.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"execution_hook_templates": schema.ListAttribute{
+				Description: "Execution hook ids (hook-<uuid>) associated with every workspace this rule creates.",
 				Optional:    true,
 				ElementType: types.StringType,
 			},
@@ -592,6 +598,14 @@ func buildAutodiscoveryRuleAttrs(m *autodiscoveryRuleModel) map[string]any {
 		attrs["var-files"] = varFiles
 	}
 
+	if !m.ExecutionHookTemplates.IsNull() && !m.ExecutionHookTemplates.IsUnknown() {
+		hooks := make([]string, 0, len(m.ExecutionHookTemplates.Elements()))
+		for _, v := range m.ExecutionHookTemplates.Elements() {
+			hooks = append(hooks, v.(types.String).ValueString())
+		}
+		attrs["execution-hook-templates"] = hooks
+	}
+
 	if !m.RunTaskTemplates.IsNull() && !m.RunTaskTemplates.IsUnknown() {
 		tasks := make([]map[string]any, 0, len(m.RunTaskTemplates.Elements()))
 		for _, e := range m.RunTaskTemplates.Elements() {
@@ -726,6 +740,14 @@ func readAutodiscoveryRuleIntoModel(ctx context.Context, res *terrapod.Resource,
 		m.VarFiles = v
 	} else {
 		m.VarFiles = types.ListNull(types.StringType)
+	}
+
+	if hooks := terrapod.GetListAttr(res, "execution-hook-templates"); len(hooks) > 0 {
+		v, d := types.ListValueFrom(ctx, types.StringType, hooks)
+		diags.Append(d...)
+		m.ExecutionHookTemplates = v
+	} else {
+		m.ExecutionHookTemplates = types.ListNull(types.StringType)
 	}
 
 	rtObjType := types.ObjectType{AttrTypes: runTaskTemplateAttrTypes}

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -81,6 +81,9 @@ def _rule_json(rule: AutodiscoveryRule) -> dict:
             "var-files": list(rule.var_files or []),
             "run-task-templates": list(rule.run_task_templates or []),
             "notification-templates": list(rule.notification_templates or []),
+            "execution-hook-templates": [
+                f"hook-{h}" for h in (rule.execution_hook_templates or [])
+            ],
             "created-at": _rfc3339(rule.created_at),
             "updated-at": _rfc3339(rule.updated_at),
         },
@@ -245,6 +248,23 @@ def _coerce_attrs(attrs: dict, *, on_create: bool) -> dict[str, Any]:
         out["run_task_templates"] = validate_run_task_specs(attrs["run-task-templates"])
     if "notification-templates" in attrs:
         out["notification_templates"] = validate_notification_specs(attrs["notification-templates"])
+    # #672: execution-hook ids to associate with every materialised workspace.
+    # Stored as bare UUIDs; accepts hook-<uuid> or bare uuid. Existence is
+    # checked at materialisation (skip-if-missing), not here.
+    if "execution-hook-templates" in attrs:
+        eht = attrs["execution-hook-templates"]
+        if not isinstance(eht, list):
+            raise HTTPException(status_code=422, detail="execution-hook-templates must be a list")
+        ids: list[str] = []
+        for item in eht:
+            try:
+                ids.append(str(uuid.UUID(str(item).removeprefix("hook-"))))
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Invalid execution hook id: {item}",
+                ) from exc
+        out["execution_hook_templates"] = ids
 
     return out
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -1100,6 +1100,9 @@ class AutodiscoveryRule(Base):
     notification_templates: Mapped[list[dict[str, Any]]] = mapped_column(
         JSONB, default=list, nullable=False
     )
+    # #672: execution hooks (by id) to associate with every workspace this rule
+    # materialises, so discovered workspaces inherit their hooks automatically.
+    execution_hook_templates: Mapped[list[str]] = mapped_column(JSONB, default=list, nullable=False)
     # #314 deletion lifecycle: what to do when a discovered directory is
     # removed on the tracked branch. "flag" (default, safe) marks the
     # workspace pending_deletion and requires an explicit operator

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -38,6 +38,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.db.models import (
     AutodiscoveryRule,
+    ExecutionHook,
+    ExecutionHookWorkspace,
     NotificationConfiguration,
     RunTask,
     Workspace,
@@ -321,6 +323,21 @@ async def find_or_autocreate_workspace(
         db.add(RunTask(workspace_id=ws.id, **spec))
     for spec in rule.notification_templates or []:
         db.add(NotificationConfiguration(workspace_id=ws.id, **spec))
+
+    # #672: associate the rule's execution-hook templates with the new
+    # workspace. Non-interactive path — skip (log) any hook that no longer
+    # exists rather than aborting the poll cycle.
+    for hook_id_str in rule.execution_hook_templates or []:
+        try:
+            hook_uuid = uuid.UUID(str(hook_id_str).removeprefix("hook-"))
+        except ValueError:
+            logger.warning("autodiscovery: skipping invalid hook id", hook_id=hook_id_str)
+            continue
+        hook = await db.get(ExecutionHook, hook_uuid)
+        if hook is None:
+            logger.warning("autodiscovery: skipping missing hook", hook_id=hook_id_str)
+            continue
+        db.add(ExecutionHookWorkspace(hook_id=hook_uuid, workspace_id=ws.id))
 
     await db.commit()
 

--- a/services/tests/api/test_autodiscovery_rules.py
+++ b/services/tests/api/test_autodiscovery_rules.py
@@ -135,6 +135,61 @@ class TestCreateRule:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
+    async def test_201_with_execution_hook_templates(self, *_mocks):
+        conn_id = uuid.uuid4()
+        hook_id = uuid.uuid4()
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(side_effect=[MagicMock(id=conn_id)])  # _validate_connection
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        body = {
+            "data": {
+                "type": "autodiscovery-rules",
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{conn_id}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "execution-hook-templates": [f"hook-{hook_id}", str(hook_id)],
+                },
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 201, resp.text
+        # Both forms normalise to bare uuid stored, serialized back as hook-<uuid>.
+        assert resp.json()["data"]["attributes"]["execution-hook-templates"] == [
+            f"hook-{hook_id}",
+            f"hook-{hook_id}",
+        ]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_422_invalid_execution_hook_template_id(self, *_mocks):
+        conn_id = uuid.uuid4()
+        app, db = _make_app(_admin())
+        db.get = AsyncMock(side_effect=[MagicMock(id=conn_id)])
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "monorepo",
+                    "vcs-connection-id": f"vcs-{conn_id}",
+                    "repo-url": "https://github.com/example/repo",
+                    "pattern": "accounts/*/**/*.tf",
+                    "execution-mode": "agent",
+                    "execution-hook-templates": ["not-a-uuid"],
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post("/api/terrapod/v1/autodiscovery-rules", json=body, headers=_AUTH)
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
     async def test_422_when_pattern_missing(self, *_mocks):
         app, _db = _make_app(_admin())
         body = {

--- a/web/src/app/admin/autodiscovery/page.tsx
+++ b/web/src/app/admin/autodiscovery/page.tsx
@@ -42,6 +42,7 @@ interface AutodiscoveryRule {
     labels: Record<string, string>
     'owner-email': string
     'var-files': string[]
+    'execution-hook-templates'?: string[]
     'run-task-templates': RunTaskSpec[]
     'notification-templates': NotificationSpec[]
     'created-at': string
@@ -92,6 +93,7 @@ export default function AutodiscoveryPage() {
   const [labels, setLabels] = useState<Record<string, string>>({})
   const [ownerEmail, setOwnerEmail] = useState('')
   const [varFiles, setVarFiles] = useState<string[]>([])
+  const [executionHookTemplates, setExecutionHookTemplates] = useState<string[]>([])
   const [runTaskTemplates, setRunTaskTemplates] = useState<RunTaskSpec[]>([])
   const [notificationTemplates, setNotificationTemplates] = useState<NotificationSpec[]>([])
   const [submitting, setSubmitting] = useState(false)
@@ -216,6 +218,7 @@ export default function AutodiscoveryPage() {
     setLabels(a.labels || {})
     setOwnerEmail(a['owner-email'] || '')
     setVarFiles(a['var-files'] || [])
+    setExecutionHookTemplates(a['execution-hook-templates'] || [])
     setRunTaskTemplates(a['run-task-templates'] || [])
     setNotificationTemplates(a['notification-templates'] || [])
     setShowForm(true)
@@ -252,6 +255,7 @@ export default function AutodiscoveryPage() {
       labels,
       'owner-email': ownerEmail,
       'var-files': varFiles.map(s => s.trim()).filter(Boolean),
+      'execution-hook-templates': executionHookTemplates.map(s => s.trim()).filter(Boolean),
       'run-task-templates': runTaskTemplates,
       'notification-templates': notificationTemplates,
     }
@@ -648,6 +652,16 @@ export default function AutodiscoveryPage() {
                   onChange={setVarFiles}
                   placeholder="env/prod.tfvars"
                   addLabel="Add var file"
+                />
+              </div>
+              <div className="mt-4 pt-4 border-t border-slate-800">
+                <label className="block text-sm text-slate-300 mb-1">Execution hook ids (associated with each new workspace)</label>
+                <p className="text-xs text-slate-500 mb-2">Existing execution hook ids (<code>hook-…</code>) from the Execution Hooks admin page.</p>
+                <StringListEditor
+                  values={executionHookTemplates}
+                  onChange={setExecutionHookTemplates}
+                  placeholder="hook-0190…"
+                  addLabel="Add hook id"
                 />
               </div>
               <div className="mt-4 pt-4 border-t border-slate-800">

--- a/web/src/app/admin/autodiscovery/page.tsx
+++ b/web/src/app/admin/autodiscovery/page.tsx
@@ -60,6 +60,11 @@ interface AgentPool {
   attributes: { name: string }
 }
 
+interface ExecutionHookRef {
+  id: string
+  attributes: { name: string; 'hook-point': string; enabled: boolean }
+}
+
 type SortKey = 'name' | 'repo' | 'pattern' | 'enabled' | 'created'
 
 export default function AutodiscoveryPage() {
@@ -67,6 +72,7 @@ export default function AutodiscoveryPage() {
   const [rules, setRules] = useState<AutodiscoveryRule[]>([])
   const [connections, setConnections] = useState<VCSConnection[]>([])
   const [pools, setPools] = useState<AgentPool[]>([])
+  const [hooks, setHooks] = useState<ExecutionHookRef[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
@@ -143,10 +149,11 @@ export default function AutodiscoveryPage() {
 
   async function loadAll() {
     try {
-      const [rulesRes, connsRes, poolsRes] = await Promise.all([
+      const [rulesRes, connsRes, poolsRes, hooksRes] = await Promise.all([
         apiFetch('/api/terrapod/v1/autodiscovery-rules'),
         apiFetch('/api/terrapod/v1/vcs-connections'),
         apiFetch('/api/terrapod/v1/agent-pools'),
+        apiFetch('/api/terrapod/v1/execution-hooks'),
       ])
       if (!rulesRes.ok) throw new Error('Failed to load autodiscovery rules')
       const rulesData = await rulesRes.json()
@@ -158,6 +165,10 @@ export default function AutodiscoveryPage() {
       if (poolsRes.ok) {
         const pd = await poolsRes.json()
         setPools(pd.data || [])
+      }
+      if (hooksRes.ok) {
+        const hd = await hooksRes.json()
+        setHooks(hd.data || [])
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load')
@@ -187,6 +198,7 @@ export default function AutodiscoveryPage() {
     setLabels({})
     setOwnerEmail('')
     setVarFiles([])
+    setExecutionHookTemplates([])
     setRunTaskTemplates([])
     setNotificationTemplates([])
   }
@@ -655,14 +667,62 @@ export default function AutodiscoveryPage() {
                 />
               </div>
               <div className="mt-4 pt-4 border-t border-slate-800">
-                <label className="block text-sm text-slate-300 mb-1">Execution hook ids (associated with each new workspace)</label>
-                <p className="text-xs text-slate-500 mb-2">Existing execution hook ids (<code>hook-…</code>) from the Execution Hooks admin page.</p>
-                <StringListEditor
-                  values={executionHookTemplates}
-                  onChange={setExecutionHookTemplates}
-                  placeholder="hook-0190…"
-                  addLabel="Add hook id"
-                />
+                <label className="block text-sm text-slate-300 mb-1">Execution hooks (associated with each new workspace)</label>
+                <p className="text-xs text-slate-500 mb-2">
+                  Pick from hooks defined on the{' '}
+                  <span className="text-slate-400">Execution Hooks</span> admin page — each selected hook is
+                  associated with every workspace this rule creates.
+                </p>
+                {hooks.length === 0 ? (
+                  <p className="text-xs text-slate-500 italic">
+                    No execution hooks defined yet. Create one on the Execution Hooks admin page first.
+                  </p>
+                ) : (
+                  <div className="space-y-1.5 rounded-lg border border-slate-800 bg-slate-900/40 p-3 max-h-56 overflow-y-auto">
+                    {hooks.map(h => {
+                      const checked = executionHookTemplates.includes(h.id)
+                      return (
+                        <label key={h.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={e => {
+                              setExecutionHookTemplates(prev =>
+                                e.target.checked
+                                  ? [...prev, h.id]
+                                  : prev.filter(id => id !== h.id),
+                              )
+                            }}
+                            className="rounded border-slate-600 bg-slate-800 text-brand-500 focus:ring-brand-500"
+                          />
+                          <span className="text-slate-200">{h.attributes.name}</span>
+                          <span className="font-mono text-xs text-slate-500">{h.attributes['hook-point']}</span>
+                          {!h.attributes.enabled && (
+                            <span className="text-xs text-amber-400/80">(disabled)</span>
+                          )}
+                        </label>
+                      )
+                    })}
+                  </div>
+                )}
+                {/* Preserve any templated hook id no longer present in the library (e.g. a
+                    since-deleted hook) so editing an existing rule doesn't silently drop it. */}
+                {executionHookTemplates
+                  .filter(id => !hooks.some(h => h.id === id))
+                  .map(id => (
+                    <label key={id} className="flex items-center gap-2 text-xs mt-1.5 text-slate-500">
+                      <input
+                        type="checkbox"
+                        checked
+                        onChange={() =>
+                          setExecutionHookTemplates(prev => prev.filter(x => x !== id))
+                        }
+                        className="rounded border-slate-600 bg-slate-800 text-brand-500 focus:ring-brand-500"
+                      />
+                      <span className="font-mono">{id}</span>
+                      <span className="text-amber-400/80">(not in library — untick to remove)</span>
+                    </label>
+                  ))}
               </div>
               <div className="mt-4 pt-4 border-t border-slate-800">
                 <label className="block text-sm text-slate-300 mb-1">Run task templates (created on each new workspace)</label>


### PR DESCRIPTION
Closes #672 (follow-up to #619).

Autodiscovery rules can now carry an `execution-hook-templates` list; every workspace the rule materialises is auto-associated with those execution hooks, so discovered monorepo workspaces inherit their hooks with no second pass — mirroring `run-task-templates` / `notification-templates` (#318).

## Changes
- **Model** — `AutodiscoveryRule.execution_hook_templates` (JSONB list of hook ids) + migration `1429df8c538a` (additive, default `[]`).
- **Materialisation** — associate each templated hook onto the new workspace; **skip-if-missing** (a stale/deleted hook id is logged and skipped, never aborts the poll cycle).
- **Router** — validate (accepts `hook-<uuid>` or bare uuid; 422 on bad id) + serialize back as `hook-<uuid>`.
- **Provider** — `execution_hook_templates` list attribute on `terrapod_autodiscovery_rule`. go-terrapod passes the attribute map through, so no SDK change.
- **Web** — a **name-based hook picker** on the autodiscovery rule form: it loads the hook library and shows each hook as a checkbox labelled by name + hook point (no typing raw `hook-<uuid>` ids). Selection stores the ids under the hood, so the wire/API contract is unchanged. Also resets the selection between creates and preserves any templated id no longer in the library as a labelled "not in library — untick to remove" row so editing a rule can't silently drop a since-deleted hook.
- **Docs** — `autodiscovery.md` + `api-reference.md` rows.

## Tests
Router create-with-templates round-trips (`hook-<uuid>` and bare-uuid forms both normalise); invalid id → 422. `make lint` clean (ruff + tsc + eslint); api+services tiers green; single Alembic head; provider `go build` clean. Web `npm run build` passes. **Verified live in Tilt**: the autodiscovery create form renders seeded hooks as name-labelled checkboxes and no free-text id input remains.