### PR TITLE
feat: wire the version-compatibility handshake end to end

### DIFF
--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -60,6 +60,18 @@ rolling upgrade or live in a separate, independently-upgraded cluster.
 - **API ↔ go-terrapod / provider / `terraform` CLI:** an SDK/provider/CLI built
   against API version `N` keeps working against API `≥ N` within the same MAJOR.
 
+### Runtime version handshake
+
+The API advertises its running version as `terrapod-version` in the
+`/.well-known/terraform.json` discovery document, and `go-terrapod`'s
+`Client.VersionCheck` compares it against the SDK's build-pinned version using
+exactly the policy above: compatible when they share the same MAJOR and the API
+is at least as new as the SDK (`api >= sdk`). The provider (a startup warning
+diagnostic), `terrapod-migrate`, and `terrapod-publish` (a stderr warning) all
+run this check so a version-skew surfaces as a clear, actionable message instead
+of a confusing downstream failure. It only ever **warns** — never blocks — and a
+dev build on either side skips the check.
+
 ## Deprecation window
 
 Nothing on a stable surface is removed without notice. To remove or rename

--- a/go-terrapod/version.go
+++ b/go-terrapod/version.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -41,8 +42,12 @@ const versionProbeTimeout = 10 * time.Second
 
 // VersionCheck probes the target Terrapod deployment's reported
 // version and compares it against the SDK's build-time-pinned
-// SDKVersion. Returns nil on exact match, wrapped ErrVersionMismatch
-// or ErrVersionUnreported otherwise, or a network/HTTP error.
+// SDKVersion using the support policy: compatible when they share the
+// same MAJOR and the API is at least as new as the SDK (api >= sdk).
+// Returns nil when compatible (or when either side is a dev build),
+// wrapped ErrVersionMismatch on an incompatible major / too-old API,
+// ErrVersionUnreported when the deployment doesn't report a version,
+// or a network/HTTP error.
 //
 // Most callers should invoke this once at startup (after constructing
 // a Client) as a fail-fast probe before any further work. Tools that
