### PR TITLE
feat(rbac): add platform:hook-admin capability to the vocabulary (#673)

### DIFF
--- a/docs/rbac-capabilities.md
+++ b/docs/rbac-capabilities.md
@@ -190,7 +190,7 @@ catalog-RBAC.
 `platform:registry-admin`, `platform:varset-admin`, `platform:user-admin`,
 `platform:audit-admin`, `platform:policy-admin`,
 `platform:autodiscovery-admin`, `platform:catalog-admin`,
-`platform:bulk-admin`, `platform:settings-admin`.
+`platform:bulk-admin`, `platform:settings-admin`, `platform:hook-admin`.
 
 These enumerate every `require_admin` / `require_admin_or_audit` surface in the
 API (roles, role-assignments, vcs-connections, pool create, binary/provider

--- a/services/terrapod/auth/capabilities.py
+++ b/services/terrapod/auth/capabilities.py
@@ -112,6 +112,7 @@ PLATFORM_AUTODISCOVERY_ADMIN = "platform:autodiscovery-admin"  # autodiscovery r
 PLATFORM_CATALOG_ADMIN = "platform:catalog-admin"  # catalog item + provider-template authoring
 PLATFORM_BULK_ADMIN = "platform:bulk-admin"  # bulk workspace operations
 PLATFORM_SETTINGS_ADMIN = "platform:settings-admin"  # platform settings (e.g. state-encryption)
+PLATFORM_HOOK_ADMIN = "platform:hook-admin"  # execution hooks + workspace association
 
 PLATFORM_CAPABILITIES: frozenset[str] = frozenset(
     {
@@ -127,6 +128,7 @@ PLATFORM_CAPABILITIES: frozenset[str] = frozenset(
         PLATFORM_CATALOG_ADMIN,
         PLATFORM_BULK_ADMIN,
         PLATFORM_SETTINGS_ADMIN,
+        PLATFORM_HOOK_ADMIN,
     }
 )
 

--- a/services/tests/auth/test_capabilities.py
+++ b/services/tests/auth/test_capabilities.py
@@ -222,6 +222,9 @@ def test_builtin_capability_sets():
     # admin = superuser: every grantable capability + every platform capability.
     assert cap.PLATFORM_CAPABILITIES <= admin
     assert cap.GRANTABLE_CAPABILITIES <= admin
+    # execution-hooks management (#619/#673) is part of the platform vocabulary,
+    # so admin's advertised capability set names it.
+    assert cap.PLATFORM_HOOK_ADMIN in admin
     # audit = read-only everywhere + the (read-only) audit-log power; no
     # write/manage caps and no platform capability other than audit-admin.
     assert {cap.WORKSPACE_READ, cap.POOL_READ, cap.REGISTRY_READ, cap.CATALOG_READ} <= audit


### PR DESCRIPTION
## What

Adds `platform:hook-admin` to `PLATFORM_CAPABILITIES` so the platform capability vocabulary — and therefore `capabilities_for_builtin("admin")` — names execution-hook management (the library CRUD + workspace association added in #619).

## Why

Execution hooks were the only platform surface with no corresponding `platform:*` capability, so the admin capability set under-reported what admin can actually do. Every other platform-admin surface (roles, VCS, pools, registry, varsets, users, audit, policy, autodiscovery, catalog, bulk, settings) already has a named entry.

## Scope / no behaviour change

Like every other `platform:*` capability today, this entry is **vocabulary only** — it documents the capability an admin holds and gives the scoped platform-admin split its target term. Enforcement across all platform surfaces stays `require_admin`-based until that split lands, so **no gate behaviour changes here**: hook management remains admin-only, consistent with the rest of the platform surface. Adding a standalone grantable gate for hooks alone would have made hooks the only inconsistent platform surface, front-running the deliberate whole-surface decomposition.

## Tests

- `services/tests/auth/test_capabilities.py::test_builtin_capability_sets` now asserts `platform:hook-admin` is in the admin capability set (and the existing `PLATFORM_CAPABILITIES <= admin` invariant covers it structurally).
- `docs/rbac-capabilities.md` platform enumeration updated.

closes #673