### PR TITLE
feat(web): mobile-first nav + workspace list — #719 Stage 0/1

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -5,9 +5,14 @@ test.describe('Admin access control', () => {
     await adminPage.goto('/workspaces');
     await expect(adminPage.locator('h1:has-text("Workspaces")')).toBeVisible();
 
-    // Admin-only links should be visible
-    await expect(adminPage.locator('nav >> text=Roles')).toBeVisible();
-    await expect(adminPage.locator('nav >> text=Users')).toBeVisible();
+    // Admin destinations now live behind the Admin▾ dropdown (#719 IA):
+    // the trigger is visible, and opening it reveals the admin items.
+    await expect(adminPage.getByRole('button', { name: 'Admin', exact: true })).toBeVisible();
+    await adminPage.getByRole('button', { name: 'Admin', exact: true }).click();
+    await expect(adminPage.getByRole('menuitem', { name: 'Roles' })).toBeVisible();
+    await expect(adminPage.getByRole('menuitem', { name: 'Users' })).toBeVisible();
+    await adminPage.keyboard.press('Escape');
+    // Agent Pools stays top-level (visible to all users).
     await expect(adminPage.locator('nav >> text=Agent Pools')).toBeVisible();
   });
 
@@ -15,9 +20,8 @@ test.describe('Admin access control', () => {
     await userPage.goto('/workspaces');
     await expect(userPage.locator('h1:has-text("Workspaces")')).toBeVisible();
 
-    // Admin-only links should not be visible
-    await expect(userPage.locator('nav >> text=Roles')).not.toBeVisible();
-    await expect(userPage.locator('nav >> text=Users')).not.toBeVisible();
+    // A non-admin/non-audit user gets no Admin▾ menu at all.
+    await expect(userPage.getByRole('button', { name: 'Admin', exact: true })).not.toBeVisible();
     // Agent Pools is visible to all users (RBAC-filtered server-side)
     await expect(userPage.locator('nav >> text=Agent Pools')).toBeVisible();
   });

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -56,8 +56,10 @@ test.describe('Authentication', () => {
       timeout: 15_000,
     });
 
