### PR TITLE
feat(ui): mobile-friendly agent pools (buttons, confirms, in-row status)

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -285,6 +285,31 @@ export async function createRegistryModule(
 }
 
 /**
+ * Create an agent pool via the management API. Returns the bare pool UUID.
+ */
+export async function createAgentPool(
+  token: string,
+  name: string,
+): Promise<string> {
+  const res = await fetch(`${API_URL}/api/terrapod/v1/agent-pools`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      data: { type: 'agent-pools', attributes: { name } },
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Create agent pool failed: ${res.status} ${body}`);
+  }
+  const data = await res.json();
+  return data.data.id as string;
+}
+
+/**
  * Seed a run so the run-detail page can be exercised in E2E.
  *
  * The E2E stack has no runner/listener, so a seeded run simply sits in

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { getStoredToken, createWorkspace, seedRun, seedStateVersion, seedRunTask, uniqueName } from '../helpers/api';
+import { getStoredToken, createWorkspace, createAgentPool, seedRun, seedStateVersion, seedRunTask, uniqueName } from '../helpers/api';
 
 /**
  * Responsive / mobile harness (#719).
@@ -208,6 +208,29 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(page.getByText(/^cv-/).filter({ visible: true }).first()).toBeVisible({ timeout: 15_000 });
     await expect(page.getByRole('checkbox', { name: /Select cv-.* for compare/ }).filter({ visible: true }).first()).toBeVisible();
 
+    await expectNoHorizontalPageScroll(page);
+  });
+
+  test('agent pools list + detail fit a phone viewport', async ({ page }) => {
+    // Agent Pools is a top-level admin surface (#719). The list hides the
+    // STATUS column below md, so the pool's health dot must reflow inline into
+    // the row; the detail page (settings + tokens + listeners tables) must not
+    // introduce horizontal page scroll.
+    const token = getStoredToken();
+    const poolName = uniqueName('resp-pool');
+    const poolId = await createAgentPool(token, poolName);
+
+    await page.goto('/admin/agent-pools');
+    const row = page.getByRole('row').filter({ hasText: poolName });
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    // The dedicated desktop STATUS column header stays hidden at phone width.
+    await expect(page.getByRole('columnheader', { name: 'Status' })).toBeHidden();
+    await expectNoHorizontalPageScroll(page);
+
+    await page.goto(`/admin/agent-pools/${poolId}`);
+    await expect(
+      page.getByRole('heading', { name: new RegExp(poolName), level: 1 }),
+    ).toBeVisible({ timeout: 15_000 });
     await expectNoHorizontalPageScroll(page);
   });
 

--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from '@/components/empty-state'
 import { ConnectionStatus } from '@/components/connection-status'
 import { LabelsEditor } from '@/components/labels-editor'
 import { getAuthState } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 import { usePoolEvents } from '@/lib/use-pool-events'
 import { usePollingInterval } from '@/lib/use-polling-interval'
@@ -85,6 +86,7 @@ export default function AgentPoolDetailPage() {
   const router = useRouter()
   const params = useParams()
   const poolId = params.id as string
+  const { confirmDelete } = useConfirm()
 
   const [pool, setPool] = useState<Pool | null>(null)
   const [loading, setLoading] = useState(true)
@@ -269,6 +271,7 @@ export default function AgentPoolDetailPage() {
   }
 
   async function handleRevokeToken(tokenId: string) {
+    if (!confirmDelete('Revoke this join token? Listeners using it can no longer join, and this cannot be undone.')) return
     setError('')
     setSuccess('')
     try {
@@ -282,6 +285,7 @@ export default function AgentPoolDetailPage() {
   }
 
   async function handleDeleteListener(listenerId: string) {
+    if (!confirmDelete('Delete this listener? It will re-register on its next heartbeat if the pod is still running.')) return
     setError('')
     setSuccess('')
     try {
@@ -379,11 +383,11 @@ export default function AgentPoolDetailPage() {
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm font-medium text-slate-300">Pool Settings</h3>
                 {isPoolAdmin && (!editing ? (
-                  <button onClick={startEditing} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
+                  <button onClick={startEditing} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Edit</button>
                 ) : (
                   <div className="flex gap-2">
-                    <button onClick={() => setEditing(false)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                    <button onClick={handleSave} disabled={saving} className="text-xs text-brand-400 hover:text-brand-300">
+                    <button onClick={() => setEditing(false)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Cancel</button>
+                    <button onClick={handleSave} disabled={saving} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50">
                       {saving ? 'Saving...' : 'Save'}
                     </button>
                   </div>
@@ -522,7 +526,7 @@ export default function AgentPoolDetailPage() {
             ) : tokens.length === 0 ? (
               <EmptyState message="No tokens for this pool." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -554,7 +558,7 @@ export default function AgentPoolDetailPage() {
                         <td className="px-4 py-3 text-xs text-slate-400 hidden lg:table-cell">{tok.attributes['created-by']}</td>
                         <td className="px-4 py-3 text-right">
                           {!tok.attributes.revoked && (
-                            <button onClick={() => handleRevokeToken(tok.id)} className="text-xs text-red-400 hover:text-red-300">Revoke</button>
+                            <button onClick={() => handleRevokeToken(tok.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors">Revoke</button>
                           )}
                         </td>
                       </tr>
@@ -574,7 +578,7 @@ export default function AgentPoolDetailPage() {
             ) : listeners.length === 0 ? (
               <EmptyState message="No listeners registered for this pool." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -609,7 +613,7 @@ export default function AgentPoolDetailPage() {
                           {formatDate(l.attributes['certificate-expires-at'])}
                         </td>
                         <td className="px-4 py-3 text-right">
-                          <button onClick={() => handleDeleteListener(l.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
+                          <button onClick={() => handleDeleteListener(l.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors">Delete</button>
                         </td>
                       </tr>
                     ))}

--- a/web/src/app/admin/agent-pools/page.tsx
+++ b/web/src/app/admin/agent-pools/page.tsx
@@ -171,7 +171,7 @@ export default function AgentPoolsPage() {
         ) : pools.length === 0 ? (
           <EmptyState message="No agent pools configured." />
         ) : (
-          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-slate-700/50">
@@ -193,6 +193,17 @@ export default function AgentPoolsPage() {
                         </Link>
                         {pool.attributes['is-default'] && (
                           <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-brand-900/50 text-brand-300">default</span>
+                        )}
+                        {/* Below md the STATUS column is hidden, so reflow the health dot inline —
+                            otherwise a phone loses the healthy/degraded signal entirely (#719). */}
+                        {pool.attributes.status && (
+                          <span
+                            className="md:hidden inline-flex items-center gap-1"
+                            data-testid="pool-row-status-mobile"
+                            title={pool.attributes.status}
+                          >
+                            <span className={`w-2 h-2 rounded-full ${statusDotClass(pool.attributes.status)}`} />
+                          </span>
                         )}
                       </div>
                     </td>

--- a/web/src/lib/use-confirm.ts
+++ b/web/src/lib/use-confirm.ts
@@ -1,0 +1,15 @@
+import { useIsTouch } from './use-media-query'
+
+/**
+ * The #719 two-tier confirm() policy as a hook (see AGENTS.md → Responsive →
+ * Touch model). `confirmDelete` prompts in BOTH modes (irreversible deletes);
+ * `confirmTouchMutation` prompts on touch only (other single-tap mutations).
+ * Both return true to proceed / false to abort.
+ */
+export function useConfirm() {
+  const isTouch = useIsTouch()
+  return {
+    confirmDelete: (message: string) => window.confirm(message),
+    confirmTouchMutation: (message: string) => !isTouch || window.confirm(message),
+  }
+}


### PR DESCRIPTION
Part of #719 (does not close it — the epic tracks the whole UX sweep).

Agent Pools is a top-level nav surface, so it gets the #719 mobile treatment ahead of the deep-admin CRUD.

## What changed
- **Real buttons, not clickable text** — the detail page's Edit/Cancel/Save, per-token **Revoke**, and per-listener **Delete** were bare coloured text; they're now real buttons (matching the established `px-2.5 py-1 rounded-md` / red-variant styling).
- **Two-tier confirm() policy** via the shared `useConfirm` hook — revoke-token and delete-listener are irreversible, so they `confirm()` in **both** modes. The pool delete keeps its existing prominent two-step guard.
- **Mobile-safe tables** — list + detail tables use `overflow-x-auto` so they can't clip a phone. The list hides the STATUS column below `md`, so the pool **health dot reflows inline** into the name cell — a phone never loses the healthy/degraded signal (the #719 'never drop the primary signal' rule).

## Tests
- `createAgentPool` e2e factory.
- A `responsive` (phone-viewport) assertion driving the list **and** detail pages: row visible, STATUS column header hidden, no horizontal page scroll.
- Verified locally: full `responsive` (11) + `confirm-guards` suites green against the e2e stack; `npm run build` + ESLint clean.