### PR TITLE
feat(helm): optional control-plane PriorityClass + fix Burstable-QoS comment (#751)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,6 +658,29 @@ jobs:
               --set redis.url=redis://redis:6379)
           echo "$stock" | grep -A1 "encryption:" | grep -q "enabled: true" && { echo "FAIL: encryption enabled by default"; exit 1; }
           echo "encryption-at-rest config + secret wiring OK and off by default (#553)"
+      - name: Control-plane PriorityClasses render and are off by default (#751)
+        run: |
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+              --set priorityClasses.create=true)
+          echo "$out" | grep -q "kind: PriorityClass" || { echo "FAIL: PriorityClass not rendered when create=true"; exit 1; }
+          echo "$out" | grep -q "name: terrapod-control-plane" || { echo "FAIL: control-plane PriorityClass missing"; exit 1; }
+          echo "$out" | grep -q "name: terrapod-runner" || { echo "FAIL: runner PriorityClass missing"; exit 1; }
+          # api/listener/web default their priorityClassName to the control-plane class.
+          n=$(echo "$out" | grep -c 'priorityClassName: "terrapod-control-plane"')
+          [ "$n" -eq 3 ] || { echo "FAIL: expected 3 control-plane priorityClassName (got $n)"; exit 1; }
+          # runner config carries the runner class (config-channel contract).
+          echo "$out" | grep -q 'priority_class_name: "terrapod-runner"' || { echo "FAIL: runner priority_class_name not rendered"; exit 1; }
+          # Off by default — no PriorityClass object, no priorityClassName default.
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            template terrapod helm/terrapod \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379)
+          echo "$stock" | grep -q "kind: PriorityClass" && { echo "FAIL: PriorityClass rendered by default (should be opt-in)"; exit 1; }
+          echo "$stock" | grep -q "priorityClassName:" && { echo "FAIL: priorityClassName set by default"; exit 1; }
+          echo "control-plane PriorityClasses render OK and are off by default (#751)"
 
   # ── Config-channel contract (#617) ────────────────────
   # Renders the chart (every values profile) and parses the rendered ConfigMaps

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -76,6 +76,7 @@ A step-by-step checklist for preparing a Terrapod instance for production use. E
 - [ ] **HPA is configured for the API** -- Recommended: min 2, max 10 replicas targeting 70% CPU. See [Deployment: Scaling](deployment.md#scaling-considerations).
 - [ ] **Database connection pool is sized correctly** -- Total max connections = `(pool_size + max_overflow) x replicas`. Verify this does not exceed the database's `max_connections`. See [Deployment: Connection Pooling](deployment.md#connection-pool-tuning).
 - [ ] **Pod anti-affinity spreads replicas across nodes** -- Prevent all API replicas from landing on the same node. The Helm chart supports `affinity` configuration for API, web, and listener Deployments.
+- [ ] **Control-plane PriorityClasses are enabled on fixed-size node pools** -- Set `priorityClasses.create=true` to create a higher-priority class for the control plane (api/listener/web) and a lower one for runner Jobs, so under node pressure the kubelet reaps runners before the control plane. This is **off by default** (it creates cluster-scoped objects). PodDisruptionBudgets do **not** protect against node-pressure eviction -- only pod priority does. Strongly recommended when Terrapod runs on a fixed node pool it shares with runner Jobs. See [Deployment](deployment.md).
 
 ---
 

--- a/helm/terrapod/templates/_helpers.tpl
+++ b/helm/terrapod/templates/_helpers.tpl
@@ -534,3 +534,32 @@ roots. Same mount as the Node helper; named distinctly so the intent is clear.
   value: /etc/terrapod-ca-src/{{ include "terrapod.caBundle.key" . }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Resolved priorityClassName for a control-plane component (api/listener/web,
+#751). The component's own explicit value always wins; otherwise, when
+priorityClasses.create is true, fall back to the created control-plane class.
+Empty string (falsy) when neither applies. Call with:
+  (dict "explicit" .Values.api.priorityClassName "root" .)
+*/}}
+{{- define "terrapod.controlPlanePriorityClassName" -}}
+{{- if .explicit -}}
+{{- .explicit -}}
+{{- else if .root.Values.priorityClasses.create -}}
+{{- .root.Values.priorityClasses.controlPlane.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolved priority_class_name for runner Jobs (#751). runners.priorityClassName
+wins; otherwise, when priorityClasses.create AND the runner class is enabled,
+fall back to the created runner class. Empty (falsy) when neither applies.
+Call with the root context (.).
+*/}}
+{{- define "terrapod.runnerPriorityClassName" -}}
+{{- if .Values.runners.priorityClassName -}}
+{{- .Values.runners.priorityClassName -}}
+{{- else if and .Values.priorityClasses.create .Values.priorityClasses.runner.enabled -}}
+{{- .Values.priorityClasses.runner.name -}}
+{{- end -}}
+{{- end -}}

--- a/helm/terrapod/templates/configmap-runner.yaml
+++ b/helm/terrapod/templates/configmap-runner.yaml
@@ -69,8 +69,9 @@ data:
     pod_annotations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if .Values.runners.priorityClassName }}
