### PR TITLE
feat(ui): mobile-friendly deep-admin pages (#719)

### DIFF
--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { getStoredToken, createWorkspace, seedRun, seedStateVersion, seedRunTask, uniqueName } from '../helpers/api';
+import { getStoredToken, createWorkspace, createUser, seedRun, seedStateVersion, seedRunTask, uniqueName } from '../helpers/api';
 
 /**
  * Responsive / mobile harness (#719).
@@ -209,6 +209,38 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expect(page.getByRole('checkbox', { name: /Select cv-.* for compare/ }).filter({ visible: true }).first()).toBeVisible();
 
     await expectNoHorizontalPageScroll(page);
+  });
+
+  test('admin users page fits a phone + delete/toggle are two-tier confirm buttons', async ({ page }) => {
+    // Representative deep-admin surface (#719): the users table hides secondary
+    // columns below breakpoints but keeps the Active/Inactive status in-row; the
+    // row actions are real buttons; delete confirms in BOTH modes and the
+    // activate/deactivate toggle confirms on touch (this Pixel project).
+    const token = getStoredToken();
+    const email = `${uniqueName('resp-user')}@example.com`;
+    await createUser(token, email, 'Sup3rSecret!pw', 'Resp User');
+
+    await page.goto('/admin/users');
+    const row = page.getByRole('row').filter({ hasText: email });
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    // Status stays visible at phone width (not hidden behind a breakpoint).
+    await expect(row.getByRole('button', { name: /Active|Inactive/ })).toBeVisible();
+    // Row actions are real buttons (Delete present as a button, not bare text).
+    await expect(row.getByRole('button', { name: 'Delete' })).toBeVisible();
+    await expectNoHorizontalPageScroll(page);
+
+    // Tier-1 delete prompts on touch (and would on desktop too); dismiss keeps the row.
+    let deleteMsg = '';
+    page.once('dialog', async (d) => { deleteMsg = d.message(); await d.dismiss(); });
+    await row.getByRole('button', { name: 'Delete' }).click();
+    await expect.poll(() => deleteMsg, { timeout: 5_000 }).toContain('Delete user');
+    await expect(row).toBeVisible();
+
+    // Tier-2 activate/deactivate toggle prompts on touch; dismiss keeps state.
+    let toggleMsg = '';
+    page.once('dialog', async (d) => { toggleMsg = d.message(); await d.dismiss(); });
+    await row.getByRole('button', { name: /Active|Inactive/ }).click();
+    await expect.poll(() => toggleMsg, { timeout: 5_000 }).toMatch(/Deactivate|Activate/);
   });
 
   test('touch: both a reversible toggle and an irreversible delete prompt confirm()', async ({ page }) => {

--- a/e2e/tests/roles.spec.ts
+++ b/e2e/tests/roles.spec.ts
@@ -116,8 +116,8 @@ test.describe('Roles & Assignments', () => {
     await expect(card.getByText('run:apply', { exact: true })).toHaveCount(0);
 
     // Teardown: delete the role (other specs in this file self-teardown).
+    page.once("dialog", (d) => d.accept());
     await card.locator('button:has-text("Delete")').click();
-    await card.locator('button:has-text("Confirm")').click();
     await expect(page.locator(`h3:has-text("${roleName}")`)).not.toBeVisible({ timeout: 10_000 });
   });
 
@@ -137,10 +137,9 @@ test.describe('Roles & Assignments', () => {
 
     // Find the role card (a rounded-lg div containing the h3 with the role name)
     const card = page.locator('div.rounded-lg').filter({ has: page.locator(`h3:has-text("${roleName}")`) });
-    await card.locator('button:has-text("Delete")').click();
+    page.once("dialog", (d) => d.accept());
 
-    // Click Confirm (replaces Delete inline)
-    await card.locator('button:has-text("Confirm")').click();
+    await card.locator('button:has-text("Delete")').click();
 
     // Role should be gone
     await expect(page.locator(`h3:has-text("${roleName}")`)).not.toBeVisible({ timeout: 10_000 });

--- a/e2e/tests/users.spec.ts
+++ b/e2e/tests/users.spec.ts
@@ -68,9 +68,9 @@ test.describe('User Management', () => {
     const row = page.locator(`tr:has-text("${email}")`);
     await expect(row).toBeVisible({ timeout: 10_000 });
 
-    // Click Delete button in the row, then Confirm
+    // Delete → native confirm() dialog (#719 two-tier policy)
+    page.once("dialog", (d) => d.accept());
     await row.locator('button:has-text("Delete")').click();
-    await row.locator('button:has-text("Confirm")').click();
 
     // User should be gone
     await expect(row).not.toBeVisible({ timeout: 10_000 });

--- a/e2e/tests/variable-sets.spec.ts
+++ b/e2e/tests/variable-sets.spec.ts
@@ -27,7 +27,7 @@ test.describe('Variable Sets', () => {
     // Variable set should appear in the table with Global badge
     const row = page.locator(`tr:has-text("${name}")`);
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await expect(row.locator('text=Global')).toBeVisible();
+    await expect(row.locator('text=Global').filter({ visible: true })).toBeVisible();
   });
 
   test('navigate to detail page shows tabs', async ({ page }) => {

--- a/web/src/app/admin/autodiscovery/page.tsx
+++ b/web/src/app/admin/autodiscovery/page.tsx
@@ -768,6 +768,7 @@ export default function AutodiscoveryPage() {
         {sortedItems.length === 0 ? (
           <EmptyState message="No autodiscovery rules yet. Create one to start auto-provisioning workspaces from PRs in your monorepo." />
         ) : (
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="text-left text-slate-400 border-b border-slate-800">
               <tr>
@@ -800,30 +801,33 @@ export default function AutodiscoveryPage() {
                       : ''}
                   </td>
                   <td className="py-3 text-right">
-                    <button
-                      onClick={() => openPreview(r.id, r.attributes.name)}
-                      className="text-brand-400 hover:text-brand-300 text-xs px-2 py-1"
-                      title="Walk the repo and preview which workspaces this rule would create"
-                    >
-                      Preview
-                    </button>
-                    <button
-                      onClick={() => openEditForm(r)}
-                      className="text-slate-400 hover:text-slate-200 text-xs px-2 py-1"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      onClick={() => setDeleteId(r.id)}
-                      className="text-red-400 hover:text-red-300 text-xs px-2 py-1"
-                    >
-                      Delete
-                    </button>
+                    <div className="flex justify-end gap-2">
+                      <button
+                        onClick={() => openPreview(r.id, r.attributes.name)}
+                        className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-brand-300 transition-colors"
+                        title="Walk the repo and preview which workspaces this rule would create"
+                      >
+                        Preview
+                      </button>
+                      <button
+                        onClick={() => openEditForm(r)}
+                        className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => setDeleteId(r.id)}
+                        className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
+          </div>
         )}
 
         {deleteId && (

--- a/web/src/app/admin/binary-cache/page.tsx
+++ b/web/src/app/admin/binary-cache/page.tsx
@@ -11,6 +11,7 @@ import { SortableHeader } from '@/components/sortable-header'
 import { useSortable } from '@/lib/use-sortable'
 import { usePollingInterval } from '@/lib/use-polling-interval'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 
 interface CachedBinary {
@@ -42,6 +43,7 @@ interface CachedProvider {
 
 export default function CachePage() {
   const router = useRouter()
+  const { confirmDelete, confirmTouchMutation } = useConfirm()
   const [entries, setEntries] = useState<CachedBinary[]>([])
   const [providerEntries, setProviderEntries] = useState<CachedProvider[]>([])
   const [loading, setLoading] = useState(true)
@@ -129,6 +131,7 @@ export default function CachePage() {
   }
 
   async function handleBulkWarm() {
+    if (!confirmTouchMutation('Warm the selected cache entries now?')) return
     setError('')
     setSuccess('')
     setWarmResults(null)
@@ -184,6 +187,7 @@ export default function CachePage() {
   }
 
   async function handlePurge(tool: string, version: string) {
+    if (!confirmDelete(`Purge ${tool} ${version} from the cache? It will be re-fetched from upstream on the next request.`)) return
     setError('')
     setSuccess('')
     try {
@@ -200,6 +204,7 @@ export default function CachePage() {
   }
 
   async function handleProviderPurge(hostname: string, namespace: string, type: string, version: string) {
+    if (!confirmDelete(`Purge ${namespace}/${type} ${version} from the provider cache? It will be re-fetched from upstream on the next request.`)) return
     setError('')
     setSuccess('')
     try {
@@ -248,6 +253,7 @@ export default function CachePage() {
   }
 
   async function handleBatchPurgeBinaries() {
+    if (!confirmDelete('Purge all selected binary cache entries? They will be re-fetched from upstream on the next request.')) return
     setPurging(true)
     setError('')
     setSuccess('')
@@ -278,6 +284,7 @@ export default function CachePage() {
   }
 
   async function handleBatchPurgeProviders() {
+    if (!confirmDelete('Purge all selected provider cache entries? They will be re-fetched from upstream on the next request.')) return
     setPurging(true)
     setError('')
     setSuccess('')
@@ -424,7 +431,7 @@ export default function CachePage() {
             {entries.length === 0 ? (
               <EmptyState message="No cached CLI binaries yet." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden mb-8">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto mb-8">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -455,7 +462,7 @@ export default function CachePage() {
                         <td className="px-4 py-3 text-right">
                           <button
                             onClick={() => handlePurge(entry.attributes.tool, entry.attributes.version)}
-                            className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                            className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors"
                           >
                             Purge
                           </button>
@@ -483,7 +490,7 @@ export default function CachePage() {
             {providerEntries.length === 0 ? (
               <EmptyState message="No cached provider binaries yet." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -523,7 +530,7 @@ export default function CachePage() {
                               entry.attributes['provider-type'],
                               entry.attributes.version,
                             )}
-                            className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                            className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors"
                           >
                             Purge
                           </button>

--- a/web/src/app/admin/bulk-update/page.tsx
+++ b/web/src/app/admin/bulk-update/page.tsx
@@ -246,7 +246,7 @@ export default function BulkUpdatePage() {
         <h3 className="text-sm font-semibold text-slate-200 mb-2">
           {title} ({entries.length})
         </h3>
-        <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+        <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-700/50 text-left text-xs text-slate-400 uppercase">
@@ -409,7 +409,7 @@ export default function BulkUpdatePage() {
             {searchResult.workspaces.length === 0 ? (
               <EmptyState message="No workspaces matched this filter." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-slate-700/50 text-left text-xs text-slate-400 uppercase">

--- a/web/src/app/admin/execution-hooks/[id]/page.tsx
+++ b/web/src/app/admin/execution-hooks/[id]/page.tsx
@@ -9,6 +9,7 @@ import { LoadingSpinner } from '@/components/loading-spinner'
 import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 import { usePollingInterval } from '@/lib/use-polling-interval'
 
@@ -42,6 +43,7 @@ export default function ExecutionHookDetailPage() {
   const router = useRouter()
   const params = useParams()
   const hookId = params.id as string
+  const { confirmDelete } = useConfirm()
 
   const [hook, setHook] = useState<Hook | null>(null)
   const [loading, setLoading] = useState(true)
@@ -198,6 +200,7 @@ export default function ExecutionHookDetailPage() {
   }
 
   async function handleRemoveWorkspace(wsId: string) {
+    if (!confirmDelete('Remove this workspace from the hook? The hook will no longer run for it.')) return
     setError('')
     try {
       const res = await apiFetch(`/api/terrapod/v1/execution-hooks/${hookId}/relationships/workspaces`, {
@@ -270,11 +273,11 @@ export default function ExecutionHookDetailPage() {
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm font-medium text-slate-300">Settings</h3>
                 {!editing ? (
-                  <button onClick={startEditing} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
+                  <button onClick={startEditing} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Edit</button>
                 ) : (
                   <div className="flex gap-2">
-                    <button onClick={() => setEditing(false)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                    <button onClick={handleSave} disabled={saving} className="text-xs text-brand-400 hover:text-brand-300">
+                    <button onClick={() => setEditing(false)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Cancel</button>
+                    <button onClick={handleSave} disabled={saving} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50">
                       {saving ? 'Saving...' : 'Save'}
                     </button>
                   </div>
@@ -409,7 +412,7 @@ export default function ExecutionHookDetailPage() {
             ) : assigned.length === 0 ? (
               <EmptyState message="No workspaces associated with this hook." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -426,7 +429,7 @@ export default function ExecutionHookDetailPage() {
                           </Link>
                         </td>
                         <td className="px-4 py-3 text-right">
-                          <button onClick={() => handleRemoveWorkspace(ws.id)} className="text-xs text-red-400 hover:text-red-300">Remove</button>
+                          <button onClick={() => handleRemoveWorkspace(ws.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors">Remove</button>
                         </td>
                       </tr>
                     ))}

--- a/web/src/app/admin/execution-hooks/page.tsx
+++ b/web/src/app/admin/execution-hooks/page.tsx
@@ -193,7 +193,7 @@ export default function ExecutionHooksPage() {
         ) : hooks.length === 0 ? (
           <EmptyState message="No execution hooks configured." />
         ) : (
-          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-slate-700/50">
@@ -215,6 +215,11 @@ export default function ExecutionHooksPage() {
                       </Link>
                       {h.attributes.description && (
                         <div className="text-xs text-slate-500 mt-0.5">{h.attributes.description}</div>
+                      )}
+                      {/* Below md the ENABLED column is hidden — reflow a Disabled badge inline
+                          so a phone doesn't miss a silently-disabled hook (#719). */}
+                      {!h.attributes.enabled && (
+                        <span className="md:hidden mt-1 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-slate-700 text-slate-400">Disabled</span>
                       )}
                     </td>
                     <td className="px-4 py-3 hidden sm:table-cell">

