### PR TITLE
feat(web): catalog mobile pass — real buttons, native confirm, mobile-safe tables (#719)

### DIFF
--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -242,4 +242,12 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect.poll(() => deleteMsg, { timeout: 5_000 }).toContain('Delete run task');
     await expect(page.getByText(rtName)).toBeVisible();
   });
+
+  test('catalog browse page renders without horizontal scroll at phone width', async ({ page }) => {
+    // The catalog browse page is a responsive card grid (or an empty state);
+    // either way it must not scroll horizontally on a phone.
+    await page.goto('/catalog');
+    await expect(page.getByRole('heading', { name: 'Service Catalog' })).toBeVisible({ timeout: 15_000 });
+    await expectNoHorizontalPageScroll(page);
+  });
 });

--- a/web/src/app/admin/catalog/page.tsx
+++ b/web/src/app/admin/catalog/page.tsx
@@ -10,6 +10,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { LabelsEditor } from '@/components/labels-editor'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 
 interface CatalogItem {
@@ -61,6 +62,7 @@ const EMPTY_FORM = {
 }
 
 export default function AdminCatalogPage() {
+  const { confirmDelete } = useConfirm()
   const router = useRouter()
   const [items, setItems] = useState<CatalogItem[]>([])
   const [modules, setModules] = useState<ModuleOption[]>([])
@@ -79,7 +81,6 @@ export default function AdminCatalogPage() {
   const [saving, setSaving] = useState(false)
 
   // Delete confirmation
-  const [deleteId, setDeleteId] = useState<string | null>(null)
 
   useEffect(() => {
     if (!getAuthState()) { router.push('/login'); return }
@@ -205,6 +206,7 @@ export default function AdminCatalogPage() {
   }
 
   async function handleDelete(id: string) {
+    if (!confirmDelete('Delete this catalog item? Existing provisioned instances are unaffected.')) return
     setError(''); setSuccess('')
     try {
       const res = await apiFetch(`/api/terrapod/v1/catalog-items/${id}`, { method: 'DELETE' })
@@ -213,11 +215,9 @@ export default function AdminCatalogPage() {
         throw new Error(data.detail || 'Cannot delete: this catalog item has provisioned instances.')
       }
       if (!res.ok) throw new Error('Failed to delete catalog item')
-      setDeleteId(null)
       setSuccess('Catalog item deleted')
       await loadAll()
     } catch (err) {
-      setDeleteId(null)
       setError(err instanceof Error ? err.message : 'Failed to delete catalog item')
     }
   }
@@ -403,7 +403,7 @@ export default function AdminCatalogPage() {
             ) : items.length === 0 ? (
               <EmptyState message="No catalog items yet." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -431,17 +431,10 @@ export default function AdminCatalogPage() {
                           </span>
                         </td>
                         <td className="px-4 py-3 text-right">
-                          {deleteId === item.id ? (
-                            <div className="flex justify-end gap-2">
-                              <button onClick={() => setDeleteId(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                              <button onClick={() => handleDelete(item.id)} className="text-xs text-red-400 hover:text-red-300">Confirm</button>
-                            </div>
-                          ) : (
-                            <div className="flex justify-end gap-3">
-                              <button onClick={() => startEdit(item)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
-                              <button onClick={() => setDeleteId(item.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
-                            </div>
-                          )}
+                          <div className="flex justify-end gap-2">
+                            <button onClick={() => startEdit(item)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Edit</button>
+                            <button onClick={() => handleDelete(item.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300">Delete</button>
+                          </div>
                         </td>
                       </tr>
                     ))}

--- a/web/src/app/catalog/[id]/page.tsx
+++ b/web/src/app/catalog/[id]/page.tsx
@@ -603,7 +603,7 @@ export default function CatalogItemPage() {
           {instances.length === 0 ? (
             <EmptyState message="No instances provisioned from this item yet." />
           ) : (
-            <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+            <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-slate-700/50">
@@ -630,11 +630,11 @@ export default function CatalogItemPage() {
                           {poolName || inst.attributes['agent-pool-id'] || '—'}
                         </td>
                         <td className="px-4 py-3 text-right">
-                          <div className="flex justify-end gap-3">
-                            <button onClick={() => startReconfigure(inst)} className="text-xs text-brand-400 hover:text-brand-300">Reconfigure</button>
-                            <button onClick={() => { setDestroyInstance(inst); setDestroyError(''); setDestroyAutoApply(false) }} className="text-xs text-red-400 hover:text-red-300">Destroy</button>
+                          <div className="flex justify-end gap-2">
+                            <button onClick={() => startReconfigure(inst)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Reconfigure</button>
+                            <button onClick={() => { setDestroyInstance(inst); setDestroyError(''); setDestroyAutoApply(false) }} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300">Destroy</button>
                             {canOrphan && (
-                              <button onClick={() => { setOrphanInstance(inst); setOrphanError(''); setOrphanConfirm('') }} className="text-xs text-slate-500 hover:text-slate-300" title="Delete the catalog record without destroying its infrastructure (discouraged)">Orphan…</button>
+                              <button onClick={() => { setOrphanInstance(inst); setOrphanError(''); setOrphanConfirm('') }} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-400" title="Delete the catalog record without destroying its infrastructure (discouraged)">Orphan…</button>
                             )}
                           </div>
                         </td>

--- a/web/src/lib/use-confirm.ts
+++ b/web/src/lib/use-confirm.ts
@@ -1,0 +1,15 @@
+import { useIsTouch } from './use-media-query'
+
+/**
+ * The #719 two-tier confirm() policy as a hook (see AGENTS.md → Responsive →
+ * Touch model). `confirmDelete` prompts in BOTH modes (irreversible deletes);
+ * `confirmTouchMutation` prompts on touch only (other single-tap mutations).
+ * Both return true to proceed / false to abort.
+ */
+export function useConfirm() {
+  const isTouch = useIsTouch()
+  return {
+    confirmDelete: (message: string) => window.confirm(message),
+    confirmTouchMutation: (message: string) => !isTouch || window.confirm(message),
+  }
+}


### PR DESCRIPTION
Part of the mobile UX epic #719 — the **Catalog** surface (top-level nav + admin).

- **Catalog browse** (`/catalog`) was already a clean responsive card grid — no changes.
- **catalog/[id]** instance detail: Reconfigure/Destroy/Orphan → real buttons; the instances table is `overflow-x-auto`. Destroy + Orphan already use type-to-confirm modals (both modes).
- **admin/catalog**: Edit/Delete → real buttons; delete routes through `confirmDelete` (native, both modes) replacing the inline two-step; items table `overflow-x-auto`.
- Uses the shared `useConfirm` hook.

## Tests
New `responsive` assertion (catalog browse renders, no horizontal page scroll). Verified locally: `catalog` + `responsive` projects (13 tests) pass against the e2e stack — including the existing catalog admin/RBAC specs, confirming the button/confirm changes don't regress.