### PR TITLE
feat(api): deprecation-header mechanism + docs/deprecations.md

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,75 @@
+# Deprecations
+
+This page is the authoritative list of **deprecated** Terrapod surfaces — parts of
+the public API, wire protocol, configuration, or Helm chart that are scheduled for
+removal in a future major release. It is the human-readable companion to the
+machine-readable `Deprecation` / `Sunset` headers the API emits (see below), and it
+is governed by the compatibility guarantees in
+[versioning-and-support.md](versioning-and-support.md).
+
+## The promise
+
+Terrapod does **not** remove or rename anything on a public surface without notice.
+Every removal goes through a deprecation window:
+
+1. The thing is **marked deprecated** — it keeps working exactly as before, but the
+   API advertises a sunset date (and, for endpoints, emits deprecation headers).
+2. The deprecation is **announced** here and in the release notes, with a
+   replacement and a migration note.
+3. It stays working for **at least two minor releases** (and never disappears in a
+   MINOR or PATCH).
+4. It is **removed only in the next MAJOR**, on or after the published sunset date.
+
+If you keep your consumers (runner/listener images, `go-terrapod`,
+`terraform-provider-terrapod`, your `values.yaml`) reasonably current — within the
+[supported skew window](versioning-and-support.md) — a deprecation will always reach
+you as a warning before it can reach you as a break.
+
+## How to read the API's deprecation signal
+
+A deprecated HTTP endpoint returns its normal body and status, plus these response
+headers (per the IETF Deprecation draft and [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594)):
+
+| Header | Example | Meaning |
+|---|---|---|
+| `Deprecation` | `true` | This endpoint is deprecated. |
+| `Sunset` | `Wed, 30 Jun 2027 00:00:00 GMT` | The date on/after which it may stop working (removed in a MAJOR). |
+| `Link` | `<https://…/docs/deprecations.md>; rel="deprecation"; type="text/html"` | Where to read what to use instead. |
+
+Automated clients should surface a `Deprecation: true` response as a warning in
+their logs and plan a migration before the `Sunset` date. Nothing breaks at the
+moment the header appears — it is advance notice.
+
+## Active deprecations
+
+**None.** No public Terrapod surface is currently deprecated.
+
+When the first deprecation lands, it will be listed here in this shape:
+
+<!--
+| Surface | Deprecated in | Sunset (removed no earlier than) | Replacement | Notes |
+|---|---|---|---|---|
+| `GET /api/…/old-thing` | v1.3.0 | v2.0.0 / 2027-06-30 | `GET /api/…/new-thing` | Response shape is identical; only the path changed. |
+-->
+
+## For maintainers
+
+Mark an endpoint deprecated by injecting the FastAPI `Response` into the handler and
+calling the helper from `terrapod.api.deprecation`:
+
+```python
+from datetime import date
+from fastapi import Response
+from terrapod.api.deprecation import mark_deprecated
+
+@router.get("/old-thing")
+async def old_thing(response: Response, ...):
+    mark_deprecated(response, sunset=date(2027, 6, 30))
+    ...  # keep serving the normal response
+```
+
+Then add a row to the **Active deprecations** table above and a note to the release
+notes. The `sunset` date must be at least two minor releases out. Removal is a
+separate change in a future MAJOR — and per the pre-release backward-compatibility
+gate, dropping the route/attribute/key before its window completes will fail the
+contract tests in CI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,6 +151,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [Forward proxy & custom CA trust](deployment-proxy.md) | Route all outbound HTTP(S) through a corporate proxy and trust a private/MITM CA, across every component including runner Jobs |
 | [Security Hardening](security-hardening.md) | TLS, secrets management, network policies, rate limiting |
 | [Versioning & Support](versioning-and-support.md) | What each version bump guarantees, the stable surfaces + their CI gates, component version-skew support, the deprecation window, and the support matrix |
+| [Deprecations](deprecations.md) | The authoritative list of deprecated surfaces and their sunset dates, plus how to read the API's `Deprecation`/`Sunset` headers |
 | [Known Limitations](known-limitations.md) | What Terrapod does not (yet) do — deployment, scope, and feature constraints, stated plainly |
 | [Production Checklist](production-checklist.md) | Step-by-step checklist for go-live readiness |
 | [Disaster Recovery](disaster-recovery.md) | Break-glass state recovery, shipped DB backup CronJob + restore-verification DR drill, per-backend object-storage protection |

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -63,12 +63,16 @@ rolling upgrade or live in a separate, independently-upgraded cluster.
 Nothing on a stable surface is removed without notice. To remove or rename
 anything:
 
