### PR TITLE
fix(listener): admit runs on real running-Job count, not launch ops (#749)

### DIFF
--- a/services/terrapod/runner/job_manager.py
+++ b/services/terrapod/runner/job_manager.py
@@ -313,9 +313,10 @@ async def count_active_runner_jobs(namespace: str = "") -> int:
     if not namespace:
         namespace = _default_namespace()
 
-    batch_api = _get_batch_api()
-
     try:
+        # Inside the try so a not-yet-initialised client also fails open —
+        # the whole helper is best-effort (see docstring), not just the list.
+        batch_api = _get_batch_api()
         loop = asyncio.get_event_loop()
         jobs = await loop.run_in_executor(
             _executor,

--- a/services/terrapod/runner/job_manager.py
+++ b/services/terrapod/runner/job_manager.py
@@ -287,6 +287,59 @@ async def get_job_status(job_name: str, namespace: str = "") -> str | None:
         raise
 
 
+async def count_active_runner_jobs(namespace: str = "") -> int:
+    """Count runner Jobs currently occupying capacity in the namespace — i.e.
+    non-terminal Jobs with at least one active (Pending or Running) pod (#749).
+
+    The listener admits runs up to `max_concurrent`, but its in-process
+    `_active_launches` counter only tracks launch *operations* (the brief
+    create window), not Jobs that are actually running. On a fixed-size
+    cluster that let the listener over-admit: it would keep claiming runs and
+    spawning Jobs that then sit Pending, unschedulable. Counting real Jobs
+    from K8s — the authoritative source — keeps the listener stateless and
+    makes admission reflect actual occupancy.
+
+    Selects by the runner component label (`app.kubernetes.io/component=runner`)
+    that every runner Job carries, scoped to `namespace`. Terminal Jobs
+    (succeeded/failed) are excluded — they no longer occupy a slot. A Job that
+    exists but has no active pod yet is covered by `_active_launches` on the
+    listener, so it is not double-counted here.
+
+    Best-effort: on any K8s API error returns 0 (fail-open). A transient list
+    error must not wedge the whole pool, and #748 is the backstop — if
+    fail-open lets a Job launch that can't be placed, the scheduler declares it
+    unschedulable and the reconciler fails it fast with a clear reason.
+    """
+    if not namespace:
+        namespace = _default_namespace()
+
+    batch_api = _get_batch_api()
+
+    try:
+        loop = asyncio.get_event_loop()
+        jobs = await loop.run_in_executor(
+            _executor,
+            lambda: batch_api.list_namespaced_job(
+                namespace=namespace,
+                label_selector="app.kubernetes.io/component=runner",
+            ),
+        )
+        batch_api.api_client.last_response = None
+
+        count = 0
+        for job in jobs.items:
+            st = job.status
+            if not st:
+                continue
+            if (st.succeeded and st.succeeded > 0) or (st.failed and st.failed > 0):
+                continue  # terminal — no longer occupies a slot
+            if st.active and st.active > 0:
+                count += 1
+        return count
+    except Exception:
+        return 0
+
+
 async def get_pod_terminated_info(
     job_name: str, namespace: str = ""
 ) -> dict[str, int | str] | None:

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -71,6 +71,10 @@ class RunnerListener:
         self._identity_ready = False
         self._last_heartbeat_at: float | None = None
         self._active_launches = 0  # count of concurrent launch operations
+        # Real running-Job count from K8s, refreshed each heartbeat (#749).
+        # `_active_launches` only covers the create window; this is the honest
+        # occupancy operators see in the pool/listener status and metrics.
+        self._active_runs_observed = 0
 
         # Track background tasks to prevent GC accumulation (Finding 1: memory leak)
         self._background_tasks: set[asyncio.Task] = set()
@@ -329,7 +333,7 @@ class RunnerListener:
         """Generate Prometheus metrics for the listener."""
         from prometheus_client import generate_latest
 
-        self._metric_active_runs.set(self._active_launches)
+        self._metric_active_runs.set(self._active_runs_observed)
         self._metric_identity_ready.set(1 if self._identity_ready else 0)
 
         if self._last_heartbeat_at is not None:
@@ -371,6 +375,16 @@ class RunnerListener:
         name — but is not guaranteed by every CRI, so non-Helm operators
         running this listener should set POD_NAME explicitly.
         """
+        # Report the real running-Job count from K8s, not the launch counter,
+        # so the pool/listener status operators see reflects actual occupancy
+        # (#749). Best-effort — a K8s blip returns 0 and the value self-heals
+        # on the next heartbeat.
+        from terrapod.runner.job_manager import count_active_runner_jobs
+
+        self._active_runs_observed = await count_active_runner_jobs(
+            self.runner_config.runner_namespace
+        )
+
         await arequest_with_retry(
             self._http_client,
             "POST",
@@ -378,7 +392,7 @@ class RunnerListener:
             idempotent=True,  # idempotent presence upsert — safe to retry on timeout/5xx
             json={
                 "capacity": self._max_concurrent,
-                "active_runs": self._active_launches,
+                "active_runs": self._active_runs_observed,
                 "pod_name": os.environ.get("POD_NAME") or os.environ.get("HOSTNAME") or "",
             },
             headers=self._auth_headers(),
@@ -582,7 +596,27 @@ class RunnerListener:
 
     async def _handle_run_available(self) -> None:
         """Claim a run, launch a Job, report back — done."""
+        # Fast local guard — never exceed max_concurrent from launch ops alone.
         if self._active_launches >= self._max_concurrent:
+            return
+
+        # Capacity-aware admission (#749): `_active_launches` only tracks the
+        # brief create window, not Jobs already running. On a fixed-size
+        # cluster that let the listener over-admit and pile up Pending,
+        # unschedulable Jobs. Gate on the real running-Job count from K8s
+        # (authoritative — keeps the listener stateless) plus in-flight
+        # launches. Best-effort: a K8s blip returns 0, and #748 (unschedulable
+        # detection) is the backstop that fails an unplaceable Job fast.
+        from terrapod.runner.job_manager import count_active_runner_jobs
+
+        active_jobs = await count_active_runner_jobs(self.runner_config.runner_namespace)
+        if self._active_launches + active_jobs >= self._max_concurrent:
+            logger.debug(
+                "At capacity — deferring run claim",
+                active_jobs=active_jobs,
+                active_launches=self._active_launches,
+                max_concurrent=self._max_concurrent,
+            )
             return
 
         response = await arequest_with_retry(

--- a/services/tests/runner/test_job_manager.py
+++ b/services/tests/runner/test_job_manager.py
@@ -253,3 +253,13 @@ class TestCountActiveRunnerJobs:
 
         mock_batch.return_value.list_namespaced_job.side_effect = ApiException(status=500)
         assert await count_active_runner_jobs() == 0
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_uninitialised_client_fails_open_to_zero(self, _ns, mock_batch):
+        # A not-yet-initialised K8s client (e.g. init_k8s never ran) must fail
+        # open too — the client acquisition is inside the guarded block.
+        from terrapod.runner.job_manager import count_active_runner_jobs
+
+        mock_batch.side_effect = RuntimeError("k8s config not loaded")
+        assert await count_active_runner_jobs() == 0

--- a/services/tests/runner/test_job_manager.py
+++ b/services/tests/runner/test_job_manager.py
@@ -202,3 +202,54 @@ class TestUnschedulableDetection:
 
         assert await get_job_status("tprun-x-plan") == "succeeded"
         mock_core.return_value.list_namespaced_pod.assert_not_called()
+
+
+class TestCountActiveRunnerJobs:
+    """#749 — the listener admits runs on real running-Job occupancy, not the
+    near-instant launch counter. count_active_runner_jobs counts non-terminal
+    Jobs with an active pod; terminal Jobs don't occupy a slot; K8s errors
+    fail open (return 0, #748 is the backstop)."""
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_counts_only_active_non_terminal(self, _ns, mock_batch):
+        from terrapod.runner.job_manager import count_active_runner_jobs
+
+        mock_batch.return_value.list_namespaced_job.return_value = SimpleNamespace(
+            items=[
+                _job(active=1),  # running/pending — counts
+                _job(active=1),  # counts
+                _job(succeeded=1, active=0),  # terminal — excluded
+                _job(failed=1),  # terminal — excluded
+                _job(active=None),  # created, no pod yet — not counted here
+            ]
+        )
+        assert await count_active_runner_jobs() == 2
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_selects_by_runner_component_label_in_namespace(self, _ns, mock_batch):
+        from terrapod.runner.job_manager import count_active_runner_jobs
+
+        mock_batch.return_value.list_namespaced_job.return_value = SimpleNamespace(items=[])
+        await count_active_runner_jobs("runners-ns")
+        mock_batch.return_value.list_namespaced_job.assert_called_once_with(
+            namespace="runners-ns",
+            label_selector="app.kubernetes.io/component=runner",
+        )
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_empty_is_zero(self, _ns, mock_batch):
+        from terrapod.runner.job_manager import count_active_runner_jobs
+
+        mock_batch.return_value.list_namespaced_job.return_value = SimpleNamespace(items=[])
+        assert await count_active_runner_jobs() == 0
+
+    @patch("terrapod.runner.job_manager._get_batch_api")
+    @patch("terrapod.runner.job_manager._default_namespace", return_value="terrapod")
+    async def test_k8s_error_fails_open_to_zero(self, _ns, mock_batch):
+        from terrapod.runner.job_manager import count_active_runner_jobs
+
+        mock_batch.return_value.list_namespaced_job.side_effect = ApiException(status=500)
+        assert await count_active_runner_jobs() == 0

--- a/services/tests/runner/test_listener_admission.py
+++ b/services/tests/runner/test_listener_admission.py
@@ -1,0 +1,109 @@
+"""Capacity-aware admission tests for the listener (#749).
+
+The listener must gate run claims on the *real* running-Job count from K8s
+(``count_active_runner_jobs``) plus in-flight launches, not just its
+in-process ``_active_launches`` counter — which only tracks the brief Job
+create window and let the listener over-admit onto a fixed-size cluster,
+piling up Pending/unschedulable Jobs.
+
+These build a listener with a mock-transport client and assert whether the
+``GET .../runs/next`` claim is issued for a given occupancy.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from terrapod.runner.listener import RunnerListener
+
+
+def _make_listener(client: httpx.AsyncClient) -> RunnerListener:
+    listener = RunnerListener()
+    listener._http_client = client
+    listener.identity = SimpleNamespace(
+        listener_id="11111111-1111-1111-1111-111111111111",
+        name="listener",
+        api_url="http://test",
+        certificate_pem="",
+    )
+    return listener
+
+
+def _counting_client(calls: dict) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/runs/next"):
+            calls["next"] += 1
+            return httpx.Response(204)  # no runs — stop cleanly
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    return httpx.AsyncClient(base_url="http://test", transport=transport)
+
+
+@pytest.mark.asyncio
+async def test_at_capacity_by_real_jobs_does_not_claim():
+    """max_concurrent running Jobs → no claim even though _active_launches is 0."""
+    calls = {"next": 0}
+    async with _counting_client(calls) as client:
+        listener = _make_listener(client)
+        listener._max_concurrent = 2
+        listener._active_launches = 0
+        with patch(
+            "terrapod.runner.job_manager.count_active_runner_jobs",
+            AsyncMock(return_value=2),
+        ):
+            await listener._handle_run_available()
+    assert calls["next"] == 0  # gated on real occupancy
+
+
+@pytest.mark.asyncio
+async def test_free_capacity_claims():
+    """Below capacity → the listener issues the claim GET."""
+    calls = {"next": 0}
+    async with _counting_client(calls) as client:
+        listener = _make_listener(client)
+        listener._max_concurrent = 2
+        listener._active_launches = 0
+        with patch(
+            "terrapod.runner.job_manager.count_active_runner_jobs",
+            AsyncMock(return_value=1),
+        ):
+            await listener._handle_run_available()
+    assert calls["next"] == 1
+
+
+@pytest.mark.asyncio
+async def test_launches_plus_jobs_sum_to_capacity_blocks():
+    """In-flight launches + running Jobs together reaching the cap blocks a claim
+    (the create window is counted so a Job mid-launch isn't double-admitted)."""
+    calls = {"next": 0}
+    async with _counting_client(calls) as client:
+        listener = _make_listener(client)
+        listener._max_concurrent = 3
+        listener._active_launches = 1
+        with patch(
+            "terrapod.runner.job_manager.count_active_runner_jobs",
+            AsyncMock(return_value=2),
+        ):
+            await listener._handle_run_available()
+    assert calls["next"] == 0
+
+
+@pytest.mark.asyncio
+async def test_launch_counter_alone_at_cap_skips_k8s_call():
+    """The fast local guard short-circuits before the K8s list when launches
+    alone already saturate the listener."""
+    calls = {"next": 0}
+    async with _counting_client(calls) as client:
+        listener = _make_listener(client)
+        listener._max_concurrent = 1
+        listener._active_launches = 1
+        with patch(
+            "terrapod.runner.job_manager.count_active_runner_jobs",
+            AsyncMock(return_value=0),
+        ) as mock_count:
+            await listener._handle_run_available()
+    assert calls["next"] == 0
+    mock_count.assert_not_called()


### PR DESCRIPTION
Closes #749 (Part 1 — the higher-value fix; Part 2 deferred, see below).

## Problem

`_handle_run_available` gated on `_active_launches >= max_concurrent`, but `_active_launches` only tracks the brief Job *create* window: ARC is fire-and-forget, so `_launch_run` returns as soon as the Job + Secrets are created and `job-launched` is POSTed. That counter is ~0 almost always, so `max_concurrent` barely bounded the number of Jobs *actually running*. On a fixed-size cluster the listener kept claiming runs and spawning Jobs that then sat Pending/unschedulable. `active_runs`/`capacity` in the heartbeat were near-meaningless as a live-load signal.

## Fix

Gate admission on the **authoritative running-Job count from K8s** plus in-flight launches — the listener stays stateless (K8s is the source of truth):

- **`job_manager.count_active_runner_jobs(namespace)`** — lists Jobs by the runner component label (`app.kubernetes.io/component=runner`) and counts non-terminal Jobs with an active pod. Best-effort: a K8s blip returns `0`, and **#748 (unschedulable detection) is the backstop** that fails an unplaceable Job fast, so fail-open is safe and self-correcting.
- **`_handle_run_available`** — keeps the cheap `_active_launches` pre-check (avoids a K8s list when launches alone already saturate), then gates on `_active_launches + active_jobs >= max_concurrent` before claiming.
- **Heartbeat + Prometheus gauge** — now report the real running-Job count as `active_runs`, so pool/listener status reflects actual occupancy.

## Semantics worth a reviewer's eye

- **Namespace-scoped count.** The issue assumed a per-pool/listener Job label exists — it doesn't (runner Jobs carry only `component=runner`, `name`, `run-id`, `phase`). So the count is namespace-scoped. The standard topology is **one listener pool per runner namespace**, where namespace-scoped == pool-scoped; multiple pools sharing a namespace get a *conservative* (safe) shared cap. Per-pool scoping would need a new Job label — deferred.
- **Multi-replica change (per-pod → per-namespace).** Every replica of a pool now sees the same namespace total and gates consistently, replacing the old per-pod `_active_launches` view. This is more correct, not less.
- **Part 2 deferred.** Node-allocatable / ResourceQuota schedulability pre-check (#749 part 2) is the larger follow-up; a ResourceQuota on the runner namespace is the lighter operational guardrail in the meantime.

## RBAC

No new verbs — `jobs: list` is already granted in `helm/terrapod/templates/rbac-listener.yaml` (verified).

## Tests

- `tests/runner/test_job_manager.py::TestCountActiveRunnerJobs` — counts only active non-terminal Jobs, excludes terminal, selects by component label in the given namespace, empty→0, K8s error fails open to 0.
- `tests/runner/test_listener_admission.py` — at-capacity-by-real-Jobs doesn't claim; free capacity claims; launches+jobs summing to cap blocks; launch-counter-alone at cap short-circuits before the K8s call.

`make lint` + runner test shard green in Docker.