### PR TITLE
docs: adoption surfaces — accurate migration guide, buyer-focused positioning, provenance + known-limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Terrapod is **not** a fork of Terraform or OpenTofu. It orchestrates them.
 
 ![Workspaces](docs/images/workspaces.png)
 
+## Is Terrapod for you?
+
+Terrapod earns its keep when the network, the credentials boundary, or the migration is the hard part. You're likely a fit if:
+
+- **You run Terraform/OpenTofu across networks a SaaS can't reach into** — isolated VPCs, other regions, on-prem, or behind egress-only firewalls. Terrapod's control plane **never needs a route into an execution cluster**: runners dial *out* and create Jobs locally, so a cluster only ever makes outbound connections. VCS is polled outbound too, and cached providers/binaries can be served with no upstream internet.
+- **State and cloud credentials must not leave your boundary** — Terrapod is self-hosted end to end. One Helm release owns the API, state, registry, and caches; nothing is handed to an external control plane.
+- **You're leaving Terraform Enterprise / HCP Terraform** (cost, licensing, or the Replicated end-of-life) and want an open, self-hosted landing spot — often paired with a move to OpenTofu. The [`terrapod-migrate`](docs/migration.md) CLI imports workspaces, variables, VCS wiring, and state with a dry-run-first, reversible flow.
+- **You're a Kubernetes-native platform team** — Terrapod deploys only on Kubernetes, via Helm, and runs as just another workload in your stack.
+
+If none of these describe you — a single team, a freely-reachable network, happy on a hosted service — a managed platform may be less to operate. Terrapod is built for the harder-network, own-your-boundary case.
+
 ## Why Terrapod
 
 Beyond broad TFE compatibility, Terrapod is built with three deliberate design foci:
@@ -22,6 +33,8 @@ Beyond broad TFE compatibility, Terrapod is built with three deliberate design f
 ---
 
 > **Drop-in replacement for HCP Terraform.** Point your existing `cloud` blocks, `go-tfe` clients, and CI/CD pipelines at Terrapod — zero code changes required.