-    // Click the logout button in the nav bar
-    await page.click('button:has-text("Logout")');
+    // Log out now lives inside the Account menu (whose desktop trigger is
+    // labelled with the signed-in user's email) — #719 grouped-nav IA.
+    await page.getByRole('button', { name: ADMIN_EMAIL }).click();
+    await page.getByRole('menuitem', { name: 'Log out' }).click();
 
     // Should redirect to /login
     await page.waitForURL('**/login', { timeout: 10_000 });

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -7,10 +7,11 @@ test.describe('Navigation', () => {
     // Terrapod logo/brand should be visible in nav
     await expect(page.locator('nav >> text=Terrapod').first()).toBeVisible();
 
-    // Core nav links should be visible
+    // Primary nav links stay visible on desktop (#719 IA); Modules/Providers
+    // now live behind the Registry▾ dropdown, so assert the trigger instead.
     await expect(page.locator('nav >> text=Workspaces').first()).toBeVisible();
-    await expect(page.locator('nav >> text=Modules').first()).toBeVisible();
-    await expect(page.locator('nav >> text=Providers').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Registry' })).toBeVisible();
+    await expect(page.locator('nav >> text=Catalog').first()).toBeVisible();
   });
 
   test('navigate between pages', async ({ page }) => {
@@ -18,17 +19,19 @@ test.describe('Navigation', () => {
     await page.goto('/workspaces');
     await expect(page.locator('h1:has-text("Workspaces")')).toBeVisible();
 
-    // Navigate to modules
-    await page.locator('nav >> text=Modules').first().click();
+    // Open Registry▾ and navigate to Modules
+    await page.getByRole('button', { name: 'Registry' }).click();
+    await page.getByRole('menuitem', { name: 'Modules' }).click();
     await page.waitForURL('**/registry/modules');
     await expect(page.locator('h1:has-text("Modules")')).toBeVisible();
 
-    // Navigate to providers
-    await page.locator('nav >> text=Providers').first().click();
+    // Open Registry▾ again and navigate to Providers
+    await page.getByRole('button', { name: 'Registry' }).click();
+    await page.getByRole('menuitem', { name: 'Providers' }).click();
     await page.waitForURL('**/registry/providers');
     await expect(page.locator('h1:has-text("Providers")')).toBeVisible();
 
-    // Navigate back to workspaces
+    // Navigate back to workspaces (top-level link)
     await page.locator('nav >> text=Workspaces').first().click();
     await page.waitForURL('**/workspaces');
     await expect(page.locator('h1:has-text("Workspaces")')).toBeVisible();

--- a/e2e/tests/rbac-negatives.spec.ts
+++ b/e2e/tests/rbac-negatives.spec.ts
@@ -57,9 +57,12 @@ test.describe('RBAC — audit user is read-only', () => {
 
   test('audit can reach the audit log but not the admin management links', async ({ page }) => {
     await page.goto('/workspaces');
-    // Audit-or-admin gate → the audit log link IS visible to an audit user.
+    // Audit-or-admin gate → an audit user sees the Admin▾ menu, and opening it
+    // reveals the Audit Log link (its only entry for a non-admin) — #719 IA.
+    await page.getByRole('button', { name: 'Admin', exact: true }).click();
     await expect(page.locator('a[href="/admin/audit-log"]')).toBeVisible();
-    // …but the admin-only management links are not.
+    // …but the admin-only management links are not — they are gated on `admin`
+    // and never render for the audit role even with the menu open.
     for (const href of ADMIN_LINKS) {
       await expect(page.locator(`a[href="${href}"]`)).toHaveCount(0);
     }

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -85,4 +85,19 @@ test.describe('Responsive harness (phone viewport)', () => {
 
     await expectNoHorizontalPageScroll(page);
   });
+
+  test('workspace list trims secondary chrome at phone width', async ({ page }) => {
+    // On a phone we drop the explanatory subtitle and the Total/Locked
+    // stat cards (secondary), but KEEP Health Issues (the primary signal
+    // that something needs attention) — #719.
+    await page.goto('/workspaces');
+    await expect(page.getByRole('heading', { name: 'Workspaces', level: 1 })).toBeVisible();
+
+    await expect(page.getByText('Manage Terraform workspaces, state, and runs')).toBeHidden();
+    await expect(page.getByText('Total', { exact: true })).toBeHidden();
+    await expect(page.getByText('Locked', { exact: true })).toBeHidden();
+    await expect(page.getByText('Health Issues', { exact: true })).toBeVisible();
+
+    await expectNoHorizontalPageScroll(page);
+  });
 });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -38,19 +38,27 @@ test.describe('Responsive harness (phone viewport)', () => {
     expect(vp!.width, 'responsive project runs below the md breakpoint').toBeLessThan(768);
   });
 
-  test('nav adapts to mobile: hamburger shown, desktop bar hidden', async ({ page }) => {
+  test('nav adapts to mobile: hamburger shown, grouped sheet', async ({ page }) => {
     await page.goto('/workspaces');
+    await expectNoHorizontalPageScroll(page);
 
     // The mobile branch of the nav renders a hamburger toggle; the desktop
     // link row is hidden below md. Proves the single nav component adapts
-    // by width (the foundation the Stage 1 nav restructure builds on).
+    // by width — no forked mobile build (#719).
     const hamburger = page.getByRole('button', { name: /open menu/i });
     await expect(hamburger).toBeVisible();
 
-    // Opening it reveals the nav destinations (currently the full list;
-    // Stage 1 groups these).
+    // Opening it reveals the grouped sheet: primary links plus labelled
+    // sections (Registry / Account, + Admin for admins). Stage 1 groups the
+    // destinations rather than dumping ~22 flat items.
     await hamburger.click();
-    await expect(page.locator('#mobile-nav-menu')).toBeVisible();
-    await expect(page.locator('#mobile-nav-menu >> text=Workspaces').first()).toBeVisible();
+    const menu = page.locator('#mobile-nav-menu');
+    await expect(menu).toBeVisible();
+    await expect(menu.getByRole('link', { name: 'Workspaces' })).toBeVisible();
+    await expect(menu.getByText('Registry', { exact: true })).toBeVisible();
+    await expect(menu.getByText('Account', { exact: true })).toBeVisible();
+    await expect(menu.getByRole('link', { name: 'Modules' })).toBeVisible();
+    // Opening the sheet must not introduce horizontal overflow.
+    await expectNoHorizontalPageScroll(page);
   });
 });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api';
 
 /**
  * Responsive / mobile harness (#719).
@@ -59,6 +60,29 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(menu.getByText('Account', { exact: true })).toBeVisible();
     await expect(menu.getByRole('link', { name: 'Modules' })).toBeVisible();
     // Opening the sheet must not introduce horizontal overflow.
+    await expectNoHorizontalPageScroll(page);
+  });
+
+  test('workspace list surfaces status in-row at phone width', async ({ page }) => {
+    // Below `lg` the STATUS table column is hidden, so the row must carry an
+    // inline status indicator — otherwise a phone loses the running/errored/
+    // applied signal entirely (regression the mobile status line fixes, #719).
+    const token = getStoredToken();
+    const name = uniqueName('resp-status');
+    await createWorkspace(token, name);
+
+    // The client-side filter reads the `q` query param — narrow to our row.
+    await page.goto(`/workspaces?q=${encodeURIComponent(name)}`);
+    const row = page.getByRole('row').filter({ hasText: name });
+    await expect(row).toBeVisible();
+
+    // The inline mobile status indicator is present (a fresh workspace shows
+    // "—", a run-bearing one shows its coloured pill — either way, not hidden).
+    await expect(row.getByTestId('ws-row-status-mobile')).toBeVisible();
+
+    // The dedicated desktop STATUS column header stays hidden at this width.
+    await expect(page.getByRole('columnheader', { name: 'Status' })).toBeHidden();
+
     await expectNoHorizontalPageScroll(page);
   });
 });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -50,16 +50,26 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(hamburger).toBeVisible();
 
     // Opening it reveals the grouped sheet: primary links plus labelled
-    // sections (Registry / Account, + Admin for admins). Stage 1 groups the
-    // destinations rather than dumping ~22 flat items.
+    // sections (Registry / Help, + Admin for admins). Account is NOT here — it
+    // has its own trigger + drawer.
     await hamburger.click();
     const menu = page.locator('#mobile-nav-menu');
     await expect(menu).toBeVisible();
     await expect(menu.getByRole('link', { name: 'Workspaces' })).toBeVisible();
     await expect(menu.getByText('Registry', { exact: true })).toBeVisible();
-    await expect(menu.getByText('Account', { exact: true })).toBeVisible();
+    await expect(menu.getByText('Help', { exact: true })).toBeVisible();
     await expect(menu.getByRole('link', { name: 'Modules' })).toBeVisible();
+    await expect(menu.getByText('Account', { exact: true })).toHaveCount(0);
     // Opening the sheet must not introduce horizontal overflow.
+    await expectNoHorizontalPageScroll(page);
+
+    // Account has its own trigger + drawer (personal/session items + log out).
+    await menu.getByRole('button', { name: /close menu/i }).click();
+    await page.getByRole('button', { name: 'Open account menu' }).click();
+    const account = page.locator('#mobile-account-menu');
+    await expect(account).toBeVisible();
+    await expect(account.getByRole('link', { name: 'API Tokens' })).toBeVisible();
+    await expect(account.getByRole('button', { name: 'Log out' })).toBeVisible();
     await expectNoHorizontalPageScroll(page);
   });
 
@@ -94,9 +104,10 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(page.getByRole('heading', { name: 'Workspaces', level: 1 })).toBeVisible();
 
     await expect(page.getByText('Manage Terraform workspaces, state, and runs')).toBeHidden();
+    // Compact stat chips: Total/Locked are desktop-only; Health always shows.
     await expect(page.getByText('Total', { exact: true })).toBeHidden();
     await expect(page.getByText('Locked', { exact: true })).toBeHidden();
-    await expect(page.getByText('Health Issues', { exact: true })).toBeVisible();
+    await expect(page.getByText('Health', { exact: true })).toBeVisible();
 
     await expectNoHorizontalPageScroll(page);
   });

--- a/e2e/tests/users.spec.ts
+++ b/e2e/tests/users.spec.ts
@@ -5,8 +5,10 @@ test.describe('User Management', () => {
     await page.goto('/admin/users');
     await expect(page.locator('h1:has-text("Users")')).toBeVisible();
 
-    // Bootstrap admin should be in the table
-    await expect(page.locator('text=admin@terrapod.local')).toBeVisible();
+    // Bootstrap admin should be in the table. Scope to the table: the email
+    // also appears as the Account-menu trigger label in the nav (#719 IA), so
+    // an unscoped text lookup is now ambiguous (strict-mode violation).
+    await expect(page.locator('table').getByText('admin@terrapod.local')).toBeVisible();
   });
 
   test('create new user appears in table', async ({ page }) => {

--- a/web/RESPONSIVE-AUDIT.md
+++ b/web/RESPONSIVE-AUDIT.md
@@ -1,0 +1,69 @@
+# Responsive / mobile audit (#719 Stage 0)
+
+Per-route treatment decisions for the first-class mobile pass. Derived from
+a static scan of every `src/app/**/page.tsx` for the mobile-hostile patterns
+in the #719 touch model: unwrapped tables (horizontal overflow), nested
+inner-scroll panes, `useState` tabs (reset on reload), and `title=` hover
+tooltips (invisible on touch). Governing constraints (from AGENTS.md): **one
+DRY, viewport-driven implementation; desktop never sacrificed.**
+
+Treatment legend:
+- **card** — below `md`, the table becomes a stacked card/row list surfacing
+  the fields that matter (one `<ResponsiveList>`, table on wide).
+- **scroll** — acceptable last-resort `overflow-x-auto` fallback for a
+  low-traffic, genuinely tabular admin grid.
+- **drop-inner** — remove the nested scroll region so the page is the single
+  scroll container on mobile (esp. the run-log viewer).
+- **url-tab** — move `useState` tab state into the URL (survives reload/back).
+- **tooltip→tap** — replace hover-only `title=` info with a tap-visible
+  equivalent (or make it decorative only).
+
+## Priority surfaces (day-to-day + the hard cases)
+
+| Route | Issues | Treatment | Stage |
+|---|---|---|---|
+| `/workspaces` | 1 table + **4 inner-scroll**, 9 hover tooltips | **card** list + **drop-inner** (filter/label popovers shouldn't nest-scroll) + tooltip→tap | 2 |
+| `/workspaces/[id]` | **4 tables** (1 wrapped), **13 hover tooltips**, dense multi-tab | **card** the var/state/run tables + tooltip→tap + tab bar responsive (already url-synced) | 2–3 |
+| `/workspaces/[id]/runs/[runId]` | **2 inner-scroll** (log viewer), 8 hover tooltips, 6–7 stacked panels | **drop-inner** (page follows the log tail) + run-page IA split + SSE cadence + tooltip→tap | 3 |
+| `/catalog` | clean | card grid already; verify at 390px | 2 |
+| `/registry/modules`, `/registry/providers` | clean lists | verify; likely fine | 2 |
+| `/registry/modules/[name]/[provider]` | 3 tables (2 wrapped) + 1 inner-scroll | card the unwrapped table + drop-inner | 2 |
+
+## Admin surfaces (mostly tabular — card the primary ones, scroll-fallback the rest)
+
+| Route | Issues | Treatment | Stage |
+|---|---|---|---|
+| `/admin/agent-pools/[id]` | 2 tables (1 wrapped), **url-tab** | card + **url-tab** | 1/4 |
+| `/admin/variable-sets/[id]` | 2 unwrapped tables, **url-tab** | card + **url-tab** | 1/4 |
+| `/admin/roles` | 1 table, **url-tab** | card + **url-tab** | 1/4 |
+| `/admin/execution-hooks/[id]` | 1 table (wrapped), **url-tab** | **url-tab** (table already wrapped) | 1/4 |
+| `/admin/autodiscovery` | 2 tables + **2 inner-scroll**, 5 tooltips | card + drop-inner + tooltip→tap | 4 |
+| `/admin/vcs-connections` | 1 table, **6 tooltips** | scroll + tooltip→tap | 4 |
+| `/admin/users`, `/admin/roles`, `/admin/variable-sets`, `/admin/policy-sets`, `/admin/provider-templates`, `/admin/execution-hooks`, `/admin/catalog`, `/admin/agent-pools`, `/admin/binary-cache`, `/admin/bulk-update` | 1–2 unwrapped tables | card the list where cheap, else **scroll** fallback | 4 |
+| `/admin/audit-log` | table already wrapped | verify | 4 |
+| `/catalog/[id]` | 1 table + 1 inner-scroll, 6 tooltips | card + drop-inner + tooltip→tap | 4 |
+| `/labels` | 2 unwrapped tables | card | 4 |
+| `/settings/tokens` | table wrapped | verify | 4 |
+| `/settings/sessions` | 1 unwrapped table | card | 4 |
+| `/registry/providers/[name]` | 1 unwrapped table | card/scroll | 4 |
+
+## Clean / no work (verify only at 390px)
+
+`/` (dashboard), `/login`, `/catalog`, `/registry/modules`, `/registry/providers`,
+`/api-docs`, `/slack/link`, `/auth/*`, `/app/[...path]`.
+
+## Cross-cutting (global foundation — Stage 1)
+
+- **Nav** (`components/nav-bar.tsx`) — ~22 top-level items → grouped adaptive nav (see the nav-IA mockup / #719). Mobile menu currently dumps all vertically.
+- **`title=` hover tooltips** — 96 across the app; audit each for real-info-on-hover and convert to tap-visible.
+- **URL-state tabs** — 4 pages hold the tab in `useState` (agent-pools/[id], variable-sets/[id], roles, execution-hooks/[id]); move to URL + land the reload/back regression suite.
+- **Clickable rows** — ~46 `onClick`/`cursor-pointer` row/card targets; scroll-vs-tap review.
+- **Viewport/safe-area** — `viewport-fit=cover`, kill horizontal page scroll globally.
+
+## Totals (scan)
+
+24 `<table>` across 22 routes, only 7 wrapped in `overflow-x-auto`; 11
+inner-scroll regions; 96 `title=` tooltips; 4 `useState` tabs; ~46 clickable
+rows. The worst offenders by density are the two workspace pages and the run
+detail page — the surfaces on the incident-response critical path, which is
+exactly where mobile must be excellent.

--- a/web/RESPONSIVE-AUDIT.md
+++ b/web/RESPONSIVE-AUDIT.md
@@ -42,7 +42,7 @@ Treatment legend:
 | `/admin/users`, `/admin/roles`, `/admin/variable-sets`, `/admin/policy-sets`, `/admin/provider-templates`, `/admin/execution-hooks`, `/admin/catalog`, `/admin/agent-pools`, `/admin/binary-cache`, `/admin/bulk-update` | 1–2 unwrapped tables | card the list where cheap, else **scroll** fallback | 4 |
 | `/admin/audit-log` | table already wrapped | verify | 4 |
 | `/catalog/[id]` | 1 table + 1 inner-scroll, 6 tooltips | card + drop-inner + tooltip→tap | 4 |
-| `/labels` | 2 unwrapped tables | card | 4 |
+| `/labels` | 2 unwrapped tables | **deprecated** — dropped from nav + banner; no mobile work | — |
 | `/settings/tokens` | table wrapped | verify | 4 |
 | `/settings/sessions` | 1 unwrapped table | card | 4 |
 | `/registry/providers/[name]` | 1 unwrapped table | card/scroll | 4 |

--- a/web/src/app/labels/page.tsx
+++ b/web/src/app/labels/page.tsx
@@ -367,6 +367,29 @@ export default function LabelsPage() {
           title="Labels"
           description="Browse labels in use across workspaces, agent pools, registry modules, and registry providers. Read-only — labels are edited on each entity's own page."
         />
+        {/* Deprecated surface — removed from the primary nav; reachable by
+            direct link only, pending removal in a future release. */}
+        <div
+          role="status"
+          className="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200"
+        >
+          <span className="font-semibold">Deprecated &amp; unsupported.</span>{' '}
+          The Labels browser is no longer in the main navigation and will be
+          removed in a future release. Filter by label from the{' '}
+          <Link href="/workspaces" className="underline hover:text-amber-100">
+            Workspaces
+          </Link>{' '}
+          page instead. If you rely on this page, please{' '}
+          <a
+            href="https://github.com/mattrobinsonsre/terrapod/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-amber-100"
+          >
+            open an issue
+          </a>
+          .
+        </div>
         <Suspense fallback={<LoadingSpinner />}>
           <LabelsBrowserInner />
         </Suspense>

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -11,6 +11,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
 import { WorkspaceStatusBadges } from '@/components/workspace-status-badges'
+import { StatChip } from '@/components/stat-chip'
 import { getAuthState } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
@@ -19,6 +20,7 @@ import {
   hasLabelTerm,
   hasStatusTerm,
   HEALTH_ISSUE_STATUS,
+  LOCKED_STATUS,
   matchWorkspace,
   parseFilterQuery,
   removeTerm,
@@ -241,6 +243,20 @@ function WorkspacesPageInner() {
     }
     return counts
   }, [workspaces])
+
+  // "Health issues" is ONE control rendered two ways (#719): the desktop
+  // stat-grid card and the compact chip on the mobile filter row. Compute the
+  // count + toggle once so both forms stay in sync.
+  const withConditions = useMemo(
+    () => workspaces.filter(ws => (ws.attributes['health-conditions'] || []).length > 0).length,
+    [workspaces],
+  )
+  const healthFilterActive = hasStatusTerm(parsedFilter, HEALTH_ISSUE_STATUS)
+  const toggleHealth = () =>
+    setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, HEALTH_ISSUE_STATUS)))
+  const lockedFilterActive = hasStatusTerm(parsedFilter, LOCKED_STATUS)
+  const toggleLocked = () =>
+    setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, LOCKED_STATUS)))
 
   // Distinct labels across the unfiltered list: key → sorted unique values
   // with workspace counts. Drives the two-level "+ Label" picker. Computed
