### PR TITLE
fix(runner): execute post_plan hooks + harden hook input validation (#619)

### DIFF
--- a/docs/execution-hooks.md
+++ b/docs/execution-hooks.md
@@ -41,8 +41,9 @@ run is marked errored with an "apply succeeded; post-apply hook failed" message
 ## Security
 
 A hook is operator-supplied shell that runs with the **runner's cloud identity**
-and can read the run's environment (including resolved variables). The trust
-boundary is the same as "who can run `terraform` here", so:
+and can read the run's environment — including resolved workspace variables
+(env-category secrets among them) and the short-lived runner API token. The
+trust boundary is the same as "who can run `terraform` here", so:
 
 - Managing hooks and their associations requires platform **`admin`**.
 - Every hook create/edit/associate is **audit-logged**.

--- a/services/terrapod/api/routers/execution_hooks.py
+++ b/services/terrapod/api/routers/execution_hooks.py
@@ -28,6 +28,16 @@ from terrapod.services import execution_hook_service
 router = APIRouter(tags=["execution-hooks"])
 
 
+def _coerce_priority(raw) -> int:
+    """Parse the priority attribute, returning 422 (not 500) on non-numeric input."""
+    try:
+        return int(raw or 0)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=422, detail="Execution hook priority must be an integer"
+        ) from exc
+
+
 def _rfc3339(dt) -> str:
     if dt is None:
         return ""
@@ -113,8 +123,8 @@ async def create_hook(
         description=attrs.get("description", ""),
         hook_point=hook_point,
         script=attrs.get("script", ""),
-        enabled=attrs.get("enabled", True),
-        priority=int(attrs.get("priority", 0) or 0),
+        enabled=bool(attrs.get("enabled", True)),
+        priority=_coerce_priority(attrs.get("priority", 0)),
     )
     db.add(hook)
     try:
@@ -164,7 +174,7 @@ async def update_hook(
     if "enabled" in attrs:
         hook.enabled = bool(attrs["enabled"])
     if "priority" in attrs:
-        hook.priority = int(attrs["priority"] or 0)
+        hook.priority = _coerce_priority(attrs["priority"])
 
     try:
         await db.commit()
@@ -213,8 +223,17 @@ async def add_hook_workspaces(
                 ExecutionHookWorkspace.workspace_id == ws_uuid,
             )
         )
-        if existing.scalar_one_or_none() is None:
-            db.add(ExecutionHookWorkspace(hook_id=hook.id, workspace_id=ws_uuid))
+        if existing.scalar_one_or_none() is not None:
+            continue
+        # Insert inside a SAVEPOINT so a concurrent request that created the same
+        # (hook, workspace) pair between our SELECT and INSERT is absorbed
+        # idempotently (409-worthy in general, but this endpoint is idempotent by
+        # contract) without a 500 or poisoning the rest of the batch.
+        try:
+            async with db.begin_nested():
+                db.add(ExecutionHookWorkspace(hook_id=hook.id, workspace_id=ws_uuid))
+        except IntegrityError:
+            pass
     await db.commit()
 
 

--- a/services/terrapod/runner/job_entrypoint.py
+++ b/services/terrapod/runner/job_entrypoint.py
@@ -329,6 +329,18 @@ def _run_plan_phase(
         except Exception as exc:  # noqa: BLE001
             log.warning("plan-json upload raised (non-fatal)", err=str(exc))
 
+    # post_plan execution hooks (#619) — after a successful plan and after its
+    # artifacts (plan file + show-json) are uploaded, so the hook can inspect
+    # the plan and the plan is visible in the UI regardless of the gate result.
+    # Runs last in the plan phase (mirroring post_apply): a failing hook returns
+    # non-zero, which errors the run and — for a plan+apply run — prevents the
+    # apply, the same way an OPA mandatory-set denial does.
+    try:
+        execution_hooks.run_point("post_plan", env=os.environ.copy())
+    except execution_hooks.HookError as exc:
+        log.error("post_plan hook failed", hook=exc.name, rc=exc.exit_code)
+        return exc.exit_code
+
     return 0
 
 

--- a/services/tests/api/test_execution_hooks.py
+++ b/services/tests/api/test_execution_hooks.py
@@ -99,6 +99,17 @@ class TestCreateHook:
             r = await c.post(_HOOKS, json=body, headers=_AUTH)
         assert r.status_code == 403
 
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_non_numeric_priority_422(self, *_mocks) -> None:
+        # A non-numeric priority must be a 422 (client error), never a 500.
+        app, _db = _make_app(_user())
+        body = {"data": {"attributes": {"name": "x", "hook-point": "pre_init", "priority": "high"}}}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            r = await c.post(_HOOKS, json=body, headers=_AUTH)
+        assert r.status_code == 422
+
 
 class TestListHooks:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)

--- a/services/tests/runner/test_job_entrypoint.py
+++ b/services/tests/runner/test_job_entrypoint.py
@@ -327,3 +327,78 @@ class TestApplyPhaseExecutionHooks:
         assert rc == 3, "pre_apply failure errors the run"
         run_apply.assert_not_called()  # nothing applied
         up.assert_not_called()  # no state touched
