### PR TITLE
feat(hooks): server-side kill-switch enforcement + script length bound (#678)

### DIFF
--- a/docs/execution-hooks.md
+++ b/docs/execution-hooks.md
@@ -56,14 +56,20 @@ trust boundary is the same as "who can run `terraform` here", so:
 ## Enabling / kill-switch
 
 Execution hooks are available by default. The platform kill-switch is the Helm
-value **`runners.hooksEnabled`** (default `true`); set it to `false` to stop the
-listener from ever delivering hooks to runner Jobs — for sealed or
-security-conscious deployments that want to disallow custom-shell hooks:
+value **`runners.hooksEnabled`** (default `true`); set it to `false` to disallow
+custom-shell hooks entirely — for sealed or security-conscious deployments:
 
 ```yaml
 runners:
   hooksEnabled: false
 ```
+
+When disabled, the switch is enforced in two places: the **API** serves no hooks
+in the run payload (authoritative — a custom listener that ignores the flag still
+receives nothing), and the bundled **listener** also drops hooks when building
+the Job (defense in depth).
+
+A hook `script` is capped at **64 KiB** (larger values are rejected with `422`).
 
 ## Managing hooks
 

--- a/services/terrapod/api/routers/execution_hooks.py
+++ b/services/terrapod/api/routers/execution_hooks.py
@@ -27,6 +27,20 @@ from terrapod.services import execution_hook_service
 
 router = APIRouter(tags=["execution-hooks"])
 
+# A hook script is delivered verbatim in the per-run vars Secret; bound it so a
+# runaway value can't bloat the Secret. 64 KiB is far above any real hook.
+_MAX_SCRIPT_LEN = 64 * 1024
+
+
+def _validate_script(script: str) -> str:
+    """Reject an over-long hook script with 422 (never store an unbounded blob)."""
+    if len(script) > _MAX_SCRIPT_LEN:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Execution hook script exceeds the {_MAX_SCRIPT_LEN}-byte limit",
+        )
+    return script
+
 
 def _coerce_priority(raw) -> int:
     """Parse the priority attribute, returning 422 (not 500) on non-numeric input."""
@@ -122,7 +136,7 @@ async def create_hook(
         name=name,
         description=attrs.get("description", ""),
         hook_point=hook_point,
-        script=attrs.get("script", ""),
+        script=_validate_script(attrs.get("script", "")),
         enabled=bool(attrs.get("enabled", True)),
         priority=_coerce_priority(attrs.get("priority", 0)),
     )