--- a/web/src/app/admin/policy-sets/page.tsx
+++ b/web/src/app/admin/policy-sets/page.tsx
@@ -246,7 +246,7 @@ export default function PolicySetsPage() {
         ) : sets.length === 0 ? (
           <EmptyState message="No policy sets configured." />
         ) : (
-          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-slate-700/50">
@@ -269,6 +269,13 @@ export default function PolicySetsPage() {
                       {!ps.attributes.enabled && (
                         <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-slate-700 text-slate-400">Disabled</span>
                       )}
+                      {/* Below md the ENFORCEMENT column is hidden — reflow it inline so a phone
+                          still sees whether a policy blocks applies or only advises (#719). */}
+                      <span className={`md:hidden ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        ps.attributes['enforcement-level'] === 'mandatory' ? 'bg-red-900/50 text-red-300' : 'bg-amber-900/50 text-amber-300'
+                      }`}>
+                        {ps.attributes['enforcement-level'] === 'mandatory' ? 'Mandatory' : 'Advisory'}
+                      </span>
                     </td>
                     <td className="px-4 py-3 text-sm text-slate-400 hidden sm:table-cell">
                       {ps.attributes.description || '-'}

--- a/web/src/app/admin/provider-templates/page.tsx
+++ b/web/src/app/admin/provider-templates/page.tsx
@@ -9,6 +9,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { LabelsEditor } from '@/components/labels-editor'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 
 interface ProviderTemplate {
@@ -33,6 +34,7 @@ const EMPTY_FORM = {
 
 export default function ProviderTemplatesPage() {
   const router = useRouter()
+  const { confirmDelete } = useConfirm()
   const [templates, setTemplates] = useState<ProviderTemplate[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -44,7 +46,6 @@ export default function ProviderTemplatesPage() {
   const [f, setF] = useState({ ...EMPTY_FORM })
   const [saving, setSaving] = useState(false)
 
-  const [deleteId, setDeleteId] = useState<string | null>(null)
 
   useEffect(() => {
     if (!getAuthState()) { router.push('/login'); return }
@@ -145,6 +146,7 @@ export default function ProviderTemplatesPage() {
   }
 
   async function handleDelete(id: string) {
+    if (!confirmDelete('Delete this provider template? Catalog items referencing it will fail to provision. This cannot be undone.')) return
     setError(''); setSuccess('')
     try {
       const res = await apiFetch(`/api/terrapod/v1/provider-templates/${id}`, { method: 'DELETE' })
@@ -153,11 +155,9 @@ export default function ProviderTemplatesPage() {
         throw new Error(data.detail || 'Cannot delete: this template is referenced by a catalog item.')
       }
       if (!res.ok) throw new Error('Failed to delete provider template')
-      setDeleteId(null)
       setSuccess('Provider template deleted')
       await loadTemplates()
     } catch (err) {
-      setDeleteId(null)
       setError(err instanceof Error ? err.message : 'Failed to delete provider template')
     }
   }
@@ -243,7 +243,7 @@ export default function ProviderTemplatesPage() {
             ) : templates.length === 0 ? (
               <EmptyState message="No provider templates yet." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -266,17 +266,10 @@ export default function ProviderTemplatesPage() {
                           {(t.attributes.parameters || []).length}
                         </td>
                         <td className="px-4 py-3 text-right">
-                          {deleteId === t.id ? (
-                            <div className="flex justify-end gap-2">
-                              <button onClick={() => setDeleteId(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                              <button onClick={() => handleDelete(t.id)} className="text-xs text-red-400 hover:text-red-300">Confirm</button>
-                            </div>
-                          ) : (
-                            <div className="flex justify-end gap-3">
-                              <button onClick={() => startEdit(t)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
-                              <button onClick={() => setDeleteId(t.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
-                            </div>
-                          )}
+                          <div className="flex justify-end gap-2">
+                            <button onClick={() => startEdit(t)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Edit</button>
+                            <button onClick={() => handleDelete(t.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors">Delete</button>
+                          </div>
                         </td>
                       </tr>
                     ))}

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -9,6 +9,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
 import { useSortable } from '@/lib/use-sortable'
+import { useConfirm } from '@/lib/use-confirm'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import { usePollingInterval } from '@/lib/use-polling-interval'
@@ -208,6 +209,7 @@ interface Identity {
 type Tab = 'roles' | 'assignments'
 
 export default function RolesPage() {
+  const { confirmDelete } = useConfirm()
   const router = useRouter()
   const [activeTab, setActiveTab] = useState<Tab>('roles')
 
@@ -254,7 +256,6 @@ export default function RolesPage() {
   const [editRoleCapsCustom, setEditRoleCapsCustom] = useState(false)
 
   // Delete role
-  const [deleteRoleName, setDeleteRoleName] = useState<string | null>(null)
 
   // Display: which role rows have their capability list expanded
   const [expandedCaps, setExpandedCaps] = useState<Set<string>>(new Set())
@@ -535,12 +536,12 @@ export default function RolesPage() {
   }
 
   async function handleDeleteRole(name: string) {
+    if (!confirmDelete(`Delete role "${name}"? Any assignments referencing it are affected.`)) return
     setError('')
     setSuccess('')
     try {
       const res = await apiFetch(`/api/terrapod/v1/roles/${name}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete role')
-      setDeleteRoleName(null)
       setSuccess(`Role "${name}" deleted`)
       await loadRoles()
     } catch (err) {
@@ -585,6 +586,7 @@ export default function RolesPage() {
   }
 
   async function handleDeleteAssignment(provider: string, email: string, roleName: string) {
+    if (!confirmDelete(`Remove role "${roleName}" from ${email}?`)) return
     setError('')
     setSuccess('')
     try {
@@ -776,8 +778,8 @@ export default function RolesPage() {
                           <div className="flex items-center justify-between">
                             <h3 className="text-sm font-medium text-slate-200">{role.name}</h3>
                             <div className="flex gap-2">
-                              <button onClick={() => setEditingRole(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                              <button onClick={handleSaveRole} disabled={savingRole} className="text-xs text-brand-400 hover:text-brand-300">
+                              <button onClick={() => setEditingRole(null)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Cancel</button>
+                              <button onClick={handleSaveRole} disabled={savingRole} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 disabled:bg-brand-800 disabled:text-brand-400 text-white">
                                 {savingRole ? 'Saving...' : 'Save'}
                               </button>
                             </div>
@@ -924,15 +926,8 @@ export default function RolesPage() {
                           </div>
                           {!a['built-in'] && (
                             <div className="flex gap-2 flex-shrink-0">
-                              <button onClick={() => startEditRole(role)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
-                              {deleteRoleName === role.name ? (
-                                <>
-                                  <button onClick={() => setDeleteRoleName(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                                  <button onClick={() => handleDeleteRole(role.name)} className="text-xs text-red-400 hover:text-red-300">Confirm</button>
-                                </>
-                              ) : (
-                                <button onClick={() => setDeleteRoleName(role.name)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
-                              )}
+                              <button onClick={() => startEditRole(role)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200">Edit</button>
+                              <button onClick={() => handleDeleteRole(role.name)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300">Delete</button>
                             </div>
                           )}
                         </div>
@@ -1036,7 +1031,7 @@ export default function RolesPage() {
                         <td className="px-4 py-3 text-right">
                           <button
                             onClick={() => handleDeleteAssignment(a.attributes['provider-name'], a.attributes.email, a.attributes['role-name'])}
-                            className="text-xs text-red-400 hover:text-red-300"
+                            className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300"
                           >
                             Remove
                           </button>

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
 import { useSortable } from '@/lib/use-sortable'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 import { usePollingInterval } from '@/lib/use-polling-interval'
 
@@ -243,6 +244,7 @@ function PasswordResetForm({
 
 export default function UsersPage() {
   const router = useRouter()
+  const { confirmDelete, confirmTouchMutation } = useConfirm()
   const [users, setUsers] = useState<UserRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -262,7 +264,6 @@ export default function UsersPage() {
   const [resettingPassword, setResettingPassword] = useState(false)
 
   // Delete
-  const [deleteEmail, setDeleteEmail] = useState<string | null>(null)
 
   type SortKey = 'email' | 'displayName' | 'active' | 'lastLogin' | 'created'
   const accessor = useCallback((item: UserRecord, key: SortKey) => {
@@ -361,6 +362,7 @@ export default function UsersPage() {
   }
 
   async function handleToggleActive(email: string, currentlyActive: boolean) {
+    if (!confirmTouchMutation(`${currentlyActive ? 'Deactivate' : 'Activate'} user "${email}"?`)) return
     setError('')
     setSuccess('')
     try {
@@ -406,12 +408,12 @@ export default function UsersPage() {
   }
 
   async function handleDelete(email: string) {
+    if (!confirmDelete(`Delete user "${email}"? This cannot be undone.`)) return
     setError('')
     setSuccess('')
     try {
       const res = await apiFetch(`/api/terrapod/v1/users/${encodeURIComponent(email)}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete user')
-      setDeleteEmail(null)
       if (resetEmail === email) setResetEmail(null)
       if (editingEmail === email) setEditingEmail(null)
       setSuccess(`User "${email}" deleted`)
@@ -457,7 +459,7 @@ export default function UsersPage() {
         ) : users.length === 0 ? (
           <EmptyState message="No users found." />
         ) : (
-          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-slate-700/50">
@@ -486,10 +488,10 @@ export default function UsersPage() {
                               onChange={(e) => setEditDisplayName(e.target.value)}
                               className="px-2 py-1 text-sm border border-slate-600 rounded bg-slate-700 text-slate-100 focus:outline-none focus:ring-1 focus:ring-brand-500 w-40"
                             />
-                            <button onClick={handleSaveEdit} disabled={savingEdit} className="text-xs text-brand-400 hover:text-brand-300">
+                            <button onClick={handleSaveEdit} disabled={savingEdit} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50">
                               {savingEdit ? 'Saving...' : 'Save'}
                             </button>
-                            <button onClick={() => setEditingEmail(null)} className="text-xs text-slate-400 hover:text-slate-200">
+                            <button onClick={() => setEditingEmail(null)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">
                               Cancel
                             </button>
                           </div>
@@ -518,23 +520,16 @@ export default function UsersPage() {
                       <td className="px-4 py-3 text-right">
                         <div className="flex gap-2 justify-end">
                           {!isEditing && (
-                            <button onClick={() => startEdit(u)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
+                            <button onClick={() => startEdit(u)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Edit</button>
                           )}
                           {!isResetting ? (
-                            <button onClick={() => { setResetEmail(a.email); setEditingEmail(null) }} className="text-xs text-yellow-400 hover:text-yellow-300">
+                            <button onClick={() => { setResetEmail(a.email); setEditingEmail(null) }} className="px-2.5 py-1 rounded-md text-xs font-medium bg-yellow-900/40 hover:bg-yellow-900/60 text-yellow-300 transition-colors">
                               {a['has-password'] ? 'Reset PW' : 'Set PW'}
                             </button>
                           ) : (
-                            <button onClick={() => setResetEmail(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel PW</button>
+                            <button onClick={() => setResetEmail(null)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Cancel PW</button>
                           )}
-                          {deleteEmail === a.email ? (
-                            <>
-                              <button onClick={() => setDeleteEmail(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                              <button onClick={() => handleDelete(a.email)} className="text-xs text-red-400 hover:text-red-300">Confirm</button>
-                            </>
-                          ) : (
-                            <button onClick={() => setDeleteEmail(a.email)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
-                          )}
+                          <button onClick={() => handleDelete(a.email)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors">Delete</button>
                         </div>
                       </td>
                     </tr>

--- a/web/src/app/admin/variable-sets/[id]/page.tsx
+++ b/web/src/app/admin/variable-sets/[id]/page.tsx
@@ -10,6 +10,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { SensitiveValueInput } from '@/components/sensitive-value-input'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 import { usePollingInterval } from '@/lib/use-polling-interval'
 
@@ -53,6 +54,7 @@ export default function VariableSetDetailPage() {
   const router = useRouter()
   const params = useParams()
   const varsetId = params.id as string
+  const { confirmDelete } = useConfirm()
 
   const [varset, setVarset] = useState<Varset | null>(null)
   const [loading, setLoading] = useState(true)
@@ -299,6 +301,7 @@ export default function VariableSetDetailPage() {
   }
 
   async function handleDeleteVariable(varId: string) {
+    if (!confirmDelete('Delete this variable? This cannot be undone.')) return
     setError('')
     try {
       const res = await apiFetch(`/api/v2/varsets/${varsetId}/relationships/vars/${varId}`, { method: 'DELETE' })
@@ -339,6 +342,7 @@ export default function VariableSetDetailPage() {
   }
 
   async function handleRemoveWorkspace(wsId: string) {
+    if (!confirmDelete('Remove this workspace from the variable set? Its variables will no longer apply to that workspace.')) return
     setError('')
     try {
       const res = await apiFetch(`/api/v2/varsets/${varsetId}/relationships/workspaces`, {
@@ -412,11 +416,11 @@ export default function VariableSetDetailPage() {
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm font-medium text-slate-300">Settings</h3>
                 {!editing ? (
-                  <button onClick={startEditing} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
+                  <button onClick={startEditing} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Edit</button>
                 ) : (
                   <div className="flex gap-2">
-                    <button onClick={() => setEditing(false)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                    <button onClick={handleSave} disabled={saving} className="text-xs text-brand-400 hover:text-brand-300">
+                    <button onClick={() => setEditing(false)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Cancel</button>
+                    <button onClick={handleSave} disabled={saving} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50">
                       {saving ? 'Saving...' : 'Save'}
                     </button>
                   </div>
@@ -551,7 +555,7 @@ export default function VariableSetDetailPage() {
             ) : variables.length === 0 ? (
               <EmptyState message="No variables in this set." />
             ) : (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -597,8 +601,8 @@ export default function VariableSetDetailPage() {
                           </td>
                           <td className="px-4 py-3 text-right">
                             <div className="flex justify-end gap-2">
-                              <button onClick={() => setEditingVarId(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                              <button onClick={handleSaveVar} disabled={savingVar} className="text-xs text-brand-400 hover:text-brand-300">
+                              <button onClick={() => setEditingVarId(null)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Cancel</button>
+                              <button onClick={handleSaveVar} disabled={savingVar} className="px-2.5 py-1 rounded-md text-xs font-medium bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50">
                                 {savingVar ? 'Saving...' : 'Save'}
                               </button>
                             </div>
@@ -619,8 +623,8 @@ export default function VariableSetDetailPage() {
                           </td>
                           <td className="px-4 py-3 text-right">
                             <div className="flex justify-end gap-2">
-                              <button onClick={() => startEditingVar(v)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
-                              <button onClick={() => handleDeleteVariable(v.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
+                              <button onClick={() => startEditingVar(v)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Edit</button>
+                              <button onClick={() => handleDeleteVariable(v.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors">Delete</button>
                             </div>
                           </td>
                         </tr>
@@ -679,7 +683,7 @@ export default function VariableSetDetailPage() {
             ) : workspaces.length === 0 && !varset.attributes.global ? (
               <EmptyState message="No workspaces assigned to this variable set." />
             ) : workspaces.length > 0 ? (
-              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+              <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-slate-700/50">
@@ -696,7 +700,7 @@ export default function VariableSetDetailPage() {
                           </Link>
                         </td>
                         <td className="px-4 py-3 text-right">
-                          <button onClick={() => handleRemoveWorkspace(ws.id)} className="text-xs text-red-400 hover:text-red-300">Remove</button>
+                          <button onClick={() => handleRemoveWorkspace(ws.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors">Remove</button>
                         </td>
                       </tr>
                     ))}

--- a/web/src/app/admin/variable-sets/page.tsx
+++ b/web/src/app/admin/variable-sets/page.tsx
@@ -171,7 +171,7 @@ export default function VariableSetsPage() {
         ) : varsets.length === 0 ? (
           <EmptyState message="No variable sets configured." />
         ) : (
-          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-slate-700/50">
@@ -187,10 +187,20 @@ export default function VariableSetsPage() {
                   <tr key={vs.id} className="hover:bg-slate-700/20 transition-colors cursor-pointer"
                     onClick={() => router.push(`/admin/variable-sets/${vs.id}`)}>
                     <td className="px-4 py-3">
-                      <Link href={`/admin/variable-sets/${vs.id}`} className="text-sm font-medium text-brand-400 hover:text-brand-300"
-                        onClick={(e) => e.stopPropagation()}>
-                        {vs.attributes.name}
-                      </Link>
+                      <div className="flex items-center gap-2">
+                        <Link href={`/admin/variable-sets/${vs.id}`} className="text-sm font-medium text-brand-400 hover:text-brand-300"
+                          onClick={(e) => e.stopPropagation()}>
+                          {vs.attributes.name}
+                        </Link>
+                        {/* Below md the SCOPE column is hidden — reflow the Global/Priority badges
+                            inline so a phone still sees a varset's reach/precedence (#719). */}
+                        {vs.attributes.global && (
+                          <span className="md:hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-900/50 text-blue-300">Global</span>
+                        )}
+                        {vs.attributes.priority && (
+                          <span className="md:hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-900/50 text-amber-300">Priority</span>
+                        )}
+                      </div>
                     </td>
                     <td className="px-4 py-3 text-sm text-slate-400 hidden sm:table-cell">
                       {vs.attributes.description || '-'}

--- a/web/src/app/admin/vcs-connections/page.tsx
+++ b/web/src/app/admin/vcs-connections/page.tsx
@@ -9,6 +9,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { SortableHeader } from '@/components/sortable-header'
 import { getAuthState, isAdmin } from '@/lib/auth'
+import { useConfirm } from '@/lib/use-confirm'
 import { apiFetch } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
 import { usePollingInterval } from '@/lib/use-polling-interval'
@@ -33,6 +34,7 @@ type VCSSortKey = 'name' | 'provider' | 'server-url' | 'status' | 'created'
 
 export default function VCSConnectionsPage() {
   const router = useRouter()
+  const { confirmDelete } = useConfirm()
   const [connections, setConnections] = useState<VCSConnection[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -57,7 +59,6 @@ export default function VCSConnectionsPage() {
   const [editId, setEditId] = useState<string | null>(null)
 
   // Delete confirmation
-  const [deleteId, setDeleteId] = useState<string | null>(null)
 
   function resetForm() {
     setName(''); setServerUrl(''); setAppId(''); setInstallationId('')
@@ -166,12 +167,12 @@ export default function VCSConnectionsPage() {
   }
 
   async function handleDelete(id: string) {
+    if (!confirmDelete('Delete this VCS connection? Workspaces using it will lose VCS integration. This cannot be undone.')) return
     setError('')
     setSuccess('')
     try {
       const res = await apiFetch(`/api/terrapod/v1/vcs-connections/${id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error('Failed to delete connection')
-      setDeleteId(null)
       setSuccess('VCS connection deleted')
       await loadConnections()
     } catch (err) {
@@ -330,7 +331,7 @@ export default function VCSConnectionsPage() {
         ) : connections.length === 0 ? (
           <EmptyState message="No VCS connections configured." />
         ) : (
-          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-hidden">
+          <div className="bg-slate-800/50 rounded-lg border border-slate-700/50 overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-slate-700/50">
@@ -345,7 +346,16 @@ export default function VCSConnectionsPage() {
               <tbody className="divide-y divide-slate-700/30">
                 {sortedItems.map((conn) => (
                   <tr key={conn.id} className="hover:bg-slate-700/20 transition-colors">
-                    <td className="px-4 py-3 text-sm text-slate-200">{conn.attributes.name}</td>
+                    <td className="px-4 py-3 text-sm text-slate-200">
+                      <div className="flex items-center gap-2">
+                        <span>{conn.attributes.name}</span>
+                        {/* Below md the STATUS column is hidden — reflow the status pill inline so a
+                            phone doesn't lose the connection health signal (#719). */}
+                        <span className={`md:hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusBadge(conn.attributes.status)}`}>
+                          {conn.attributes.status}
+                        </span>
+                      </div>
+                    </td>
                     <td className="px-4 py-3">
                       <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${providerBadge(conn.attributes.provider)}`}>
                         {conn.attributes.provider}
@@ -363,17 +373,10 @@ export default function VCSConnectionsPage() {
                       {conn.attributes['created-at'] ? new Date(conn.attributes['created-at']).toLocaleDateString() : ''}
                     </td>
                     <td className="px-4 py-3 text-right">
-                      {deleteId === conn.id ? (
-                        <div className="flex justify-end gap-2">
-                          <button onClick={() => setDeleteId(null)} className="text-xs text-slate-400 hover:text-slate-200">Cancel</button>
-                          <button onClick={() => handleDelete(conn.id)} className="text-xs text-red-400 hover:text-red-300">Confirm</button>
-                        </div>
-                      ) : (
-                        <div className="flex justify-end gap-3">
-                          <button onClick={() => startEdit(conn)} className="text-xs text-brand-400 hover:text-brand-300">Edit</button>
-                          <button onClick={() => setDeleteId(conn.id)} className="text-xs text-red-400 hover:text-red-300">Delete</button>
-                        </div>
-                      )}
+                      <div className="flex justify-end gap-2">
+                        <button onClick={() => startEdit(conn)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">Edit</button>
+                        <button onClick={() => handleDelete(conn.id)} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-900/40 hover:bg-red-900/60 text-red-300 transition-colors">Delete</button>
+                      </div>
                     </td>
                   </tr>
                 ))}

--- a/web/src/lib/use-confirm.ts
+++ b/web/src/lib/use-confirm.ts
@@ -1,0 +1,27 @@
+import { useIsTouch } from './use-media-query'
+
+/**
+ * The #719 two-tier confirm() policy as a hook (see AGENTS.md → Responsive →
+ * Touch model). Use across every surface with mutating actions so the two tiers
+ * stay identical everywhere:
+ *
+ *   - `confirmDelete(msg)` — an irreversible delete/remove. Prompts in BOTH
+ *     modes (touch and precise pointer): losing data on a stray click is a
+ *     desktop hazard too.
+ *   - `confirmTouchMutation(msg)` — any other single-tap mutation (toggle,
+ *     lock, enable/disable, …). Prompts on touch ONLY, where a mis-tap is easy;
+ *     a precise pointer proceeds.
+ *
+ * Both return `true` to proceed / `false` to abort, so the caller does
+ * `if (!confirmDelete('Delete X?')) return`.
+ *
+ * Form *submits* after deliberate data entry (create/edit Save) are not
+ * single-tap mutations and don't need a guard.
+ */
+export function useConfirm() {
+  const isTouch = useIsTouch()
+  return {
+    confirmDelete: (message: string) => window.confirm(message),
+    confirmTouchMutation: (message: string) => !isTouch || window.confirm(message),
+  }
+}


### PR DESCRIPTION
Part of #719 (does not close it). The deep-admin CRUD surfaces get the mobile treatment, after the top-level nav surfaces (Registry #729, Catalog #730, Agent Pools #731).

## Surfaces
roles, users, vcs-connections, variable-sets (+ detail), binary-cache, provider-templates, policy-sets, autodiscovery, execution-hooks (+ detail). (audit-log and bulk-update already used real buttons + horizontal-scroll wrappers.)

## What changed (the six #719 patterns)
- **Real buttons, not clickable text** — every bare coloured-text row action (Edit / Save / Cancel / Delete / Remove / Revoke / Purge / Reset PW) is now a real button with a background + ~44px tap target.
- **Two-tier confirm()** via the shared `useConfirm` hook — irreversible deletes/removes/purges `confirm()` in **both** modes; reversible single-tap mutations (user activate/deactivate, cache warm) `confirm()` on **touch** only. Bespoke inline two-step `Delete→Confirm` swaps are replaced with the native `confirm()`; prominent danger-zone two-step *cards* (varset/hook delete) are kept as both-mode guards.
- **Mobile-safe tables** — table wrappers use `overflow-x-auto`; autodiscovery gains a wrapper it lacked.
- **Primary-signal reflow** — where a column is hidden below `md`, the signal reflows into the visible row: VCS connection **status**, variable-set **Global/Priority** scope, policy-set **enforcement** level, and a **Disabled** badge for execution hooks. (No status/health/enabled signal is dropped on a phone.)

## Tests
- A `responsive` (phone-viewport) e2e assertion for the admin **users** page: no horizontal page scroll, status stays in-row, actions are buttons, and both the delete (tier-1) and the activate/deactivate toggle (tier-2) prompt `confirm()` on touch.
- Verified locally: full `responsive` suite (10) green against the e2e stack; `npm run build` compiles; ESLint clean (only a pre-existing exhaustive-deps warning).