-    priority_class_name: {{ .Values.runners.priorityClassName | quote }}
+    {{- $rpc := include "terrapod.runnerPriorityClassName" . }}
+    {{- if $rpc }}
+    priority_class_name: {{ $rpc | quote }}
     {{- end }}
     {{- with .Values.runners.topologySpreadConstraints }}
     topology_spread_constraints:

--- a/helm/terrapod/templates/deployment-api.yaml
+++ b/helm/terrapod/templates/deployment-api.yaml
@@ -280,8 +280,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- include "terrapod.podAntiAffinity" (dict "enabled" .Values.api.podAntiAffinity.enabled "affinity" .Values.api.affinity "labels" (include "terrapod.api.selectorLabels" .)) }}
-      {{- if .Values.api.priorityClassName }}
-      priorityClassName: {{ .Values.api.priorityClassName | quote }}
+      {{- $pc := include "terrapod.controlPlanePriorityClassName" (dict "explicit" .Values.api.priorityClassName "root" .) }}
+      {{- if $pc }}
+      priorityClassName: {{ $pc | quote }}
       {{- end }}
       {{- with .Values.api.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/helm/terrapod/templates/deployment-listener.yaml
+++ b/helm/terrapod/templates/deployment-listener.yaml
@@ -155,8 +155,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- include "terrapod.podAntiAffinity" (dict "enabled" .Values.listener.podAntiAffinity.enabled "affinity" .Values.listener.affinity "labels" (include "terrapod.listener.selectorLabels" .)) }}
-      {{- if .Values.listener.priorityClassName }}
-      priorityClassName: {{ .Values.listener.priorityClassName | quote }}
+      {{- $pc := include "terrapod.controlPlanePriorityClassName" (dict "explicit" .Values.listener.priorityClassName "root" .) }}
+      {{- if $pc }}
+      priorityClassName: {{ $pc | quote }}
       {{- end }}
       {{- with .Values.listener.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/helm/terrapod/templates/deployment-web.yaml
+++ b/helm/terrapod/templates/deployment-web.yaml
@@ -138,8 +138,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- include "terrapod.podAntiAffinity" (dict "enabled" .Values.web.podAntiAffinity.enabled "affinity" .Values.web.affinity "labels" (include "terrapod.web.selectorLabels" .)) }}
-      {{- if .Values.web.priorityClassName }}
-      priorityClassName: {{ .Values.web.priorityClassName | quote }}
+      {{- $pc := include "terrapod.controlPlanePriorityClassName" (dict "explicit" .Values.web.priorityClassName "root" .) }}
+      {{- if $pc }}
+      priorityClassName: {{ $pc | quote }}
       {{- end }}
       {{- with .Values.web.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/helm/terrapod/templates/priorityclass.yaml
+++ b/helm/terrapod/templates/priorityclass.yaml
@@ -1,0 +1,30 @@
+{{- /*
+Optional control-plane priority protection (#751). Cluster-scoped, so OFF by
+default — only rendered when priorityClasses.create is true. Values stay well
+below the reserved system classes (system-cluster-critical = 2000000000). The
+Deployments/runner config default their priorityClassName to these names when
+create is true and the component's own priorityClassName is unset.
+*/ -}}
+{{- if .Values.priorityClasses.create }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClasses.controlPlane.name }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+value: {{ .Values.priorityClasses.controlPlane.value | int }}
+globalDefault: false
+description: "Terrapod control plane (API, listener, web) — protected from node-pressure eviction ahead of runner Jobs and lower-priority workloads."
+{{- if .Values.priorityClasses.runner.enabled }}
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClasses.runner.name }}
+  labels:
+    {{- include "terrapod.labels" . | nindent 4 }}
+value: {{ .Values.priorityClasses.runner.value | int }}
+globalDefault: false
+description: "Terrapod runner Jobs — lower priority than the control plane, so runners are reaped first under node pressure."
+{{- end }}
+{{- end }}

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -415,6 +415,31 @@
       }
     },
 