@@ -701,67 +717,55 @@ function WorkspacesPageInner() {
 
         {!loading && workspaces.length > 0 && (() => {
           const total = workspaces.length
-          const withConditions = workspaces.filter(ws => (ws.attributes['health-conditions'] || []).length > 0).length
           const locked = workspaces.filter(ws => ws.attributes.locked).length
-          const healthFilterActive = hasStatusTerm(parsedFilter, HEALTH_ISSUE_STATUS)
-          // On mobile only Health Issues matters — Total and Locked are
-          // secondary counts we can live without on a small screen (#719), so
-          // they're hidden below `sm` and the grid collapses to a single
-          // full-width Health Issues card. Desktop keeps all three.
-          return (
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-              <div className="hidden sm:block bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
-                <p className="text-xs text-slate-500 uppercase tracking-wider">Total</p>
-                <p className="text-2xl font-semibold text-slate-100 mt-1">{total}</p>
-              </div>
-              {/* Clicking a non-zero Health Issues count toggles the
-                  `status:unhealthy` filter so the operator can jump straight to
-                  the affected workspaces (and click again to clear). When the
-                  count is zero there's nothing to filter to, so it stays a
-                  plain card. */}
-              {withConditions > 0 ? (
-                <button
-                  type="button"
-                  aria-pressed={healthFilterActive}
-                  aria-label={healthFilterActive ? 'Clear health issues filter' : 'Filter to workspaces with health issues'}
-                  title={healthFilterActive ? 'Clear health issues filter' : 'Filter to workspaces with health issues'}
-                  onClick={() => setFilterInput(serializeFilter(toggleStatusTerm(parsedFilter, HEALTH_ISSUE_STATUS)))}
-                  className={
-                    'text-left rounded-lg border p-4 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 ' +
-                    (healthFilterActive
-                      ? 'bg-red-500/10 border-red-500/50'
-                      : 'bg-slate-800/50 border-slate-700/50 hover:bg-slate-700/40 hover:border-slate-600')
-                  }
-                >
-                  <p className="text-xs text-slate-500 uppercase tracking-wider">Health Issues</p>
-                  <p className="text-2xl font-semibold mt-1 text-red-400">{withConditions}</p>
-                </button>
-              ) : (
-                <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
-                  <p className="text-xs text-slate-500 uppercase tracking-wider">Health Issues</p>
-                  <p className="text-2xl font-semibold mt-1 text-slate-100">{withConditions}</p>
-                </div>
-              )}
-              <div className="hidden sm:block bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
-                <p className="text-xs text-slate-500 uppercase tracking-wider">Locked</p>
-                <p className={`text-2xl font-semibold mt-1 ${locked > 0 ? 'text-amber-400' : 'text-slate-100'}`}>{locked}</p>
-              </div>
-            </div>
-          )
-        })()}
-
-        {!loading && workspaces.length > 0 && (() => {
-          // The aggregate `unhealthy` term is driven by the Health Issues card
-          // + its filter chip, not the Status dropdown, so it doesn't count
-          // toward the dropdown's active badge (which would otherwise show a
-          // count with no matching checked row inside).
+          // `unhealthy` is driven by the Health chip, not the Status dropdown,
+          // so it doesn't count toward the dropdown's active badge (which would
+          // otherwise show a count with no matching checked row inside).
           const activeStatusCount = parsedFilter.terms.filter(
-            t => t.kind === 'status' && t.value !== HEALTH_ISSUE_STATUS,
+            t => t.kind === 'status' && t.value !== HEALTH_ISSUE_STATUS && t.value !== LOCKED_STATUS,
           ).length
+          const healthLabel = healthFilterActive
+            ? 'Clear health issues filter'
+            : 'Filter to workspaces with health issues'
           return (
             <div className="mb-4">
-              <div className="flex items-center gap-2">
-                <div className="relative flex-1" ref={suggestWrapRef}>
+              {/* Compact toolbar (#719): stat chips + Status/Label share one
+                  row; the filter input drops to its own row (basis-full) via
+                  flex `order`. Total/Locked are desktop-only secondary counts;
+                  Health is always shown (primary signal) and toggles the
+                  `status:unhealthy` filter. No big stat cards on any viewport. */}
+              <div className="flex flex-wrap items-center gap-2">
+                <StatChip
+                  label="Total"
+                  value={total}
+                  onClick={parsedFilter.terms.length > 0 ? () => setFilterInput('') : undefined}
+                  ariaLabel="Clear all filters"
+                  className="order-1 max-sm:hidden"
+                />
+                <StatChip
+                  label="Health"
+                  value={withConditions}
+                  valueClassName={withConditions > 0 ? 'text-red-400' : 'text-slate-300'}
+                  onClick={withConditions > 0 ? toggleHealth : undefined}
+                  active={healthFilterActive}
+                  ariaLabel={healthLabel}
+                  className="order-2"
+                />
+                <StatChip
+                  label="Locked"
+                  value={locked}
+                  valueClassName={locked > 0 ? 'text-amber-400' : undefined}
+                  onClick={locked > 0 ? toggleLocked : undefined}
+                  active={lockedFilterActive}
+                  activeClassName="bg-amber-500/10 border-amber-500/50"
+                  ariaLabel={lockedFilterActive ? 'Clear locked filter' : 'Filter to locked workspaces'}
+                  className="order-3 max-sm:hidden"
+                />
+                <div className="order-4 flex-1 min-w-0" />
+                {/* Input + Clear share their own full-width row (order-7),
+                    Clear pinned to the right of the input — desktop and mobile. */}
+                <div className="order-7 basis-full flex items-center gap-2">
+                  <div className="relative flex-1 min-w-0" ref={suggestWrapRef}>
                   <input
                     type="text"
                     value={filterInput}
@@ -814,11 +818,21 @@ function WorkspacesPageInner() {
                       ))}
                     </div>
                   )}
+                  </div>
+                  {parsedFilter.terms.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setFilterInput('')}
+                      className="px-3 py-2 rounded-lg text-sm text-slate-400 hover:text-slate-200 transition-colors whitespace-nowrap flex-shrink-0"
+                    >
+                      Clear
+                    </button>
+                  )}
                 </div>
                 {/* Status dropdown — single entry point for all status presets.
                     Picks any combination via toggle; the existing chips below
                     show what's active and let the user remove individually. */}
-                <div className="relative" ref={statusMenuRef}>
+                <div className="relative order-5" ref={statusMenuRef}>
                   <button
                     type="button"
                     aria-haspopup="menu"
