### PR TITLE
feat(web): workspace mobile UX pass — card views, MobileCard primitive, touch model, confirm policy (#719)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,19 @@ Mobile is a **first-class target**, not an afterthought — a UI change that is
 not mobile-friendly is **not done** and must not merge. The full brief and the
 staged plan live in issue **#719**; the rules a contributor must follow:
 
+- **Two axes — width drives *layout*, pointer drives *touch-friendliness*.**
+  These are independent signals; never infer one from the other (a wide
+  tablet/foldable is touch; a narrow desktop window is not). **Viewport width**
+  governs layout density — cards↔table, tab-bar↔`<select>` picker, hidden
+  columns — and is expressed in **CSS** (`sm:`/`md:`/`lg:`, `@container`), or in
+  JS via `useIsMobile()` only where *layout behaviour* must branch.
+  **Pointer type** governs touch-friendliness — destructive-action `confirm()`
+  guards, avoiding nested scroll traps, tap-target sizing — via the `touch:` /
+  `fine:` CSS custom variants (in `globals.css`) or `useIsTouch()`
+  (`= matchMedia('(pointer: coarse)')`, reflecting the *primary* pointer, in
+  `web/src/lib/use-media-query.ts`). So the same page can be a roomy
+  desktop-width layout **and** touch-safe at once. Still **never** branch on the
+  user agent for either axis.
 - **One DRY, viewport-driven implementation.** No forked `Mobile*`/`Desktop*`
   component trees, and **never** branch on the user agent
   (`navigator.userAgent`, device-detect libraries, server-side "is this a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,19 @@ staged plan live in issue **#719**; the rules a contributor must follow:
   at any width; **URL is the source of truth for tab/view state** (it must
   survive reload / back / deep-link — no `useState`-only tabs). Prefer
   drill-down to a route over cramming panels into one dense page.
+- **Confirmation guards on mutating actions (hard).** Two tiers, and they are
+  not the same: **(1) an irreversible destructive action — a delete or remove
+  with no undo (delete variable / notification / run task, remove run trigger /
+  remote-state consumer, delete state version, delete workspace) — MUST prompt a
+  `confirm()` in BOTH modes** (touch *and* precise pointer). Losing data on a
+  single stray click is a desktop hazard too, not just a touch one. **(2) Any
+  other single-tap mutation that is reversible or lower-stakes (enable/disable
+  toggles, lock/unlock, queue a destroy run, …) MUST prompt a `confirm()` on
+  touch** (via `useIsTouch()`), where a mis-tap is easy; on a precise pointer it
+  may proceed without one. Do NOT rely on a bespoke inline two-step
+  (Delete→Confirm swap) as the guard — use the native `confirm()` so the tiers
+  stay uniform. Form *submits* after deliberate data entry (create/edit save)
+  are not "single-tap mutations" and don't need a guard.
 - **Enforcement (this is what blocks non-mobile-friendly changes):** the
   `responsive` Playwright project runs the suite at a **phone viewport**
   (`e2e/tests/responsive.spec.ts`) and is the **mobile guard**; the existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,17 @@ staged plan live in issue **#719**; the rules a contributor must follow:
   (Delete→Confirm swap) as the guard — use the native `confirm()` so the tiers
   stay uniform. Form *submits* after deliberate data entry (create/edit save)
   are not "single-tap mutations" and don't need a guard.
+- **Actions are real buttons, not clickable text (hard).** Any control that
+  performs an action — a row action (Edit / Delete / Enable-Disable / Verify /
+  Download / Rollback / Remove), a form Save/Cancel, a toggle — MUST render as a
+  proper button with a background, padding, and rounded corners (e.g.
+  `px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-700 hover:bg-slate-600`;
+  destructive variants use `bg-red-900/40 … text-red-300`), giving it a real
+  tap target (~44px). Do NOT ship "little clickable chunks of text" — a bare
+  coloured-text `<button>` (e.g. `text-xs text-brand-400` with no background) —
+  as an action affordance: it reads as a link, is a poor tap target on touch,
+  and is easy to miss on desktop. Genuine *navigation* (to another
+  page/resource) may still be a text link; *actions* are buttons.
 - **Enforcement (this is what blocks non-mobile-friendly changes):** the
   `responsive` Playwright project runs the suite at a **phone viewport**
   (`e2e/tests/responsive.spec.ts`) and is the **mobile guard**; the existing

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -356,6 +356,42 @@ export async function seedRun(
 }
 
 /**
+ * Seed a state-version record on a workspace (the record alone is enough to
+ * render the State tab; content upload is not needed for a UI-render test).
+ * Returns the state-version id.
+ */
+export async function seedStateVersion(
+  token: string,
+  workspaceId: string,
+  serial = 1,
+): Promise<string> {
+  const res = await fetch(
+    `${API_URL}/api/v2/workspaces/${workspaceId}/state-versions`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        data: {
+          type: 'state-versions',
+          attributes: {
+            serial,
+            md5: 'd41d8cd98f00b204e9800998ecf8427e',
+            lineage: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          },
+        },
+      }),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Create state version failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()).data.id as string;
+}
+
+/**
  * Wait for the stack to be healthy by polling the API ping endpoint.
  */
 export async function waitForStack(timeoutMs = 120_000): Promise<void> {

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -355,6 +355,54 @@ export async function seedRun(
   return (await runRes.json()).data.id as string;
 }
 
+/** Seed a workspace Terraform variable. Returns the variable id. */
+export async function seedVariable(
+  token: string,
+  workspaceId: string,
+  key: string,
+  value = 'seed-value',
+): Promise<string> {
+  const res = await fetch(`${API_URL}/api/v2/workspaces/${workspaceId}/vars`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      data: {
+        type: 'vars',
+        attributes: { key, value, category: 'terraform', sensitive: false, hcl: false },
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`Create variable failed: ${res.status} ${await res.text()}`);
+  return (await res.json()).data.id as string;
+}
+
+/** Seed a workspace run task (enabled). Returns the run-task id. */
+export async function seedRunTask(
+  token: string,
+  workspaceId: string,
+  name: string,
+  url = 'https://run-tasks.example.com/validate',
+): Promise<string> {
+  const res = await fetch(`${API_URL}/api/terrapod/v1/workspaces/${workspaceId}/run-tasks`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      data: {
+        type: 'run-tasks',
+        attributes: { name, url, stage: 'post_plan', 'enforcement-level': 'mandatory', enabled: true },
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`Create run task failed: ${res.status} ${await res.text()}`);
+  return (await res.json()).data.id as string;
+}
+
 /**
  * Seed a state-version record on a workspace (the record alone is enough to
  * render the State tab; content upload is not needed for a UI-render test).

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -100,6 +100,13 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
     },
     {
+      // The precise-pointer half of the #719 confirm() guards (Desktop Chrome →
+      // fine pointer). The coarse-pointer half is in the 'responsive' project.
+      name: 'confirm-guards',
+      testMatch: 'confirm-guards.spec.ts',
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
+    },
+    {
       name: 'ai-summary',
       testMatch: 'ai-summary.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },

--- a/e2e/tests/confirm-guards.spec.ts
+++ b/e2e/tests/confirm-guards.spec.ts
@@ -39,11 +39,13 @@ test.describe('confirm() guards — precise pointer', () => {
     page.off('dialog', spy);
 
     // Tier 1 — delete MUST prompt a confirm() even on a precise pointer.
-    const dialogP = page.waitForEvent('dialog');
+    // Register the handler BEFORE the click: window.confirm() is synchronous and
+    // blocks the click handler, so it must be accepted as it opens (waitForEvent
+    // + click deadlocks).
+    let deleteMsg = '';
+    page.once('dialog', async (d) => { deleteMsg = d.message(); await d.accept(); });
     await page.getByRole('button', { name: 'Delete' }).click();
-    const dialog = await dialogP;
-    expect(dialog.message()).toContain('Delete run task');
-    await dialog.accept();
+    await expect.poll(() => deleteMsg, { timeout: 5_000 }).toContain('Delete run task');
     await expect(page.getByText(rtName)).toBeHidden({ timeout: 10_000 });
   });
 });

--- a/e2e/tests/confirm-guards.spec.ts
+++ b/e2e/tests/confirm-guards.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Dialog } from '@playwright/test';
+import { getStoredToken, createWorkspace, seedRunTask, uniqueName } from '../helpers/api';
+
+/**
+ * #719 two-tier confirm() policy — the DESKTOP (precise-pointer) half.
+ *
+ * The maintainer does not test on a real touch device, so these Playwright
+ * assertions are the contract that proves the guards behave and catch
+ * regressions. This file runs on Desktop Chrome (fine pointer); the coarse-
+ * pointer half lives in responsive.spec.ts (Pixel).
+ *
+ * Tier 1 — irreversible delete/remove → confirm() in BOTH modes (so it fires
+ *          even on a precise pointer, asserted here).
+ * Tier 2 — other mutation (toggle) → confirm() on touch ONLY (so on a precise
+ *          pointer it proceeds with NO dialog, asserted here).
+ *
+ * A run task exposes both a Delete (tier 1) and an Enable/Disable toggle
+ * (tier 2) on one unambiguous row, so it exercises the whole matrix.
+ */
+test.describe('confirm() guards — precise pointer', () => {
+  test('delete prompts a confirm; reversible toggle does not', async ({ page }) => {
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('confirm-desktop'));
+    const rtName = uniqueName('rt');
+    await seedRunTask(token, wsId, rtName);
+
+    await page.goto(`/workspaces/${wsId}?tab=run-tasks`);
+    await expect(page.getByText(rtName)).toBeVisible({ timeout: 15_000 });
+
+    // Tier 2 — toggle must NOT prompt on a precise pointer; it proceeds and the
+    // status pill flips to "Disabled". Register a dialog spy that would trip if
+    // an unexpected confirm() appeared.
+    let toggleDialogFired = false;
+    const spy = async (d: Dialog) => { toggleDialogFired = true; await d.dismiss(); };
+    page.on('dialog', spy);
+    await page.getByRole('button', { name: 'Disable' }).click();
+    await expect(page.getByText('Disabled', { exact: true })).toBeVisible({ timeout: 10_000 });
+    expect(toggleDialogFired).toBe(false);
+    page.off('dialog', spy);
+
+    // Tier 1 — delete MUST prompt a confirm() even on a precise pointer.
+    const dialogP = page.waitForEvent('dialog');
+    await page.getByRole('button', { name: 'Delete' }).click();
+    const dialog = await dialogP;
+    expect(dialog.message()).toContain('Delete run task');
+    await dialog.accept();
+    await expect(page.getByText(rtName)).toBeHidden({ timeout: 10_000 });
+  });
+});

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { getStoredToken, createWorkspace, seedRun, seedStateVersion, uniqueName } from '../helpers/api';
+import { getStoredToken, createWorkspace, seedRun, seedStateVersion, seedRunTask, uniqueName } from '../helpers/api';
 
 /**
  * Responsive / mobile harness (#719).
@@ -207,5 +207,35 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(page.getByRole('checkbox', { name: /Select cv-.* for compare/ }).first()).toBeVisible();
 
     await expectNoHorizontalPageScroll(page);
+  });
+
+  test('touch: both a reversible toggle and an irreversible delete prompt confirm()', async ({ page }) => {
+    // #719 two-tier confirm policy, coarse-pointer half. On touch EVERY mutation
+    // prompts: tier-2 (toggle) — which on a precise pointer would NOT — and
+    // tier-1 (delete). This Pixel project is the only proof of the touch path,
+    // since the maintainer doesn't test on a real device.
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('confirm-touch'));
+    const rtName = uniqueName('rt');
+    await seedRunTask(token, wsId, rtName);
+
+    await page.goto(`/workspaces/${wsId}?tab=run-tasks`);
+    await expect(page.getByText(rtName)).toBeVisible({ timeout: 15_000 });
+
+    // Tier 2 — the Disable toggle DOES prompt on touch; dismiss keeps it enabled.
+    const toggleDialogP = page.waitForEvent('dialog');
+    await page.getByRole('button', { name: 'Disable' }).click();
+    const toggleDialog = await toggleDialogP;
+    expect(toggleDialog.message()).toContain('Disable this run task');
+    await toggleDialog.dismiss();
+    await expect(page.getByText('Enabled', { exact: true })).toBeVisible();
+
+    // Tier 1 — delete prompts on touch too; dismiss keeps the row.
+    const deleteDialogP = page.waitForEvent('dialog');
+    await page.getByRole('button', { name: 'Delete' }).click();
+    const deleteDialog = await deleteDialogP;
+    expect(deleteDialog.message()).toContain('Delete run task');
+    await deleteDialog.dismiss();
+    await expect(page.getByText(rtName)).toBeVisible();
   });
 });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -139,4 +139,24 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(page).toHaveURL(/[?&]view=plan/);
     await expectNoHorizontalPageScroll(page);
   });
+
+  test('workspace runs list becomes tappable cards at phone width', async ({ page }) => {
+    // The 7-column runs table is unreadable on a phone, so below md it renders
+    // as stacked cards driven by the same data (#719 Stage 2). The desktop
+    // table header is hidden; the seeded run shows as a card that is itself a
+    // link to the run (one big tap target).
+    const token = getStoredToken();
+    const wsName = uniqueName('resp-runs');
+    const wsId = await createWorkspace(token, wsName);
+    await seedRun(token, wsId);
+
+    await page.goto(`/workspaces/${wsId}?tab=runs`);
+
+    // The desktop table's column header is hidden at phone width...
+    await expect(page.getByRole('columnheader', { name: 'Run ID' })).toBeHidden();
+    // ...and the run renders as a card linking to the run detail page.
+    await expect(page.locator('a[href*="/runs/run-"]').first()).toBeVisible({ timeout: 15_000 });
+
+    await expectNoHorizontalPageScroll(page);
+  });
 });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -152,6 +152,9 @@ test.describe('Responsive harness (phone viewport)', () => {
 
     await page.goto(`/workspaces/${wsId}?tab=runs`);
 
+    // The 9-tab strip collapses to a native <select> section picker at phone
+    // width (the tab bar overflows a phone), driven by the same ?tab= URL.
+    await expect(page.locator('#ws-tab-select')).toBeVisible();
     // The desktop table's column header is hidden at phone width...
     await expect(page.getByRole('columnheader', { name: 'Run ID' })).toBeHidden();
     // ...and the run renders as a card linking to the run detail page.

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { getStoredToken, createWorkspace, seedRun, uniqueName } from '../helpers/api';
+import { getStoredToken, createWorkspace, seedRun, seedStateVersion, uniqueName } from '../helpers/api';
 
 /**
  * Responsive / mobile harness (#719).
@@ -159,6 +159,29 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(page.getByRole('columnheader', { name: 'Run ID' })).toBeHidden();
     // ...and the run renders as a card linking to the run detail page.
     await expect(page.locator('a[href*="/runs/run-"]').first()).toBeVisible({ timeout: 15_000 });
+
+    await expectNoHorizontalPageScroll(page);
+  });
+
+  test('workspace state list becomes cards at phone width', async ({ page }) => {
+    // The state-version table hid Created-by / Run / Size / Created behind
+    // sm/md/lg breakpoints, leaving a phone with only the serial. Below md it
+    // renders as cards driven by the same data (#719), so nothing is dropped.
+    const token = getStoredToken();
+    const wsName = uniqueName('resp-state');
+    const wsId = await createWorkspace(token, wsName);
+    await seedStateVersion(token, wsId, 1);
+
+    await page.goto(`/workspaces/${wsId}?tab=state`);
+
+    // The 9-tab strip is the native <select> picker at phone width.
+    await expect(page.locator('#ws-tab-select')).toBeVisible();
+    // The desktop table's Serial column header is hidden below md...
+    await expect(page.getByRole('columnheader', { name: 'Serial' })).toBeHidden();
+    // ...and the state version renders as a card with its serial and a
+    // Download button (the card's action, not a tiny text link).
+    await expect(page.getByText('#1', { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('button', { name: 'Download' }).first()).toBeVisible();
 
     await expectNoHorizontalPageScroll(page);
   });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -185,4 +185,27 @@ test.describe('Responsive harness (phone viewport)', () => {
 
     await expectNoHorizontalPageScroll(page);
   });
+
+  test('workspace configurations list becomes cards at phone width', async ({ page }) => {
+    // The 6-column configuration-versions table is 529px wide and was clipped
+    // by its overflow-hidden wrapper on a phone (Created + Download vanished).
+    // Below md it renders as cards driven by the same data (#719). Seeding a run
+    // uploads a configuration version.
+    const token = getStoredToken();
+    const wsName = uniqueName('resp-cfg');
+    const wsId = await createWorkspace(token, wsName);
+    await seedRun(token, wsId);
+
+    await page.goto(`/workspaces/${wsId}?tab=configurations`);
+
+    await expect(page.locator('#ws-tab-select')).toBeVisible();
+    // The desktop table's column header is hidden at phone width...
+    await expect(page.getByRole('columnheader', { name: 'Source' })).toBeHidden();
+    // ...and the config version renders as a card exposing its full id + the
+    // Compare checkbox that the clipped table hid.
+    await expect(page.getByText(/^cv-/).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('checkbox', { name: /Select cv-.* for compare/ }).first()).toBeVisible();
+
+    await expectNoHorizontalPageScroll(page);
+  });
 });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -178,10 +178,11 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(page.locator('#ws-tab-select')).toBeVisible();
     // The desktop table's Serial column header is hidden below md...
     await expect(page.getByRole('columnheader', { name: 'Serial' })).toBeHidden();
-    // ...and the state version renders as a card with its serial and a
-    // Download button (the card's action, not a tiny text link).
-    await expect(page.getByText('#1', { exact: true })).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByRole('button', { name: 'Download' }).first()).toBeVisible();
+    // ...and the state version renders as a card with its serial and a Download
+    // button. `#1` + Download also exist in the hidden desktop table, so filter
+    // to the visible (mobile-card) copy.
+    await expect(page.getByText('#1', { exact: true }).filter({ visible: true })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('button', { name: 'Download' }).filter({ visible: true })).toBeVisible();
 
     await expectNoHorizontalPageScroll(page);
   });
@@ -202,9 +203,10 @@ test.describe('Responsive harness (phone viewport)', () => {
     // The desktop table's column header is hidden at phone width...
     await expect(page.getByRole('columnheader', { name: 'Source' })).toBeHidden();
     // ...and the config version renders as a card exposing its full id + the
-    // Compare checkbox that the clipped table hid.
-    await expect(page.getByText(/^cv-/).first()).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByRole('checkbox', { name: /Select cv-.* for compare/ }).first()).toBeVisible();
+    // Compare checkbox. Both also exist in the hidden desktop table, so filter
+    // to the visible (mobile-card) copy.
+    await expect(page.getByText(/^cv-/).filter({ visible: true }).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('checkbox', { name: /Select cv-.* for compare/ }).filter({ visible: true }).first()).toBeVisible();
 
     await expectNoHorizontalPageScroll(page);
   });
@@ -222,20 +224,22 @@ test.describe('Responsive harness (phone viewport)', () => {
     await page.goto(`/workspaces/${wsId}?tab=run-tasks`);
     await expect(page.getByText(rtName)).toBeVisible({ timeout: 15_000 });
 
+    // Handlers registered BEFORE the click: window.confirm() is synchronous and
+    // blocks the click handler, so the dialog must be handled as it opens
+    // (waitForEvent + click deadlocks).
+
     // Tier 2 — the Disable toggle DOES prompt on touch; dismiss keeps it enabled.
-    const toggleDialogP = page.waitForEvent('dialog');
+    let toggleMsg = '';
+    page.once('dialog', async (d) => { toggleMsg = d.message(); await d.dismiss(); });
     await page.getByRole('button', { name: 'Disable' }).click();
-    const toggleDialog = await toggleDialogP;
-    expect(toggleDialog.message()).toContain('Disable this run task');
-    await toggleDialog.dismiss();
+    await expect.poll(() => toggleMsg, { timeout: 5_000 }).toContain('Disable this run task');
     await expect(page.getByText('Enabled', { exact: true })).toBeVisible();
 
     // Tier 1 — delete prompts on touch too; dismiss keeps the row.
-    const deleteDialogP = page.waitForEvent('dialog');
+    let deleteMsg = '';
+    page.once('dialog', async (d) => { deleteMsg = d.message(); await d.dismiss(); });
     await page.getByRole('button', { name: 'Delete' }).click();
-    const deleteDialog = await deleteDialogP;
-    expect(deleteDialog.message()).toContain('Delete run task');
-    await deleteDialog.dismiss();
+    await expect.poll(() => deleteMsg, { timeout: 5_000 }).toContain('Delete run task');
     await expect(page.getByText(rtName)).toBeVisible();
   });
 });

--- a/e2e/tests/variables.spec.ts
+++ b/e2e/tests/variables.spec.ts
@@ -38,8 +38,9 @@ test.describe('Variables', () => {
     // Submit (the submit button also says "Add Variable")
     await page.click('form button:has-text("Add Variable")');
 
-    // Variable should appear in the table
-    await expect(page.locator('text=test-value')).toBeVisible({ timeout: 10_000 });
+    // Variable should appear in the table. Scope to the <tr> — the value also
+    // renders in the (hidden) mobile card, so a bare text= match is ambiguous.
+    await expect(page.locator('tr:has-text("test-value")')).toBeVisible({ timeout: 10_000 });
   });
 
   test('create sensitive variable shows masked value', async ({ page }) => {
@@ -99,9 +100,9 @@ test.describe('Variables', () => {
     const row = page.locator(`tr:has-text("${varKey}")`);
     await expect(row).toBeVisible({ timeout: 10_000 });
 
-    // Delete it — two-click inline confirm (Delete → Confirm)
+    // Delete it — a native confirm() now guards the delete (#719); accept it.
+    page.once('dialog', (d) => d.accept());
     await row.locator('button:has-text("Delete")').click();
-    await row.locator('button:has-text("Confirm")').click();
 
     // Should be gone
     await expect(row).not.toBeVisible({ timeout: 10_000 });

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,5 +1,13 @@
 @import "tailwindcss";
 
+/* Interaction-media variants (#719). Touch-friendliness is keyed on the
+   pointer, NOT viewport width: `touch:` = the primary pointer is coarse (finger
+   / stylus), `fine:` = a precise pointer (mouse / trackpad). Layout density
+   stays on width (sm:/md:/lg:); these govern interaction (scroll traps, tap
+   targets, hover-only affordances) so tablets & foldables stay touch-safe. */
+@custom-variant touch (@media (pointer: coarse));
+@custom-variant fine (@media (pointer: fine));
+
 @theme {
   --color-brand-50: #f5f3ff;
   --color-brand-100: #ede9fe;

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -3357,67 +3357,128 @@ function WorkspaceDetailContent() {
             ) : cvs.length === 0 ? (
               <EmptyState message="No configuration versions yet. They appear here as soon as a `terraform plan` uploads or a VCS push triggers a run." />
             ) : (
-              <div className="overflow-hidden rounded-xl border border-slate-800">
-                <table className="w-full text-sm">
-                  <thead className="bg-slate-900/50 text-slate-400">
-                    <tr>
-                      <th className="w-8 px-2 py-3" aria-hidden />
-                      <th className="px-4 py-3 text-left font-medium">ID</th>
-                      <th className="px-4 py-3 text-left font-medium">Source</th>
-                      <th className="px-4 py-3 text-left font-medium">Status</th>
-                      <th className="px-4 py-3 text-left font-medium">Created</th>
-                      <th className="px-4 py-3 text-right font-medium">Download</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-slate-800">
-                    {cvs.map(cv => {
-                      const isCurrent = cv.id === cvCurrentId
-                      const isSelected = cvSelected.has(cv.id)
-                      const canDownload = cv.attributes.status === 'uploaded'
-                      return (
-                        <tr key={cv.id} className={isSelected ? 'bg-blue-900/20' : 'hover:bg-slate-900/30 transition-colors'}>
-                          <td className="px-2 py-3 align-middle">
-                            <input
-                              type="checkbox"
-                              aria-label={`Select ${cv.id} for compare`}
-                              checked={isSelected}
-                              onChange={() => toggleCvSelected(cv.id)}
-                              className="h-4 w-4"
-                              disabled={!canDownload}
-                            />
-                          </td>
-                          <td className="px-4 py-3 font-mono text-xs">
-                            <span className="text-slate-200">{cv.id}</span>
-                            {isCurrent && (
-                              <span className="ml-2 inline-flex items-center rounded bg-green-900/40 px-1.5 py-0.5 text-xs font-medium text-green-300">
-                                current
-                              </span>
-                            )}
-                          </td>
-                          <td className="px-4 py-3 text-slate-300">{cv.attributes.source}</td>
-                          <td className="px-4 py-3 text-slate-400">{cv.attributes.status}</td>
-                          <td className="px-4 py-3 text-slate-400">
-                            {new Date(cv.attributes['created-at']).toLocaleString()}
-                          </td>
-                          <td className="px-4 py-3 text-right">
-                            {canDownload ? (
+              <>
+                {/* Desktop (md+): the table with per-row compare checkboxes. */}
+                <div className="hidden md:block overflow-hidden rounded-xl border border-slate-800">
+                  <table className="w-full text-sm">
+                    <thead className="bg-slate-900/50 text-slate-400">
+                      <tr>
+                        <th className="w-8 px-2 py-3" aria-hidden />
+                        <th className="px-4 py-3 text-left font-medium">ID</th>
+                        <th className="px-4 py-3 text-left font-medium">Source</th>
+                        <th className="px-4 py-3 text-left font-medium">Status</th>
+                        <th className="px-4 py-3 text-left font-medium">Created</th>
+                        <th className="px-4 py-3 text-right font-medium">Download</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-800">
+                      {cvs.map(cv => {
+                        const isCurrent = cv.id === cvCurrentId
+                        const isSelected = cvSelected.has(cv.id)
+                        const canDownload = cv.attributes.status === 'uploaded'
+                        return (
+                          <tr key={cv.id} className={isSelected ? 'bg-blue-900/20' : 'hover:bg-slate-900/30 transition-colors'}>
+                            <td className="px-2 py-3 align-middle">
+                              <input
+                                type="checkbox"
+                                aria-label={`Select ${cv.id} for compare`}
+                                checked={isSelected}
+                                onChange={() => toggleCvSelected(cv.id)}
+                                className="h-4 w-4"
+                                disabled={!canDownload}
+                              />
+                            </td>
+                            <td className="px-4 py-3 font-mono text-xs">
+                              <span className="text-slate-200">{cv.id}</span>
+                              {isCurrent && (
+                                <span className="ml-2 inline-flex items-center rounded bg-green-900/40 px-1.5 py-0.5 text-xs font-medium text-green-300">
+                                  current
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 text-slate-300">{cv.attributes.source}</td>
+                            <td className="px-4 py-3 text-slate-400">{cv.attributes.status}</td>
+                            <td className="px-4 py-3 text-slate-400">
+                              {new Date(cv.attributes['created-at']).toLocaleString()}
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              {canDownload ? (
+                                <button
+                                  type="button"
+                                  onClick={() => downloadCv(cv.id)}
+                                  className="text-blue-400 hover:text-blue-300 text-sm font-medium"
+                                >
+                                  Download
+                                </button>
+                              ) : (
+                                <span className="text-slate-600 text-sm">—</span>
+                              )}
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Mobile (< md): cards — the 6-column table is 529px wide and was
+                    clipped by its overflow-hidden wrapper on a phone, hiding
+                    Created + Download entirely. Cards keep every field plus the
+                    compare checkbox and Download as tap targets. */}
+                <MobileCardList>
+                  {cvs.map(cv => {
+                    const isCurrent = cv.id === cvCurrentId
+                    const isSelected = cvSelected.has(cv.id)
+                    const canDownload = cv.attributes.status === 'uploaded'
+                    return (
+                      <MobileCard
+                        key={cv.id}
+                        title={<span className="min-w-0 text-xs font-mono text-slate-200 break-all">{cv.id}</span>}
+                        badge={
+                          isCurrent && (
+                            <span className="shrink-0 inline-flex items-center rounded bg-green-900/40 px-1.5 py-0.5 text-xs font-medium text-green-300">
+                              current
+                            </span>
+                          )
+                        }
+                        fields={[
+                          { label: 'Source', value: cv.attributes.source },
+                          { label: 'Status', value: cv.attributes.status, valueClassName: 'text-slate-400' },
+                          {
+                            label: 'Created',
+                            value: new Date(cv.attributes['created-at']).toLocaleString(),
+                            valueClassName: 'text-slate-400',
+                          },
+                        ]}
+                        actions={
+                          <>
+                            <label className={`flex items-center gap-1.5 text-xs ${canDownload ? 'text-slate-400' : 'text-slate-600'}`}>
+                              <input
+                                type="checkbox"
+                                aria-label={`Select ${cv.id} for compare`}
+                                checked={isSelected}
+                                onChange={() => toggleCvSelected(cv.id)}
+                                className="h-4 w-4"
+                                disabled={!canDownload}
+                              />
+                              Compare
+                            </label>
+                            {canDownload && (
                               <button
                                 type="button"
                                 onClick={() => downloadCv(cv.id)}
-                                className="text-blue-400 hover:text-blue-300 text-sm font-medium"
+                                className="px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200"
                               >
                                 Download
                               </button>
-                            ) : (
-                              <span className="text-slate-600 text-sm">—</span>
                             )}
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
+                          </>
+                        }
+                      />
+                    )
+                  })}
+                </MobileCardList>
+              </>
             )}
 
             {cvDiffError && (

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1740,7 +1740,7 @@ function WorkspaceDetailContent() {
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm font-medium text-slate-300">Settings</h3>
                 {!editing ? (
-                  perms['can-update'] && <button onClick={startEditing} className="text-xs text-brand-400 hover:text-brand-300">
+                  perms['can-update'] && <button onClick={startEditing} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">
                     Edit
                   </button>
                 ) : (
@@ -2640,8 +2640,8 @@ function WorkspaceDetailContent() {
                           </td>
                           <td className="px-4 py-3 text-right">
                             <div className="flex justify-end gap-2">
-                              <button onClick={() => setEditingVarId(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                              <button onClick={handleSaveVar} disabled={savingVar} className="text-xs text-brand-400 hover:text-brand-300">
+                              <button onClick={() => setEditingVarId(null)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Cancel</button>
+                              <button onClick={handleSaveVar} disabled={savingVar} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white">
                                 {savingVar ? 'Saving...' : 'Save'}
                               </button>
                             </div>
@@ -2663,8 +2663,8 @@ function WorkspaceDetailContent() {
                           {perms['can-update-variable'] && (
                             <td className="px-4 py-3 text-right">
                               <div className="flex justify-end gap-2">
-                                <button onClick={() => startEditingVar(v)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
-                                <button onClick={() => handleDeleteVariable(v.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
+                                <button onClick={() => startEditingVar(v)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Edit</button>
+                                <button onClick={() => handleDeleteVariable(v.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300">Delete</button>
                               </div>
                             </td>
                           )}
@@ -3648,8 +3648,8 @@ function WorkspaceDetailContent() {
 
                   return (
                     <div key={nc.id} className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
-                      <div className="px-4 py-3 flex items-center gap-3">
-                        <div className="flex-1 min-w-0">
+                      <div className="px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center">
+                        <div className="min-w-0 sm:flex-1">
                           <div className="flex items-center gap-2 mb-1">
                             <span className="text-sm font-medium text-slate-200 truncate">{a.name}</span>
                             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${destTypeBadge(a['destination-type'])}`}>
@@ -3667,7 +3667,7 @@ function WorkspaceDetailContent() {
                             ))}
                           </div>
                         </div>
-                        <div className="flex items-center gap-1.5 shrink-0">
+                        <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
                           {lastResponse && (
                             <span className={`text-xs ${lastResponse.success ? 'text-green-400' : 'text-red-400'}`}>
                               {lastResponse.success ? 'OK' : `Err ${lastResponse.status}`}
@@ -3675,23 +3675,23 @@ function WorkspaceDetailContent() {
                           )}
                           {perms['can-update'] && (
                             <>
-                              <button onClick={() => handleToggleNotif(nc)} className="text-xs text-brand-400 hover:text-brand-300 px-1">
+                              <button onClick={() => handleToggleNotif(nc)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">
                                 {a.enabled ? 'Disable' : 'Enable'}
                               </button>
                               <button onClick={() => handleVerifyNotif(nc.id)} disabled={verifyingId === nc.id}
-                                className="text-xs text-brand-400 hover:text-brand-300 px-1">
+                                className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 disabled:opacity-50">
                                 {verifyingId === nc.id ? 'Sending...' : 'Verify'}
                               </button>
                             </>
                           )}
                           {responses.length > 0 && (
                             <button onClick={() => setExpandedNotifId(isExpanded ? null : nc.id)}
-                              className="text-xs text-slate-400 hover:text-slate-200 px-1">
+                              className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-300">
                               {isExpanded ? 'Hide' : 'History'}
                             </button>
                           )}
                           {perms['can-update'] && (
-                            <button onClick={() => handleDeleteNotif(nc.id)} className="text-xs text-red-400 hover:text-red-300 px-1">Delete</button>
+                            <button onClick={() => handleDeleteNotif(nc.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300">Delete</button>
                           )}
                         </div>
                       </div>
@@ -3810,16 +3810,13 @@ function WorkspaceDetailContent() {
                         <div className="text-xs text-slate-500 break-all sm:truncate">{a.url}</div>
                       </div>
                       {perms['can-update'] && (
-                        // Tap-friendly buttons below sm (px-3 py-1.5 pill); sm+
-                        // revert to the compact inline text links (desktop
-                        // unchanged).
-                        <div className="flex items-center gap-2 sm:gap-1.5 sm:shrink-0">
-                          <button onClick={() => handleToggleRunTask(rt)} className="text-xs text-brand-400 hover:text-brand-300 rounded-lg bg-slate-700 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0">
+                        <div className="flex items-center gap-2 sm:shrink-0">
+                          <button onClick={() => handleToggleRunTask(rt)} className="px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">
                             {a.enabled ? 'Disable' : 'Enable'}
                           </button>
                           <button
                             onClick={() => handleDeleteRunTask(rt.id)}
-                            className="text-xs text-red-400 hover:text-red-300 rounded-lg bg-red-900/40 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0"
+                            className="px-3 py-1.5 rounded-lg text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300"
                           >
                             Delete
                           </button>

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -2561,7 +2561,11 @@ function WorkspaceDetailContent() {
             ) : variables.length === 0 ? (
               <EmptyState message="No variables configured for this workspace." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <>
+              {/* Desktop (md+): the variables table. Below md it's replaced by
+                  the stacked cards (a phone can't show the table + inline edit
+                  legibly). #719 Stage 2. */}
+              <div className="hidden md:block bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -2648,6 +2652,90 @@ function WorkspaceDetailContent() {
                   </tbody>
                 </table>
               </div>
+
+              {/* Mobile (< md): variables as stacked cards — same data + inline
+                  edit / delete states as the table. Value is masked when
+                  sensitive; the category pill is kept; actions are proper
+                  buttons (not tiny text). */}
+              <ul className="md:hidden space-y-2">
+                {sortedVars.map((v) => (
+                  <li key={v.id} className="rounded-lg border border-slate-700/50 bg-slate-800/50 p-3">
+                    {editingVarId === v.id ? (
+                      <div className="space-y-2">
+                        <input
+                          type="text"
+                          value={editVarKey}
+                          onChange={(e) => setEditVarKey(e.target.value)}
+                          placeholder="Key"
+                          className="w-full px-2 py-1.5 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 font-mono focus:outline-none focus:ring-1 focus:ring-brand-500"
+                        />
+                        <SensitiveValueInput
+                          value={editVarValue}
+                          onChange={setEditVarValue}
+                          sensitive={editVarSensitive}
+                          placeholder={editVarSensitive ? 'Enter new value' : ''}
+                          rows={2}
+                          className="w-full px-2 py-1.5 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 font-mono focus:outline-none focus:ring-1 focus:ring-brand-500 resize-y"
+                        />
+                        <div className="flex flex-wrap items-center gap-3">
+                          <select
+                            value={editVarCategory}
+                            onChange={(e) => setEditVarCategory(e.target.value)}
+                            className="px-2 py-1 text-xs border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                          >
+                            <option value="terraform">terraform</option>
+                            <option value="env">env</option>
+                          </select>
+                          <label className="flex items-center gap-1 cursor-pointer">
+                            <input type="checkbox" checked={editVarSensitive} onChange={(e) => setEditVarSensitive(e.target.checked)} className="rounded border-slate-600 bg-slate-700 text-brand-600" />
+                            <span className="text-xs text-slate-400">Sensitive</span>
+                          </label>
+                          <label className="flex items-center gap-1 cursor-pointer">
+                            <input type="checkbox" checked={editVarHcl} onChange={(e) => setEditVarHcl(e.target.checked)} className="rounded border-slate-600 bg-slate-700 text-brand-600" />
+                            <span className="text-xs text-slate-400">HCL</span>
+                          </label>
+                        </div>
+                        <div className="flex gap-2 pt-1">
+                          <button onClick={() => setEditingVarId(null)} className="px-3 py-1.5 rounded-lg text-sm font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Cancel</button>
+                          <button onClick={handleSaveVar} disabled={savingVar} className="px-3 py-1.5 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white">
+                            {savingVar ? 'Saving…' : 'Save'}
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <>
+                        <div className="flex items-start justify-between gap-2 mb-1.5">
+                          <span className="text-sm font-mono font-medium text-slate-200 break-all">{v.attributes.key}</span>
+                          <span className={`shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                            v.attributes.category === 'terraform' ? 'bg-purple-900/50 text-purple-300' : 'bg-cyan-900/50 text-cyan-300'
+                          }`}>
+                            {v.attributes.category}
+                          </span>
+                        </div>
+                        <div className="mb-2 text-sm text-slate-400 font-mono break-all">
+                          {v.attributes.sensitive ? '***' : (v.attributes.value || <span className="text-slate-600 italic">empty</span>)}
+                        </div>
+                        {perms['can-update-variable'] && (
+                          <div className="flex gap-2">
+                            <button onClick={() => startEditingVar(v)} className="px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Edit</button>
+                            {/* Native confirm on delete — a destructive tap on a
+                                phone deserves a guard. */}
+                            <button
+                              onClick={() => {
+                                if (window.confirm(`Delete variable "${v.attributes.key}"?`)) handleDeleteVariable(v.id)
+                              }}
+                              className="px-3 py-1.5 rounded-lg text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </li>
+                ))}
+              </ul>
+              </>
             )}
           </div>
         )}

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -15,6 +15,7 @@ import { HealthConditions } from '@/components/health-conditions'
 import { PlanSummaryBadges } from '@/components/plan-summary-badges'
 import { WorkspacePicker } from '@/components/workspace-picker'
 import { SensitiveValueInput } from '@/components/sensitive-value-input'
+import { useIsMobile } from '@/lib/use-media-query'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
@@ -300,6 +301,8 @@ function WorkspaceDetailContent() {
   const [varSensitive, setVarSensitive] = useState(false)
   const [varHcl, setVarHcl] = useState(false)
   const [addingVar, setAddingVar] = useState(false)
+
+  const isMobile = useIsMobile()
 
   // Runs
   const [runs, setRuns] = useState<RunItem[]>([])
@@ -1295,6 +1298,15 @@ function WorkspaceDetailContent() {
   }
 
   async function handleQueuePlan() {
+    // Mobile fat-finger guard — queuing a run is a state change (and on a
+    // non-VCS agent workspace a `plan + apply` run can change infrastructure),
+    // so a stray tap on a phone gets a native confirm. Desktop is unchanged.
+    if (isMobile) {
+      const msg = planOnly
+        ? 'Queue a speculative plan for this workspace?'
+        : 'Queue a plan + apply run? This can change infrastructure.'
+      if (!window.confirm(msg)) return
+    }
     setQueueingPlan(true)
     setError('')
     try {

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -3005,86 +3005,72 @@ function WorkspaceDetailContent() {
                   the link (big touch target); Status stays prominent (never
                   hidden — the primary signal), destroy/plan-only keep their
                   coloured pills, and the rest reflow as label/value rows. */}
-              <ul className="md:hidden space-y-2">
+              <MobileCardList>
                 {sortedRuns.map((run) => {
                   const shortId = run.id.replace(/^run-/, '').split('-').pop()
                   return (
-                    <li key={run.id}>
-                      <Link
-                        href={`/workspaces/${workspaceId}/runs/${run.id}`}
-                        className="block rounded-lg border border-slate-700/50 bg-slate-800/50 p-3 active:bg-slate-700/30"
-                      >
-                        <div className="flex items-center justify-between gap-2 mb-2">
-                          <span className="text-sm font-mono text-brand-400">{shortId}</span>
-                          {run.attributes.actions?.['is-confirmable'] ? (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-900/50 text-amber-300">
-                              needs confirm
+                    <MobileCard
+                      key={run.id}
+                      href={`/workspaces/${workspaceId}/runs/${run.id}`}
+                      title={<span className="text-sm font-mono text-brand-400">{shortId}</span>}
+                      badge={
+                        run.attributes.actions?.['is-confirmable'] ? (
+                          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-900/50 text-amber-300">
+                            needs confirm
+                          </span>
+                        ) : (
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusColor(run.attributes.status)}`}>
+                            {run.attributes.status}
+                          </span>
+                        )
+                      }
+                      fields={[
+                        {
+                          label: 'Type',
+                          value: run.attributes['is-destroy'] ? (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-900/50 text-red-300">
+                              destroy
+                            </span>
+                          ) : run.attributes['plan-only'] ? (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-900/50 text-cyan-300">
+                              plan only
                             </span>
                           ) : (
-                            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusColor(run.attributes.status)}`}>
-                              {run.attributes.status}
-                            </span>
-                          )}
-                        </div>
-                        <dl className="space-y-1 text-xs">
-                          <div className="flex items-baseline justify-between gap-3">
-                            <dt className="text-slate-500">Type</dt>
-                            <dd>
-                              {run.attributes['is-destroy'] ? (
-                                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-900/50 text-red-300">
-                                  destroy
-                                </span>
-                              ) : run.attributes['plan-only'] ? (
-                                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-900/50 text-cyan-300">
-                                  plan only
-                                </span>
-                              ) : (
-                                <span className="text-slate-400">plan + apply</span>
-                              )}
-                            </dd>
-                          </div>
-                          {run.attributes['plan-summary'] && (
-                            <div className="flex items-baseline justify-between gap-3">
-                              <dt className="text-slate-500">Changes</dt>
-                              <dd>
-                                <PlanSummaryBadges summary={run.attributes['plan-summary']} size="sm" />
-                              </dd>
-                            </div>
-                          )}
-                          <div className="flex items-baseline justify-between gap-3">
-                            <dt className="text-slate-500">Source</dt>
-                            <dd className="text-slate-300">
-                              {run.attributes.source === 'module-test' ? (
-                                <span className="text-purple-400">module test</span>
-                              ) : run.attributes.source === 'module-publish' ? (
-                                <span className="text-purple-400">module publish</span>
-                              ) : (
-                                run.attributes.source
-                              )}
-                            </dd>
-                          </div>
-                          {run.attributes['created-by'] && (
-                            <div className="flex items-baseline justify-between gap-3">
-                              <dt className="shrink-0 text-slate-500">Triggered by</dt>
-                              <dd className="min-w-0 break-words text-right text-slate-300">
-                                {run.attributes['created-by']}
-                              </dd>
-                            </div>
-                          )}
-                          {run.attributes['created-at'] && (
-                            <div className="flex items-baseline justify-between gap-3">
-                              <dt className="text-slate-500">Created</dt>
-                              <dd className="text-right text-slate-400">
-                                {new Date(run.attributes['created-at']).toLocaleString()}
-                              </dd>
-                            </div>
-                          )}
-                        </dl>
-                      </Link>
-                    </li>
+                            <span className="text-slate-400">plan + apply</span>
+                          ),
+                        },
+                        ...(run.attributes['plan-summary']
+                          ? [{
+                              label: 'Changes',
+                              value: <PlanSummaryBadges summary={run.attributes['plan-summary']} size="sm" />,
+                            }]
+                          : []),
+                        {
+                          label: 'Source',
+                          value:
+                            run.attributes.source === 'module-test' ? (
+                              <span className="text-purple-400">module test</span>
+                            ) : run.attributes.source === 'module-publish' ? (
+                              <span className="text-purple-400">module publish</span>
+                            ) : (
+                              run.attributes.source
+                            ),
+                        },
+                        ...(run.attributes['created-by']
+                          ? [{ label: 'Triggered by', value: run.attributes['created-by'] }]
+                          : []),
+                        ...(run.attributes['created-at']
+                          ? [{
+                              label: 'Created',
+                              value: new Date(run.attributes['created-at']).toLocaleString(),
+                              valueClassName: 'text-slate-400',
+                            }]
+                          : []),
+                      ]}
+                    />
                   )
                 })}
-              </ul>
+              </MobileCardList>
               </>
             )}
           </div>

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -3793,10 +3793,14 @@ function WorkspaceDetailContent() {
                 {runTasks.map((rt) => {
                   const a = rt.attributes
                   return (
-                    <div key={rt.id} className="bg-slate-800/50 rounded-lg border border-slate-700/50 px-4 py-3 flex items-center gap-3">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="text-sm font-medium text-slate-200 truncate">{a.name}</span>
+                    <div key={rt.id} className="bg-slate-800/50 rounded-lg border border-slate-700/50 px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center">
+                      <div className="min-w-0 sm:flex-1">
+                        {/* Below sm the name takes its own line (w-full) so the
+                            badges wrap beneath it instead of squeezing it to an
+                            ellipsis; sm+ they share one line and the name
+                            truncates as before. */}
+                        <div className="flex flex-wrap items-center gap-2 mb-1">
+                          <span className="w-full sm:w-auto text-sm font-medium text-slate-200 break-words sm:truncate">{a.name}</span>
                           <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${stageBadge(a.stage)}`}>
                             {a.stage.replace('_', ' ')}
                           </span>
@@ -3809,20 +3813,37 @@ function WorkspaceDetailContent() {
                             {a.enabled ? 'Enabled' : 'Disabled'}
                           </span>
                         </div>
-                        <div className="text-xs text-slate-500 truncate">{a.url}</div>
+                        <div className="text-xs text-slate-500 break-all sm:truncate">{a.url}</div>
                       </div>
                       {perms['can-update'] && (
-                        <div className="flex items-center gap-1.5 shrink-0">
-                          <button onClick={() => handleToggleRunTask(rt)} className="text-xs text-brand-400 hover:text-brand-300 px-1">
+                        // Tap-friendly buttons below sm (px-3 py-1.5 pill); sm+
+                        // revert to the compact inline text links (desktop
+                        // unchanged).
+                        <div className="flex items-center gap-2 sm:gap-1.5 sm:shrink-0">
+                          <button onClick={() => handleToggleRunTask(rt)} className="text-xs text-brand-400 hover:text-brand-300 rounded-lg bg-slate-700 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0">
                             {a.enabled ? 'Disable' : 'Enable'}
                           </button>
                           {deleteRtId === rt.id ? (
                             <>
-                              <button onClick={() => setDeleteRtId(null)} className="text-xs text-slate-400 hover:text-slate-200 px-1">Cancel</button>
-                              <button onClick={() => handleDeleteRunTask(rt.id)} className="text-xs text-red-400 hover:text-red-300 px-1">Confirm</button>
+                              <button onClick={() => setDeleteRtId(null)} className="text-xs text-slate-400 hover:text-slate-200 rounded-lg bg-slate-700 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0">Cancel</button>
+                              <button onClick={() => handleDeleteRunTask(rt.id)} className="text-xs text-red-400 hover:text-red-300 rounded-lg bg-red-900/40 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0">Confirm</button>
                             </>
                           ) : (
-                            <button onClick={() => setDeleteRtId(rt.id)} className="text-xs text-red-400 hover:text-red-300 px-1">Delete</button>
+                            // Touch: a native confirm() (the inline two-step
+                            // swap is fiddly on a phone); desktop keeps the
+                            // inline Cancel/Confirm.
+                            <button
+                              onClick={() => {
+                                if (isTouch) {
+                                  if (window.confirm(`Delete run task "${a.name}"?`)) handleDeleteRunTask(rt.id)
+                                } else {
+                                  setDeleteRtId(rt.id)
+                                }
+                              }}
+                              className="text-xs text-red-400 hover:text-red-300 rounded-lg bg-red-900/40 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0"
+                            >
+                              Delete
+                            </button>
                           )}
                         </div>
                       )}

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback, Suspense } from 'react'
+import Link from 'next/link'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
@@ -2779,7 +2780,11 @@ function WorkspaceDetailContent() {
             ) : runs.length === 0 ? (
               <EmptyState message="No runs yet for this workspace." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <>
+              {/* Desktop (md+): the sortable table, unchanged. Below md it is
+                  hidden in favour of the stacked cards (#719 Stage 2) — a phone
+                  can't show a 7-column table legibly. */}
+              <div className="hidden md:block bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -2849,6 +2854,92 @@ function WorkspaceDetailContent() {
                   </tbody>
                 </table>
               </div>
+
+              {/* Mobile (< md): each run is a tappable card. The whole card is
+                  the link (big touch target); Status stays prominent (never
+                  hidden — the primary signal), destroy/plan-only keep their
+                  coloured pills, and the rest reflow as label/value rows. */}
+              <ul className="md:hidden space-y-2">
+                {sortedRuns.map((run) => {
+                  const shortId = run.id.replace(/^run-/, '').split('-').pop()
+                  return (
+                    <li key={run.id}>
+                      <Link
+                        href={`/workspaces/${workspaceId}/runs/${run.id}`}
+                        className="block rounded-lg border border-slate-700/50 bg-slate-800/50 p-3 active:bg-slate-700/30"
+                      >
+                        <div className="flex items-center justify-between gap-2 mb-2">
+                          <span className="text-sm font-mono text-brand-400">{shortId}</span>
+                          {run.attributes.actions?.['is-confirmable'] ? (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-900/50 text-amber-300">
+                              needs confirm
+                            </span>
+                          ) : (
+                            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusColor(run.attributes.status)}`}>
+                              {run.attributes.status}
+                            </span>
+                          )}
+                        </div>
+                        <dl className="space-y-1 text-xs">
+                          <div className="flex items-baseline justify-between gap-3">
+                            <dt className="text-slate-500">Type</dt>
+                            <dd>
+                              {run.attributes['is-destroy'] ? (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-900/50 text-red-300">
+                                  destroy
+                                </span>
+                              ) : run.attributes['plan-only'] ? (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-900/50 text-cyan-300">
+                                  plan only
+                                </span>
+                              ) : (
+                                <span className="text-slate-400">plan + apply</span>
+                              )}
+                            </dd>
+                          </div>
+                          {run.attributes['plan-summary'] && (
+                            <div className="flex items-baseline justify-between gap-3">
+                              <dt className="text-slate-500">Changes</dt>
+                              <dd>
+                                <PlanSummaryBadges summary={run.attributes['plan-summary']} size="sm" />
+                              </dd>
+                            </div>
+                          )}
+                          <div className="flex items-baseline justify-between gap-3">
+                            <dt className="text-slate-500">Source</dt>
+                            <dd className="text-slate-300">
+                              {run.attributes.source === 'module-test' ? (
+                                <span className="text-purple-400">module test</span>
+                              ) : run.attributes.source === 'module-publish' ? (
+                                <span className="text-purple-400">module publish</span>
+                              ) : (
+                                run.attributes.source
+                              )}
+                            </dd>
+                          </div>
+                          {run.attributes['created-by'] && (
+                            <div className="flex items-baseline justify-between gap-3">
+                              <dt className="shrink-0 text-slate-500">Triggered by</dt>
+                              <dd className="min-w-0 break-words text-right text-slate-300">
+                                {run.attributes['created-by']}
+                              </dd>
+                            </div>
+                          )}
+                          {run.attributes['created-at'] && (
+                            <div className="flex items-baseline justify-between gap-3">
+                              <dt className="text-slate-500">Created</dt>
+                              <dd className="text-right text-slate-400">
+                                {new Date(run.attributes['created-at']).toLocaleString()}
+                              </dd>
+                            </div>
+                          )}
+                        </dl>
+                      </Link>
+                    </li>
+                  )
+                })}
+              </ul>
+              </>
             )}
           </div>
         )}

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState, useCallback, Suspense } from 'react'
-import Link from 'next/link'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import NavBar from '@/components/nav-bar'
 import { PageHeader } from '@/components/page-header'
@@ -305,6 +304,12 @@ function WorkspaceDetailContent() {
 
   const isTouch = useIsTouch()
 
+  // #719 two-tier confirm policy (see AGENTS.md → Responsive → Touch model):
+  // an irreversible delete/remove prompts in BOTH modes; any other single-tap
+  // mutation prompts on touch only (a mis-tap is easy on a phone).
+  const confirmDelete = (msg: string) => window.confirm(msg)
+  const confirmTouchMutation = (msg: string) => !isTouch || window.confirm(msg)
+
   // Runs
   const [runs, setRuns] = useState<RunItem[]>([])
   const [runsLoading, setRunsLoading] = useState(false)
@@ -418,7 +423,6 @@ function WorkspaceDetailContent() {
   const [notifEmails, setNotifEmails] = useState('')
   const [notifTriggers, setNotifTriggers] = useState<Set<string>>(new Set())
   const [addingNotif, setAddingNotif] = useState(false)
-  const [deleteNotifId, setDeleteNotifId] = useState<string | null>(null)
   const [verifyingId, setVerifyingId] = useState<string | null>(null)
   const [expandedNotifId, setExpandedNotifId] = useState<string | null>(null)
 
@@ -432,8 +436,6 @@ function WorkspaceDetailContent() {
   const [rtEnforcement, setRtEnforcement] = useState<string>('mandatory')
   const [rtHmacKey, setRtHmacKey] = useState('')
   const [addingRunTask, setAddingRunTask] = useState(false)
-  const [deleteRtId, setDeleteRtId] = useState<string | null>(null)
-  const [deleteVarId, setDeleteVarId] = useState<string | null>(null)
 
   // Sorting for runs tab
   type RunSortKey = 'id' | 'status' | 'type' | 'source' | 'created-by' | 'created-at'
@@ -785,6 +787,8 @@ function WorkspaceDetailContent() {
   }
 
   async function revokeRemoteStateConsumer(edgeId: string) {
+    // Irreversible: the consumer loses access to this workspace's state.
+    if (!confirmDelete('Remove this remote state sharing? The consumer will lose access to this state.')) return
     try {
       const res = await apiFetch(`/api/terrapod/v1/remote-state-consumers/${edgeId}`, { method: 'DELETE' })
       if (!res.ok) {
@@ -858,6 +862,8 @@ function WorkspaceDetailContent() {
   }
 
   async function removeRunTrigger(triggerId: string) {
+    // Irreversible: removes the cross-workspace trigger edge.
+    if (!confirmDelete('Remove this run trigger?')) return
     try {
       const res = await apiFetch(`/api/terrapod/v1/run-triggers/${triggerId}`, { method: 'DELETE' })
       if (!res.ok) {
@@ -922,6 +928,7 @@ function WorkspaceDetailContent() {
   }
 
   async function handleToggleRunTask(rt: RunTaskItem) {
+    if (!confirmTouchMutation(rt.attributes.enabled ? 'Disable this run task?' : 'Enable this run task?')) return
     try {
       const res = await apiFetch(`/api/terrapod/v1/run-tasks/${rt.id}`, {
         method: 'PATCH',
@@ -936,10 +943,11 @@ function WorkspaceDetailContent() {
   }
 
   async function handleDeleteRunTask(rtId: string) {
+    // Irreversible delete → confirm in both modes.
+    if (!confirmDelete(`Delete run task "${runTasks.find(r => r.id === rtId)?.attributes.name ?? ''}"?`)) return
     try {
       const res = await apiFetch(`/api/terrapod/v1/run-tasks/${rtId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete')
-      setDeleteRtId(null)
       await loadRunTasks()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete run task')
@@ -1065,6 +1073,7 @@ function WorkspaceDetailContent() {
   async function handleLockToggle() {
     if (!workspace) return
     const action = workspace.attributes.locked ? 'unlock' : 'lock'
+    if (!confirmTouchMutation(action === 'unlock' ? 'Unlock this workspace?' : 'Lock this workspace?')) return
     try {
       // lock/unlock are TFE V2 CLI-contract endpoints — only at /api/v2/.
       const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/actions/${action}`, {
@@ -1303,10 +1312,11 @@ function WorkspaceDetailContent() {
   }
 
   async function handleDeleteVariable(varId: string) {
+    // Irreversible delete → confirm in both modes.
+    if (!confirmDelete(`Delete variable "${variables.find(v => v.id === varId)?.attributes.key ?? ''}"?`)) return
     try {
       const res = await apiFetch(`/api/v2/workspaces/${workspaceId}/vars/${varId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete variable')
-      setDeleteVarId(null)
       await loadVariables()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete variable')
@@ -1499,6 +1509,7 @@ function WorkspaceDetailContent() {
   }
 
   async function handleToggleNotif(nc: NotificationConfig) {
+    if (!confirmTouchMutation(nc.attributes.enabled ? 'Disable this notification?' : 'Enable this notification?')) return
     try {
       const res = await apiFetch(`/api/terrapod/v1/notification-configurations/${nc.id}`, {
         method: 'PATCH',
@@ -1513,10 +1524,11 @@ function WorkspaceDetailContent() {
   }
 
   async function handleDeleteNotif(ncId: string) {
+    // Irreversible delete → confirm in both modes.
+    if (!confirmDelete(`Delete notification "${notifications.find(n => n.id === ncId)?.attributes.name ?? ''}"?`)) return
     try {
       const res = await apiFetch(`/api/terrapod/v1/notification-configurations/${ncId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete')
-      setDeleteNotifId(null)
       await loadNotifications()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete notification')
@@ -2652,14 +2664,7 @@ function WorkspaceDetailContent() {
                             <td className="px-4 py-3 text-right">
                               <div className="flex justify-end gap-2">
                                 <button onClick={() => startEditingVar(v)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
-                                {deleteVarId === v.id ? (
-                                  <>
-                                    <button onClick={() => setDeleteVarId(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                                    <button onClick={() => handleDeleteVariable(v.id)} className="text-xs text-red-400 hover:text-red-300">Confirm</button>
-                                  </>
-                                ) : (
-                                  <button onClick={() => setDeleteVarId(v.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
-                                )}
+                                <button onClick={() => handleDeleteVariable(v.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
                               </div>
                             </td>
                           )}
@@ -2735,12 +2740,8 @@ function WorkspaceDetailContent() {
                         {perms['can-update-variable'] && (
                           <div className="flex gap-2">
                             <button onClick={() => startEditingVar(v)} className="px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Edit</button>
-                            {/* Native confirm on delete — a destructive tap on a
-                                phone deserves a guard. */}
                             <button
-                              onClick={() => {
-                                if (window.confirm(`Delete variable "${v.attributes.key}"?`)) handleDeleteVariable(v.id)
-                              }}
+                              onClick={() => handleDeleteVariable(v.id)}
                               className="px-3 py-1.5 rounded-lg text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300"
                             >
                               Delete
@@ -3690,14 +3691,7 @@ function WorkspaceDetailContent() {
                             </button>
                           )}
                           {perms['can-update'] && (
-                            deleteNotifId === nc.id ? (
-                              <>
-                                <button onClick={() => setDeleteNotifId(null)} className="text-xs text-slate-400 hover:text-slate-200 px-1">Cancel</button>
-                                <button onClick={() => handleDeleteNotif(nc.id)} className="text-xs text-red-400 hover:text-red-300 px-1">Confirm</button>
-                              </>
-                            ) : (
-                              <button onClick={() => setDeleteNotifId(nc.id)} className="text-xs text-red-400 hover:text-red-300 px-1">Delete</button>
-                            )
+                            <button onClick={() => handleDeleteNotif(nc.id)} className="text-xs text-red-400 hover:text-red-300 px-1">Delete</button>
                           )}
                         </div>
                       </div>
@@ -3823,28 +3817,12 @@ function WorkspaceDetailContent() {
                           <button onClick={() => handleToggleRunTask(rt)} className="text-xs text-brand-400 hover:text-brand-300 rounded-lg bg-slate-700 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0">
                             {a.enabled ? 'Disable' : 'Enable'}
                           </button>
-                          {deleteRtId === rt.id ? (
-                            <>
-                              <button onClick={() => setDeleteRtId(null)} className="text-xs text-slate-400 hover:text-slate-200 rounded-lg bg-slate-700 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0">Cancel</button>
-                              <button onClick={() => handleDeleteRunTask(rt.id)} className="text-xs text-red-400 hover:text-red-300 rounded-lg bg-red-900/40 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0">Confirm</button>
-                            </>
-                          ) : (
-                            // Touch: a native confirm() (the inline two-step
-                            // swap is fiddly on a phone); desktop keeps the
-                            // inline Cancel/Confirm.
-                            <button
-                              onClick={() => {
-                                if (isTouch) {
-                                  if (window.confirm(`Delete run task "${a.name}"?`)) handleDeleteRunTask(rt.id)
-                                } else {
-                                  setDeleteRtId(rt.id)
-                                }
-                              }}
-                              className="text-xs text-red-400 hover:text-red-300 rounded-lg bg-red-900/40 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0"
-                            >
-                              Delete
-                            </button>
-                          )}
+                          <button
+                            onClick={() => handleDeleteRunTask(rt.id)}
+                            className="text-xs text-red-400 hover:text-red-300 rounded-lg bg-red-900/40 px-3 py-1.5 sm:rounded-none sm:bg-transparent sm:px-1 sm:py-0"
+                          >
+                            Delete
+                          </button>
                         </div>
                       )}
                     </div>

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -15,7 +15,7 @@ import { HealthConditions } from '@/components/health-conditions'
 import { PlanSummaryBadges } from '@/components/plan-summary-badges'
 import { WorkspacePicker } from '@/components/workspace-picker'
 import { SensitiveValueInput } from '@/components/sensitive-value-input'
-import { useIsMobile } from '@/lib/use-media-query'
+import { useIsTouch } from '@/lib/use-media-query'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
@@ -302,7 +302,7 @@ function WorkspaceDetailContent() {
   const [varHcl, setVarHcl] = useState(false)
   const [addingVar, setAddingVar] = useState(false)
 
-  const isMobile = useIsMobile()
+  const isTouch = useIsTouch()
 
   // Runs
   const [runs, setRuns] = useState<RunItem[]>([])
@@ -1298,10 +1298,11 @@ function WorkspaceDetailContent() {
   }
 
   async function handleQueuePlan() {
-    // Mobile fat-finger guard — queuing a run is a state change (and on a
+    // Touch fat-finger guard — queuing a run is a state change (and on a
     // non-VCS agent workspace a `plan + apply` run can change infrastructure),
-    // so a stray tap on a phone gets a native confirm. Desktop is unchanged.
-    if (isMobile) {
+    // so a stray tap on a touch device (any width) gets a native confirm; a
+    // precise pointer runs immediately.
+    if (isTouch) {
       const msg = planOnly
         ? 'Queue a speculative plan for this workspace?'
         : 'Queue a plan + apply run? This can change infrastructure.'

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1664,8 +1664,28 @@ function WorkspaceDetailContent() {
           </div>
         )}
 
-        {/* Tabs */}
-        <div className="border-b border-slate-700/50 mb-6">
+        {/* Tabs. Nine sections overflow a phone-width strip, so below md they
+            collapse to a native <select> picker (same pattern as the run page);
+            the tab bar returns at md+. One source (`tabs`), two viewport-driven
+            presentations; the URL (?tab=) stays the source of truth either way. */}
+        <div className="mb-6 md:hidden">
+          <label htmlFor="ws-tab-select" className="sr-only">
+            Workspace section
+          </label>
+          <select
+            id="ws-tab-select"
+            value={activeTab}
+            onChange={(e) => setActiveTab(e.target.value as Tab)}
+            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2.5 text-sm font-medium text-slate-100 focus:border-brand-500 focus:outline-none"
+          >
+            {tabs.map((tab) => (
+              <option key={tab.key} value={tab.key}>
+                {tab.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="hidden border-b border-slate-700/50 mb-6 md:block">
           <div className="flex gap-1 -mb-px">
             {tabs.map((tab) => (
               <button

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1716,9 +1716,18 @@ function WorkspaceDetailContent() {
                   </button>
                 ) : (
                   <div className="flex gap-2">
-                    <button onClick={() => setEditing(false)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                    <button onClick={() => handleSave()} disabled={saving} className="text-xs text-brand-400 hover:text-brand-300">
-                      {saving ? 'Saving...' : 'Save'}
+                    <button
+                      onClick={() => setEditing(false)}
+                      className="px-4 py-2 rounded-lg text-sm font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => handleSave()}
+                      disabled={saving}
+                      className="px-4 py-2 rounded-lg text-sm font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white transition-colors"
+                    >
+                      {saving ? 'Saving…' : 'Save changes'}
                     </button>
                   </div>
                 )}

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -15,6 +15,7 @@ import { HealthConditions } from '@/components/health-conditions'
 import { PlanSummaryBadges } from '@/components/plan-summary-badges'
 import { WorkspacePicker } from '@/components/workspace-picker'
 import { SensitiveValueInput } from '@/components/sensitive-value-input'
+import { MobileCardList, MobileCard } from '@/components/mobile-card-list'
 import { useIsTouch } from '@/lib/use-media-query'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
@@ -591,6 +592,21 @@ function WorkspaceDetailContent() {
       setError(err instanceof Error ? err.message : 'Failed to load state versions')
     } finally {
       setStateLoading(false)
+    }
+  }
+
+  async function downloadStateVersion(sv: StateVersionItem) {
+    try {
+      const resp = await apiFetch(`/api/v2/state-versions/${sv.id}/download`)
+      const blob = await resp.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `state-${sv.attributes.serial}.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      alert('Failed to download state file')
     }
   }
 
@@ -3174,68 +3190,139 @@ function WorkspaceDetailContent() {
             ) : stateVersions.length === 0 ? (
               <EmptyState message="No state versions yet for this workspace." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
-                <table className="w-full">
-                  <thead>
-                    <tr className="border-b border-slate-700/50">
-                      <SortableHeader label="Serial" sortKey="serial" sortState={stateSortState} onSort={toggleStateSort} />
-                      <SortableHeader label="Created By" sortKey="created-by" sortState={stateSortState} onSort={toggleStateSort} className="hidden sm:table-cell" />
-                      <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider hidden sm:table-cell">Run</th>
-                      <SortableHeader label="Size" sortKey="size" sortState={stateSortState} onSort={toggleStateSort} className="hidden md:table-cell" />
-                      <SortableHeader label="Created" sortKey="created-at" sortState={stateSortState} onSort={toggleStateSort} className="hidden lg:table-cell" />
-                      <th className="px-4 py-3 text-right text-xs font-medium text-slate-400 uppercase tracking-wider">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-slate-700/30">
-                    {sortedState.map((sv) => {
-                      const maxSerial = Math.max(...stateVersions.map(s => s.attributes.serial))
-                      const isLatest = sv.attributes.serial === maxSerial
-                      const runData = sv.relationships?.run?.data
-                      return (
-                        <tr key={sv.id} className="hover:bg-slate-700/20 transition-colors">
-                          <td className="px-4 py-3 text-sm text-slate-200 font-mono">#{sv.attributes.serial}</td>
-                          <td className="px-4 py-3 text-xs text-slate-400 hidden sm:table-cell">
-                            {sv.attributes['created-by'] || <span className="text-slate-500">runner</span>}
-                          </td>
-                          <td className="px-4 py-3 text-xs hidden sm:table-cell">
-                            {runData ? (
+              <>
+                {/* Desktop (md+): the sortable table, unchanged columns. Actions
+                    are proper buttons (Download/Rollback/Delete), not tiny text. */}
+                <div className="hidden md:block bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-slate-700/50">
+                        <SortableHeader label="Serial" sortKey="serial" sortState={stateSortState} onSort={toggleStateSort} />
+                        <SortableHeader label="Created By" sortKey="created-by" sortState={stateSortState} onSort={toggleStateSort} />
+                        <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">Run</th>
+                        <SortableHeader label="Size" sortKey="size" sortState={stateSortState} onSort={toggleStateSort} />
+                        <SortableHeader label="Created" sortKey="created-at" sortState={stateSortState} onSort={toggleStateSort} className="hidden lg:table-cell" />
+                        <th className="px-4 py-3 text-right text-xs font-medium text-slate-400 uppercase tracking-wider">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-700/30">
+                      {sortedState.map((sv) => {
+                        const maxSerial = Math.max(...stateVersions.map(s => s.attributes.serial))
+                        const isLatest = sv.attributes.serial === maxSerial
+                        const runData = sv.relationships?.run?.data
+                        return (
+                          <tr key={sv.id} className="hover:bg-slate-700/20 transition-colors">
+                            <td className="px-4 py-3 text-sm text-slate-200 font-mono">#{sv.attributes.serial}</td>
+                            <td className="px-4 py-3 text-xs text-slate-400">
+                              {sv.attributes['created-by'] || <span className="text-slate-500">runner</span>}
+                            </td>
+                            <td className="px-4 py-3 text-xs">
+                              {runData ? (
+                                <a href={`/workspaces/${workspaceId}/runs/${runData.id}`} className="text-brand-400 hover:text-brand-300">
+                                  {runData.id.replace('run-', '').slice(0, 8)}
+                                </a>
+                              ) : (
+                                <span className="text-slate-500">-</span>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 text-xs text-slate-400">
+                              {sv.attributes.size > 0 ? `${(sv.attributes.size / 1024).toFixed(1)} KB` : '-'}
+                            </td>
+                            <td className="px-4 py-3 text-xs text-slate-500 hidden lg:table-cell">
+                              {sv.attributes['created-at'] ? new Date(sv.attributes['created-at']).toLocaleString() : ''}
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              <div className="flex items-center justify-end gap-2">
+                                <button
+                                  onClick={() => downloadStateVersion(sv)}
+                                  className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200"
+                                >
+                                  Download
+                                </button>
+                                {!isLatest && perms['can-create-state-versions'] && (
+                                  <button
+                                    onClick={() => setConfirmStateAction({ action: 'rollback', sv })}
+                                    className="px-2.5 py-1 rounded-md text-xs font-medium bg-amber-900/40 hover:bg-amber-900/60 text-amber-300"
+                                  >
+                                    Rollback
+                                  </button>
+                                )}
+                                {!isLatest && perms['can-update'] && (
+                                  <button
+                                    onClick={() => setConfirmStateAction({ action: 'delete', sv })}
+                                    className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300"
+                                  >
+                                    Delete
+                                  </button>
+                                )}
+                              </div>
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Mobile (< md): state versions as cards so nothing is dropped —
+                    the table hid Created-by / Run / Size / Created behind
+                    sm/md/lg breakpoints, leaving phones with only the serial. */}
+                <MobileCardList>
+                  {sortedState.map((sv) => {
+                    const maxSerial = Math.max(...stateVersions.map(s => s.attributes.serial))
+                    const isLatest = sv.attributes.serial === maxSerial
+                    const runData = sv.relationships?.run?.data
+                    return (
+                      <MobileCard
+                        key={sv.id}
+                        title={<span className="text-sm font-mono text-slate-200">#{sv.attributes.serial}</span>}
+                        badge={
+                          isLatest && (
+                            <span className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-900/40 text-green-300">
+                              latest
+                            </span>
+                          )
+                        }
+                        fields={[
+                          {
+                            label: 'Created by',
+                            value: sv.attributes['created-by'] || 'runner',
+                            valueClassName: sv.attributes['created-by'] ? 'text-slate-300' : 'text-slate-500',
+                          },
+                          {
+                            label: 'Run',
+                            value: runData ? (
                               <a href={`/workspaces/${workspaceId}/runs/${runData.id}`} className="text-brand-400 hover:text-brand-300">
                                 {runData.id.replace('run-', '').slice(0, 8)}
                               </a>
                             ) : (
-                              <span className="text-slate-500">-</span>
-                            )}
-                          </td>
-                          <td className="px-4 py-3 text-xs text-slate-400 hidden md:table-cell">
-                            {sv.attributes.size > 0 ? `${(sv.attributes.size / 1024).toFixed(1)} KB` : '-'}
-                          </td>
-                          <td className="px-4 py-3 text-xs text-slate-500 hidden lg:table-cell">
-                            {sv.attributes['created-at'] ? new Date(sv.attributes['created-at']).toLocaleString() : ''}
-                          </td>
-                          <td className="px-4 py-3 text-right space-x-2">
+                              '—'
+                            ),
+                            valueClassName: 'text-slate-400',
+                          },
+                          {
+                            label: 'Size',
+                            value: sv.attributes.size > 0 ? `${(sv.attributes.size / 1024).toFixed(1)} KB` : '—',
+                            valueClassName: 'text-slate-400',
+                          },
+                          {
+                            label: 'Created',
+                            value: sv.attributes['created-at'] ? new Date(sv.attributes['created-at']).toLocaleString() : '—',
+                            valueClassName: 'text-slate-500',
+                          },
+                        ]}
+                        actions={
+                          <>
                             <button
-                              onClick={async () => {
-                                try {
-                                  const resp = await apiFetch(`/api/v2/state-versions/${sv.id}/download`)
-                                  const blob = await resp.blob()
-                                  const url = URL.createObjectURL(blob)
-                                  const a = document.createElement('a')
-                                  a.href = url
-                                  a.download = `state-${sv.attributes.serial}.json`
-                                  a.click()
-                                  URL.revokeObjectURL(url)
-                                } catch {
-                                  alert('Failed to download state file')
-                                }
-                              }}
-                              className="text-xs text-brand-400 hover:text-brand-300"
+                              onClick={() => downloadStateVersion(sv)}
+                              className="px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200"
                             >
                               Download
                             </button>
                             {!isLatest && perms['can-create-state-versions'] && (
                               <button
                                 onClick={() => setConfirmStateAction({ action: 'rollback', sv })}
-                                className="text-xs text-amber-400 hover:text-amber-300"
+                                className="px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-900/40 hover:bg-amber-900/60 text-amber-300"
                               >
                                 Rollback
                               </button>
@@ -3243,18 +3330,18 @@ function WorkspaceDetailContent() {
                             {!isLatest && perms['can-update'] && (
                               <button
                                 onClick={() => setConfirmStateAction({ action: 'delete', sv })}
-                                className="text-xs text-red-400 hover:text-red-300"
+                                className="px-3 py-1.5 rounded-lg text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300"
                               >
                                 Delete
                               </button>
                             )}
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
+                          </>
+                        }
+                      />
+                    )
+                  })}
+                </MobileCardList>
+              </>
             )}
           </div>
         )}

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -14,7 +14,7 @@ import { ResourceUsage, parseMemoryToBytes, humanBytes } from '@/components/reso
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { useRunEvents } from '@/lib/use-run-events'
-import { useIsMobile } from '@/lib/use-media-query'
+import { useIsTouch } from '@/lib/use-media-query'
 import { ArrowDownToLine, RefreshCw, Download, Copy, Check, Palette } from 'lucide-react'
 
 interface RunActions {
@@ -296,8 +296,11 @@ function LogPanel({
   // normal inner-scroll pane (the familiar CI-log behaviour — it scrolls
   // independently of the page); on a phone a nested scroll region is a touch
   // trap, so the pane just expands and the *page* is the scroll container.
-  // Same component, the scroll target branches on width.
-  const isMobile = useIsMobile()
+  // Same component; the scroll target branches on POINTER, not width — a nested
+  // scroll region is a touch trap regardless of how wide the screen is, so a
+  // touch tablet/foldable page-scrolls too, while a mouse (any width) keeps the
+  // inner pane. Mirrors the CSS `fine:` overflow on the <pre> below.
+  const isTouch = useIsTouch()
   const [colorMode, setColorMode] = useState(true)
   // Follow the tail by default while streaming; a static (finished) log opens
   // at the top so the operator reads from the start.
@@ -320,22 +323,22 @@ function LogPanel({
   }, [cleanLog])
 
   const isAtBottom = useCallback(() => {
-    if (isMobile) {
+    if (isTouch) {
       const doc = document.documentElement
       return window.innerHeight + window.scrollY >= doc.scrollHeight - 80
     }
     const el = preRef.current
     if (!el) return true
     return el.scrollHeight - el.scrollTop - el.clientHeight < 60
-  }, [isMobile])
+  }, [isTouch])
 
   const scrollToBottom = useCallback(
     (smooth = false) => {
       const opts: ScrollToOptions = { behavior: smooth ? 'smooth' : 'auto' }
-      if (isMobile) window.scrollTo({ top: document.documentElement.scrollHeight, ...opts })
+      if (isTouch) window.scrollTo({ top: document.documentElement.scrollHeight, ...opts })
       else preRef.current?.scrollTo({ top: preRef.current.scrollHeight, ...opts })
     },
-    [isMobile],
+    [isTouch],
   )
 
   // Pin the active scroller to the tail when following and the content changes.
@@ -347,17 +350,17 @@ function LogPanel({
 
   // Track the scroller's position so scrolling up to read disengages follow and
   // scrolling back to the bottom re-engages it. The listener is on the window
-  // (mobile) or the inner pane (desktop).
+  // (touch — the page scrolls) or the inner pane (mouse).
   useEffect(() => {
     const onScroll = () => {
       setFollowing(isAtBottom())
     }
-    const el = isMobile ? window : preRef.current
+    const el = isTouch ? window : preRef.current
     if (!el) return
     el.addEventListener('scroll', onScroll, { passive: true })
     onScroll()
     return () => el.removeEventListener('scroll', onScroll)
-  }, [isMobile, isAtBottom])
+  }, [isTouch, isAtBottom])
 
   if (loading) {
     return (
@@ -487,24 +490,25 @@ function LogPanel({
         </div>
       </div>
 
-      {/* On desktop (`md:`) the pane is a bounded inner-scroll region — it
-          scrolls independently of the page, the familiar CI-log behaviour.
-          Below `md` it has no max-height and no inner overflow, so it expands
-          and the page scrolls (no nested-scroll touch trap). The `md` boundary
-          matches `useIsMobile` (768px), so the CSS scroller and the JS scroll
-          logic agree. */}
+      {/* With a precise pointer (`fine:`) the pane is a bounded inner-scroll
+          region — it scrolls independently of the page, the familiar CI-log
+          behaviour. On a touch device it has no max-height and no inner
+          overflow, so it expands and the *page* scrolls (no nested-scroll touch
+          trap) — regardless of width, so a wide touch tablet is safe too. The
+          `fine:` CSS variant matches `useIsTouch()`, so the CSS scroller and
+          the JS tail-follow logic agree. */}
       {colorMode ? (
         <pre
           ref={preRef}
           data-testid={`log-pre-${phase}`}
-          className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words md:max-h-[70vh] md:overflow-y-auto"
+          className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words fine:max-h-[70vh] fine:overflow-y-auto"
           dangerouslySetInnerHTML={{ __html: htmlContent }}
         />
       ) : (
         <pre
           ref={preRef}
           data-testid={`log-pre-${phase}`}
-          className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words md:max-h-[70vh] md:overflow-y-auto"
+          className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words fine:max-h-[70vh] fine:overflow-y-auto"
         >
           {plainContent}
         </pre>
@@ -531,7 +535,7 @@ function RunDetailPageInner() {
   const workspaceId = params.id as string
   const runId = params.runId as string
 
-  const isMobile = useIsMobile()
+  const isTouch = useIsTouch()
   const [run, setRun] = useState<Run | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -841,13 +845,13 @@ function RunDetailPageInner() {
     }
   }
 
-  // Mobile is a fat-finger danger zone — a stray tap on Apply/Discard/Cancel/
-  // Retry mutates infra or state. On a phone, gate every state-changing action
-  // behind the browser-native confirm() (accessible, familiar, and reusable for
-  // any future mobile action); on desktop (larger targets, precise pointer)
-  // execute immediately, unchanged.
+  // Touch is a fat-finger danger zone — a stray tap on Apply/Discard/Cancel/
+  // Retry mutates infra or state. On a touch device (phone, tablet, foldable —
+  // any width) gate every state-changing action behind the browser-native
+  // confirm(); with a precise pointer (mouse/trackpad) execute immediately.
+  // Keyed on pointer, not width, so a wide touch tablet is still guarded.
   function requestAction(action: 'confirm' | 'discard' | 'cancel' | 'retry') {
-    if (isMobile) {
+    if (isTouch) {
       const prompts: Record<string, string> = {
         confirm: 'Apply this run? This applies the plan and changes infrastructure.',
         discard: 'Discard this plan?',

--- a/web/src/components/mobile-card-list.tsx
+++ b/web/src/components/mobile-card-list.tsx
@@ -1,0 +1,78 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+/**
+ * Mobile-card primitive for the `< md` half of the responsive list pattern
+ * (#719). Desktop keeps its bespoke, sortable `<table>` (gated `hidden
+ * md:block`); this renders the `md:hidden` stacked-card view that every list
+ * tab was hand-rolling identically (runs, variables, state, …).
+ *
+ * Deliberately owns ONLY the mobile half — it never touches the desktop table,
+ * which is what sank the earlier "own both halves" abstraction (each table has
+ * different columns + its own SortableHeaders). A card is: a `title`, an
+ * optional `badge` pill, a set of `{label, value}` `fields` that reflow as
+ * label/value rows, and either an `actions` row (buttons) or an `href` that
+ * makes the whole card tappable (mutually exclusive — you can't nest buttons
+ * inside a Link).
+ *
+ * The row markup mirrors what the tabs already emitted so migrating an existing
+ * hand-rolled card onto it is a visual no-op.
+ */
+export interface MobileCardField {
+  label: string
+  value: ReactNode
+  /** dd colour class; defaults to `text-slate-300`. */
+  valueClassName?: string
+}
+
+export function MobileCardList({ children }: { children: ReactNode }) {
+  return <ul className="md:hidden space-y-2">{children}</ul>
+}
+
+interface MobileCardProps {
+  title: ReactNode
+  /** Optional pill shown top-right (status, "latest", category, …). */
+  badge?: ReactNode
+  fields: MobileCardField[]
+  /** Action buttons row, rendered below the fields. Ignored when `href` is set. */
+  actions?: ReactNode
+  /** When set, the whole card is a `<Link>` (no actions row possible). */
+  href?: string
+}
+
+export function MobileCard({ title, badge, fields, actions, href }: MobileCardProps) {
+  const body = (
+    <>
+      <div className="mb-2 flex items-start justify-between gap-2">
+        {title}
+        {badge}
+      </div>
+      {fields.length > 0 && (
+        <dl className="space-y-1 text-xs">
+          {fields.map((f) => (
+            <div key={f.label} className="flex items-baseline justify-between gap-3">
+              <dt className="shrink-0 text-slate-500">{f.label}</dt>
+              <dd className={`min-w-0 break-words text-right ${f.valueClassName ?? 'text-slate-300'}`}>
+                {f.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {actions && <div className="mt-2 flex flex-wrap gap-2">{actions}</div>}
+    </>
+  )
+
+  const cardClass = 'block rounded-lg border border-slate-700/50 bg-slate-800/50 p-3'
+
+  if (href) {
+    return (
+      <li>
+        <Link href={href} className={`${cardClass} active:bg-slate-700/30`}>
+          {body}
+        </Link>
+      </li>
+    )
+  }
+  return <li className={cardClass}>{body}</li>
+}

--- a/web/src/components/plan-ai-summary.tsx
+++ b/web/src/components/plan-ai-summary.tsx
@@ -21,6 +21,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Sparkles, AlertTriangle, Info, ShieldAlert, ShieldX, RefreshCw } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
+import { useIsTouch } from '@/lib/use-media-query'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { PlanSummaryChat } from '@/components/plan-summary-chat'
 
@@ -73,6 +74,7 @@ export function PlanAiSummary({ runId, refreshKey = 0 }: Props) {
   const [transportError, setTransportError] = useState<string | null>(null)
   const [regenerating, setRegenerating] = useState(false)
   const [regenerateError, setRegenerateError] = useState<string | null>(null)
+  const isTouch = useIsTouch()
 
   const load = useCallback(async () => {
     try {
@@ -102,9 +104,10 @@ export function PlanAiSummary({ runId, refreshKey = 0 }: Props) {
   }, [load, refreshKey])
 
   const regenerate = useCallback(async () => {
-    // Skip confirmation modal: errored/skipped clicks are clearly an
-    // operator asking for a retry; ready→regen is also unambiguous —
-    // they're saying "this one wasn't good enough".
+    // On a precise pointer a regenerate click is unambiguous ("this one wasn't
+    // good enough"); on touch it re-runs the model on a mis-tap, so guard it
+    // (#719 tier-2 mutation → touch-only confirm).
+    if (isTouch && !window.confirm('Regenerate the AI analysis? This runs the model again.')) return
     setRegenerating(true)
     setRegenerateError(null)
     try {
@@ -136,7 +139,7 @@ export function PlanAiSummary({ runId, refreshKey = 0 }: Props) {
     } finally {
       setRegenerating(false)
     }
-  }, [runId])
+  }, [runId, isTouch])
 
   // When the feature is globally disabled (no row will ever appear) we
   // render nothing — operators on a non-AI deployment don't see this

--- a/web/src/lib/use-media-query.ts
+++ b/web/src/lib/use-media-query.ts
@@ -48,7 +48,30 @@ export const BREAKPOINTS = {
  * True when the viewport is narrower than the `md` breakpoint (the phone /
  * small-tablet range). Keyed to the same 768px boundary as Tailwind's `md:`
  * and the nav's mobile switch, so CSS and JS agree.
+ *
+ * Use this for **layout density** decisions only (though CSS `md:` handles
+ * almost all of those). For **touch-friendliness** — destructive-action
+ * confirms, avoiding nested scroll traps — use `useIsTouch()` instead: width
+ * does NOT imply touch (a wide tablet/foldable is touch; a narrow desktop
+ * window is not).
  */
 export function useIsMobile(): boolean {
   return useMediaQuery(`(max-width: ${BREAKPOINTS.md - 0.02}px)`)
+}
+
+/**
+ * True when the **primary pointing device is coarse** — i.e. the person is
+ * most likely interacting by touch (finger / stylus), as opposed to a precise
+ * mouse / trackpad. This is the correct signal for touch-friendliness (guard
+ * destructive taps with `confirm()`, avoid nested scroll traps), independent
+ * of viewport width — so a tablet or unfolded foldable at desktop width still
+ * gets the touch-safe behaviour while keeping the roomy desktop layout.
+ *
+ * Reflects the *primary* pointer (`(pointer: coarse)`), so a laptop with a
+ * trackpad + touchscreen reads as precise and isn't nagged. Mirrors the CSS
+ * `touch:` custom variant in globals.css. (Switch to `(any-pointer: coarse)`
+ * if any touch-capable input should trigger the touch treatment.)
+ */
+export function useIsTouch(): boolean {
+  return useMediaQuery('(pointer: coarse)')
 }


### PR DESCRIPTION
Part of the mobile UX epic #719. A broad mobile pass over the **workspace surface** (detail page + its tabs, plus the shared touch conventions). Every layout change is breakpoint-scoped, so desktop stays intact except where a change is a deliberate improvement (real buttons, confirm guards).

## Card views for tables that broke on a phone
- **Runs**, **State**, **Configurations** → stacked cards below `md` (desktop sortable `<table>` kept, gated `hidden md:block`). State and Configurations were the worst offenders: their tables were clipped by `overflow-hidden`, hiding columns (Created / Download) entirely on a phone. Cards keep every field + proper action buttons.
- **Variables** kept its bespoke card (hero value line) by design.
- Extracted the repeated mobile-card markup into a shared **`MobileCard` / `MobileCardList` primitive** (`components/mobile-card-list.tsx`) — title, badge, `{label,value}` fields, and either an actions row or a whole-card `href`. Runs + State + Configurations use it; the desktop tables stay bespoke and sortable (which is what sank an earlier both-halves abstraction). Runs migrated onto it verified pixel-identical.

## Navigation + layout
- Nine-tab strip → native `<select>` section picker below `md` (driven by the same `?tab=` URL); tab bar returns at `md+`.
- **Run Tasks** row stacks on a phone (name on its own line, badges wrap, full URL, tap-target buttons); one-line at `md+`.
- Full Save/Cancel buttons on workspace-settings edit.

## Two-axis responsive model (documented in AGENTS.md)
Width drives **layout density** (CSS `md:` / `useIsMobile`); pointer drives **touch-friendliness** (`useIsTouch()` + `touch:`/`fine:` CSS variants). So a wide touch tablet is touch-safe *and* gets the roomy desktop layout. Never inferred from the user agent.

## Two-tier confirm() policy (documented in AGENTS.md)
- **Irreversible delete/remove** (variable, notification, run task, run trigger, remote-state consumer) → `confirm()` in **both** modes. Replaces the bespoke inline two-step swaps with a native `confirm()` in each handler.
- **Other single-tap mutation** (enable/disable toggle, lock/unlock, AI regenerate) → `confirm()` on **touch only** (`useIsTouch`).
- Workspace delete / state delete+rollback / queue-destroy already guarded in both modes.

## Actions are real buttons, not clickable text (documented in AGENTS.md)
Converted every bare coloured-text action (run-task Enable/Delete, notification Enable/Verify/History/Delete, settings Edit, variables Edit/Delete/Save/Cancel) to proper buttons (bg + padding + rounded, red variant for destructive).

## Tests
Since touch isn't tested on a real device, the guards are pinned by Playwright:
- New **`confirm-guards`** project (Desktop Chrome / fine pointer): delete prompts a `confirm()`; a reversible toggle does **not**.
- **`responsive`** project (Pixel / coarse pointer): both a toggle and a delete prompt on touch; State + Configurations + Runs render as cards with no horizontal page scroll.
- `seedVariable` / `seedRunTask` / `seedStateVersion` E2E helpers added.
- Live-verified the desktop tier on Tilt (delete confirms, toggle doesn't; buttons render).