### PR TITLE
fix: v0.58.0 pre-release review fixes (impact-graph 500 + listener docs)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -425,7 +425,7 @@ Enable encryption on your managed database and object storage services. For file
 | `listener.image.repository` | `ghcr.io/mattrobinsonsre/terrapod-listener` | Listener Docker image |
 | `listener.image.tag` | `""` (appVersion) | Image tag |
 | `listener.replicas` | `1` | Number of listener replicas |
-| `listener.maxConcurrent` | `3` | Max runner Jobs a single listener pod runs concurrently. Admission is gated on the **real** running-Job count, so the listener never exceeds this even under a burst. The primary knob for [sizing a fixed-resource cluster](#sizing-runner-concurrency-on-a-fixed-resource-cluster). |
+| `listener.maxConcurrent` | `3` | **Pool-wide** max concurrent runner Jobs. Admission is gated on the **real** namespace-wide running-Job count, which every listener replica shares — so this is the pool ceiling regardless of `listener.replicas` (replicas are for HA, not extra concurrency; raise this, not replicas, for more). The primary knob for [sizing a fixed-resource cluster](#sizing-runner-concurrency-on-a-fixed-resource-cluster). |
 | `listener.name` | `"listener"` | Listener name (registered in the pool) |
 | `listener.joinToken` | `""` | Raw join token (use `existingSecret` for production) |
 | `listener.existingSecret` | `""` | K8s Secret containing the join token |
@@ -480,18 +480,25 @@ don't fit. On a **fixed-size** pool (a single k3s VM, a capped node group, a
 size concurrency to the capacity you have — otherwise runner Jobs sit
 **Pending / unschedulable** and never start.
 
-**How the multiplier works.** Each listener pod runs up to `listener.maxConcurrent`
-runner Jobs at once (default **3**). Each Job requests its workspace's
-`resource_cpu` / `resource_memory` (default **1 CPU / 2Gi** *requests*; limits are
-computed as **2×** the requests). The Kubernetes scheduler fits pods by their
-**requests**, so the worst-case simultaneous runner demand a single listener can
-place is:
+**How the multiplier works.** A listener admits a run only while the **real**
+count of running runner Jobs in the pool's namespace is below
+`listener.maxConcurrent` (default **3**). Every listener replica counts that same
+namespace-wide Job total, so `listener.maxConcurrent` is the **pool-wide**
+concurrency ceiling — running multiple `listener.replicas` gives you
+**high availability** (any replica can claim a run and launch its Job; if one
+dies the others carry on), **not** more concurrency. To raise the ceiling,
+increase `listener.maxConcurrent`, not `listener.replicas`.
+
+Each Job requests its workspace's `resource_cpu` / `resource_memory` (default
+**1 CPU / 2Gi** *requests*; limits are computed as **2×** the requests). The
+Kubernetes scheduler fits pods by their **requests**, so the worst-case
+simultaneous runner demand across the whole pool is:
 
 ```
 listener.maxConcurrent × max(per-workspace resource_cpu / resource_memory requests)
 ```
 
-With multiple listener replicas, multiply again by `listener.replicas`.
+— independent of how many listener replicas you run.
 
 **The inequality to keep true** (per node, using requests):
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -196,7 +196,7 @@ These metrics are emitted by the **API server**, since it receives all heartbeat
 |---|---|---|---|
 | `terrapod_listener_heartbeats_total` | Counter | pool_id | Heartbeats received from listeners |
 | `terrapod_listener_joins_total` | Counter | pool_name | Listener join events |
-| `terrapod_pool_queued_runs` | Gauge | pool_id | Runs waiting for a listener slot per pool (backlog depth). Refreshed each reconciler cycle (~10s); reads 0 for an idle pool. A sustained non-zero value means the pool needs more listener capacity |
+| `terrapod_pool_queued_runs` | Gauge | pool_id | Runs waiting for a listener slot per pool (backlog depth). Refreshed each reconciler cycle (2s); reads 0 for an idle pool. A sustained non-zero value means the pool needs more listener capacity. With multiple API replicas the distributed scheduler runs the reconciler on one replica per cycle, so aggregate this gauge with `max by (pool_id)` |
 
 ### Listeners (Self-Reported)
 

--- a/services/terrapod/api/metrics.py
+++ b/services/terrapod/api/metrics.py
@@ -262,7 +262,7 @@ POOL_QUEUED_RUNS = Gauge(
     "terrapod_pool_queued_runs",
     (
         "Runs currently in `queued` state per agent pool — the backlog waiting "
-        "for a listener slot. Refreshed each reconciler cycle (~10s) with a "
+        "for a listener slot. Refreshed each reconciler cycle (2s) with a "
         "single grouped COUNT. An operator watches this to see 'N runs waiting "
         "on pool X' and decide whether the pool needs more listener capacity "
         "(#750)."

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -133,7 +133,12 @@ class RunnerConfig(BaseSettings):
     )
     heartbeat_interval: int = Field(default=60, description="Listener heartbeat interval (s).")
     max_concurrent: int = Field(
-        default=3, description="Max concurrent run launches per listener pod."
+        default=3,
+        description=(
+            "Pool-wide max concurrent runner Jobs. Every listener replica admits on the "
+            "shared namespace-wide running-Job count, so this is the pool ceiling regardless "
+            "of replica count (raise this, not replicas, for more concurrency)."
+        ),
     )
     poll_interval: int = Field(
         default=30, description="Fallback poll interval when SSE is idle (s)."

--- a/services/terrapod/services/plan_graph_service.py
+++ b/services/terrapod/services/plan_graph_service.py
@@ -30,9 +30,13 @@ import asyncio
 import json
 import re
 
+import structlog
+
 from terrapod.db.models import Run
 from terrapod.storage import get_storage
 from terrapod.storage.keys import plan_json_output_key
+
+logger = structlog.get_logger(__name__)
 
 # Normalised planned action per resource_change.
 _ACTION = {
@@ -214,7 +218,10 @@ def derive_graph(plan_bytes: bytes) -> dict:
         if not addr:
             continue
         block = _block_of(addr)
-        action = _ACTION.get(tuple(rc.get("change", {}).get("actions", [])), "update")
+        # `change` is normally always present, but guard `change: null` (older /
+        # truncated / hand-rolled plan JSON) so a weird-but-parseable plan yields
+        # a graph instead of raising AttributeError → HTTP 500.
+        action = _ACTION.get(tuple((rc.get("change") or {}).get("actions", [])), "update")
         node = node_by_block.get(block)
         if node is None:
             node = {
@@ -240,7 +247,7 @@ def derive_graph(plan_bytes: bytes) -> dict:
 
     # Block-level reference map from the configuration, walked across the whole
     # module tree (root + every module_call) with cross-module var/output binding.
-    root_cfg = plan.get("configuration", {}).get("root_module", {}) or {}
+    root_cfg = (plan.get("configuration") or {}).get("root_module") or {}
     modules, calls = _index_modules(root_cfg)
     resolve_ref = _make_resolver(modules, calls, resource_types)
     block_refs: dict[str, set[str]] = {}
@@ -303,4 +310,10 @@ async def get_impact_graph(run: Run) -> dict | None:
         return None
     raw = await storage.get(key)
     # Parse + derive off the event loop (large buffer, CPU-bound) — rule 13.
-    return await asyncio.to_thread(derive_graph, raw)
+    # A corrupt / truncated plan blob must degrade to "no graph" (caller → 404),
+    # not a 500 — mirrors state_graph_service's parse guard.
+    try:
+        return await asyncio.to_thread(derive_graph, raw)
+    except (ValueError, TypeError) as exc:
+        logger.warning("impact_graph_parse_failed", run_id=str(run.id), error=str(exc))
+        return None

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -70,7 +70,7 @@ async def _persist_live_log_if_missing(run: Run, phase: str) -> None:
 async def _refresh_pool_queue_depth(db: AsyncSession) -> None:
     """Publish the per-pool `queued` backlog as a Prometheus gauge (#750).
 
-    One grouped COUNT per reconciler cycle (~10s). Every existing pool is given
+    One grouped COUNT per reconciler cycle (2s). Every existing pool is given
     an explicit value (0 when idle) so the series is stable — a pool that drains
     to empty reads as 0, not absent. Queued runs on a since-deleted pool are
     still surfaced (they are a real backlog). Best-effort: never raises into the

--- a/services/tests/services/test_plan_graph_service.py
+++ b/services/tests/services/test_plan_graph_service.py
@@ -100,6 +100,22 @@ class TestDeriveGraph:
         assert g["edges"] == []
         assert all(v == 0 for v in g["meta"]["counts"].values())
 
+    def test_null_change_and_configuration_do_not_raise(self):
+        # A parseable-but-weird plan (older/truncated/hand-rolled JSON) with
+        # `change: null` and `configuration: null` must degrade to a graph, not
+        # raise AttributeError → HTTP 500. Regression for the impact-graph 500.
+        plan = {
+            "resource_changes": [
+                {"address": "null_resource.a", "type": "null_resource", "change": None},
+            ],
+            "configuration": None,
+        }
+        g = plan_graph_service.derive_graph(json.dumps(plan).encode())
+        assert len(g["nodes"]) == 1
+        # unknown/absent actions fall back to the "update" default
+        assert g["nodes"][0]["instance_actions"] == ["update"]
+        assert g["edges"] == []
+
 
 class TestGetImpactGraph:
     async def test_none_when_no_json_output(self):
@@ -123,6 +139,15 @@ class TestGetImpactGraph:
         assert g is not None
         assert len(g["nodes"]) == 3  # per-block (for_each cert collapses to one)
         assert len(g["edges"]) == 1
+
+    @patch("terrapod.services.plan_graph_service.get_storage")
+    async def test_corrupt_plan_blob_returns_none(self, mock_storage):
+        # A truncated/corrupt plan blob degrades to None (caller → 404), not 500.
+        run = MagicMock(has_json_output=True, workspace_id=uuid.uuid4(), id=uuid.uuid4())
+        st = mock_storage.return_value
+        st.exists = AsyncMock(return_value=True)
+        st.get = AsyncMock(return_value=b'{"resource_changes": [trunc')
+        assert await plan_graph_service.get_impact_graph(run) is None
 
 
 # A modular plan: root calls `net` + `app`; `app` nests `inner`. Exercises


### PR DESCRIPTION
Fixes from the **v0.58.0 pre-release third-party review** (verified against the code before acting).

## Impact graph 500 on malformed plan JSON (closes #776)
`plan_graph_service.derive_graph` / `get_impact_graph` returned HTTP 500 on a parseable-but-weird plan (`change: null` / `configuration: null` → `AttributeError`) or a corrupt/truncated blob (unguarded `json.loads`), while the equivalent **state**-graph path degrades gracefully. Guarded the null access (`(rc.get("change") or {})`) and wrapped the parse in `get_impact_graph` to degrade to `None` (caller → 404), mirroring `state_graph_service`. Regression tests added (`change: null` doesn't raise; corrupt blob → None).

## Listener maxConcurrent is a pool-wide ceiling (closes #777)
`config.py` + `docs/deployment.md` said `listener.maxConcurrent` is *"per listener pod"* and to *"multiply by `listener.replicas`"*. The code counts the **namespace-wide** running-Job total on every replica, so it's the **pool-wide** ceiling regardless of replica count — replicas are for HA, not extra concurrency. The behaviour is correct and fail-safe (never over-admits); the docs were wrong. Corrected both. (Decision confirmed with the maintainer: keep the safer pool-wide-cap behaviour, fix the docs.)

## Metric doc accuracy
`terrapod_pool_queued_runs` help text + `monitoring.md` said the reconciler cycle is "~10s"; it's **2s** (`app.py` `interval_seconds=2`). Fixed, and added `max by (pool_id)` aggregation guidance (the gauge is populated by whichever replica wins each reconciler cycle).

## Verification
`make test` green. Docs-only for the listener/metric parts; the impact-graph fix has unit + regression coverage.