### PR TITLE
feat(runs): drain freed listener slots + per-pool queued-runs gauge (#750)

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -196,6 +196,7 @@ These metrics are emitted by the **API server**, since it receives all heartbeat
 |---|---|---|---|
 | `terrapod_listener_heartbeats_total` | Counter | pool_id | Heartbeats received from listeners |
 | `terrapod_listener_joins_total` | Counter | pool_name | Listener join events |
+| `terrapod_pool_queued_runs` | Gauge | pool_id | Runs waiting for a listener slot per pool (backlog depth). Refreshed each reconciler cycle (~10s); reads 0 for an idle pool. A sustained non-zero value means the pool needs more listener capacity |
 
 ### Listeners (Self-Reported)
 

--- a/services/terrapod/api/metrics.py
+++ b/services/terrapod/api/metrics.py
@@ -10,7 +10,13 @@ instrumentation points (1-2 lines each).
 import time
 
 from fastapi import Request, Response
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
 
 # ---------------------------------------------------------------------------
 # HTTP request metrics
@@ -250,6 +256,18 @@ LISTENER_PRELAUNCH_TIMEOUTS = Counter(
         "manage to PATCH the failure (its cert was rejected, or it crashed). "
         "Backstop signal for silent listener failures."
     ),
+)
+
+POOL_QUEUED_RUNS = Gauge(
+    "terrapod_pool_queued_runs",
+    (
+        "Runs currently in `queued` state per agent pool — the backlog waiting "
+        "for a listener slot. Refreshed each reconciler cycle (~10s) with a "
+        "single grouped COUNT. An operator watches this to see 'N runs waiting "
+        "on pool X' and decide whether the pool needs more listener capacity "
+        "(#750)."
+    ),
+    ["pool_id"],
 )
 
 

--- a/services/terrapod/runner/listener.py
+++ b/services/terrapod/runner/listener.py
@@ -595,51 +595,63 @@ class RunnerListener:
     # ── Event Handlers ───────────────────────────────────────────────
 
     async def _handle_run_available(self) -> None:
-        """Claim a run, launch a Job, report back — done."""
-        # Fast local guard — never exceed max_concurrent from launch ops alone.
-        if self._active_launches >= self._max_concurrent:
-            return
+        """Claim and launch queued runs up to capacity, then stop.
 
-        # Capacity-aware admission (#749): `_active_launches` only tracks the
-        # brief create window, not Jobs already running. On a fixed-size
-        # cluster that let the listener over-admit and pile up Pending,
-        # unschedulable Jobs. Gate on the real running-Job count from K8s
-        # (authoritative — keeps the listener stateless) plus in-flight
-        # launches. Best-effort: a K8s blip returns 0, and #748 (unschedulable
-        # detection) is the backstop that fails an unplaceable Job fast.
+        Keeps claiming until the pool has no more queued runs (204) or the
+        listener is at capacity, so a backlog drains as fast as slots free
+        (#750) instead of one run per 30s poll — the API nudges the pool with a
+        fresh `run_available` on every terminal transition, and this loop
+        drains everything that fits in one pass. Each iteration re-checks real
+        capacity (#749), so a single event never over-admits onto a fixed
+        cluster.
+        """
         from terrapod.runner.job_manager import count_active_runner_jobs
 