+    "priorityClasses": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "controlPlane": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "value": { "type": "integer", "minimum": 0, "maximum": 1000000000 }
+          }
+        },
+        "runner": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "name": { "type": "string" },
+            "value": { "type": "integer", "minimum": 0, "maximum": 1000000000 }
+          }
+        }
+      }
+    },
+
     "namespace": {
       "type": "object",
       "additionalProperties": false,

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -71,9 +71,14 @@ api:
     annotations: {}
 
   resources:
-    # Request/limit ratios deliberately tight: CPU ≤ 2× request,
-    # memory = request (Guaranteed QoS). Wide bands cause noisy-neighbour
-    # evictions on memory and unpredictable throttling on CPU.
+    # Request/limit ratios deliberately tight: CPU ≤ 2× request, memory
+    # request == limit. This is **Burstable** QoS, not Guaranteed — Guaranteed
+    # requires requests == limits for BOTH cpu and memory, and the CPU request
+    # (500m) is intentionally below the limit (1) so the API can burst on spiky
+    # request load. Memory is pinned (request == limit) so it never bursts into
+    # noisy-neighbour OOM territory. Wide bands cause noisy-neighbour evictions
+    # on memory and unpredictable throttling on CPU. (To make the API Guaranteed
+    # instead, raise the CPU request to match the limit.)
     #
     # Memory raised from 1Gi after the parallel VCS poller (v0.17.2,
     # PR #233) started holding up to 10 concurrent per-workspace archive
@@ -1415,6 +1420,34 @@ storage:
 # Requires a CNI plugin that supports NetworkPolicy (Calico, Cilium, etc.).
 networkPolicies:
   enabled: false
+
+# ── Priority Classes ─────────────────────────────────────────────────────────
+# Optional control-plane priority protection. OFF by default — enabling creates
+# CLUSTER-SCOPED PriorityClass objects (they affect scheduling globally), so we
+# don't inject them silently. Recommended for FIXED-SIZE node pools where
+# node-pressure eviction would otherwise reap the control plane: PDBs do NOT
+# help there — the kubelet ignores PodDisruptionBudgets when evicting for node
+# pressure, and only pod priority decides who gets reaped first.
+#
+# When create=true the chart renders a higher-priority class for the control
+# plane (api, listener, web) and (optionally) a lower one for runner Jobs, and
+# defaults each component's priorityClassName to it — unless that component's
+# own api/listener/web.priorityClassName (or runners.priorityClassName) is set,
+# which always wins. Values stay well below the reserved system classes
+# (system-cluster-critical = 2000000000).
+priorityClasses:
+  create: false
+  # Higher-priority class for the control plane (api, listener, web).
+  controlPlane:
+    name: terrapod-control-plane
+    value: 1000000
+  # Lower-priority class for runner Jobs — so runners are evicted before the
+  # control plane under node pressure. Set enabled=false to skip it (runner
+  # Jobs then fall back to the cluster's global-default priority).
+  runner:
+    enabled: true
+    name: terrapod-runner
+    value: 100000
 
 # ── Namespace ───────────────────────────────────────────────────────────────
 # Optionally create the namespace with Pod Security Standards labels.


### PR DESCRIPTION
Closes #751. Split from #738 (fixed-resource resilience audit). Helm-only.

## Problem

`priorityClassName` was already a first-class value on the api/listener/web Deployments and runner Jobs, but the chart shipped **no PriorityClass object and no default** — a fresh install gave Terrapod's control plane no protection from node-pressure eviction. PDBs don't help here: the kubelet **ignores PodDisruptionBudgets on node-pressure eviction**; only pod priority decides who gets reaped first.

## 1. Optional control-plane PriorityClass (off by default)

New `priorityClasses.create` block (default `false` — it creates cluster-scoped objects, so never injected silently). When enabled:
- Renders a **higher-priority** PriorityClass for the control plane (api/listener/web) and a **lower** one for runner Jobs (`priorityClasses.runner.enabled`, default on) — so runners are reaped before the control plane under node pressure.
- **Defaults** each component's `priorityClassName` to the created class. A component's own explicit `priorityClassName` (or `runners.priorityClassName`) **always wins** — two `_helpers.tpl` resolvers keep the fallback DRY.
- Values (`1000000` / `100000`) stay well below the reserved system classes (`system-cluster-critical = 2000000000`).

Documented in the production checklist as strongly recommended for fixed-size node pools shared with runner Jobs.

## 2. Fix the wrong Guaranteed-QoS comment

`values.yaml` claimed the API pod is Guaranteed QoS — it's **Burstable** (CPU request `500m` < limit `1`; Guaranteed needs requests == limits for *both* cpu and memory). Corrected the comment and noted how to make it Guaranteed (raise the CPU request to the limit) if desired.

## Contract legs (config-channel / values↔schema)

- `values.yaml` block with rationale + `values.schema.json` constraint (`additionalProperties:false`, integer bounds).
- Template `templates/priorityclass.yaml` + defaulting wired into the 3 Deployments and `configmap-runner.yaml`.
- `helm-smoke` CI assertion: renders when `create=true` (2 PriorityClass objects, 3 control-plane `priorityClassName`, runner `priority_class_name`), absent by default.
- Verified: `helm lint` + `helm template` on `values.yaml` / `values-local.yaml` / `values-eval.yaml`; create=true wiring; explicit override wins; `runner.enabled=false` drops the runner class.