### PR TITLE
fix(migrate): address v0.56.0 review follow-ups (closes #717)

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -94,8 +94,11 @@ is advisory by policy; the registry artefacts below are limited by the
   tree. **Dry-run by default**; pass `--write` to touch disk. No VCS
   interaction — you commit and push after.
 - `terrapod-migrate verify` — confirm each migrated workspace still matches
-  what the migration recorded: it's present, the variable count is intact,
-  and the state serial/lineage is unchanged. Exits non-zero on any mismatch.
+  what the migration recorded (present, variable count intact, state
+  serial/lineage unchanged), and existence-check the other migration-created
+  resources (variable sets, run triggers, notifications, agent pools, GPG
+  keys) — a resource deleted post-migration is flagged. Exits non-zero on any
+  mismatch.
 - `terrapod-migrate rollback` — reverse a migration by deleting the
   workspaces it created. **Dry-run by default**; pass `--apply` to delete.
   Safe by construction (see [Reversibility](#reversibility-dry-run--rollback)).

--- a/migrate/cmd/terrapod-migrate/verify.go
+++ b/migrate/cmd/terrapod-migrate/verify.go
@@ -12,18 +12,20 @@ import (
 	"github.com/mattrobinsonsre/terrapod/migrate/internal/framework"
 )
 
-// verifyCmd is the verify subcommand. For every workspace recorded
-// in the migration state file, it confirms the Terrapod side still
-// has the expected workspace ID, name, and variable count. Discrepan-
-// cies are reported per-workspace and the command exits non-zero if
-// any check fails.
+// verifyCmd is the verify subcommand. For every workspace recorded in
+// the migration state file it confirms the Terrapod side still has the
+// expected workspace ID, name, variable count, and state serial/lineage;
+// then it existence-checks the other migration-created resources
+// (variable sets, run triggers, notifications, agent pools, GPG keys) —
+// a NotFound means the resource was deleted post-migration. Discrepancies
+// are reported per-item and the command exits non-zero if any check fails.
 //
-// This is a "did the migration land?" lightweight check, not a full
-// behavioural verification (running plans against the migrated work-
-// spaces is a separate increment — it touches run lifecycle which is
+// This is a "did the migration land, and is it still there?" check, not a
+// full behavioural verification (running plans against the migrated
+// workspaces is a separate increment — it touches run lifecycle which is
 // more involved). Operators still see clear signal when a record's
-// TerrapodID points at a deleted workspace, or when variables go
-// missing between apply and a follow-up bulk-update.
+// TerrapodID points at a deleted resource, or when variables go missing
+// between apply and a follow-up bulk-update.
 func verifyCmd(args []string) int {
 	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
 	var (
@@ -91,6 +93,10 @@ type VerifyReport struct {
 	OkCount      int                     `json:"ok_count"`
 	FailedCount  int                     `json:"failed_count"`
 	Workspaces   []WorkspaceVerification `json:"workspaces"`
+	// Resources holds the non-workspace migration-created resources
+	// (variable sets, run triggers, notifications, agent pools, GPG
+	// keys) — an existence check that each still exists on Terrapod.
+	Resources []ResourceVerification `json:"resources,omitempty"`
 }
 
 // WorkspaceVerification is the per-workspace result.
@@ -101,6 +107,37 @@ type WorkspaceVerification struct {
 	Failures              []string `json:"failures,omitempty"`
 	VariableCount         int      `json:"variable_count"`
 	ExpectedVariableCount int      `json:"expected_variable_count,omitempty"`
+}
+
+// ResourceVerification is the per-resource existence-check result for the
+// non-workspace resources the migration created.
+type ResourceVerification struct {
+	Kind       string   `json:"kind"`
+	Name       string   `json:"name"`
+	TerrapodID string   `json:"terrapod_id"`
+	OK         bool     `json:"ok"`
+	Failures   []string `json:"failures,omitempty"`
+}
+
+// checkResource GETs a migration-created resource and records whether it
+// still exists on Terrapod. A NotFound means it was deleted post-migration.
+func (r *VerifyReport) checkResource(kind, name, id string, get func() error) {
+	rv := ResourceVerification{Kind: kind, Name: name, TerrapodID: id}
+	if err := get(); err != nil {
+		if terrapod.IsNotFound(err) {
+			rv.Failures = append(rv.Failures, fmt.Sprintf("%s not found on Terrapod (deleted post-migration?)", kind))
+		} else {
+			rv.Failures = append(rv.Failures, fmt.Sprintf("Terrapod lookup failed: %v", err))
+		}
+	}
+	rv.OK = len(rv.Failures) == 0
+	r.Resources = append(r.Resources, rv)
+	r.CheckedCount++
+	if rv.OK {
+		r.OkCount++
+	} else {
+		r.FailedCount++
+	}
 }
 
 func runVerify(ctx context.Context, c *terrapod.Client, state *framework.State) *VerifyReport {
@@ -189,6 +226,42 @@ func runVerify(ctx context.Context, c *terrapod.Client, state *framework.State) 
 			report.FailedCount++
 		}
 	}
+
+	// Non-workspace migration-created resources: an existence check that
+	// each still exists on Terrapod (a NotFound means it was deleted
+	// post-migration). Only resources this migration positively created
+	// (CreatedByMigration + a recorded TerrapodID, not rolled back) are
+	// checked — the same provenance gate rollback uses.
+	for _, rec := range state.VarsetRollbackTargets() {
+		report.checkResource("variable-set", rec.Name, rec.TerrapodID, func() error {
+			_, err := c.GetVariableSet(ctx, rec.TerrapodID)
+			return err
+		})
+	}
+	for _, rec := range state.RunTriggerRollbackTargets() {
+		report.checkResource("run-trigger", fmt.Sprintf("%s→%s", rec.SourceWorkspaceRef, rec.DestinationWorkspaceRef), rec.TerrapodID, func() error {
+			_, err := c.GetRunTrigger(ctx, rec.TerrapodID)
+			return err
+		})
+	}
+	for _, rec := range state.NotificationRollbackTargets() {
+		report.checkResource("notification", fmt.Sprintf("%s/%s", rec.WorkspaceRef, rec.Name), rec.TerrapodID, func() error {
+			_, err := c.GetNotificationConfiguration(ctx, rec.TerrapodID)
+			return err
+		})
+	}
+	for _, rec := range state.AgentPoolRollbackTargets() {
+		report.checkResource("agent-pool", rec.Name, rec.TerrapodID, func() error {
+			_, err := c.GetAgentPool(ctx, rec.TerrapodID)
+			return err
+		})
+	}
+	for _, rec := range state.GPGKeyRollbackTargets() {
+		report.checkResource("gpg-key", rec.KeyID, rec.TerrapodID, func() error {
+			_, err := c.GetGPGKey(ctx, rec.TerrapodID)
+			return err
+		})
+	}
 	return report
 }
 
@@ -202,6 +275,16 @@ func printVerifySummary(r *VerifyReport) {
 		}
 		fmt.Printf("  [%s] %s (terrapod_id=%s, vars=%d)\n", marker, w.SourceName, w.TerrapodID, w.VariableCount)
 		for _, f := range w.Failures {
+			fmt.Printf("        - %s\n", f)
+		}
+	}
+	for _, rv := range r.Resources {
+		marker := "ok "
+		if !rv.OK {
+			marker = "FAIL"
+		}
+		fmt.Printf("  [%s] %s %s (terrapod_id=%s)\n", marker, rv.Kind, rv.Name, rv.TerrapodID)
+		for _, f := range rv.Failures {
 			fmt.Printf("        - %s\n", f)
 		}
 	}

--- a/migrate/cmd/terrapod-migrate/verify_test.go
+++ b/migrate/cmd/terrapod-migrate/verify_test.go
@@ -83,3 +83,76 @@ func TestVerify_Parity_StateMissing_Fails(t *testing.T) {
 		t.Fatalf("expected missing-state to fail: %+v", r.Workspaces)
 	}
 }
+
+// newResourceVerifyServer answers GETs for the non-workspace resource
+// types. missingID (if set) returns 404 for that resource id; every
+// other id returns 200.
+func newResourceVerifyServer(t *testing.T, missingID string) *terrapod.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		if missingID != "" && strings.HasSuffix(r.URL.Path, "/"+missingID) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		switch {
+		case strings.Contains(r.URL.Path, "/varsets/"):
+			_, _ = fmt.Fprint(w, `{"data":{"id":"vs-a","type":"varsets","attributes":{"name":"n"}}}`)
+		case strings.Contains(r.URL.Path, "/run-triggers/"):
+			_, _ = fmt.Fprint(w, `{"data":{"id":"rt-a","type":"run-triggers","attributes":{}}}`)
+		case strings.Contains(r.URL.Path, "/notification-configurations/"):
+			_, _ = fmt.Fprint(w, `{"data":{"id":"nc-a","type":"notification-configurations","attributes":{"name":"n","destination-type":"generic"}}}`)
+		case strings.Contains(r.URL.Path, "/agent-pools/"):
+			_, _ = fmt.Fprint(w, `{"data":{"id":"ap-a","type":"agent-pools","attributes":{"name":"n"}}}`)
+		case strings.Contains(r.URL.Path, "/gpg-keys/"):
+			_, _ = fmt.Fprint(w, `{"data":{"id":"gpg-a","type":"gpg-keys","attributes":{"key-id":"ABC"}}}`)
+		default:
+			http.Error(w, "unhandled "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := terrapod.NewClient(terrapod.Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func resourceState() *framework.State {
+	return &framework.State{
+		VariableSets:  []framework.VariableSetRecord{{Name: "vs", TerrapodID: "vs-a", State: "created", CreatedByMigration: true}},
+		RunTriggers:   []framework.RunTriggerRecord{{SourceWorkspaceRef: "ws-a", DestinationWorkspaceRef: "ws-b", TerrapodID: "rt-a", State: "created", CreatedByMigration: true}},
+		Notifications: []framework.NotificationRecord{{WorkspaceRef: "ws-a", Name: "hook", TerrapodID: "nc-a", State: "created", CreatedByMigration: true}},
+		AgentPools:    []framework.AgentPoolRecord{{Name: "pool", TerrapodID: "ap-a", State: "created", CreatedByMigration: true}},
+		GPGKeys:       []framework.GPGKeyRecord{{KeyID: "ABC", TerrapodID: "gpg-a", State: "created", CreatedByMigration: true}},
+	}
+}
+
+func TestVerify_Resources_AllPresent_OK(t *testing.T) {
+	c := newResourceVerifyServer(t, "")
+	r := runVerify(t.Context(), c, resourceState())
+	if len(r.Resources) != 5 {
+		t.Fatalf("expected 5 resource checks (varset/trigger/notification/pool/gpg), got %d: %+v", len(r.Resources), r.Resources)
+	}
+	if r.FailedCount != 0 {
+		t.Fatalf("expected all resources OK, got failures: %+v", r.Resources)
+	}
+}
+
+func TestVerify_Resources_Deleted_Fails(t *testing.T) {
+	// The agent pool was deleted post-migration (404); verify must flag it.
+	c := newResourceVerifyServer(t, "ap-a")
+	r := runVerify(t.Context(), c, resourceState())
+	if r.FailedCount != 1 {
+		t.Fatalf("expected exactly the deleted agent-pool to fail, got %d failures: %+v", r.FailedCount, r.Resources)
+	}
+	var found bool
+	for _, rv := range r.Resources {
+		if rv.Kind == "agent-pool" && !rv.OK {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected agent-pool to be the failing resource: %+v", r.Resources)
+	}
+}

--- a/migrate/internal/writer/writer.go
+++ b/migrate/internal/writer/writer.go
@@ -926,12 +926,10 @@ func (w *Writer) applyVarsetContents(ctx context.Context, varsetID string, vs *i
 			out.Unresolved = append(out.Unresolved, ref)
 			continue
 		}
+		// The assign endpoint is idempotent (204 on already-assigned,
+		// never 409), so a resume re-assign just succeeds — no special
+		// conflict handling needed.
 		if err := w.client.AssignWorkspaceToVarset(ctx, varsetID, rec.TerrapodID); err != nil {
-			var conflict *terrapod.ConflictError
-			if errors.As(err, &conflict) {
-				out.Assignments++ // already assigned by a prior run
-				continue
-			}
 			out.Unresolved = append(out.Unresolved, ref)
 			continue
 		}
@@ -1000,7 +998,10 @@ func (w *Writer) planVarsetAssignments(vs *ir.VariableSet) (int, []string) {
 	var resolved int
 	var unresolved []string
 	for _, ref := range vs.WorkspaceRefs {
-		if w.state.WorkspaceBySourceID(ref) != nil {
+		// A workspace that errored during apply has a state record but was
+		// not successfully created — don't count it as a would-be
+		// assignment; report it as unresolved instead (optimistic-count fix).
+		if ws := w.state.WorkspaceBySourceID(ref); ws != nil && ws.State != "errored" {
 			resolved++
 		} else {
 			unresolved = append(unresolved, ref)
@@ -1285,7 +1286,9 @@ func (w *Writer) applyAgentPool(ctx context.Context, ap *ir.AgentPool, opts Opti
 // in dry-run and to seed the outcome). Mirrors planVarsetAssignments.
 func (w *Writer) planPoolAssignments(ap *ir.AgentPool) (assigned int, unresolved []string) {
 	for _, ref := range ap.WorkspaceRefs {
-		if ws := w.state.WorkspaceBySourceID(ref); ws != nil {
+		// Skip workspaces that errored during apply — a record exists but
+		// the workspace wasn't successfully created (optimistic-count fix).
+		if ws := w.state.WorkspaceBySourceID(ref); ws != nil && ws.State != "errored" {
 			assigned++
 		} else {
 			unresolved = append(unresolved, ref)

--- a/migrate/internal/writer/writer_test.go
+++ b/migrate/internal/writer/writer_test.go
@@ -520,6 +520,60 @@ func TestWriter_Apply_AgentPool_CreatesAndRepointsWorkspaces(t *testing.T) {
 	}
 }
 
+func TestWriter_VariableSet_NonGlobal_Resume_ReassignsIdempotently(t *testing.T) {
+	// A non-global varset with a workspace assignment: on resume, the
+	// varset is reused and its workspace assignment is re-applied. The
+	// assign endpoint is idempotent (204 on already-assigned), so resume
+	// re-assigns cleanly with no error — this exercises the real re-assign
+	// path (the global-only resume test can't, since global skips assignment).
+	fs, c := newFakeServer(t)
+	state := &framework.State{}
+	w := New(c, state, "")
+
+	plan := ir.Plan{
+		Source:     "tfe",
+		Workspaces: []ir.Workspace{{SourceID: "ws-src-1", Name: "app"}},
+		VariableSets: []ir.VariableSet{
+			{SourceID: "vs-src-1", Name: "app-vars", WorkspaceRefs: []string{"ws-src-1"},
+				Variables: []ir.Variable{{Key: "region", Value: "eu-west-1", Category: "terraform"}}},
+		},
+	}
+
+	report1, err := w.Run(t.Context(), plan, Options{})
+	if err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if len(report1.Errors) != 0 {
+		t.Fatalf("first run errors: %+v", report1.Errors)
+	}
+	if report1.VariableSets[0].State != "created" || report1.VariableSets[0].Assignments != 1 {
+		t.Fatalf("first run varset outcome: %+v", report1.VariableSets[0])
+	}
+	if fs.varsetAssignments != 1 {
+		t.Errorf("expected 1 assignment POST on first run, got %d", fs.varsetAssignments)
+	}
+
+	// Resume: varset reused (not re-created), assignment re-applied via the
+	// idempotent 204 path — no error, count still 1.
+	fs.varsetsCreated = 0
+	report2, err := w.Run(t.Context(), plan, Options{})
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if len(report2.Errors) != 0 {
+		t.Fatalf("resume run errors: %+v", report2.Errors)
+	}
+	if fs.varsetsCreated != 0 {
+		t.Errorf("varset re-created on resume: %d", fs.varsetsCreated)
+	}
+	if report2.VariableSets[0].State != "reused" {
+		t.Errorf("expected reused, got %+v", report2.VariableSets[0])
+	}
+	if report2.VariableSets[0].Assignments != 1 {
+		t.Errorf("resume should re-assign idempotently (1), got %d", report2.VariableSets[0].Assignments)
+	}
+}
+
 func TestWriter_Apply_GPGKey_CreatesAndIsIdempotent(t *testing.T) {
 	fs, c := newFakeServer(t)
 	state := &framework.State{}


### PR DESCRIPTION
Fixes the three MINOR findings from the v0.56.0 third-party review **now**, instead of leaving them deferred in #717 (they should have been addressed before the tag).

1. **Dead 409 branch removed + real resume test.** `AssignWorkspaceToVarset` is idempotent server-side (204 on already-assigned, never 409 — `variables.py:539`/`:562`), so the `ConflictError` handler in the varset-assignment loop was unreachable dead code based on a false premise; resume re-assign is handled by the normal success path. Added `TestWriter_VariableSet_NonGlobal_Resume_ReassignsIdempotently`, which actually exercises re-assignment (the existing resume test used a **global** set, which skips assignment entirely).

2. **`verify` now covers the new resources.** Previously workspace-only; it now existence-checks every other migration-created resource — variable sets, run triggers, notifications, agent pools, GPG keys — via the SDK `Get*` methods, provenance-gated the same way `rollback` is. A resource deleted post-migration is flagged as a failure. Tests: all-present OK + a deleted-agent-pool failure. Docstring + `docs/migration.md` updated.

3. **Optimistic dry-run counts fixed.** `planVarsetAssignments` / `planPoolAssignments` no longer count a workspace whose state record is `errored` as a would-be assignment — it's reported as unresolved.

`go build ./...`, `go test ./...` (all green), and `golangci-lint` (0 issues on changed packages) pass.

Closes #717