@@ -65,12 +70,10 @@ const versionProbeTimeout = 10 * time.Second
 // terrapod.Options when constructing the Client.
 func (c *Client) VersionCheck(ctx context.Context) error {
 	if SDKVersion == "" || SDKVersion == "dev" {
-		// Dev builds have no meaningful version to compare against.
-		// Surface as Mismatch (not Unreported) — the operator action
-		// is "use a tagged SDK build, or pass an override flag in
-		// the consuming tool".
-		return fmt.Errorf("%w: SDK version is %q (likely a development build); use a tagged SDK build or pass --allow-api-version-mismatch in the consuming tool",
-			ErrVersionMismatch, SDKVersion)
+		// Dev builds have no pinned version to compare against — the
+		// compatibility check can't be performed, so skip it silently
+		// rather than fail. A release build always has a real SDKVersion.
+		return nil
 	}
 
 	url := c.BaseURL + DiscoveryPath
@@ -112,10 +115,67 @@ func (c *Client) VersionCheck(ctx context.Context) error {
 	if !ok || api == "" {
 		return ErrVersionUnreported
 	}
-	if api != SDKVersion {
-		return fmt.Errorf("%w: SDK=%s API=%s — install the matching release: https://github.com/mattrobinsonsre/terrapod/releases/tag/v%s",
-			ErrVersionMismatch, SDKVersion, api, api)
+	if api == "dev" {
+		// The target is a dev build of Terrapod — no meaningful version to
+		// compare against; skip rather than false-alarm.
+		return nil
+	}
+	if compatible, reason := versionsCompatible(SDKVersion, api); !compatible {
+		return fmt.Errorf("%w: SDK=%s API=%s (%s) — install a matching SDK/provider release: https://github.com/mattrobinsonsre/terrapod/releases",
+			ErrVersionMismatch, SDKVersion, api, reason)
 	}
 	return nil
 }
 
+// parseSemver parses a "MAJOR.MINOR.PATCH" string (ignoring any leading "v" and
+// any "-prerelease"/"+build" suffix) into its numeric parts. ok is false if the
+// string isn't three dot-separated integers.
+func parseSemver(v string) (major, minor, patch int, ok bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	var err error
+	if major, err = strconv.Atoi(parts[0]); err != nil {
+		return 0, 0, 0, false
+	}
+	if minor, err = strconv.Atoi(parts[1]); err != nil {
+		return 0, 0, 0, false
+	}
+	if patch, err = strconv.Atoi(parts[2]); err != nil {
+		return 0, 0, 0, false
+	}
+	return major, minor, patch, true
+}
+
+// versionsCompatible implements the go-terrapod support policy: an SDK built at
+// version `sdk` works against an API at version `api` when they share the same
+// MAJOR and the API is at least as new as the SDK (`api >= sdk`). A newer API is
+// forward-compatible within the major; an older API may be missing endpoints the
+// SDK expects, and a different major is a hard break. If either version is
+// unparseable, treat as compatible (fail-open) so a non-semver tag never blocks.
+func versionsCompatible(sdk, api string) (ok bool, reason string) {
+	sMaj, sMin, sPat, sOK := parseSemver(sdk)
+	aMaj, aMin, aPat, aOK := parseSemver(api)
+	if !sOK || !aOK {
+		return true, ""
+	}
+	if aMaj != sMaj {
+		return false, fmt.Sprintf("incompatible major version — SDK is v%d.x, API is v%d.x", sMaj, aMaj)
+	}
+	sTuple := [3]int{sMaj, sMin, sPat}
+	aTuple := [3]int{aMaj, aMin, aPat}
+	for i := range 3 {
+		if aTuple[i] != sTuple[i] {
+			if aTuple[i] < sTuple[i] {
+				return false, "API is older than the SDK was built against; upgrade the Terrapod deployment or use an older SDK/provider"
+			}
+			return true, "" // API newer within the same major — forward-compatible
+		}
+	}
+	return true, "" // exact match
+}

--- a/go-terrapod/version_test.go
+++ b/go-terrapod/version_test.go
@@ -45,10 +45,12 @@ func TestVersionCheck_ExactMatch(t *testing.T) {
 	}
 }
 
-func TestVersionCheck_Mismatch(t *testing.T) {
-	withSDKVersion(t, "0.27.0")
+func TestVersionCheck_APIOlderIsMismatch(t *testing.T) {
+	// Same major, but the API is OLDER than the SDK was built against —
+	// the SDK may call endpoints the older API lacks. Mismatch.
+	withSDKVersion(t, "1.4.0")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"terrapod-version": "0.26.0"}`))
+		_, _ = w.Write([]byte(`{"terrapod-version": "1.2.0"}`))
 	}))
 	defer srv.Close()
 
@@ -57,12 +59,43 @@ func TestVersionCheck_Mismatch(t *testing.T) {
 	if !errors.Is(err, ErrVersionMismatch) {
 		t.Fatalf("expected ErrVersionMismatch, got: %v", err)
 	}
-	// Message must name both versions and the release URL.
 	msg := err.Error()
-	for _, want := range []string{"SDK=0.27.0", "API=0.26.0", "v0.26.0"} {
+	for _, want := range []string{"SDK=1.4.0", "API=1.2.0"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error message missing %q: %s", want, msg)
 		}
+	}
+}
+
+func TestVersionCheck_NewerAPISameMajorIsOK(t *testing.T) {
+	// The API is NEWER than the SDK, same major → forward-compatible → nil.
+	// This is the core case the old exact-match logic wrongly failed.
+	withSDKVersion(t, "1.0.0")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"terrapod-version": "1.7.3"}`))
+	}))
+	defer srv.Close()
+
+	c := makeClient(t, srv.URL)
+	if err := c.VersionCheck(context.Background()); err != nil {
+		t.Fatalf("newer API within same major must be compatible, got: %v", err)
+	}
+}
+
+func TestVersionCheck_DifferentMajorIsMismatch(t *testing.T) {
+	withSDKVersion(t, "1.9.0")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"terrapod-version": "2.0.0"}`))
+	}))
+	defer srv.Close()
+
+	c := makeClient(t, srv.URL)
+	err := c.VersionCheck(context.Background())
+	if !errors.Is(err, ErrVersionMismatch) {
+		t.Fatalf("expected ErrVersionMismatch across majors, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "major") {
+		t.Errorf("error should name the major mismatch: %v", err)
 	}
 }
 
@@ -95,14 +128,26 @@ func TestVersionCheck_EmptyFieldIsUnreported(t *testing.T) {
 	}
 }
 
-func TestVersionCheck_DevBuildIsMismatch(t *testing.T) {
-	// SDKVersion="dev" → can't compare; surface as Mismatch so the
-	// consuming tool can offer --allow-api-version-mismatch override.
+func TestVersionCheck_DevSDKSkips(t *testing.T) {
+	// SDKVersion="dev" → no pinned version to compare; skip silently
+	// (return nil) rather than false-alarm. Must not even probe the server.
 	withSDKVersion(t, "dev")
 	c := makeClient(t, "https://unreachable.example")
-	err := c.VersionCheck(context.Background())
-	if !errors.Is(err, ErrVersionMismatch) {
-		t.Errorf("expected ErrVersionMismatch for dev build, got: %v", err)
+	if err := c.VersionCheck(context.Background()); err != nil {
+		t.Errorf("dev SDK build should skip the check (nil), got: %v", err)
+	}
+}
+
+func TestVersionCheck_DevAPISkips(t *testing.T) {
+	// The target reports "dev" → no meaningful version; skip → nil.
+	withSDKVersion(t, "1.0.0")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"terrapod-version": "dev"}`))
+	}))
+	defer srv.Close()
+	c := makeClient(t, srv.URL)
+	if err := c.VersionCheck(context.Background()); err != nil {
+		t.Errorf("dev API build should skip the check (nil), got: %v", err)
 	}
 }
 

