### PR TITLE
test(db): migration reversibility + expand/contract gate (#550)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
             # Root-level tests/*.py are NOT auto-collected by the directory
             # shards below — each must be listed here explicitly, or it silently
             # never runs in CI. All of these are pure-unit (no Postgres/Redis/S3).
-            paths: tests/auth tests/runner tests/storage tests/ai_eval tests/test_logging_config.py tests/test_dependency_pins.py tests/test_api_sdk_contract.py tests/test_schema_version.py tests/test_gpg_verify.py tests/test_http_retry.py tests/test_db_iam_auth.py tests/test_redis_iam_auth.py
+            paths: tests/auth tests/runner tests/storage tests/ai_eval tests/db tests/test_logging_config.py tests/test_dependency_pins.py tests/test_api_sdk_contract.py tests/test_schema_version.py tests/test_gpg_verify.py tests/test_http_retry.py tests/test_db_iam_auth.py tests/test_redis_iam_auth.py
             pytest_args: -n auto
           - name: services-api
             paths: tests/services tests/api

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,10 +294,21 @@ staged plan live in issue **#719**; the rules a contributor must follow:
 - **Namespace package (hard requirement)** — `services/terrapod/__init__.py`
   must **not** exist. Its absence enables PEP 420 implicit namespace packages
   so each Docker image can include only the sub-packages it needs.
-- **Migrations** — Alembic with async SQLAlchemy and hash-based revision IDs
-  (generate with `python3 -c "import secrets; print(secrets.token_hex(6))"`),
-  not sequential numbers. Every migration has a real `upgrade()` **and**
-  `downgrade()`.
+- **Migrations — reversible + expand/contract (hard requirement, gated)** —
+  Alembic with async SQLAlchemy and hash-based revision IDs (generate with
+  `python3 -c "import secrets; print(secrets.token_hex(6))"`), not sequential
+  numbers. Every migration has a real `upgrade()` **and** `downgrade()` (no
+  stubs — enforced by `tests/db/test_migration_contract.py`). Because the API
+  runs multiple replicas, a rolling upgrade runs **old and new code against the
+  same database at once**, so a migration must never **contract** the schema
+  (drop/rename/retype a column or table in `upgrade()`) in the same release the
+  code stops using it — that breaks the old replica still serving traffic.
+  Follow **expand → migrate → wait a release → contract**: add the new column
+  and dual-write/backfill in release N, switch reads in N, and only drop the old
+  column in N+1 (or later). Every `upgrade()`-side contraction is ledgered
+  (`tests/db/migration_contractions.json`); a new one fails CI until you
+  consciously acknowledge it followed this discipline (regenerate the ledger
+  with `UPDATE_API_CONTRACT=1 pytest tests/db/test_migration_contract.py`).
 - **Substantial API tempfiles go on the attached PVC, not `/tmp`** — on the
   API pod `/tmp` is RAM-backed. Anything that can hold tens of MB (provider
   archives, VCS tarballs, state snapshots, config tarballs) must be written to

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -59,6 +59,9 @@ RUN poetry config virtualenvs.create false \
 # Copy application and test code
 COPY services/terrapod ./terrapod
 COPY services/tests ./tests
+# Alembic migrations — the migration-reversibility + expand/contract contract
+# tests (tests/db) parse these; schema_version.py also resolves them at runtime.
+COPY alembic ./alembic
 # AI-analysis evaluation harness (#602) — committed eval suite. Imported by
 # the offline corpus/rubric tests and run live (model sweep) on demand.
 COPY services/ai_eval ./ai_eval

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -103,6 +103,10 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 target-version = "py313"
 line-length = 100
+# Alembic migrations are auto-generated with the conventional revision-vars-
+# before-imports layout (E402) and are not hand-linted. (They're now present in
+# the test image so tests/db can parse them — this keeps ruff off them.)
+extend-exclude = ["alembic"]
 
 [tool.ruff.lint]
 select = [

--- a/services/tests/db/migration_contractions.json
+++ b/services/tests/db/migration_contractions.json
@@ -1,0 +1,36 @@
+{
+  "00a2cf7e0345_update_default_tofu_version": [
+    "alter_column(runs, terraform_version)",
+    "alter_column(workspaces, terraform_version)"
+  ],
+  "166efacb7b5d_ca_key_truthful_name": [
+    "alter_column(certificate_authority, ca_key_encrypted)"
+  ],
+  "1f15ac58564c_drop_agent_pool_service_account_name": [
+    "drop_column(agent_pools, service_account_name)"
+  ],
+  "2b369cd58093_widen_webhook_secret_for_encryption": [
+    "alter_column(vcs_connections, webhook_secret)"
+  ],
+  "3fbcb2885b93_service_token_kind_columns": [
+    "alter_column(api_tokens, created_by)",
+    "alter_column(api_tokens, user_email)"
+  ],
+  "7dac5695bc0e_default_tofu_1_12": [
+    "alter_column(autodiscovery_rules, terraform_version)",
+    "alter_column(workspaces, terraform_version)"
+  ],
+  "a0b6c95a281d_audit_dual_actor": [
+    "alter_column(audit_logs, action)"
+  ],
+  "a7e74cad11d5_drop_role_level_columns": [
+    "drop_column(roles)"
+  ],
+  "bb5e7f11d575_unify_working_directory": [
+    "drop_column(workspaces, vcs_working_directory)"
+  ],
+  "f3e984cc98cf_drop_runner_listeners": [
+    "drop_constraint(runs_listener_id_fkey, runs)",
+    "drop_table(runner_listeners)"
+  ]
+}

--- a/services/tests/db/test_migration_contract.py
+++ b/services/tests/db/test_migration_contract.py
@@ -1,0 +1,154 @@
+"""Migration reversibility + expand/contract contract gate (#550).
+
+Two zero-downtime-upgrade hazards that no API/attribute contract catches:
+
+1. **Reversibility** — every Alembic migration must have a real `upgrade()` AND
+   `downgrade()` (not a stub), so a bad release can be rolled back. This is a
+   stated project invariant; this test enforces it.
+
+2. **Expand/contract** — during a rolling upgrade, old and new API replicas run
+   against the SAME database at the same time. A migration that DROPS or RETYPES
+   a column/table in `upgrade()` breaks the *old* replica still serving traffic,
+   the moment the migration Job runs. Such contractions are only safe when the
+   column has already been unused for a prior release (expand → migrate → wait a
+   release → contract). This test ledgers every `upgrade()`-side contraction so a
+   NEW one fails CI until it's consciously acknowledged (i.e. you confirm it
+   followed expand/contract), rather than slipping in silently.
+
+Regenerate the contraction ledger after an intentional, expand/contract-safe
+contraction:
+
+    UPDATE_API_CONTRACT=1 pytest tests/db/test_migration_contract.py
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+
+_LEDGER = Path(__file__).parent / "migration_contractions.json"
+_CONTRACTION_OPS = frozenset({"drop_column", "drop_table", "drop_constraint", "alter_column"})
+
+
+def _versions_dir() -> Path:
+    for base in (
+        Path("/app/alembic/versions"),  # test image
+        Path(__file__).resolve().parents[3] / "alembic" / "versions",  # repo
+    ):
+        if base.is_dir():
+            return base
+    raise AssertionError("Could not locate alembic/versions")
+
+
+def _migration_files() -> list[Path]:
+    return sorted(p for p in _versions_dir().glob("*.py") if p.name != "__init__.py")
+
+
+def _func(tree: ast.Module, name: str) -> ast.FunctionDef | None:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def _is_real_body(fn: ast.FunctionDef | None) -> bool:
+    """A migration hook is 'real' if it does more than a docstring / pass / a bare
+    NotImplementedError raise."""
+    if fn is None:
+        return False
+    stmts = list(fn.body)
+    # drop a leading docstring
+    if stmts and isinstance(stmts[0], ast.Expr) and isinstance(stmts[0].value, ast.Constant):
+        stmts = stmts[1:]
+    if not stmts:
+        return False
+    if len(stmts) == 1 and isinstance(stmts[0], ast.Pass | ast.Raise):
+        return False
+    return True
+
+
+def _op_signature(call: ast.Call) -> str | None:
+    """`op.<contraction>(...)` → a stable signature from its string-literal args."""
+    func = call.func
+    if not (isinstance(func, ast.Attribute) and func.attr in _CONTRACTION_OPS):
+        return None
+    args = [a.value for a in call.args if isinstance(a, ast.Constant) and isinstance(a.value, str)]
+    return f"{func.attr}({', '.join(args)})"
+
+
+def _upgrade_contractions(tree: ast.Module) -> set[str]:
+    """Contraction ops that run in `upgrade()` only (a drop in `downgrade()` is a
+    normal reversal of a create and is NOT a contraction)."""
+    up = _func(tree, "upgrade")
+    if up is None:
+        return set()
+    out: set[str] = set()
+    for node in ast.walk(up):
+        if isinstance(node, ast.Call):
+            sig = _op_signature(node)
+            if sig:
+                out.add(sig)
+    return out
+
+
+def test_every_migration_is_reversible() -> None:
+    offenders: list[str] = []
+    for path in _migration_files():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        if not _is_real_body(_func(tree, "upgrade")):
+            offenders.append(f"{path.name}: upgrade() is missing or a stub")
+        if not _is_real_body(_func(tree, "downgrade")):
+            offenders.append(f"{path.name}: downgrade() is missing or a stub")
+    assert not offenders, (
+        "Every migration must have a real upgrade() AND downgrade() (reversibility "
+        "is a hard invariant). Stubs found:\n  " + "\n  ".join(offenders)
+    )
+
+
+def _current_contractions() -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for path in _migration_files():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        sigs = _upgrade_contractions(tree)
+        if sigs:
+            out[path.stem] = sorted(sigs)
+    return out
+
+
+def test_upgrade_contractions_are_acknowledged() -> None:
+    current = _current_contractions()
+
+    if os.environ.get("UPDATE_API_CONTRACT"):
+        _LEDGER.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        return
+
+    assert _LEDGER.exists(), (
+        f"Contraction ledger missing at {_LEDGER}. Generate it with:\n"
+        "  UPDATE_API_CONTRACT=1 pytest tests/db/test_migration_contract.py"
+    )
+    ledger: dict[str, list[str]] = json.loads(_LEDGER.read_text())
+
+    new: list[str] = []
+    for revision, sigs in current.items():
+        unacked = sorted(set(sigs) - set(ledger.get(revision, [])))
+        for sig in unacked:
+            new.append(f"{revision}: {sig}")
+
+    assert not new, (
+        "New schema CONTRACTION(s) in a migration `upgrade()`. During a rolling "
+        "upgrade the OLD API replica runs against this new schema — dropping or "
+        "retyping a column/table it still reads breaks it. Only acknowledge this "
+        "if the column/table has been UNUSED for a prior release (expand → migrate "
+        "→ wait a release → contract). If so, regenerate the ledger:\n"
+        "  UPDATE_API_CONTRACT=1 pytest tests/db/test_migration_contract.py\n"
+        "Unacknowledged contractions:\n  " + "\n  ".join(new)
+    )
+
+
+def test_ledger_and_scan_are_nonempty() -> None:
+    # Bite-check: prove the scanner resolves migrations + finds real contractions,
+    # so an empty ledger can't silently disable the gate.
+    assert len(_migration_files()) > 40
+    assert _current_contractions(), "expected at least one upgrade() contraction historically"


### PR DESCRIPTION
Measure #7 of the v1.0.0 program (#550) — the zero-downtime-upgrade guard no API/attribute gate catches.

## Two hazards
1. **Reversibility** — every migration must have a real `upgrade()` **and** `downgrade()` (no stubs). A stated invariant, now enforced across all 53 migrations.
2. **Expand/contract** — a rolling upgrade runs **old and new API code against the same DB at once**. A migration that drops/retypes a column/table in `upgrade()` breaks the **old** replica still serving traffic the moment the migration Job runs. Safe only after the column has been unused for a prior release (expand → migrate → wait a release → contract).

## What
`tests/db/test_migration_contract.py` AST-scans `alembic/versions`:
- asserts real `upgrade`+`downgrade` on every migration;
- **ledgers every `upgrade()`-side contraction** (`op.drop_column`/`drop_table`/`drop_constraint`/`alter_column`) — 10 historical ones grandfathered into `migration_contractions.json`. A **new** contraction fails CI until consciously acknowledged (confirming it followed expand/contract), then regenerated with `UPDATE_API_CONTRACT=1`.
- Correctly scopes to `upgrade()` only — the ~48 `drop_table`/90 `drop_column` calls in `downgrade()` (normal create-reversal) are ignored.

Adds `COPY alembic` to `Dockerfile.test` so tests see the migrations, wires `tests/db` into the unit CI shard, and documents the **expand/contract discipline** as a hard rule in AGENTS.md.

## Verified
`scripts/test.sh python -- tests/db/test_migration_contract.py` → 3 passed. Runs in the `unit` shard.

Part of #550.