### PR TITLE
feat(web): mobile responsive harness — viewport hook + phone-viewport E2E project (#719 Stage 0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,9 @@ Routing rules of thumb:
 - A **new frontend page / RBAC gate / user-facing flow** → an E2E spec. For
   RBAC, include a **negative-path** spec with a non-admin session asserting the
   action is blocked. `tsc` + ESLint are necessary but **not** sufficient — the
-  page must actually render in the E2E stack.
+  page must actually render in the E2E stack. It must **also** carry a
+  responsive guard (see *Responsive / mobile-first UI* below) — a page that
+  only works on desktop is an incomplete change, not a done one.
 - A **new hard invariant** ("X must never happen") → a source-introspection
   test that reads the implementation and asserts the absence of the forbidden
   pattern, so the invariant fails CI loudly if a future change violates it.
@@ -206,6 +208,41 @@ not deterministic): every test creates its own uniquely-named resources and
 tears them down; never assert global counts or absolute list positions; never
 depend on another spec having run; no fixed `setTimeout` waits — use
 Playwright's auto-waiting.
+
+## Responsive / mobile-first UI (hard requirement)
+
+Mobile is a **first-class target**, not an afterthought — a UI change that is
+not mobile-friendly is **not done** and must not merge. The full brief and the
+staged plan live in issue **#719**; the rules a contributor must follow:
+
+- **One DRY, viewport-driven implementation.** No forked `Mobile*`/`Desktop*`
+  component trees, and **never** branch on the user agent
+  (`navigator.userAgent`, device-detect libraries, server-side "is this a
+  phone"). Adapt on **actual available width**: CSS first — Tailwind
+  responsive utilities (`sm:`/`md:`/`lg:`) and CSS container queries
+  (`@container`); reach for JS (`useMediaQuery`/`useIsMobile` in
+  `web/src/lib/use-media-query.ts`) only where *behaviour* must branch (e.g.
+  bottom-sheet vs inline panel), keyed to the same breakpoints, SSR-safe.
+- **Desktop is never sacrificed.** Every change is breakpoint-scoped; at
+  desktop widths the result is pixel-identical to before. A desktop window
+  narrowed to phone width adapting is *expected*, not a regression.
+- **Touch model** (touch is not a small mouse): no hover-only affordances (no
+  hover-reveal actions, no info that only appears in a `:hover` tooltip); no
+  reliance on double-tap or right-click; **no inner scrollbars nested inside a
+  scrolling page** (the page is the scroll container on mobile); tap targets
+  ≥44px; inputs ≥16px (no iOS zoom-on-focus); **no horizontal *page* scroll**
+  at any width; **URL is the source of truth for tab/view state** (it must
+  survive reload / back / deep-link — no `useState`-only tabs). Prefer
+  drill-down to a route over cramming panels into one dense page.
+- **Enforcement (this is what blocks non-mobile-friendly changes):** the
+  `responsive` Playwright project runs the suite at a **phone viewport**
+  (`e2e/tests/responsive.spec.ts`) and is the **mobile guard**; the existing
+  Desktop Chrome projects are the **desktop guard**. Both run in CI. A new
+  frontend page or major component **must add a responsive assertion** to the
+  mobile suite (at minimum `expectNoHorizontalPageScroll`, plus the
+  touch-model checks relevant to it) **in the same PR** as its desktop spec,
+  and **must not** break the mobile guard. Breaking the mobile guard fails CI
+  — that is the gate.
 
 ## Conventions
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -141,5 +141,14 @@ export default defineConfig({
       testMatch: 'slack.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
     },
+    {
+      // The mobile / responsive guard (#719): runs the responsive suite at a
+      // phone viewport (Pixel 7, ~412px). The existing Desktop Chrome projects
+      // are the desktop guard — together they enforce "one DRY UI, adapted by
+      // width, desktop never sacrificed". Grows as #719 stages land.
+      name: 'responsive',
+      testMatch: 'responsive.spec.ts',
+      use: { ...devices['Pixel 7'], storageState: ADMIN_AUTH },
+    },
   ],
 });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Responsive / mobile harness (#719).
+ *
+ * This project runs at a phone viewport (see the `responsive` project in
+ * playwright.config.ts — a Pixel device descriptor). It is the "mobile"
+ * half of the two-sided testing contract: this suite proves the UI works
+ * at phone width, while the existing desktop projects prove the desktop
+ * view is unchanged (the desktop guard). One DRY UI, adapted by width —
+ * never a forked mobile build, never user-agent sniffing.
+ *
+ * Per-page assertions (no horizontal page scroll, tables reflow, tab
+ * survives reload, log tail visible, …) are added to this suite as each
+ * stage of #719 fixes the corresponding surface, so the guard grows with
+ * the work and can't silently regress.
+ */
+
+/**
+ * Asserts the page does not scroll horizontally at the current viewport —
+ * the single most important mobile invariant. Allows a 1px rounding slack.
+ */
+export async function expectNoHorizontalPageScroll(page: Page) {
+  const overflow = await page.evaluate(() => {
+    const el = document.documentElement;
+    return el.scrollWidth - el.clientWidth;
+  });
+  expect(
+    overflow,
+    `page scrolls horizontally by ${overflow}px at ${page.viewportSize()?.width}px viewport`,
+  ).toBeLessThanOrEqual(1);
+}
+
+test.describe('Responsive harness (phone viewport)', () => {
+  test('runs at a phone viewport', async ({ page }) => {
+    const vp = page.viewportSize();
+    expect(vp, 'responsive project must set a viewport').not.toBeNull();
+    expect(vp!.width, 'responsive project runs below the md breakpoint').toBeLessThan(768);
+  });
+
+  test('nav adapts to mobile: hamburger shown, desktop bar hidden', async ({ page }) => {
+    await page.goto('/workspaces');
+
+    // The mobile branch of the nav renders a hamburger toggle; the desktop
+    // link row is hidden below md. Proves the single nav component adapts
+    // by width (the foundation the Stage 1 nav restructure builds on).
+    const hamburger = page.getByRole('button', { name: /open menu/i });
+    await expect(hamburger).toBeVisible();
+
+    // Opening it reveals the nav destinations (currently the full list;
+    // Stage 1 groups these).
+    await hamburger.click();
+    await expect(page.locator('#mobile-nav-menu')).toBeVisible();
+    await expect(page.locator('#mobile-nav-menu >> text=Workspaces').first()).toBeVisible();
+  });
+});

--- a/web/src/lib/use-media-query.ts
+++ b/web/src/lib/use-media-query.ts
@@ -1,0 +1,54 @@
+import { useCallback, useSyncExternalStore } from 'react'
+
+/**
+ * SSR-safe viewport/container adaptation primitive.
+ *
+ * The UI is one DRY implementation that adapts on **actual available
+ * width** — never on the user agent, and never as two forked component
+ * trees (#719). CSS is the primary tool: prefer Tailwind responsive
+ * utilities (`sm:`/`md:`/`lg:`) and CSS container queries (`@container`),
+ * which need no JS and cannot cause a hydration mismatch. Reach for this
+ * hook ONLY where behaviour (not just styling) must branch on width — e.g.
+ * mounting a bottom-sheet vs an inline panel.
+ *
+ * SSR safety: the server has no viewport, so the hook returns `false` on
+ * the first (server + initial client) render and corrects after mount.
+ * Because CSS handles the visual adaptation, that first frame is already
+ * laid out correctly; the hook only flips JS-level behaviour a tick later,
+ * so there is no hydration mismatch and no layout flash for CSS-driven UI.
+ */
+export function useMediaQuery(query: string): boolean {
+  // useSyncExternalStore is the hydration-safe way to read an external
+  // (browser) value: the server snapshot is always `false`, the client
+  // subscribes to matchMedia. No cascading renders, no hydration mismatch.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mql = window.matchMedia(query)
+      mql.addEventListener('change', onStoreChange)
+      return () => mql.removeEventListener('change', onStoreChange)
+    },
+    [query],
+  )
+  const getSnapshot = () => window.matchMedia(query).matches
+  const getServerSnapshot = () => false
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}
+
+// Breakpoints mirror Tailwind's defaults so JS branches align with the CSS
+// utilities used everywhere else. "Mobile" is below `md` (the same boundary
+// the nav switches at).
+export const BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+} as const
+
+/**
+ * True when the viewport is narrower than the `md` breakpoint (the phone /
+ * small-tablet range). Keyed to the same 768px boundary as Tailwind's `md:`
+ * and the nav's mobile switch, so CSS and JS agree.
+ */
+export function useIsMobile(): boolean {
+  return useMediaQuery(`(max-width: ${BREAKPOINTS.md - 0.02}px)`)
+}


