### PR TITLE
feat(web): registry mobile pass — real buttons, confirms, mobile-safe tables (#719)

### DIFF
--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { getStoredToken, createWorkspace, seedRun, seedStateVersion, seedRunTask, uniqueName } from '../helpers/api';
+import { getStoredToken, createWorkspace, seedRun, seedStateVersion, seedRunTask, createRegistryModule, uniqueName } from '../helpers/api';
 
 /**
  * Responsive / mobile harness (#719).
@@ -241,5 +241,18 @@ test.describe('Responsive harness (phone viewport)', () => {
     await page.getByRole('button', { name: 'Delete' }).click();
     await expect.poll(() => deleteMsg, { timeout: 5_000 }).toContain('Delete run task');
     await expect(page.getByText(rtName)).toBeVisible();
+  });
+
+  test('registry module list renders as a card grid at phone width', async ({ page }) => {
+    // The registry list pages are responsive card grids (grid-cols-1 at phone),
+    // so a seeded module shows as a full-width card with no horizontal scroll.
+    const token = getStoredToken();
+    const modName = uniqueName('respmod').replace(/[^a-z0-9]/gi, '');
+    await createRegistryModule(token, modName, 'aws');
+
+    await page.goto('/registry/modules');
+    await expect(page.getByText(modName).first()).toBeVisible({ timeout: 15_000 });
+
+    await expectNoHorizontalPageScroll(page);
   });
 });

--- a/web/src/app/registry/modules/[name]/[provider]/page.tsx
+++ b/web/src/app/registry/modules/[name]/[provider]/page.tsx
@@ -11,6 +11,7 @@ import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 import { LabelsEditor } from '@/components/labels-editor'
 import { usePollingInterval } from '@/lib/use-polling-interval'
@@ -143,6 +144,7 @@ async function buildTarGz(files: File[]): Promise<Uint8Array> {
 }
 
 export default function ModuleDetailPage() {
+  const { confirmDelete } = useConfirm()
   const router = useRouter()
   const params = useParams<{ name: string; provider: string }>()
   const { name, provider } = params
@@ -316,6 +318,7 @@ export default function ModuleDetailPage() {
   }
 
   async function handleUnlinkWorkspace(linkId: string) {
+    if (!confirmDelete('Unlink this workspace from the module? Impact analysis will no longer run for it.')) return
     setError('')
     try {
       const res = await apiFetch(
@@ -728,7 +731,7 @@ export default function ModuleDetailPage() {
                   </div>
                   <button
                     onClick={() => setShowLinkPicker(!showLinkPicker)}
-                    className="text-xs text-brand-400 hover:text-brand-300 flex items-center gap-1"
+                    className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 flex items-center gap-1"
                   >
                     <Plus size={12} />
                     Link Workspace
@@ -764,7 +767,7 @@ export default function ModuleDetailPage() {
                         </a>
                         <button
                           onClick={() => handleUnlinkWorkspace(link.id)}
-                          className="text-slate-500 hover:text-red-400 transition-colors"
+                          className="p-1.5 rounded-md text-slate-500 hover:text-red-400 hover:bg-slate-700/50 transition-colors"
                           title="Unlink workspace"
                         >
                           <Trash2 size={14} />
@@ -781,11 +784,11 @@ export default function ModuleDetailPage() {
               <div className="flex items-center justify-between mb-3">
                 <h3 className="text-sm font-medium text-slate-300">Metadata</h3>
                 {!editingMeta ? (
-                  modPerms['can-update'] && <button onClick={startEditingMeta} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
+                  modPerms['can-update'] && <button onClick={startEditingMeta} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Edit</button>
                 ) : (
                   <div className="flex gap-2">
-                    <button onClick={() => { setEditingMeta(false); setLockoutWarning('') }} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                    <button onClick={() => handleSaveMeta()} disabled={savingMeta} className="text-xs text-brand-400 hover:text-brand-300">{savingMeta ? 'Saving...' : 'Save'}</button>
+                    <button onClick={() => { setEditingMeta(false); setLockoutWarning('') }} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Cancel</button>
+                    <button onClick={() => handleSaveMeta()} disabled={savingMeta} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white">{savingMeta ? 'Saving...' : 'Save'}</button>
                   </div>
                 )}
               </div>
@@ -1027,7 +1030,7 @@ export default function ModuleDetailPage() {
                               <td className="px-4 py-3 text-right">
                                 <button
                                   onClick={() => setDeleteTarget(v.version)}
-                                  className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                                  className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors"
                                 >
                                   Delete
                                 </button>

--- a/web/src/app/registry/providers/[name]/page.tsx
+++ b/web/src/app/registry/providers/[name]/page.tsx
@@ -212,11 +212,11 @@ export default function ProviderDetailPage() {
             <div className="flex items-center justify-between mb-3">
               <h3 className="text-sm font-medium text-slate-300">Metadata</h3>
               {!editingMeta ? (
-                provPerms['can-update'] && <button onClick={startEditingMeta} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
+                provPerms['can-update'] && <button onClick={startEditingMeta} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Edit</button>
               ) : (
                 <div className="flex gap-2">
-                  <button onClick={() => { setEditingMeta(false); setLockoutWarning('') }} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                  <button onClick={() => handleSaveMeta()} disabled={savingMeta} className="text-xs text-brand-400 hover:text-brand-300">{savingMeta ? 'Saving...' : 'Save'}</button>
+                  <button onClick={() => { setEditingMeta(false); setLockoutWarning('') }} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Cancel</button>
+                  <button onClick={() => handleSaveMeta()} disabled={savingMeta} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white">{savingMeta ? 'Saving...' : 'Save'}</button>
                 </div>
               )}
             </div>
@@ -293,7 +293,7 @@ export default function ProviderDetailPage() {
                       {provPerms['can-destroy'] && (
                         <button
                           onClick={(e) => { e.stopPropagation(); setDeleteTarget({ type: 'version', version: v.attributes.version }) }}
-                          className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                          className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors"
                         >
                           Delete
                         </button>
@@ -316,12 +316,12 @@ export default function ProviderDetailPage() {
                             <tr key={`${p.os}-${p.arch}`} className="border-t border-slate-700/20">
                               <td className="py-1.5 text-slate-300">{p.os}</td>
                               <td className="py-1.5 text-slate-300">{p.arch}</td>
-                              <td className="py-1.5 text-slate-400 font-mono text-xs">{p.filename}</td>
+                              <td className="py-1.5 text-slate-400 font-mono text-xs break-all">{p.filename}</td>
                               {provPerms['can-destroy'] && (
                                 <td className="py-1.5 text-right">
                                   <button
                                     onClick={() => setDeleteTarget({ type: 'platform', version: v.attributes.version, os: p.os, arch: p.arch })}
-                                    className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                                    className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors"
                                   >
                                     Delete
                                   </button>

--- a/web/src/lib/use-confirm.ts
+++ b/web/src/lib/use-confirm.ts
@@ -1,0 +1,27 @@
+import { useIsTouch } from './use-media-query'
+
+/**
+ * The #719 two-tier confirm() policy as a hook (see AGENTS.md → Responsive →
+ * Touch model). Use across every surface with mutating actions so the two tiers
+ * stay identical everywhere:
+ *
+ *   - `confirmDelete(msg)` — an irreversible delete/remove. Prompts in BOTH
+ *     modes (touch and precise pointer): losing data on a stray click is a
+ *     desktop hazard too.
+ *   - `confirmTouchMutation(msg)` — any other single-tap mutation (toggle,
+ *     lock, enable/disable, …). Prompts on touch ONLY, where a mis-tap is easy;
+ *     a precise pointer proceeds.
+ *
+ * Both return `true` to proceed / `false` to abort, so the caller does
+ * `if (!confirmDelete('Delete X?')) return`.
+ *
+ * Form *submits* after deliberate data entry (create/edit Save) are not
+ * single-tap mutations and don't need a guard.
+ */
+export function useConfirm() {
+  const isTouch = useIsTouch()
+  return {
+    confirmDelete: (message: string) => window.confirm(message),
+    confirmTouchMutation: (message: string) => !isTouch || window.confirm(message),
+  }
+}


### PR DESCRIPTION
Part of the mobile UX epic #719 — the **Registry** surface (top-level nav).

## Findings
- **List pages** (modules, providers) were **already mobile-clean** — responsive `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` card grids. No changes needed.
- **Detail pages** needed the pattern applied.

## Changes
- **Provider detail**: Edit/Cancel/Save + version/platform Delete → real buttons; platforms table filename cell `break-all` so the nested table doesn't overflow a phone. Deletes already go through the Radix confirm modal (both modes).
- **Module detail**: Edit/Cancel/Save + link-workspace + version Delete → real buttons; the unlink icon button gets a padded tap target and its remove routes through `confirmDelete` (both modes). Interface tables already `overflow-x-auto`; version delete already modal-confirmed.
- Adds the shared **`useConfirm`** hook (`confirmDelete` = both modes; `confirmTouchMutation` = touch only) — reused across the remaining sweep.

## Tests
- New `responsive` (Pixel) assertion: a seeded module renders as a card at phone width with no horizontal page scroll.
- Verified locally: `registry` + `responsive` projects (15 tests) pass against the e2e stack — including the existing registry specs, confirming the detail-page button changes don't regress.