### PR TITLE
fix(slack): never lose a deferred needs-approval post (#687)

### DIFF
--- a/docs/slack-integration.md
+++ b/docs/slack-integration.md
@@ -190,6 +190,13 @@ it's in the message from the first post rather than racing it. The wait is
 bounded by the model call's own timeout (the summary always settles), and if the
 model is disabled or fails the message still posts — just without the review.
 
+**Delivery is guaranteed.** The approval prompt is never lost to that wait: a
+background safety net posts any needs-approval message that the AI step didn't
+deliver within a few minutes (e.g. a runner that died mid-plan), without the
+review if it genuinely never arrived. So a run that needs approval always
+reaches the channel — worst case a couple of minutes later and review-less —
+rather than waiting silently.
+
 ### Approving from Slack (RBAC)
 
 Clicking **Approve** / **Discard** carries no standing permission. Every click is
@@ -226,6 +233,8 @@ edited to record who approved, so a button can't be pressed twice.
 | Symptom | Likely cause |
 |---|---|
 | Bot shows offline; no `slack.socket_mode_connected` log | App-level token missing or lacks `connections:write`; `enabled` false; wrong Secret name. |
+| `enabled: true` but nothing connects; log shows `slack.disabled_socket_mode_off_unsupported` | `socket_mode` is set to `false`. Socket Mode is the only supported mode — set `socket_mode: true`. |
+| Clicked Approve/Discard, the run acted, but the message still shows the buttons | The action succeeded in Terrapod; only the in-place message edit (which drops the buttons / adds *Approved by …*) failed — a transient Slack error. Re-clicking is a no-op (the run has already moved on); check the run in the UI. |
 | A workspace's run notifications never appear | The workspace's **Slack channel** is unset (notifications are opt-in per workspace), or the bot isn't in that channel (`/invite @terrapod`). |
 | Messages post but the plan `.txt` never attaches | The app is missing the **`files:write`** bot scope. Add it under **OAuth & Permissions → Scopes**, then **Reinstall** the app (scope changes require reinstall). Apps created from the current manifest already include it. |
 | `not_in_channel` / `channel_not_found` in logs | Invite the bot to the channel, or use a channel the bot can post to (`chat:write.public` covers public channels). |

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -200,12 +200,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # Registered only when the Slack app is enabled; the handler also no-ops
     # unless the target workspace opted in with its own channel.
     if settings.slack.enabled:
-        from terrapod.services.slack_notify_service import handle_slack_run_notify
+        from terrapod.services.slack_notify_service import (
+            handle_slack_run_notify,
+            slack_approval_backfill_cycle,
+        )
 
         register_trigger_handler(
             "slack_run_notify",
             handler=handle_slack_run_notify,
             description="Post/update the Slack run message for a run event",
+        )
+        # Safety net (#687): post any needs-approval message that was deferred
+        # to the AI summariser but never fired (e.g. the runner died before the
+        # plan-JSON upload). No-ops unless AI is on (nothing is deferred then).
+        register_periodic_task(
+            "slack_approval_backfill",
+            interval_seconds=60,
+            handler=slack_approval_backfill_cycle,
+            description="Backfill deferred Slack approval posts the summariser missed",
         )
 
     # Run task webhook delivery handler

--- a/services/terrapod/services/slack_notify_service.py
+++ b/services/terrapod/services/slack_notify_service.py
@@ -308,6 +308,11 @@ async def handle_slack_run_notify(payload: dict) -> None:
 
     try:
         if trigger == "run:needs_attention":
+            # Idempotent: the approval parent may be posted by the summariser
+            # (deferred, AI-bearing) OR by the backfill safety net. Whichever
+            # runs first wins; a second fire must not post a duplicate parent.
+            if await redis.hgetall(ref_key):
+                return
             resp = await client.chat_postMessage(
                 channel=channel, blocks=message["blocks"], text=message["text"]
             )
@@ -342,3 +347,65 @@ async def handle_slack_run_notify(payload: dict) -> None:
             )
     except Exception as exc:  # noqa: BLE001
         logger.warning("slack.run_notify_failed", trigger=trigger, err=str(exc))