@@ -170,7 +184,7 @@ async def update_hook(
         execution_hook_service.validate_hook_point(attrs["hook-point"])
         hook.hook_point = attrs["hook-point"]
     if "script" in attrs:
-        hook.script = attrs["script"]
+        hook.script = _validate_script(attrs["script"] or "")
     if "enabled" in attrs:
         hook.enabled = bool(attrs["enabled"])
     if "priority" in attrs:

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1475,11 +1475,19 @@ async def next_run(
     # Resolve execution hooks associated with this workspace (#619). Delivered
     # alongside the vars via the per-run Secret; the runner runs each hook_point
     # at its boundary. Enforced-empty for local execution never reaches here
-    # (next_run is the agent-mode listener endpoint). The listener applies the
-    # runners.hooks.enabled kill-switch when building the Job.
+    # (next_run is the agent-mode listener endpoint).
+    #
+    # Kill-switch (#678): enforce `runners.hooksEnabled` HERE, server-side and
+    # authoritatively — when disabled the API serves NO hooks, so a custom
+    # listener that ignores the flag still never receives any hook script. The
+    # bundled listener also drops hooks when building the Job (defense in depth).
+    from terrapod.config import load_runner_config
     from terrapod.services.execution_hook_service import resolve_hooks_for_workspace
 
-    execution_hooks = await resolve_hooks_for_workspace(db, run.workspace_id)
+    if load_runner_config().hooks_enabled:
+        execution_hooks = await resolve_hooks_for_workspace(db, run.workspace_id)
+    else:
+        execution_hooks = []
 
     await db.commit()
 

--- a/services/tests/api/test_execution_hooks.py
+++ b/services/tests/api/test_execution_hooks.py
@@ -110,6 +110,25 @@ class TestCreateHook:
             r = await c.post(_HOOKS, json=body, headers=_AUTH)
         assert r.status_code == 422
 
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_oversized_script_422(self, *_mocks) -> None:
+        # A script beyond the 64 KiB bound must be a 422, not stored unbounded.
+        app, _db = _make_app(_user())
+        body = {
+            "data": {
+                "attributes": {
+                    "name": "big",
+                    "hook-point": "pre_init",
+                    "script": "x" * (64 * 1024 + 1),
+                }
+            }
+        }
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            r = await c.post(_HOOKS, json=body, headers=_AUTH)
+        assert r.status_code == 422
+
 
 class TestListHooks:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)

--- a/services/tests/integration/test_run_execution.py
+++ b/services/tests/integration/test_run_execution.py
@@ -428,6 +428,59 @@ class TestClaimRun:
         env = {v["key"]: v for v in data["attributes"]["env-vars"]}
         assert env["MY_ENV"]["value"] == "envval"
 
+    async def test_execution_hooks_killswitch_enforced_server_side(
+        self, app, client, setup, monkeypatch
+    ):
+        """The API serves NO execution hooks when the kill-switch is off (#678),
+        so a listener that ignores the flag still never receives a hook script.
+        Enabled (default) delivers the associated hook; disabled delivers []."""
+        from types import SimpleNamespace
+
+        pool_id, listener_id = setup
+
+        async def _mk_hook_ws(suffix):
+            ws_id = await _create_remote_workspace(client, pool_id, f"hook-ks-{suffix}")
+            r = await client.post(
+                "/api/terrapod/v1/execution-hooks",
+                json={
+                    "data": {
+                        "type": "execution-hooks",
+                        "attributes": {
+                            "name": f"ks-{suffix}",
+                            "hook-point": "pre_init",
+                            "script": "echo hi",
+                        },
+                    }
+                },
+                headers=AUTH,
+            )
+            assert r.status_code == 201, r.text
+            hook_id = r.json()["data"]["id"]
+            r = await client.post(
+                f"/api/terrapod/v1/execution-hooks/{hook_id}/relationships/workspaces",
+                json={"data": [{"id": ws_id, "type": "workspaces"}]},
+                headers=AUTH,
+            )
+            assert r.status_code == 204, r.text
+            return ws_id
+
+        # Enabled (default): the associated hook is delivered to the runner.
+        ws_on = await _mk_hook_ws("on")
+        await _create_run(client, ws_on)
+        data_on, _ = await _claim_run(client, listener_id)
+        assert len(data_on["attributes"]["execution-hooks"]) == 1
+
+        # Kill-switch off: the API serves no hooks even though one is associated.
+        from terrapod import config as _cfg
+
+        monkeypatch.setattr(
+            _cfg, "load_runner_config", lambda *a, **k: SimpleNamespace(hooks_enabled=False)
+        )
+        ws_off = await _mk_hook_ws("off")
+        await _create_run(client, ws_off)
+        data_off, _ = await _claim_run(client, listener_id)
+        assert data_off["attributes"]["execution-hooks"] == []
+
 
 class TestPlanOnlyLifecycle:
     async def test_plan_only_full_lifecycle(self, app, client, setup):


### PR DESCRIPTION
Hardening follow-ups from the pre-release review of execution hooks, requested for the v0.53.0 release. (The BLOCKER — post_plan never executing — landed separately in #677.)

## Changes

- **Kill-switch is now authoritative server-side.** `runners.hooksEnabled` was enforced only at the listener; a custom/third-party listener that ignored the flag would still receive hook scripts in the run payload. `next_run` now gates hook resolution on `load_runner_config().hooks_enabled` (the same flag, already loaded by the API) — when off, the API serves an empty `execution-hooks` list, so no listener can run a hook. The bundled listener still drops hooks too (defense in depth). No new config plumbing.
- **Hook `script` bounded at 64 KiB** (`_validate_script` on create + update → 422), so a runaway value can't bloat the per-run vars Secret.

## Tests

- Integration (`test_run_execution.py`): the associated hook IS delivered when enabled, and `[]` when the kill-switch is off (real DB + `next_run` payload).
- Router (`test_execution_hooks.py`): oversized script → 422.
- `make lint` clean; api + runner + integration tiers green.

closes #678