### PR TITLE
fix(ci): bump APT_REFRESH to pull curl deb13u4 (CVE-2026-5773)

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -57,7 +57,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # CVE-2026-27135). Without this the apt-upgrade layer is reused from
 # before the patch was published — same cache-staleness issue the
 # runner image's APK_REFRESH solves.
-ARG APT_REFRESH=2026-06-26
+ARG APT_REFRESH=2026-07-13
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -21,7 +21,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 
 # Bump APT_REFRESH to bust the cached apt layer and re-pull Debian
 # security patches (CVE-2026-27135 etc.) — see Dockerfile.api.
-ARG APT_REFRESH=2026-06-26
+ARG APT_REFRESH=2026-07-13
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -21,7 +21,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # Pick up post-publish Debian security patches. Bump APT_REFRESH to
 # bust the cached apt layer and re-pull patches (CVE-2026-27135 etc.) —
 # see Dockerfile.api. No new packages installed — just upgrades.
-ARG APT_REFRESH=2026-06-04
+ARG APT_REFRESH=2026-07-13
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -50,7 +50,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 
 # Bump APT_REFRESH to bust the cached apt layer and re-pull Debian
 # security patches. See Dockerfile.api for the same pattern.
-ARG APT_REFRESH=2026-06-26
+ARG APT_REFRESH=2026-07-13
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
         git \


### PR DESCRIPTION
Trivy is failing every image `Scan` on **CVE-2026-5773** (HIGH, curl/libcurl) — a fresh Debian advisory, **fixed** in `8.14.1-2+deb13u4` (images ship `deb13u3`).

The Dockerfiles already run `apt-get upgrade -y`, but the buildx `type=gha` layer cache reuses the apt-upgrade layer from before the patch published, so the fix is never actually pulled. Bumping the `APT_REFRESH` cache-bust ARG — the mechanism built for exactly this — invalidates the layer and forces a fresh `apt-get upgrade` → `deb13u4`.

Bumps all four Debian images (api/listener/runner `2026-06-26`, migrations `2026-06-04`) → `2026-07-13`.

This is a **repo-wide CI blocker independent of the dependabot bumps** — it fails on `main` too. Unblocks the image scans for the web/CodeQL/uvicorn rollups (#825/#826/#822) and the i18n PR #813.