### PR TITLE
feat(slack): /terrapod link slash command + web connect page (#556)

### DIFF
--- a/docs/slack-integration.md
+++ b/docs/slack-integration.md
@@ -132,6 +132,28 @@ If all three are true, the connection is live.
 
 ---
 
+## Account linking (`/terrapod`)
+
+Before anyone can act on runs from Slack (approve/discard, later), their Slack
+identity must be linked to their Terrapod identity. This is a **one-time,
+explicit login** — Slack membership alone never implies Terrapod permission.
+
+From any channel the bot is in:
+
+- **`/terrapod link`** — Terrapod replies (only to you) with a *Connect your
+  Terrapod account* button. Click it, log in to Terrapod as you normally would,
+  and the binding is recorded. The link is **single-use and expires in 10
+  minutes**.
+- **`/terrapod status`** — shows whether you're linked, and as whom.
+- **`/terrapod unlink`** — removes your binding.
+
+The binding is durable **identity**, not permission: every future Slack action
+re-checks your Terrapod RBAC live, so a link never grants standing access, and if
+your Terrapod permissions change the next action reflects it immediately. You can
+also view/remove your links from the Terrapod web UI. Under the hood the connect
+link carries a Terrapod-signed, single-use token, so no one can forge a binding
+for someone else's Slack id.
+
 ## Reference
 
 **Helm values** (`api.config.slack`):

--- a/services/terrapod/api/routers/slack.py
+++ b/services/terrapod/api/routers/slack.py
@@ -45,13 +45,21 @@ async def link_account(
     if not state:
         raise HTTPException(status_code=422, detail="Missing link state")
     try:
-        team_id, slack_user_id = await slack_link_service.verify_and_consume_state(state)
+        team_id, slack_user_id, response_url = await slack_link_service.verify_and_consume_state(
+            state
+        )
     except slack_link_service.LinkStateError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     link = await slack_link_service.create_link(
         db, team_id=team_id, user_id=slack_user_id, email=user.email
     )
+    # Confirm back in the Slack conversation the /terrapod link came from, so the
+    # user gets closure in Slack (not only in the browser). Best-effort.
+    if response_url:
+        await slack_link_service.post_response_url(
+            response_url, f":white_check_mark: Linked to Terrapod as *{user.email}*."
+        )
     return JSONResponse(content={"data": _link_json(link)})
 
 

--- a/services/terrapod/services/slack_commands.py
+++ b/services/terrapod/services/slack_commands.py
@@ -23,10 +23,10 @@ def _connect_url(state: str) -> str:
     return f"{base}/slack/link?state={state}"
 
 
-async def _handle_link(team_id: str, user_id: str) -> dict:
+async def _handle_link(team_id: str, user_id: str, response_url: str = "") -> dict:
     from terrapod.services.slack_link_service import mint_link_state
 
-    url = _connect_url(await mint_link_state(team_id, user_id))
+    url = _connect_url(await mint_link_state(team_id, user_id, response_url))
     return {
         "response_type": "ephemeral",
         "blocks": [
@@ -89,12 +89,14 @@ async def _handle_unlink(team_id: str, user_id: str) -> dict:
     return {"response_type": "ephemeral", "text": "You had no Terrapod link to remove."}
 
 
-async def build_slash_response(text: str, team_id: str, user_id: str) -> dict:
+async def build_slash_response(
+    text: str, team_id: str, user_id: str, response_url: str = ""
+) -> dict:
     """Dispatch a `/terrapod <sub>` command to an ephemeral response payload."""
     parts = (text or "").strip().split()
     sub = parts[0].lower() if parts else "help"
     if sub == "link":
-        return await _handle_link(team_id, user_id)
+        return await _handle_link(team_id, user_id, response_url)
     if sub == "status":
         return await _handle_status(team_id, user_id)
     if sub == "unlink":
@@ -128,7 +130,10 @@ async def handle_socket_request(client, req) -> None:
 
     try:
         response = await build_slash_response(
-            payload.get("text", ""), payload.get("team_id", ""), payload.get("user_id", "")
+            payload.get("text", ""),
+            payload.get("team_id", ""),
+            payload.get("user_id", ""),
+            payload.get("response_url", ""),
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("slack.slash_command_failed", err=str(exc))

--- a/services/terrapod/services/slack_commands.py
+++ b/services/terrapod/services/slack_commands.py
@@ -1,0 +1,138 @@
+"""Slack slash-command handling over Socket Mode (#556).
+
+`/terrapod link | status | unlink` — account linking from the channel. `link`
+mints a signed, single-use state and returns an ephemeral "Connect your Terrapod
+account" link that drives the user through Terrapod's own login; `status` /
+`unlink` operate on the caller's existing binding.
+
+Interaction payloads (approve/discard buttons) are ack'd here too but not yet
+acted on — that lands with the interactive-approval slice.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def _connect_url(state: str) -> str:
+    from terrapod.config import settings
+
+    base = (settings.external_url or "").rstrip("/")
+    return f"{base}/slack/link?state={state}"
+
+
+async def _handle_link(team_id: str, user_id: str) -> dict:
+    from terrapod.services.slack_link_service import mint_link_state
+
+    url = _connect_url(await mint_link_state(team_id, user_id))
+    return {
+        "response_type": "ephemeral",
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Connect your Terrapod account* to act on runs from Slack.",
+                },
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Connect Terrapod"},
+                        "url": url,
+                        "style": "primary",
+                    }
+                ],
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {"type": "mrkdwn", "text": "This link is single-use and expires in 10 minutes."}
+                ],
+            },
+        ],
+    }
+
+
+async def _handle_status(team_id: str, user_id: str) -> dict:
+    from terrapod.db.session import get_db_session
+    from terrapod.services.slack_link_service import get_link
+
+    async with get_db_session() as db:
+        link = await get_link(db, team_id, user_id)
+    if link:
+        return {
+            "response_type": "ephemeral",
+            "text": f":white_check_mark: Linked to Terrapod as *{link.terrapod_email}*.",
+        }
+    return {
+        "response_type": "ephemeral",
+        "text": "Not linked yet. Run `/terrapod link` to connect your Terrapod account.",
+    }
+
+
+async def _handle_unlink(team_id: str, user_id: str) -> dict:
+    from terrapod.db.session import get_db_session
+    from terrapod.services.slack_link_service import unlink
+
+    async with get_db_session() as db:
+        removed = await unlink(db, team_id, user_id)
+    if removed:
+        return {
+            "response_type": "ephemeral",
+            "text": "Your Terrapod account has been unlinked from Slack.",
+        }
+    return {"response_type": "ephemeral", "text": "You had no Terrapod link to remove."}
+
+
+async def build_slash_response(text: str, team_id: str, user_id: str) -> dict:
+    """Dispatch a `/terrapod <sub>` command to an ephemeral response payload."""
+    parts = (text or "").strip().split()
+    sub = parts[0].lower() if parts else "help"
+    if sub == "link":
+        return await _handle_link(team_id, user_id)
+    if sub == "status":
+        return await _handle_status(team_id, user_id)
+    if sub == "unlink":
+        return await _handle_unlink(team_id, user_id)
+    return {
+        "response_type": "ephemeral",
+        "text": "Usage: `/terrapod link` · `/terrapod status` · `/terrapod unlink`",
+    }
+
+
+async def handle_socket_request(client, req) -> None:
+    """slack_sdk Socket Mode request listener: ack + respond to /terrapod commands."""
+    try:
+        from slack_sdk.socket_mode.response import SocketModeResponse
+    except ImportError:
+        return
+
+    async def _ack(payload=None):
+        await client.send_socket_mode_response(
+            SocketModeResponse(envelope_id=req.envelope_id, payload=payload)
+        )
+
+    if req.type != "slash_commands":
+        await _ack()  # ack interactions/events; handled in a later slice
+        return
+
+    payload = req.payload or {}
+    if payload.get("command") != "/terrapod":
+        await _ack()
+        return
+
+    try:
+        response = await build_slash_response(
+            payload.get("text", ""), payload.get("team_id", ""), payload.get("user_id", "")
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("slack.slash_command_failed", err=str(exc))
+        response = {"response_type": "ephemeral", "text": "Something went wrong handling that."}
+
+    # For slash commands the ack payload IS the ephemeral reply.
+    await _ack(response)

--- a/services/terrapod/services/slack_link_service.py
+++ b/services/terrapod/services/slack_link_service.py
@@ -53,22 +53,34 @@ def _sign(payload_b64: str) -> str:
     return _b64u(sig)
 
 
-async def mint_link_state(team_id: str, user_id: str) -> str:
-    """Mint a signed, single-use state token binding this Slack (team, user)."""
+async def mint_link_state(team_id: str, user_id: str, response_url: str = "") -> str:
+    """Mint a signed, single-use state token binding this Slack (team, user).
+
+    The originating slash command's ``response_url`` is stashed under the nonce so
+    the link-completion handler can post a confirmation back to the same Slack
+    conversation — no extra Slack scope needed.
+    """
     nonce = uuid.uuid4().hex
     payload = {"t": team_id, "u": user_id, "n": nonce, "exp": int(time.time()) + _STATE_TTL_SECONDS}
     payload_b64 = _b64u(json.dumps(payload, separators=(",", ":")).encode())
     token = f"{payload_b64}.{_sign(payload_b64)}"
 
     # Register the nonce for single-use redemption (TTL mirrors the token expiry).
+    # Value is the response_url ("-" sentinel when absent).
     from terrapod.redis.client import get_redis_client
 
-    await get_redis_client().set(f"{_NONCE_PREFIX}{nonce}", "1", ex=_STATE_TTL_SECONDS)
+    await get_redis_client().set(
+        f"{_NONCE_PREFIX}{nonce}", response_url or "-", ex=_STATE_TTL_SECONDS
+    )
     return token
 
 
-async def verify_and_consume_state(state: str) -> tuple[str, str]:
-    """Verify signature + expiry and BURN the nonce (single use). Returns (team, user)."""
+async def verify_and_consume_state(state: str) -> tuple[str, str, str]:
+    """Verify signature + expiry and BURN the nonce (single use).
+
+    Returns ``(team_id, user_id, response_url)`` — response_url is "" when none was
+    captured at mint time.
+    """
     try:
         payload_b64, sig = state.split(".", 1)
     except ValueError as exc:
@@ -88,12 +100,30 @@ async def verify_and_consume_state(state: str) -> tuple[str, str]:
     nonce = payload.get("n", "")
     from terrapod.redis.client import get_redis_client
 
-    # Atomic single-use: only the first redemption finds the nonce present.
-    burned = await get_redis_client().delete(f"{_NONCE_PREFIX}{nonce}")
-    if not burned:
+    # Atomic single-use: GETDEL returns the stored value (response_url) and removes
+    # the nonce in one op; a second redemption finds nothing.
+    stored = await get_redis_client().getdel(f"{_NONCE_PREFIX}{nonce}")
+    if stored is None:
         raise LinkStateError("link state already used or expired")
+    if isinstance(stored, bytes):
+        stored = stored.decode()
+    response_url = "" if stored == "-" else stored
 
-    return str(payload["t"]), str(payload["u"])
+    return str(payload["t"]), str(payload["u"]), response_url
+
+
+async def post_response_url(response_url: str, text: str) -> None:
+    """Best-effort follow-up to a Slack slash-command response_url (no scope needed)."""
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            await client.post(
+                response_url,
+                json={"response_type": "ephemeral", "replace_original": True, "text": text},
+            )
+    except Exception:  # noqa: BLE001
+        pass
 
 
 async def create_link(

--- a/services/terrapod/services/slack_service.py
+++ b/services/terrapod/services/slack_service.py
@@ -64,6 +64,11 @@ async def start_slack(settings) -> None:
     web = AsyncWebClient(token=cfg.bot_token)
     _socket_client = SocketModeClient(app_token=cfg.app_token, web_client=web)
 
+    # Dispatch /terrapod slash commands (+ ack interactions) over the socket (#556).
+    from terrapod.services.slack_commands import handle_socket_request
+
+    _socket_client.socket_mode_request_listeners.append(handle_socket_request)
+
     try:
         await _socket_client.connect()
     except Exception as exc:  # noqa: BLE001

--- a/services/tests/api/test_slack_link.py
+++ b/services/tests/api/test_slack_link.py
@@ -76,7 +76,7 @@ class TestLinkAccount:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     async def test_link_happy_binds_current_user(self, _idb, _ir, _is, verify, create):
-        verify.return_value = ("T123", "U456")
+        verify.return_value = ("T123", "U456", "")
         create.return_value = _fake_link("alice@example.com")
         app, _db = _make_app(_user("alice@example.com"))
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:

--- a/services/tests/services/test_slack_commands.py
+++ b/services/tests/services/test_slack_commands.py
@@ -1,0 +1,77 @@
+"""Tests for the /terrapod Slack slash-command handler (#556)."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.config import settings
+from terrapod.services import slack_commands as sc
+
+
+@pytest.mark.asyncio
+async def test_link_returns_connect_button_with_state_url():
+    with (
+        patch(
+            "terrapod.services.slack_link_service.mint_link_state",
+            new=AsyncMock(return_value="ST8"),
+        ),
+        patch.object(settings, "external_url", "https://terrapod.example.com"),
+    ):
+        resp = await sc.build_slash_response("link", "T1", "U1")
+    assert resp["response_type"] == "ephemeral"
+    button = resp["blocks"][1]["elements"][0]
+    assert button["url"] == "https://terrapod.example.com/slack/link?state=ST8"
+
+
+@pytest.mark.asyncio
+async def test_unknown_subcommand_returns_usage():
+    resp = await sc.build_slash_response("wat", "T1", "U1")
+    assert "Usage:" in resp["text"]
+
+
+@pytest.mark.asyncio
+async def test_status_reports_binding():
+    @asynccontextmanager
+    async def _fake_session():
+        yield MagicMock()
+
+    link = SimpleNamespace(terrapod_email="alice@example.com")
+    with (
+        patch("terrapod.db.session.get_db_session", _fake_session),
+        patch("terrapod.services.slack_link_service.get_link", new=AsyncMock(return_value=link)),
+    ):
+        resp = await sc.build_slash_response("status", "T1", "U1")
+    assert "alice@example.com" in resp["text"]
+
+
+@pytest.mark.asyncio
+async def test_socket_request_acks_terrapod_command_with_reply():
+    sent = []
+    client = MagicMock()
+    client.send_socket_mode_response = AsyncMock(side_effect=lambda r: sent.append(r))
+    req = SimpleNamespace(
+        type="slash_commands",
+        envelope_id="e1",
+        payload={"command": "/terrapod", "text": "help", "team_id": "T", "user_id": "U"},
+    )
+    await sc.handle_socket_request(client, req)
+    assert client.send_socket_mode_response.await_count == 1
+    # The ack carries the ephemeral reply payload for a slash command.
+    assert sent[0].payload is not None
+
+
+@pytest.mark.asyncio
+async def test_socket_request_acks_foreign_command_without_reply():
+    client = MagicMock()
+    client.send_socket_mode_response = AsyncMock()
+    req = SimpleNamespace(
+        type="slash_commands",
+        envelope_id="e2",
+        payload={"command": "/somethingelse", "text": "", "team_id": "T", "user_id": "U"},
+    )
+    await sc.handle_socket_request(client, req)
+    # Ack'd, but with no reply payload (not our command).
+    sent = client.send_socket_mode_response.await_args.args[0]
+    assert sent.payload is None

--- a/services/tests/services/test_slack_link_service.py
+++ b/services/tests/services/test_slack_link_service.py
@@ -16,17 +16,18 @@ class FakeRedis:
         self.store[k] = v
         return True
 
-    async def delete(self, k):
-        return 1 if self.store.pop(k, None) is not None else 0
+    async def getdel(self, k):
+        return self.store.pop(k, None)
 
 
 @pytest.mark.asyncio
 async def test_state_roundtrip_and_single_use():
     fake = FakeRedis()
     with patch("terrapod.redis.client.get_redis_client", return_value=fake):
-        state = await svc.mint_link_state("T123", "U456")
-        team, user = await svc.verify_and_consume_state(state)
+        state = await svc.mint_link_state("T123", "U456", "https://hooks.slack/resp")
+        team, user, response_url = await svc.verify_and_consume_state(state)
         assert (team, user) == ("T123", "U456")
+        assert response_url == "https://hooks.slack/resp"
         # Nonce is burned — a replay must fail.
         with pytest.raises(svc.LinkStateError):
             await svc.verify_and_consume_state(state)

--- a/web/src/app/slack/link/page.tsx
+++ b/web/src/app/slack/link/page.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { Suspense, useEffect, useRef, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { getAuthState } from '@/lib/auth'
+import { apiFetch } from '@/lib/api'
+
+type Status = 'working' | 'success' | 'error'
+
+function SlackLinkInner() {
+  const params = useSearchParams()
+  const state = params.get('state') || ''
+  const [status, setStatus] = useState<Status>('working')
+  const [message, setMessage] = useState('Linking your Slack account…')
+  const [email, setEmail] = useState('')
+  const ran = useRef(false)
+
+  useEffect(() => {
+    if (ran.current) return // link state is single-use — never POST it twice
+    ran.current = true
+
+    if (!state) {
+      setStatus('error')
+      setMessage('Missing or invalid link. Run `/terrapod link` in Slack again.')
+      return
+    }
+
+    const auth = getAuthState()
+    if (!auth?.token) {
+      // Send the user through Terrapod's own login, then back here to finish.
+      const back = `/slack/link?state=${encodeURIComponent(state)}`
+      window.location.href = `/login?redirect=${encodeURIComponent(back)}`
+      return
+    }
+
+    ;(async () => {
+      try {
+        const res = await apiFetch('/api/terrapod/v1/slack/link', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ state }),
+        })
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          throw new Error(
+            data.detail ||
+              'This link is invalid, expired, or already used. Run `/terrapod link` again.',
+          )
+        }
+        const data = await res.json()
+        setEmail(data?.data?.email || auth.email)
+        setStatus('success')
+        setMessage('Your Slack account is now linked to Terrapod.')
+      } catch (e) {
+        setStatus('error')
+        setMessage(e instanceof Error ? e.message : 'Linking failed.')
+      }
+    })()
+  }, [state])
+
+  const tone =
+    status === 'success'
+      ? 'text-green-400 border-green-800/50 bg-green-900/20'
+      : status === 'error'
+        ? 'text-red-400 border-red-800/50 bg-red-900/20'
+        : 'text-slate-300 border-slate-700/50 bg-slate-800/50'
+
+  return (
+    <main className="h-dvh flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <h1 className="text-xl font-semibold text-slate-100 mb-4 text-center">
+          Connect Slack to Terrapod
+        </h1>
+        <div className={`rounded-lg border p-6 text-sm ${tone}`}>
+          <p>{message}</p>
+          {status === 'success' && email && (
+            <p className="mt-2 text-slate-400">
+              Linked as <span className="font-medium text-slate-200">{email}</span>. You can close
+              this tab and return to Slack.
+            </p>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}
+
+export default function SlackLinkPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="h-dvh flex items-center justify-center text-slate-400">Loading…</main>
+      }
+    >
+      <SlackLinkInner />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
Slice 2b — the interactive half of account linking, closing the loop on 2a (the binding + signed-state + link API). After this, a user can link their Slack identity to Terrapod end-to-end from the channel.

## What's here

- **`/terrapod` slash command** (`slack_commands.py`, registered as a Socket Mode request listener on the existing connection):
  - `link` → mints a signed, single-use state and replies **ephemerally** with a *Connect Terrapod* button (link expires in 10 min).
  - `status` → shows whether/as-whom you're linked.
  - `unlink` → removes your binding.
  - Non-slash interactions are ack'd (approve/discard buttons land in a later slice).
- **Web `/slack/link` page** — reads the state; sends unauthenticated users through **Terrapod's own login** (`/login?redirect=…`) then POSTs the state with the user's Bearer. So the binding is **proven against the Terrapod identity**, not asserted by Slack. Single-use guarded (never re-POSTs the state).
- Docs: the `/terrapod` linking flow added to `slack-integration.md`.

## Tests

Slash dispatch (link button carries the `external_url`+state URL; status reports the binding; unknown → usage) and the socket ack (our command carries the ephemeral reply; a foreign command acks with no payload). `make lint` clean; web `npm run build` prerenders `/slack/link`.

## F-gate

The live `/terrapod link` → click → login → bind flow is driven interactively against the dev Slack workspace (needs a human click); verifying now.

Refs #556.