+
+
+# When AI plan summaries are enabled, the needs-approval post is deferred to the
+# summariser (so the AI review is in the first render). But the summariser is
+# enqueued off the plan-JSON upload — if the runner dies between the plan-result
+# POST and that upload, the summariser never runs and the approval prompt is
+# never posted, leaving the approver waiting silently (#687). This backfill is
+# the safety net: a run that has sat in `planned` awaiting manual apply for
+# longer than the grace window (so we're past the happy-path race with the
+# summariser) with no parent message yet gets posted now — without the AI review
+# if it genuinely never arrived. Delivery is guaranteed; the AI review is not.
+_BACKFILL_GRACE_SECONDS = 180
+
+
+async def slack_approval_backfill_cycle() -> None:
+    """Periodic safety net: post any deferred needs-approval message the
+    summariser never fired (see the note above). Registered only when the Slack
+    app is on; short-circuits when AI is off (nothing is deferred then)."""
+    from datetime import timedelta
+    from types import SimpleNamespace
+
+    from terrapod.config import settings
+    from terrapod.db.models import Run, Workspace, now_utc
+    from terrapod.db.session import get_db_session
+    from terrapod.redis.client import get_redis_client
+
+    if not settings.slack.enabled or not settings.ai_summary.enabled:
+        return  # deferral only happens with AI on → nothing to back-fill otherwise
+
+    cutoff = now_utc() - timedelta(seconds=_BACKFILL_GRACE_SECONDS)
+    async with get_db_session() as db:
+        rows = (
+            await db.execute(
+                select(Run.id, Run.workspace_id)
+                .join(Workspace, Workspace.id == Run.workspace_id)
+                .where(
+                    Run.status == "planned",
+                    Run.auto_apply.is_(False),
+                    Run.plan_only.is_(False),
+                    Run.is_drift_detection.is_(False),
+                    Run.plan_finished_at.is_not(None),
+                    Run.plan_finished_at < cutoff,
+                    Workspace.slack_channel != "",
+                )
+                .limit(200)
+            )
+        ).all()
+
+    if not rows:
+        return
+    redis = get_redis_client()
+    for run_id, ws_id in rows:
+        if await redis.hgetall(f"{_MSGREF_PREFIX}{run_id}"):
+            continue  # already posted (by the summariser or a prior backfill)
+        logger.info("slack.approval_backfill", run_id=str(run_id))
+        # _from_summariser=True bypasses the AI-defer so it posts now; the
+        # handler is idempotent, so a late summariser fire won't double-post.
+        await enqueue_slack_notify(
+            SimpleNamespace(id=run_id, workspace_id=ws_id),
+            "run:needs_attention",
+            _from_summariser=True,
+        )

--- a/services/terrapod/services/slack_service.py
+++ b/services/terrapod/services/slack_service.py
@@ -39,8 +39,11 @@ async def start_slack(settings) -> None:
     if not cfg.enabled:
         return
     if not cfg.socket_mode:
