### PR TITLE
feat(slack): confirm step on account link + E2E coverage (closes #687)

### DIFF
--- a/docs/slack-integration.md
+++ b/docs/slack-integration.md
@@ -147,8 +147,10 @@ From any channel the bot is in:
 
 - **`/terrapod link`** — Terrapod replies (only to you) with a *Connect your
   Terrapod account* button. Click it, log in to Terrapod as you normally would,
-  and the binding is recorded. The link is **single-use and expires in 10
-  minutes**.
+  and you land on a **confirmation screen** that names the Slack user + team
+  being linked to your Terrapod account. The binding is recorded only when you
+  click **Confirm & link** — so opening someone else's link never binds your
+  account silently. The link is **single-use and expires in 10 minutes**.
 - **`/terrapod status`** — shows whether you're linked, and as whom.
 - **`/terrapod unlink`** — removes your binding.
 
@@ -157,7 +159,9 @@ re-checks your Terrapod RBAC live, so a link never grants standing access, and i
 your Terrapod permissions change the next action reflects it immediately. You can
 also view/remove your links from the Terrapod web UI. Under the hood the connect
 link carries a Terrapod-signed, single-use token, so no one can forge a binding
-for someone else's Slack id.
+for someone else's Slack id; and because the browser shows the Slack identity on
+an explicit confirm step before binding, a link tricked into someone else's
+browser can't silently bind their Terrapod account to an attacker's Slack user.
 
 ## Run notifications (opt-in, per workspace)
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -136,5 +136,10 @@ export default defineConfig({
       testMatch: 'sse-live-update.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
     },
+    {
+      name: 'slack',
+      testMatch: 'slack.spec.ts',
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
+    },
   ],
 });

--- a/e2e/tests/slack.spec.ts
+++ b/e2e/tests/slack.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api';
+
+// Slack integration UI surfaces (#556 / #687).
+//   1. The opt-in per-workspace `slack-channel` field round-trips through the
+//      workspace settings PATCH and re-renders on reload.
+//   2. The /slack/link page is a deliberate confirm flow: it surfaces a clear
+//      error for a missing/invalid state and never auto-binds on load.
+
+test.describe('Slack workspace channel', () => {
+  test('slack-channel round-trips through workspace settings', async ({ page }) => {
+    const token = getStoredToken('admin.json');
+    const wsName = uniqueName('e2e-slack-ch');
+    const wsId = await createWorkspace(token, wsName);
+    const channel = `#e2e-${Date.now()}`;
+
+    await page.goto(`/workspaces/${wsId}`);
+
+    // The opt-in Slack channel input (admin has can-update, so it's editable).
+    const input = page.getByPlaceholder(/channel ID/i);
+    await expect(input).toBeVisible();
+    await expect(input).toHaveValue(''); // starts silent
+
+    await input.fill(channel);
+    // Saves on blur → PATCH /api/v2/workspaces/{id}. Wait for the write.
+    const [resp] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes(`/api/v2/workspaces/${wsId}`) && r.request().method() === 'PATCH',
+      ),
+      input.blur(),
+    ]);
+    expect(resp.ok()).toBeTruthy();
+
+    // Reload: the saved channel must survive server-side (the round-trip is the
+    // part that regressed for other settings fields historically).
+    await page.reload();
+    await expect(page.getByPlaceholder(/channel ID/i)).toHaveValue(channel);
+  });
+});
+
+test.describe('Slack account link page', () => {
+  test('missing state shows an error, does not bind', async ({ page }) => {
+    await page.goto('/slack/link');
+    await expect(page.getByText(/Missing or invalid link/i)).toBeVisible();
+    // No confirm button — nothing to bind.
+    await expect(page.getByRole('button', { name: /Confirm/i })).toHaveCount(0);
+  });
+
+  test('invalid state is rejected at the confirm/preview step', async ({ page }) => {
+    await page.goto('/slack/link?state=not-a-valid-signed-state');
+    // The preview call rejects a forged state → error card, never a confirm.
+    await expect(page.getByText(/invalid, expired, or already used|Could not check/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole('button', { name: /Confirm/i })).toHaveCount(0);
+  });
+});

--- a/services/terrapod/api/routers/slack.py
+++ b/services/terrapod/api/routers/slack.py
@@ -34,6 +34,34 @@ def _link_json(link: SlackIdentityLink) -> dict:
     }
 
 
