### PR TITLE
feat(slack): per-deployment command + label for multi-deployment (closes #691)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,7 @@ jobs:
           # Slack config-channel: non-secret settings render into config.yaml,
           # secret tokens arrive via secretKeyRef env (never the ConfigMap).
           echo "$out" | grep -q "socket_mode: true" || { echo "FAIL: slack config not rendered into config.yaml"; exit 1; }
+          echo "$out" | grep -q 'command: "/terrapod"' || { echo "FAIL: slack command not rendered into config.yaml (#691)"; exit 1; }
           echo "$out" | grep -q "TERRAPOD_SLACK__BOT_TOKEN" || { echo "FAIL: slack bot-token secretKeyRef env missing"; exit 1; }
           echo "values-local renders OK (incl. Slack config + secretKeyRef)"
       - name: Eval values render (embedded Postgres/Redis)

--- a/docs/slack-integration.md
+++ b/docs/slack-integration.md
@@ -211,6 +211,38 @@ to `/terrapod link`; if you're linked but lack permission on that workspace, an
 ephemeral "no permission" — neither touches the run. On success the message is
 edited to record who approved, so a button can't be pressed twice.
 
+## Running multiple Terrapod deployments in one Slack workspace
+
+Terrapod is single-org and self-hosted — a company often runs **several
+deployments** (per team, per environment). They can all talk to the **same
+Slack workspace**, but two Slack-workspace-level resources are singletons and
+must be made distinct per deployment:
+
+1. **The slash command.** A Slack workspace treats a slash command as unique, so
+   only one app can own `/terrapod`. Give each deployment's Slack app a distinct
+   command in its manifest (e.g. `/terrapod-prod`, `/terrapod-staging`) and set
+   the matching **`api.config.slack.command`** so Terrapod answers it.
+2. **The app identity.** Each deployment installs its own Slack app; give them
+   distinct **names** (and icons) in the manifest so `@terrapod-prod` vs
+   `@terrapod-staging` are recognisable. Set a short **`api.config.slack.label`**
+   (e.g. `prod`) — it's rendered in the footer of every run message and the
+   approval, so a **shared channel** clearly attributes each Terrapod.
+
+Everything else already isolates per deployment: each has its own database and
+account-link table, its own signing key, and its own outbound Socket Mode
+connection — so account linking, RBAC, approvals, and notifications never cross
+between deployments. Only the command name and app identity need to be unique.
+
+```yaml
+# deployment "prod"
+api:
+  config:
+    slack:
+      enabled: true
+      command: "/terrapod-prod"   # matches this app's manifest command
+      label: "prod"               # shown in every message footer
+```
+
 ## Reference
 
 **Helm values** (`api.config.slack`):
@@ -219,6 +251,8 @@ edited to record who approved, so a button can't be pressed twice.
 |---|---|---|
 | `enabled` | `false` | Master switch for the integration. |
 | `socket_mode` | `true` | Outbound Socket Mode (the only supported mode today). |
+| `command` | `/terrapod` | The slash command this deployment answers — must match the command in its Slack app manifest. Give each deployment sharing one Slack workspace a distinct command (see below). |
+| `label` | `""` | Short per-deployment label shown in every Slack message (e.g. `prod`), so a shared channel can tell deployments apart. Empty → omitted. |
 | `existingSecret` | `""` | Name of the K8s Secret holding the three tokens. |
 | `existingSecretKeys.botToken` / `.appToken` / `.signingSecret` | `bot-token` / `app-token` / `signing-secret` | Keys within that Secret. |
 

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -300,6 +300,8 @@ data:
       # never rendered here.
       enabled: {{ .Values.api.config.slack.enabled }}
       socket_mode: {{ .Values.api.config.slack.socket_mode }}
+      command: {{ .Values.api.config.slack.command | default "/terrapod" | quote }}
+      label: {{ .Values.api.config.slack.label | default "" | quote }}
     {{- end }}
     {{- if .Values.api.config.notifications }}
     notifications:

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -891,6 +891,8 @@
           "properties": {
             "enabled": { "type": "boolean" },
             "socket_mode": { "type": "boolean" },
+            "command": { "type": "string" },
+            "label": { "type": "string" },
             "existingSecret": { "type": "string" },
             "existingSecretKeys": {
               "type": "object",

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -508,6 +508,9 @@ api:
     slack:
       enabled: false
       socket_mode: true              # false → Request-URL mode (needs webhook ingress)
+      command: "/terrapod"           # slash command this deployment answers (must match the app manifest)
+      label: ""                      # short per-deployment label shown in messages (e.g. "prod"); disambiguates
+                                     # multiple Terrapods sharing one Slack workspace — see #691
       existingSecret: ""             # K8s Secret holding the three tokens
       existingSecretKeys:            # keys within that Secret
         botToken: bot-token

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -858,6 +858,27 @@ class SlackConfig(BaseModel):
             "Slack reaches the Request-URL endpoint via the public webhook ingress."
         ),
     )
+    # Multi-deployment (#691): a Slack workspace treats a slash command as unique
+    # and every app is named "Terrapod", so several Terrapod deployments sharing
+    # one Slack workspace collide. Give each deployment a distinct `command`
+    # (matching the command set in its Slack app manifest) and a short `label`
+    # rendered in every message so a shared channel attributes each one.
+    command: str = Field(
+        default="/terrapod",
+        description=(
+            "The slash command this deployment answers (must match the command in "
+            "its Slack app manifest). Give each deployment sharing one Slack "
+            "workspace a distinct command, e.g. /terrapod-prod."
+        ),
+    )
+    label: str = Field(
+        default="",
+        description=(
+            "Short human label for this deployment (e.g. 'prod', 'us-west-2'), shown "
+            "in Slack run messages so a shared channel can tell deployments apart. "
+            "Empty → omitted."
+        ),
+    )
     # --- secrets: delivered via secretKeyRef → env, never rendered to the ConfigMap ---
     bot_token: str = Field(default="", description="Bot User OAuth Token (xoxb-…)")
     app_token: str = Field(

--- a/services/terrapod/services/slack_commands.py
+++ b/services/terrapod/services/slack_commands.py
@@ -69,9 +69,12 @@ async def _handle_status(team_id: str, user_id: str) -> dict:
             "response_type": "ephemeral",
             "text": f":white_check_mark: Linked to Terrapod as *{link.terrapod_email}*.",
         }
+    from terrapod.config import settings
+
+    cmd = settings.slack.command
     return {
         "response_type": "ephemeral",
-        "text": "Not linked yet. Run `/terrapod link` to connect your Terrapod account.",
+        "text": f"Not linked yet. Run `{cmd} link` to connect your Terrapod account.",
     }
 
 
@@ -101,9 +104,12 @@ async def build_slash_response(
         return await _handle_status(team_id, user_id)
     if sub == "unlink":
         return await _handle_unlink(team_id, user_id)
+    from terrapod.config import settings
+
+    cmd = settings.slack.command
     return {
         "response_type": "ephemeral",
-        "text": "Usage: `/terrapod link` · `/terrapod status` · `/terrapod unlink`",
+        "text": f"Usage: `{cmd} link` · `{cmd} status` · `{cmd} unlink`",
     }
 
 
@@ -134,8 +140,10 @@ async def handle_socket_request(client, req) -> None:
         await _ack()  # ack other events; nothing to act on
         return
 
+    from terrapod.config import settings
+
     payload = req.payload or {}
-    if payload.get("command") != "/terrapod":
+    if payload.get("command") != settings.slack.command:
         await _ack()
         return
 

--- a/services/terrapod/services/slack_notify_service.py
+++ b/services/terrapod/services/slack_notify_service.py
@@ -145,11 +145,18 @@ def counts_text(run) -> str:
 
 
 def _link_ctx(url: str) -> list:
-    return (
-        [{"type": "context", "elements": [{"type": "mrkdwn", "text": f"<{url}|Open in Terrapod>"}]}]
-        if url
-        else []
-    )
+    """Footer context: the deep link plus this deployment's label (#691), so a
+    shared Slack channel can tell multiple Terrapod deployments apart. Either
+    element is omitted when unset; the whole block drops if both are empty."""
+    from terrapod.config import settings
+
+    elements = []
+    if url:
+        elements.append({"type": "mrkdwn", "text": f"<{url}|Open in Terrapod>"})
+    label = (settings.slack.label or "").strip()
+    if label:
+        elements.append({"type": "mrkdwn", "text": f"Terrapod: *{label}*"})
+    return [{"type": "context", "elements": elements}] if elements else []
 
 
 def resolved_parent_blocks(ws_name: str, counts: str, status_line: str, url: str) -> list:

--- a/services/tests/services/test_slack_commands.py
+++ b/services/tests/services/test_slack_commands.py
@@ -29,6 +29,43 @@ async def test_link_returns_connect_button_with_state_url():
 async def test_unknown_subcommand_returns_usage():
     resp = await sc.build_slash_response("wat", "T1", "U1")
     assert "Usage:" in resp["text"]
+    # Usage echoes the default command.
+    assert "/terrapod link" in resp["text"]
+
+
+@pytest.mark.asyncio
+async def test_usage_echoes_configured_command():
+    """Multi-deployment (#691): help text uses this deployment's command, not a
+    hardcoded /terrapod, so a second deployment's /terrapod-prod reads right."""
+    with patch.object(settings.slack, "command", "/terrapod-prod"):
+        resp = await sc.build_slash_response("wat", "T1", "U1")
+    assert "/terrapod-prod link" in resp["text"]
+    assert "/terrapod link" not in resp["text"]
+
+
+@pytest.mark.asyncio
+async def test_socket_request_matches_configured_command():
+    """The socket listener answers this deployment's configured command and acks
+    (no reply) for the default /terrapod when it's been reconfigured away."""
+    client = MagicMock()
+    client.send_socket_mode_response = AsyncMock()
+    with patch.object(settings.slack, "command", "/terrapod-prod"):
+        # The configured command → ephemeral reply payload.
+        req = SimpleNamespace(
+            type="slash_commands",
+            envelope_id="e1",
+            payload={"command": "/terrapod-prod", "text": "help", "team_id": "T", "user_id": "U"},
+        )
+        await sc.handle_socket_request(client, req)
+        assert client.send_socket_mode_response.await_args.args[0].payload is not None
+        # The bare /terrapod is now a foreign command for this deployment → no reply.
+        req2 = SimpleNamespace(
+            type="slash_commands",
+            envelope_id="e2",
+            payload={"command": "/terrapod", "text": "help", "team_id": "T", "user_id": "U"},
+        )
+        await sc.handle_socket_request(client, req2)
+        assert client.send_socket_mode_response.await_args.args[0].payload is None
 
 
 @pytest.mark.asyncio

--- a/services/tests/services/test_slack_notify_service.py
+++ b/services/tests/services/test_slack_notify_service.py
@@ -118,6 +118,28 @@ async def test_ai_disabled_enqueues_everything_immediately():
 
 
 @pytest.mark.asyncio
+async def test_footer_shows_deployment_label_when_set():
+    """Multi-deployment (#691): a per-deployment label renders in the message
+    footer so a shared channel can attribute each Terrapod; absent when unset."""
+    db = _fake_db_no_ai()
+    run = _run()
+    ws = SimpleNamespace(id="ws-1", name="prod")
+    with (
+        patch.object(settings, "external_url", "https://terrapod.example.com"),
+        patch.object(settings.slack, "label", "us-west-2"),
+    ):
+        msg = await sn._build_message(db, run, ws, "run:completed")
+    assert "Terrapod: *us-west-2*" in str(msg["blocks"])
+
+    with (
+        patch.object(settings, "external_url", "https://terrapod.example.com"),
+        patch.object(settings.slack, "label", ""),
+    ):
+        msg2 = await sn._build_message(db, run, ws, "run:completed")
+    assert "Terrapod: *" not in str(msg2["blocks"])
+
+
+@pytest.mark.asyncio
 async def test_needs_attention_message_has_approve_discard_buttons():
     db = _fake_db_no_ai()
     run = _run()


### PR DESCRIPTION
Closes #691.

The Slack integration assumed **one Terrapod deployment per Slack workspace**, which conflicts with running several deployments per company (single-org, self-hosted → an instance per team/env). Two Slack-workspace-level singletons collided:
- the **`/terrapod` slash command** was hardcoded — a Slack workspace treats a command as unique, so only one app could own it (a second deployment's renamed command was ignored by our code); and
- every app was named **"Terrapod"**, indistinguishable in a shared channel.

Everything else already isolates per deployment (own DB + link table, per-deployment signing key, own Socket Mode connection), so linking/RBAC/approvals/notifications never cross between deployments.

## Changes
- **`slack.command`** (default `/terrapod`) — the command this deployment answers, compared in the socket listener and echoed in all help/status/usage text.
- **`slack.label`** (default `""`) — a short per-deployment label rendered in every run-message footer + the resolved approval, so a shared channel attributes each Terrapod.
- **Config-channel contract** — `values.yaml` + `values.schema.json` + `configmap-api.yaml` render + a `helm-smoke` assertion that `command:` reaches the rendered `config.yaml`. Renders clean on all three profiles (prod/local/eval).
- **Docs** — new "Running multiple Terrapod deployments in one Slack workspace" section + reference rows.
- **Tests** — the configured command is honoured (the default `/terrapod` is ignored once moved), usage text echoes the command, and the footer shows the label when set.

## Verification
`make lint` green; helm lint + `helm template` green on `values.yaml` / `values-local.yaml` / `values-eval.yaml`; slack command + notify suites green (26 passed).

No release — rolls into a future one.