### PR TITLE
fix(runner): surface unschedulable Jobs fast instead of a 1h 'stale' hang (#748)

### DIFF
--- a/services/terrapod/runner/job_manager.py
+++ b/services/terrapod/runner/job_manager.py
@@ -177,6 +177,44 @@ async def _check_pod_stuck(job_name: str, namespace: str) -> str | None:
     return None
 
 
+async def _pod_unschedulable(job_name: str, namespace: str) -> bool:
+    """True if the Job's pod is Pending and the scheduler has declared it
+    Unschedulable — insufficient cluster resources, or an unsatisfiable
+    nodeSelector / affinity / taint (#748).
+
+    A Pending pod counts toward `job.status.active`, so without this check the
+    run looks "running" and only fails at the 1h stale timeout. We key off the
+    scheduler's own `PodScheduled=False, reason=Unschedulable` condition (not a
+    bare Pending) so a pod that's merely mid-scheduling is not misflagged.
+    """
+    core_api = _get_core_api()
+    try:
+        loop = asyncio.get_event_loop()
+        pods = await loop.run_in_executor(
+            _executor,
+            lambda: core_api.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=f"job-name={job_name}",
+            ),
+        )
+        core_api.api_client.last_response = None
+
+        for pod in pods.items:
+            if not pod.status or pod.status.phase != "Pending":
+                continue
+            for cond in pod.status.conditions or []:
+                if (
+                    cond.type == "PodScheduled"
+                    and cond.status == "False"
+                    and cond.reason == "Unschedulable"
+                ):
+                    return True
+    except Exception:
+        return False
+
+    return False
+
+
 async def delete_job(
     job_name: str,
     namespace: str = "",
@@ -236,9 +274,13 @@ async def get_job_status(job_name: str, namespace: str = "") -> str | None:
             return "succeeded"
         if job.status.failed and job.status.failed > 0:
             return "failed"
-        if job.status.active and job.status.active > 0:
-            return "running"
-        return "running"  # Job exists but no status yet
+        # Not terminal. A Pending pod the scheduler cannot place still counts
+        # toward `job.status.active`, so it otherwise looks "running" and the
+        # run hangs until the stale timeout. Surface it explicitly so the
+        # reconciler can fail fast with a clear reason (#748).
+        if await _pod_unschedulable(job_name, namespace):
+            return "unschedulable"
+        return "running"  # active, or Job exists but no pod status yet
     except ApiException as e:
         if e.status == 404:
             return None

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -162,6 +162,15 @@ async def _reconcile_one(db: AsyncSession, run: Run) -> None:
     if status == "running":
         return  # Still running, no-op
 
+    if status == "unschedulable":
+        # The Job's pod can't be scheduled (insufficient cluster resources, or
+        # an unsatisfiable nodeSelector/affinity/taint). Give a short grace in
+        # case the scheduler catches up — a node is added, another Job frees
+        # capacity — then fail fast with a clear reason, instead of hanging to
+        # the 1h stale timeout and reporting a vague "stale" (#748).
+        await _check_unschedulable(db, run)
+        return
+
     # `canceling` resolution is keyed on the Job-completion signal AND
     # whether a state-version was uploaded by this run; both branches
     # of the normal-path handlers (succeeded → applied, failed →
@@ -264,6 +273,40 @@ async def _handle_failed(db: AsyncSession, run: Run, error_message: str) -> None
         ws.lock_id = None
 
     logger.info("Run errored", run_id=str(run.id), reason=error_message)
+
+
+async def _check_unschedulable(db: AsyncSession, run: Run) -> None:
+    """Fail a run whose pod has been Unschedulable past the launch grace, with
+    an explicit "insufficient cluster resources" reason (#748).
+
+    Uses `launch_timeout_seconds` (default 5 min) as the grace — long enough to
+    ride out a transient scheduling gap (cluster-autoscaler adding a node, a
+    peer Job finishing), short enough that an operator on a fixed-resource
+    cluster gets a fast, actionable signal rather than a 1h "stale" hang.
+    """
+    phase_start = run.plan_started_at if run.status == "planning" else run.apply_started_at
+    if phase_start is None:
+        return
+
+    cfg = load_runner_config()
+    if datetime.now(UTC) - phase_start <= timedelta(seconds=cfg.launch_timeout_seconds):
+        return  # within grace — the scheduler may still place the pod
+
+    msg = (
+        f"Runner pod could not be scheduled for >{cfg.launch_timeout_seconds}s — "
+        f"insufficient cluster resources, or an unsatisfiable nodeSelector / "
+        f"affinity / taint. The workspace requests {run.resource_cpu} CPU / "
+        f"{run.resource_memory} memory (limits are 2× the request); no node had "
+        f"room. Reduce the request, free capacity, or add a node."
+    )
+    await _handle_failed(db, run, msg)
+    logger.warning(
+        "Run errored: pod unschedulable past grace",
+        run_id=str(run.id),
+        status=run.status,
+        resource_cpu=run.resource_cpu,
+        resource_memory=run.resource_memory,
+    )
 
 
 async def _check_stale(db: AsyncSession, run: Run) -> None:

--- a/services/tests/runner/test_job_manager.py
+++ b/services/tests/runner/test_job_manager.py
@@ -137,3 +137,68 @@ class TestDefaultNamespace:
         fake_cfg = SimpleNamespace(runner_namespace="cfg-runner-ns")
         with patch("terrapod.config.load_runner_config", return_value=fake_cfg):
             assert job_manager._default_namespace() == "cfg-runner-ns"
+
+
+def _pod(phase, sched_status="True", reason=None):
+    cond = SimpleNamespace(type="PodScheduled", status=sched_status, reason=reason)
+    return SimpleNamespace(status=SimpleNamespace(phase=phase, conditions=[cond]))
+
+
+def _job(succeeded=None, failed=None, active=None):
+    return SimpleNamespace(
+        status=SimpleNamespace(succeeded=succeeded, failed=failed, active=active)
+    )
+
+
+class TestUnschedulableDetection:
+    """#748 — a Pending pod the scheduler can't place counts as job.active, so
+    get_job_status must surface it as `unschedulable` (not `running`) so the
+    reconciler can fail fast with a clear reason."""
+
+    @patch("terrapod.runner.job_manager._get_core_api")
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_pending_unschedulable_reports_unschedulable(self, _ns, mock_batch, mock_core):
+        from terrapod.runner.job_manager import get_job_status
+
+        mock_batch.return_value.read_namespaced_job.return_value = _job(active=1)
+        mock_core.return_value.list_namespaced_pod.return_value = SimpleNamespace(
+            items=[_pod("Pending", sched_status="False", reason="Unschedulable")]
+        )
+        assert await get_job_status("tprun-x-plan") == "unschedulable"
+
+    @patch("terrapod.runner.job_manager._get_core_api")
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_pending_but_still_scheduling_is_running(self, _ns, mock_batch, mock_core):
+        # PodScheduled=False without reason=Unschedulable means "mid-scheduling",
+        # not "can't be placed" — must NOT be flagged.
+        mock_batch.return_value.read_namespaced_job.return_value = _job(active=1)
+        mock_core.return_value.list_namespaced_pod.return_value = SimpleNamespace(
+            items=[_pod("Pending", sched_status="False", reason=None)]
+        )
+        from terrapod.runner.job_manager import get_job_status
+
+        assert await get_job_status("tprun-x-plan") == "running"
+
+    @patch("terrapod.runner.job_manager._get_core_api")
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_running_pod_is_running(self, _ns, mock_batch, mock_core):
+        mock_batch.return_value.read_namespaced_job.return_value = _job(active=1)
+        mock_core.return_value.list_namespaced_pod.return_value = SimpleNamespace(
+            items=[_pod("Running")]
+        )
+        from terrapod.runner.job_manager import get_job_status
+
+        assert await get_job_status("tprun-x-plan") == "running"
+
+    @patch("terrapod.runner.job_manager._get_core_api")
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_succeeded_short_circuits_before_pod_check(self, _ns, mock_batch, mock_core):
+        mock_batch.return_value.read_namespaced_job.return_value = _job(succeeded=1)
+        from terrapod.runner.job_manager import get_job_status
+
+        assert await get_job_status("tprun-x-plan") == "succeeded"
+        mock_core.return_value.list_namespaced_pod.assert_not_called()

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -9,6 +9,7 @@ import pytest
 from terrapod.services.run_reconciler import (
     DEFAULT_STALE_TIMEOUT_SECONDS,
     _check_stale,
+    _check_unschedulable,
     _handle_failed,
     _handle_succeeded,
     _reconcile_one,
@@ -744,3 +745,68 @@ class TestReconcileOneWithoutJobName:
         mock_publish.assert_not_called()
         mock_status.assert_not_called()
         mock_check_stale.assert_called_once()
+
+
+# ── unschedulable handling (#748) ─────────────────────────────────────
+
+
+class TestUnschedulable:
+    @patch("terrapod.services.run_reconciler._check_unschedulable", new_callable=AsyncMock)
+    @patch("terrapod.redis.client.get_job_status_from_redis", new_callable=AsyncMock)
+    @patch("terrapod.redis.client.publish_listener_event", new_callable=AsyncMock)
+    async def test_reconcile_routes_unschedulable_to_grace_check(
+        self, mock_publish, mock_get_status, mock_unsched
+    ):
+        db = AsyncMock()
+        run = _mock_run()
+        mock_get_status.return_value = "unschedulable"
+
+        await _reconcile_one(db, run)
+
+        mock_unsched.assert_called_once_with(db, run)
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_unschedulable_past_grace_errors_with_clear_reason(
+        self, mock_handle, mock_config
+    ):
+        mock_config.return_value = MagicMock(launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            plan_started_at=datetime.now(UTC) - timedelta(minutes=10),
+        )
+        run.resource_cpu = "1"
+        run.resource_memory = "2Gi"
+
+        await _check_unschedulable(db, run)
+
+        mock_handle.assert_called_once()
+        msg = mock_handle.call_args.args[2]
+        assert "could not be scheduled" in msg
+        assert "2Gi" in msg  # names the actionable resource request
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_unschedulable_within_grace_is_noop(self, mock_handle, mock_config):
+        mock_config.return_value = MagicMock(launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            plan_started_at=datetime.now(UTC) - timedelta(seconds=30),
+        )
+
+        await _check_unschedulable(db, run)
+
+        mock_handle.assert_not_called()  # scheduler may still place it
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_unschedulable_no_phase_start_skips(self, mock_handle, mock_config):
+        mock_config.return_value = MagicMock(launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(status="planning", plan_started_at=None)
+
+        await _check_unschedulable(db, run)
+
+        mock_handle.assert_not_called()


### PR DESCRIPTION
## Problem

On a fixed-resource cluster (k3s / a node pool with no autoscaling), a runner Job whose pod the scheduler cannot place — `FailedScheduling: Insufficient cpu/memory`, or an unsatisfiable `nodeSelector`/affinity/taint — sits `Pending`. A `Pending` pod counts toward `job.status.active`, so `get_job_status` reported it as `"running"`. The run then hung until the **1-hour** `stale_timeout` and finally errored with a vague `Run stale — no progress for >1:00:00` — naming neither "unschedulable" nor "insufficient resources".

*A fast, honest "the cluster is full" beats a silent 60-minute hang.*

## Fix

- **`get_job_status` (`job_manager.py`)** now inspects the Job's pod when the Job isn't terminal: a `Pending` pod carrying the scheduler's own `PodScheduled=False, reason=Unschedulable` condition is reported as `"unschedulable"`. Keyed off that specific condition (not a bare `Pending`), so a pod that's merely mid-scheduling is never misflagged.
- **The reconciler** routes `"unschedulable"` to a short grace (`launch_timeout_seconds`, default 5 min — long enough to ride out a transient scheduling gap or a cluster-autoscaler adding a node) and then fails fast with an explicit reason naming the cause **and** the workspace's `resource_cpu`/`resource_memory` request, e.g.:

  > Runner pod could not be scheduled for >300s — insufficient cluster resources, or an unsatisfiable nodeSelector / affinity / taint. The workspace requests 1 CPU / 2Gi memory (limits are 2× the request); no node had room. Reduce the request, free capacity, or add a node.

No listener or API-endpoint change: the listener forwards the status unchanged and `report_job_status` stores it verbatim.

## Tests

- `job_manager`: `get_job_status` → `unschedulable` for a Pending+Unschedulable pod; stays `running` for a still-scheduling or Running pod; `succeeded` short-circuits before the pod check.
- `run_reconciler`: `_reconcile_one` routes `unschedulable` to the grace check; past-grace errors with a clear reason (names the resource request); within-grace and no-phase-start are no-ops.

Closes #748