--- a/migrate/cmd/terrapod-migrate/apply.go
+++ b/migrate/cmd/terrapod-migrate/apply.go
@@ -136,6 +136,7 @@ func applyCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "apply: build terrapod client: %v\n", err)
 		return 1
 	}
+	warnVersionMismatch(c)
 
 	// --workspace mode: pre-seed the state file with the existing
 	// workspace's Terrapod ID so the writer takes the "reused" path

--- a/migrate/cmd/terrapod-migrate/main.go
+++ b/migrate/cmd/terrapod-migrate/main.go
@@ -18,9 +18,23 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
 )
+
+// warnVersionMismatch prints a non-fatal stderr warning if this terrapod-migrate
+// build is incompatible with the target Terrapod API version (#550) — a
+// different major, or an API older than the SDK was built against. Never aborts:
+// a version probe that itself fails must not block a migration.
+func warnVersionMismatch(c *terrapod.Client) {
+	if err := c.VersionCheck(context.Background()); err != nil && errors.Is(err, terrapod.ErrVersionMismatch) {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+	}
+}
 
 // Version is the build-time-pinned tool version. It MUST match the target
 // Terrapod API's reported version on startup (compared via

--- a/migrate/cmd/terrapod-migrate/rollback.go
+++ b/migrate/cmd/terrapod-migrate/rollback.go
@@ -88,6 +88,7 @@ func rollbackCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "rollback: build terrapod client: %v\n", err)
 		return 1
 	}
+	warnVersionMismatch(c)
 
 	report := runRollback(context.Background(), c, state, *statePath, *apply, *force)
 

--- a/migrate/cmd/terrapod-migrate/verify.go
+++ b/migrate/cmd/terrapod-migrate/verify.go
@@ -67,6 +67,7 @@ func verifyCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "verify: build terrapod client: %v\n", err)
 		return 1
 	}
+	warnVersionMismatch(c)
 
 	report := runVerify(context.Background(), c, state)
 

--- a/provider/internal/provider/provider.go
+++ b/provider/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
 	"github.com/mattrobinsonsre/terrapod/provider/internal/client"
 	agentPoolDS "github.com/mattrobinsonsre/terrapod/provider/internal/datasources/agent_pool"
 	catalogInstancesDS "github.com/mattrobinsonsre/terrapod/provider/internal/datasources/catalog_instances"
@@ -121,6 +123,19 @@ func (p *terrapodProvider) Configure(ctx context.Context, req provider.Configure
 	}
 
 	c := client.NewClient(hostname, token, skipTLS)
+
+	// Compatibility check (#550): warn — never block — if this provider build
+	// is incompatible with the target Terrapod API version (different major, or
+	// an API older than the provider was built against). A warning keeps a
+	// version-skew from silently causing confusing downstream errors, without
+	// failing the plan on a probe that might itself be misconfigured.
+	if tc, err := terrapod.NewClient(terrapod.Options{
+		BaseURL: c.BaseURL, Token: c.Token, SkipTLSVerify: c.SkipTLSVerify,
+	}); err == nil {
+		if verr := tc.VersionCheck(ctx); verr != nil && errors.Is(verr, terrapod.ErrVersionMismatch) {
+			resp.Diagnostics.AddWarning("Terrapod provider/API version mismatch", verr.Error())
+		}
+	}
 
 	resp.DataSourceData = c
 	resp.ResourceData = c

--- a/publish/cmd/terrapod-publish/main.go
+++ b/publish/cmd/terrapod-publish/main.go
@@ -4,10 +4,24 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
 )
+
+// warnVersionMismatch prints a non-fatal stderr warning if this terrapod-publish
+// build is incompatible with the target Terrapod API version (#550) — a
+// different major, or an API older than the SDK was built against. Never aborts:
+// a version probe that itself fails must not block a publish.
+func warnVersionMismatch(c *terrapod.Client) {
+	if err := c.VersionCheck(context.Background()); err != nil && errors.Is(err, terrapod.ErrVersionMismatch) {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+	}
+}
 
 // Version is stamped at build time via -ldflags "-X main.Version=...".
 var Version = "dev"
