### PR TITLE
docs: add a "Why Terrapod" design-focus section (#559)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 
 ![Workspaces](docs/images/workspaces.png)
 
+## Why Terrapod
+
+Beyond broad TFE compatibility, Terrapod is built with three deliberate design foci:
+
+- **Restricted-network & multi-cluster execution.** Runner listeners connect *outbound* over SSE and create Kubernetes Jobs locally, so the API never needs inbound reach into the clusters where runs happen — they can sit in isolated VPCs, other regions, or behind firewalls. VCS is polling-first (webhooks optional), and a pull-through provider mirror + CLI binary cache — with an air-gap **sealed mode** — let runners resolve providers and binaries with no upstream internet for cached platforms. See [docs/deployment-network-isolation.md](docs/deployment-network-isolation.md) and the [ARC execution model](docs/architecture.md#runner-architecture-arc-pattern).
+- **An AI-augmented review layer.** Every plan can carry an LLM-generated change summary and risk assessment, with failure analysis on errored plans and a chat to interrogate a run — provider-agnostic via LiteLLM, and **disabled by default** for AI-averse deployments. See [docs/ai-plan-summary.md](docs/ai-plan-summary.md).
+- **A low contribution barrier.** The platform core is **Python** (FastAPI + async SQLAlchemy), so the surface most changes touch is approachable; the consumer ecosystem (Go SDK, Terraform provider, migration/publish CLIs) is **Go**. AI-assisted contributions are welcome — point your assistant at [`llms.txt`](llms.txt) and [AGENTS.md](AGENTS.md), then see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
 > **Drop-in replacement for HCP Terraform.** Point your existing `cloud` blocks, `go-tfe` clients, and CI/CD pipelines at Terrapod — zero code changes required.
 
 > **AI-augmented plans.** Every plan can carry an LLM-generated change description, risk assessment, and (on failure) suggested fixes — provider-agnostic via [LiteLLM](https://github.com/BerriAI/litellm). Wire AWS Bedrock (Claude, Nova, gpt-oss) with native IAM auth, or point at OpenAI, Anthropic, Gemini, Azure OpenAI, or any OpenAI-compatible endpoint. See [docs/ai-plan-summary.md](docs/ai-plan-summary.md).

--- a/docs/ai-plan-summary.md
+++ b/docs/ai-plan-summary.md
@@ -1,5 +1,7 @@
 # AI Plan Summary
 
+> Part of Terrapod's **AI-augmented review layer** design focus — see [Why Terrapod](../README.md#why-terrapod). Disabled by default; opt in per the configuration below.
+
 Terrapod can attach an AI-generated change summary and risk assessment
 to every plan, and an AI-generated failure analysis to every plan that
 errors. The summary lands in the run UI alongside the plan output, can

--- a/docs/deployment-network-isolation.md
+++ b/docs/deployment-network-isolation.md
@@ -1,5 +1,7 @@
 # Split-networking deployments
 
+> Part of Terrapod's **restricted-network & multi-cluster execution** design focus — see [Why Terrapod](../README.md#why-terrapod). Related: the [ARC execution model](architecture.md#runner-architecture-arc-pattern), the [webhook split](deployment-webhook-ingress.md), and [forward-proxy support](deployment-proxy.md).
+
 By default, every Terrapod consumer — a human's browser, the `terraform` CLI cloud block, listener pods in remote clusters, runner Jobs uploading state — reaches the API through a single `Ingress`. That works fine when the management plane is freely reachable from every network the consumers live in.
 
 It often isn't. Common shapes where it isn't:

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,16 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 
 ---
 
+## Why Terrapod
+
+Beyond broad TFE compatibility, Terrapod is built with three deliberate design foci:
+
+- **Restricted-network & multi-cluster execution.** Runner listeners connect *outbound* over SSE and create Kubernetes Jobs locally, so the API never needs inbound reach into the clusters where runs happen. VCS is polling-first (webhooks optional), and a pull-through provider mirror + CLI binary cache — with an air-gap **sealed mode** — let runners resolve providers and binaries with no upstream internet for cached platforms. See [Split-networking deployments](deployment-network-isolation.md) and the [ARC execution model](architecture.md#runner-architecture-arc-pattern).
+- **An AI-augmented review layer.** Every plan can carry an LLM-generated change summary and risk assessment, with failure analysis on errored plans and a chat to interrogate a run — provider-agnostic via LiteLLM, and **disabled by default**. See [AI Plan Summary](ai-plan-summary.md).
+- **A low contribution barrier.** The platform core is **Python** (FastAPI + async SQLAlchemy); the consumer ecosystem (Go SDK, Terraform provider, migration/publish CLIs) is **Go**. AI-assisted contributions are welcome — see [`llms.txt`](../llms.txt), [AGENTS.md](../AGENTS.md), and [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+---
+
 ## Features
 
 | Feature | Description |


### PR DESCRIPTION
Closes #559.

Sharpens Terrapod's positioning around the three things it's deliberately built for, stated **on their own merits** (no comparison/ranking framing, per the repo's peer-respect convention):

1. **Restricted-network & multi-cluster execution** — outbound SSE listeners that create Jobs locally, polling-first VCS (webhooks optional), pull-through provider mirror + CLI binary cache + air-gap sealed mode.
2. **AI-augmented review layer** — plan summaries, failure analysis, chat; provider-agnostic via LiteLLM; disabled by default.
3. **Low contribution barrier** — Python platform core, Go consumer ecosystem; AI-assisted contributions welcome.

## Changes
- New **`## Why Terrapod`** section near the top of `README.md`, each bullet linking the relevant `docs/` page (network-isolation, ARC execution model, AI plan summary; `llms.txt`/`AGENTS.md`/`CONTRIBUTING.md` for the on-ramp).
- Mirrored into `docs/index.md` (the docs entry point) with docs-relative links.
- Back-links from `docs/deployment-network-isolation.md` and `docs/ai-plan-summary.md` to the framing.

Docs-only; all link targets + the `architecture.md#runner-architecture-arc-pattern` anchor verified to resolve.