-1. **Announce** — mark it deprecated in the release notes and (for API responses)
-   emit a `Deprecation` / `Sunset` HTTP header; keep the old behaviour working.
+1. **Announce** — mark it deprecated in the release notes, list it in
+   [`deprecations.md`](deprecations.md), and (for API responses) emit
+   `Deprecation` / `Sunset` / `Link` HTTP headers; keep the old behaviour working.
 2. **Grace period** — leave the deprecated surface in place for at least **2
    minor releases** (or until the next MAJOR, whichever is longer).
-3. **Remove** — only in a MAJOR release, with the removal listed in the migration
-   notes.
+3. **Remove** — only in a MAJOR release, on or after the published `Sunset` date,
+   with the removal listed in the migration notes.
+
+The live list of what is currently deprecated and when it sunsets is
+[`deprecations.md`](deprecations.md).
 
 Database columns follow the stricter **expand → migrate → wait a release →
 contract** rule (a rolling upgrade runs old and new code against the same DB, so
@@ -101,9 +105,11 @@ Compatibility isn't a promise on paper — it's checked three ways:
 
 These gates are landing incrementally under
 [#550](https://github.com/mattrobinsonsre/terrapod/issues/550): the route,
-response-attribute, config-key, and migration (reversibility + expand/contract)
-gates are live today; the go-terrapod, provider-schema, and Helm-value-removal
-gates and the `Deprecation`/`Sunset` header mechanism follow before `1.0.0`.
+response-attribute, **runner/listener wire-protocol**, config-key, and migration
+(reversibility + expand/contract) gates are live today, as is the
+`Deprecation`/`Sunset` header mechanism (see [`deprecations.md`](deprecations.md));
+the go-terrapod, provider-schema, and Helm-value-removal gates follow before
+`1.0.0`.
 
 If you find a compatibility break that slipped through, it's a bug — please
 [open an issue](https://github.com/mattrobinsonsre/terrapod/issues).

--- a/llms.txt
+++ b/llms.txt
@@ -112,6 +112,7 @@ How each capability is turned on. **Platform-level** features are Helm values un
 - [docs/deployment-proxy.md](docs/deployment-proxy.md): forward proxy (`proxy.*`) + custom outbound CA trust (`caBundle.*`) across all components incl. runner Jobs; for no-direct-egress / TLS-intercepting networks.
 - [docs/security-hardening.md](docs/security-hardening.md), [docs/production-checklist.md](docs/production-checklist.md), [docs/disaster-recovery.md](docs/disaster-recovery.md): go-live and break-glass.
 - [docs/versioning-and-support.md](docs/versioning-and-support.md): the SemVer compatibility contract — what each bump guarantees, the stable surfaces + their CI gates, runner/listener/SDK version-skew support (N-2), the deprecation window (`Deprecation`/`Sunset` headers + 2-minor grace), and the support matrix.
+- [docs/deprecations.md](docs/deprecations.md): the authoritative list of deprecated public surfaces and their sunset dates, plus how automated clients should read the `Deprecation`/`Sunset`/`Link` response headers (currently: nothing is deprecated).
 - [docs/known-limitations.md](docs/known-limitations.md): what Terrapod does **not** (yet) do — K8s-only deployment, single-org by design, no teams/projects, `local`/`agent` execution only, GitHub/GitLab VCS only, migration checklist gaps, OPA-only policy — each marked *by design* vs *not yet*.
 - [docs/runbooks.md](docs/runbooks.md): operator runbooks for high-blast-radius surfaces.
 - [docs/local-development.md](docs/local-development.md): run from source with Tilt (contributors).

--- a/services/terrapod/api/deprecation.py
+++ b/services/terrapod/api/deprecation.py
@@ -1,0 +1,63 @@
+"""Deprecation signalling for the public API surface (#550).
+
+Part of the v1.0.0 stability program. When an endpoint (or a response attribute
+served by one) is scheduled for removal, Terrapod must give consumers advance,
+machine-readable warning **before** the breaking change lands in a future MAJOR —
+never remove-without-notice. This is the runtime half of the deprecation policy in
+`docs/versioning-and-support.md`; the human-facing list of what is deprecated and
+when it sunsets lives in `docs/deprecations.md`.
+
+The contract we emit on a deprecated endpoint, per the IETF drafts the ecosystem
+already understands:
+
+- ``Deprecation: true`` — the resource is deprecated (draft-ietf-httpapi-deprecation-header).
+- ``Sunset: <IMF-fixdate>`` — the date at/after which it may stop working (RFC 8594).
+- ``Link: <url>; rel="deprecation"; type="text/html"`` — where to read what to do instead.
+
+Call ``mark_deprecated(response, ...)`` from any handler being wound down. It only
+*adds* headers — it never changes the response body or status — so a lagging client
+keeps working through the whole deprecation window (>= 2 minor releases) and simply
+sees the warning. Removal happens only in a MAJOR, after the ``Sunset`` date has
+passed and the window is complete.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from email.utils import format_datetime
+
+from fastapi import Response
+
+# Canonical docs page listing every active deprecation and its sunset date.
+DEPRECATIONS_DOC_URL = "https://github.com/mattrobinsonsre/terrapod/blob/main/docs/deprecations.md"
+
+
+def _imf_fixdate(sunset: date) -> str:
+    """RFC 7231 IMF-fixdate (e.g. ``Wed, 01 Jan 2027 00:00:00 GMT``) for a date.
+
+    ``Sunset`` (RFC 8594) is an HTTP-date; midnight UTC of the given day is the
+    conventional encoding for a whole-day sunset.
+    """
+    dt = datetime(sunset.year, sunset.month, sunset.day, tzinfo=UTC)
+    return format_datetime(dt, usegmt=True)
+
+
+def mark_deprecated(
+    response: Response,
+    *,
+    sunset: date,
+    link: str = DEPRECATIONS_DOC_URL,
+) -> None:
+    """Attach ``Deprecation`` / ``Sunset`` / ``Link`` headers to a response.
+
+    Args:
+        response: the FastAPI ``Response`` the handler will return (inject it as a
+            handler parameter — FastAPI populates it).
+        sunset: the date on/after which the endpoint may stop working. MUST be at
+            least two minor releases out per the deprecation policy.
+        link: URL explaining the deprecation and the replacement; defaults to the
+            project deprecations page.
+    """
+    response.headers["Deprecation"] = "true"
+    response.headers["Sunset"] = _imf_fixdate(sunset)
+    response.headers["Link"] = f'<{link}>; rel="deprecation"; type="text/html"'

--- a/services/tests/api/test_deprecation.py
+++ b/services/tests/api/test_deprecation.py
@@ -1,0 +1,39 @@
+"""Tests for the deprecation-header helper (#550)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import Response
+
+from terrapod.api.deprecation import DEPRECATIONS_DOC_URL, _imf_fixdate, mark_deprecated
+
+
+def test_imf_fixdate_is_rfc7231_gmt() -> None:
+    assert _imf_fixdate(date(2027, 1, 1)) == "Fri, 01 Jan 2027 00:00:00 GMT"
+
+
+def test_mark_deprecated_sets_all_three_headers() -> None:
+    resp = Response()
+    mark_deprecated(resp, sunset=date(2027, 6, 30))
+
+    assert resp.headers["Deprecation"] == "true"
+    assert resp.headers["Sunset"] == "Wed, 30 Jun 2027 00:00:00 GMT"
+    assert resp.headers["Link"] == (
+        f'<{DEPRECATIONS_DOC_URL}>; rel="deprecation"; type="text/html"'
+    )
+
+
+def test_mark_deprecated_custom_link() -> None:
+    resp = Response()
+    mark_deprecated(resp, sunset=date(2027, 6, 30), link="https://example.test/x")
+    assert 'rel="deprecation"' in resp.headers["Link"]
+    assert "https://example.test/x" in resp.headers["Link"]
+
+
+def test_mark_deprecated_does_not_touch_body_or_status() -> None:
+    # A deprecated endpoint must keep working for lagging clients — headers only.
+    resp = Response(content=b"payload", status_code=200)
+    mark_deprecated(resp, sunset=date(2027, 6, 30))
+    assert resp.body == b"payload"
+    assert resp.status_code == 200


### PR DESCRIPTION
The runtime half of the deprecation policy from #550 — so the first post-1.0 deprecation has a ready, tested path.

## What
- **`terrapod.api.deprecation.mark_deprecated(response, sunset=..., link=...)`** — attaches `Deprecation: true`, `Sunset: <RFC 8594 IMF-fixdate>`, and `Link: <docs>; rel="deprecation"` to a deprecated endpoint's response. **Headers only** — never touches the body or status, so a lagging client keeps working through the whole grace window and simply sees advance notice. Removal stays MAJOR-only, after the published sunset date.
- **`docs/deprecations.md`** — authoritative list of deprecated surfaces + sunset dates + how automated clients should read the headers (currently: **none deprecated**), plus a maintainer how-to. Linked from the versioning doc, docs index, and llms.txt.

## Tests
Unit tests for the IMF-fixdate formatting, all three headers, custom link, and the body/status-untouched invariant.

Closes #790. Part of #550.