@@ -50,7 +64,7 @@ Auth resolution order: --token, then $TERRAPOD_TOKEN, then
 // multiFlag is a repeatable string flag.
 type multiFlag []string
 
-func (m *multiFlag) String() string  { return strings.Join(*m, ",") }
+func (m *multiFlag) String() string { return strings.Join(*m, ",") }
 func (m *multiFlag) Set(v string) error {
 	*m = append(*m, v)
 	return nil

--- a/publish/cmd/terrapod-publish/module.go
+++ b/publish/cmd/terrapod-publish/module.go
@@ -40,6 +40,7 @@ func moduleCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "client: %v\n", err)
 		return 1
 	}
+	warnVersionMismatch(client)
 
 	err = publisher.PublishModule(
 		context.Background(), client, *name, *provider, *version, *source,

--- a/publish/cmd/terrapod-publish/provider.go
+++ b/publish/cmd/terrapod-publish/provider.go
@@ -78,6 +78,7 @@ func providerCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "client: %v\n", err)
 		return 1
 	}
+	warnVersionMismatch(client)
 
 	err = publisher.PublishProvider(context.Background(), client, publisher.ProviderInput{
 		Name:       *name,

--- a/services/terrapod/api/routers/oauth.py
+++ b/services/terrapod/api/routers/oauth.py
@@ -10,6 +10,7 @@ Endpoints:
 """
 
 import hmac
+import os
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -29,6 +30,14 @@ from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
 
 router = APIRouter(tags=["oauth"])
+
+
+def _terrapod_version() -> str:
+    """The running Terrapod version, injected by the release pipeline via the
+    ``TERRAPOD_VERSION`` env var (``"dev"`` for local/untagged builds). Read at
+    request time so tests and redeploys pick up the current value."""
+    return os.environ.get("TERRAPOD_VERSION", "dev")
+
 
 # Terrapod-only CLI login completion check. Terrapod-native: mounted
 # only under /api/terrapod/v1 (the /api/v2 alias was removed in
@@ -58,6 +67,10 @@ async def terraform_service_discovery() -> JSONResponse:
             "tfe.v2": "/api/v2/",
             "tfe.v2.1": "/api/v2/",
             "tfe.v2.2": "/api/v2/",
+            # The running Terrapod version, so the go-terrapod SDK / provider can
+            # run a compatibility check (Client.VersionCheck) at startup. Not
+            # consumed by terraform/tofu/tfci — they ignore unknown keys.
+            "terrapod-version": _terrapod_version(),
         }
     )
 

--- a/services/tests/api/test_oauth.py
+++ b/services/tests/api/test_oauth.py
@@ -56,6 +56,10 @@ class TestTerraformServiceDiscovery:
         assert data["tfe.v2"] == "/api/v2/"
         assert data["tfe.v2.1"] == "/api/v2/"
         assert data["tfe.v2.2"] == "/api/v2/"
+        # #550: the running version is advertised so go-terrapod/provider can
+        # run a compatibility check (Client.VersionCheck) at startup.
+        assert "terrapod-version" in data
+        assert isinstance(data["terrapod-version"], str) and data["terrapod-version"]
 
 
 class TestSessionStatus:


### PR DESCRIPTION
Found during the v1.0.0 pre-release review: go-terrapod's `VersionCheck`/`SDKVersion` are frozen into the 1.0 SDK contract but were **dead code** — the server never emitted the version, the check used broken exact-string equality, and no consumer called it. Rather than freeze broken API into a stability guarantee, finish #550 objective F.

## Changes
- **Server** (`oauth.py`): emit `terrapod-version` in `/.well-known/terraform.json` (additive; CLIs ignore unknown keys).
- **SDK** (`version.go`): `VersionCheck` is now a **semver compatibility check** — compatible when same MAJOR and `api >= sdk` (a newer API within the major is forward-compatible; the old exact-match wrongly failed it). Dev builds on either side skip. **Exported surface unchanged** (only unexported helpers added — surface.golden untouched).
- **Consumers**: the provider (startup **warning diagnostic**), `terrapod-migrate`, and `terrapod-publish` (stderr **warning**) all run the check. **Warn-only** — a version-skew (or a misconfigured probe) never blocks a plan/migrate/publish.
- Tests: server emit + all semver cases (older/newer/same-major/cross-major/dev). Docs: a runtime-handshake note in the versioning policy.

Verified: `go build/vet/test` + golangci-lint (0 issues) across all four modules; ruff + oauth + route/attribute contract gates green.

Closes #802. Part of #550.