+@router.post("/slack/link/preview")
+async def preview_link(
+    body: dict = Body(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+) -> JSONResponse:
+    """Describe (without consuming) the Slack identity a signed state would bind,
+    so the browser can show a confirm screen before committing. This is the
+    confused-deputy defence: binding is a deliberate act on a page that names the
+    Slack user + team being linked to *your* Terrapod account, not an automatic
+    bind on page load."""
+    state = (body.get("state") or "").strip()
+    if not state:
+        raise HTTPException(status_code=422, detail="Missing link state")
+    try:
+        team_id, slack_user_id = await slack_link_service.peek_link_state(state)
+    except slack_link_service.LinkStateError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return JSONResponse(
+        content={
+            "data": {
+                "slack-team-id": team_id,
+                "slack-user-id": slack_user_id,
+                "email": user.email,
+            }
+        }
+    )
+
+
 @router.post("/slack/link")
 async def link_account(
     body: dict = Body(...),

--- a/services/terrapod/services/slack_link_service.py
+++ b/services/terrapod/services/slack_link_service.py
@@ -75,12 +75,9 @@ async def mint_link_state(team_id: str, user_id: str, response_url: str = "") ->
     return token
 
 
-async def verify_and_consume_state(state: str) -> tuple[str, str, str]:
-    """Verify signature + expiry and BURN the nonce (single use).
-
-    Returns ``(team_id, user_id, response_url)`` — response_url is "" when none was
-    captured at mint time.
-    """
+def _decode_verified_payload(state: str) -> dict:
+    """Verify the signature + expiry of a link state and return its payload.
+    Does NOT touch the single-use nonce — callers decide whether to peek or burn."""
     try:
         payload_b64, sig = state.split(".", 1)
     except ValueError as exc:
@@ -96,7 +93,31 @@ async def verify_and_consume_state(state: str) -> tuple[str, str, str]:
 
     if int(payload.get("exp", 0)) < int(time.time()):
         raise LinkStateError("link state expired")
+    return payload
 
+
+async def peek_link_state(state: str) -> tuple[str, str]:
+    """Verify the state and confirm its nonce is still live WITHOUT consuming it —
+    so the browser confirm screen can show *which* Slack identity a state would
+    bind before the user commits (confused-deputy defence). Returns
+    ``(team_id, user_id)``. Consumption still happens in
+    ``verify_and_consume_state`` when the user confirms."""
+    payload = _decode_verified_payload(state)
+    nonce = payload.get("n", "")
+    from terrapod.redis.client import get_redis_client
+
+    if not await get_redis_client().exists(f"{_NONCE_PREFIX}{nonce}"):
+        raise LinkStateError("link state already used or expired")
+    return str(payload["t"]), str(payload["u"])
+
+
+async def verify_and_consume_state(state: str) -> tuple[str, str, str]:
+    """Verify signature + expiry and BURN the nonce (single use).
+
+    Returns ``(team_id, user_id, response_url)`` — response_url is "" when none was
+    captured at mint time.
+    """
+    payload = _decode_verified_payload(state)
     nonce = payload.get("n", "")
     from terrapod.redis.client import get_redis_client
 

--- a/services/tests/api/test_slack_link.py
+++ b/services/tests/api/test_slack_link.py
@@ -90,6 +90,47 @@ class TestLinkAccount:
         assert kwargs["email"] == "alice@example.com"
 
 
+class TestPreviewLink:
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_missing_state_422(self, *_m):
+        app, _db = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            r = await c.post(f"{_LINK}/preview", json={}, headers=_AUTH)
+        assert r.status_code == 422
+
+    @patch("terrapod.services.slack_link_service.peek_link_state", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_bad_state_400(self, _idb, _ir, _is, peek):
+        from terrapod.services.slack_link_service import LinkStateError
+
+        peek.side_effect = LinkStateError("link state already used or expired")
+        app, _db = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            r = await c.post(f"{_LINK}/preview", json={"state": "bad"}, headers=_AUTH)
+        assert r.status_code == 400
+
+    @patch("terrapod.services.slack_link_service.peek_link_state", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_preview_describes_identity_against_caller(self, _idb, _ir, _is, peek):
+        """Preview shows WHICH Slack identity would bind + the caller's email, and
+        does NOT consume the state (that only happens on confirm)."""
+        peek.return_value = ("T123", "U456")
+        app, _db = _make_app(_user("alice@example.com"))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            r = await c.post(f"{_LINK}/preview", json={"state": "good"}, headers=_AUTH)
+        assert r.status_code == 200
+        attrs = r.json()["data"]
+        assert attrs["slack-team-id"] == "T123"
+        assert attrs["slack-user-id"] == "U456"
+        assert attrs["email"] == "alice@example.com"
+
+
 class TestListLinks:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/services/test_slack_link_service.py
+++ b/services/tests/services/test_slack_link_service.py
@@ -19,6 +19,9 @@ class FakeRedis:
     async def getdel(self, k):
         return self.store.pop(k, None)
 
+    async def exists(self, k):
+        return 1 if k in self.store else 0
+
 
 @pytest.mark.asyncio
 async def test_state_roundtrip_and_single_use():
@@ -59,3 +62,34 @@ async def test_expired_state_rejected():
 async def test_malformed_state_rejected():
     with pytest.raises(svc.LinkStateError):
         await svc.verify_and_consume_state("not-a-valid-token")
+
+
+@pytest.mark.asyncio
+async def test_peek_does_not_consume_the_nonce():
+    """The confirm-screen preview reveals the Slack identity WITHOUT burning the
+    single-use nonce, so the subsequent confirm can still bind."""
+    fake = FakeRedis()
+    with patch("terrapod.redis.client.get_redis_client", return_value=fake):
+        state = await svc.mint_link_state("T123", "U456", "https://hooks.slack/resp")
+        # Peek twice — both succeed, nonce still live.
+        assert await svc.peek_link_state(state) == ("T123", "U456")
+        assert await svc.peek_link_state(state) == ("T123", "U456")
+        # Confirm burns it; a further peek now fails (already used).
+        team, user, _ = await svc.verify_and_consume_state(state)
+        assert (team, user) == ("T123", "U456")
+        with pytest.raises(svc.LinkStateError):
+            await svc.peek_link_state(state)
+
+
+@pytest.mark.asyncio
+async def test_peek_rejects_tampered_and_expired():
+    fake = FakeRedis()
+    with patch("terrapod.redis.client.get_redis_client", return_value=fake):
+        state = await svc.mint_link_state("T1", "U1")
+        payload_b64, _sig = state.split(".", 1)
+        forged = f"{payload_b64}.{svc._b64u(b'not-the-real-hmac-signature-here!!')}"
+        with pytest.raises(svc.LinkStateError):
+            await svc.peek_link_state(forged)
+        with patch.object(time, "time", return_value=time.time() + svc._STATE_TTL_SECONDS + 10):
+            with pytest.raises(svc.LinkStateError):
+                await svc.peek_link_state(state)

--- a/web/src/app/slack/link/page.tsx
+++ b/web/src/app/slack/link/page.tsx
@@ -47,21 +47,17 @@ function SlackLinkInner() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ state }),
         })
