### PR TITLE
docs: surface terrapod-migrate in the Features tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Everything below is implemented and shipped today.
 | State resource graph | Per-workspace resource dependency graph from Terraform state — resources wired by `depends-on`; current state version by default with an older-version picker; group by type / module / provider / mode; accessible table fallback |
 | Workspace health | Per-workspace health conditions, VCS polling status, drift detection indicators |
 
+### Migration & onboarding
+
+| Feature | Description |
+|---|---|
+| Migrate in from TFE / HCP / Atlantis | [`terrapod-migrate`](docs/migration.md) — a dry-run-first, reversible CLI that moves an existing Terraform Enterprise / HCP Terraform / Atlantis platform onto Terrapod: previews, then creates VCS connections, workspaces, variables, variable sets, state (serial + lineage preserved), run triggers, notifications, agent pools, and registry signing keys; verifies parity and rolls back cleanly. Registry module/provider *versions* are reported for re-publish (a source-API + signing-key limit), and RBAC is suggested, never auto-applied |
+
 ### AI (optional, off by default)
 
 | Feature | Description |

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ Beyond broad TFE compatibility, Terrapod is built with three deliberate design f
 | **Workspace Autodiscovery** | Atlantis-style monorepo autodiscovery with rule templating; safe-by-default rename/delete/orphan lifecycle (opt-in destroy) |
 | **Bulk Workspace Operations** | Server-side workspace search + all-or-nothing bulk settings update (dry-run by default; never triggers runs) |
 | **Cross-Workspace Remote State** | `terraform_remote_state` composition with a producer-controlled consumer allowlist (secure by default; secret-bearing state stays with its owner) |
+| **Migrate in (TFE / HCP / Atlantis)** | [`terrapod-migrate`](migration.md) — a dry-run-first, reversible CLI that moves an existing Terraform Enterprise / HCP Terraform / Atlantis platform onto Terrapod: previews, creates the core (VCS connections, workspaces, variables, variable sets, state with serial + lineage preserved, run triggers, notifications, agent pools, registry signing keys), verifies parity, and rolls back cleanly. Registry versions are reported for re-publish; RBAC is suggested, never auto-applied |
 
 ---
 


### PR DESCRIPTION
## What

Adds a **Migration** row to the machine-readable Features tables in `README.md` (a new `### Migration & onboarding` subsection) and `docs/index.md`.

## Why

A repo-only AI assistant asked to *enumerate Terrapod's features* was consistently omitting `terrapod-migrate` — verified empirically with a fresh, repo-only agent. It scrapes the **Features** tables, and migration was in neither README's nor docs/index.md's Features table; it appeared only in prose (README top-matter), the Documentation table, and the codebase map (and as the trailing bullet in `llms.txt`). So the migrate-in capability wasn't discoverable via feature enumeration, even though the `docs/migration.md` runbook is complete.

This is the AI-onboarding gate (audit step H): a shipped capability an agent can't find is a docs defect. Putting migration in the exact structure agents scrape closes the gap.

## Scope

Docs-only, 7 lines added across two files. No code, no Helm, no release needed.

Closes #771