### PR TITLE
feat(slack): config channel + Socket Mode connection + operator runbook (#556)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,14 +519,21 @@ jobs:
           # Execution-hooks kill-switch (#619) renders into runners.yaml on by
           # default (config-channel contract).
           echo "$out" | grep -q "hooks_enabled: true" || { echo "FAIL: runners.yaml hooks_enabled not rendered"; exit 1; }
+          # Slack integration (#556) is OFF by default: config renders but no
+          # secret env is injected (no existingSecret) — config-channel contract.
+          echo "$out" | grep -q "TERRAPOD_SLACK__" && { echo "FAIL: Slack secret env injected when disabled"; exit 1; }
           echo "Stock install renders web + Ingress + bootstrap + hooks_enabled OK"
       - name: Local dev values render
         run: |
-          docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
             template terrapod helm/terrapod \
               --values helm/terrapod/values.yaml \
-              --values helm/terrapod/values-local.yaml > /dev/null
-          echo "values-local renders OK"
+              --values helm/terrapod/values-local.yaml)
+          # Slack config-channel: non-secret settings render into config.yaml,
+          # secret tokens arrive via secretKeyRef env (never the ConfigMap).
+          echo "$out" | grep -q 'default_channel: "#integration"' || { echo "FAIL: slack config not rendered into config.yaml"; exit 1; }
+          echo "$out" | grep -q "TERRAPOD_SLACK__BOT_TOKEN" || { echo "FAIL: slack bot-token secretKeyRef env missing"; exit 1; }
+          echo "values-local renders OK (incl. Slack config + secretKeyRef)"
       - name: Eval values render (embedded Postgres/Redis)
         run: |
           out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \

--- a/docs/slack-app-manifest.json
+++ b/docs/slack-app-manifest.json
@@ -1,0 +1,37 @@
+{
+  "display_information": {
+    "name": "Terrapod",
+    "description": "Interactive Terraform run approvals and status from Slack"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "terrapod",
+      "always_online": true
+    },
+    "slash_commands": [
+      {
+        "command": "/terrapod",
+        "description": "Query workspaces, runs, and pending approvals",
+        "usage_hint": "status | runs | approvals",
+        "should_escape": false
+      }
+    ]
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "chat:write",
+        "chat:write.public",
+        "commands"
+      ]
+    }
+  },
+  "settings": {
+    "interactivity": {
+      "is_enabled": true
+    },
+    "socket_mode_enabled": true,
+    "org_deploy_enabled": false,
+    "token_rotation_enabled": false
+  }
+}

