### PR TITLE
docs: multi-axis accuracy review (part of #720)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Terrapod earns its keep when the network, the credentials boundary, or the migra
 
 - **You run Terraform/OpenTofu across networks a SaaS can't reach into** — isolated VPCs, other regions, on-prem, or behind egress-only firewalls. Terrapod's control plane **never needs a route into an execution cluster**: runners dial *out* and create Jobs locally, so a cluster only ever makes outbound connections. VCS is polled outbound too, and cached providers/binaries can be served with no upstream internet.
 - **State and cloud credentials must not leave your boundary** — Terrapod is self-hosted end to end. One Helm release owns the API, state, registry, and caches; nothing is handed to an external control plane.
-- **You're leaving Terraform Enterprise / HCP Terraform** (cost, licensing, or the Replicated end-of-life) and want an open, self-hosted landing spot — often paired with a move to OpenTofu. The [`terrapod-migrate`](docs/migration.md) CLI imports workspaces, variables, VCS wiring, and state with a dry-run-first, reversible flow.
+- **You're leaving Terraform Enterprise / HCP Terraform** (cost, licensing, or the Replicated end-of-life) and want an open, self-hosted landing spot — often paired with a move to OpenTofu. The [`terrapod-migrate`](docs/migration.md) CLI imports workspaces, variables, variable sets, VCS wiring, state, run triggers, notifications, agent pools, and registry signing keys with a dry-run-first, reversible flow.
 - **You're a Kubernetes-native platform team** — Terrapod deploys only on Kubernetes, via Helm, and runs as just another workload in your stack.
 
 If none of these describe you — a single team, a freely-reachable network, happy on a hosted service — a managed platform may be less to operate. Terrapod is built for the harder-network, own-your-boundary case.
@@ -34,7 +34,7 @@ Beyond broad TFE compatibility, Terrapod is built with three deliberate design f
 
 > **Drop-in replacement for HCP Terraform.** Point your existing `cloud` blocks, `go-tfe` clients, and CI/CD pipelines at Terrapod — zero code changes required.
 
-> **Migrating from Terraform Enterprise / HCP Terraform / Atlantis.** The [`terrapod-migrate`](docs/migration.md) CLI imports workspaces, variables, VCS connections, and state with a **dry-run-first, fully reversible** flow — preview everything, apply, verify parity, and roll back cleanly if needed.
+> **Migrating from Terraform Enterprise / HCP Terraform / Atlantis.** The [`terrapod-migrate`](docs/migration.md) CLI imports workspaces, variables, variable sets, VCS connections, state, run triggers, notifications, agent pools, and registry signing keys with a **dry-run-first, fully reversible** flow — preview everything, apply, verify parity, and roll back cleanly if needed.
 
 > **AI-augmented plans.** Every plan can carry an LLM-generated change description, risk assessment, and (on failure) suggested fixes — provider-agnostic via [LiteLLM](https://github.com/BerriAI/litellm). Wire AWS Bedrock (Claude, Nova, gpt-oss) with native IAM auth, or point at OpenAI, Anthropic, Gemini, Azure OpenAI, or any OpenAI-compatible endpoint. See [docs/ai-plan-summary.md](docs/ai-plan-summary.md).
 
@@ -208,7 +208,7 @@ Terrapod runs **only on Kubernetes** (the runner uses the Jobs API). Deploy it o
 
 - A Kubernetes cluster (1.27+). No cluster? `curl -sfL https://get.k3s.io | sh -` gives you one on a single VM, with an ingress controller (Traefik) and storage included.
 - Helm 3.x
-- **External** PostgreSQL 14+ and Redis 7+ (the chart does not bundle them) — a managed service or run them on the cluster/VM.
+- **External** PostgreSQL 14+ and Redis 7+ (the chart does not bundle a production-grade datastore; it can deploy in-cluster Postgres/Redis via `postgresql.deploy`/`redis.deploy` for eval/dev only) — use a managed service or run them on the cluster/VM.
 
 ### Deploy
 
@@ -372,7 +372,7 @@ All builds, tests, and linting run in Docker -- no local Python or Node.js insta
 make dev          # Start local dev environment (Tilt)
 make dev-down     # Stop local dev environment
 make test         # Run pytest in Docker (with LocalStack for S3)
-make lint         # Run ruff + mypy in Docker
+make lint         # Run ruff (check + format) in Docker
 make images       # Build production Docker images
 ```
 
@@ -403,7 +403,7 @@ make pentest          # All three layers
 | Layer | Tool | What it covers |
 |-------|------|----------------|
 | SAST | [Semgrep](https://semgrep.dev/) | OWASP Top 10, secrets detection, project-specific rules (naive datetimes, raw background tasks) |
-| Container scanning | [Trivy](https://trivy.dev/) | HIGH/CRITICAL CVEs in `terrapod-api` and `terrapod-web` images |
+| Container scanning | [Trivy](https://trivy.dev/) | HIGH/CRITICAL CVEs in the `terrapod-api`, `terrapod-web`, and `terrapod-runner` images |
 | DAST | [Nuclei](https://nuclei.projectdiscovery.io/) | Auth bypass, header injection, CORS validation, state endpoint security, HTTP method restriction |
 
 Reports are written to `reports/pentest/`. See [SECURITY.md](SECURITY.md) for the full security policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,7 @@ If you are unable to use GitHub's reporting, email the maintainer directly.
 - **API tokens**: Long-lived tokens for CLI and automation are SHA-256 hashed
   at rest. Only the raw token value is returned once at creation time.
   Configurable max TTL via `auth.api_token_max_ttl_hours`.
-- **Label-based RBAC**: Hierarchical workspace permissions (read/plan/write/admin)
+- **Label-based RBAC**: Hierarchical workspace permissions (read/plan/write/admin); the presets expand to fine-grained `resource:verb` capabilities for precise scoping (#585)
   with label-based access control. No teams — labels replace teams entirely.
 - **MFA delegated to IdP**: Terrapod never implements MFA directly. Your
   identity provider (Auth0, Okta, Azure AD) handles MFA enforcement.

--- a/docs/ai-plan-summary.md
+++ b/docs/ai-plan-summary.md
@@ -46,7 +46,7 @@ For a run that errored during EITHER plan or apply (`errored`):
   targeted re-apply (`-target=...`).
 
 Both kinds are persisted in the `plan_summaries` table, returned by
-`GET /api/v2/plans/{plan-id}/summary`, and announced over the
+`GET /api/terrapod/v1/runs/{run_id}/plan-summary`, and announced over the
 per-workspace SSE channel as a `plan_summary_ready` event so the UI
 re-fetches without polling.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -791,7 +791,7 @@ The endpoint is mounted at `/api/v2/` because `go-tfe` and Terraform's `cloud` b
 ### Plan Summary
 
 ```
-GET /api/v2/plans/{plan_id}/summary
+GET /api/terrapod/v1/runs/{run_id}/plan-summary
 ```
 
 Returns the AI-generated plan summary (or failure analysis on errored plans) when the optional `ai_summary` feature is enabled and a summary has been produced for the run. See [docs/ai-plan-summary.md](ai-plan-summary.md) for the operator-side setup.

--- a/docs/run-tasks.md
+++ b/docs/run-tasks.md
@@ -277,10 +277,15 @@ def handle_task():
     access_token = payload["access_token"]
     run_id = payload["run_id"]
 
-    # 2. Fetch plan JSON from Terrapod
+    # 2. Resolve the plan id from the run, then fetch the structured plan JSON.
+    #    The plan-JSON endpoint 302-redirects to a presigned URL (httpx follows it).
+    auth = {"Authorization": f"Bearer {TERRAPOD_TOKEN}"}
+    run = httpx.get(f"https://terrapod.local/api/terrapod/v1/runs/{run_id}", headers=auth).json()
+    plan_id = run["data"]["relationships"]["plans"]["data"][0]["id"]
     plan_resp = httpx.get(
-        f"https://terrapod.local/api/terrapod/v1/runs/{run_id}/plan/json-output",
-        headers={"Authorization": f"Bearer {TERRAPOD_TOKEN}"},
+        f"https://terrapod.local/api/v2/plans/{plan_id}/json-output",
+        headers=auth,
+        follow_redirects=True,
     )
     plan_json = plan_resp.json()
 


### PR DESCRIPTION
Part of #720 — **part 2 (the multi-axis documentation review)**. Part 1 (screenshot refresh) is intentionally **deferred** until the #719 mobile PRs (#729/#730/#731/#734) land, per the issue's sequencing note (reshooting before the responsive pass lands means reshooting everything twice). #720 stays open for the screenshots.

## Entry-point punch-list (from a prior review pass — each verified against source, then fixed)
- **README** `make lint` said *ruff + mypy*; `scripts/lint.sh` only runs `ruff check` + `ruff format --check` → reworded to *ruff (check + format)*.
- **README** `terrapod-migrate` front-door blurb only listed workspaces/variables/VCS/state; v0.56.0 (#709) also imports **variable sets, run triggers, notifications, agent pools, and registry signing keys** (matches `llms.txt`) → updated both blurbs.
- **README** Trivy scans **three** images (adds `terrapod-runner`) per `scripts/pentest.sh`, not two.
- **README** "the chart does not bundle them" (PG/Redis) is literally inaccurate — the chart *can* deploy in-cluster datastores via `postgresql.deploy`/`redis.deploy` (eval/dev only) → softened to *does not bundle a production-grade datastore*.
- **SECURITY.md** RBAC bullet predated capability RBAC (#585) → notes presets expand to fine-grained `resource:verb` capabilities.

## Broader `docs/` sweep (delegated read-heavy review; every finding re-verified against the routers before fixing)
One endpoint-path drift class, three sites:
- **api-reference.md** + **ai-plan-summary.md**: AI plan summary is served at `GET /api/terrapod/v1/runs/{run_id}/plan-summary` (runs.py:940), **not** the non-existent `/api/v2/plans/{plan_id}/summary`.
- **run-tasks.md**: the OPA code example fetched a non-existent `/runs/{run_id}/plan/json-output`; corrected to resolve the plan id from the run then `GET /api/v2/plans/{plan_id}/json-output` (runs.py:1892; 302 → presigned).

**Content hygiene:** the review found **no** internal-identifier leaks and **no** peer-project disparagement across all 46 `docs/*.md` files. All cited Helm keys, `make` targets, CLI subcommands, links, and image refs otherwise resolve.

Docs-only; no code changes.