### PR TITLE
fix(provider): decode workspace slack-channel in go-terrapod

### DIFF
--- a/go-terrapod/workspaces.go
+++ b/go-terrapod/workspaces.go
@@ -57,9 +57,9 @@ type Workspace struct {
 	// PlanExpirySeconds is the per-workspace plan-expiry TTL (#646); nil =
 	// disabled (the default). An apply-capable plan older than this is
 	// auto-discarded and must be re-planned.
-	PlanExpirySeconds             *int64   `json:"plan-expiry-seconds,omitempty"`
-	DriftStatus                   string   `json:"drift-status,omitempty"`
-	DriftLastCheckedAt            string   `json:"drift-last-checked-at,omitempty"`
+	PlanExpirySeconds  *int64 `json:"plan-expiry-seconds,omitempty"`
+	DriftStatus        string `json:"drift-status,omitempty"`
+	DriftLastCheckedAt string `json:"drift-last-checked-at,omitempty"`
 	// DriftLatestRunID is the ID (prefixed `run-…`) of the drift run that
 	// produced the current DriftStatus, or "" when drift has never run or
 	// was just cleared by a successful apply. Lets consumers link the
@@ -582,6 +582,7 @@ func workspaceFromResource(res *Resource) *Workspace {
 		VCSConnectionName:     GetStringAttr(res, "vcs-connection-name"),
 		AISummaryMode:         GetStringAttr(res, "ai-summary-mode"),
 		AISummaryContext:      GetStringAttr(res, "ai-summary-context"),
+		SlackChannel:          GetStringAttr(res, "slack-channel"),
 		CreatedAt:             GetStringAttr(res, "created-at"),
 		UpdatedAt:             GetStringAttr(res, "updated-at"),
 	}

--- a/go-terrapod/workspaces_test.go
+++ b/go-terrapod/workspaces_test.go
@@ -389,7 +389,8 @@ func TestWorkspaceFromResource_ContractParity(t *testing.T) {
 	    "vcs-last-error": "github app token expired",
 	    "vcs-last-error-at": "2026-06-10T11:45:00Z",
 	    "agent-pool-name": "dev-pool-1",
-	    "vcs-connection-name": "example-github"
+	    "vcs-connection-name": "example-github",
+	    "slack-channel": "C0XXXXXXXXX"
 	  }
 	}}`
 	ws, err := parseWorkspace([]byte(body))
@@ -414,6 +415,12 @@ func TestWorkspaceFromResource_ContractParity(t *testing.T) {
 	}
 	if ws.AgentPoolName != "dev-pool-1" || ws.VCSConnectionName != "example-github" {
 		t.Errorf("derived names: pool=%q conn=%q", ws.AgentPoolName, ws.VCSConnectionName)
+	}
+	// slack-channel (#556) must decode — the resource reads ws.SlackChannel
+	// into state, so dropping it here made every apply that sets
+	// slack_channel fail with "inconsistent result after apply" (#732).
+	if ws.SlackChannel != "C0XXXXXXXXX" {
+		t.Errorf("SlackChannel = %q, want C0XXXXXXXXX", ws.SlackChannel)
 	}
 }
 


### PR DESCRIPTION
Closes #732.

## Bug

Any \`terrapod_workspace\` resource that sets \`slack_channel\` failed on **every** apply:

```
Error: Provider produced inconsistent result after apply
… produced an unexpected new value: .slack_channel:
was cty.StringVal("C0XXXXXXXXX"), but now cty.StringVal("").
```

The plan is right and the server-side create/update succeeds — but the provider writes \`""\` back to state, so Terraform rejects the result and the workspace is left unmanageable via the provider.

## Root cause — consumer-contract drift

\`slack-channel\` (opt-in Slack run notifications, #556) is handled everywhere **except** the one place the resource reads from:

- ✅ \`Workspace.SlackChannel\` struct field + JSON tag
- ✅ \`CreateWorkspaceRequest\` / \`UpdateWorkspaceRequest\` marshalling
- ✅ provider resource schema (\`Optional\`+\`Computed\`) + state-map (\`m.SlackChannel = types.StringValue(ws.SlackChannel)\`)
- ✅ provider **data source** (maps it directly off the response)
- ❌ **\`workspaceFromResource()\` in \`go-terrapod/workspaces.go\` never decoded \`slack-channel\`** → \`Workspace.SlackChannel\` was always \`""\`

Because the resource relies on the SDK-decoded \`ws.SlackChannel\`, the state map always wrote \`""\`.

## Fix

- Add \`SlackChannel: GetStringAttr(res, "slack-channel")\` to \`workspaceFromResource()\`.
- Extend \`TestWorkspaceFromResource_ContractParity\` to include \`slack-channel\` so this class of drop stays caught. Verified red→green (fails on pre-fix source with \`SlackChannel = "", want C0XXXXXXXXX\`; passes after).

## Scope

SDK-only, one decode line + test. CLI/API/UI paths were unaffected (the server persists and returns the value correctly) — this is purely the Terraform provider read path. Should ship in the next release.