### PR TITLE
chore(deps): bump golang.org/x/crypto to 0.54.0 in /publish

### DIFF
--- a/publish/go.mod
+++ b/publish/go.mod
@@ -9,8 +9,8 @@ require (
 
 require (
 	github.com/cloudflare/circl v1.6.3 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 )
 
 replace github.com/mattrobinsonsre/terrapod/go-terrapod => ../go-terrapod

--- a/publish/go.sum
+++ b/publish/go.sum
@@ -2,7 +2,7 @@ github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
-golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
Clears the **13 open Dependabot alerts** (critical/high/medium) against `golang.org/x/crypto < 0.52.0` — all of which target `publish/go.mod`.

Dependabot's #759 bumped only `/migrate`; `/publish` still pinned the vulnerable `v0.45.0` (indirect), so the alerts never cleared. This bumps it to `v0.54.0`. `go-terrapod` and `provider` don't depend on x/crypto (their alerts don't exist). `go build ./...` + `go test ./...` pass for the publish module.

Required before the next release (all Dependabot alerts must be clear).