--- a/docs/slack-integration.md
+++ b/docs/slack-integration.md
@@ -1,0 +1,181 @@
+# Slack integration
+
+Terrapod integrates with Slack so run notifications land in a channel and —
+in later phases — operators can approve or discard runs from the message
+itself. This guide gets the integration **connected end to end**.
+
+It is written for the common real-world situation where **two different people
+set this up**: a **Slack admin** (often IT, who owns the Slack workspace) and a
+**Terrapod operator** (the SRE running the platform). Neither needs access to
+the other's system. Each part below says who does it.
+
+> **Phase status.** Today the integration establishes the connection and posts
+> a connectivity check to a channel. Interactive approve/discard and the
+> `/terrapod` slash command build on this same app and connection — no Slack
+> reconfiguration is needed when they land, so setting this up now is not throwaway work.
+
+---
+
+## How it connects (why there's nothing to expose)
+
+Terrapod talks to Slack over **Socket Mode**: the Terrapod API opens an
+**outbound** WebSocket *to* Slack and receives events over it. Slack never needs
+to reach into your network — there is **no public URL, no inbound firewall rule,
+no ingress change**. This is the same outbound-only posture as Terrapod's runner
+listeners, and it means the integration works even when the Terrapod management
+plane is private (VPN/tailnet/IP-restricted).
+
+(An alternative "Request URL" mode, where Slack POSTs to a public endpoint, is
+possible via the [split webhook ingress](deployment-webhook-ingress.md) — but
+Socket Mode is the default and needs none of that.)
+
+---
+
+## Who does what
+
+| Step | Slack admin (owns the Slack workspace) | Terrapod operator (owns the deployment) |
+|---|---|---|
+| 1 | Create the Slack app from the manifest | — |
+| 2 | Install it and collect the **three tokens** + channel | — |
+| 3 | — | Store the three tokens in a Kubernetes Secret |
+| 4 | — | Turn the integration on in Helm values and deploy |
+| 5 | — | Verify the bot is online and greeted the channel |
+
+The handoff between them is exactly three secret strings and one channel name.
+
+---
+
+## Part A — Slack admin: create the app and hand over the tokens
+
+You need permission to create/install apps in the target Slack workspace. If
+your workspace requires admin approval for apps, you (or a workspace owner) will
+approve it in step 2.
+
+### A1. Create the app from Terrapod's manifest
+
+The manifest pins the exact name, scopes, slash command, and Socket Mode
+setting so there's nothing to decide.
+
+1. Go to **https://api.slack.com/apps** → **Create New App** → **From an app manifest**.
+2. Choose the target workspace.
+3. Paste the contents of [`slack-app-manifest.json`](slack-app-manifest.json)
+   (JSON tab) — the operator will send you this file, or grab it from the
+   Terrapod repo. Review and **Create**.
+
+### A2. Generate the three tokens
+
+All three come from the app you just created (left sidebar of the app's page):
+
+| # | Token | Where | Notes |
+|---|---|---|---|
+| 1 | **App-Level Token** (`xapp-…`) | **Basic Information → App-Level Tokens → Generate Token and Scopes** | Add the **`connections:write`** scope. This is what Socket Mode dials out with. |
+| 2 | **Bot User OAuth Token** (`xoxb-…`) | **OAuth & Permissions → Install to Workspace** → then copy the token | Installing is what mints this. Approve the install if prompted. |
+| 3 | **Signing Secret** | **Basic Information → App Credentials → Signing Secret → Show** | Belt-and-braces; used only if you ever switch to Request-URL mode. |
+
+### A3. Add the bot to a channel
+
+In Slack, pick or create the channel Terrapod should post to (e.g. `#integration`)
+and run `/invite @terrapod` in it. Note the **channel name** for the operator.
+
+### A4. Hand over
+
+Give the Terrapod operator, over a secure channel (password manager share, not
+plain email/chat):
+
+- the three tokens from A2, and
+- the channel name from A3.
+
+That's the entire Slack-side job. You do **not** need any Terrapod access.
+
+---
+
+## Part B — Terrapod operator: wire it into Terrapod
+
+You never touch Slack. You take the three tokens + channel and configure Terrapod.
+
+### B1. Store the tokens in a Kubernetes Secret
+
+Secrets are delivered to the API via `secretKeyRef` — they are **never** put in
+Helm values or a ConfigMap. Create the Secret in Terrapod's namespace:
+
+```sh
+kubectl -n <terrapod-namespace> create secret generic terrapod-slack \
+  --from-literal=bot-token='xoxb-…' \
+  --from-literal=app-token='xapp-…' \
+  --from-literal=signing-secret='…'
+```
+
+(The key names `bot-token` / `app-token` / `signing-secret` are the chart
+defaults; override them under `api.config.slack.existingSecretKeys` if you must.)
+
+### B2. Turn it on in Helm values
+
+```yaml
+api:
+  config:
+    slack:
+      enabled: true
+      socketMode: true                 # outbound WebSocket; no ingress change
+      defaultChannel: "#integration"   # the channel from A3
+      existingSecret: terrapod-slack   # the Secret from B1
+```
+
+Apply with `helm upgrade` (or your GitOps flow).
+
+### B3. Verify
+
+- In Slack, the **Terrapod** app shows as **online**.
+- The channel receives a **connectivity message** from Terrapod shortly after the API pod starts.
+- API logs show `slack.socket_mode_connected`.
+
+If all three are true, the connection is live.
+
+---
+
+## Reference
+
+**Helm values** (`api.config.slack`):
+
+| Value | Default | Purpose |
+|---|---|---|
+| `enabled` | `false` | Master switch for the integration. |
+| `socketMode` | `true` | Outbound Socket Mode. `false` → Request-URL mode (needs the webhook ingress). |
+| `defaultChannel` | `""` | Channel for the connectivity check / fallback posts. |
+| `existingSecret` | `""` | Name of the K8s Secret holding the three tokens. |
+| `existingSecretKeys.botToken` / `.appToken` / `.signingSecret` | `bot-token` / `app-token` / `signing-secret` | Keys within that Secret. |
+
+**Secret → env mapping** (set on the API deployment via `secretKeyRef`):
+
+| Secret key | Env var |
+|---|---|
+| bot-token | `TERRAPOD_SLACK__BOT_TOKEN` |
+| app-token | `TERRAPOD_SLACK__APP_TOKEN` |
+| signing-secret | `TERRAPOD_SLACK__SIGNING_SECRET` |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Bot shows offline; no `slack.socket_mode_connected` log | App-level token missing or lacks `connections:write`; `enabled` false; wrong Secret name. |
+| Connected, but no channel message | Bot not invited to the channel (`/invite @terrapod`), or `defaultChannel` wrong/empty. |
+| `not_in_channel` / `channel_not_found` in logs | Invite the bot to the channel, or use a channel the bot can post to (`chat:write.public` covers public channels). |
+| `invalid_auth` in logs | Bot token wrong or revoked — reinstall the app and update the Secret. |
+| Log shows tokens missing while `enabled: true` | The Secret isn't wired: check `existingSecret` and that the Secret has all three keys. |
+
+---
+
+## Security notes
+
+- **No inbound exposure.** Socket Mode is outbound-only; nothing about this
+  opens a path into your network.
+- **Tokens are secrets.** They live in a Kubernetes Secret and reach the pod via
+  `secretKeyRef` — never in Helm values, ConfigMaps, or source control. Treat
+  the bot and app-level tokens like any credential; rotate them (regenerate in
+  the Slack app, update the Secret) if exposed.
+- **Least privilege.** The manifest requests only `chat:write`,
+  `chat:write.public`, and `commands`. Interactive approvals (a later phase) are
+  authorised against the acting user's **Terrapod** identity and RBAC, not by
+  Slack channel membership — so being in the channel never implies permission to
+  apply.

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -293,6 +293,15 @@ data:
       poll_interval_seconds: {{ .Values.api.config.drift_detection.poll_interval_seconds | default 300 }}
       min_workspace_interval_seconds: {{ .Values.api.config.drift_detection.min_workspace_interval_seconds | default 3600 }}
     {{- end }}
+    {{- if .Values.api.config.slack }}
+    slack:
+      # Non-secret Slack settings only. The bot/app/signing tokens are secrets
+      # and are injected via secretKeyRef on the Deployment (see deployment-api.yaml),
+      # never rendered here.
+      enabled: {{ .Values.api.config.slack.enabled }}
+      socket_mode: {{ .Values.api.config.slack.socket_mode }}
+      default_channel: {{ .Values.api.config.slack.default_channel | default "" | quote }}
+    {{- end }}
     {{- if .Values.api.config.notifications }}
     notifications:
       enabled: {{ .Values.api.config.notifications.enabled }}

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -130,6 +130,24 @@ spec:
                   name: {{ .Values.api.config.vcs.github.existingSecret }}
                   key: {{ .Values.api.config.vcs.github.existingSecretKey | default "webhook_secret" }}
             {{- end }}
+            {{- if (.Values.api.config.slack).existingSecret }}
+            # Slack integration (#556) — bot/app/signing tokens via secretKeyRef.
+            - name: TERRAPOD_SLACK__BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.config.slack.existingSecret }}
+                  key: {{ (.Values.api.config.slack.existingSecretKeys).botToken | default "bot-token" }}
+            - name: TERRAPOD_SLACK__APP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.config.slack.existingSecret }}
+                  key: {{ (.Values.api.config.slack.existingSecretKeys).appToken | default "app-token" }}
+            - name: TERRAPOD_SLACK__SIGNING_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.config.slack.existingSecret }}
+                  key: {{ (.Values.api.config.slack.existingSecretKeys).signingSecret | default "signing-secret" }}
+            {{- end }}
             {{- if and .Values.api.config.vcs.gitlab .Values.api.config.vcs.gitlab.existingSecret }}
             - name: TERRAPOD_VCS__GITLAB__WEBHOOK_SECRET
               valueFrom:

--- a/helm/terrapod/values-local.yaml
+++ b/helm/terrapod/values-local.yaml
@@ -83,6 +83,14 @@ api:
     # surface are exercised in Tilt. Production defaults to off.
     catalog:
       enabled: true
+    # Interactive Slack integration (#556) on in local dev. Tokens live in the
+    # hand-created `terrapod-slack` K8s Secret (see docs/slack-integration.md);
+    # Socket Mode means no ingress/tunnel is needed for the dev loop.
+    slack:
+      enabled: true
+      socket_mode: true
+      default_channel: "#integration"
+      existingSecret: terrapod-slack
     # Fast cert renewal cycle for Tilt — listener cert valid for 5min so the
     # full bootstrap → renew → rotate loop is observable in a few minutes
     # instead of an hour. Production stays at the 1h default.

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -885,6 +885,26 @@
           }
         },
 
+        "slack": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "socket_mode": { "type": "boolean" },
+            "default_channel": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretKeys": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "botToken": { "type": "string" },
+                "appToken": { "type": "string" },
+                "signingSecret": { "type": "string" }
+              }
+            }
+          }
+        },
+
         "notifications": {
           "type": "object",
           "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -499,6 +499,22 @@ api:
       poll_interval_seconds: 300
       min_workspace_interval_seconds: 3600
 
+    # Interactive Slack integration (#556). OFF by default. Transport is Socket
+    # Mode — an OUTBOUND WebSocket to Slack, so no public URL / ingress change is
+    # needed (matches the restricted-network execution model). The bot/app/signing
+    # tokens are SECRETS: put them in a K8s Secret and reference it via
+    # `existingSecret` — they are injected via secretKeyRef, never rendered into
+    # the ConfigMap. See docs/slack-integration.md for the full setup.
+    slack:
+      enabled: false
+      socket_mode: true              # false → Request-URL mode (needs webhook ingress)
+      default_channel: ""            # e.g. "#integration" — connectivity check / fallback
+      existingSecret: ""             # K8s Secret holding the three tokens
+      existingSecretKeys:            # keys within that Secret
+        botToken: bot-token
+        appToken: app-token
+        signingSecret: signing-secret
+
     # Notifications
     notifications:
       enabled: true

--- a/llms.txt
+++ b/llms.txt
@@ -61,6 +61,7 @@ Build/lint/test all run in Docker via `make` (`make test`, `make lint`, `make de
 - [Run Tasks](docs/run-tasks.md): pre/post-plan external webhook validation hooks.
 - [Execution Hooks](docs/execution-hooks.md): admin-managed custom shell steps run in the runner Job at five lifecycle points (pre_init/pre_plan/post_plan/pre_apply/post_apply), associated with workspaces.
 - [Notifications](docs/notifications.md): webhook (HMAC), Slack Block Kit, email on run events.
+- [Slack integration](docs/slack-integration.md): interactive Slack via outbound Socket Mode (no public URL). Enable with `api.config.slack.enabled` + a K8s Secret of tokens. Phase 1 wires the connection; interactive approve/discard is in progress (#556).
 - [AI Plan Summary](docs/ai-plan-summary.md): LLM change summary + risk + failure analysis, provider-agnostic via LiteLLM (Bedrock/OpenAI/Anthropic/Gemini/vLLM).
 - [Audit Logging](docs/audit-logging.md), [Monitoring](docs/monitoring.md), [Artifact Retention](docs/artifact-retention.md): immutable event log, Prometheus metrics + shipped Grafana dashboard + alert rules with per-alert runbooks, automated cleanup.
 - [Terragrunt](docs/terragrunt.md): per-workspace Terragrunt support for agent-mode and CLI-driven runs.

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -25,6 +25,7 @@ pydantic = "^2.10.0"
 pydantic-settings = "^2.14.2"
 structlog = ">=25.5,<27.0"
 httpx = "^0.28.0"
+slack-sdk = "^3.33.0"
 pyyaml = "^6.0.0"
 aiofiles = "^25.1.0"
 # AWS S3

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -326,7 +326,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await start_scheduler()
     logger.info("Distributed scheduler started")
 
+    # Slack integration (#556) — best-effort outbound Socket Mode connection.
+    # Never fails startup: a misconfigured/disabled Slack just logs and skips.
+    from terrapod.services.slack_service import start_slack
+
+    await start_slack(settings)
+
     yield
+
+    # Stop Slack connection
+    from terrapod.services.slack_service import stop_slack
+
+    await stop_slack()
 
     # Stop scheduler
     await stop_scheduler()

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -833,6 +833,43 @@ class DriftDetectionConfig(BaseModel):
     )
 
 
+# --- Slack Integration ---
+
+
+class SlackConfig(BaseModel):
+    """Interactive Slack integration (#556).
+
+    Phase 1 wires the connection: an outbound **Socket Mode** WebSocket to Slack
+    (no public/inbound URL required, matching the restricted-network execution
+    model) plus a connectivity check. Later phases add action buttons, the
+    `/terrapod` slash command, and account-linked, RBAC-checked approve/discard.
+
+    The three tokens are **secrets** and arrive via env (secretKeyRef), never the
+    ConfigMap — `TERRAPOD_SLACK__BOT_TOKEN` / `__APP_TOKEN` / `__SIGNING_SECRET`.
+    Full operator setup (incl. the Slack-admin ↔ operator handoff): see
+    docs/slack-integration.md.
+    """
+
+    enabled: bool = Field(default=False, description="Enable the Slack integration")
+    socket_mode: bool = Field(
+        default=True,
+        description=(
+            "Use Socket Mode — an outbound WebSocket, no public URL. When false, "
+            "Slack reaches the Request-URL endpoint via the public webhook ingress."
+        ),
+    )
+    default_channel: str = Field(
+        default="",
+        description="Channel for the connectivity check / fallback posts (e.g. #integration).",
+    )
+    # --- secrets: delivered via secretKeyRef → env, never rendered to the ConfigMap ---
+    bot_token: str = Field(default="", description="Bot User OAuth Token (xoxb-…)")
+    app_token: str = Field(
+        default="", description="App-Level Token with connections:write (xapp-…), for Socket Mode"
+    )
+    signing_secret: str = Field(default="", description="Slack app signing secret")
+
+
 # --- CORS Configuration ---
 
 
@@ -1543,6 +1580,9 @@ class Settings(BaseSettings):
 
     # Drift Detection
     drift_detection: DriftDetectionConfig = Field(default_factory=DriftDetectionConfig)
+
+    # Slack integration (#556)
+    slack: SlackConfig = Field(default_factory=SlackConfig)
 
     # CORS
     cors: CORSConfig = Field(default_factory=CORSConfig)

--- a/services/terrapod/services/slack_service.py
+++ b/services/terrapod/services/slack_service.py
@@ -80,9 +80,9 @@ async def start_slack(settings) -> None:
 async def _post_hello(web, channel: str) -> None:
     """Post a one-time connectivity check, de-duplicated across replicas."""
     try:
-        from terrapod.redis.client import get_redis
+        from terrapod.redis.client import get_redis_client
 
-        redis = get_redis()
+        redis = get_redis_client()
         # Only the replica that wins the SET NX greets the channel.
         won = await redis.set(_HELLO_DEDUP_KEY, "1", nx=True, ex=_HELLO_DEDUP_TTL)
         if not won:

--- a/services/terrapod/services/slack_service.py
+++ b/services/terrapod/services/slack_service.py
@@ -1,0 +1,112 @@
+"""Slack integration — Socket Mode connection lifecycle (#556).
+
+Phase 1 establishes the outbound **Socket Mode** WebSocket to Slack and posts a
+connectivity check to the configured channel, so operators can confirm the app
+is wired end to end before any approval logic exists. Later phases attach
+interaction handlers (approve/discard) and the `/terrapod` slash command to the
+same connection.
+
+Design notes:
+- **Outbound only.** Socket Mode dials *out* to Slack; the API needs no public
+  URL or inbound firewall rule (same posture as the runner listeners).
+- **Multi-replica safe.** Every API replica may hold its own Socket Mode
+  connection; Slack load-balances each event to exactly one connection, so no
+  leader election is needed. The one-time connectivity post is de-duplicated
+  across replicas via a Redis `SET NX` guard so the channel is greeted once.
+- **All I/O is async** (`slack_sdk` aiohttp clients) per the no-sync-in-async
+  rule; nothing here blocks the event loop.
+
+See docs/slack-integration.md for operator setup.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Module-global handle so the lifespan can disconnect cleanly on shutdown.
+_socket_client = None
+
+_HELLO_DEDUP_KEY = "tp:slack:hello_posted"
+_HELLO_DEDUP_TTL = 300  # seconds — one greeting per deployment start window
+
+
+async def start_slack(settings) -> None:
+    """Open the Socket Mode connection if Slack is enabled and configured.
+
+    Best-effort: a misconfiguration logs and returns rather than failing API
+    startup — Slack is an accessory, never a hard dependency of the API.
+    """
+    cfg = settings.slack
+    if not cfg.enabled:
+        return
+    if not cfg.socket_mode:
+        # Request-URL mode is wired at the ingress/receiver layer, not here.
+        logger.info("slack.request_url_mode_selected_socket_start_skipped")
+        return
+    if not (cfg.app_token and cfg.bot_token):
+        logger.warning(
+            "slack.enabled_but_tokens_missing",
+            have_app_token=bool(cfg.app_token),
+            have_bot_token=bool(cfg.bot_token),
+        )
+        return
+
+    try:
+        from slack_sdk.socket_mode.aiohttp import SocketModeClient
+        from slack_sdk.web.async_client import AsyncWebClient
+    except ImportError:
+        logger.error("slack.slack_sdk_not_installed")
+        return
+
+    global _socket_client
+    web = AsyncWebClient(token=cfg.bot_token)
+    _socket_client = SocketModeClient(app_token=cfg.app_token, web_client=web)
+
+    try:
+        await _socket_client.connect()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("slack.socket_mode_connect_failed", err=str(exc))
+        _socket_client = None
+        return
+
+    logger.info("slack.socket_mode_connected")
+
+    if cfg.default_channel:
+        await _post_hello(web, cfg.default_channel)
+
+
+async def _post_hello(web, channel: str) -> None:
+    """Post a one-time connectivity check, de-duplicated across replicas."""
+    try:
+        from terrapod.redis.client import get_redis
+
+        redis = get_redis()
+        # Only the replica that wins the SET NX greets the channel.
+        won = await redis.set(_HELLO_DEDUP_KEY, "1", nx=True, ex=_HELLO_DEDUP_TTL)
+        if not won:
+            return
+    except Exception as exc:  # noqa: BLE001
+        # If Redis is unavailable, greet anyway (dev/single-replica) — the
+        # connectivity check matters more than perfect de-duplication.
+        logger.debug("slack.hello_dedup_unavailable", err=str(exc))
+
+    try:
+        await web.chat_postMessage(
+            channel=channel,
+            text=":white_check_mark: Terrapod is connected to Slack (Socket Mode).",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("slack.hello_post_failed", channel=channel, err=str(exc))
+
+
+async def stop_slack() -> None:
+    """Disconnect the Socket Mode connection on API shutdown."""
+    global _socket_client
+    if _socket_client is not None:
+        try:
+            await _socket_client.disconnect()
+        except Exception:  # noqa: BLE001
+            pass
+        _socket_client = None

--- a/services/tests/services/test_slack_service.py
+++ b/services/tests/services/test_slack_service.py
@@ -1,0 +1,107 @@
+"""Tests for the Slack Socket Mode connection lifecycle (#556)."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.services import slack_service
+
+
+def _settings(**slack):
+    base = {
+        "enabled": False,
+        "socket_mode": True,
+        "default_channel": "",
+        "bot_token": "",
+        "app_token": "",
+        "signing_secret": "",
+    }
+    base.update(slack)
+    return SimpleNamespace(slack=SimpleNamespace(**base))
+
+
+@pytest.mark.asyncio
+async def test_disabled_does_not_connect():
+    slack_service._socket_client = None
+    await slack_service.start_slack(_settings(enabled=False))
+    assert slack_service._socket_client is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_but_missing_tokens_does_not_connect():
+    slack_service._socket_client = None
+    await slack_service.start_slack(_settings(enabled=True, app_token="", bot_token=""))
+    assert slack_service._socket_client is None
+
+
+@pytest.mark.asyncio
+async def test_socket_mode_false_skips_socket_start():
+    slack_service._socket_client = None
+    await slack_service.start_slack(
+        _settings(enabled=True, socket_mode=False, app_token="xapp-x", bot_token="xoxb-x")
+    )
+    assert slack_service._socket_client is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_with_tokens_connects_and_greets():
+    slack_service._socket_client = None
+
+    client_inst = MagicMock()
+    client_inst.connect = AsyncMock()
+    client_inst.disconnect = AsyncMock()
+    web_inst = MagicMock()
+    web_inst.chat_postMessage = AsyncMock()
+
+    sock_mod = MagicMock()
+    sock_mod.SocketModeClient = MagicMock(return_value=client_inst)
+    web_mod = MagicMock()
+    web_mod.AsyncWebClient = MagicMock(return_value=web_inst)
+    fake_modules = {
+        "slack_sdk": MagicMock(),
+        "slack_sdk.socket_mode": MagicMock(),
+        "slack_sdk.socket_mode.aiohttp": sock_mod,
+        "slack_sdk.web": MagicMock(),
+        "slack_sdk.web.async_client": web_mod,
+    }
+
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)  # win the hello de-dup
+
+    with (
+        patch.dict(sys.modules, fake_modules),
+        patch("terrapod.redis.client.get_redis", return_value=fake_redis),
+    ):
+        await slack_service.start_slack(
+            _settings(
+                enabled=True,
+                socket_mode=True,
+                app_token="xapp-x",
+                bot_token="xoxb-x",
+                default_channel="#integration",
+            )
+        )
+
+    client_inst.connect.assert_awaited_once()
+    web_inst.chat_postMessage.assert_awaited_once()
+    assert slack_service._socket_client is client_inst
+
+    await slack_service.stop_slack()
+    client_inst.disconnect.assert_awaited_once()
+    assert slack_service._socket_client is None
+
+
+def test_slack_config_defaults_and_nested_env(monkeypatch):
+    # Secret tokens map from the nested env vars the chart injects via secretKeyRef.
+    from terrapod.config import Settings
+
+    s = Settings()
+    assert s.slack.enabled is False
+    assert s.slack.socket_mode is True
+    assert s.slack.bot_token == ""
+
+    monkeypatch.setenv("TERRAPOD_SLACK__BOT_TOKEN", "xoxb-from-env")
+    s2 = Settings()
+    assert s2.slack.bot_token == "xoxb-from-env"

--- a/services/tests/services/test_slack_service.py
+++ b/services/tests/services/test_slack_service.py
@@ -72,7 +72,7 @@ async def test_enabled_with_tokens_connects_and_greets():
 
     with (
         patch.dict(sys.modules, fake_modules),
-        patch("terrapod.redis.client.get_redis", return_value=fake_redis),
+        patch("terrapod.redis.client.get_redis_client", return_value=fake_redis),
     ):
         await slack_service.start_slack(
             _settings(


### PR DESCRIPTION
First slice of the interactive Slack integration (#556). Wires the **connection** and — the priority — the **operator docs** to set it up. Later phases add action buttons, the `/terrapod` command, and account-linked approve/discard on this same app/connection (no Slack reconfiguration needed later, so this isn't throwaway).

## Transport: Socket Mode (outbound)

Terrapod opens an **outbound** WebSocket to Slack — no public URL, no ingress change, no inbound firewall rule. Same posture as the runner listeners; works even when the management plane is private. Request-URL mode remains possible via the split webhook ingress but Socket Mode is the default.

## What's here

- **Config** — `api.config.slack` (`enabled` / `socket_mode` / `default_channel`) via the ConfigMap. The bot/app/signing tokens are **secrets** injected via `secretKeyRef` (`TERRAPOD_SLACK__*`), never the ConfigMap. **Off by default.**
- **Connection** — `slack_service.start_slack` opens the async Socket Mode client on startup and posts a one-time connectivity check (Redis `SET NX` de-duped across replicas). Best-effort — a misconfig logs and skips, never fails API startup. Async I/O throughout (no-sync-in-async rule). Multi-replica safe (Slack load-balances events across connections; no leader election).
- **Docs — the deliverable.** `docs/slack-integration.md` is an operator runbook built around the real division of labour: a **Slack admin** creates the app from the committed [`docs/slack-app-manifest.json`](docs/slack-app-manifest.json) and hands over three tokens; the **Terrapod operator** stores them in a K8s Secret and sets the Helm values. Neither needs access to the other's system.
- **Helm** — values / schema / configmap render / deployment `secretKeyRef` + `values-local` (on for the Tilt loop) + `helm-smoke` assertions (config renders; **no** secret env when disabled).

## Tests

`services/tests/services/test_slack_service.py`: both enable branches (disabled / enabled-missing-tokens / socket-mode-off all skip), the full connect→greet→disconnect path (fake `slack_sdk`), and the nested-env secret mapping (`TERRAPOD_SLACK__BOT_TOKEN` → `slack.bot_token`). Full `make test` green (2630); `make lint` clean; `helm template` renders on all three value profiles.

## Scope note

Deliberately does **not** claim a shipped "interactive Slack" feature in the README/feature catalogue — this slice only establishes the connection. `llms.txt` records the phase status.

Refs #556.