-        active_jobs = await count_active_runner_jobs(self.runner_config.runner_namespace)
-        if self._active_launches + active_jobs >= self._max_concurrent:
-            logger.debug(
-                "At capacity — deferring run claim",
-                active_jobs=active_jobs,
-                active_launches=self._active_launches,
-                max_concurrent=self._max_concurrent,
+        launched = 0
+        while True:
+            # Fast local guard — never exceed max_concurrent from launch ops
+            # alone (also bounds this loop even if K8s counting fails open).
+            if self._active_launches >= self._max_concurrent:
+                return
+
+            # Capacity-aware admission (#749): gate on the real running-Job
+            # count from K8s (authoritative — keeps the listener stateless) plus
+            # in-flight launches plus Jobs already launched *this* pass. The K8s
+            # count lags a just-created Job (its pod isn't active yet), so
+            # `launched` prevents a single drain pass from over-admitting.
+            active_jobs = await count_active_runner_jobs(self.runner_config.runner_namespace)
+            if self._active_launches + active_jobs + launched >= self._max_concurrent:
+                if launched == 0:
+                    logger.debug(
+                        "At capacity — deferring run claim",
+                        active_jobs=active_jobs,
+                        active_launches=self._active_launches,
+                        max_concurrent=self._max_concurrent,
+                    )
+                return
+
+            response = await arequest_with_retry(
+                self._http_client,
+                "GET",
+                f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}/runs/next",
+                headers=self._auth_headers(),
             )
-            return
 
-        response = await arequest_with_retry(
-            self._http_client,
-            "GET",
-            f"/api/terrapod/v1/listeners/listener-{self.identity.listener_id}/runs/next",
-            headers=self._auth_headers(),
-        )
+            if response.status_code == 204:
+                return  # No more queued runs for this pool
+            response.raise_for_status()
 
-        if response.status_code == 204:
-            return  # No runs available (another listener claimed it)
-        response.raise_for_status()
+            data = response.json()["data"]
+            run_id = data["id"].removeprefix("run-")
+            attrs = data.get("attributes", {})
 