+
+
+class TestPlanPhaseExecutionHooks:
+    """post_plan hook semantics (#619): a post_plan hook must actually be
+    invoked in the plan phase (regression for it being accepted+delivered but
+    never executed), and a failing post_plan hook must error the run — which,
+    for a plan+apply run, prevents the apply, mirroring an OPA denial. The plan
+    artifacts are finalized (plan-result posted) BEFORE the gate runs, so the
+    plan is visible in the UI regardless of the gate result."""
+
+    def _cfg(self):
+        from unittest.mock import MagicMock
+
+        cfg = MagicMock()
+        cfg.has_api = False  # skip lock-splice / plan-artifacts / upload blocks
+        cfg.plan_only = False
+        return cfg
+
+    def _plan_result(self):
+        from unittest.mock import MagicMock
+
+        pr = MagicMock()
+        pr.exit_code = 0
+        pr.has_changes = True
+        return pr
+
+    def test_post_plan_hook_invoked_and_failure_errors_run(self, tmp_path) -> None:
+        from unittest.mock import patch
+
+        from terrapod.runner.phases import execution_hooks as eh
+
+        points: list[str] = []
+
+        def _run_point(point, env=None):
+            points.append(point)
+            if point == "post_plan":
+                raise eh.HookError("post_plan", "gate denied", 7)
+
+        with (
+            patch.object(job_entrypoint.plan_apply, "run_plan", return_value=self._plan_result()),
+            patch.object(job_entrypoint.opa, "evaluate_policies"),
+            patch.object(job_entrypoint.uploads, "post_plan_result") as ppr,
+            patch.object(job_entrypoint.uploads, "upload_plan_json"),
+            patch.object(job_entrypoint.execution_hooks, "run_point", side_effect=_run_point),
+        ):
+            rc = job_entrypoint._run_plan_phase(
+                self._cfg(), binary="tofu", var_file_argv=[], strip_dir=tmp_path, child_grace=1.0
+            )
+
+        assert rc == 7, "a failing post_plan hook errors the run with its exit code"
+        assert "post_plan" in points, "post_plan hook must actually be invoked (#619 regression)"
+        assert points == ["pre_plan", "post_plan"]
+        ppr.assert_called_once()  # plan finalized/visible BEFORE the gate ran
+
+    def test_post_plan_hook_success_returns_zero(self, tmp_path) -> None:
+        from unittest.mock import patch
+
+        points: list[str] = []
+
+        def _run_point(point, env=None):
+            points.append(point)
+
+        with (
+            patch.object(job_entrypoint.plan_apply, "run_plan", return_value=self._plan_result()),
+            patch.object(job_entrypoint.opa, "evaluate_policies"),
+            patch.object(job_entrypoint.uploads, "post_plan_result"),
+            patch.object(job_entrypoint.uploads, "upload_plan_json"),
+            patch.object(job_entrypoint.execution_hooks, "run_point", side_effect=_run_point),
+        ):
+            rc = job_entrypoint._run_plan_phase(
+                self._cfg(), binary="tofu", var_file_argv=[], strip_dir=tmp_path, child_grace=1.0
+            )
+
+        assert rc == 0
+        assert points == ["pre_plan", "post_plan"]


### PR DESCRIPTION
## Context

Pre-release adversarial review of the execution-hooks feature (shipping in the next minor) surfaced a **silent control-bypass**: `post_plan` hooks were accepted, delivered to the runner, documented (`docs/execution-hooks.md` describes post_plan as an "external gate"), and selectable in the UI — but the orchestrator **never invoked them**. It called `run_point` only for `pre_init`/`pre_plan`/`pre_apply`/`post_apply`.

Impact: an operator defining a `post_plan` hook as a gate would have it silently no-op, and the plan would proceed to apply un-gated.

## Fixes

- **Wire `run_point("post_plan", …)`** into the plan phase, after the plan + its artifacts (plan file, show-json, plan-result) are finalized — so the plan is visible in the UI regardless of the gate — with the same fail-the-run semantics as the other points. A non-zero `post_plan` hook errors the run and, for a plan+apply run, prevents the apply, mirroring an OPA mandatory-set denial.
- **Router hardening** (`execution_hooks.py`):
  - Non-numeric `priority` → **422** instead of 500 (shared `_coerce_priority` on create + update).
  - `enabled` bool-coerced on create (consistency with update).
  - Workspace-association endpoint absorbs a concurrent-insert `IntegrityError` via a per-item **SAVEPOINT**, staying idempotent (204) instead of 500, without poisoning the rest of the batch.
- **Docs**: the hook Security note now explicitly states a hook can read the runner's API token and env-category secrets.

## Tests

- New plan-phase runner tests: assert `post_plan` **is invoked** and that a failing `post_plan` errors the run **after** the plan is finalized (regression for the bypass).
- Router test: non-numeric `priority` → 422.
- Full `make test` green (2141 passed); `make lint` clean.

Refs #619. Found by the pre-release third-party review; landing before the v0.53.0 tag.