### PR DESCRIPTION
First increment of #719 (first-class mobile support) — **Stage 0 foundation.** No user-visible change; desktop untouched. Establishes the two things everything else builds on.

## What's here

- **`web/src/lib/use-media-query.ts`** — the DRY adaptation primitive. `useMediaQuery` / `useIsMobile` via `useSyncExternalStore` (server snapshot `false`, client subscribes to `matchMedia`) — hydration-safe, no cascading renders, matching the codebase's existing `useSyncExternalStore` usage in the nav. This is the **one** place JS branches on width; CSS stays primary (Tailwind responsive utilities + v4 container queries). Keyed to Tailwind's `md` (768px) so JS and CSS agree. **No user-agent sniffing, no forked component trees** (the governing #719 constraint).
- **`e2e/tests/responsive.spec.ts` + a `responsive` Playwright project** (Pixel 7 viewport) — the **mobile guard**. The existing Desktop Chrome projects are the **desktop guard**; together they enforce *"one DRY UI, adapted by width, desktop never sacrificed"*. Exports `expectNoHorizontalPageScroll` for later stages and asserts the nav already adapts to a hamburger at phone width. Per-page assertions (no horizontal scroll, tables reflow, tab survives reload, log tail visible) grow as each stage fixes the surface.

## Verification
- `npx tsc --noEmit` + ESLint clean (rewrote the hook to `useSyncExternalStore` after ESLint flagged sync setState-in-effect).
- `npm run build` passes.
- `npx playwright test --list --project=responsive` registers the 2 harness tests; CI picks the project up via the existing `--shard` matrix.

## Next (per the staged plan on #719)
Stage 0 continues with the shared responsive primitives (`<ResponsiveList>`, `<Sheet>`, `<OverflowMenu>`) + the per-route audit doc; then Stage 1 (global foundation + nav restructure + URL-state regression suite).

Part of #719.