### PR TITLE
fix(web): reconcile session-expiry banner against the server's true TTL (#726)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2565,6 +2565,21 @@ POST /api/terrapod/v1/auth/callback
 GET /api/terrapod/v1/auth/sessions
 ```
 
+### Session Status
+
+```
+GET /api/terrapod/v1/auth/session
+```
+
+Returns the caller's live web-session status for the expiry-warning banner
+(#726): `{ "authenticated": true, "ttl_seconds": <int> }`. `ttl_seconds` is the
+session's true remaining lifetime read straight from Redis **without sliding
+it**, so the web client reconciles against the server's real TTL instead of a
+stale client-cached timestamp — SSE-driven views slide the server session
+without emitting the `X-Session-Expires` header, which used to make the banner
+warn falsely. A `401` is the authoritative "session is gone → re-authenticate"
+signal (session auth only; API-token callers get `401` here).
+
 ### Logout
 
 ```

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -29,6 +29,42 @@ test.describe('Authentication', () => {
     expect(parsed.roles).toContain('admin');
   });
 
+  test('session-status endpoint reflects the true TTL; banner stays hidden on a fresh session (#726)', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForSelector('#email', { timeout: 15_000 });
+    await page.fill('#email', ADMIN_EMAIL);
+    await page.fill('#password', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 15_000 });
+
+    // A fresh 12h session is nowhere near expiry, so the amber expiry banner
+    // must NOT show. The old banner warned falsely off a stale local clock; the
+    // fix reconciles against the server's true TTL (#726).
+    await expect(page.getByText(/Session expires in/)).toHaveCount(0);
+
+    // The banner reconciles against GET /auth/session. Prove it works through
+    // the full BFF proxy chain and returns a large positive TTL (well beyond
+    // the 5-minute warning threshold) rather than a stale/near-zero value.
+    const token = await page.evaluate(
+      () => JSON.parse(localStorage.getItem('terrapod_auth')!).token,
+    );
+    const res = await page.request.get('/api/terrapod/v1/auth/session', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.authenticated).toBe(true);
+    expect(typeof body.ttl_seconds).toBe('number');
+    expect(body.ttl_seconds).toBeGreaterThan(10 * 60);
+
+    // A bogus token is rejected with 401 — the authoritative "log back in"
+    // signal the banner (via apiFetch) acts on, instead of a local countdown.
+    const bad = await page.request.get('/api/terrapod/v1/auth/session', {
+      headers: { Authorization: 'Bearer not-a-real-session' },
+    });
+    expect(bad.status()).toBe(401);
+  });
+
   test('invalid credentials show error and stay on login', async ({ page }) => {
     await page.goto('/login');
     await page.waitForSelector('#email', { timeout: 15_000 });

--- a/services/terrapod/api/routers/auth.py
+++ b/services/terrapod/api/routers/auth.py
@@ -45,6 +45,7 @@ from terrapod.auth.pkce import s256_challenge
 from terrapod.auth.sessions import (
     create_session,
     get_session,
+    get_session_ttl,
     list_all_sessions,
     list_user_sessions,
     revoke_all_user_sessions,
@@ -102,6 +103,22 @@ class SessionInfo(BaseModel):
     last_active_at: str
     token_hint: str
     is_current: bool = False
+
+
+class SessionStatus(BaseModel):
+    """Live status of the caller's web session (#726).
+
+    The web session-expiry banner polls this to reconcile against the
+    server's TRUE remaining TTL rather than a stale client-cached expiry —
+    SSE-driven views slide the server session without emitting the
+    ``X-Session-Expires`` header, so the client clock drifts. ``ttl_seconds``
+    is the authoritative remaining lifetime read straight off Redis (no
+    slide); a 401 from this endpoint is the authoritative "session is gone"
+    signal that should trigger a re-login.
+    """
+
+    authenticated: bool
+    ttl_seconds: int
 
 
 # --- Endpoints ---
@@ -581,6 +598,26 @@ async def exchange_token(
 
 
 # --- Session management endpoints ---
+
+
+@router.get("/session", response_model=SessionStatus)
+async def session_status_endpoint(request: Request) -> SessionStatus:
+    """Return the caller's live session TTL for the expiry banner (#726).
+
+    Reads the true Redis TTL WITHOUT sliding the session, so the web client
+    can reconcile a stale local expiry against the server's real remaining
+    lifetime. A 401 (raised by ``_require_session``) means the session is
+    genuinely gone — that is the authoritative re-login signal, not a local
+    countdown. On the (shouldn't-happen) edge of a live session with no TTL,
+    fall back to the full configured lifetime rather than 0 so a transient
+    read never triggers a spurious logout; a genuinely-expired session
+    surfaces as the 401 above.
+    """
+    session = await _require_session(request)
+    ttl = await get_session_ttl(session.token)
+    if ttl is None:
+        ttl = settings.auth.session_ttl_hours * 3600
+    return SessionStatus(authenticated=True, ttl_seconds=ttl)
 
 
 @router.get("/sessions", response_model=list[SessionInfo])

--- a/services/terrapod/auth/sessions.py
+++ b/services/terrapod/auth/sessions.py
@@ -109,6 +109,21 @@ async def get_session(token: str) -> Session | None:
     return Session(token=token, **parsed)
 
 
+async def get_session_ttl(token: str) -> int | None:
+    """Return the session's true remaining TTL in seconds, WITHOUT sliding it.
+
+    Reads the Redis key TTL directly so a caller (the web session-expiry
+    banner, #726) can reconcile against the server's real remaining lifetime
+    rather than a stale client-cached timestamp. Returns None when the key is
+    gone (`-2`) or has no expiry (`-1`); a non-negative int otherwise. This is
+    a pure read — it must never call refresh_session, or polling it would keep
+    the session alive forever and the warning could never fire.
+    """
+    redis = get_redis_client()
+    ttl = await redis.ttl(SESSION_PREFIX + token)
+    return ttl if ttl is not None and ttl >= 0 else None
+
+
 # Minimum interval between session TTL refreshes (seconds).
 SESSION_REFRESH_INTERVAL = 300  # 5 minutes
 

--- a/services/tests/api/test_oauth.py
+++ b/services/tests/api/test_oauth.py
@@ -58,6 +58,76 @@ class TestTerraformServiceDiscovery:
         assert data["tfe.v2.2"] == "/api/v2/"
 
 
+class TestSessionStatus:
+    """#726: GET /auth/session returns the true remaining TTL for the banner."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.auth.get_session_ttl", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.auth.get_session", new_callable=AsyncMock)
+    async def test_returns_ttl_for_valid_session(
+        self, mock_get_session, mock_get_ttl, mock_init_db, mock_init_redis, mock_init_storage
+    ):
+        from terrapod.auth.sessions import Session
+
+        mock_get_session.return_value = Session(
+            token="sess-tok",
+            email="u@example.com",
+            display_name="U",
+            roles=["everyone"],
+            provider_name="local",
+            created_at="2026-01-01T00:00:00+00:00",
+            expires_at="2026-01-01T12:00:00+00:00",
+            last_active_at="2026-01-01T00:00:00+00:00",
+        )
+        mock_get_ttl.return_value = 41234
+
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.get(
+                "/api/terrapod/v1/auth/session",
+                headers={"Authorization": "Bearer sess-tok"},
+            )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["authenticated"] is True
+        assert body["ttl_seconds"] == 41234
+        # The endpoint must not slide — it reads the TTL, nothing else.
+        mock_get_ttl.assert_awaited_once_with("sess-tok")
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.auth.get_session", new_callable=AsyncMock)
+    async def test_no_session_is_401(
+        self, mock_get_session, mock_init_db, mock_init_redis, mock_init_storage
+    ):
+        # A gone/invalid session → 401. This is the authoritative "log back in"
+        # signal the banner acts on (never a stale local countdown).
+        mock_get_session.return_value = None
+
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.get(
+                "/api/terrapod/v1/auth/session",
+                headers={"Authorization": "Bearer gone"},
+            )
+
+        assert res.status_code == 401
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_missing_bearer_is_401(self, mock_init_db, mock_init_redis, mock_init_storage):
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.get("/api/terrapod/v1/auth/session")
+
+        assert res.status_code == 401
+
+
 class TestOAuthAuthorize:
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/auth/test_sessions.py
+++ b/services/tests/auth/test_sessions.py
@@ -12,6 +12,7 @@ from terrapod.auth.sessions import (
     _should_refresh_session,
     create_session,
     get_session,
+    get_session_ttl,
     revoke_session,
 )
 
@@ -121,6 +122,43 @@ class TestGetSession:
 
         session = await get_session("nonexistent-token")
         assert session is None
+
+
+class TestGetSessionTTL:
+    """#726: the banner reconciles against the server's TRUE remaining TTL."""
+
+    @patch("terrapod.auth.sessions.get_redis_client")
+    async def test_returns_positive_ttl_without_sliding(self, mock_get_redis):
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        redis.ttl.return_value = 41234
+
+        ttl = await get_session_ttl("test-token")
+
+        assert ttl == 41234
+        # It is a pure read of the key TTL — must never touch expiry (no
+        # set/expire/pipeline), or polling it would keep the session alive.
+        redis.ttl.assert_awaited_once_with(SESSION_PREFIX + "test-token")
+        redis.set.assert_not_called()
+        redis.expire.assert_not_called()
+
+    @patch("terrapod.auth.sessions.get_redis_client")
+    async def test_missing_key_returns_none(self, mock_get_redis):
+        # redis TTL returns -2 when the key does not exist.
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        redis.ttl.return_value = -2
+
+        assert await get_session_ttl("gone") is None
+
+    @patch("terrapod.auth.sessions.get_redis_client")
+    async def test_no_expiry_returns_none(self, mock_get_redis):
+        # redis TTL returns -1 when the key exists but has no expiry set.
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        redis.ttl.return_value = -1
+
+        assert await get_session_ttl("no-ttl") is None
 
 
 class TestRevokeSession:

--- a/web/src/components/session-expiry-banner.tsx
+++ b/web/src/components/session-expiry-banner.tsx
@@ -1,25 +1,48 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { clearAuth, getExpiresAt, loginRedirectUrl } from '@/lib/auth'
+import { getAuthState, getExpiresAt, updateExpiresAt } from '@/lib/auth'
+import { apiFetch } from '@/lib/api'
 
 const WARNING_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes
-const CHECK_INTERVAL_MS = 30_000 // 30 seconds
+const TICK_MS = 30_000 // re-render the countdown every 30s
+const POLL_MS = 60_000 // reconcile against the server every 60s
 
+/**
+ * Session-expiry warning banner (#726).
+ *
+ * The warning must reflect the SERVER's true remaining session TTL, not a
+ * stale client-cached expiry. SSE-driven views slide the server session
+ * (each `authenticate_request`) without emitting the `X-Session-Expires`
+ * header, so the local `expiresAt` in localStorage drifts stale and the old
+ * banner warned (and redirected) falsely — a reload always cleared it, and
+ * the user never actually had to log back in.
+ *
+ * Fix: poll a lightweight, non-sliding status endpoint and reconcile the
+ * local expiry from the server's real `ttl_seconds` (applied to the client's
+ * own clock, so absolute clock skew can't matter). Logout is now
+ * server-authoritative: `apiFetch` clears auth + redirects on a genuine 401
+ * from the poll. The local countdown only DISPLAYS the warning — it never
+ * triggers a redirect on its own.
+ */
 export function SessionExpiryBanner() {
   const [showWarning, setShowWarning] = useState(false)
   const [remaining, setRemaining] = useState('')
 
   useEffect(() => {
-    const check = () => {
-      const exp = getExpiresAt()
-      if (!exp) return
+    let cancelled = false
 
+    // Render the amber warning from the (reconciled) local expiry. Never
+    // redirects — the server poll owns logout.
+    const render = () => {
+      if (cancelled) return
+      const exp = getExpiresAt()
+      if (!exp) {
+        setShowWarning(false)
+        return
+      }
       const ms = exp.getTime() - Date.now()
-      if (ms <= 0) {
-        clearAuth()
-        window.location.href = loginRedirectUrl()
-      } else if (ms < WARNING_THRESHOLD_MS) {
+      if (ms > 0 && ms < WARNING_THRESHOLD_MS) {
         const mins = Math.ceil(ms / 60_000)
         setShowWarning(true)
         setRemaining(`${mins} minute${mins !== 1 ? 's' : ''}`)
@@ -28,9 +51,42 @@ export function SessionExpiryBanner() {
       }
     }
 
-    check()
-    const id = setInterval(check, CHECK_INTERVAL_MS)
-    return () => clearInterval(id)
+    // Reconcile the local expiry against the server's true remaining TTL.
+    // apiFetch handles a genuine 401 (clear auth + redirect) — the only path
+    // that logs the user out — and re-syncs on success. A transient network
+    // blip is swallowed; the next poll re-syncs, so we never log out on a blip.
+    const reconcile = async () => {
+      if (cancelled || !getAuthState()) return
+      try {
+        const res = await apiFetch('/api/terrapod/v1/auth/session')
+        if (cancelled || !res.ok) return
+        const data = await res.json().catch(() => null)
+        if (data && typeof data.ttl_seconds === 'number') {
+          updateExpiresAt(new Date(Date.now() + data.ttl_seconds * 1000).toISOString())
+        }
+      } catch {
+        // transient — leave the local expiry as-is; the next poll re-syncs
+      }
+      render()
+    }
+
+    render()
+    reconcile()
+    const tick = setInterval(render, TICK_MS)
+    const poll = setInterval(reconcile, POLL_MS)
+    // Re-sync promptly when the user returns to a backgrounded tab — a hidden
+    // tab's timers are throttled, so its local expiry may be well out of date.
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') reconcile()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+
+    return () => {
+      cancelled = true
+      clearInterval(tick)
+      clearInterval(poll)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
   }, [])
 
   if (!showWarning) return null


### PR DESCRIPTION
Closes #726. Part of the #719 UX epic.

## Bug
The *"Session expires in N minutes — re-authenticate"* banner warned falsely even though the session was fine: it cleared on reload and never actually required a re-login.

## Root cause
SSE-driven views slide the **server** session (each `authenticate_request`) but do **not** emit the `X-Session-Expires` header — that header is only set on the `get_current_user` refresh path. So on an SSE-heavy page the client's `localStorage` expiry drifts stale while the real Redis session keeps sliding, and the banner counts down against the stale value. A reload re-syncs (first `apiFetch` returns a fresh header), which is exactly why it always cleared and never logged you out.

## Fix — reconcile against the server; make logout server-authoritative
- **New non-sliding endpoint** `GET /api/terrapod/v1/auth/session` → `{ authenticated, ttl_seconds }`, reading the true Redis TTL via `sessions.get_session_ttl` (a pure `TTL` read — it must never call `refresh_session`, or polling would keep the session alive forever and the warning could never fire). `401` = session genuinely gone.
- **The banner** polls it every 60s (and on tab re-focus) and reconciles the local expiry from `ttl_seconds` applied to the client's *own* clock, so absolute clock skew can't matter. The local countdown now only **displays** the warning; **logout happens solely when the server poll returns 401** (via `apiFetch`'s 401 handling), never on a local countdown hitting zero.

Session-only (API-token callers `401` here); no go-terrapod method — the SDK authenticates with API tokens, not web sessions.

## Tests
- **Unit** (`test_sessions.py`): `get_session_ttl` returns the TTL without sliding (asserts no `set`/`expire`); `-1`/`-2` → `None`.
- **Services-API** (`test_oauth.py`): endpoint returns `ttl_seconds` for a valid session; `401` without a session / without a bearer.
- **E2E** (`auth.spec.ts`): a fresh session shows **no** banner; `GET /auth/session` returns a large positive TTL **through the BFF**; a bogus token → `401`.
- **Docs**: `api-reference.md` session-status entry.

Verified locally: 6 new Python tests pass in Docker; full `auth` e2e project (4) green; `tsc`/ESLint clean.