+
+> **Migrating from Terraform Enterprise / HCP Terraform / Atlantis.** The [`terrapod-migrate`](docs/migration.md) CLI imports workspaces, variables, VCS connections, and state with a **dry-run-first, fully reversible** flow — preview everything, apply, verify parity, and roll back cleanly if needed.
 
 > **AI-augmented plans.** Every plan can carry an LLM-generated change description, risk assessment, and (on failure) suggested fixes — provider-agnostic via [LiteLLM](https://github.com/BerriAI/litellm). Wire AWS Bedrock (Claude, Nova, gpt-oss) with native IAM auth, or point at OpenAI, Anthropic, Gemini, Azure OpenAI, or any OpenAI-compatible endpoint. See [docs/ai-plan-summary.md](docs/ai-plan-summary.md).
 
@@ -212,6 +225,22 @@ Defaults give you filesystem storage on a PVC, local password auth, the migratio
 
 Object storage options: S3, Azure Blob, GCS, or the default PVC-backed filesystem.
 
+### Verify what you're deploying (optional)
+
+Every released image and the Helm chart are keyless-signed with [cosign](https://github.com/sigstore/cosign) and carry SBOM (SPDX) + SLSA build-provenance attestations. To verify an image's signature and provenance before you deploy:
+
+```zsh
+# Signature (keyless — identity pinned to the release workflow's GitHub OIDC):
+cosign verify ghcr.io/mattrobinsonsre/terrapod-api:vX.Y.Z \
+  --certificate-identity-regexp '^https://github.com/mattrobinsonsre/terrapod/\.github/workflows/ci\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# SBOM + build provenance (discoverable as OCI referrers on the same digest):
+gh attestation verify oci://ghcr.io/mattrobinsonsre/terrapod-api:vX.Y.Z --repo mattrobinsonsre/terrapod
+```
+
+Full details and admission-time enforcement patterns: [Supply-chain Verification](docs/supply-chain-verification.md#verifying-terrapods-own-release-artifacts).
+
 ### Create Your First Workspace
 
 ```zsh
@@ -278,6 +307,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 |---|---|
 | [Architecture](docs/architecture.md) | System components, BFF pattern, storage, runners, auth flows |
 | [Getting Started](docs/getting-started.md) | Deploy the Helm chart on Kubernetes (or k3s), first workspace, first plan/apply |
+| [Migration](docs/migration.md) | Move a TFE / HCP Terraform or Atlantis platform onto Terrapod with `terrapod-migrate` — dry-run-first, reversible, what transfers vs. what's left as a checklist |
 | [Local Development](docs/local-development.md) | Run Terrapod from source with Tilt (contributors only) |
 | [Authentication](docs/authentication.md) | Local auth, OIDC, SAML, terraform login, API tokens |
 | [RBAC](docs/rbac.md) | Permission model, label-based access control, custom roles |
@@ -307,6 +337,8 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Optional Webhook Ingress](docs/deployment-webhook-ingress.md) | Split public webhook ingress so the management plane can stay private |
 | [Forward Proxy & Custom CA](docs/deployment-proxy.md) | Route all outbound HTTP(S) through a corporate proxy and trust a private/MITM CA, across every component including runner Jobs |
 | [Security Hardening](docs/security-hardening.md) | Pod hardening defaults, secrets, network posture |
+| [Supply-chain Verification](docs/supply-chain-verification.md) | Verify Terrapod's own signed images + SBOM/SLSA attestations, and how cached binaries/providers are verified against publisher signatures |
+| [Known Limitations](docs/known-limitations.md) | What Terrapod does not (yet) do — deployment, scope, and feature constraints, stated plainly |
 | [Production Checklist](docs/production-checklist.md) | Pre-go-live checklist for a production deployment |
 | [Disaster Recovery](docs/disaster-recovery.md) | Break-glass state recovery, shipped DB backup CronJob + restore-verification DR drill, per-backend object-storage protection |
 | [Encryption at Rest](docs/encryption-at-rest.md) | Optional off-by-default app-layer (BYOK) envelope encryption of DB secrets **and state files** — for no-/niche-CSP, bare-metal, or air-gapped deployments (static / Vault Transit / AWS KMS) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,35 @@ If you are unable to use GitHub's reporting, email the maintainer directly.
 - Static analysis via Semgrep with OWASP Top 10 and custom project rules.
 - Dynamic application security testing via Nuclei with custom templates.
 
+### Release Artifact Provenance
+
+Every release is cryptographically verifiable. Each container image and the
+Helm chart are **keyless-signed with [cosign](https://github.com/sigstore/cosign)**
+(via GitHub OIDC — no long-lived signing key), and each image carries an
+**SBOM (SPDX)** attestation and a **SLSA build-provenance** attestation,
+discoverable as OCI referrers on the image digest. SBOMs and a checksums file
+are also attached to every GitHub Release.
+
+Verify before deploying:
+
+```zsh
+# Image (or chart) signature — identity pinned to the release workflow's OIDC:
+cosign verify ghcr.io/mattrobinsonsre/terrapod-api:vX.Y.Z \
+  --certificate-identity-regexp '^https://github.com/mattrobinsonsre/terrapod/\.github/workflows/ci\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# SBOM + build provenance:
+gh attestation verify oci://ghcr.io/mattrobinsonsre/terrapod-api:vX.Y.Z --repo mattrobinsonsre/terrapod
+```
+
+Full verification details, the complete artifact list, and admission-time
+enforcement patterns (e.g. Kyverno) are in
+[Supply-chain Verification](docs/supply-chain-verification.md#verifying-terrapods-own-release-artifacts).
+That guide also covers the *other* direction — how Terrapod verifies the
+upstream terraform/tofu binaries and provider archives it caches against the
+publisher's GPG-signed `SHA256SUMS`, with the runner re-verifying the
+executable before it runs.
+
 ## Security Testing
 
 Terrapod includes a three-layer security testing framework:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,7 +29,7 @@ go-terrapod targets the full Terrapod API surface — both the TFE-V2-compatible
 
 ### Version contract
 
-go-terrapod pins to a specific Terrapod API version at build time via the `SDKVersion` constant. Consuming tools call `Client.VersionCheck` at startup to fail-fast on a mismatch. The migration tool requires this match by default and exposes `--allow-api-version-mismatch` for advanced operators. Releases of Terrapod, go-terrapod, the provider, and the migration tool all happen at the same tag — they ship together.
+go-terrapod pins to a specific Terrapod API version at build time via the `SDKVersion` constant and exposes `Client.VersionCheck` so a consumer can fail-fast on a version mismatch. Releases of Terrapod, go-terrapod, the provider, and the migration tool all happen at the same tag — they ship together, so keeping the CLIs and the server on matching versions avoids schema drift.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,6 +112,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | Guide | Description |
 |---|---|
 | [Getting Started](getting-started.md) | Deploy the Helm chart on Kubernetes (or k3s), first workspace, first plan/apply |
+| [Migration](migration.md) | Move a TFE / HCP Terraform or Atlantis platform onto Terrapod with `terrapod-migrate` — dry-run-first, reversible, with an explicit "what transfers vs. what's a checklist" breakdown |
 | [Local Development](local-development.md) | Run Terrapod from source with Tilt (contributors only) |
 | [Architecture](architecture.md) | System components, storage, runners, auth flows |
 | [Authentication](authentication.md) | Local auth, OIDC, SAML, terraform login, API tokens, scoped service tokens (bound/detached) + offboarding idle guard |
@@ -144,6 +145,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Optional split webhook ingress](deployment-webhook-ingress.md) | Optional second Ingress for the public-must-reach surface (VCS webhooks, run-task callbacks) |
 | [Forward proxy & custom CA trust](deployment-proxy.md) | Route all outbound HTTP(S) through a corporate proxy and trust a private/MITM CA, across every component including runner Jobs |
 | [Security Hardening](security-hardening.md) | TLS, secrets management, network policies, rate limiting |
+| [Known Limitations](known-limitations.md) | What Terrapod does not (yet) do — deployment, scope, and feature constraints, stated plainly |
 | [Production Checklist](production-checklist.md) | Step-by-step checklist for go-live readiness |
 | [Disaster Recovery](disaster-recovery.md) | Break-glass state recovery, shipped DB backup CronJob + restore-verification DR drill, per-backend object-storage protection |
 | [API Reference](api-reference.md) | All API endpoints with examples |

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1,0 +1,107 @@
+# Known Limitations
+
+This page states plainly what Terrapod does **not** do — the constraints worth
+knowing before you adopt it. Some are deliberate design boundaries; some are
+"not yet" and are on the roadmap. We keep this list honest on purpose: it's
+better to find a constraint here than in production.
+
+Two categories are marked throughout:
+
+- **By design** — a deliberate choice; not planned to change.
+- **Not yet** — a current gap with an intended direction (issue linked where one exists).
+
+## Deployment
+
+- **Kubernetes only** *(by design)*. Terrapod deploys exclusively via its Helm
+  chart, onto a Kubernetes cluster (a single-node [k3s](https://k3s.io/) VM
+  counts). There is no Docker Compose, bare-metal installer, or Nomad target —
+  the runner relies on the Kubernetes Jobs API, and the whole architecture
+  assumes Kubernetes primitives. If you can't run Kubernetes, Terrapod isn't a
+  fit. See [Getting Started](getting-started.md).
+- **External PostgreSQL + Redis for production** *(by design)*. The production
+  chart does not bundle datastores; you bring PostgreSQL 14+ and Redis 7+ (a
+  managed service, or run them yourself). The chart *can* deploy in-cluster
+  Postgres/Redis, but only for the **evaluation / dev** profiles
+  (`make eval`, Tilt) — single-replica, no HA, no backups. Don't run those in
+  production. See [Deployment](deployment.md).
+
+## Organization, tenancy & access model
+
+- **Single organization** *(by design)*. There is exactly one implicit
+  organization, always named `default`, with no `org_name` anywhere in the data
+  model or API. Multi-org is a SaaS multi-tenancy mechanism; a self-hosted
+  install *is* one tenant. When you genuinely need two isolated tenants, run a
+  second Terrapod instance (a second Helm release) — which gives stronger
+  isolation than org-scoping inside one database. See
+  [Architecture → Why a single organization](architecture.md#why-a-single-organization).
+- **No teams; no projects** *(by design)*. Terrapod replaces TFE's team model
+  with **label-based RBAC** — a "team" is a label, and access is resolved from
+  labels + roles. There is no project concept. If your mental model depends on
+  teams-as-objects or projects, you map those onto labels.
+
+## Execution
+
+- **`local` and `agent` execution modes only** *(by design)*. TFE's `remote`
+  mode (TFE-hosted workers) is not supported and won't be — Terrapod has no
+  built-in execution infrastructure; all server-side execution goes through
+  agent pools. The API rejects `execution-mode: "remote"` with a 422.
+
+## VCS integration
+
+- **GitHub and GitLab only** *(not yet for others)*. VCS connections support
+  GitHub (App) and GitLab (access token). Bitbucket and Azure DevOps are not
+  supported; workspaces backed by them migrate as CLI-driven (no VCS
+  connection). See [VCS Integration](vcs-integration.md).
+
+## Migration
+
+- **`terrapod-migrate` auto-creates a core subset** *(partly not yet)*. The tool
+  imports VCS connections, workspaces, workspace variables, and state today.
+  Variable sets, run triggers, notifications, agent pools, and the private
+  registry are **read and reported** (surfaced as a checklist in the handover
+  doc) but not yet auto-created — you recreate them by hand, typically via the
+  Terraform provider. Extending this is tracked in
+  [#709](https://github.com/mattrobinsonsre/terrapod/issues/709). RBAC is
+  intentionally *suggested, never auto-applied*. See
+  [Migration](migration.md#what-actually-transfers-today).
+
+## Terragrunt
+
+- **Agent-mode Terragrunt has caveats** *(by design + not yet)*. Terrapod runs
+  Terragrunt in agent mode via the `terragrunt_enabled` workspace flag, and
+  CLI-driven Terragrunt works with zero extra config. The migration tool does
+  **not** auto-translate Terragrunt-driven Atlantis projects (their dependency
+  graphs and `generate` blocks aren't mechanically convertible). See
+  [Terragrunt](terragrunt.md) for the current boundaries.
+
+## Policy
+
+- **OPA/Rego only** *(by design)*. Policy-as-code uses Open Policy Agent and the
+  Rego language — the open-source equivalent of TFE's Sentinel. Sentinel itself
+  is proprietary and not supported; migrated Sentinel policies are listed by
+  name for you to rewrite as Rego. See [Policy-as-Code](policies.md).
+
+## Object storage
+
+- **Native SDKs + filesystem; no S3-compat shim** *(by design)*. State and
+  artifacts go to AWS S3, Azure Blob, or GCS via each provider's native SDK, or
+  to a filesystem PVC for dev. There is no generic S3-compatible shim (and no
+  bundled MinIO). See [Deployment](deployment.md).
+
+## Explicitly out of scope (by design)
+
+Terrapod orchestrates `terraform`/`tofu`; it does not reimplement them, and it
+deliberately does not attempt:
+
+- The Terraform/OpenTofu **engine** itself.
+- **Sentinel** (proprietary policy language) and **Terraform Stacks**
+  (proprietary orchestration runtime with no local-execution path).
+- **Terraform Cloud Business-tier** SaaS features.
+- A **built-in Vault** — configure Vault externally if you need it.
+- **Non-Kubernetes** deployment of any kind.
+
+---
+
+Found something missing or inaccurate here? Please
+[open an issue](https://github.com/mattrobinsonsre/terrapod/issues) — an honest
+limitations list is only useful if it stays current.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -22,38 +22,138 @@ every Terrapod release. Each release publishes:
 Each archive is accompanied by a SHA256 checksum file, and the checksum
 file is detached-GPG-signed with the same key that signs the provider.
 
-Releases pin to a Terrapod API version — the tool refuses to run against
-a deployment whose version doesn't match, to keep schema drift from
-producing half-migrated state.
-
 > This page is the operator-facing runbook. Per-increment design rationale
 > lives in code comments under `migrate/internal/`; that's where to start
 > reading if you want to extend a source plugin.
 
-## Status
+## What actually transfers today
 
-Available since **v0.27.0**. The `apply`, `status`, `rewrite`, `verify`,
-`rollback`, `cutover`, and `module` subcommands are fully implemented;
-`terrapod-migrate` ships as a GitHub Release artifact (universal-macOS +
-linux/windows amd64+arm64).
+`terrapod-migrate` is built in increments. It is important to be precise
+about what the tool **creates on Terrapod for you** versus what it
+**reads, reports, and hands back to you as a checklist** — so nothing is
+silently assumed done. The design principle is: auto-create the core that
+gets a workspace planning again, surface everything else with
+operator-readable guidance, and never pretend a resource migrated when it
+didn't.
+
+### Auto-created on Terrapod (the core)
+
+| Resource | Detail |
+|---|---|
+| **VCS connections** | One Terrapod connection per source OAuth/PAT (TFE oauth-client, or one shared connection for Atlantis). GitHub and GitLab only. |
+| **Workspaces** | Name, execution mode, terraform/tofu version, working directory, auto-apply, owner, VCS repo + branch link. TFE **tags → Terrapod labels** (`"k:v"` → `{k: "v"}`, bare `"k"` → `{k: ""}`). |
+| **Workspace variables** | Terraform + env, sensitive flag, HCL flag, description. Sensitive values are read from the source **at apply time** and never written into the state file or dry-run report. |
+| **State** | The current state version per workspace, with **serial + lineage preserved**, guarded against lineage mismatch and destination-serial-ahead (see [Reversibility](#reversibility-dry-run--rollback)). For **non-VCS** workspaces, the latest uploaded **configuration-version tarball** is migrated too (without it the workspace has no code to run on first plan). |
+
+### Read, reported, and left for you (a checklist, not yet auto-created)
+
+The source plugin discovers these and lists them in the skipped-items
+report + handover document with operator-readable guidance, but the tool
+does **not** create them on Terrapod yet — you complete them by hand
+(typically via `terraform-provider-terrapod`). They are on the roadmap as
+later increments.
+
+| Not-yet-created | How to complete it |
+|---|---|
+| **Variable sets** | Reported per varset (name + workspace count). Recreate as Terrapod variable sets and assign to workspaces. |
+| **Run triggers** | Reported per source→destination pair. Recreate with `terrapod_run_trigger`. |
+| **Notification configurations** | Reported per workspace (webhook / Slack / email). Recreate with `terrapod_notification_configuration`. |
+| **Agent pools** | Reported by name + workspace assignments. Tokens are never portable — create the pool and regenerate a join token. |
+| **Private registry** (modules, module versions, providers, GPG keys) | Reported for awareness. Republish with [`terrapod-publish`](registry-publishing.md), or point Terrapod's registry at the module's VCS tag stream. |
+| **RBAC roles** | The tool generates a **suggested** role mapping from the source's teams/permissions into the handover doc. RBAC is the highest-blast-radius decision in a migration, so it is advisory only — you review, edit, and apply it via `terrapod_role` + `terrapod_role_assignment`. Nothing is applied automatically. |
+
+### Not migrated by design (and why)
+
+- **Sentinel policies** — proprietary to HashiCorp; Terrapod uses OPA/Rego.
+  Every Sentinel policy attached to a migrated workspace is listed by name
+  so you can rewrite it as Rego on your own schedule.
+- **Run history** — out of scope; too lossy to be useful. The handover doc
+  records the last successful run per workspace as a reference point.
+- **Projects** — Terrapod is single-org with no project concept. Project
+  membership is surfaced in the report; fold it onto workspace labels.
+- **Teams as first-class objects** — replaced by label-RBAC (see the
+  suggested-roles output above).
+- **HCP Terraform Stacks** and **cost-estimation history** — out of scope.
+- **The `hashicorp/tfe` provider in your own IaC** — if you manage your TFE
+  setup with the `tfe` provider, that module doesn't carry over: the
+  `terrapod` provider has different attribute shapes (no projects, no teams,
+  label-RBAC vs team-permissions). Rewriting it is a manual exercise.
 
 ## Subcommands
 
+`terrapod-migrate` has six subcommands:
+
 - `terrapod-migrate apply` — read from `--source` (`tfe` | `atlantis`),
-  write to `--target` Terrapod. Dry-run by default; pass `--apply` to
+  write to `--target` Terrapod. **Dry-run by default**; pass `--apply` to
   actually write.
 - `terrapod-migrate rewrite` — mechanically rewrite HCL `cloud {}` /
-  `backend "remote"` blocks and private module sources in a local
-  directory tree. No VCS interaction — operator commits and pushes after.
-- `terrapod-migrate verify` — confirm each migrated workspace still
-  matches what the migration recorded: it's present, the variable count
-  is intact, and the state serial/lineage is unchanged. Exits non-zero on
-  any mismatch.
+  `backend "remote"` blocks (hostname + organization) in a local directory
+  tree. **Dry-run by default**; pass `--write` to touch disk. No VCS
+  interaction — you commit and push after.
+- `terrapod-migrate verify` — confirm each migrated workspace still matches
+  what the migration recorded: it's present, the variable count is intact,
+  and the state serial/lineage is unchanged. Exits non-zero on any mismatch.
 - `terrapod-migrate rollback` — reverse a migration by deleting the
-  workspaces it created. Dry-run by default; pass `--apply` to delete.
+  workspaces it created. **Dry-run by default**; pass `--apply` to delete.
   Safe by construction (see [Reversibility](#reversibility-dry-run--rollback)).
-- `terrapod-migrate status` — print the contents of the migration state
-  file.
+- `terrapod-migrate status` — print the contents of the migration state file.
+- `terrapod-migrate cutover` — lock/unlock the source TFE workspaces and
+  write the handover document (TFE source only).
+
+## Quickstart
+
+### From TFE / HCP Terraform
+
+```bash
+# 1. Preview — writes nothing. Reports every workspace, variable, VCS
+#    connection, and state version that WOULD be created, plus the
+#    skipped-items checklist. Add --json for a machine-readable plan.
+terrapod-migrate apply \
+  --source tfe \
+  --tfe-org example-org \
+  --tfe-token "$TFE_TOKEN" \
+  --target https://terrapod.example.com \
+  --token "$TERRAPOD_TOKEN"
+
+# 2. Commit — same command with --apply.
+terrapod-migrate apply \
+  --source tfe --tfe-org example-org --tfe-token "$TFE_TOKEN" \
+  --target https://terrapod.example.com --token "$TERRAPOD_TOKEN" \
+  --apply
+
+# 3. Verify parity.
+terrapod-migrate verify \
+  --target https://terrapod.example.com --token "$TERRAPOD_TOKEN"
+
+# 4. Rewrite each repo's cloud/backend block (locally cloned).
+terrapod-migrate rewrite --dir ~/code/my-repo            # dry-run diff
+terrapod-migrate rewrite --dir ~/code/my-repo --write    # write in place
+
+# 5. Cut over: lock the source workspaces and generate the handover doc.
+terrapod-migrate cutover \
+  --tfe-org example-org --tfe-token "$TFE_TOKEN" \
+  --lock --write-handover cutover-handover.md
+```
+
+### From Atlantis
+
+```bash
+# With an atlantis.yaml (projects → workspaces or an autodiscovery rule):
+terrapod-migrate apply \
+  --source atlantis \
+  --source-dir ~/code/infra-repo \
+  --target https://terrapod.example.com --token "$TERRAPOD_TOKEN" \
+  --apply
+
+# Autodiscovery mode (no atlantis.yaml) — push state for one existing
+# Terrapod workspace directly from the repo's declared backend:
+terrapod-migrate apply \
+  --source atlantis \
+  --source-dir ~/code/infra-repo/prod \
+  --workspace prod-networking \
+  --target https://terrapod.example.com --token "$TERRAPOD_TOKEN" \
+  --apply
+```
 
 ## Reversibility: dry-run + rollback
 
@@ -67,15 +167,10 @@ variable, VCS-connection wiring, and **state version** (it reads the
 source state to report its serial/lineage/size, but uploads nothing) —
 plus the skipped-items report. Add `--json` for a machine-readable plan.
 
-```bash
-terrapod-migrate apply --source tfe --tfe-org acme --target https://terrapod.example.com --json   # preview
-terrapod-migrate apply --source tfe --tfe-org acme --target https://terrapod.example.com --apply  # commit
-```
-
 **2. Verify it landed.**
 
 ```bash
-terrapod-migrate verify --target https://terrapod.example.com   # exits non-zero on any parity mismatch
+terrapod-migrate verify --target https://terrapod.example.com --token "$TERRAPOD_TOKEN"
 ```
 
 **3. Roll back if it goes sideways.** `rollback` reads the state file and
@@ -83,8 +178,8 @@ deletes the workspaces the migration created (cascading their variables
 and state). It is built to never destroy anything it shouldn't:
 
 ```bash
-terrapod-migrate rollback --target https://terrapod.example.com           # dry-run: lists what would be deleted
-terrapod-migrate rollback --target https://terrapod.example.com --apply   # delete
+terrapod-migrate rollback --target https://terrapod.example.com --token "$TERRAPOD_TOKEN"           # dry-run: lists what would be deleted
+terrapod-migrate rollback --target https://terrapod.example.com --token "$TERRAPOD_TOKEN" --apply   # delete
 ```
 
 Safety guarantees:
@@ -117,62 +212,13 @@ metadata the rewriter needs.
 Re-running `apply` against the same state file is idempotent: previously
 created resources are skipped. The `rewrite` subcommand can consume the
 state file via `--state-file` (Mode 1) to derive the source/dest hosts
-and the set of workspace names to rewrite — or operators can pass
+and the set of workspace names to rewrite — or you can pass
 `--source-host` / `--source-org` / `--dest-host` flags directly (Mode 2)
 for ad-hoc rewriting without a migration record.
 
-## Source: TFE / HCP Terraform
-
-### What we migrate
-
-- **Workspaces** — settings, tags → Terrapod labels, working directory,
-  execution mode, VCS link, terraform/tofu version, resource sizing
-- **State** — current state version per workspace, with serial + lineage
-  preserved. For non-VCS workspaces, the latest uploaded configuration
-  version tarball is migrated too (without it the migrated workspace has
-  no code to run on first plan).
-- **Variables and variable sets** — terraform + env, sensitive flag, HCL
-  flag, varset scope. Sensitive values require an org-owner token to
-  read; with a worker-tier token the tool emits a report of which
-  variables the operator must re-enter post-migration.
-- **Run triggers** — cross-workspace dependencies, when both endpoints
-  are in the migration scope.
-- **Notification configurations** — webhook, Slack, email; unsupported
-  delivery types appear in the skipped-items report.
-- **VCS connections** — one Terrapod connection per TFE oauth-client.
-  GitHub and GitLab only; Bitbucket / Azure DevOps workspaces are
-  migrated as CLI-driven (no VCS connection) with a skipped-items entry.
-- **Private registry** — modules + module versions + providers + GPG
-  signing keys. Tarballs and binaries are pulled from TFE and re-uploaded
-  to Terrapod.
-- **Agent pools** — pool names and workspace assignments. Tokens are not
-  portable; the report lists each pool with a regenerate-token reminder.
-
-### What we don't migrate (and why)
-
-- **Sentinel policies** — proprietary to HashiCorp; Terrapod uses OPA
-  via Rego. The skipped-items report lists every Sentinel policy
-  attached to migrated workspaces by name so the operator can rewrite
-  them as Rego under their own schedule.
-- **Run history** — out of scope. Historic runs are too lossy to be
-  useful and Terrapod treats the cutover as a clean line. The handover
-  document records the last successful run per workspace as a reference.
-- **Projects** — Terrapod is single-org with no project concept.
-  Project tags are flattened onto workspace labels via the operator's
-  `--project-label-key` mapping (default: `project`).
-- **HCP Terraform Stacks** — out of scope.
-- **Cost estimation history** — out of scope.
-- **The `hashicorp/tfe` provider in your own IaC** — if you manage your
-  TFE setup with HCL using the `tfe` provider, that whole module is
-  broken post-migration: the `terrapod` provider has different attribute
-  shapes (no projects, no teams, label-RBAC vs team-permissions). The
-  tool emits `tfe-provider-references.md` listing every file using the
-  `tfe` provider with a shape-change-per-resource summary — the actual
-  rewrite is manual.
-
 ## Source: Atlantis
 
-### What we migrate
+### What we read
 
 - **Projects in `atlantis.yaml`** → Terrapod workspaces, or (when the
   pattern fits) a single autodiscovery rule covering them all.
@@ -181,19 +227,19 @@ for ad-hoc rewriting without a migration record.
   and autodiscovery rule fields.
 - **VCS connection** — one Terrapod connection covering the source repos.
 
-### What we don't migrate (and why)
+### What we don't read (and why)
 
 - **Workflows** (multi-command pre/post steps) — Terrapod has no
-  first-class equivalent. Recorded in the skipped-items report.
+  first-class equivalent. Recorded in the skipped-items report. (For custom
+  pre/post steps, see [execution-hooks.md](execution-hooks.md).)
 - **`apply_requirements`** (`approved`, `mergeable`, `undiverged`) — no
   direct Terrapod equivalent. Recorded as advisory metadata.
-- **`terragrunt` projects** — the migration tool does not auto-translate
-  terragrunt-driven Atlantis projects (their `terragrunt.hcl` dependency
-  graphs and `generate` blocks aren't mechanically convertible), so they're
-  detected and listed in the skipped-items report. This is a *migration-tool*
-  limitation, not a runtime one: Terrapod itself runs Terragrunt in agent
-  mode via the `terragrunt_enabled` workspace flag, so a skipped project can
-  be re-created by hand. See [terragrunt.md](terragrunt.md).
+- **`terragrunt` projects** — not auto-translated (their `terragrunt.hcl`
+  dependency graphs and `generate` blocks aren't mechanically convertible),
+  so they're detected and listed in the skipped-items report. This is a
+  *migration-tool* limitation, not a runtime one: Terrapod itself runs
+  Terragrunt in agent mode via the `terragrunt_enabled` workspace flag, so a
+  skipped project can be re-created by hand. See [terragrunt.md](terragrunt.md).
 - **PR comment history** — out of scope.
 
 ### Autodiscovery mode (no `atlantis.yaml`)
@@ -203,12 +249,12 @@ terraform directories automatically without an `atlantis.yaml` file. For
 these setups, use the `--workspace` flag to target an existing Terrapod
 workspace directly:
 
-```
+```bash
 terrapod-migrate apply \
-  --source=atlantis \
+  --source atlantis \
   --source-dir /path/to/terraform/project \
   --workspace my-workspace-name \
-  --target https://terrapod.example.com \
+  --target https://terrapod.example.com --token "$TERRAPOD_TOKEN" \
   --apply
 ```
 
@@ -227,17 +273,17 @@ state lives in Terrapod's own storage; foreign backends aren't a
 supported execution model.
 
 Migration therefore reads each project's state from its declared
-source-side location, pushes it into Terrapod, and rewrites the HCL to
-replace the foreign `backend "..." {}` with `terraform { cloud { ... }
-}` pointing at Terrapod. There is no "leave state in place" option.
+source-side location, pushes it into Terrapod, and (via `rewrite`)
+replaces the foreign `backend "..." {}` with `terraform { cloud { ... } }`
+pointing at Terrapod. There is no "leave state in place" option.
 
 Supported source-side backends (more can be added; these cover the
 common cases):
 
 - `s3` — AWS S3, reads via `aws-sdk-go-v2`, credentials via the SDK's
   default chain (env vars, `AWS_PROFILE`, IRSA, etc.). Lock-table
-  configuration is read but not respected — the operator must pause
-  Atlantis before running migration.
+  configuration is read but not respected — pause Atlantis before running
+  migration.
 - `gcs` — Google Cloud Storage via `cloud.google.com/go/storage`,
   credentials via `GOOGLE_APPLICATION_CREDENTIALS` or `gcloud auth`.
 - `azurerm` — Azure Blob Storage via `azure-sdk-for-go/sdk/storage/azblob`,
@@ -245,8 +291,8 @@ common cases):
 - `local` — file on disk inside the local clone (small dev setups only).
 
 Workspaces using `backend "remote" { ... }` that points at TFE / HCP
-are detected and rejected with a clear message — the operator should
-run the migration with `--source=tfe` against the actual state holder.
+are detected and rejected with a clear message — run the migration with
+`--source=tfe` against the actual state holder instead.
 
 State migration preserves serial + lineage so a re-run of
 `terraform plan` against the migrated state matches what the source
@@ -254,174 +300,73 @@ produced.
 
 ## HCL rewriting
 
-The `apply` subcommand writes to Terrapod's API; it does not edit the
-operator's source repos. After `apply` succeeds, the operator runs:
+The `apply` subcommand writes to Terrapod's API; it does not edit your
+source repos. After `apply` succeeds, run `rewrite` against each repo
+(locally cloned, on your own machine):
 
+```bash
+terrapod-migrate rewrite --state-file migration-state.json --dir ~/code/my-repo
 ```
-terrapod-migrate rewrite --state-file migration-state.json --source-dir ~/code/api
-```
 
-against each repo (locally cloned, on the operator's own machine). The
-tool walks the directory tree and mechanically rewrites:
+The tool walks the directory tree (recursing into `*.tf`, skipping
+`.terraform` / `.git` / `node_modules`) and mechanically rewrites the
+**backend declaration** — the hostname and organization only:
 
-- `terraform { cloud { hostname = "app.terraform.io", organization = "acme" ... } }` blocks → Terrapod hostname + `"default"` organization. Both `workspaces { name = "..." }` and `workspaces { tags = [...] }` forms are supported — only `hostname` and `organization` change; the workspace selection inside stays as-is (Terrapod's `tfe_v2` endpoint accepts the same `tags = [...]` syntax and translates internally). Tags are matched against workspace **labels**: a bare tag (`"core"`) matches any workspace with that label key, and a `key:value` tag (`"repo:web-app"`) matches that exact label. Use the colon form to select by key+value — OpenTofu rejects the Terraform 1.10+ map form (`tags = { repo = "..." }`), so `tags = ["repo:web-app"]` is the portable equivalent.
-- `terraform { backend "remote" { hostname = "app.terraform.io", organization = "acme" ... } }` blocks → same destination as `cloud {}`.
-- `source = "app.terraform.io/acme/<module>"` private-module references → `"<terrapod-host>/default/<module>"`.
-
-The following are detected and listed but **not** rewritten because the
-substitutions aren't mechanical:
-
-- `provider "tfe" {}` declarations and `resource "tfe_*" {}` / `data
-  "tfe_*" {}` blocks — different attribute shapes.
-
-Module source rewriting is **opt-in** via `--rewrite-modules` on the
-`rewrite` subcommand. Module pins are higher-blast-radius than backend
-blocks (a working `source = "github.com/acme/vpc?ref=v1.0.0"` line is
-easy to break with the wrong substitution) so the operator turns it on
-consciously. When `--rewrite-modules` is set, the rewriter walks every
-`module "..." { source = "..." }` block:
-
-- **TFE-registry form** (`"app.terraform.io/<org>/<name>/<provider>"`)
-  — looks up the matching Terrapod registry entry in the migration
-  state file. If found, rewrites to the Terrapod coord. If missing,
-  **hard error** by default (the operator just asked to rewrite and we
-  can't fulfil it). `--allow-missing-module-mapping` downgrades to a
-  warning.
-- **Git form** (`"git::https://..."`) — looks up the matching `module
-  register` record by git URL. Same hard-error-by-default behaviour.
-- **Public registry form** (`"hashicorp/aws"`) — ignored, never
-  rewritten.
-- **Local path** (`"./modules/vpc"`) — ignored, never rewritten.
-
-The Terrapod registry entries the rewriter looks up are created by
-`apply --source=tfe` (for tarball-based migration of TFE's private
-registry) and by the `module register` subcommand (for VCS-linked
-modules). See "Module migration" below.
+- `terraform { cloud { hostname = "app.terraform.io", organization = "acme" ... } }`
+  → Terrapod hostname + `"default"` organization. Both
+  `workspaces { name = "..." }` and `workspaces { tags = [...] }` forms are
+  supported — only `hostname` and `organization` change; the workspace
+  selection inside stays as-is. Tags are matched against workspace
+  **labels**: a bare tag (`"core"`) matches any workspace with that label
+  key, and a `key:value` tag (`"repo:web-app"`) matches that exact label.
+  Use the colon form to select by key+value — OpenTofu rejects the
+  Terraform 1.10+ map form (`tags = { repo = "..." }`), so
+  `tags = ["repo:web-app"]` is the portable equivalent.
+- `terraform { backend "remote" { hostname = "app.terraform.io", organization = "acme" ... } }`
+  → same destination as `cloud {}`.
 
 `rewrite` defaults to dry-run and prints a unified-diff report; pass
-`--apply` to write files in place. The tool does not run `git` — the
-operator inspects the diff, commits, and pushes via their normal flow.
+`--write` to write files in place. The tool does not run `git` — you
+inspect the diff, commit, and push via your normal flow.
 
-## Module migration
-
-Modules — like workspaces — are first-class migration targets. The
-tool supports two subtypes:
-
-### Tarball-based (TFE private registry → Terrapod private registry)
-
-Pulls every version of every module from the source TFE org's private
-registry, uploads to Terrapod's two-step module-version + tarball
-upload endpoints. Full version history preserved. Runs automatically
-as part of `apply --source=tfe` — no separate operator action.
-
-Each migrated module gets a record in `migration-state.json` mapping
-old source coordinate (`app.terraform.io/<org>/<name>/<provider>`) to
-new Terrapod coordinate (`<terrapod-host>/default/<name>/<provider>`).
-The `rewrite --rewrite-modules` step later consumes this record.
-
-Providers and GPG signing keys travel with the modules.
-
-### VCS-linked (`terrapod-migrate module register`)
-
-For modules whose sources live in git (rather than in a private TFE
-registry) the migration is a registration, not a tarball copy:
-Terrapod's registry is told to watch the git repo's tag stream and
-will publish versions over time as new tags appear. The operator
-brings their own git URL.
-
-Single module:
-
-```bash
-terrapod-migrate module register \
-   --source-vcs https://github.com/acme/modules-vpc \
-   --name vpc --provider aws --tag-prefix v \
-   --target https://terrapod.acme.com \
-   --apply
-```
-
-Batch via a config file (preferred for ≥10 modules — one source-
-controlled file the team can review):
-
-```bash
-terrapod-migrate module register \
-   --config-file modules.yaml \
-   --target https://terrapod.acme.com \
-   --apply
-```
-
-```yaml
-# modules.yaml
-modules:
-  - source_vcs: https://github.com/acme/modules-vpc
-    name: vpc
-    provider: aws
-    tag_prefix: v
-  - source_vcs: https://github.com/acme/modules-eks
-    name: eks
-    provider: aws
-    tag_prefix: v
-```
-
-Repeated single-shot invocations work too (idempotent thanks to the
-migration state file) — useful for shell loops over an external list
-of modules.
-
-Each registered module gets a record in `migration-state.json` mapping
-git URL → Terrapod coordinate, consumed by `rewrite --rewrite-modules`
-when the operator opts in to rewriting `module "x" { source =
-"git::..." }` references.
-
-### Ordering invariant
-
-Within `apply --source=tfe`, the call order is:
-
-1. VCS connections
-2. Workspaces (settings, vars, varsets)
-3. **Private registry: modules + providers + GPG keys**
-4. State (per workspace)
-5. Run triggers, notifications, agent pools
-
-Registry migration before state because the `rewrite` step (later)
-needs the registry mapping in `migration-state.json` to rewrite
-`source = "..."` lines. The operator runs `rewrite` after `apply`
-completes.
+**Module sources are not rewritten.** If your configs reference private
+modules by a source that changes under Terrapod (e.g. a TFE private-registry
+coordinate), update those `source = "..."` lines by hand — module pins are
+high-blast-radius and the tool leaves them to you deliberately.
 
 ## Cutover
 
-`apply --lock-source` locks every TFE workspace before reading its state.
-With the workspace locked, no in-flight TFE runs can change state under
-the migration. The lock is released only by the cutover-handover step
-(or by the operator manually if the migration aborts midway).
+The `cutover` subcommand (TFE source only) locks the source workspaces so
+no in-flight TFE run can change state under the migration, and writes the
+handover document:
 
-The handover document, written to `cutover-handover.md` at the end of an
-`apply` run, lists:
+```bash
+terrapod-migrate cutover --tfe-org example-org --tfe-token "$TFE_TOKEN" \
+  --lock --write-handover cutover-handover.md   # lock + handover
+terrapod-migrate cutover --tfe-org example-org --tfe-token "$TFE_TOKEN" \
+  --unlock                                       # release the locks
+```
+
+The handover document lists:
 
 - New Terrapod URLs per workspace.
-- Every HCL change the operator needs to make (with file paths derived
-  from TFE workspace `vcs-working-directory` + repo URL).
-- Every skipped item with rationale.
-- The state of any in-flight TFE runs at the moment of source-lock.
-- A short checklist for the operator: rewrite HCL, redirect CI, retire
-  TFE tokens.
+- The HCL changes you still need to make (backend blocks via `rewrite`;
+  module sources by hand).
+- Every skipped/checklist item with rationale — including the suggested
+  RBAC role mapping (see below).
+- The last successful run per workspace as a reference point.
 
-## Pre-migration RBAC check
+## RBAC: suggested, never auto-applied
 
 State files routinely contain secrets — database passwords, API keys,
-cloud creds captured into outputs. If the destination Terrapod workspace
-has broader read access than the source TFE workspace did, migration
-silently widens who can read those secrets.
+cloud creds captured into outputs. If a destination Terrapod workspace has
+broader read access than the source did, migration would silently widen who
+can read those secrets.
 
-`apply` performs a pre-migration check: for each workspace, the tool
-compares the source-side permission scope (TFE teams + workspace
-permissions) against the destination's expected reachability (Terrapod
-label-RBAC roles + assignments resolved through the planned mapping). If
-the destination resolves looser, the tool warns and refuses to migrate
-state for that workspace unless `--allow-rbac-widening` is set.
-
-## Version match
-
-The tool's build-time version must match the target Terrapod API's
-reported version exactly (compared via `/.well-known/terraform.json`).
-Mismatch refuses to run with a link to the matching release. Use
-`--allow-api-version-mismatch` to bypass — useful for hotfixing within a
-patch series but never recommended cross-minor.
+Because that boundary is the highest-blast-radius decision in a migration,
+`terrapod-migrate` does **not** apply RBAC automatically. Instead it
+generates a **suggested** role mapping from the source's teams and
+workspace permissions and writes it into the handover document as a
+"suggested roles" section. You review, edit, and apply it via
+`terrapod_role` + `terrapod_role_assignment` (the Terraform provider) — a
+human signs off on every role boundary before it takes effect.

--- a/llms.txt
+++ b/llms.txt
@@ -65,7 +65,7 @@ Build/lint/test all run in Docker via `make` (`make test`, `make lint`, `make de
 - [AI Plan Summary](docs/ai-plan-summary.md): LLM change summary + risk + failure analysis, provider-agnostic via LiteLLM (Bedrock/OpenAI/Anthropic/Gemini/vLLM).
 - [Audit Logging](docs/audit-logging.md), [Monitoring](docs/monitoring.md), [Artifact Retention](docs/artifact-retention.md): immutable event log, Prometheus metrics + shipped Grafana dashboard + alert rules with per-alert runbooks, automated cleanup.
 - [Terragrunt](docs/terragrunt.md): per-workspace Terragrunt support for agent-mode and CLI-driven runs.
-- [Migration](docs/migration.md): move TFE/HCP and Atlantis platforms onto Terrapod with `terrapod-migrate`.
+- [Migration](docs/migration.md): move a TFE/HCP Terraform or Atlantis platform onto Terrapod with the `terrapod-migrate` CLI (six subcommands: `apply`/`rewrite`/`verify`/`rollback`/`status`/`cutover`). **Dry-run-first + reversible** (provenance-gated `rollback`). Auto-creates the core — VCS connections, workspaces, workspace variables, state (serial+lineage preserved; config-version tarball for non-VCS). Variable sets, run triggers, notifications, agent pools, and the private registry are **read + reported as a checklist**, not yet auto-created ([#709](https://github.com/mattrobinsonsre/terrapod/issues/709)); RBAC is *suggested, never auto-applied*.
 
 ## Enabling features (operator quick-reference)
 
@@ -103,6 +103,7 @@ How each capability is turned on. **Platform-level** features are Helm values un
 - [docs/deployment-network-isolation.md](docs/deployment-network-isolation.md) and [docs/deployment-webhook-ingress.md](docs/deployment-webhook-ingress.md): split-ingress topologies.
 - [docs/deployment-proxy.md](docs/deployment-proxy.md): forward proxy (`proxy.*`) + custom outbound CA trust (`caBundle.*`) across all components incl. runner Jobs; for no-direct-egress / TLS-intercepting networks.
 - [docs/security-hardening.md](docs/security-hardening.md), [docs/production-checklist.md](docs/production-checklist.md), [docs/disaster-recovery.md](docs/disaster-recovery.md): go-live and break-glass.
+- [docs/known-limitations.md](docs/known-limitations.md): what Terrapod does **not** (yet) do — K8s-only deployment, single-org by design, no teams/projects, `local`/`agent` execution only, GitHub/GitLab VCS only, migration checklist gaps, OPA-only policy — each marked *by design* vs *not yet*.
 - [docs/runbooks.md](docs/runbooks.md): operator runbooks for high-blast-radius surfaces.
 - [docs/local-development.md](docs/local-development.md): run from source with Tilt (contributors).
 


### PR DESCRIPTION
Delivers three of the four adoption issues (the fourth, #707 eval seeding, is code/config and ships as a separate PR).

## #705 — Migration path (the top adoption lever)
Rewrites `docs/migration.md` to match what `terrapod-migrate` **actually does**. The doc had drifted to an aspirational shape and documented commands/flags that don't exist:
- `module register` subcommand — **not implemented**
- `rewrite --rewrite-modules` (+ `--allow-missing-module-mapping`) — **not implemented** (rewrite only touches `cloud {}`/`backend "remote"` hostname+org, and uses `--write`, not `--apply`)
- `apply --lock-source`, `--allow-rbac-widening`, `--allow-api-version-mismatch` — **do not exist**

Corrected to the **six real subcommands** (`apply`, `rewrite`, `verify`, `rollback`, `status`, `cutover`) with their real flags, plus an honest **"auto-created vs. read-and-reported-as-a-checklist"** split:
- **Auto-created:** VCS connections, workspaces, workspace variables, state (serial+lineage preserved; config-version tarball for non-VCS).
- **Read + reported, not yet created:** variable sets, run triggers, notifications, agent pools, private registry. RBAC is *suggested, never auto-applied*.

Also **foregrounds** migration (it was missing from the docs index entirely): README highlight blockquote + docs table + `docs/index.md` row + accurate `llms.txt` entry. Fixes an adjacent phantom-flag claim in `docs/api-reference.md`.

## #706 — Positioning re-pitch (follow-up to #559)
Adds an **"Is Terrapod for you?"** persona hook to the README, framing the niche as an *outcome* — *the control plane never needs a route into an execution cluster* — for the restricted-network / own-your-boundary / TFE-migration buyer. Peer-neutral, on our own merits.

## #708 — Confidence surfaces
- Surfaces the supply-chain provenance the pipeline **already produces**: a README verify snippet + a `SECURITY.md` "Release Artifact Provenance" section (cosign keyless signatures, SBOM/SLSA attestations, correct verify commands).
- Adds `docs/known-limitations.md` — an honest, consolidated "what Terrapod does not (yet) do", each item marked *by design* vs *not yet*.

## Verification
Docs-only. All cross-links/anchors verified to resolve; no phantom subcommand/flag references remain in `docs/`, `README.md`, `llms.txt`, or `AGENTS.md`. Every migration claim was checked directly against `migrate/` source (subcommand switch, FlagSets, IR types, writer functions).

Closes #705, #706, #708. Refs #709 (migration-tool extension follow-up), #559.