### PR TITLE
fix(run-tasks): stop runs wedging in `planning` on a post_plan run task (#739)

### DIFF
--- a/services/terrapod/services/run_task_service.py
+++ b/services/terrapod/services/run_task_service.py
@@ -97,9 +97,34 @@ async def create_task_stage(
     with individual TaskStageResults, and enqueues webhook triggers for each.
 
     Returns None if no applicable run tasks exist (caller should proceed).
+
+    **Idempotent per (run, stage).** A run has exactly one stage per boundary
+    (one ``post_plan``, one ``pre_apply``, …). The gate caller
+    (``run_service.complete_plan``) is re-driven on every reconciler tick while
+    the run sits in ``planning``, so a non-idempotent create would spawn a fresh
+    stage — with a fresh, still-``running`` webhook — on every tick, and the
+    gate would never resolve to ``passed``. That wedges the run in ``planning``
+    forever, accumulating one dead stage per tick (observed live: an advisory
+    ``post_plan`` task pointed at an unreachable URL produced dozens of
+    duplicate stages and a run that never reached ``planned``). If a stage
+    already exists for this run+boundary, return it so the caller re-resolves
+    the SAME stage each tick.
     """
     if stage_name not in VALID_STAGES:
         raise ValueError(f"Invalid stage: {stage_name}")
+
+    # Idempotency: reuse an existing stage for this run+boundary if present.
+    # Order by creation so re-entry deterministically returns the canonical
+    # (first-created) stage rather than an arbitrary row.
+    existing = await db.execute(
+        select(TaskStage)
+        .where(TaskStage.run_id == run_id, TaskStage.stage == stage_name)
+        .order_by(TaskStage.created_at.asc())
+        .limit(1)
+    )
+    prior = existing.scalars().first()
+    if prior is not None:
+        return prior
 
     # Find applicable run tasks
     result = await db.execute(

--- a/services/terrapod/services/run_task_service.py
+++ b/services/terrapod/services/run_task_service.py
@@ -148,9 +148,8 @@ async def create_task_stage(
     db.add(ts)
     await db.flush()
 
-    # Create results and enqueue webhook calls
-    from terrapod.services.scheduler import enqueue_trigger
-
+    # Create results (webhook delivery is enqueued AFTER commit — see below).
+    result_ids: list[uuid.UUID] = []
     for task in tasks:
         tsr = TaskStageResult(
             task_stage_id=ts.id,
@@ -163,13 +162,29 @@ async def create_task_stage(
         # Generate callback token
         tsr.callback_token = generate_callback_token(tsr.id)
         await db.flush()
+        result_ids.append(tsr.id)
 
-        # Enqueue webhook delivery
+    ts_id = ts.id
+
+    # Commit the stage + result rows BEFORE enqueuing the delivery triggers
+    # (#739). The `run_task_call` consumer runs in a *separate* DB session
+    # (and possibly on another replica) and looks the TaskStageResult up by
+    # id. If we enqueue while the rows are only flushed-not-committed — the
+    # caller (`run_service.complete_plan`) commits much later, up the stack —
+    # the consumer races ahead, reads "task stage result not found", and
+    # silently drops the webhook. The result then sits at `pending` forever,
+    # the stage never resolves, and the run wedges in `planning`. Committing
+    # here makes the rows visible before any trigger can fire.
+    await db.commit()
+
+    from terrapod.services.scheduler import enqueue_trigger
+
+    for tsr_id in result_ids:
         try:
             await enqueue_trigger(
                 "run_task_call",
-                {"task_stage_result_id": str(tsr.id)},
-                dedup_key=f"run_task:{tsr.id}",
+                {"task_stage_result_id": str(tsr_id)},
+                dedup_key=f"run_task:{tsr_id}",
                 dedup_ttl=300,
             )
         except Exception as e:
@@ -177,13 +192,15 @@ async def create_task_stage(
 
     logger.info(
         "Task stage created",
-        task_stage_id=str(ts.id),
+        task_stage_id=str(ts_id),
         run_id=str(run_id),
         stage=stage_name,
         task_count=len(tasks),
     )
 
-    return ts
+    # `commit()` expired the instance; return a live one for the caller
+    # (complete_plan immediately reads ts.id / resolves the stage).
+    return await db.get(TaskStage, ts_id)
 
 
 async def get_task_stage(db: AsyncSession, ts_id: uuid.UUID) -> TaskStage | None:

--- a/services/tests/integration/test_run_task_stage_idempotency.py
+++ b/services/tests/integration/test_run_task_stage_idempotency.py
@@ -1,0 +1,153 @@
+"""
+Integration test — task-stage creation is idempotent per (run, stage) (#739).
+
+Regression guard for the bug where `run_task_service.create_task_stage` was
+called on every reconciler tick by `run_service.complete_plan` while a run sat
+in `planning`, and each call unconditionally inserted a *new* `TaskStage` with
+a fresh, still-`running` webhook. That wedged the run in `planning` forever and
+accumulated one dead stage per tick (observed live: 98 duplicate `post_plan`
+stages, run never reaching `planned`). The fix makes creation idempotent: a run
+has exactly one stage per boundary, so a second call returns the existing row.
+
+These need a real database (unique rows, FK to `runs`, row counts), so they
+live in the integration tier.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import func, select
+
+from terrapod.db.models import TaskStage
+from terrapod.db.session import get_db_session
+from terrapod.services import run_task_service
+from tests.integration.conftest import AUTH, admin_user, set_auth
+
+pytestmark = pytest.mark.integration
+
+WS_ENDPOINT = "/api/v2/organizations/default/workspaces"
+RUNS_ENDPOINT = "/api/v2/runs"
+
+
+async def _upload_cv(client, ws_id: str) -> None:
+    resp = await client.post(
+        f"/api/v2/workspaces/{ws_id}/configuration-versions",
+        json={"data": {"type": "configuration-versions", "attributes": {"auto-queue-runs": False}}},
+        headers=AUTH,
+    )
+    assert resp.status_code == 201, resp.text
+    cv_id = resp.json()["data"]["id"]
+    resp = await client.put(
+        f"/api/v2/configuration-versions/{cv_id}/upload",
+        content=b"placeholder-tarball-for-tests",
+        headers={"Content-Type": "application/x-tar"},
+    )
+    assert resp.status_code in (200, 204), resp.text
+
+
+async def _create_workspace(client, name: str) -> str:
+    resp = await client.post(
+        WS_ENDPOINT,
+        json={"data": {"type": "workspaces", "attributes": {"name": name}}},
+        headers=AUTH,
+    )
+    assert resp.status_code == 201, resp.text
+    ws_id = resp.json()["data"]["id"]
+    await _upload_cv(client, ws_id)
+    return ws_id
+
+
+async def _create_run(client, ws_id: str) -> str:
+    resp = await client.post(
+        RUNS_ENDPOINT,
+        json={
+            "data": {
+                "type": "runs",
+                "attributes": {},
+                "relationships": {
+                    "workspace": {"data": {"id": ws_id, "type": "workspaces"}},
+                },
+            }
+        },
+        headers=AUTH,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["data"]["id"]
+
+
+async def _create_post_plan_task(client, ws_id: str, name: str) -> None:
+    resp = await client.post(
+        f"/api/terrapod/v1/workspaces/{ws_id}/run-tasks",
+        json={
+            "data": {
+                "type": "run-tasks",
+                "attributes": {
+                    "name": name,
+                    # Deliberately unreachable — mirrors the misconfig that
+                    # first surfaced the bug (an advisory task whose webhook
+                    # never resolves within one reconciler tick).
+                    "url": "https://cost-api.example.invalid/validate",
+                    "stage": "post_plan",
+                    "enforcement-level": "advisory",
+                    "enabled": True,
+                },
+            }
+        },
+        headers=AUTH,
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _rid(run_id_str: str) -> uuid.UUID:
+    return uuid.UUID(run_id_str.removeprefix("run-"))
+
+
+def _wid(ws_id_str: str) -> uuid.UUID:
+    return uuid.UUID(ws_id_str.removeprefix("ws-"))
+
+
+class TestTaskStageIdempotency:
+    async def test_second_create_returns_same_stage_no_duplicate(self, app, client):
+        """The gate is re-driven every reconciler tick; creation must reuse the
+        existing stage rather than accumulate duplicates (#739)."""
+        set_auth(app, admin_user())
+        ws_id = await _create_workspace(client, f"ts-idem-{uuid.uuid4().hex[:8]}")
+        await _create_post_plan_task(client, ws_id, "opa-cost-check")
+        run_id = await _create_run(client, ws_id)
+
+        rid, wid = _rid(run_id), _wid(ws_id)
+
+        async with get_db_session() as db:
+            first = await run_task_service.create_task_stage(db, rid, wid, "post_plan")
+            assert first is not None
+            await db.commit()
+            first_id = first.id
+
+        # Simulate many subsequent reconciler ticks re-driving the gate.
+        for _ in range(5):
+            async with get_db_session() as db:
+                again = await run_task_service.create_task_stage(db, rid, wid, "post_plan")
+                assert again is not None
+                assert again.id == first_id, "create_task_stage must reuse the existing stage"
+                await db.commit()
+
+        # Exactly one post_plan stage exists for this run — no accumulation.
+        async with get_db_session() as db:
+            count = await db.scalar(
+                select(func.count())
+                .select_from(TaskStage)
+                .where(TaskStage.run_id == rid, TaskStage.stage == "post_plan")
+            )
+            assert count == 1
+
+    async def test_no_applicable_tasks_returns_none(self, app, client):
+        """Workspaces without a matching run task get no stage (caller proceeds)."""
+        set_auth(app, admin_user())
+        ws_id = await _create_workspace(client, f"ts-none-{uuid.uuid4().hex[:8]}")
+        run_id = await _create_run(client, ws_id)
+
+        async with get_db_session() as db:
+            ts = await run_task_service.create_task_stage(
+                db, _rid(run_id), _wid(ws_id), "post_plan"
+            )
+            assert ts is None

--- a/services/tests/integration/test_run_task_stage_idempotency.py
+++ b/services/tests/integration/test_run_task_stage_idempotency.py
@@ -18,7 +18,7 @@ import uuid
 import pytest
 from sqlalchemy import func, select
 
-from terrapod.db.models import TaskStage
+from terrapod.db.models import TaskStage, TaskStageResult
 from terrapod.db.session import get_db_session
 from terrapod.services import run_task_service
 from tests.integration.conftest import AUTH, admin_user, set_auth
@@ -151,3 +151,46 @@ class TestTaskStageIdempotency:
                 db, _rid(run_id), _wid(ws_id), "post_plan"
             )
             assert ts is None
+
+    async def test_delivery_trigger_enqueued_after_result_committed(self, app, client):
+        """The result row must be committed and visible to the (separate-session)
+        delivery consumer *before* its trigger is enqueued (#739).
+
+        Enqueuing while the row is only flushed-not-committed races the
+        consumer, which then reads "task stage result not found" and silently
+        drops the webhook — wedging the run in `planning`. We assert the fix by
+        patching the enqueue and, from a *fresh* session, confirming the
+        TaskStageResult is already visible at enqueue time.
+        """
+        import terrapod.services.scheduler as scheduler_mod
+
+        set_auth(app, admin_user())
+        ws_id = await _create_workspace(client, f"ts-commit-{uuid.uuid4().hex[:8]}")
+        await _create_post_plan_task(client, ws_id, "opa-cost-check")
+        run_id = await _create_run(client, ws_id)
+
+        visibility: list[bool] = []
+        orig = scheduler_mod.enqueue_trigger
+
+        async def _spy_enqueue(trigger_type, payload, **kwargs):
+            # A brand-new session — sees only committed data.
+            async with get_db_session() as fresh:
+                tsr_uuid = uuid.UUID(payload["task_stage_result_id"])
+                row = await fresh.get(TaskStageResult, tsr_uuid)
+                visibility.append(row is not None)
+            # Don't actually enqueue (no consumer running in this test).
+
+        scheduler_mod.enqueue_trigger = _spy_enqueue
+        try:
+            async with get_db_session() as db:
+                ts = await run_task_service.create_task_stage(
+                    db, _rid(run_id), _wid(ws_id), "post_plan"
+                )
+                assert ts is not None
+        finally:
+            scheduler_mod.enqueue_trigger = orig
+
+        assert visibility, "expected at least one delivery trigger to be enqueued"
+        assert all(visibility), (
+            "result row must be committed/visible before its trigger is enqueued"
+        )


### PR DESCRIPTION
Closes #739. Two bugs in the same failure mode — **a run with a `post_plan` run task wedges in `planning` forever** — found while live-seeding for the #719/#720 UX release. Both are needed; the first alone is necessary but not sufficient.

## 1. `create_task_stage` was not idempotent

`run_service.complete_plan` (the post-plan gate) is re-driven on **every reconciler tick** (~2s) while a run sits in `planning`. It called `create_task_stage(run, ws, "post_plan")` each tick, and that unconditionally **inserted a new `TaskStage`** + results + webhooks. A run has exactly one stage per boundary, so creation must be idempotent per `(run_id, stage)` — it now returns the existing stage (ordered by `created_at`). Observed live: **98 duplicate stages** accumulated on one run.

## 2. The delivery trigger was enqueued before the result row was committed (root cause)

Even with idempotency, the run still wedged. `create_task_stage` flushed the `TaskStageResult` rows and enqueued the `run_task_call` delivery triggers **inside the caller's uncommitted transaction** (the commit happens later, up the reconciler stack). The delivery consumer runs in a **separate DB session** (possibly another replica), dequeued the trigger, and looked the result up by id **before the commit landed** → `task stage result not found` → the webhook was silently dropped → the result sat `pending` → the stage never resolved → the run wedged.

Log proof:
```
Executing trigger run_task_call
Task stage created
Task stage result not found   <- consumer read before caller committed
```

Fix: **commit the stage + result rows before enqueuing** the delivery triggers, so they're always visible to the consumer (capture ids before commit expires the ORM instances; re-load the stage to return a live one).

## Tests

New integration tests (real DB):
- idempotency: a second create returns the same stage; exactly one stage after five simulated ticks;
- ordering: patches enqueue and, from a **fresh session**, asserts every `TaskStageResult` is committed/visible at enqueue time;
- a no-applicable-task workspace still returns `None`.

`make test` green for the new file + adjacent `test_run_tasks.py` / `test_run_service.py` / `test_run_reconciler.py` (120 passed).

## Live F-gate

On the Tilt stack, a run with an **advisory `post_plan` task pointed at an unreachable URL** now reaches **`planned`** in ~12s with **stages=1** (webhook delivered → advisory-unreachable → stage passed), where before the fix it wedged in `planning` with duplicate stages accumulating. Ships in the next minor.