@@ -879,7 +893,7 @@ function WorkspacesPageInner() {
                     key/value pairs. First level lists distinct label keys
                     in the visible workspaces; clicking a key drills into a
                     second menu of distinct values for that key. */}
-                <div className="relative" ref={labelMenuRef}>
+                <div className="relative order-6" ref={labelMenuRef}>
                   {(() => {
                     const activeLabelCount = parsedFilter.terms.filter(t => t.kind === 'label' && t.value !== null).length
                     return (
@@ -968,15 +982,6 @@ function WorkspacesPageInner() {
                     )
                   })()}
                 </div>
-                {parsedFilter.terms.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={() => setFilterInput('')}
-                    className="px-3 py-2 rounded-lg text-sm text-slate-400 hover:text-slate-200 transition-colors"
-                  >
-                    Clear
-                  </button>
-                )}
               </div>
               {parsedFilter.terms.length > 0 && (
                 <div className="flex flex-wrap gap-2 mt-2">

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -1044,7 +1044,7 @@ function WorkspacesPageInner() {
                       <div className="flex flex-col gap-1.5">
                         <Link
                           href={`/workspaces/${ws.id}`}
-                          className="text-sm font-medium text-brand-400 hover:text-brand-300"
+                          className="text-sm font-medium text-brand-400 hover:text-brand-300 break-all"
                         >
                           {ws.attributes.name}
                         </Link>

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -704,9 +704,13 @@ function WorkspacesPageInner() {
           const withConditions = workspaces.filter(ws => (ws.attributes['health-conditions'] || []).length > 0).length
           const locked = workspaces.filter(ws => ws.attributes.locked).length
           const healthFilterActive = hasStatusTerm(parsedFilter, HEALTH_ISSUE_STATUS)
+          // On mobile only Health Issues matters — Total and Locked are
+          // secondary counts we can live without on a small screen (#719), so
+          // they're hidden below `sm` and the grid collapses to a single
+          // full-width Health Issues card. Desktop keeps all three.
           return (
-            <div className="grid grid-cols-3 gap-4 mb-6">
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+              <div className="hidden sm:block bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
                 <p className="text-xs text-slate-500 uppercase tracking-wider">Total</p>
                 <p className="text-2xl font-semibold text-slate-100 mt-1">{total}</p>
               </div>
@@ -738,7 +742,7 @@ function WorkspacesPageInner() {
                   <p className="text-2xl font-semibold mt-1 text-slate-100">{withConditions}</p>
                 </div>
               )}
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
+              <div className="hidden sm:block bg-slate-800/50 rounded-lg border border-slate-700/50 p-4">
                 <p className="text-xs text-slate-500 uppercase tracking-wider">Locked</p>
                 <p className={`text-2xl font-semibold mt-1 ${locked > 0 ? 'text-amber-400' : 'text-slate-100'}`}>{locked}</p>
               </div>

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -10,6 +10,7 @@ import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
+import { WorkspaceStatusBadges } from '@/components/workspace-status-badges'
 import { getAuthState } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
@@ -367,15 +368,6 @@ function WorkspacesPageInner() {
       else setSuggestOpen(false)
     }
     else if (e.key === 'Escape') { e.preventDefault(); setSuggestOpen(false) }
-  }
-
-  const badgeColors: Record<string, string> = {
-    amber: 'bg-amber-900/50 text-amber-300',
-    red: 'bg-red-900/50 text-red-300',
-    blue: 'bg-blue-900/50 text-blue-300',
-    green: 'bg-green-900/50 text-green-300',
-    slate: 'bg-slate-700/50 text-slate-400',
-    gray: 'text-slate-500',
   }
 
   const { sortedItems: sortedWorkspaces, sortState, toggleSort } = useSortable<Workspace, WsSortKey>(
@@ -1071,6 +1063,22 @@ function WorkspacesPageInner() {
                             })}
                           </div>
                         )}
+                        {/*
+                          Mobile-only status (#719). Below `lg` the STATUS
+                          column is hidden, so surface the same badges here
+                          where the row is name-only — a phone must never lose
+                          the running/errored/applied signal. Hidden at `lg`+
+                          where the dedicated STATUS column takes over, so
+                          desktop is pixel-identical.
+                        */}
+                        <div className="lg:hidden" data-testid="ws-row-status-mobile">
+                          <WorkspaceStatusBadges
+                            workspaceId={ws.id}
+                            def={def}
+                            runId={runId}
+                            lifecycleState={ws.attributes['lifecycle-state']}
+                          />
+                        </div>
                       </div>
                     </td>
                     <td className="px-4 py-3 hidden sm:table-cell">