-        if (!res.ok) {
-          const data = await res.json().catch(() => ({}))
-          throw new Error(
-            data.detail ||
-              'This link is invalid, expired, or already used. Run `/terrapod link` again.',
-          )
-        }
+        if (!res.ok) throw new Error('preview rejected')
         const data = await res.json()
         setSlackTeam(data?.data?.['slack-team-id'] || '')
         setSlackUser(data?.data?.['slack-user-id'] || '')
         setEmail(data?.data?.email || auth.email)
         setStatus('confirm')
-      } catch (e) {
+      } catch {
+        // Any preview failure (invalid signature, expired, already used) is the
+        // same to the user — one friendly message, never a raw server detail.
         setStatus('error')
-        setMessage(e instanceof Error ? e.message : 'Could not check this link.')
+        setMessage('This link is invalid, expired, or already used. Run `/terrapod link` again.')
       }
     })()
   }, [state])

--- a/web/src/app/slack/link/page.tsx
+++ b/web/src/app/slack/link/page.tsx
@@ -5,18 +5,25 @@ import { useSearchParams } from 'next/navigation'
 import { getAuthState } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 
-type Status = 'working' | 'success' | 'error'
+// The link is a deliberate act, not an automatic bind on page load: we first
+// PREVIEW which Slack identity the signed state would bind (without consuming
+// it), show it against the logged-in Terrapod account, and only bind when the
+// user clicks Confirm. This is the confused-deputy defence — a victim tricked
+// into opening someone else's link sees an unfamiliar Slack user and can bail.
+type Status = 'loading' | 'confirm' | 'linking' | 'success' | 'error'
 
 function SlackLinkInner() {
   const params = useSearchParams()
   const state = params.get('state') || ''
-  const [status, setStatus] = useState<Status>('working')
-  const [message, setMessage] = useState('Linking your Slack account…')
+  const [status, setStatus] = useState<Status>('loading')
+  const [message, setMessage] = useState('Checking your link…')
   const [email, setEmail] = useState('')
+  const [slackTeam, setSlackTeam] = useState('')
+  const [slackUser, setSlackUser] = useState('')
   const ran = useRef(false)
 
   useEffect(() => {
-    if (ran.current) return // link state is single-use — never POST it twice
+    if (ran.current) return
     ran.current = true
 
     if (!state) {
@@ -35,7 +42,7 @@ function SlackLinkInner() {
 
     ;(async () => {
       try {
-        const res = await apiFetch('/api/terrapod/v1/slack/link', {
+        const res = await apiFetch('/api/terrapod/v1/slack/link/preview', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ state }),
@@ -48,15 +55,42 @@ function SlackLinkInner() {
           )
         }
         const data = await res.json()
+        setSlackTeam(data?.data?.['slack-team-id'] || '')
+        setSlackUser(data?.data?.['slack-user-id'] || '')
         setEmail(data?.data?.email || auth.email)
-        setStatus('success')
-        setMessage('Your Slack account is now linked to Terrapod.')
+        setStatus('confirm')
       } catch (e) {
         setStatus('error')
-        setMessage(e instanceof Error ? e.message : 'Linking failed.')
+        setMessage(e instanceof Error ? e.message : 'Could not check this link.')
       }
     })()
   }, [state])
+
+  async function confirmLink() {
+    setStatus('linking')
+    setMessage('Linking your Slack account…')
+    try {
+      const res = await apiFetch('/api/terrapod/v1/slack/link', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ state }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(
+          data.detail ||
+            'This link is invalid, expired, or already used. Run `/terrapod link` again.',
+        )
+      }
+      const data = await res.json()
+      setEmail(data?.data?.email || email)
+      setStatus('success')
+      setMessage('Your Slack account is now linked to Terrapod.')
+    } catch (e) {
+      setStatus('error')
+      setMessage(e instanceof Error ? e.message : 'Linking failed.')
+    }
+  }
 
   const tone =
     status === 'success'
@@ -72,12 +106,48 @@ function SlackLinkInner() {
           Connect Slack to Terrapod
         </h1>
         <div className={`rounded-lg border p-6 text-sm ${tone}`}>
-          <p>{message}</p>
-          {status === 'success' && email && (
-            <p className="mt-2 text-slate-400">
-              Linked as <span className="font-medium text-slate-200">{email}</span>. You can close
-              this tab and return to Slack.
-            </p>
+          {status === 'confirm' ? (
+            <div>
+              <p className="text-slate-300">
+                Link this Slack account to <span className="font-medium text-slate-100">your</span>{' '}
+                Terrapod identity? Every future Slack action (approve/discard) will run as this
+                Terrapod user with their permissions.
+              </p>
+              <dl className="mt-4 space-y-2">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-xs text-slate-500">Slack user</dt>
+                  <dd className="text-slate-200 font-mono text-xs">{slackUser || 'unknown'}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-xs text-slate-500">Slack team</dt>
+                  <dd className="text-slate-200 font-mono text-xs">{slackTeam || 'unknown'}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-xs text-slate-500">Terrapod account</dt>
+                  <dd className="text-slate-200 font-medium">{email}</dd>
+                </div>
+              </dl>
+              <p className="mt-4 text-xs text-amber-400/90">
+                Only continue if you just ran <code>/terrapod link</code> in Slack yourself. If this
+                Slack user isn&apos;t you, close this tab and don&apos;t link.
+              </p>
+              <button
+                onClick={confirmLink}
+                className="mt-4 w-full rounded bg-brand-600 hover:bg-brand-500 px-4 py-2 text-sm font-medium text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+              >
+                Confirm &amp; link
+              </button>
+            </div>
+          ) : (
+            <>
+              <p>{message}</p>
+              {status === 'success' && email && (
+                <p className="mt-2 text-slate-400">
+                  Linked as <span className="font-medium text-slate-200">{email}</span>. You can
+                  close this tab and return to Slack.
+                </p>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
Closes #687 — the two follow-ups left after the v0.54.1 reliability fix.

## Confused-deputy hardening (account link)
`/slack/link` previously **auto-bound on page load**: a victim tricked into opening an attacker's link would silently bind *their* Terrapod account to the *attacker's* Slack id, letting the attacker act on runs with the victim's RBAC.

Now binding is a deliberate act:
- **`POST /slack/link/preview`** — `peek_link_state()` verifies the signed state's signature + expiry and confirms the nonce is still live **without consuming it**, returning the `(team, user)` the state would bind. The verify/decode logic is refactored into a shared helper; `verify_and_consume_state` still burns the nonce on confirm.
- **Web** — two-phase flow: the page previews the Slack identity against the logged-in Terrapod account and binds only when the user clicks **Confirm & link**. An unfamiliar Slack user is the operator's cue to bail.
- **Docs** — the account-linking section describes the confirm step.

## E2E coverage
New `e2e/tests/slack.spec.ts` (registered in `playwright.config.ts`):
- the workspace **`slack-channel`** field round-trips through settings (fill → save-on-blur PATCH → reload → persisted);
- `/slack/link` surfaces an **error, never a confirm/bind**, for missing and invalid states.

Plus services-api tests for the preview endpoint (200/400/422) and a service-level test asserting `peek_link_state` does **not** consume the nonce.

## Verification
`make lint` green; `web` build green (`/slack/link` prerenders); slack service + api suites green. E2E runs in the CI e2e shard.

No release — rolling into a future one, per the plan.