### PR TITLE
test(api): freeze JSON:API response attributes across all serializers (#550)

### DIFF
--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -1,0 +1,560 @@
+{
+  "agent_pools._token_json": [
+    "created-at",
+    "created-by",
+    "description",
+    "expires-at",
+    "is-revoked",
+    "max-uses",
+    "use-count"
+  ],
+  "audit.list_audit_log": [
+    "action",
+    "actor-email",
+    "actor-ip",
+    "detail",
+    "duration-ms",
+    "request-id",
+    "resource-id",
+    "resource-type",
+    "status-code",
+    "timestamp"
+  ],
+  "autodiscovery_rules._rule_json": [
+    "agent-pool-id",
+    "auto-apply",
+    "branch",
+    "created-at",
+    "enabled",
+    "execution-backend",
+    "execution-hook-templates",
+    "execution-mode",
+    "ignore-patterns",
+    "labels",
+    "name",
+    "name-template",
+    "notification-templates",
+    "on-directory-delete",
+    "owner-email",
+    "pattern",
+    "repo-url",
+    "resource-cpu",
+    "resource-memory",
+    "run-task-templates",
+    "terraform-version",
+    "updated-at",
+    "var-files",
+    "vcs-connection-id"
+  ],
+  "autodiscovery_rules.preview_rule": [
+    "entries",
+    "files-walked",
+    "ref"
+  ],
+  "autodiscovery_rules.preview_unsaved_rule": [
+    "entries",
+    "files-walked",
+    "ref"
+  ],
+  "autodiscovery_rules.scan_rule": [
+    "files-walked",
+    "ref",
+    "workspace-ids",
+    "workspaces-created"
+  ],
+  "binary_cache.list_cached_binaries_endpoint": [
+    "arch",
+    "cached-at",
+    "download-url",
+    "os",
+    "shasum",
+    "tool",
+    "version"
+  ],
+  "binary_cache.list_cached_providers_endpoint": [
+    "arch",
+    "cached-at",
+    "hostname",
+    "namespace",
+    "os",
+    "provider-type",
+    "shasum",
+    "version"
+  ],
+  "catalog._instance_json": [
+    "agent-pool-id",
+    "catalog-item-id",
+    "catalog-version-pin",
+    "labels",
+    "name",
+    "owner-email"
+  ],
+  "catalog._item_json": [
+    "allowed-agent-pool-ids",
+    "created-at",
+    "default-version-pin",
+    "description",
+    "display-name",
+    "enabled",
+    "labels",
+    "module-id",
+    "module-name",
+    "module-provider",
+    "name",
+    "owner-email",
+    "provider-template-ids",
+    "updated-at",
+    "variable-options"
+  ],
+  "catalog._run_ref": [
+    "is-destroy",
+    "status"
+  ],
+  "catalog._template_json": [
+    "body",
+    "created-at",
+    "labels",
+    "name",
+    "owner-email",
+    "parameters",
+    "provider-type",
+    "updated-at"
+  ],
+  "catalog.get_catalog_item_form": [
+    "fields",
+    "resolved-version"
+  ],
+  "config_versions._cv_json": [
+    "auto-queue-runs",
+    "created-at",
+    "source",
+    "speculative",
+    "status",
+    "upload-url"
+  ],
+  "config_versions.diff_configuration_versions": [
+    "from-id",
+    "to-id"
+  ],
+  "config_versions.mint_download_ticket": [
+    "expires-at",
+    "ticket",
+    "url"
+  ],
+  "encryption.rotate_data_encryption_key": [
+    "rotated_to_version"
+  ],
+  "execution_hooks._hook_json": [
+    "created-at",
+    "description",
+    "enabled",
+    "hook-point",
+    "name",
+    "priority",
+    "script",
+    "updated-at",
+    "workspace-count"
+  ],
+  "gpg_keys._gpg_key_to_jsonapi": [
+    "ascii-armor",
+    "created-at",
+    "key-id",
+    "namespace",
+    "source",
+    "source-url",
+    "updated-at"
+  ],
+  "notification_configurations._nc_json": [
+    "created-at",
+    "delivery-responses",
+    "destination-type",
+    "email-addresses",
+    "enabled",
+    "has-token",
+    "name",
+    "triggers",
+    "updated-at",
+    "url"
+  ],
+  "policy_sets._evaluation_json": [
+    "created-at",
+    "enforcement-level",
+    "outcome",
+    "overridden-at",
+    "overridden-by",
+    "policy-set-name",
+    "result"
+  ],
+  "policy_sets._policy_json": [
+    "created-at",
+    "description",
+    "name",
+    "rego",
+    "updated-at"
+  ],
+  "registry_modules._link_to_jsonapi": [
+    "created-at",
+    "created-by",
+    "workspace-id",
+    "workspace-name"
+  ],
+  "registry_modules._module_to_jsonapi": [
+    "created-at",
+    "labels",
+    "name",
+    "namespace",
+    "owner-email",
+    "permissions",
+    "provider",
+    "source",
+    "status",
+    "updated-at",
+    "vcs-branch",
+    "vcs-connection-id",
+    "vcs-last-tag",
+    "vcs-repo-url",
+    "vcs-tag-pattern",
+    "version-statuses"
+  ],
+  "registry_modules.create_module_version_endpoint": [
+    "created-at",
+    "status",
+    "version"
+  ],
+  "registry_modules.module_interface_endpoint": [
+    "inputs",
+    "outputs",
+    "version"
+  ],
+  "registry_modules.upload_module_version_endpoint": [
+    "created-at",
+    "status",
+    "version"
+  ],
+  "registry_providers._platform_to_jsonapi": [
+    "arch",
+    "filename",
+    "os",
+    "shasum",
+    "upload-status"
+  ],
+  "registry_providers._provider_to_jsonapi": [
+    "created-at",
+    "labels",
+    "name",
+    "namespace",
+    "owner-email",
+    "permissions",
+    "updated-at"
+  ],
+  "registry_providers._version_to_jsonapi": [
+    "created-at",
+    "platforms",
+    "protocols",
+    "shasums-sig-uploaded",
+    "shasums-uploaded",
+    "version"
+  ],
+  "remote_state_consumers._consumer_json": [
+    "consumer-workspace-name",
+    "created-at",
+    "created-by",
+    "producer-workspace-name"
+  ],
+  "role_assignments._assignment_json": [
+    "created-at",
+    "email",
+    "provider-name",
+    "role-name"
+  ],
+  "roles._builtin_role_json": [
+    "allow-labels",
+    "allow-names",
+    "built-in",
+    "capabilities",
+    "catalog-permission",
+    "created-at",
+    "deny-labels",
+    "deny-names",
+    "description",
+    "pool-permission",
+    "registry-permission",
+    "updated-at",
+    "workspace-permission"
+  ],
+  "roles._role_json": [
+    "allow-labels",
+    "allow-names",
+    "built-in",
+    "capabilities",
+    "catalog-permission",
+    "created-at",
+    "deny-labels",
+    "deny-names",
+    "description",
+    "pool-permission",
+    "registry-permission",
+    "updated-at",
+    "workspace-permission"
+  ],
+  "run_tasks._run_task_json": [
+    "created-at",
+    "enabled",
+    "enforcement-level",
+    "has-hmac-key",
+    "name",
+    "stage",
+    "updated-at",
+    "url"
+  ],
+  "run_tasks._task_stage_json": [
+    "created-at",
+    "stage",
+    "status",
+    "updated-at"
+  ],
+  "run_tasks._task_stage_result_json": [
+    "created-at",
+    "finished-at",
+    "message",
+    "started-at",
+    "status"
+  ],
+  "run_triggers._trigger_json": [
+    "created-at",
+    "sourceable-name",
+    "workspace-name"
+  ],
+  "runs._apply_json": [
+    "log-read-url",
+    "status"
+  ],
+  "runs._run_json": [
+    "actions",
+    "allow-empty-apply",
+    "auto-apply",
+    "created-at",
+    "created-by",
+    "discard-reason",
+    "error-message",
+    "execution-backend",
+    "has-changes",
+    "has-json-output",
+    "is-destroy",
+    "is-drift-detection",
+    "message",
+    "module-overrides",
+    "peak-cpu-usec",
+    "peak-memory-bytes",
+    "permissions",
+    "plan-only",
+    "plan-summary",
+    "refresh",
+    "refresh-only",
+    "replace-addrs",
+    "resource-cpu",
+    "resource-memory",
+    "runner-exit-code",
+    "runner-exit-reason",
+    "runner-exit-status",
+    "source",
+    "status",
+    "status-timestamps",
+    "target-addrs",
+    "terraform-version",
+    "terragrunt-enabled",
+    "terragrunt-version",
+    "updated-at",
+    "vcs-branch",
+    "vcs-commit-sha",
+    "vcs-pull-request-number",
+    "workspace-has-vcs",
+    "workspace-name"
+  ],
+  "runs.list_run_events": [
+    "action",
+    "created-at"
+  ],
+  "runs.regenerate_plan_summary": [
+    "created-at",
+    "description",
+    "error-message",
+    "input-tokens",
+    "kind",
+    "model",
+    "output-tokens",
+    "risk-factors",
+    "risk-level",
+    "status",
+    "updated-at"
+  ],
+  "runs.show_plan_summary": [
+    "created-at",
+    "description",
+    "error-message",
+    "input-tokens",
+    "kind",
+    "model",
+    "output-tokens",
+    "risk-factors",
+    "risk-level",
+    "status",
+    "updated-at"
+  ],
+  "tfe_v2._state_version_json": [
+    "created-at",
+    "created-by",
+    "hosted-json-state-upload-url",
+    "hosted-state-download-url",
+    "hosted-state-upload-url",
+    "lineage",
+    "md5",
+    "serial",
+    "size"
+  ],
+  "tfe_v2._workspace_json": [
+    "actions",
+    "agent-pool-id",
+    "agent-pool-name",
+    "ai-summary-context",
+    "ai-summary-mode",
+    "auto-apply",
+    "auto-merge",
+    "auto-merge-strategy",
+    "created-at",
+    "drift-detection-enabled",
+    "drift-detection-interval-seconds",
+    "drift-ignore-rules",
+    "drift-last-checked-at",
+    "drift-latest-run-id",
+    "drift-status",
+    "execution-backend",
+    "execution-mode",
+    "health-conditions",
+    "labels",
+    "latest-run",
+    "lifecycle-reason",
+    "lifecycle-state",
+    "locked",
+    "name",
+    "operations",
+    "owner-email",
+    "permissions",
+    "plan-expiry-seconds",
+    "resource-cpu",
+    "resource-memory",
+    "slack-channel",
+    "state-diverged",
+    "tag-names",
+    "terraform-version",
+    "terragrunt-enabled",
+    "terragrunt-version",
+    "trigger-prefixes",
+    "updated-at",
+    "var-files",
+    "vcs-branch",
+    "vcs-connection-id",
+    "vcs-connection-name",
+    "vcs-last-error",
+    "vcs-last-error-at",
+    "vcs-last-polled-at",
+    "vcs-repo-url",
+    "vcs-workflow",
+    "working-directory"
+  ],
+  "tfe_v2.account_details": [
+    "avatar-url",
+    "email",
+    "is-service-account",
+    "permissions",
+    "username",
+    "v2-only"
+  ],
+  "tfe_v2.list_workspace_effective_tag_bindings": [
+    "key",
+    "value"
+  ],
+  "tfe_v2.list_workspace_tag_bindings": [
+    "key",
+    "value"
+  ],
+  "tfe_v2.organization_entitlements": [
+    "agents",
+    "audit-logging",
+    "configuration-designer",
+    "cost-estimation",
+    "global-run-tasks",
+    "operations",
+    "policy-enforcement",
+    "policy-limit",
+    "policy-mandatory-enforcement-limit",
+    "policy-set-limit",
+    "private-module-registry",
+    "private-policy-agents",
+    "private-vcs",
+    "run-task-limit",
+    "run-task-mandatory-enforcement-limit",
+    "run-task-workspace-limit",
+    "run-tasks",
+    "self-serve-billing",
+    "sentinel",
+    "sso",
+    "state-storage",
+    "teams",
+    "user-limit",
+    "vcs-integrations"
+  ],
+  "tfe_v2.show_organization": [
+    "created-at",
+    "email",
+    "external-id",
+    "name",
+    "permissions"
+  ],
+  "users._user_to_jsonapi": [
+    "created-at",
+    "display-name",
+    "email",
+    "has-password",
+    "is-active",
+    "last-login-at",
+    "updated-at"
+  ],
+  "variables._var_json": [
+    "category",
+    "created-at",
+    "description",
+    "hcl",
+    "key",
+    "sensitive",
+    "updated-at",
+    "value",
+    "version-id"
+  ],
+  "variables._varset_json": [
+    "created-at",
+    "description",
+    "global",
+    "name",
+    "priority",
+    "updated-at",
+    "var-count",
+    "workspace-count"
+  ],
+  "variables._vsvar_json": [
+    "category",
+    "created-at",
+    "description",
+    "hcl",
+    "key",
+    "sensitive",
+    "updated-at",
+    "value",
+    "version-id"
+  ],
+  "workspace_extensions.dismiss_drift": [
+    "drift-detection-enabled",
+    "drift-last-checked-at",
+    "drift-status"
+  ]
+}

--- a/services/tests/api/test_attribute_contract.py
+++ b/services/tests/api/test_attribute_contract.py
@@ -1,0 +1,128 @@
+"""API attribute contract gate (#550) — freeze JSON:API response attribute names.
+
+The single most common silent break: dropping or renaming a `data.attributes`
+key breaks every consumer that reads it (go-terrapod, the Terraform provider,
+the web UI, third-party automation) even though the *route* is unchanged and no
+error is raised — the field just vanishes. The existing `test_api_sdk_contract`
+guards only the `workspace` resource; this gate covers **every** JSON:API
+serializer.
+
+It AST-parses each router, finds every serializer's inline `"attributes": {...}`
+block, and diffs the attribute-name set per serializer against a committed
+snapshot (`api_attribute_contract.json`):
+
+- a **removed / renamed** attribute is a **breaking change** — MAJOR bump or a
+  documented deprecation window, NOT a snapshot regen;
+- a **new** attribute is additive — accept it by regenerating
+  (`UPDATE_API_CONTRACT=1 pytest tests/api/test_attribute_contract.py`).
+
+Scope/limits: only statically-declared inline `"attributes": {...}` keys are
+frozen. Attributes added conditionally after the dict literal (rare) are not yet
+covered — a known gap, never a false failure.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+
+import terrapod.api.routers as _routers_pkg
+
+_ROUTERS_DIR = Path(_routers_pkg.__file__).resolve().parent
+_SNAPSHOT = Path(__file__).parent / "api_attribute_contract.json"
+
+
+def _attributes_of_function(fn: ast.AST) -> set[str] | None:
+    """Return the string keys of the first inline ``"attributes": {...}`` dict in
+    a function, or None if it isn't a JSON:API serializer."""
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values, strict=True):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "attributes"
+                and isinstance(value, ast.Dict)
+            ):
+                return {
+                    k.value
+                    for k in value.keys
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                }
+    return None
+
+
+def extract_attribute_contract() -> dict[str, list[str]]:
+    """`{"<router>.<serializer>": [sorted attribute names]}` for every JSON:API
+    serializer across the routers — discovered by structure (a function whose
+    body builds an ``"attributes"`` dict), not by name."""
+    contract: dict[str, list[str]] = {}
+    for path in sorted(_ROUTERS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            attrs = _attributes_of_function(node)
+            if attrs:
+                contract[f"{path.stem}.{node.name}"] = sorted(attrs)
+    return contract
+
+
+def test_attribute_contract_unchanged() -> None:
+    current = extract_attribute_contract()
+
+    if os.environ.get("UPDATE_API_CONTRACT"):
+        _SNAPSHOT.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        return
+
+    assert _SNAPSHOT.exists(), (
+        f"Attribute contract snapshot missing at {_SNAPSHOT}. Generate it with:\n"
+        "  UPDATE_API_CONTRACT=1 pytest tests/api/test_attribute_contract.py"
+    )
+    snapshot: dict[str, list[str]] = json.loads(_SNAPSHOT.read_text())
+
+    breaking: list[str] = []
+    additive: list[str] = []
+
+    for serializer, snap_attrs in snapshot.items():
+        if serializer not in current:
+            breaking.append(f"{serializer}: entire serializer removed/renamed")
+            continue
+        removed = sorted(set(snap_attrs) - set(current[serializer]))
+        if removed:
+            breaking.append(f"{serializer}: removed/renamed attributes {removed}")
+    for serializer, cur_attrs in current.items():
+        added = sorted(set(cur_attrs) - set(snapshot.get(serializer, [])))
+        if added:
+            additive.append(f"{serializer}: added {added}")
+
+    problems: list[str] = []
+    if breaking:
+        problems.append(
+            "BREAKING: JSON:API response attributes were REMOVED or RENAMED. Every "
+            "consumer that reads them (go-terrapod, the provider, the web UI, "
+            "third-party automation) breaks silently. This requires a MAJOR bump or "
+            "a documented deprecation window — do NOT just regenerate the snapshot:\n"
+            "  " + "\n  ".join(breaking)
+        )
+    if additive:
+        problems.append(
+            "New attributes were added (additive, non-breaking). Accept them by "
+            "regenerating the snapshot:\n"
+            "  UPDATE_API_CONTRACT=1 pytest tests/api/test_attribute_contract.py\n"
+            "  " + "\n  ".join(additive)
+        )
+    assert not problems, "\n\n".join(problems)
+
+
+def test_extractor_finds_the_known_serializers() -> None:
+    # Bite-check: the extractor must actually resolve real serializers (guards
+    # against a silently-empty contract that would disable the gate).
+    contract = extract_attribute_contract()
+    assert len(contract) >= 25
+    assert "variables._var_json" in contract
+    assert "key" in contract["variables._var_json"]
+    assert "runs._run_json" in contract
+    assert "status" in contract["runs._run_json"]


### PR DESCRIPTION
Measure #2 of the v1.0.0 "no breaking API changes" program (#550) — and the highest-leverage one: the **response-attribute contract**.

## What
Dropping or renaming a `data.attributes` key is the **#1 silent break** — every consumer that reads it (go-terrapod, the provider, the web UI, third-party automation) loses the field even though the route is unchanged and no error is raised. The existing `test_api_sdk_contract` guarded only the **workspace** resource.

This AST-parses every router, **auto-discovers all 55 JSON:API serializers by structure** (any function that builds an `"attributes"` dict — not by name, so it also catches inline-attribute endpoint handlers like `audit.list_audit_log`), and freezes each serializer's attribute-name set in `services/tests/api/api_attribute_contract.json`.

- a **removed / renamed** attribute → **breaking** (MAJOR bump or documented deprecation, not a regen);
- a **new** attribute → additive (regenerate with `UPDATE_API_CONTRACT=1 pytest tests/api/test_attribute_contract.py`).
- bite-check test asserts the extractor resolves ≥25 real serializers (guards against a silently-empty contract).

## Coverage jump
**1 resource → 55 serializers.**

## Verified
`scripts/test.sh python -- tests/api/test_attribute_contract.py tests/api/test_route_contract.py` → 5 passed. Runs in the `services-api` shard.

## Scope limit
Only statically-declared inline `"attributes": {...}` keys are frozen; attributes appended conditionally after the dict literal (rare) aren't yet covered — a known gap, never a false failure.

Part of #550.