### PR TITLE
docs: fixed-resource sizing guidance + document listener.maxConcurrent (#752)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -425,6 +425,7 @@ Enable encryption on your managed database and object storage services. For file
 | `listener.image.repository` | `ghcr.io/mattrobinsonsre/terrapod-listener` | Listener Docker image |
 | `listener.image.tag` | `""` (appVersion) | Image tag |
 | `listener.replicas` | `1` | Number of listener replicas |
+| `listener.maxConcurrent` | `3` | Max runner Jobs a single listener pod runs concurrently. Admission is gated on the **real** running-Job count, so the listener never exceeds this even under a burst. The primary knob for [sizing a fixed-resource cluster](#sizing-runner-concurrency-on-a-fixed-resource-cluster). |
 | `listener.name` | `"listener"` | Listener name (registered in the pool) |
 | `listener.joinToken` | `""` | Raw join token (use `existingSecret` for production) |
 | `listener.existingSecret` | `""` | K8s Secret containing the join token |
@@ -470,6 +471,68 @@ listener:
 | `runners.serviceAccount.name` | `""` | SA name (cloud identity) |
 | `runners.serviceAccount.annotations` | `{}` | SA annotations (for IRSA, GCP WIF, Azure WI) |
 | `runners.hooksEnabled` | `true` | Master kill-switch: when false, execution hooks are never delivered to runner Jobs |
+
+### Sizing runner concurrency on a fixed-resource cluster
+
+On an autoscaling node pool the scheduler simply adds nodes when runner Jobs
+don't fit. On a **fixed-size** pool (a single k3s VM, a capped node group, a
+`ResourceQuota`-bound namespace) there is nothing to scale onto, so you must
+size concurrency to the capacity you have — otherwise runner Jobs sit
+**Pending / unschedulable** and never start.
+
+**How the multiplier works.** Each listener pod runs up to `listener.maxConcurrent`
+runner Jobs at once (default **3**). Each Job requests its workspace's
+`resource_cpu` / `resource_memory` (default **1 CPU / 2Gi** *requests*; limits are
+computed as **2×** the requests). The Kubernetes scheduler fits pods by their
+**requests**, so the worst-case simultaneous runner demand a single listener can
+place is:
+
+```
+listener.maxConcurrent × max(per-workspace resource_cpu / resource_memory requests)
+```
+
+With multiple listener replicas, multiply again by `listener.replicas`.
+
+**The inequality to keep true** (per node, using requests):
+
+```
+Σ(runner requests) + api + web + listener + (embedded Postgres/Redis if used) ≤ node allocatable
+```
+
+**Worked example.** A single 8-CPU / 16Gi node, one listener replica,
+`maxConcurrent: 3`, default workspace resources (1 CPU / 2Gi requests):
+
+- Runners: `3 × (1 CPU / 2Gi)` = **3 CPU / 6Gi** of requests.
+- Control plane (defaults): api `500m / 2Gi` + web + listener `100m / 256Mi` ≈ **~1 CPU / ~2.5Gi**.
+- Headroom for the kubelet + system pods: leave ~1 CPU / ~1Gi.
+
+That fits comfortably in 8 CPU / 16Gi. Bump `maxConcurrent` to 6 and the runner
+requests alone become **6 CPU / 12Gi** — now a fourth concurrent run, or one
+larger workspace, tips past allocatable and the extra Job goes **Pending**.
+
+**Failure mode (distinct from OOMKilled).** Over-committing *requests* means a
+Job can't be *scheduled* — it stays Pending with a `PodScheduled=False,
+reason=Unschedulable` condition. This is different from
+[OOMKilled](runners.md#memory-pressure--oom-visibility-430), which happens at
+*runtime* when a running Job exceeds its memory *limit*. Terrapod surfaces the
+unschedulable case explicitly: the reconciler fails the run after
+`runners.launchTimeoutSeconds` with a message naming the requested CPU/memory
+and the likely cause (insufficient capacity or an unsatisfiable
+nodeSelector/affinity/taint). Watch the per-pool backlog with the
+[`terrapod_pool_queued_runs`](monitoring.md) gauge — a sustained non-zero value
+on a fixed pool means demand exceeds `maxConcurrent`.
+
+**What to do on a fixed pool:** lower `listener.maxConcurrent`, lower the
+per-workspace `resource_cpu` / `resource_memory`, or add node capacity.
+
+**Safety cap (strongly recommended).** Put a **ResourceQuota** on the runner
+namespace (`listener.runnerNamespace`) so runaway concurrency can never
+over-subscribe the node, plus a **LimitRange** to default/limit per-Job
+requests. The quota is the hard backstop; `maxConcurrent` is the soft one. On a
+shared fixed pool, also enable the control-plane PriorityClasses
+(`priorityClasses.create=true`, see the
+[production checklist](production-checklist.md)) so that if the node *does* come
+under pressure, the kubelet reaps runner Jobs before the API/web/listener.
 
 ### Ingress
 

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -85,6 +85,7 @@ A step-by-step checklist for preparing a Terrapod instance for production use. E
 - [ ] **Agent pool is created** -- At least one agent pool exists for scheduling runs. See [Architecture: Agent Pools](architecture.md).
 - [ ] **Listener is deployed and connected** -- The listener registers via join token, maintains heartbeat, and appears as "online" in the admin UI.
 - [ ] **Runner resource limits are appropriate** -- Default: 1 CPU / 2Gi memory (requests), 2 CPU / 4Gi (limits). Adjust per-workspace via `resource_cpu` and `resource_memory` for workspaces managing large state files. See [Deployment: Runner Jobs](deployment.md#runner-jobs).
+- [ ] **Runner concurrency fits the cluster** -- `listener.maxConcurrent` (default 3) × per-workspace requests must fit node allocatable on a **fixed-size** pool, or extra runner Jobs sit Pending/unschedulable. Size it, and cap it with a `ResourceQuota` on the runner namespace. See [Deployment: Sizing runner concurrency on a fixed-resource cluster](deployment.md#sizing-runner-concurrency-on-a-fixed-resource-cluster).
 - [ ] **Cloud workload identity is configured** (if applicable) -- AWS IRSA, GCP WIF, or Azure WI annotations on the runner ServiceAccount. See [Cloud Credentials](cloud-credentials.md).
 - [ ] **Graceful termination period is sufficient** -- Default 120 seconds. Increase for workspaces with large provider downloads or slow applies. See [Deployment: Graceful Termination](deployment.md#runner-jobs).
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -167,6 +167,12 @@ All runner Jobs inherit the following settings from `runners.*` in Helm values:
 
 Each workspace has `resource_cpu` and `resource_memory` settings (default: 1 CPU / 2Gi memory) that control the resource **requests** for its runner Jobs. Limits are computed as 2x the requests automatically. These are set via the workspace API or UI.
 
+### Concurrency (`listener.maxConcurrent`)
+
+Each listener pod runs at most `listener.maxConcurrent` runner Jobs at once (default **3**, set in Helm values). Admission is gated on the **real** running-Job count queried from Kubernetes — not an in-memory launch counter — so the listener never exceeds the cap even during a burst, and it drains a backlog as fast as slots free (rather than one run per poll). Watch the per-pool backlog with the [`terrapod_pool_queued_runs`](monitoring.md) gauge.
+
+`maxConcurrent` is the primary knob for **sizing a fixed-resource cluster**: on an autoscaling pool the scheduler just adds nodes, but on a fixed pool `maxConcurrent × per-workspace requests` must fit within node allocatable or the extra runner Jobs sit **Pending / unschedulable** (a schedule-time failure, distinct from the runtime OOMKilled case below). The reconciler fails an unplaceable run after `runners.launchTimeoutSeconds` with a message naming the requested CPU/memory. See [Deployment → Sizing runner concurrency on a fixed-resource cluster](deployment.md#sizing-runner-concurrency-on-a-fixed-resource-cluster) for the formula, a worked example, and the recommended ResourceQuota backstop.
+
 ### Memory Pressure & OOM Visibility (#430)
 
 Terraform/OpenTofu provider plugins can consume substantial memory — particularly the AWS provider when refreshing thousands of resources, or any provider that pulls a large module tarball into memory. If a runner Job hits its memory limit (`2 × resource_memory`), Kubernetes OOM-kills the container. Without explicit surfacing, the symptom is just a "Job failed" with no signal that memory was the cause — leaving an operator to guess + incrementally bump the limit. Terrapod surfaces it explicitly.


### PR DESCRIPTION
Closes #752. Split from #738. Docs-only — ties together the #748/#750/#751 fixed-resource work.

## Problem

No doc gave a fixed-resource sizing formula, and `listener.maxConcurrent` was a Helm-value-only knob documented nowhere. The only documented runner failure mode was **OOMKilled** (a runtime limit breach); the **requests-exceed-allocatable-at-schedule-time** mode (Pending / unschedulable) — the one the #748/#750/#751 work targets — was absent.

## Changes

- **`deployment.md`** — new **"Sizing runner concurrency on a fixed-resource cluster"** section:
  - the `maxConcurrent × per-workspace requests` multiplier (× `replicas`),
  - the `Σ(runner requests) + control plane + datastores ≤ node allocatable` inequality,
  - a worked example (8 CPU / 16Gi node),
  - the **unschedulable** failure mode explained as *distinct from OOMKilled*, and how the reconciler surfaces it after `runners.launchTimeoutSeconds`,
  - the `terrapod_pool_queued_runs` backlog signal (#750),
  - the recommended **ResourceQuota + LimitRange** backstop and control-plane **PriorityClasses** (#751).
  - Also adds `listener.maxConcurrent` to the Runner Listener values table.
- **`runners.md`** — new **"Concurrency (`listener.maxConcurrent`)"** subsection (first documentation of the value anywhere): the admission cap, real-Job gating, and a cross-link to the sizing section.
- **`production-checklist.md`** — a "Runner concurrency fits the cluster" item.

## Verification

All cross-reference anchors resolve to real headings; `launchTimeoutSeconds` is correctly cited as `runners.*` (not `listener.*` — verified against `values.yaml`); the `terrapod_pool_queued_runs` gauge doc it links exists (merged in #750). No hallucinated Helm values.