-        data = response.json()["data"]
-        run_id = data["id"].removeprefix("run-")
-        attrs = data.get("attributes", {})
-
-        # Launch the Job in the background (fire-and-forget)
-        self._active_launches += 1
-        try:
-            await self._launch_run(run_id, attrs)
-        finally:
-            self._active_launches -= 1
+            # Launch the Job in the background (fire-and-forget)
+            self._active_launches += 1
+            try:
+                await self._launch_run(run_id, attrs)
+            finally:
+                self._active_launches -= 1
+            launched += 1
 
     async def _launch_run(self, run_id: str, attrs: dict) -> None:
         """Build and launch a K8s Job for a claimed run, then report back.

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -14,7 +14,7 @@ Registered as a periodic task (2s interval) in app.py.
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.config import load_runner_config
@@ -67,6 +67,38 @@ async def _persist_live_log_if_missing(run: Run, phase: str) -> None:
         logger.warning("Failed to persist live log", run_id=run_id, error=str(e))
 
 
+async def _refresh_pool_queue_depth(db: AsyncSession) -> None:
+    """Publish the per-pool `queued` backlog as a Prometheus gauge (#750).
+
+    One grouped COUNT per reconciler cycle (~10s). Every existing pool is given
+    an explicit value (0 when idle) so the series is stable — a pool that drains
+    to empty reads as 0, not absent. Queued runs on a since-deleted pool are
+    still surfaced (they are a real backlog). Best-effort: never raises into the
+    reconcile cycle.
+    """
+    from terrapod.api.metrics import POOL_QUEUED_RUNS
+    from terrapod.db.models import AgentPool
+
+    try:
+        counts_result = await db.execute(
+            select(Run.pool_id, func.count())
+            .where(Run.status == "queued", Run.pool_id.isnot(None))
+            .group_by(Run.pool_id)
+        )
+        counts = {row[0]: row[1] for row in counts_result.all()}
+
+        pool_ids_result = await db.execute(select(AgentPool.id))
+        pool_ids = {row[0] for row in pool_ids_result.all()}
+
+        # Clear + re-set so pools that drained to 0 (or were deleted) don't keep
+        # a stale non-zero value from a prior cycle.
+        POOL_QUEUED_RUNS.clear()
+        for pid in pool_ids | set(counts):
+            POOL_QUEUED_RUNS.labels(pool_id=str(pid)).set(counts.get(pid, 0))
+    except Exception as e:
+        logger.debug("Failed to refresh pool queue-depth gauge", error=str(e))
+
+
 async def reconcile_runs() -> None:
     """Drive run state transitions based on Job outcomes.
 
@@ -81,6 +113,11 @@ async def reconcile_runs() -> None:
        this cohort so failures surface in minutes, not hours.
     """
     async with get_db_session() as db:
+        # Refresh the per-pool queued-backlog gauge first — queued runs exist
+        # independently of in-flight ones, so this must run before the early
+        # return below (#750).
+        await _refresh_pool_queue_depth(db)
+
         # `canceling` joins planning/applying here: it's the intermediate
         # state entered when a user cancels an in-flight apply. The
         # reconciler waits for the listener's Job-status report (the

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -704,6 +704,14 @@ async def transition_run(
     # Notify listeners when a run becomes claimable
     if target_status in ("queued", "confirmed") and run.pool_id:
         await _publish_run_available(run)
+    # A freed slot: when a run reaches a terminal state it releases the runner
+    # capacity it held, so nudge its pool to re-drive any backlog immediately
+    # rather than waiting for the listener's ~30s poll fallback (#750). The
+    # listener drains everything that now fits in one pass; a spurious nudge on
+    # an idle pool just yields a 204, so this is safe to fire unconditionally on
+    # terminal transitions.
+    elif target_status in TERMINAL_STATES and run.pool_id:
+        await _publish_run_available(run)
 
     # Auto-discard superseded runs. When a full run becomes claimable
     # (`queued`), discard older un-applied full runs on the same workspace

--- a/services/tests/runner/test_listener_admission.py
+++ b/services/tests/runner/test_listener_admission.py
@@ -107,3 +107,72 @@ async def test_launch_counter_alone_at_cap_skips_k8s_call():
             await listener._handle_run_available()
     assert calls["next"] == 0
     mock_count.assert_not_called()
+
+
+def _run_claim(n: int) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "data": {
+                "id": f"run-{n:08d}-0000-0000-0000-000000000000",
+                "attributes": {"phase": "plan"},
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_drains_backlog_in_one_pass_up_to_capacity():
+    """A backlog drains in a single _handle_run_available pass, bounded by
+    max_concurrent — even if the queue never empties (#750/#749). The
+    `launched`-this-pass counter is what stops it (K8s count lags the just-
+    created Jobs)."""
+    launches = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/runs/next"):
+            launches["n"] += 1
+            return _run_claim(launches["n"])  # queue never empties
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(base_url="http://test", transport=transport) as client:
+        listener = _make_listener(client)
+        listener._max_concurrent = 3
+        listener._active_launches = 0
+        listener._launch_run = AsyncMock()
+        with patch(
+            "terrapod.runner.job_manager.count_active_runner_jobs",
+            AsyncMock(return_value=0),
+        ):
+            await listener._handle_run_available()
+
+    assert listener._launch_run.await_count == 3  # capped at max_concurrent
+
+
+@pytest.mark.asyncio
+async def test_drain_stops_on_empty_queue_before_capacity():
+    """The loop stops as soon as the pool returns 204, even below capacity."""
+    responses = [_run_claim(1), _run_claim(2), httpx.Response(204)]
+    idx = {"i": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/runs/next"):
+            r = responses[idx["i"]]
+            idx["i"] += 1
+            return r
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(base_url="http://test", transport=transport) as client:
+        listener = _make_listener(client)
+        listener._max_concurrent = 5
+        listener._active_launches = 0
+        listener._launch_run = AsyncMock()
+        with patch(
+            "terrapod.runner.job_manager.count_active_runner_jobs",
+            AsyncMock(return_value=0),
+        ):
+            await listener._handle_run_available()
+
+    assert listener._launch_run.await_count == 2  # drained the 2 queued, then 204

--- a/services/tests/services/test_listener.py
+++ b/services/tests/services/test_listener.py
@@ -129,7 +129,8 @@ class TestHandleRunAvailable:
         mock_client.get.assert_called_once()
 
     async def test_claims_and_launches_run(self, fresh_shutdown_event):
-        """Successful claim triggers _launch_run."""
+        """Successful claim triggers _launch_run, then the drain loop stops on
+        the next 204 (no more queued runs)."""
         listener = _make_listener(fresh_shutdown_event)
 
         run_data = {
@@ -138,19 +139,27 @@ class TestHandleRunAvailable:
                 "attributes": {"phase": "plan"},
             }
         }
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = run_data
-        mock_response.raise_for_status = MagicMock()
+        claimed = MagicMock()
+        claimed.status_code = 200
+        claimed.json.return_value = run_data
+        claimed.raise_for_status = MagicMock()
+        empty = MagicMock()
+        empty.status_code = 204
 
         mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
+        # One run, then the queue is empty — the loop drains and stops (#750).
+        mock_client.get.side_effect = [claimed, empty]
         listener._http_client = mock_client
 
         listener._launch_run = AsyncMock()
-        await listener._handle_run_available()
+        with patch(
+            "terrapod.runner.job_manager.count_active_runner_jobs",
+            AsyncMock(return_value=0),
+        ):
+            await listener._handle_run_available()
 
         listener._launch_run.assert_called_once()
+        assert mock_client.get.call_count == 2  # claim, then 204
         assert listener._active_launches == 0  # Decremented after launch
 
 

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -13,6 +13,7 @@ from terrapod.services.run_reconciler import (
     _handle_failed,
     _handle_succeeded,
     _reconcile_one,
+    _refresh_pool_queue_depth,
 )
 
 
@@ -810,3 +811,48 @@ class TestUnschedulable:
         await _check_unschedulable(db, run)
 
         mock_handle.assert_not_called()
+
+
+class TestPoolQueueDepth:
+    """#750 — per-pool queued-runs gauge refreshed each reconciler cycle."""
+
+    async def test_sets_gauge_per_pool_with_explicit_zero(self):
+        from terrapod.api.metrics import POOL_QUEUED_RUNS
+
+        p1 = uuid.uuid4()  # 3 queued
+        p2 = uuid.uuid4()  # idle → explicit 0, not absent
+
+        counts_result = MagicMock()
+        counts_result.all.return_value = [(p1, 3)]
+        pools_result = MagicMock()
+        pools_result.all.return_value = [(p1,), (p2,)]
+
+        db = AsyncMock()
+        db.execute.side_effect = [counts_result, pools_result]
+
+        await _refresh_pool_queue_depth(db)
+
+        assert POOL_QUEUED_RUNS.labels(pool_id=str(p1))._value.get() == 3
+        assert POOL_QUEUED_RUNS.labels(pool_id=str(p2))._value.get() == 0
+
+    async def test_queued_on_deleted_pool_still_surfaced(self):
+        from terrapod.api.metrics import POOL_QUEUED_RUNS
+
+        p3 = uuid.uuid4()  # has queued runs but the pool row is gone
+        counts_result = MagicMock()
+        counts_result.all.return_value = [(p3, 2)]
+        pools_result = MagicMock()
+        pools_result.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.side_effect = [counts_result, pools_result]
+
+        await _refresh_pool_queue_depth(db)
+
+        assert POOL_QUEUED_RUNS.labels(pool_id=str(p3))._value.get() == 2
+
+    async def test_db_error_fails_open(self):
+        db = AsyncMock()
+        db.execute.side_effect = RuntimeError("db down")
+        # Must not raise into the reconcile cycle.
+        await _refresh_pool_queue_depth(db)

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -354,6 +354,36 @@ class TestTransitionRun:
         assert run.apply_finished_at is not None
 
 
+class TestTerminalTransitionNudge:
+    """#750 — a run reaching a terminal state frees runner capacity, so its
+    pool is nudged with a fresh run_available to re-drive any backlog."""
+
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    async def test_terminal_transition_nudges_pool(self, mock_pub):
+        db = AsyncMock(spec=AsyncSession)
+        run = _mock_run(status="planning")
+        run.pool_id = uuid.uuid4()
+        await transition_run(db, run, "errored")
+        mock_pub.assert_awaited_once_with(run)
+
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    async def test_terminal_transition_without_pool_does_not_nudge(self, mock_pub):
+        db = AsyncMock(spec=AsyncSession)
+        run = _mock_run(status="planning")
+        run.pool_id = None
+        await transition_run(db, run, "errored")
+        mock_pub.assert_not_awaited()
+
+    @patch("terrapod.services.run_service._publish_run_available", new_callable=AsyncMock)
+    async def test_non_terminal_transition_does_not_nudge(self, mock_pub):
+        db = AsyncMock(spec=AsyncSession)
+        run = _mock_run(status="queued")
+        run.pool_id = uuid.uuid4()
+        # queued → planning is neither claimable (queued/confirmed) nor terminal
+        await transition_run(db, run, "planning")
+        mock_pub.assert_not_awaited()
+
+
 # ── create_run ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #750. Split from #738 (fixed-resource resilience audit). Two at-capacity gaps in the run queue.

## 1. Freed slots weren't re-driven

A terminal run transition didn't re-publish `run_available` (only `queued`/`confirmed` did), and `_handle_run_available` claimed exactly one run per event — so under backlog a freed slot was only picked up by the ~30s poll fallback, draining at roughly one run / 30s / listener.

- **API nudge** — `transition_run` now publishes a `run_available` to the run's pool on **every terminal transition** (`applied`/`errored`/`discarded`/`canceled`) — a freed slot. A spurious nudge on an idle pool just yields a 204, so it fires unconditionally on terminal.
- **Listener drain loop** — `_handle_run_available` keeps claiming until the pool returns 204 or the listener hits capacity, so one nudge drains everything that now fits. Each iteration re-checks the real running-Job count (#749) **plus Jobs launched this pass** — the K8s count lags a just-created Job (its pod isn't active yet), so the per-pass counter is what prevents a single drain from over-admitting onto a fixed cluster.

## 2. Queue depth wasn't observable

Added **`terrapod_pool_queued_runs{pool_id}`** — refreshed each reconciler cycle (~10s) with one grouped `COUNT(*) WHERE status='queued'`. Every existing pool gets an **explicit value (0 when idle, not absent)** so dashboards read a stable series; queued runs on a since-deleted pool are still surfaced (real backlog). Best-effort — never raises into the reconcile cycle. Runs before the reconciler's early return (queued runs exist independently of in-flight ones). Documented in `docs/monitoring.md`.

## Tests

- `test_listener_admission.py` — drain bounded by `max_concurrent` even when the queue never empties; drain stops on 204 below capacity. (#749 admission tests still hold.)
- `test_listener.py` — updated the pre-existing claim test for the drain-loop (claim, then 204).
- `test_run_service.py::TestTerminalTransitionNudge` — nudge fires on terminal with a pool, not without a pool, not on a non-terminal transition.
- `test_run_reconciler.py::TestPoolQueueDepth` — gauge per pool with explicit 0 for idle, deleted-pool backlog surfaced, DB-error fails open.

`make lint` + the affected shards green in Docker.

## Notes for review

- The nudge fires on **all** terminal transitions (incl. plan-only / drift / speculative). That's intentional — it's a cheap pub/sub nudge and the listener no-ops (204) when there's no backlog; scoping it to apply-capable runs would miss slots freed by a canceled plan.
- Part 2 of #749 (node-allocatable schedulability pre-check) stays a separate follow-up; a ResourceQuota on the runner namespace is the lighter operational guardrail meanwhile.