### PR TITLE
feat(slack): identity-link backend — binding + signed state + link API (#556)

### DIFF
--- a/alembic/versions/526699f9e991_slack_identity_links.py
+++ b/alembic/versions/526699f9e991_slack_identity_links.py
@@ -1,0 +1,38 @@
+"""slack identity links (#556)
+
+Durable binding of a Slack user (team_id + user_id) to a Terrapod identity
+(email), established once via explicit login and reused for every subsequent
+Slack-initiated action. New table; no change to existing behaviour.
+
+Revision ID: 526699f9e991
+Revises: 1429df8c538a
+Create Date: 2026-07-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "526699f9e991"
+down_revision: str | None = "1429df8c538a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "slack_identity_links",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("slack_team_id", sa.String(length=32), nullable=False),
+        sa.Column("slack_user_id", sa.String(length=32), nullable=False),
+        sa.Column("terrapod_email", sa.String(length=320), nullable=False),
+        sa.Column("linked_via", sa.String(length=32), nullable=False),
+        sa.Column("linked_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("slack_team_id", "slack_user_id", name="uq_slack_identity"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("slack_identity_links")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2750,6 +2750,41 @@ Sends a test payload to the configured destination and returns the delivery resp
 
 ---
 
+## Slack account linking
+
+Binds a Slack identity (team + user) to a Terrapod identity, established once via
+an explicit login (the "connect your Terrapod account" flow) and reused for every
+subsequent Slack-initiated action. The binding is long-lived **identity**, never
+entitlement — RBAC is re-checked live on each action. See
+[Slack integration](slack-integration.md) (#556).
+
+### Link account
+
+```
+POST /api/terrapod/v1/slack/link
+```
+
+Body `{"state": "<signed-state>"}`. Requires an authenticated Terrapod user;
+verifies + consumes the single-use signed state (minted by the `/terrapod link`
+flow) and binds the **acting** user's identity to the Slack (team, user) in the
+state. `422` if the state is missing, `400` if it is invalid/expired/already used.
+
+### List my Slack links
+
+```
+GET /api/terrapod/v1/slack/links
+```
+
+Returns the current user's Slack identity links.
+
+### Unlink
+
+```
+DELETE /api/terrapod/v1/slack/links/{link_id}
+```
+
+Removes one of the current user's own links (`404` if it isn't theirs).
+
 ## Execution Hooks
 
 Reusable custom-shell steps run inside the runner Job at fixed points

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -835,6 +835,11 @@ def create_application() -> FastAPI:
 
     include_terrapod(execution_hooks_router)
 
+    # Slack account-linking — bind a Slack identity to a Terrapod identity (#556).
+    from terrapod.api.routers.slack import router as slack_router
+
+    include_terrapod(slack_router)
+
     # Remote-state consumer allowlist — Terrapod-native management of the
     # producer-controlled cross-workspace `terraform_remote_state` grants
     # (#344). The CLI never manages these; the read-path authorization

--- a/services/terrapod/api/routers/slack.py
+++ b/services/terrapod/api/routers/slack.py
@@ -1,0 +1,91 @@
+"""Slack account-linking API (#556).
+
+Browser-driven surface consumed by the web `/slack/link` page: the user
+authenticates to Terrapod normally, then POSTs the signed state, which binds
+their Slack identity to their Terrapod identity. Also lists/removes a user's own
+links. Any authenticated user links THEIR OWN identity — no admin needed; the
+binding is attributed to the acting user.
+"""
+
+import uuid
+from datetime import UTC
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.models import SlackIdentityLink
+from terrapod.db.session import get_db
+from terrapod.services import slack_link_service
+
+router = APIRouter(tags=["slack"])
+
+
+def _link_json(link: SlackIdentityLink) -> dict:
+    return {
+        "id": f"slk-{link.id}",
+        "slack-team-id": link.slack_team_id,
+        "slack-user-id": link.slack_user_id,
+        "email": link.terrapod_email,
+        "linked-via": link.linked_via,
+        "linked-at": link.linked_at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+@router.post("/slack/link")
+async def link_account(
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Bind the current Terrapod user to the Slack identity in the signed state."""
+    state = (body.get("state") or "").strip()
+    if not state:
+        raise HTTPException(status_code=422, detail="Missing link state")
+    try:
+        team_id, slack_user_id = await slack_link_service.verify_and_consume_state(state)
+    except slack_link_service.LinkStateError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    link = await slack_link_service.create_link(
+        db, team_id=team_id, user_id=slack_user_id, email=user.email
+    )
+    return JSONResponse(content={"data": _link_json(link)})
+
+
+@router.get("/slack/links")
+async def list_my_links(
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """List the current user's Slack identity links."""
+    rows = (
+        (
+            await db.execute(
+                select(SlackIdentityLink).where(SlackIdentityLink.terrapod_email == user.email)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return JSONResponse(content={"data": [_link_json(r) for r in rows]})
+
+
+@router.delete("/slack/links/{link_id}", status_code=204)
+async def unlink_account(
+    link_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Remove one of the current user's own Slack links."""
+    try:
+        lid = uuid.UUID(link_id.removeprefix("slk-"))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Link not found") from exc
+    link = await db.get(SlackIdentityLink, lid)
+    if link is None or link.terrapod_email != user.email:
+        raise HTTPException(status_code=404, detail="Link not found")
+    await db.delete(link)
+    await db.commit()

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -1392,6 +1393,36 @@ class ExecutionHookWorkspace(Base):
     )
 
     workspace: Mapped["Workspace"] = relationship(lazy="joined")
+
+
+# --- Slack identity linking (#556) ---
+
+
+class SlackIdentityLink(Base):
+    """Durable binding of a Slack user to a Terrapod identity (#556).
+
+    Established once via an explicit login (the "connect your account" flow), then
+    reused for every subsequent Slack-initiated action. Long-lived **identity**,
+    never entitlement: authorization (RBAC) is re-checked live on each action, so a
+    persistent binding never grants standing permission. Keyed by
+    (team, user) so one Terrapod can serve multiple Slack workspaces.
+    """
+
+    __tablename__ = "slack_identity_links"
+    __table_args__ = (UniqueConstraint("slack_team_id", "slack_user_id", name="uq_slack_identity"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=generate_uuid7
+    )
+    slack_team_id: Mapped[str] = mapped_column(String(32), nullable=False)
+    slack_user_id: Mapped[str] = mapped_column(String(32), nullable=False)
+    # The bound Terrapod principal. Email-first identity; no FK (a user row may not
+    # exist for SSO-only identities, mirroring role_assignments' email keying).
+    terrapod_email: Mapped[str] = mapped_column(String(320), nullable=False)
+    linked_via: Mapped[str] = mapped_column(String(32), nullable=False, default="slash_command")
+    linked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=now_utc
+    )
 
 
 # --- Configuration Versions ---

--- a/services/terrapod/services/slack_link_service.py
+++ b/services/terrapod/services/slack_link_service.py
@@ -1,0 +1,154 @@
+"""Slack account-linking: signed state + the durable identity binding (#556).
+
+The "connect your Terrapod account" flow:
+
+1. From Slack (`/terrapod link`), Terrapod mints a **signed, single-use,
+   short-TTL state token** that encodes the Slack (team, user) — only Terrapod
+   (holding the signing key) can produce it, so a user can't forge a link
+   binding an arbitrary Slack id to their own account.
+2. The user opens the link in their browser and authenticates to Terrapod
+   normally (existing session/SSO). The web page then POSTs the state with the
+   user's auth; the API verifies + consumes the state and writes the binding to
+   the *authenticated* Terrapod identity.
+
+The binding is long-lived **identity**, not entitlement: RBAC is re-checked live
+on every Slack-initiated action, so a persistent binding never grants standing
+permission.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+import uuid
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.db.models import SlackIdentityLink
+
+_STATE_TTL_SECONDS = 600  # 10 minutes to complete the link
+_NONCE_PREFIX = "tp:slack:linkstate:"
+
+
+class LinkStateError(Exception):
+    """Raised when a link-state token is invalid, expired, or already used."""
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _b64u_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def _sign(payload_b64: str) -> str:
+    from terrapod.auth.token_signing import get_token_signing_key
+
+    sig = hmac.new(get_token_signing_key(), payload_b64.encode(), hashlib.sha256).digest()
+    return _b64u(sig)
+
+
+async def mint_link_state(team_id: str, user_id: str) -> str:
+    """Mint a signed, single-use state token binding this Slack (team, user)."""
+    nonce = uuid.uuid4().hex
+    payload = {"t": team_id, "u": user_id, "n": nonce, "exp": int(time.time()) + _STATE_TTL_SECONDS}
+    payload_b64 = _b64u(json.dumps(payload, separators=(",", ":")).encode())
+    token = f"{payload_b64}.{_sign(payload_b64)}"
+
+    # Register the nonce for single-use redemption (TTL mirrors the token expiry).
+    from terrapod.redis.client import get_redis_client
+
+    await get_redis_client().set(f"{_NONCE_PREFIX}{nonce}", "1", ex=_STATE_TTL_SECONDS)
+    return token
+
+
+async def verify_and_consume_state(state: str) -> tuple[str, str]:
+    """Verify signature + expiry and BURN the nonce (single use). Returns (team, user)."""
+    try:
+        payload_b64, sig = state.split(".", 1)
+    except ValueError as exc:
+        raise LinkStateError("malformed link state") from exc
+
+    if not hmac.compare_digest(sig, _sign(payload_b64)):
+        raise LinkStateError("bad link-state signature")
+
+    try:
+        payload = json.loads(_b64u_decode(payload_b64))
+    except Exception as exc:  # noqa: BLE001
+        raise LinkStateError("undecodable link state") from exc
+
+    if int(payload.get("exp", 0)) < int(time.time()):
+        raise LinkStateError("link state expired")
+
+    nonce = payload.get("n", "")
+    from terrapod.redis.client import get_redis_client
+
+    # Atomic single-use: only the first redemption finds the nonce present.
+    burned = await get_redis_client().delete(f"{_NONCE_PREFIX}{nonce}")
+    if not burned:
+        raise LinkStateError("link state already used or expired")
+
+    return str(payload["t"]), str(payload["u"])
+
+
+async def create_link(
+    db: AsyncSession,
+    *,
+    team_id: str,
+    user_id: str,
+    email: str,
+    via: str = "slash_command",
+) -> SlackIdentityLink:
+    """Upsert the (team, user) → email binding. Idempotent (re-link updates email)."""
+    from terrapod.db.models import now_utc
+
+    existing = (
+        await db.execute(
+            select(SlackIdentityLink).where(
+                SlackIdentityLink.slack_team_id == team_id,
+                SlackIdentityLink.slack_user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if existing is not None:
+        existing.terrapod_email = email
+        existing.linked_via = via
+        existing.linked_at = now_utc()
+        link = existing
+    else:
+        link = SlackIdentityLink(
+            slack_team_id=team_id, slack_user_id=user_id, terrapod_email=email, linked_via=via
+        )
+        db.add(link)
+    await db.commit()
+    await db.refresh(link)
+    return link
+
+
+async def get_link(db: AsyncSession, team_id: str, user_id: str) -> SlackIdentityLink | None:
+    return (
+        await db.execute(
+            select(SlackIdentityLink).where(
+                SlackIdentityLink.slack_team_id == team_id,
+                SlackIdentityLink.slack_user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+
+async def unlink(db: AsyncSession, team_id: str, user_id: str) -> int:
+    """Remove a binding. Returns the number of rows deleted (0 or 1)."""
+    result = await db.execute(
+        delete(SlackIdentityLink).where(
+            SlackIdentityLink.slack_team_id == team_id,
+            SlackIdentityLink.slack_user_id == user_id,
+        )
+    )
+    await db.commit()
+    return result.rowcount or 0

--- a/services/tests/api/test_slack_link.py
+++ b/services/tests/api/test_slack_link.py
@@ -1,0 +1,90 @@
+"""Tests for the Slack account-linking API (#556)."""
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.app import create_application as create_app
+from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.db.session import get_db
+
+_BASE = "http://test"
+_AUTH = {"Authorization": "Bearer dummy"}
+_LINK = "/api/terrapod/v1/slack/link"
+
+
+def _user(email="alice@example.com"):
+    return AuthenticatedUser(
+        email=email,
+        display_name="Alice",
+        roles=["everyone"],
+        provider_name="local",
+        auth_method="session",
+    )
+
+
+def _make_app(user, mock_db=None):
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    if mock_db is None:
+        mock_db = AsyncMock()
+        mock_db.add = MagicMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app, mock_db
+
+
+def _fake_link(email="alice@example.com"):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        slack_team_id="T123",
+        slack_user_id="U456",
+        terrapod_email=email,
+        linked_via="slash_command",
+        linked_at=datetime(2026, 7, 3, tzinfo=UTC),
+    )
+
+
+class TestLinkAccount:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_missing_state_422(self, *_m):
+        app, _db = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            r = await c.post(_LINK, json={}, headers=_AUTH)
+        assert r.status_code == 422
+
+    @patch("terrapod.services.slack_link_service.verify_and_consume_state")
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_bad_state_400(self, _idb, _ir, _is, verify):
+        from terrapod.services.slack_link_service import LinkStateError
+
+        verify.side_effect = LinkStateError("link state already used or expired")
+        app, _db = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            r = await c.post(_LINK, json={"state": "bad"}, headers=_AUTH)
+        assert r.status_code == 400
+
+    @patch("terrapod.services.slack_link_service.create_link", new_callable=AsyncMock)
+    @patch("terrapod.services.slack_link_service.verify_and_consume_state")
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_link_happy_binds_current_user(self, _idb, _ir, _is, verify, create):
+        verify.return_value = ("T123", "U456")
+        create.return_value = _fake_link("alice@example.com")
+        app, _db = _make_app(_user("alice@example.com"))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            r = await c.post(_LINK, json={"state": "good"}, headers=_AUTH)
+        assert r.status_code == 200
+        attrs = r.json()["data"]
+        assert attrs["email"] == "alice@example.com"
+        assert attrs["slack-team-id"] == "T123"
+        # The binding is attributed to the AUTHENTICATED user, not the payload.
+        _args, kwargs = create.call_args
+        assert kwargs["email"] == "alice@example.com"

--- a/services/tests/services/test_slack_link_service.py
+++ b/services/tests/services/test_slack_link_service.py
@@ -1,0 +1,60 @@
+"""Tests for the Slack account-linking signed state (#556)."""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from terrapod.services import slack_link_service as svc
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict[str, str] = {}
+
+    async def set(self, k, v, ex=None, nx=None):
+        self.store[k] = v
+        return True
+
+    async def delete(self, k):
+        return 1 if self.store.pop(k, None) is not None else 0
+
+
+@pytest.mark.asyncio
+async def test_state_roundtrip_and_single_use():
+    fake = FakeRedis()
+    with patch("terrapod.redis.client.get_redis_client", return_value=fake):
+        state = await svc.mint_link_state("T123", "U456")
+        team, user = await svc.verify_and_consume_state(state)
+        assert (team, user) == ("T123", "U456")
+        # Nonce is burned — a replay must fail.
+        with pytest.raises(svc.LinkStateError):
+            await svc.verify_and_consume_state(state)
+
+
+@pytest.mark.asyncio
+async def test_tampered_signature_rejected():
+    fake = FakeRedis()
+    with patch("terrapod.redis.client.get_redis_client", return_value=fake):
+        state = await svc.mint_link_state("T1", "U1")
+        payload_b64, _sig = state.split(".", 1)
+        forged = f"{payload_b64}.{svc._b64u(b'not-the-real-hmac-signature-here!!')}"
+        with pytest.raises(svc.LinkStateError):
+            await svc.verify_and_consume_state(forged)
+
+
+@pytest.mark.asyncio
+async def test_expired_state_rejected():
+    fake = FakeRedis()
+    with patch("terrapod.redis.client.get_redis_client", return_value=fake):
+        state = await svc.mint_link_state("T1", "U1")
+        # Advance time past the TTL so the exp check trips.
+        with patch.object(time, "time", return_value=time.time() + svc._STATE_TTL_SECONDS + 10):
+            with pytest.raises(svc.LinkStateError):
+                await svc.verify_and_consume_state(state)
+
+
+@pytest.mark.asyncio
+async def test_malformed_state_rejected():
+    with pytest.raises(svc.LinkStateError):
+        await svc.verify_and_consume_state("not-a-valid-token")


### PR DESCRIPTION
Slice 2a of Slack account linking — the backend foundation the interactive flow (`/terrapod link` command + web "connect your account" page, slice 2b) builds on. **No Slack-side interaction needed to test this slice.**

## What's here

- **Binding model** — `SlackIdentityLink`: `(slack_team_id, slack_user_id) → terrapod_email`, unique on team+user, email-first (no FK, mirroring `role_assignments`' email keying), keyed by team so one Terrapod serves many Slack workspaces. Migration `526699f9e991` (real `upgrade`/`downgrade`, **applied live in Tilt**). The binding is long-lived **identity, never entitlement** — RBAC is re-checked live on every action.
- **Signed state** (`slack_link_service`) — the trust anchor of the explicit-login flow: HMAC-signed with the existing token-signing key, **single-use** (Redis nonce burned on redemption), short TTL. Only Terrapod can mint it, so a user can't forge a link binding an arbitrary Slack id to their own account.
- **Link API** — `POST /api/terrapod/v1/slack/link` (auth required; verify+consume state → bind the **acting** Terrapod user; `422` missing state, `400` invalid/expired/reused), `GET /slack/links` (my links), `DELETE /slack/links/{id}` (own only).

## Tests

State: roundtrip, tampered-signature rejected, expiry, single-use replay rejected, malformed. Router: `422`/`400`/happy — including that the binding is attributed to the **authenticated** user, not the state payload. Full `make test` green (2637); `make lint` clean.

## Scope

go-terrapod coverage deliberately deferred — the linking surface is browser-only (the web `/slack/link` page in 2b); there's no Go consumer. Slice **2b** wires the `/terrapod link` slash command + the web link page, which is the part that needs a live Slack click — I'll drive that next.

Refs #556.