### PR TITLE
fix(scan): ignore CVE-2026-39822 (Go stdlib os.Root in bundled OPA)

### DIFF
--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -44,3 +44,13 @@ CVE-2026-46680
 # the upstream fixes — so Trivy reads clean buildinfo and no longer reports
 # them. Preferring the bump over a standing ignore per the release-audit
 # rule "drop the ignore in the same PR as the bump.")
+
+# CVE-2026-39822 — Go stdlib `os.Root` symlink-following (fixed in Go
+# 1.25.12 / 1.26.5). Pulled into the API + runner images as the Go stdlib
+# version the *bundled `opa` binary* was compiled with — Trivy reads OPA's
+# embedded buildinfo and flags its stdlib. Terrapod downloads OPA's official
+# release binary; we can't recompile it, and Terrapod invokes only `opa eval`
+# / `opa check` (pure in-memory Rego over trusted inputs) — no path handling
+# reaches the vulnerable `os.Root` symlink code. Same class as the OPA-Go
+# CVEs above. Drop when OPA ships a release built with a patched Go toolchain.
+CVE-2026-39822


### PR DESCRIPTION
A newly-published Go stdlib CVE (`CVE-2026-39822`, `os.Root` symlink-following, fixed in Go 1.25.12/1.26.5) now fails Trivy on the API + runner images — it's the Go stdlib version **OPA's release binary** was compiled with (Trivy reads OPA's embedded buildinfo). We download OPA's official binary and invoke only `opa eval`/`opa check` over trusted in-memory Rego, so the vulnerable `os.Root` path handling is never reached. Same class as the existing OPA-Go ignores in `.trivyignore`; drop when OPA ships a release built with a patched Go.

**This is currently failing the `Scan` job on every open PR and would fail the next release** — a Trivy-DB-update incident, not a regression. Ignore-with-rationale is the consistent fix (we can't recompile OPA).