@@ -1087,32 +1095,12 @@ function WorkspacesPageInner() {
                       </span>
                     </td>
                     <td className="px-4 py-3 hidden lg:table-cell">
-                      <div className="flex flex-wrap items-center gap-1.5">
-                        {!def ? (
-                          <span className="text-xs text-slate-500">&mdash;</span>
-                        ) : runId ? (
-                          <Link
-                            href={`/workspaces/${ws.id}/runs/${runId}`}
-                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap hover:opacity-80 transition-opacity ${badgeColors[def.color]}`}
-                          >
-                            {def.label}
-                          </Link>
-                        ) : (
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${badgeColors[def.color]}`}>
-                            {def.label}
-                          </span>
-                        )}
-                        {ws.attributes['lifecycle-state'] === 'pending_deletion' && (
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${badgeColors.amber}`}>
-                            Pending deletion
-                          </span>
-                        )}
-                        {ws.attributes['lifecycle-state'] === 'archived' && (
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${badgeColors.slate}`}>
-                            Archived
-                          </span>
-                        )}
-                      </div>
+                      <WorkspaceStatusBadges
+                        workspaceId={ws.id}
+                        def={def}
+                        runId={runId}
+                        lifecycleState={ws.attributes['lifecycle-state']}
+                      />
                     </td>
                     <td className="px-4 py-3 hidden xl:table-cell">
                       <span className="text-xs text-slate-500">

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -22,7 +22,6 @@ import {
   LogOut,
   Menu,
   X,
-  Tags,
   Compass,
   Wrench,
   ScrollText,
@@ -316,7 +315,6 @@ export default function NavBar() {
               <NavDropdown label="Registry" icon={Library} items={REGISTRY_ITEMS} active={registryActive} />
               <NavLink href="/catalog" icon={LayoutGrid} label="Catalog" />
               <NavLink href="/admin/agent-pools" icon={Server} label="Agent Pools" />
-              <NavLink href="/labels" icon={Tags} label="Labels" />
             </div>
             {adminOrAudit && (
               <NavDropdown label="Admin" icon={Cog} items={adminMenuItems} active={adminActive} align="end" />
@@ -376,7 +374,6 @@ export default function NavBar() {
                 item={{ href: '/admin/agent-pools', label: 'Agent Pools', icon: Server }}
                 onClick={closeMenu}
               />
-              <MobileLink item={{ href: '/labels', label: 'Labels', icon: Tags }} onClick={closeMenu} />
 
               <MobileSection label="Registry" />
               {REGISTRY_ITEMS.map((it) => (

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useSyncExternalStore } from 'react'
+import { forwardRef, useEffect, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
@@ -183,8 +183,19 @@ function NavDropdown({
   )
 }
 
-/** A single link row inside a desktop dropdown. */
-function MenuLink({ item }: { item: NavItem }) {
+/**
+ * A single link row inside a desktop dropdown. Rendered as the `asChild`
+ * target of `DropdownMenu.Item`, so it MUST forward the ref and spread the
+ * props Radix's Slot injects (`role="menuitem"`, `tabindex`, the highlight /
+ * keyboard handlers, `data-*`). Dropping them — as an earlier version did by
+ * accepting only `{item}` — left the anchor with no `menuitem` role, breaking
+ * keyboard navigation and making the items invisible to assistive tech and to
+ * `getByRole('menuitem')`. `forwardRef` + `{...rest}` restores the contract.
+ */
+const MenuLink = forwardRef<
+  HTMLAnchorElement,
+  { item: NavItem } & React.AnchorHTMLAttributes<HTMLAnchorElement>
+>(function MenuLink({ item, className, ...rest }, ref) {
   const pathname = usePathname()
   const Icon = item.icon
   const cls =
@@ -192,10 +203,12 @@ function MenuLink({ item }: { item: NavItem }) {
   if (item.external) {
     return (
       <a
+        ref={ref}
         href={item.href}
         target="_blank"
         rel="noopener noreferrer"
-        className={`${cls} text-slate-300 hover:bg-slate-700 hover:text-slate-100`}
+        className={`${cls} text-slate-300 hover:bg-slate-700 hover:text-slate-100${className ? ' ' + className : ''}`}
+        {...rest}
       >
         <Icon size={16} />
         {item.label}
@@ -205,14 +218,16 @@ function MenuLink({ item }: { item: NavItem }) {
   const active = isPathActive(pathname, item.href)
   return (
     <Link
+      ref={ref}
       href={item.href}
-      className={`${cls} ${active ? 'text-brand-400' : 'text-slate-300 hover:bg-slate-700 hover:text-slate-100'}`}
+      className={`${cls} ${active ? 'text-brand-400' : 'text-slate-300 hover:bg-slate-700 hover:text-slate-100'}${className ? ' ' + className : ''}`}
+      {...rest}
     >
       <Icon size={16} />
       {item.label}
     </Link>
   )
-}
+})
 
 /** A section header in the mobile sheet. */
 function MobileSection({ label }: { label: string }) {

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -364,17 +364,24 @@ export default function NavBar() {
           </div>
           {menuOpen && (
             <div id="mobile-nav-menu" className="md:hidden flex flex-col gap-0.5 pb-4">
+              {/*
+                Primary destinations first, flat and un-headed (they are the
+                default group). Registry is a delimited section BELOW them —
+                otherwise Catalog/Agent Pools/Labels read as if they belong to
+                the Registry section header.
+              */}
               <MobileLink item={{ href: '/workspaces', label: 'Workspaces', icon: Layers }} onClick={closeMenu} />
-              <MobileSection label="Registry" />
-              {REGISTRY_ITEMS.map((it) => (
-                <MobileLink key={it.href} item={it} onClick={closeMenu} />
-              ))}
               <MobileLink item={{ href: '/catalog', label: 'Catalog', icon: LayoutGrid }} onClick={closeMenu} />
               <MobileLink
                 item={{ href: '/admin/agent-pools', label: 'Agent Pools', icon: Server }}
                 onClick={closeMenu}
               />
               <MobileLink item={{ href: '/labels', label: 'Labels', icon: Tags }} onClick={closeMenu} />
+
+              <MobileSection label="Registry" />
+              {REGISTRY_ITEMS.map((it) => (
+                <MobileLink key={it.href} item={it} onClick={closeMenu} />
+              ))}
 
               {adminOrAudit && (
                 <>

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -83,11 +83,16 @@ const ADMIN_ITEMS: NavItem[] = [
 
 const AUDIT_ITEM: NavItem = { href: '/admin/audit-log', label: 'Audit Log', icon: FileText }
 
-// Account / reference destinations (behind Account▾ on desktop). Logout is
+// Personal / session destinations (behind the Account menu). Logout is
 // rendered separately (it is an action, not a link).
 const ACCOUNT_ITEMS: NavItem[] = [
   { href: '/settings/tokens', label: 'API Tokens', icon: Key },
   { href: '/settings/sessions', label: 'Sessions', icon: Activity },
+]
+
+// Help / reference destinations — NOT account items. Grouped separately so
+// the Account menu stays personal (tokens, sessions, log out).
+const HELP_ITEMS: NavItem[] = [
   { href: '/api-docs', label: 'API Reference', icon: Code },
   {
     href: 'https://github.com/mattrobinsonsre/terrapod/blob/main/docs/index.md',
@@ -253,6 +258,46 @@ function MobileLink({ item, onClick }: { item: NavItem; onClick: () => void }) {
   )
 }
 
+/**
+ * A full-screen mobile drawer: its own top bar (title + close) plus an
+ * internally-scrolling body. Being `fixed inset-0` it's self-contained and
+ * always aligned regardless of the sticky nav / expiry banners above it;
+ * `overscroll-contain` + the body-scroll lock stop scrolling from chaining to
+ * the page behind it.
+ */
+function MobileDrawer({
+  id,
+  title,
+  onClose,
+  children,
+}: {
+  id: string
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      id={id}
+      className="md:hidden fixed top-0 left-0 right-0 h-dvh z-40 bg-slate-900 flex flex-col"
+    >
+      <div className="flex items-center justify-between h-14 px-4 border-b border-slate-800 flex-shrink-0">
+        <span className="font-bold text-lg text-slate-100">{title}</span>
+        <button
+          onClick={onClose}
+          aria-label="Close menu"
+          className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+        >
+          <X size={22} />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto overscroll-contain px-4 pt-2 pb-8 flex flex-col gap-0.5">
+        {children}
+      </div>
+    </div>
+  )
+}
+
 export default function NavBar() {
   const router = useRouter()
   const noopSubscribe = () => () => {}
@@ -265,6 +310,7 @@ export default function NavBar() {
   )
   const pathname = usePathname()
   const [menuOpen, setMenuOpen] = useState(false)
+  const [accountOpen, setAccountOpen] = useState(false)
   const [version, setVersion] = useState('')
 
   useEffect(() => {
@@ -274,17 +320,33 @@ export default function NavBar() {
       .catch(() => {})
   }, [])
 
-  // Close the mobile sheet on route change (tapping a link navigates).
+  // Close both mobile drawers on route change (tapping a link navigates).
   useEffect(() => {
     setMenuOpen(false)
+    setAccountOpen(false)
   }, [pathname])
+
+  // A mobile drawer is a full-screen, internally-scrolling overlay; lock the
+  // body while one is open so scrolling the drawer doesn't chain to the page
+  // behind it. Restored on close/unmount.
+  useEffect(() => {
+    if (!menuOpen && !accountOpen) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [menuOpen, accountOpen])
 
   const handleLogout = () => {
     clearAuth()
     router.push('/login')
   }
 
-  const closeMenu = () => setMenuOpen(false)
+  const closeDrawers = () => {
+    setMenuOpen(false)
+    setAccountOpen(false)
+  }
 
   // Admin menu contents: full admin list for admins; audit-only users see
   // just the Audit Log entry. Audit Log is appended for anyone admin-or-audit.
@@ -292,8 +354,8 @@ export default function NavBar() {
 
   const registryActive = REGISTRY_ITEMS.some((i) => isPathActive(pathname, i.href))
   const adminActive = adminMenuItems.some((i) => isPathActive(pathname, i.href))
-  const accountActive =
-    ACCOUNT_ITEMS.some((i) => !i.external && isPathActive(pathname, i.href))
+  const helpActive = HELP_ITEMS.some((i) => !i.external && isPathActive(pathname, i.href))
+  const accountActive = ACCOUNT_ITEMS.some((i) => !i.external && isPathActive(pathname, i.href))
 
   const accountLabel = email || 'Account'
 
@@ -319,6 +381,7 @@ export default function NavBar() {
             {adminOrAudit && (
               <NavDropdown label="Admin" icon={Cog} items={adminMenuItems} active={adminActive} align="end" />
             )}
+            <NavDropdown label="Help" icon={BookOpen} items={HELP_ITEMS} active={helpActive} align="end" />
             <NavDropdown
               label={accountLabel}
               icon={User}
@@ -343,55 +406,80 @@ export default function NavBar() {
             />
           </div>
 
-          {/* Mobile nav */}
+          {/* Mobile top bar — logo + Account trigger + hamburger */}
           <div className="md:hidden flex items-center justify-between h-14">
             <Link href="/" className="flex items-center gap-2">
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
               {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
-            <button
-              onClick={() => setMenuOpen(!menuOpen)}
-              aria-label={menuOpen ? 'Close menu' : 'Open menu'}
-              aria-expanded={menuOpen}
-              aria-controls="mobile-nav-menu"
-              className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
-            >
-              {menuOpen ? <X size={22} /> : <Menu size={22} />}
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => {
+                  setAccountOpen(true)
+                  setMenuOpen(false)
+                }}
+                aria-label="Open account menu"
+                aria-expanded={accountOpen}
+                aria-controls="mobile-account-menu"
+                className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+              >
+                <User size={22} />
+              </button>
+              <button
+                onClick={() => {
+                  setMenuOpen(true)
+                  setAccountOpen(false)
+                }}
+                aria-label="Open menu"
+                aria-expanded={menuOpen}
+                aria-controls="mobile-nav-menu"
+                className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+              >
+                <Menu size={22} />
+              </button>
+            </div>
           </div>
+
+          {/* Mobile main drawer — primary destinations, then Registry / Admin /
+              Help sections. Account is deliberately NOT here — it has its own
+              trigger + drawer. */}
           {menuOpen && (
-            <div id="mobile-nav-menu" className="md:hidden flex flex-col gap-0.5 pb-4">
-              {/*
-                Primary destinations first, flat and un-headed (they are the
-                default group). Registry is a delimited section BELOW them —
-                otherwise Catalog/Agent Pools/Labels read as if they belong to
-                the Registry section header.
-              */}
-              <MobileLink item={{ href: '/workspaces', label: 'Workspaces', icon: Layers }} onClick={closeMenu} />
-              <MobileLink item={{ href: '/catalog', label: 'Catalog', icon: LayoutGrid }} onClick={closeMenu} />
+            <MobileDrawer id="mobile-nav-menu" title="Menu" onClose={closeDrawers}>
+              <MobileLink item={{ href: '/workspaces', label: 'Workspaces', icon: Layers }} onClick={closeDrawers} />
+              <MobileLink item={{ href: '/catalog', label: 'Catalog', icon: LayoutGrid }} onClick={closeDrawers} />
               <MobileLink
                 item={{ href: '/admin/agent-pools', label: 'Agent Pools', icon: Server }}
-                onClick={closeMenu}
+                onClick={closeDrawers}
               />
 
               <MobileSection label="Registry" />
               {REGISTRY_ITEMS.map((it) => (
-                <MobileLink key={it.href} item={it} onClick={closeMenu} />
+                <MobileLink key={it.href} item={it} onClick={closeDrawers} />
               ))}
 
               {adminOrAudit && (
                 <>
                   <MobileSection label="Admin" />
                   {adminMenuItems.map((it) => (
-                    <MobileLink key={it.href} item={it} onClick={closeMenu} />
+                    <MobileLink key={it.href} item={it} onClick={closeDrawers} />
                   ))}
                 </>
               )}
 
-              <MobileSection label="Account" />
+              <MobileSection label="Help" />
+              {HELP_ITEMS.map((it) => (
+                <MobileLink key={it.href} item={it} onClick={closeDrawers} />
+              ))}
+            </MobileDrawer>
+          )}
+
+          {/* Mobile account drawer — personal / session, opened by the User icon */}
+          {accountOpen && (
+            <MobileDrawer id="mobile-account-menu" title="Account" onClose={closeDrawers}>
+              {email && <div className="px-3 pb-2 text-sm text-slate-400 truncate">{email}</div>}
               {ACCOUNT_ITEMS.map((it) => (
-                <MobileLink key={it.href} item={it} onClick={closeMenu} />
+                <MobileLink key={it.href} item={it} onClick={closeDrawers} />
               ))}
               <button
                 onClick={handleLogout}
@@ -400,7 +488,7 @@ export default function NavBar() {
                 <LogOut size={18} />
                 Log out
               </button>
-            </div>
+            </MobileDrawer>
           )}
         </div>
       </nav>

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -320,8 +320,13 @@ export default function NavBar() {
       .catch(() => {})
   }, [])
 
-  // Close both mobile drawers on route change (tapping a link navigates).
+  // Close both mobile drawers whenever the route changes. Link taps already
+  // close via onClick, but this also covers navigations that don't originate
+  // from a drawer link (browser back/forward, programmatic pushes) so a
+  // full-screen drawer can never survive a page change. No cascading render:
+  // React bails out of the update when the value is already `false`.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate route-sync close; see comment above
     setMenuOpen(false)
     setAccountOpen(false)
   }, [pathname])

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -3,34 +3,253 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { Layers, Package, Blocks, Key, Activity, HardDrive, GitBranch, Users, Shield, Server, Variable, FileText, BookOpen, Code, LogOut, Menu, X, Tags, Compass, Wrench, ScrollText, LayoutGrid, Boxes, TerminalSquare } from 'lucide-react'
-import { clearAuth, isAdmin, isAdminOrAudit } from '@/lib/auth'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import {
+  Layers,
+  Package,
+  Blocks,
+  Key,
+  Activity,
+  HardDrive,
+  GitBranch,
+  Users,
+  Shield,
+  Server,
+  Variable,
+  FileText,
+  BookOpen,
+  Code,
+  LogOut,
+  Menu,
+  X,
+  Tags,
+  Compass,
+  Wrench,
+  ScrollText,
+  LayoutGrid,
+  Boxes,
+  TerminalSquare,
+  Library,
+  Cog,
+  User,
+  ChevronDown,
+  type LucideIcon,
+} from 'lucide-react'
+import { clearAuth, isAdmin, isAdminOrAudit, getAuthState } from '@/lib/auth'
 import { SessionExpiryBanner } from '@/components/session-expiry-banner'
 import { TokenExpiryBanner } from '@/components/token-expiry-banner'
 
+/**
+ * Navigation is one DRY, viewport-driven component (#719). The link model
+ * below is the single source of truth: the desktop bar renders it as flat
+ * links + grouped dropdowns, and the mobile hamburger renders the *same*
+ * groups as labelled sections. There is no forked mobile nav and no
+ * user-agent sniffing — CSS (`md:` breakpoint) decides which layout shows.
+ *
+ * IA (approved): five primary items stay visible (Workspaces, Registry▾,
+ * Catalog, Agent Pools, Labels); the ~11 admin destinations + Audit Log
+ * collapse into Admin▾; personal/reference items collapse into Account▾.
+ * Agent Pools + Labels are viewable by non-admins (RBAC-filtered), so they
+ * stay top-level rather than under the admin-only menu.
+ */
+
+type NavItem = {
+  href: string
+  label: string
+  icon: LucideIcon
+  external?: boolean
+}
+
+// Registry destinations (behind Registry▾ on desktop, a section on mobile).
+const REGISTRY_ITEMS: NavItem[] = [
+  { href: '/registry/modules', label: 'Modules', icon: Package },
+  { href: '/registry/providers', label: 'Providers', icon: Blocks },
+]
+
+// Admin destinations (admin only). Audit Log is appended separately because
+// it is visible to the audit role too.
+const ADMIN_ITEMS: NavItem[] = [
+  { href: '/admin/users', label: 'Users', icon: Users },
+  { href: '/admin/roles', label: 'Roles', icon: Shield },
+  { href: '/admin/vcs-connections', label: 'VCS Connections', icon: GitBranch },
+  { href: '/admin/variable-sets', label: 'Variable Sets', icon: Variable },
+  { href: '/admin/autodiscovery', label: 'Autodiscovery', icon: Compass },
+  { href: '/admin/bulk-update', label: 'Bulk Update', icon: Wrench },
+  { href: '/admin/execution-hooks', label: 'Execution Hooks', icon: TerminalSquare },
+  { href: '/admin/policy-sets', label: 'Policy Sets', icon: ScrollText },
+  { href: '/admin/provider-templates', label: 'Provider Templates', icon: Code },
+  { href: '/admin/catalog', label: 'Catalog Admin', icon: Boxes },
+  { href: '/admin/binary-cache', label: 'Cache', icon: HardDrive },
+]
+
+const AUDIT_ITEM: NavItem = { href: '/admin/audit-log', label: 'Audit Log', icon: FileText }
+
+// Account / reference destinations (behind Account▾ on desktop). Logout is
+// rendered separately (it is an action, not a link).
+const ACCOUNT_ITEMS: NavItem[] = [
+  { href: '/settings/tokens', label: 'API Tokens', icon: Key },
+  { href: '/settings/sessions', label: 'Sessions', icon: Activity },
+  { href: '/api-docs', label: 'API Reference', icon: Code },
+  {
+    href: 'https://github.com/mattrobinsonsre/terrapod/blob/main/docs/index.md',
+    label: 'Docs',
+    icon: BookOpen,
+    external: true,
+  },
+]
+
+function isPathActive(pathname: string, href: string): boolean {
+  return pathname === href || pathname.startsWith(href + '/')
+}
+
+/** A top-level desktop bar link (Workspaces, Catalog, Agent Pools, Labels). */
 function NavLink({
   href,
-  children,
-  onClick,
+  icon: Icon,
+  label,
 }: {
   href: string
-  children: React.ReactNode
-  onClick?: () => void
+  icon: LucideIcon
+  label: string
 }) {
   const pathname = usePathname()
-  const active = pathname === href || pathname.startsWith(href + '/')
-
+  const active = isPathActive(pathname, href)
   return (
     <Link
       href={href}
-      onClick={onClick}
       className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
         active
           ? 'bg-brand-600/20 text-brand-400'
           : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800'
       }`}
     >
-      {children}
+      <Icon size={16} />
+      {label}
+    </Link>
+  )
+}
+
+/** A desktop dropdown group (Registry / Admin / Account). */
+function NavDropdown({
+  label,
+  icon: Icon,
+  items,
+  active,
+  align = 'start',
+  footer,
+}: {
+  label: string
+  icon: LucideIcon
+  items: NavItem[]
+  active: boolean
+  align?: 'start' | 'end'
+  footer?: React.ReactNode
+}) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
+            active
+              ? 'bg-brand-600/20 text-brand-400'
+              : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800 data-[state=open]:text-slate-200 data-[state=open]:bg-slate-800'
+          }`}
+        >
+          <Icon size={16} />
+          {label}
+          <ChevronDown size={14} className="opacity-70" />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align={align}
+          sideOffset={6}
+          className="z-50 min-w-[12rem] rounded-lg border border-slate-700 bg-slate-800 p-1 shadow-xl"
+        >
+          {items.map((it) => (
+            <DropdownMenu.Item key={it.href} asChild>
+              <MenuLink item={it} />
+            </DropdownMenu.Item>
+          ))}
+          {footer}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
+/** A single link row inside a desktop dropdown. */
+function MenuLink({ item }: { item: NavItem }) {
+  const pathname = usePathname()
+  const Icon = item.icon
+  const cls =
+    'flex items-center gap-2 px-3 py-2 rounded-md text-sm cursor-pointer outline-none transition-colors data-[highlighted]:bg-slate-700 data-[highlighted]:text-slate-100'
+  if (item.external) {
+    return (
+      <a
+        href={item.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${cls} text-slate-300 hover:bg-slate-700 hover:text-slate-100`}
+      >
+        <Icon size={16} />
+        {item.label}
+      </a>
+    )
+  }
+  const active = isPathActive(pathname, item.href)
+  return (
+    <Link
+      href={item.href}
+      className={`${cls} ${active ? 'text-brand-400' : 'text-slate-300 hover:bg-slate-700 hover:text-slate-100'}`}
+    >
+      <Icon size={16} />
+      {item.label}
+    </Link>
+  )
+}
+
+/** A section header in the mobile sheet. */
+function MobileSection({ label }: { label: string }) {
+  return (
+    <div className="px-3 pt-4 pb-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
+      {label}
+    </div>
+  )
+}
+
+/** A single link row in the mobile sheet (44px tap target). */
+function MobileLink({ item, onClick }: { item: NavItem; onClick: () => void }) {
+  const pathname = usePathname()
+  const Icon = item.icon
+  const active = !item.external && isPathActive(pathname, item.href)
+  const cls =
+    'flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium min-h-[44px] transition-colors'
+  if (item.external) {
+    return (
+      <a
+        href={item.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={onClick}
+        className={`${cls} text-slate-400 hover:text-slate-200 hover:bg-slate-800`}
+      >
+        <Icon size={18} />
+        {item.label}
+      </a>
+    )
+  }
+  return (
+    <Link
+      href={item.href}
+      onClick={onClick}
+      className={`${cls} ${
+        active ? 'bg-brand-600/20 text-brand-400' : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800'
+      }`}
+    >
+      <Icon size={18} />
+      {item.label}
     </Link>
   )
 }
@@ -40,12 +259,26 @@ export default function NavBar() {
   const noopSubscribe = () => () => {}
   const admin = useSyncExternalStore(noopSubscribe, isAdmin, () => false)
   const adminOrAudit = useSyncExternalStore(noopSubscribe, isAdminOrAudit, () => false)
+  const email = useSyncExternalStore(
+    noopSubscribe,
+    () => getAuthState()?.email ?? '',
+    () => '',
+  )
+  const pathname = usePathname()
   const [menuOpen, setMenuOpen] = useState(false)
   const [version, setVersion] = useState('')
 
   useEffect(() => {
-    fetch('/api/v2/ping').then((r) => r.json()).then((d) => setVersion(d.version || '')).catch(() => {})
+    fetch('/api/v2/ping')
+      .then((r) => r.json())
+      .then((d) => setVersion(d.version || ''))
+      .catch(() => {})
   }, [])
+
+  // Close the mobile sheet on route change (tapping a link navigates).
+  useEffect(() => {
+    setMenuOpen(false)
+  }, [pathname])
 
   const handleLogout = () => {
     clearAuth()
@@ -54,96 +287,16 @@ export default function NavBar() {
 
   const closeMenu = () => setMenuOpen(false)
 
-  const navLinks = (
-    <>
-      <NavLink href="/workspaces" onClick={closeMenu}>
-        <Layers size={16} />
-        Workspaces
-      </NavLink>
-      <NavLink href="/registry/modules" onClick={closeMenu}>
-        <Package size={16} />
-        Modules
-      </NavLink>
-      <NavLink href="/registry/providers" onClick={closeMenu}>
-        <Blocks size={16} />
-        Providers
-      </NavLink>
-      <NavLink href="/catalog" onClick={closeMenu}>
-        <LayoutGrid size={16} />
-        Catalog
-      </NavLink>
-      <NavLink href="/settings/tokens" onClick={closeMenu}>
-        <Key size={16} />
-        API Tokens
-      </NavLink>
-      <NavLink href="/settings/sessions" onClick={closeMenu}>
-        <Activity size={16} />
-        Sessions
-      </NavLink>
-      <NavLink href="/admin/agent-pools" onClick={closeMenu}>
-        <Server size={16} />
-        Agent Pools
-      </NavLink>
-      <NavLink href="/labels" onClick={closeMenu}>
-        <Tags size={16} />
-        Labels
-      </NavLink>
-      {admin && (
-        <>
-          <NavLink href="/admin/binary-cache" onClick={closeMenu}>
-            <HardDrive size={16} />
-            Cache
-          </NavLink>
-          <NavLink href="/admin/vcs-connections" onClick={closeMenu}>
-            <GitBranch size={16} />
-            VCS
-          </NavLink>
-          <NavLink href="/admin/users" onClick={closeMenu}>
-            <Users size={16} />
-            Users
-          </NavLink>
-          <NavLink href="/admin/roles" onClick={closeMenu}>
-            <Shield size={16} />
-            Roles
-          </NavLink>
-          <NavLink href="/admin/variable-sets" onClick={closeMenu}>
-            <Variable size={16} />
-            Variable Sets
-          </NavLink>
-          <NavLink href="/admin/execution-hooks" onClick={closeMenu}>
-            <TerminalSquare size={16} />
-            Execution Hooks
-          </NavLink>
-          <NavLink href="/admin/policy-sets" onClick={closeMenu}>
-            <ScrollText size={16} />
-            Policy Sets
-          </NavLink>
-          <NavLink href="/admin/autodiscovery" onClick={closeMenu}>
-            <Compass size={16} />
-            Autodiscovery
-          </NavLink>
-          <NavLink href="/admin/bulk-update" onClick={closeMenu}>
-            <Wrench size={16} />
-            Bulk Update
-          </NavLink>
-          <NavLink href="/admin/catalog" onClick={closeMenu}>
-            <Boxes size={16} />
-            Catalog Admin
-          </NavLink>
-          <NavLink href="/admin/provider-templates" onClick={closeMenu}>
-            <Code size={16} />
-            Provider Templates
-          </NavLink>
-        </>
-      )}
-      {adminOrAudit && (
-        <NavLink href="/admin/audit-log" onClick={closeMenu}>
-          <FileText size={16} />
-          Audit Log
-        </NavLink>
-      )}
-    </>
-  )
+  // Admin menu contents: full admin list for admins; audit-only users see
+  // just the Audit Log entry. Audit Log is appended for anyone admin-or-audit.
+  const adminMenuItems: NavItem[] = [...(admin ? ADMIN_ITEMS : []), AUDIT_ITEM]
+
+  const registryActive = REGISTRY_ITEMS.some((i) => isPathActive(pathname, i.href))
+  const adminActive = adminMenuItems.some((i) => isPathActive(pathname, i.href))
+  const accountActive =
+    ACCOUNT_ITEMS.some((i) => !i.external && isPathActive(pathname, i.href))
+
+  const accountLabel = email || 'Account'
 
   return (
     <>
@@ -159,28 +312,37 @@ export default function NavBar() {
               {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
             <div className="flex items-center gap-1 flex-wrap flex-1">
-              {navLinks}
-              <NavLink href="/api-docs">
-                <Code size={16} />
-                API
-              </NavLink>
-              <a
-                href="https://github.com/mattrobinsonsre/terrapod/blob/main/docs/index.md"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors whitespace-nowrap"
-              >
-                <BookOpen size={16} />
-                Docs
-              </a>
+              <NavLink href="/workspaces" icon={Layers} label="Workspaces" />
+              <NavDropdown label="Registry" icon={Library} items={REGISTRY_ITEMS} active={registryActive} />
+              <NavLink href="/catalog" icon={LayoutGrid} label="Catalog" />
+              <NavLink href="/admin/agent-pools" icon={Server} label="Agent Pools" />
+              <NavLink href="/labels" icon={Tags} label="Labels" />
             </div>
-            <button
-              onClick={handleLogout}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors flex-shrink-0"
-            >
-              <LogOut size={16} />
-              Logout
-            </button>
+            {adminOrAudit && (
+              <NavDropdown label="Admin" icon={Cog} items={adminMenuItems} active={adminActive} align="end" />
+            )}
+            <NavDropdown
+              label={accountLabel}
+              icon={User}
+              items={ACCOUNT_ITEMS}
+              active={accountActive}
+              align="end"
+              footer={
+                <>
+                  <DropdownMenu.Separator className="my-1 h-px bg-slate-700" />
+                  <DropdownMenu.Item asChild>
+                    <button
+                      type="button"
+                      onClick={handleLogout}
+                      className="flex w-full items-center gap-2 px-3 py-2 rounded-md text-sm text-slate-300 cursor-pointer outline-none transition-colors data-[highlighted]:bg-slate-700 data-[highlighted]:text-slate-100"
+                    >
+                      <LogOut size={16} />
+                      Log out
+                    </button>
+                  </DropdownMenu.Item>
+                </>
+              }
+            />
           </div>
 
           {/* Mobile nav */}
@@ -190,41 +352,50 @@ export default function NavBar() {
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
               {version && <span className="text-xs text-slate-500 font-normal">{version}</span>}
             </Link>
-            <div className="flex items-center gap-1">
-              <a
-                href="https://github.com/mattrobinsonsre/terrapod/blob/main/docs/index.md"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Documentation"
-                className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
-              >
-                <BookOpen size={20} />
-              </a>
-              <button
-                onClick={() => setMenuOpen(!menuOpen)}
-                aria-label={menuOpen ? 'Close menu' : 'Open menu'}
-                aria-expanded={menuOpen}
-                aria-controls="mobile-nav-menu"
-                className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
-              >
-                {menuOpen ? <X size={20} /> : <Menu size={20} />}
-              </button>
-              <button
-                onClick={handleLogout}
-                className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
-              >
-                <LogOut size={16} />
-                Logout
-              </button>
-            </div>
+            <button
+              onClick={() => setMenuOpen(!menuOpen)}
+              aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={menuOpen}
+              aria-controls="mobile-nav-menu"
+              className="p-2 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+            >
+              {menuOpen ? <X size={22} /> : <Menu size={22} />}
+            </button>
           </div>
           {menuOpen && (
-            <div id="mobile-nav-menu" className="md:hidden flex flex-col gap-1 pb-3">
-              {navLinks}
-              <NavLink href="/api-docs" onClick={closeMenu}>
-                <Code size={16} />
-                API Reference
-              </NavLink>
+            <div id="mobile-nav-menu" className="md:hidden flex flex-col gap-0.5 pb-4">
+              <MobileLink item={{ href: '/workspaces', label: 'Workspaces', icon: Layers }} onClick={closeMenu} />
+              <MobileSection label="Registry" />
+              {REGISTRY_ITEMS.map((it) => (
+                <MobileLink key={it.href} item={it} onClick={closeMenu} />
+              ))}
+              <MobileLink item={{ href: '/catalog', label: 'Catalog', icon: LayoutGrid }} onClick={closeMenu} />
+              <MobileLink
+                item={{ href: '/admin/agent-pools', label: 'Agent Pools', icon: Server }}
+                onClick={closeMenu}
+              />
+              <MobileLink item={{ href: '/labels', label: 'Labels', icon: Tags }} onClick={closeMenu} />
+
+              {adminOrAudit && (
+                <>
+                  <MobileSection label="Admin" />
+                  {adminMenuItems.map((it) => (
+                    <MobileLink key={it.href} item={it} onClick={closeMenu} />
+                  ))}
+                </>
+              )}
+
+              <MobileSection label="Account" />
+              {ACCOUNT_ITEMS.map((it) => (
+                <MobileLink key={it.href} item={it} onClick={closeMenu} />
+              ))}
+              <button
+                onClick={handleLogout}
+                className="flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium min-h-[44px] text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
+              >
+                <LogOut size={18} />
+                Log out
+              </button>
             </div>
           )}
         </div>

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -9,8 +9,11 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
     <div className="flex items-start justify-between gap-4 mb-6">
       <div>
         <h1 className="text-2xl font-bold text-slate-100">{title}</h1>
+        {/* The explanatory subtitle is desktop-only — on a phone the title
+            alone is enough and the vertical space is better spent on content
+            (#719). Restored at `sm`+ so desktop is unchanged. */}
         {description && (
-          <p className="text-slate-400 mt-1">{description}</p>
+          <p className="text-slate-400 mt-1 hidden sm:block">{description}</p>
         )}
       </div>
       {actions && <div className="flex-shrink-0">{actions}</div>}

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -5,8 +5,13 @@ interface PageHeaderProps {
 }
 
 export function PageHeader({ title, description, actions }: PageHeaderProps) {
+  // Stack title over actions on a phone, side-by-side from `sm` up. A wide
+  // actions cluster (e.g. a "New …" button + filters) can't fit beside the
+  // title at phone width — forcing a row there pushes it off the edge
+  // (horizontal-scroll / clipped-button regression, #719). The `sm:`-prefixed
+  // row rules keep desktop pixel-identical.
   return (
-    <div className="flex items-start justify-between gap-4 mb-6">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4 mb-6">
       <div>
         <h1 className="text-2xl font-bold text-slate-100">{title}</h1>
         {/* The explanatory subtitle is desktop-only — on a phone the title
@@ -16,7 +21,7 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
           <p className="text-slate-400 mt-1 hidden sm:block">{description}</p>
         )}
       </div>
-      {actions && <div className="flex-shrink-0">{actions}</div>}
+      {actions && <div className="sm:flex-shrink-0">{actions}</div>}
     </div>
   )
 }

--- a/web/src/components/stat-chip.tsx
+++ b/web/src/components/stat-chip.tsx
@@ -1,0 +1,64 @@
+// Compact stat chip — a small inline "LABEL value" pill used for the workspace
+// list's Total / Health / Locked counts (#719). Replaces the big stat cards on
+// every viewport so the counts don't burn vertical space. When `onClick` is
+// supplied the chip is an interactive toggle (e.g. Health → `status:unhealthy`
+// filter); otherwise it's a static readout. One primitive → all three counts
+// stay visually consistent and DRY.
+
+export function StatChip({
+  label,
+  value,
+  valueClassName,
+  onClick,
+  active,
+  activeClassName = 'bg-red-500/10 border-red-500/50',
+  ariaLabel,
+  className,
+}: {
+  label: string
+  value: React.ReactNode
+  valueClassName?: string
+  onClick?: () => void
+  active?: boolean
+  // Tailwind classes for the active (filter-applied) state. Defaults to red
+  // (health/error); pass an amber variant for neutral toggles like "Locked".
+  activeClassName?: string
+  ariaLabel?: string
+  className?: string
+}) {
+  const base =
+    'inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium border transition-colors whitespace-nowrap'
+  const content = (
+    <>
+      <span className="text-xs uppercase tracking-wider text-slate-500">{label}</span>
+      <span className={'font-semibold ' + (valueClassName ?? 'text-slate-200')}>{value}</span>
+    </>
+  )
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        aria-pressed={active}
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        onClick={onClick}
+        className={
+          base +
+          ' focus:outline-none focus:ring-2 focus:ring-brand-500 ' +
+          (active
+            ? activeClassName
+            : 'bg-slate-800/50 border-slate-700/50 hover:bg-slate-700/60') +
+          (className ? ' ' + className : '')
+        }
+      >
+        {content}
+      </button>
+    )
+  }
+  return (
+    <div className={base + ' bg-slate-800/50 border-slate-700/50' + (className ? ' ' + className : '')}>
+      {content}
+    </div>
+  )
+}

--- a/web/src/components/workspace-status-badges.tsx
+++ b/web/src/components/workspace-status-badges.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import type { WorkspaceStatusDef } from '@/lib/workspace-status'
+
+// Colour → Tailwind pill classes for the workspace status/lifecycle badges.
+// Single source of truth so the desktop STATUS column and the mobile status
+// line (below the `lg` breakpoint, where the column is hidden) render
+// identically and can never drift (#719).
+const badgeColors: Record<string, string> = {
+  amber: 'bg-amber-900/50 text-amber-300',
+  red: 'bg-red-900/50 text-red-300',
+  blue: 'bg-blue-900/50 text-blue-300',
+  green: 'bg-green-900/50 text-green-300',
+  slate: 'bg-slate-700/50 text-slate-400',
+  gray: 'text-slate-500',
+}
+
+const pill =
+  'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap'
+
+/**
+ * The workspace's status pill (linked to its latest run when there is one)
+ * plus any lifecycle badge (pending-deletion / archived). Rendered in the
+ * desktop STATUS column AND inline in the row on mobile — one implementation,
+ * so the two viewports always agree.
+ */
+export function WorkspaceStatusBadges({
+  workspaceId,
+  def,
+  runId,
+  lifecycleState,
+}: {
+  workspaceId: string
+  def: WorkspaceStatusDef | null
+  runId: string | null
+  lifecycleState?: 'active' | 'pending_deletion' | 'archived'
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {!def ? (
+        <span className="text-xs text-slate-500">&mdash;</span>
+      ) : runId ? (
+        <Link
+          href={`/workspaces/${workspaceId}/runs/${runId}`}
+          className={`${pill} hover:opacity-80 transition-opacity ${badgeColors[def.color]}`}
+        >
+          {def.label}
+        </Link>
+      ) : (
+        <span className={`${pill} ${badgeColors[def.color]}`}>{def.label}</span>
+      )}
+      {lifecycleState === 'pending_deletion' && (
+        <span className={`${pill} ${badgeColors.amber}`}>Pending deletion</span>
+      )}
+      {lifecycleState === 'archived' && (
+        <span className={`${pill} ${badgeColors.slate}`}>Archived</span>
+      )}
+    </div>
+  )
+}

--- a/web/src/lib/workspace-filter.ts
+++ b/web/src/lib/workspace-filter.ts
@@ -63,6 +63,13 @@ export interface StatusTerm {
  *  `matchWorkspace` against the `health-conditions` array. */
 export const HEALTH_ISSUE_STATUS = 'unhealthy'
 
+/** The `status:` value matching manually-locked workspaces. Like
+ *  `unhealthy`, it isn't a resolved-run status — it's matched specially in
+ *  `matchWorkspace` against the workspace's `locked` attribute, and rides the
+ *  `status` facet so no new reserved label key is introduced. Drives the
+ *  clickable "Locked" stat chip. */
+export const LOCKED_STATUS = 'locked'
+
 export type FilterTerm = NameTerm | LabelTerm | StatusTerm
 
 export interface ParsedFilter {
@@ -154,6 +161,8 @@ export interface MatchableWorkspace {
     // Server-computed health conditions (see `_compute_health_conditions`).
     // Only consulted by the `status:unhealthy` aggregate term; safe to omit.
     'health-conditions'?: unknown[] | null
+    // Manual state lock. Only consulted by the `status:locked` term.
+    locked?: boolean | null
   }
 }
 
@@ -180,6 +189,10 @@ export function matchWorkspace(
         // resolved status (which can mask underlying conditions, e.g.
         // needs-confirm over state_diverged).
         if ((ws.attributes['health-conditions'] || []).length === 0) return false
+      } else if (term.value === LOCKED_STATUS) {
+        // Manual state lock — matched on the workspace attribute, not the
+        // resolved run status (a locked workspace still has a run status).
+        if (!ws.attributes.locked) return false
       } else if (resolvedStatus !== term.value) {
         return false
       }


### PR DESCRIPTION
First tranche of the first-class mobile UX initiative (#719): the global
foundation, the navigation restructure, and the full workspace-list mobile
pass. One DRY viewport-driven implementation — no forked mobile build, no
user-agent sniffing — and desktop stays pixel-identical except where
explicitly restructured.

## What's in this PR

**Foundation (Stage 0)** — `useMediaQuery`/`useIsMobile` (SSR-safe), a
`responsive` Playwright project at a phone viewport (the mobile guard), and the
responsive/mobile-first contract in AGENTS.md.

**Navigation** — desktop collapses ~22 wrapping items into five primary
destinations (Workspaces, Registry▾, Catalog, Agent Pools) + Admin▾ +
Help▾ (API reference, docs) + Account▾ (tokens, sessions, log out). Mobile is
two **full-screen drawers** (fixed + h-dvh, body-scroll locked,
overscroll-contain): a hamburger drawer (primary + Registry/Admin/Help) and a
separate **Account** drawer on its own trigger.

**Workspace list** — status now shows **in-row on mobile** via one shared
`WorkspaceStatusBadges` component (badge still links to the run). Big stat cards
replaced by one DRY `StatChip` primitive on every viewport: Total clears all
filters, Health toggles status:unhealthy, Locked toggles a new status:locked
term; Total/Locked are desktop-only, Health always shows. Compact toolbar —
stat chips + Status/Label on one row, the filter input on its own full-width
row with **Clear pinned to its right**. Page subtitle hidden on mobile.

**Labels page** — deprecated: removed from the nav, banner added, reachable by
direct link only.

## Verification
- npm run build + npm run lint (0 errors) green.
- Live-verified on Tilt at 1440px and 390px: drawers open full-screen and
  scroll without page bleed-through; toolbar chips filter and clear; status
  renders in-row and links to the run; Total/Locked hidden on mobile.
- responsive.spec asserts the grouped drawers, in-row status, hidden
  Total/Locked, and no horizontal page scroll.

Does not close #719 — run-page IA, admin tables, and mobile doc screenshots
follow in their own PRs.