-        # Request-URL mode is wired at the ingress/receiver layer, not here.
-        logger.info("slack.request_url_mode_selected_socket_start_skipped")
+        # Socket Mode is the only mode Terrapod wires up today. With it off the
+        # integration is inert — no outbound connection, no slash command, no
+        # interactive approvals — even though `enabled: true`. Warn loudly rather
+        # than skip silently so a mis-set `socket_mode: false` is diagnosable.
+        logger.warning("slack.disabled_socket_mode_off_unsupported")
         return
     if not (cfg.app_token and cfg.bot_token):
         logger.warning(

--- a/services/tests/services/test_slack_notify_service.py
+++ b/services/tests/services/test_slack_notify_service.py
@@ -251,6 +251,83 @@ async def test_needs_attention_posts_parent_stores_ref_and_threads_plan():
 
 
 @pytest.mark.asyncio
+async def test_needs_attention_idempotent_when_ref_already_exists():
+    """Idempotency (#687): if a parent approval message already exists (posted by
+    the summariser or a prior backfill), a second fire must NOT post a duplicate."""
+    run = _run()
+    ws = SimpleNamespace(id="ws-1", name="prod", slack_channel="#deploys")
+    bot = MagicMock()
+    bot.chat_postMessage = AsyncMock()
+    # ref already present → already posted
+    redis = SimpleNamespace(hgetall=AsyncMock(return_value={"channel": "C1", "ts": "111.2"}))
+    with (
+        patch.object(settings.slack, "enabled", True),
+        patch.object(settings.slack, "bot_token", "xoxb-x"),
+        patch("terrapod.db.session.get_db_session", return_value=_db_cm(run, ws)),
+        patch("terrapod.redis.client.get_redis_client", return_value=redis),
+        patch("terrapod.services.slack_notify_service._bot_client", return_value=bot),
+    ):
+        await sn.handle_slack_run_notify(
+            {"run_id": "run-1", "workspace_id": "ws-1", "trigger": "run:needs_attention"}
+        )
+    bot.chat_postMessage.assert_not_called()
+
+
+def _backfill_db(rows):
+    result = MagicMock()
+    result.all.return_value = rows
+
+    class CM:
+        async def __aenter__(self):
+            return SimpleNamespace(execute=AsyncMock(return_value=result))
+
+        async def __aexit__(self, *a):
+            return False
+
+    return CM()
+
+
+@pytest.mark.asyncio
+async def test_backfill_noop_when_ai_disabled():
+    """Nothing is deferred unless AI is on, so the backfill short-circuits."""
+    enq = AsyncMock()
+    with (
+        patch.object(settings.slack, "enabled", True),
+        patch.object(settings.ai_summary, "enabled", False),
+        patch("terrapod.services.slack_notify_service.enqueue_slack_notify", enq),
+    ):
+        await sn.slack_approval_backfill_cycle()
+    enq.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_posts_overdue_unposted_and_skips_already_posted():
+    """Overdue planned-approval runs with no parent get re-fired (bypassing the
+    AI defer); ones that already have a parent are skipped."""
+    rows = [("run-unposted", "ws-1"), ("run-posted", "ws-2")]
+
+    async def _hgetall(key):
+        return {"channel": "C", "ts": "1"} if "run-posted" in key else {}
+
+    redis = SimpleNamespace(hgetall=AsyncMock(side_effect=_hgetall))
+    enq = AsyncMock()
+    with (
+        patch.object(settings.slack, "enabled", True),
+        patch.object(settings.ai_summary, "enabled", True),
+        patch("terrapod.db.session.get_db_session", return_value=_backfill_db(rows)),
+        patch("terrapod.redis.client.get_redis_client", return_value=redis),
+        patch("terrapod.services.slack_notify_service.enqueue_slack_notify", enq),
+    ):
+        await sn.slack_approval_backfill_cycle()
+    # only the unposted run is re-fired, as a summariser-bypass needs_attention
+    enq.assert_awaited_once()
+    posted_run, trigger = enq.await_args.args[0], enq.await_args.args[1]
+    assert str(posted_run.id) == "run-unposted"
+    assert trigger == "run:needs_attention"
+    assert enq.await_args.kwargs.get("_from_summariser") is True
+
+
+@pytest.mark.asyncio
 async def test_completed_threads_under_the_approval_parent():
     run = _run()
     ws = SimpleNamespace(id="ws-1", name="prod", slack_channel="#deploys")


### PR DESCRIPTION
Addresses the reliability item in #687.

## The bug
With AI plan summaries enabled, the *needs-approval* and *errored* Slack messages are deferred to the summariser so the AI review is in the first render. But the summariser is enqueued off the plan-JSON upload — if the runner dies between the `plan-result` POST and that upload, the summariser never runs, so the approval prompt is **never posted** and the approver waits silently while the run sits in `planned`.

## The fix
- **Bounded backfill safety net** (`slack_approval_backfill`, 60s periodic; no-ops unless both Slack and AI are on): a run that has awaited manual apply past a grace window (`plan_finished_at` + 180s) with no parent message yet is posted now — without the AI review if it genuinely never arrived. **Delivery is guaranteed; the AI review is best-effort.**
- **Idempotent needs_attention post** — skips if a parent message already exists, so the summariser and the backfill can never double-post whichever fires first.
- **`socket_mode: false` now warns loudly** (`slack.disabled_socket_mode_off_unsupported`) instead of a silent info log — it's the only supported mode, so the integration is inert with it off.
- **Docs** — delivery-guarantee note + troubleshooting rows (socket_mode-off, and a swallowed in-place message edit after a successful action).

## Tests
`test_slack_notify_service.py`: idempotency guard, backfill posts overdue-unposted + skips already-posted, backfill no-ops when AI off. Full slack suite green; `make lint` green.

## Still open in #687 (follow-ups, not this PR)
Confused-deputy hardening on the account-link confirm step, and Slack E2E specs. Tracked on the issue.