### PR TITLE
fix(run-tasks): enforce one task stage per (run, stage) with a DB unique constraint (closes #742)

### DIFF
--- a/alembic/versions/5456426d7dd8_task_stage_unique_run_stage.py
+++ b/alembic/versions/5456426d7dd8_task_stage_unique_run_stage.py
@@ -1,0 +1,52 @@
+"""enforce one task stage per (run, stage) (#742)
+
+A run has exactly one stage per boundary (one post_plan, one pre_apply, …). The
+idempotency in run_task_service.create_task_stage is a read-then-insert, which a
+concurrent cross-replica insert can still race (the reconciler and the runner's
+plan-result POST can both reach complete_plan and both find no stage). This adds
+a DB-level UniqueConstraint(run_id, stage) so the invariant holds regardless.
+
+Existing databases may already hold pre-#739 duplicate stages, so the upgrade
+first dedupes — keeping the oldest stage per (run_id, stage) and cascade-deleting
+the rest (task_stage_results.task_stage_id has ON DELETE CASCADE) — before adding
+the constraint.
+
+Revision ID: 5456426d7dd8
+Revises: 5cf23a543399
+Create Date: 2026-07-09
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "5456426d7dd8"
+down_revision: str | None = "5cf23a543399"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Dedupe first: keep the oldest stage per (run_id, stage), drop the rest.
+    # Their task_stage_results cascade-delete via the FK's ON DELETE CASCADE.
+    op.execute(
+        """
+        DELETE FROM task_stages
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY run_id, stage
+                           ORDER BY created_at ASC, id ASC
+                       ) AS rn
+                FROM task_stages
+            ) ranked
+            WHERE ranked.rn > 1
+        )
+        """
+    )
+    op.create_unique_constraint("uq_task_stages_run_stage", "task_stages", ["run_id", "stage"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_task_stages_run_stage", "task_stages", type_="unique")

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -1879,7 +1879,14 @@ class TaskStage(Base):
         back_populates="task_stage", cascade="all, delete-orphan"
     )
 
-    __table_args__ = (Index("ix_task_stages_run_id", "run_id"),)
+    # A run has exactly one stage per boundary (one post_plan, one pre_apply, …).
+    # Enforced at the DB level so a concurrent cross-replica insert can't create a
+    # duplicate (the read-then-insert idempotency in run_task_service is racy on
+    # its own) (#742).
+    __table_args__ = (
+        Index("ix_task_stages_run_id", "run_id"),
+        UniqueConstraint("run_id", "stage", name="uq_task_stages_run_stage"),
+    )
 
 
 class TaskStageResult(Base):

--- a/services/terrapod/services/run_task_service.py
+++ b/services/terrapod/services/run_task_service.py
@@ -12,6 +12,7 @@ import time
 import uuid
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -85,6 +86,17 @@ def verify_callback_token(token: str) -> uuid.UUID | None:
     return result_id
 
 
+async def _existing_stage(db: AsyncSession, run_id: uuid.UUID, stage_name: str) -> TaskStage | None:
+    """Return the canonical (first-created) stage for a run+boundary, if any."""
+    res = await db.execute(
+        select(TaskStage)
+        .where(TaskStage.run_id == run_id, TaskStage.stage == stage_name)
+        .order_by(TaskStage.created_at.asc(), TaskStage.id.asc())
+        .limit(1)
+    )
+    return res.scalars().first()
+
+
 async def create_task_stage(
     db: AsyncSession,
     run_id: uuid.UUID,
@@ -116,16 +128,10 @@ async def create_task_stage(
     # Idempotency: reuse an existing stage for this run+boundary if present.
     # Order by creation (with the id as a stable tiebreak, since created_at
     # can collide within a tick) so re-entry deterministically returns the
-    # canonical first-created stage rather than an arbitrary row. NOTE: this
-    # is a read-then-insert with no DB-level uniqueness — a concurrent
-    # cross-replica insert can still duplicate; #742 adds the constraint.
-    existing = await db.execute(
-        select(TaskStage)
-        .where(TaskStage.run_id == run_id, TaskStage.stage == stage_name)
-        .order_by(TaskStage.created_at.asc(), TaskStage.id.asc())
-        .limit(1)
-    )
-    prior = existing.scalars().first()
+    # canonical first-created stage. This read-then-insert is backed by a
+    # UniqueConstraint(run_id, stage) (#742), so a concurrent cross-replica
+    # insert that slips past this check is caught below via IntegrityError.
+    prior = await _existing_stage(db, run_id, stage_name)
     if prior is not None:
         return prior
 
@@ -142,43 +148,55 @@ async def create_task_stage(
     if not tasks:
         return None
 
-    # Create task stage
-    ts = TaskStage(
-        run_id=run_id,
-        stage=stage_name,
-        status="running",
-    )
-    db.add(ts)
-    await db.flush()
-
-    # Create results (webhook delivery is enqueued AFTER commit — see below).
-    result_ids: list[uuid.UUID] = []
-    for task in tasks:
-        tsr = TaskStageResult(
-            task_stage_id=ts.id,
-            run_task_id=task.id,
-            status="pending",
+    # Create task stage + its results, then commit. The UniqueConstraint on
+    # (run_id, stage) makes this race-safe: if a concurrent tick on another
+    # replica committed the same stage between our existence check above and
+    # this commit, the commit raises IntegrityError — we roll back and return
+    # the winner (it enqueued its own delivery triggers, so we don't re-enqueue).
+    try:
+        ts = TaskStage(
+            run_id=run_id,
+            stage=stage_name,
+            status="running",
         )
-        db.add(tsr)
+        db.add(ts)
         await db.flush()
 
-        # Generate callback token
-        tsr.callback_token = generate_callback_token(tsr.id)
-        await db.flush()
-        result_ids.append(tsr.id)
+        # Create results (webhook delivery is enqueued AFTER commit — see below).
+        result_ids: list[uuid.UUID] = []
+        for task in tasks:
+            tsr = TaskStageResult(
+                task_stage_id=ts.id,
+                run_task_id=task.id,
+                status="pending",
+            )
+            db.add(tsr)
+            await db.flush()
 
-    ts_id = ts.id
+            # Generate callback token
+            tsr.callback_token = generate_callback_token(tsr.id)
+            await db.flush()
+            result_ids.append(tsr.id)
 
-    # Commit the stage + result rows BEFORE enqueuing the delivery triggers
-    # (#739). The `run_task_call` consumer runs in a *separate* DB session
-    # (and possibly on another replica) and looks the TaskStageResult up by
-    # id. If we enqueue while the rows are only flushed-not-committed — the
-    # caller (`run_service.complete_plan`) commits much later, up the stack —
-    # the consumer races ahead, reads "task stage result not found", and
-    # silently drops the webhook. The result then sits at `pending` forever,
-    # the stage never resolves, and the run wedges in `planning`. Committing
-    # here makes the rows visible before any trigger can fire.
-    await db.commit()
+        ts_id = ts.id
+
+        # Commit the stage + result rows BEFORE enqueuing the delivery triggers
+        # (#739). The `run_task_call` consumer runs in a *separate* DB session
+        # (and possibly on another replica) and looks the TaskStageResult up by
+        # id. If we enqueue while the rows are only flushed-not-committed — the
+        # caller (`run_service.complete_plan`) commits much later, up the stack —
+        # the consumer races ahead, reads "task stage result not found", and
+        # silently drops the webhook. The result then sits at `pending` forever,
+        # the stage never resolves, and the run wedges in `planning`. Committing
+        # here makes the rows visible before any trigger can fire.
+        await db.commit()
+    except IntegrityError:
+        # A concurrent creator won the (run_id, stage) race. Return their stage.
+        await db.rollback()
+        winner = await _existing_stage(db, run_id, stage_name)
+        if winner is not None:
+            return winner
+        raise
 
     from terrapod.services.scheduler import enqueue_trigger
 

--- a/services/tests/integration/test_run_task_stage_idempotency.py
+++ b/services/tests/integration/test_run_task_stage_idempotency.py
@@ -17,6 +17,7 @@ import uuid
 
 import pytest
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 
 from terrapod.db.models import TaskStage, TaskStageResult
 from terrapod.db.session import get_db_session
@@ -194,3 +195,67 @@ class TestTaskStageIdempotency:
         assert all(visibility), (
             "result row must be committed/visible before its trigger is enqueued"
         )
+
+    async def test_db_rejects_duplicate_run_stage(self, app, client):
+        """The UniqueConstraint(run_id, stage) rejects a second stage for the
+        same run+boundary at the DB level (#742)."""
+        set_auth(app, admin_user())
+        ws_id = await _create_workspace(client, f"ts-uq-{uuid.uuid4().hex[:8]}")
+        run_id = await _create_run(client, ws_id)
+        rid = _rid(run_id)
+
+        async with get_db_session() as db:
+            db.add(TaskStage(run_id=rid, stage="post_plan", status="running"))
+            await db.flush()
+            db.add(TaskStage(run_id=rid, stage="post_plan", status="running"))
+            with pytest.raises(IntegrityError):
+                await db.flush()
+            # The failed flush poisons the transaction; reset it so the
+            # session's context-manager exit doesn't raise PendingRollbackError.
+            await db.rollback()
+
+    async def test_concurrent_insert_race_returns_winner(self, app, client, monkeypatch):
+        """When a concurrent cross-replica insert wins the (run, stage) race, the
+        loser's insert hits the unique constraint; create_task_stage rolls back
+        and returns the winning stage rather than raising or duplicating (#742).
+
+        Simulated by making the idempotency lookup miss the already-committed
+        winner on the first call (a stale read), forcing the insert path.
+        """
+        set_auth(app, admin_user())
+        ws_id = await _create_workspace(client, f"ts-race-{uuid.uuid4().hex[:8]}")
+        await _create_post_plan_task(client, ws_id, "opa-cost-check")
+        run_id = await _create_run(client, ws_id)
+        rid, wid = _rid(run_id), _wid(ws_id)
+
+        # The "winner": a stage already committed for (run, post_plan).
+        async with get_db_session() as db:
+            winner = TaskStage(run_id=rid, stage="post_plan", status="running")
+            db.add(winner)
+            await db.commit()
+            winner_id = winner.id
+
+        real_existing = run_task_service._existing_stage
+        calls = {"n": 0}
+
+        async def _stale_then_real(db, run_id_, stage_name):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return None  # stale read: miss the winner, proceed to insert
+            return await real_existing(db, run_id_, stage_name)
+
+        monkeypatch.setattr(run_task_service, "_existing_stage", _stale_then_real)
+
+        async with get_db_session() as db:
+            got = await run_task_service.create_task_stage(db, rid, wid, "post_plan")
+            assert got is not None
+            assert got.id == winner_id, "must return the winner, not a new stage"
+
+        # The loser's insert was rolled back — exactly one stage exists.
+        async with get_db_session() as db:
+            count = await db.scalar(
+                select(func.count())
+                .select_from(TaskStage)
+                .where(TaskStage.run_id == rid, TaskStage.stage == "post_plan")
+            )
+            assert count == 1


### PR DESCRIPTION
Closes #742. Follow-up hardening from the #740/#739 review, deferred out of v0.57.0 because it carries a data-touching migration.

## Problem
`run_task_service.create_task_stage`'s idempotency is a **read-then-insert** with no DB-level uniqueness. A concurrent cross-replica insert — the reconciler racing the runner's `report_plan_result` POST, both reaching `complete_plan` and both missing the stage on their existence check — could still create a duplicate `post_plan` stage (a narrower recurrence of the wedge #740 fixed).

## Fix
- **`UniqueConstraint(run_id, stage)`** on `TaskStage` — the invariant now holds regardless of races.
- **Migration** (`5456426d7dd8`): dedupe existing rows first — keep the oldest per `(run_id, stage)`, the rest cascade-delete their results via the FK's `ON DELETE CASCADE` — **then** add the constraint (so it applies cleanly to DBs that already hold pre-#739 duplicates). Real `upgrade()` + `downgrade()`.
- **Race-safe `create_task_stage`**: on the unique-violation `IntegrityError`, roll back and return the **winning** stage (it enqueued its own delivery triggers, so no double-enqueue). Extracted `_existing_stage()` so the initial idempotency check and the post-conflict re-select share one query.

## Tests
Integration (real Postgres): the DB rejects a direct duplicate; and a simulated stale read drives `create_task_stage` down the `IntegrityError` path, returning the winner with exactly one row surviving. `make test` green for the touched suites (integration + `test_run_tasks` / `test_run_service` / `test_run_reconciler`). Migration exercised by the `Migration Smoke` CI job.

Ships as a patch (v0.57.1).