### PR TITLE
feat(query): terrapod-query — tofu-native discovery engine (#823)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,81 @@ jobs:
         run: go test ./... -v -count=1 -timeout 120s
         working-directory: publish
 
+  # ── Query Lint ────────────────────────────────────────
+  query-lint:
+    name: Query Lint
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: query/go.mod
+          # Stdlib-only module — no go.sum, so nothing to cache.
+          cache: false
+      - name: Vet
+        run: go vet ./...
+        working-directory: query
+      - name: Build
+        run: go build ./...
+        working-directory: query
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        with:
+          version: v2.12.2
+          working-directory: query
+          args: --config=../.golangci.yml
+
+  # ── Query Test ────────────────────────────────────────
+  query-test:
+    name: Query Test
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: query/go.mod
+          cache: false
+      - name: Test
+        run: go test ./... -v -count=1 -timeout 120s
+        working-directory: query
+
+  # ── Build terrapod-query binary (baked into api + runner images) ──────
+  build-query:
+    name: Build terrapod-query (${{ matrix.goarch }})
+    needs: prepare
+    # Runs whenever images will be built (to bake the binary in) OR on a tag
+    # (so release-query can attach the SAME linux binaries to the Release —
+    # built once here, reused by both the image bake and the release, never
+    # compiled twice).
+    if: needs.prepare.outputs.images_exist != 'true' || needs.prepare.outputs.is_tag == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: query/go.mod
+          cache: false
+      - name: Build linux/${{ matrix.goarch }}
+        working-directory: query
+        env:
+          GOOS: linux
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: go build -trimpath -ldflags "-s -w" -o "terrapod-query-linux-${{ matrix.goarch }}" ./cmd/terrapod-query
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: terrapod-query-linux-${{ matrix.goarch }}
+          path: query/terrapod-query-linux-${{ matrix.goarch }}
+          retention-days: 1
+
   # ── Python Test ────────────────────────────────────────
   python-test:
     # Sharded by directory so each shard gets its own Postgres /
@@ -895,7 +970,7 @@ jobs:
   # artifacted on PRs so scan-images can scan it.
   build-images-amd64:
     name: Build ${{ matrix.image }} (amd64)
-    needs: prepare
+    needs: [prepare, build-query]
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -928,6 +1003,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
 
+      # terrapod-query is baked into api + runner (#823) from the binary the
+      # build-query job compiled once — staged into the build context here.
+      - name: Stage terrapod-query binary (api/runner only)
+        if: matrix.image == 'terrapod-api' || matrix.image == 'terrapod-runner'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: terrapod-query-linux-amd64
+          path: docker/query-bin
+      - name: Normalise terrapod-query binary
+        if: matrix.image == 'terrapod-api' || matrix.image == 'terrapod-runner'
+        run: |
+          mv docker/query-bin/terrapod-query-linux-amd64 docker/query-bin/terrapod-query
+          chmod 0755 docker/query-bin/terrapod-query
+
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -959,7 +1048,7 @@ jobs:
 
   build-images-arm64:
     name: Build ${{ matrix.image }} (arm64)
-    needs: prepare
+    needs: [prepare, build-query]
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -991,6 +1080,20 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
+
+      # terrapod-query is baked into api + runner (#823) from the binary the
+      # build-query job compiled once — staged into the build context here.
+      - name: Stage terrapod-query binary (api/runner only)
+        if: matrix.image == 'terrapod-api' || matrix.image == 'terrapod-runner'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: terrapod-query-linux-arm64
+          path: docker/query-bin
+      - name: Normalise terrapod-query binary
+        if: matrix.image == 'terrapod-api' || matrix.image == 'terrapod-runner'
+        run: |
+          mv docker/query-bin/terrapod-query-linux-arm64 docker/query-bin/terrapod-query
+          chmod 0755 docker/query-bin/terrapod-query
 
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -1695,9 +1798,88 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
 
+  release-query:
+    name: Release — terrapod-query
+    # Reuses the linux binaries build-query already compiled (downloaded as
+    # artifacts), so linux is never compiled twice — only darwin/windows are
+    # built here. (No GoReleaser: its `prebuilt` builder is Pro-only, so this
+    # packages the artifacts + native builds directly.)
+    needs: [prepare, release-create, build-query]
+    if: |
+      always()
+      && needs.prepare.outputs.is_tag == 'true'
+      && needs.release-create.result == 'success'
+      && needs.build-query.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: query/go.mod
+          cache: false
+
+      - name: Download prebuilt linux binaries (built once by build-query)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: terrapod-query-linux-*
+          path: prebuilt
+          merge-multiple: true
+
+      - name: Import GPG signing key
+        id: gpg
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+          fingerprint=$(gpg --with-colons --import-options show-only --import <<< "${{ secrets.GPG_PRIVATE_KEY }}" | awk -F: '/^fpr:/{print $10; exit}')
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
+      - name: Package, checksum, sign, and upload
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
+        run: |
+          set -euo pipefail
+          version="${{ needs.prepare.outputs.version }}"
+          ver="${version#v}"   # archive names use the bare version, matching the other tools
+          mkdir -p dist
+
+          # Reuse the EXACT linux binaries baked into the images (built once by
+          # build-query) — tar them, don't recompile.
+          for arch in amd64 arm64; do
+            install -m 0755 "prebuilt/terrapod-query-linux-${arch}" dist/terrapod-query
+            tar -C dist -czf "dist/terrapod-query_${ver}_linux_${arch}.tar.gz" terrapod-query
+            rm dist/terrapod-query
+          done
+
+          # Build + package the remaining platforms here (punted from build-query).
+          for platform in darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
+            os="${platform%/*}"; arch="${platform#*/}"
+            out="terrapod-query"; [ "$os" = "windows" ] && out="terrapod-query.exe"
+            (cd query && GOOS="$os" GOARCH="$arch" CGO_ENABLED=0 \
+              go build -trimpath -ldflags "-s -w" -o "../dist/${out}" ./cmd/terrapod-query)
+            if [ "$os" = "windows" ]; then
+              (cd dist && zip -q "terrapod-query_${ver}_${os}_${arch}.zip" "${out}" && rm "${out}")
+            else
+              tar -C dist -czf "dist/terrapod-query_${ver}_${os}_${arch}.tar.gz" "${out}"
+              rm "dist/${out}"
+            fi
+          done
+
+          # SHA256SUMS over all archives + detached GPG signature (same shape as
+          # the provider/migrate/publish artifacts).
+          ( cd dist && sha256sum terrapod-query_${ver}_* > "terrapod-query_${ver}_SHA256SUMS" )
+          gpg --batch --local-user "$GPG_FINGERPRINT" \
+            --output "dist/terrapod-query_${ver}_SHA256SUMS.sig" \
+            --detach-sign "dist/terrapod-query_${ver}_SHA256SUMS"
+
+          # Append to the Release that release-create already opened.
+          gh release upload "$version" dist/terrapod-query_${ver}_* --clobber
+
   release-finalize:
     name: Release — Finalize (notes + chart + SBOMs)
-    needs: [prepare, release-create, release-images, release-provider, release-migrate, release-publish]
+    needs: [prepare, release-create, release-images, release-provider, release-migrate, release-publish, release-query]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
@@ -1706,6 +1888,7 @@ jobs:
       && needs.release-provider.result == 'success'
       && needs.release-migrate.result == 'success'
       && needs.release-publish.result == 'success'
+      && needs.release-query.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1790,11 +1973,11 @@ jobs:
   # ── Cleanup Tag on Failure ─────────────────────────────
   cleanup-tag:
     name: Cleanup Tag
-    needs: [prepare, build-images-amd64, build-images-arm64, scan-images, create-manifests, release-create, release-images, release-provider, release-migrate, release-publish, release-finalize]
+    needs: [prepare, build-images-amd64, build-images-arm64, build-query, scan-images, create-manifests, release-create, release-images, release-provider, release-migrate, release-publish, release-query, release-finalize]
     if: |
       always()
       && needs.prepare.outputs.is_tag == 'true'
-      && (needs.build-images-amd64.result == 'failure' || needs.build-images-arm64.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release-create.result == 'failure' || needs.release-images.result == 'failure' || needs.release-provider.result == 'failure' || needs.release-migrate.result == 'failure' || needs.release-publish.result == 'failure' || needs.release-finalize.result == 'failure')
+      && (needs.build-images-amd64.result == 'failure' || needs.build-images-arm64.result == 'failure' || needs.build-query.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release-create.result == 'failure' || needs.release-images.result == 'failure' || needs.release-provider.result == 'failure' || needs.release-migrate.result == 'failure' || needs.release-publish.result == 'failure' || needs.release-query.result == 'failure' || needs.release-finalize.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1827,6 +2010,9 @@ jobs:
       - migrate-test
       - publish-lint
       - publish-test
+      - query-lint
+      - query-test
+      - build-query
       - python-test
       - migration-check
       - python-audit
@@ -1850,6 +2036,7 @@ jobs:
       - release-provider
       - release-migrate
       - release-publish
+      - release-query
       - release-finalize
     runs-on: ubuntu-latest
     steps:
@@ -1867,6 +2054,9 @@ jobs:
             "${{ needs.migrate-test.result }}"
             "${{ needs.publish-lint.result }}"
             "${{ needs.publish-test.result }}"
+            "${{ needs.query-lint.result }}"
+            "${{ needs.query-test.result }}"
+            "${{ needs.build-query.result }}"
             "${{ needs.python-test.result }}"
             "${{ needs.migration-check.result }}"
             "${{ needs.python-audit.result }}"
@@ -1890,6 +2080,7 @@ jobs:
             "${{ needs.release-provider.result }}"
             "${{ needs.release-migrate.result }}"
             "${{ needs.release-publish.result }}"
+            "${{ needs.release-query.result }}"
             "${{ needs.release-finalize.result }}"
           )
 

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,12 @@ provider/terraform-provider-terrapod
 # Migration tool build artifacts
 migrate/terrapod-migrate
 
+# terrapod-query binary staged into the image build context (#823) — produced
+# by the build-query CI job or the local Tilt/Make go build; never committed.
+docker/query-bin/
+query/terrapod-query
+query/terrapod-query-bin
+
 # Terraform (local dev testing)
 .terraform/
 *.tfstate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ if a route is on that list it stays at `/api/v2/`; otherwise it goes under
 | `provider/` | `terraform-provider-terrapod` — a thin wrapper over go-terrapod. | Go |
 | `migrate/` | `terrapod-migrate` — TFE/HCP + Atlantis migration CLI. | Go |
 | `publish/` | `terrapod-publish` — registry publish CLI (client-signed provider/module uploads). | Go |
+| `query/` | `terrapod-query` — tofu-native discovery engine for onboarding existing resources (schema → filtered data-source query → `import {}` blocks; MPL, no BUSL). Standalone CLI + baked into the api/runner images. | Go |
 | `helm/terrapod/` | The Helm chart (the only supported deployment mechanism). | YAML |
 | `alembic/` | Async Alembic migrations (hash-based revision IDs). | Python |
 | `docs/` | User + operator documentation. | Markdown |

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ test-e2e-down:      ## Tear down E2E test containers
 
 # ── Build ─────────────────────────────────────────────────
 images:             ## Build Docker images (single-arch, local)
+	mkdir -p docker/query-bin
+	docker run --rm -v "$(PWD)/query":/src -w /src golang:1.26 go build -trimpath -o terrapod-query-bin ./cmd/terrapod-query
+	mv query/terrapod-query-bin docker/query-bin/terrapod-query
 	docker build -f docker/Dockerfile.api -t terrapod-api:local .
 	docker build -f docker/Dockerfile.web -t terrapod-web:local .
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -69,6 +69,20 @@ fi
 # Docker Builds
 # ─────────────────────────────────────────────────────────────────────────────
 
+# terrapod-query (#823) is baked into the API and runner images from a pre-built
+# linux binary staged at docker/query-bin/. In CI the build-query job produces
+# it; locally we compile it in a golang container (no host Go toolchain needed).
+# The container is linux/<host arch>, matching the local k8s nodes. This runs at
+# Tiltfile eval so the binary exists before the image builds; the runner build
+# reruns it (below) so query source edits are picked up without a Tilt restart.
+QUERY_BUILD = (
+    'mkdir -p docker/query-bin && ' +
+    'docker run --rm -v "$PWD/query":/src -w /src golang:1.26 ' +
+    'go build -trimpath -o terrapod-query-bin ./cmd/terrapod-query && ' +
+    'mv query/terrapod-query-bin docker/query-bin/terrapod-query'
+)
+local(QUERY_BUILD, quiet=True)
+
 # API Server (Python)
 docker_build(
     'terrapod-api',
@@ -109,9 +123,11 @@ docker_build(
 # pullPolicy: Never so K8s Jobs find it in the local Docker daemon.
 local_resource(
     'build-runner-image',
-    cmd='docker build -f docker/Dockerfile.runner -t terrapod-runner:local .',
+    cmd=QUERY_BUILD + ' && docker build -f docker/Dockerfile.runner -t terrapod-runner:local .',
     deps=[
         'docker/Dockerfile.runner',
+        'query/cmd',
+        'query/internal',
         'services/pyproject-runner.toml',
         'services/terrapod/http_retry.py',
         'services/terrapod/runner/__init__.py',

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -83,6 +83,30 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && chmod 0755 /usr/local/bin/opa \
     && /usr/local/bin/opa version
 
+# OpenTofu — baked in so the API can run credential-less schema introspection
+# (`tofu providers schema -json`) for terrapod-query discovery (#823) without
+# spinning up a runner Job. Pinned; the runner fetches its own tofu per-run from
+# the binary cache, so this copy serves only the API's read-only schema dump.
+# tar.gz avoids needing unzip; verified against the published SHA256SUMS.
+ARG TOFU_VERSION=1.12.4
+RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
+    && BASE="https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}" \
+    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/tofu.tar.gz "${BASE}/tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" \
+    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/tofu.sha256sums "${BASE}/tofu_${TOFU_VERSION}_SHA256SUMS" \
+    && sum="$(awk -v f="tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" '$2==f {print $1}' /tmp/tofu.sha256sums)" \
+    && echo "${sum}  /tmp/tofu.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/tofu.tar.gz -C /usr/local/bin tofu \
+    && rm /tmp/tofu.tar.gz /tmp/tofu.sha256sums \
+    && chmod 0755 /usr/local/bin/tofu \
+    && /usr/local/bin/tofu version
+
+# terrapod-query — the tofu-native discovery engine (#823), pre-built for this
+# arch by the build-query CI job (or the local Tilt/Make go build) and staged at
+# docker/query-bin/terrapod-query in the build context. Baked into the API image
+# so credential-less schema introspection (D1) runs here, no runner needed.
+COPY docker/query-bin/terrapod-query /usr/local/bin/terrapod-query
+RUN chmod 0755 /usr/local/bin/terrapod-query && /usr/local/bin/terrapod-query --help >/dev/null
+
 WORKDIR /app
 
 # Copy installed Python packages from builder

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -62,6 +62,13 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 COPY --from=builder /tmp/opa /usr/local/bin/opa
 RUN /usr/local/bin/opa version
 
+# terrapod-query — tofu-native discovery engine (#823), pre-built for this arch
+# by the build-query CI job (or the local go build) and staged in the build
+# context. The runner drives it for data-source discovery (D2) using the tofu
+# the Job fetches per-run from the binary cache.
+COPY docker/query-bin/terrapod-query /usr/local/bin/terrapod-query
+RUN chmod 0755 /usr/local/bin/terrapod-query && /usr/local/bin/terrapod-query --help >/dev/null
+
 # Python deps from builder
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [FAQ](faq.md) | Straight answers to the common buyer questions (free — and always free, no paid tier? OpenTofu? Terragrunt? air-gapped? production-ready? do I really need Kubernetes? can mixed-tool teams share one install? monorepo / dedicated / mixed repos? per-workspace CPU+memory? vs Terrakube/Atlantis/Digger?) |
 | [Getting Started](getting-started.md) | Deploy the Helm chart on Kubernetes (or k3s), first workspace, first plan/apply |
 | [Migration](migration.md) | Move a TFE / HCP Terraform or Atlantis platform onto Terrapod with `terrapod-migrate` — dry-run-first, reversible, with an explicit "what transfers vs. what's a checklist" breakdown |
+| [terrapod-query](terrapod-query.md) | Tofu-native discovery engine for onboarding existing, unmanaged cloud resources into IaC — introspect provider schema, run filtered data-source queries, emit `import {}` blocks (MPL, no BUSL). Standalone CLI + baked into the api/runner images |
 | [Local Development](local-development.md) | Run Terrapod from source with Tilt (contributors only) |
 | [Architecture](architecture.md) | System components, storage, runners, auth flows |
 | [Authentication](authentication.md) | Local auth, OIDC, SAML, terraform login, API tokens, scoped service tokens (bound/detached) + offboarding idle guard |

--- a/docs/terrapod-query.md
+++ b/docs/terrapod-query.md
@@ -1,0 +1,93 @@
+# terrapod-query — tofu-native discovery for onboarding existing resources
+
+`terrapod-query` finds existing, unmanaged cloud resources and emits candidate
+OpenTofu `import {}` blocks. It is the **discovery engine** for bringing already-
+provisioned infrastructure under Terrapod management, and it is modelled after
+Terraform's `terraform query` — but built **entirely on native OpenTofu
+functionality**, with **no BUSL-licensed Terraform binary and no bespoke
+provider-plugin client**. It is MPL-2.0, like the rest of Terrapod.
+
+It performs **no import itself**. It emits import blocks a human (or, later, the
+AI onboarding workflow) reviews; the actual import is always a normal, gated
+Terrapod run.
+
+## Why it exists
+
+Adopting an existing estate into IaC means writing an `import` block (and
+matching config) for every resource — tedious and error-prone by hand.
+`terrapod-query` automates the *discovery* half: given a provider and a filter,
+it asks the provider (through tofu) what exists and turns the answer into import
+blocks.
+
+Everything rides the `tofu` CLI — Terrapod does not reimplement the provider
+plugin protocol, because tofu already exposes what discovery needs:
+
+| Step | Native tofu mechanism |
+|---|---|
+| Find the discovery surface | `tofu providers schema -json` — which data sources accept `filter`/`tags`/name args |
+| Run a discovery query | a `data` block + `tofu output -json` — tofu executes the data source natively |
+| Generate config for the imports | `tofu plan -generate-config-out` (used by the AI workflow) |
+
+Discovery is **read-only throughout**: the configuration it runs contains only a
+`data` block and an `output`, so it issues provider read/`Describe` calls and
+never creates, changes, or destroys anything.
+
+## The fail-safe
+
+A data source returns each resource's `id`, but the *import identifier* is not
+always that `id` (some resources import by a composite key, an ARN, or a
+`name:region` tuple). Id derivation is therefore **best-effort**. It fails safe:
+a mis-derived id shows up in the plan as a **create/replace instead of an
+import**, which the operator sees and does not apply. A wrong guess never
+mutates infrastructure — the import-only plan (0 to add, 0 to destroy) is the
+gate.
+
+## Commands
+
+```
+terrapod-query schema [--dir DIR] [--tofu PATH] [--from FILE] [--all]
+terrapod-query query  --type TYPE --provider-config FILE [--filter NAME=V1,V2 ...] [--arg NAME=HCL ...] [--dir DIR]
+terrapod-query import [--from FILE] [--resource TYPE] [--out FILE]
+```
+
+**`schema`** introspects the provider schema and prints the discovery surface as
+JSON — the data sources usable for filter-based discovery and the arguments each
+accepts to narrow the search. By default it lists the strong-signal subset
+(sources with a `filter` block, a `tags` argument, or a plural/list return);
+`--all` lists every data source with its settable inputs. `--from` reads an
+already-captured `providers schema -json` document instead of running tofu.
+
+**`query`** runs one data-source query via tofu in an ephemeral directory and
+prints the structured result — the resources it found — from
+`tofu output -json`. `--filter` and `--arg` are repeatable; `--provider-config`
+points at a `.tf` file with the provider block(s) and `required_providers`.
+
+**`import`** turns a query result into candidate `import {}` blocks, mapping the
+returned ids onto the managed resource type (derived from the data-source name,
+or set with `--resource`). Composable via a pipe:
+
+```sh
+terrapod-query query --type aws_vpcs --provider-config aws.tf \
+  --filter 'tag:env=prod' | terrapod-query import --resource aws_vpc
+```
+
+## Where it runs
+
+`terrapod-query` is published as a **standalone cross-platform binary** (like
+`terrapod-publish` and `terrapod-migrate`) for local use against your own
+credentials, and is also **baked into the Terrapod API and runner images**:
+
+- **Schema introspection** is credential-less and provider-version-stable, so it
+  can run **in the API** for a responsive answer without spinning up a runner
+  Job. (The API image carries a pinned OpenTofu for exactly this.)
+- **Query execution** hits the real cloud with the workspace's identity, so it
+  runs in a **runner Job**, the same execution split as every plan/apply.
+
+## Status
+
+The `terrapod-query` engine (schema → query → import) is complete and shipped as
+a binary. The platform integration that drives it end-to-end — an AI onboarding
+workflow that chooses what to query, iterates, runs
+`tofu plan -generate-config-out`, cleans the generated config, and raises a
+reviewed VCS pull request behind the import-only plan gate — is tracked
+separately in [#824](https://github.com/mattrobinsonsre/terrapod/issues/824).

--- a/llms.txt
+++ b/llms.txt
@@ -41,6 +41,7 @@ The authoritative source is [AGENTS.md](AGENTS.md). Key invariants an agent must
 | `provider/` | `terraform-provider-terrapod` — a thin wrapper over go-terrapod. | Go |
 | `migrate/` | `terrapod-migrate` — TFE/HCP + Atlantis migration CLI. | Go |
 | `publish/` | `terrapod-publish` — registry publish CLI (client-signed uploads). | Go |
+| `query/` | `terrapod-query` — tofu-native discovery engine: introspect provider schema → run filtered data-source queries → emit `import {}` blocks (MPL, no BUSL). Baked into the api + runner images and published standalone. | Go |
 | `helm/terrapod/` | The Helm chart (the only supported deployment mechanism); `values.yaml` + `values.schema.json`. | YAML |
 | `alembic/` | Async Alembic database migrations (hash-based revision IDs). | Python |
 | `docs/` | User + operator documentation (this map's targets). | Markdown |
@@ -125,4 +126,4 @@ How each capability is turned on. **Platform-level** features are Helm values un
 - [docs/registry-publishing.md](docs/registry-publishing.md): the client-signed provider/module publish protocol.
 - [docs/supply-chain-verification.md](docs/supply-chain-verification.md): two directions. (1) Terrapod's own releases — every image + the Helm chart is keyless-signed with cosign, with per-image SBOM (SPDX) + SLSA build-provenance attestations, verifiable via `cosign verify` / `gh attestation verify` (identity pinned to the release workflow's GitHub OIDC). (2) Upstream artifacts Terrapod fetches — cached binaries + provider archives verified against the publisher's GPG-signed SHA256SUMS (pinned keys); the runner re-verifies the executable before running it. Config: `registry.binary_cache.verify` / `registry.provider_cache.verify` (off|checksum|signature, default signature).
 - [docs/remote-state.md](docs/remote-state.md): cross-workspace `terraform_remote_state` composition.
-- The four Go modules (`go-terrapod/`, `provider/`, `migrate/`, `publish/`) each have their own `go.mod` and package docs.
+- The five Go modules (`go-terrapod/`, `provider/`, `migrate/`, `publish/`, `query/`) each have their own `go.mod` and package docs.

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -54,3 +54,25 @@ CVE-2026-46680
 # reaches the vulnerable `os.Root` symlink code. Same class as the OPA-Go
 # CVEs above. Drop when OPA ships a release built with a patched Go toolchain.
 CVE-2026-39822
+
+# ── OpenTofu (`tofu`) bundled-dependency CVEs (#823) ──────────────────────────
+# The API image bakes the pinned OpenTofu release binary so it can run
+# `tofu providers schema -json` (credential-less, local, offline, read-only) for
+# terrapod-query discovery without spinning up a runner Job. Trivy reads tofu's
+# embedded Go buildinfo and flags every vendored module it sees. These are in
+# the *official OpenTofu release binary* — we download it, we can't recompile
+# it — and none of the affected code paths are reached by a schema dump:
+#   CVE-2026-39883 — go.opentelemetry.io/otel/sdk (fixed 1.43.0): OTel telemetry
+#                    export; the schema dump emits no telemetry.
+#   CVE-2026-25681 / CVE-2026-27136 — golang.org/x/net/html (fixed 0.55.0): HTML
+#                    parsing XSS; a schema dump parses no untrusted HTML.
+#   CVE-2026-39821 — golang.org/x/net/idna: IDNA name handling; not exercised.
+#   CVE-2026-50151 — oras.land/oras-go/v2 (fixed 2.6.1): OCI blob-upload
+#                    credential forwarding; the schema dump pushes no OCI blobs.
+# Same class as the OPA-Go CVEs above. Drop each when OpenTofu ships a release
+# that vendors the fixed dependency.
+CVE-2026-39883
+CVE-2026-25681
+CVE-2026-27136
+CVE-2026-39821
+CVE-2026-50151

--- a/query/README.md
+++ b/query/README.md
@@ -1,0 +1,50 @@
+# terrapod-query
+
+**tofu-native discovery for onboarding existing cloud resources into OpenTofu.**
+
+`terrapod-query` finds existing, unmanaged cloud resources and emits candidate
+`import {}` blocks. It is the discovery *engine* — the mechanical primitive that
+Terrapod's AI onboarding workflow ([#824](https://github.com/mattrobinsonsre/terrapod/issues/824))
+drives — and it decides nothing about strategy and performs no imports itself.
+The actual import is always a normal, gated Terrapod run.
+
+It is modelled after Terraform's `terraform query`, but built entirely on native
+OpenTofu functionality — **no BUSL-licensed Terraform binary and no bespoke
+provider-plugin client**. Everything rides the `tofu` CLI:
+
+| Step | Native tofu mechanism |
+|---|---|
+| Discover the surface | `tofu providers schema -json` — which data sources accept `filter`/`tags`/name args |
+| Run a discovery query | a `data` block + `tofu output -json` — tofu executes the data source natively |
+| Generate config | `tofu plan -generate-config-out` (in #824) |
+
+Discovery is **read-only throughout**: data sources only issue provider `Describe`-style
+reads; they never create, change, or destroy infrastructure. The `import {}`
+block it emits is a *proposal* — a mis-derived id surfaces as a create/replace in
+the plan (not an import), which the operator sees and doesn't merge. Wrong
+guesses fail safe.
+
+## Where it runs
+
+- **Primary home:** baked into the Terrapod **runner image**, invoked as the
+  runner's discovery mode — that's where tofu, the provider mirror, the
+  workspace's cloud (CSP) identity, and cloud egress live. Discovery is
+  API-orchestrated but runner-executed, the same split as every plan/apply.
+- **Standalone:** published as a cross-platform binary (like `terrapod-publish`
+  / `terrapod-migrate`) for local use against your own credentials.
+
+## Commands
+
+```
+terrapod-query schema [--dir DIR] [--tofu PATH] [--from FILE] [--all]
+```
+
+`schema` introspects the provider schema and prints the discovery surface as
+JSON: the data sources usable for filter-based discovery, and the arguments each
+accepts to narrow the search. By default it lists the strong-signal subset
+(sources with a `filter` block, a `tags` argument, or a plural/list return);
+`--all` lists every data source with its settable inputs. `--from` reads an
+already-captured `providers schema -json` document instead of running tofu.
+
+_This is deliverable D1 of #823. Query execution (D2) and import-block emission
+(D3) follow._

--- a/query/README.md
+++ b/query/README.md
@@ -37,14 +37,34 @@ guesses fail safe.
 
 ```
 terrapod-query schema [--dir DIR] [--tofu PATH] [--from FILE] [--all]
+terrapod-query query  --type TYPE --provider-config FILE [--filter NAME=V1,V2 ...] [--arg NAME=HCL ...] [--dir DIR] [--tofu PATH]
+terrapod-query import [--from FILE] [--resource TYPE] [--out FILE]
 ```
 
-`schema` introspects the provider schema and prints the discovery surface as
-JSON: the data sources usable for filter-based discovery, and the arguments each
-accepts to narrow the search. By default it lists the strong-signal subset
-(sources with a `filter` block, a `tags` argument, or a plural/list return);
-`--all` lists every data source with its settable inputs. `--from` reads an
-already-captured `providers schema -json` document instead of running tofu.
+**`schema`** (D1) introspects the provider schema and prints the discovery
+surface as JSON: the data sources usable for filter-based discovery, and the
+arguments each accepts to narrow the search. By default it lists the
+strong-signal subset (sources with a `filter` block, a `tags` argument, or a
+plural/list return); `--all` lists every data source with its settable inputs.
+`--from` reads an already-captured `providers schema -json` document instead of
+running tofu.
 
-_This is deliverable D1 of #823. Query execution (D2) and import-block emission
-(D3) follow._
+**`query`** (D2) runs one data-source query via tofu in an ephemeral directory
+and prints the structured result — the resources it found — from
+`tofu output -json`. Read-only: the config it runs is a `data` block plus an
+`output`, so it only issues provider reads and performs no import. `--filter`
+and `--arg` are repeatable.
+
+**`import`** (D3) turns a query result into candidate `import {}` blocks. It
+maps the returned ids onto the managed resource type (derived from the data
+source name, or set with `--resource`) and emits one block per id. Composable:
+
+```sh
+terrapod-query query --type aws_vpcs --provider-config aws.tf \
+  --filter 'tag:env=prod' | terrapod-query import --resource aws_vpc
+```
+
+The emitted blocks are candidates: a mis-derived id fails safe (it shows as a
+create/replace in the plan, not an import — the operator sees it and doesn't
+merge). Feeding them to `tofu plan -generate-config-out` behind the import-only
+plan gate is #824's job.

--- a/query/cmd/terrapod-query/import.go
+++ b/query/cmd/terrapod-query/import.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/mattrobinsonsre/terrapod/query/internal/importblock"
+	"github.com/mattrobinsonsre/terrapod/query/internal/query"
+)
+
+// runImport turns a query result (the JSON printed by `terrapod-query query`)
+// into candidate `import {}` blocks. It is composable — pipe a query result in,
+// get import blocks out:
+//
+//	terrapod-query query --type aws_vpcs ... | terrapod-query import --resource aws_vpc
+//
+// It performs no import; the emitted blocks are reviewed and, in #824, fed to
+// `tofu plan -generate-config-out` behind the import-only plan gate.
+func runImport(_ context.Context, args []string) error {
+	fs := flag.NewFlagSet("import", flag.ExitOnError)
+	from := fs.String("from", "", "read the query result JSON from this file (default: stdin)")
+	resource := fs.String("resource", "", "managed resource type to import into (default: derived from the data source name)")
+	out := fs.String("out", "", "write the import blocks to this file (default: stdout)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	raw, err := readInput(*from)
+	if err != nil {
+		return err
+	}
+	var res query.Result
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("parse query result: %w", err)
+	}
+
+	blocks, err := importblock.FromResult(&res, importblock.Options{ResourceType: *resource})
+	if err != nil {
+		return err
+	}
+	importblock.SortBlocks(blocks)
+
+	hcl := importblock.Render(blocks)
+	if *out != "" {
+		if err := os.WriteFile(*out, []byte(hcl), 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", *out, err)
+		}
+		fmt.Fprintf(os.Stderr, "wrote %d import block(s) to %s\n", len(blocks), *out)
+		return nil
+	}
+	fmt.Print(hcl)
+	if len(blocks) == 0 {
+		fmt.Fprintln(os.Stderr, "no resources found; no import blocks emitted")
+	}
+	return nil
+}
+
+// readInput reads from a file, or stdin when path is empty.
+func readInput(path string) ([]byte, error) {
+	if path != "" {
+		return os.ReadFile(path)
+	}
+	return io.ReadAll(os.Stdin)
+}

--- a/query/cmd/terrapod-query/main.go
+++ b/query/cmd/terrapod-query/main.go
@@ -28,6 +28,8 @@ Commands:
             arguments each accepts to narrow the search).
   query     Run one data-source query via tofu and print the structured
             result (the resources it found). Read-only; performs no import.
+  import    Turn a query result into candidate import {} blocks. Composable:
+            terrapod-query query ... | terrapod-query import --resource TYPE
 
 Run "terrapod-query <command> -h" for command-specific flags.
 `
@@ -47,6 +49,8 @@ func main() {
 		err = runSchema(ctx, args)
 	case "query":
 		err = runQuery(ctx, args)
+	case "import":
+		err = runImport(ctx, args)
 	case "-h", "--help", "help":
 		fmt.Print(usage)
 		return

--- a/query/cmd/terrapod-query/main.go
+++ b/query/cmd/terrapod-query/main.go
@@ -26,6 +26,8 @@ Commands:
   schema    Introspect the provider schema and print the discovery surface
             (the data sources usable for filter-based discovery and the
             arguments each accepts to narrow the search).
+  query     Run one data-source query via tofu and print the structured
+            result (the resources it found). Read-only; performs no import.
 
 Run "terrapod-query <command> -h" for command-specific flags.
 `
@@ -43,6 +45,8 @@ func main() {
 	switch cmd {
 	case "schema":
 		err = runSchema(ctx, args)
+	case "query":
+		err = runQuery(ctx, args)
 	case "-h", "--help", "help":
 		fmt.Print(usage)
 		return

--- a/query/cmd/terrapod-query/main.go
+++ b/query/cmd/terrapod-query/main.go
@@ -1,0 +1,58 @@
+// Command terrapod-query is the discovery engine for onboarding existing,
+// unmanaged cloud resources into OpenTofu (#823). It is modelled after
+// Terraform's `terraform query` — but built entirely on native OpenTofu
+// functionality (schema introspection, data-source execution, and
+// `-generate-config-out`), with no BUSL-licensed Terraform binary and no
+// bespoke provider-plugin client.
+//
+// It runs as a stateless CLI: primary home is the runner discovery mode (baked
+// into the runner image), and it is also published standalone for local use.
+// It emits candidate `import {}` blocks and never performs the import itself —
+// the actual import is a normal, gated Terrapod run (see #824).
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+const usage = `terrapod-query — tofu-native discovery for onboarding existing resources
+
+Usage:
+  terrapod-query <command> [flags]
+
+Commands:
+  schema    Introspect the provider schema and print the discovery surface
+            (the data sources usable for filter-based discovery and the
+            arguments each accepts to narrow the search).
+
+Run "terrapod-query <command> -h" for command-specific flags.
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(2)
+	}
+
+	ctx := context.Background()
+	cmd, args := os.Args[1], os.Args[2:]
+
+	var err error
+	switch cmd {
+	case "schema":
+		err = runSchema(ctx, args)
+	case "-h", "--help", "help":
+		fmt.Print(usage)
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n%s", cmd, usage)
+		os.Exit(2)
+	}
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}

--- a/query/cmd/terrapod-query/query.go
+++ b/query/cmd/terrapod-query/query.go
@@ -76,7 +76,7 @@ func runQuery(ctx context.Context, args []string) error {
 			return fmt.Errorf("create work dir: %w", err)
 		}
 		if !*keep {
-			defer os.RemoveAll(workDir)
+			defer func() { _ = os.RemoveAll(workDir) }()
 		}
 	}
 

--- a/query/cmd/terrapod-query/query.go
+++ b/query/cmd/terrapod-query/query.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mattrobinsonsre/terrapod/query/internal/query"
+	"github.com/mattrobinsonsre/terrapod/query/internal/tofu"
+)
+
+// stringSlice collects repeatable flags (--filter, --arg).
+type stringSlice []string
+
+func (s *stringSlice) String() string { return strings.Join(*s, ",") }
+func (s *stringSlice) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+// runQuery executes a single data-source discovery query via tofu and prints
+// the structured result as JSON. It is the D2 surface: given a data source and
+// its narrowing arguments, run it and return what tofu read back. It performs
+// no import — turning the result into import blocks is D3.
+func runQuery(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("query", flag.ExitOnError)
+	dsType := fs.String("type", "", "data-source type to query, e.g. aws_vpcs (required)")
+	name := fs.String("name", "q", "local name for the data block")
+	providerConfigFile := fs.String("provider-config", "", "path to a .tf file with the provider block(s) and required_providers (required)")
+	dir := fs.String("dir", "", "working directory (default: a fresh temp dir, removed unless --keep)")
+	bin := fs.String("tofu", "", `path to the tofu binary (default: "tofu" on PATH)`)
+	keep := fs.Bool("keep", false, "keep the working directory instead of removing it")
+	var filters stringSlice
+	var argVals stringSlice
+	fs.Var(&filters, "filter", "repeatable filter as NAME=VAL1,VAL2 (e.g. tag:env=prod)")
+	fs.Var(&argVals, "arg", "repeatable top-level argument as NAME=HCL (e.g. owners=[\"self\"])")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *dsType == "" {
+		return fmt.Errorf("--type is required")
+	}
+	if *providerConfigFile == "" {
+		return fmt.Errorf("--provider-config is required (provider block + required_providers)")
+	}
+	providerConfig, err := os.ReadFile(*providerConfigFile)
+	if err != nil {
+		return fmt.Errorf("read provider config: %w", err)
+	}
+
+	q := query.Query{Type: *dsType, Name: *name, Args: map[string]string{}}
+	for _, f := range filters {
+		name, valsCSV, ok := strings.Cut(f, "=")
+		if !ok {
+			return fmt.Errorf("bad --filter %q, want NAME=VAL1,VAL2", f)
+		}
+		q.Filters = append(q.Filters, query.Filter{Name: name, Values: strings.Split(valsCSV, ",")})
+	}
+	for _, a := range argVals {
+		name, hcl, ok := strings.Cut(a, "=")
+		if !ok {
+			return fmt.Errorf("bad --arg %q, want NAME=HCL", a)
+		}
+		q.Args[name] = hcl
+	}
+
+	// Resolve the working directory: caller-supplied or a fresh temp dir.
+	workDir := *dir
+	if workDir == "" {
+		workDir, err = os.MkdirTemp("", "terrapod-query-*")
+		if err != nil {
+			return fmt.Errorf("create work dir: %w", err)
+		}
+		if !*keep {
+			defer os.RemoveAll(workDir)
+		}
+	}
+
+	exec := &query.Executor{Runner: &tofu.Runner{Bin: *bin, Dir: workDir}}
+	res, err := exec.Run(ctx, string(providerConfig), q)
+	if err != nil {
+		return err
+	}
+
+	out, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(out))
+	if *keep || *dir != "" {
+		fmt.Fprintln(os.Stderr, "working directory:", workDir)
+	}
+	return nil
+}

--- a/query/cmd/terrapod-query/schema.go
+++ b/query/cmd/terrapod-query/schema.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mattrobinsonsre/terrapod/query/internal/schema"
+	"github.com/mattrobinsonsre/terrapod/query/internal/tofu"
+)
+
+// runSchema introspects the provider schema and prints the discovery surface as
+// JSON. By default it shells `tofu providers schema -json` in an initialised
+// working directory; --from lets a caller feed an already-captured schema
+// document (the API/runner may pass one it already has, and it makes the
+// command testable without a live tofu).
+func runSchema(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("schema", flag.ExitOnError)
+	dir := fs.String("dir", ".", "working directory containing an initialised OpenTofu configuration")
+	bin := fs.String("tofu", "", `path to the tofu binary (default: "tofu" on PATH)`)
+	from := fs.String("from", "", "read a captured `providers schema -json` document from this file instead of running tofu")
+	all := fs.Bool("all", false, "list every data source, not just the strong-signal discovery subset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	raw, err := loadSchema(ctx, *from, *dir, *bin)
+	if err != nil {
+		return err
+	}
+
+	s, err := schema.Parse(raw)
+	if err != nil {
+		return err
+	}
+
+	candidates := s.QueryableDataSources()
+	if *all {
+		candidates = s.Catalogue()
+	}
+
+	out, err := json.MarshalIndent(struct {
+		Count       int                 `json:"count"`
+		DataSources []schema.DataSource `json:"data_sources"`
+	}{Count: len(candidates), DataSources: candidates}, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(out))
+	return nil
+}
+
+// loadSchema returns the raw schema JSON, either from a file or by running tofu.
+func loadSchema(ctx context.Context, from, dir, bin string) ([]byte, error) {
+	if from != "" {
+		return os.ReadFile(from)
+	}
+	r := &tofu.Runner{Bin: bin, Dir: dir}
+	return r.ProvidersSchema(ctx)
+}

--- a/query/go.mod
+++ b/query/go.mod
@@ -1,0 +1,3 @@
+module github.com/mattrobinsonsre/terrapod/query
+
+go 1.26

--- a/query/internal/importblock/importblock.go
+++ b/query/internal/importblock/importblock.go
@@ -1,0 +1,157 @@
+// Package importblock turns a discovery query's structured result into
+// candidate OpenTofu `import {}` blocks.
+//
+// This is deliverable D3 of #823. It maps the ids a data source returned onto
+// the managed resource type they'd be imported into, and emits an `import`
+// block per id. It performs no import — it emits blocks a caller reviews and,
+// in #824, feeds to `tofu plan -generate-config-out` behind the import-only
+// plan gate.
+//
+// # The honest caveat
+//
+// A data source returns each resource's `id`, but the *import identifier* is
+// not always that `id` — some resources import by a composite key, an ARN, or
+// a `name:region` tuple. Id derivation here is therefore best-effort: it uses
+// the returned `id`/`ids`, which is correct for the large majority of
+// resources (VPCs, subnets, instances, security groups, volumes, …). A
+// mis-derived id fails safe: the import-only plan gate in #824 renders it as a
+// create/replace instead of an import, which the operator sees and does not
+// merge. Wrong guesses never mutate infrastructure.
+package importblock
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/mattrobinsonsre/terrapod/query/internal/query"
+)
+
+// Block is a single candidate import.
+type Block struct {
+	// To is the resource address, "<type>.<name>", e.g. "aws_vpc.vpc_0abc".
+	To string `json:"to"`
+	// ID is the import identifier passed to the provider.
+	ID string `json:"id"`
+}
+
+// HCL renders the block as an `import {}` block.
+func (b Block) HCL() string {
+	return fmt.Sprintf("import {\n  to = %s\n  id = %q\n}\n", b.To, b.ID)
+}
+
+// Options controls emission.
+type Options struct {
+	// ResourceType is the managed resource type to import into (e.g.
+	// "aws_vpc"). When empty it is derived from the data-source type by
+	// singularising it — best-effort; set it explicitly when the data source
+	// name doesn't singularise to the resource name.
+	ResourceType string
+}
+
+// FromResult derives candidate import blocks from a query result. A plural/list
+// result (a computed `ids` array) yields one block per id; a singular result (a
+// computed `id`) yields one block. An empty result yields no blocks.
+func FromResult(res *query.Result, opts Options) ([]Block, error) {
+	rtype := opts.ResourceType
+	if rtype == "" {
+		rtype = singularize(res.Type)
+	}
+
+	ids, err := extractIDs(res.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	blocks := make([]Block, 0, len(ids))
+	used := map[string]bool{}
+	for _, id := range ids {
+		name := uniqueName(sanitizeName(id), used)
+		blocks = append(blocks, Block{To: rtype + "." + name, ID: id})
+	}
+	return blocks, nil
+}
+
+// Render returns the HCL for a set of blocks, one after another.
+func Render(blocks []Block) string {
+	var b strings.Builder
+	for i, blk := range blocks {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(blk.HCL())
+	}
+	return b.String()
+}
+
+// extractIDs pulls the id(s) from a data source's output value: the `ids` list
+// (plural sources) or the scalar `id` (singular sources).
+func extractIDs(value json.RawMessage) ([]string, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(value, &obj); err != nil {
+		return nil, fmt.Errorf("result value is not an object: %w", err)
+	}
+	if raw, ok := obj["ids"]; ok {
+		var ids []string
+		if err := json.Unmarshal(raw, &ids); err != nil {
+			return nil, fmt.Errorf("ids is not a string list: %w", err)
+		}
+		return ids, nil
+	}
+	if raw, ok := obj["id"]; ok {
+		var id string
+		if err := json.Unmarshal(raw, &id); err == nil && id != "" {
+			return []string{id}, nil
+		}
+	}
+	return nil, nil
+}
+
+// singularize best-effort-maps a data-source type to its managed resource type
+// by trimming a single trailing "s" (aws_vpcs → aws_vpc, aws_subnets →
+// aws_subnet). Callers override via Options.ResourceType when this is wrong.
+func singularize(dsType string) string {
+	if s, ok := strings.CutSuffix(dsType, "s"); ok {
+		return s
+	}
+	return dsType
+}
+
+// sanitizeName turns a resource id into a valid Terraform resource name
+// (letters, digits, underscores, dashes; must start with a letter or
+// underscore).
+func sanitizeName(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		if r == '-' || r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	s := b.String()
+	if s == "" {
+		return "imported"
+	}
+	if r0 := rune(s[0]); !unicode.IsLetter(r0) && r0 != '_' {
+		s = "r_" + s
+	}
+	return s
+}
+
+// uniqueName disambiguates collisions by appending _2, _3, ….
+func uniqueName(base string, used map[string]bool) string {
+	name := base
+	for i := 2; used[name]; i++ {
+		name = fmt.Sprintf("%s_%d", base, i)
+	}
+	used[name] = true
+	return name
+}
+
+// SortBlocks orders blocks by address for stable output.
+func SortBlocks(blocks []Block) {
+	sort.Slice(blocks, func(i, j int) bool { return blocks[i].To < blocks[j].To })
+}

--- a/query/internal/importblock/importblock_test.go
+++ b/query/internal/importblock/importblock_test.go
@@ -1,0 +1,98 @@
+package importblock
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mattrobinsonsre/terrapod/query/internal/query"
+)
+
+func result(t *testing.T, dsType, valueJSON string) *query.Result {
+	t.Helper()
+	return &query.Result{Type: dsType, Name: "q", Value: json.RawMessage(valueJSON)}
+}
+
+func TestPluralResultOneBlockPerID(t *testing.T) {
+	res := result(t, "aws_vpcs", `{"ids":["vpc-0a1b","vpc-0c2d"],"tags":{}}`)
+	blocks, err := FromResult(res, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+	// Resource type singularised from the data-source name.
+	for _, b := range blocks {
+		if !strings.HasPrefix(b.To, "aws_vpc.") {
+			t.Errorf("expected aws_vpc.* address, got %q", b.To)
+		}
+	}
+	// Names derive from the ids (dashes are legal in Terraform resource names).
+	if blocks[0].To != "aws_vpc.vpc-0a1b" || blocks[0].ID != "vpc-0a1b" {
+		t.Errorf("unexpected first block: %+v", blocks[0])
+	}
+}
+
+func TestSingularResultSingleBlock(t *testing.T) {
+	res := result(t, "aws_vpc", `{"id":"vpc-single","cidr_block":"10.0.0.0/16"}`)
+	blocks, err := FromResult(res, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 || blocks[0].ID != "vpc-single" || blocks[0].To != "aws_vpc.vpc-single" {
+		t.Fatalf("unexpected blocks: %+v", blocks)
+	}
+}
+
+func TestResourceTypeOverride(t *testing.T) {
+	res := result(t, "aws_vpcs", `{"ids":["vpc-1"]}`)
+	blocks, err := FromResult(res, Options{ResourceType: "aws_vpc_custom"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocks[0].To != "aws_vpc_custom.vpc-1" {
+		t.Errorf("override ignored: %q", blocks[0].To)
+	}
+}
+
+func TestEmptyResultNoBlocks(t *testing.T) {
+	blocks, err := FromResult(result(t, "aws_subnets", `{"ids":[]}`), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 0 {
+		t.Errorf("empty ids should yield no blocks, got %d", len(blocks))
+	}
+}
+
+func TestNameSanitizationAndUniqueness(t *testing.T) {
+	// An id starting with a digit and containing an illegal char, plus a
+	// collision after sanitisation.
+	res := result(t, "custom_things", `{"ids":["9weird.id","9weird.id"]}`)
+	blocks, err := FromResult(res, Options{ResourceType: "custom_thing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// '.' → '_', leading digit gets an r_ prefix.
+	if blocks[0].To != "custom_thing.r_9weird_id" {
+		t.Errorf("sanitisation wrong: %q", blocks[0].To)
+	}
+	// Second collision disambiguated.
+	if blocks[1].To != "custom_thing.r_9weird_id_2" {
+		t.Errorf("collision not disambiguated: %q", blocks[1].To)
+	}
+	// IDs are preserved verbatim even though names were sanitised.
+	if blocks[0].ID != "9weird.id" || blocks[1].ID != "9weird.id" {
+		t.Errorf("ids should be preserved verbatim: %+v", blocks)
+	}
+}
+
+func TestRenderHCL(t *testing.T) {
+	blocks := []Block{{To: "aws_vpc.vpc_a", ID: "vpc-a"}, {To: "aws_vpc.vpc_b", ID: "vpc-b"}}
+	got := Render(blocks)
+	want := "import {\n  to = aws_vpc.vpc_a\n  id = \"vpc-a\"\n}\n\nimport {\n  to = aws_vpc.vpc_b\n  id = \"vpc-b\"\n}\n"
+	if got != want {
+		t.Errorf("Render:\n%q\nwant:\n%q", got, want)
+	}
+}

--- a/query/internal/query/query.go
+++ b/query/internal/query/query.go
@@ -1,0 +1,165 @@
+// Package query runs a single data-source discovery query via native OpenTofu
+// and returns the structured result.
+//
+// This is deliverable D2 of #823. Given a data-source query (which data source,
+// which narrowing arguments), it writes a tiny ephemeral configuration — the
+// caller's provider block plus a `data` block and an `output` — runs tofu in a
+// scratch directory, and reads the result back with `tofu output -json`. tofu
+// executes the data source natively; we parse structured JSON, never scraped
+// text.
+//
+// It is read-only: a discovery configuration contains only a `data` block and
+// an `output`, so applying it issues provider read/`Describe` calls and makes
+// no changes to infrastructure. Turning the result into `import {}` blocks is
+// D3; deciding which query to run is #824.
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mattrobinsonsre/terrapod/query/internal/tofu"
+)
+
+// outputName is the fixed name of the output the discovery config exposes.
+const outputName = "terrapod_query_result"
+
+// Filter is one repeated `filter { name, values }` block — the canonical
+// EC2-style narrowing mechanism many data sources accept.
+type Filter struct {
+	Name   string
+	Values []string
+}
+
+// Query describes one data-source discovery query.
+type Query struct {
+	// Type is the data-source type, e.g. "aws_vpcs".
+	Type string
+	// Name is the local block name; defaults to "q" when empty.
+	Name string
+	// Filters are repeated `filter {}` blocks.
+	Filters []Filter
+	// Args are additional top-level arguments, name → raw HCL expression (e.g.
+	// "owners" → `["self"]`, "most_recent" → `true`). The value is emitted
+	// verbatim as HCL, so the caller controls type; this mirrors Terrapod's
+	// existing hcl=true variable convention.
+	Args map[string]string
+}
+
+// localName returns the block name, defaulting to "q".
+func (q Query) localName() string {
+	if q.Name != "" {
+		return q.Name
+	}
+	return "q"
+}
+
+// Result is the parsed outcome of a discovery query.
+type Result struct {
+	// Type and Name echo the query's data source and local name.
+	Type string `json:"type"`
+	Name string `json:"name"`
+	// Value is the raw JSON of the data source's attributes (the `output`
+	// value). D3 derives import ids from this.
+	Value json.RawMessage `json:"value"`
+	// Empty is true when the query matched nothing (a plural/list source whose
+	// `ids` came back empty).
+	Empty bool `json:"empty"`
+}
+
+// RenderConfig returns the HCL for the discovery config's query portion — the
+// `data` block plus the `output`. The provider configuration is supplied
+// separately (RenderConfig does not know the provider); the executor writes
+// both files. Exposed for testability.
+func (q Query) RenderConfig() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "data %q %q {\n", q.Type, q.localName())
+	for _, f := range q.Filters {
+		b.WriteString("  filter {\n")
+		fmt.Fprintf(&b, "    name   = %s\n", hclString(f.Name))
+		b.WriteString("    values = [")
+		for i, v := range f.Values {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(hclString(v))
+		}
+		b.WriteString("]\n  }\n")
+	}
+	// Deterministic arg ordering for stable output and tests.
+	names := make([]string, 0, len(q.Args))
+	for name := range q.Args {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Fprintf(&b, "  %s = %s\n", name, q.Args[name])
+	}
+	b.WriteString("}\n\n")
+	fmt.Fprintf(&b, "output %q {\n  value = data.%s.%s\n}\n", outputName, q.Type, q.localName())
+	return b.String()
+}
+
+// Executor runs queries by orchestrating tofu in a working directory.
+type Executor struct {
+	// Runner is the tofu orchestrator; its Dir is the ephemeral working dir the
+	// executor writes configuration into.
+	Runner *tofu.Runner
+}
+
+// Run writes the discovery configuration (the caller's providerConfig plus the
+// query), initialises tofu, applies (read-only — data sources only), and reads
+// the output back as structured JSON.
+func (e *Executor) Run(ctx context.Context, providerConfig string, q Query) (*Result, error) {
+	dir := e.Runner.Dir
+	if err := os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(providerConfig), 0o600); err != nil {
+		return nil, fmt.Errorf("write providers.tf: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "query.tf"), []byte(q.RenderConfig()), 0o600); err != nil {
+		return nil, fmt.Errorf("write query.tf: %w", err)
+	}
+
+	if err := e.Runner.Init(ctx); err != nil {
+		return nil, fmt.Errorf("init: %w", err)
+	}
+	if err := e.Runner.Apply(ctx); err != nil {
+		// A data source that matches nothing (or too much) errors here; surface
+		// it verbatim so #824 can react (e.g. loosen the filter and retry).
+		return nil, fmt.Errorf("apply query: %w", err)
+	}
+
+	raw, err := e.Runner.OutputJSON(ctx, outputName)
+	if err != nil {
+		return nil, fmt.Errorf("read output: %w", err)
+	}
+	return parseResult(q, raw)
+}
+
+// parseResult builds a Result from the raw `output -json` value.
+func parseResult(q Query, raw []byte) (*Result, error) {
+	value := json.RawMessage(raw)
+	// Validate it's JSON and inspect for the plural-empty case.
+	var obj map[string]json.RawMessage
+	empty := false
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		if ids, ok := obj["ids"]; ok {
+			var list []json.RawMessage
+			if json.Unmarshal(ids, &list) == nil && len(list) == 0 {
+				empty = true
+			}
+		}
+	}
+	return &Result{Type: q.Type, Name: q.localName(), Value: value, Empty: empty}, nil
+}
+
+// hclString renders s as a valid HCL double-quoted string literal. HCL string
+// escaping matches Go's for the ASCII cases discovery filter names/values use
+// (quotes, backslashes, control chars); strconv via %q is correct for these.
+func hclString(s string) string {
+	return fmt.Sprintf("%q", s)
+}

--- a/query/internal/query/query_test.go
+++ b/query/internal/query/query_test.go
@@ -1,0 +1,141 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mattrobinsonsre/terrapod/query/internal/tofu"
+)
+
+func TestRenderConfigFiltersAndArgs(t *testing.T) {
+	q := Query{
+		Type: "aws_vpcs",
+		Filters: []Filter{
+			{Name: "tag:env", Values: []string{"prod", "staging"}},
+			{Name: "state", Values: []string{"available"}},
+		},
+		Args: map[string]string{
+			"region": `"eu-west-1"`,
+			"id":     `"vpc-123"`,
+		},
+	}
+	got := q.RenderConfig()
+
+	wantContains := []string{
+		`data "aws_vpcs" "q" {`,
+		"filter {",
+		`name   = "tag:env"`,
+		`values = ["prod", "staging"]`,
+		`values = ["available"]`,
+		// Args emitted in sorted order: id before region.
+		"  id = \"vpc-123\"\n  region = \"eu-west-1\"\n",
+		`output "terrapod_query_result" {`,
+		"value = data.aws_vpcs.q",
+	}
+	for _, w := range wantContains {
+		if !strings.Contains(got, w) {
+			t.Errorf("RenderConfig() missing %q in:\n%s", w, got)
+		}
+	}
+}
+
+func TestRenderConfigEscapesStrings(t *testing.T) {
+	q := Query{Type: "aws_instances", Filters: []Filter{{Name: `tag:Na"me`, Values: []string{`a"b`}}}}
+	got := q.RenderConfig()
+	if !strings.Contains(got, `name   = "tag:Na\"me"`) || !strings.Contains(got, `values = ["a\"b"]`) {
+		t.Errorf("quotes not escaped in HCL:\n%s", got)
+	}
+}
+
+// fakeTofu writes a stub `tofu` executable that emulates init/apply/output for
+// hermetic executor tests — no real tofu, no provider download, no cloud.
+func fakeTofu(t *testing.T, outputJSON string, failApply bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "out.json")
+	if err := os.WriteFile(outFile, []byte(outputJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	failFlag := ""
+	if failApply {
+		failFlag = "1"
+	}
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  init) exit 0 ;;\n" +
+		"  apply) if [ -n \"" + failFlag + "\" ]; then echo 'data source matched nothing' >&2; exit 1; fi; exit 0 ;;\n" +
+		"  output) cat " + outFile + " ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+	bin := filepath.Join(dir, "tofu")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func newExecutor(t *testing.T, bin string) *Executor {
+	t.Helper()
+	work := t.TempDir()
+	return &Executor{Runner: &tofu.Runner{Bin: bin, Dir: work}}
+}
+
+func TestRunReturnsStructuredResult(t *testing.T) {
+	out := `{"ids":["vpc-0a","vpc-0b"],"tags":{"env":"prod"}}`
+	e := newExecutor(t, fakeTofu(t, out, false))
+
+	res, err := e.Run(context.Background(), `provider "aws" {}`, Query{
+		Type:    "aws_vpcs",
+		Filters: []Filter{{Name: "tag:env", Values: []string{"prod"}}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Type != "aws_vpcs" || res.Name != "q" {
+		t.Errorf("result identity = %s.%s", res.Type, res.Name)
+	}
+	if res.Empty {
+		t.Error("result should not be empty (2 ids)")
+	}
+	var v map[string]any
+	if err := json.Unmarshal(res.Value, &v); err != nil {
+		t.Fatalf("value not JSON: %v", err)
+	}
+	ids, _ := v["ids"].([]any)
+	if len(ids) != 2 {
+		t.Errorf("expected 2 ids, got %v", v["ids"])
+	}
+
+	// The executor actually wrote the config files it ran.
+	for _, f := range []string{"providers.tf", "query.tf"} {
+		if _, err := os.Stat(filepath.Join(e.Runner.Dir, f)); err != nil {
+			t.Errorf("expected %s written: %v", f, err)
+		}
+	}
+}
+
+func TestRunDetectsEmptyPluralResult(t *testing.T) {
+	e := newExecutor(t, fakeTofu(t, `{"ids":[]}`, false))
+	res, err := e.Run(context.Background(), "", Query{Type: "aws_subnets"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.Empty {
+		t.Error("empty ids should set Empty=true")
+	}
+}
+
+func TestRunSurfacesApplyError(t *testing.T) {
+	e := newExecutor(t, fakeTofu(t, "{}", true))
+	_, err := e.Run(context.Background(), "", Query{Type: "aws_vpc"})
+	if err == nil {
+		t.Fatal("expected apply error to surface")
+	}
+	if !strings.Contains(err.Error(), "apply query") {
+		t.Errorf("error should be wrapped as apply query: %v", err)
+	}
+}

--- a/query/internal/schema/schema.go
+++ b/query/internal/schema/schema.go
@@ -1,0 +1,173 @@
+// Package schema parses `tofu providers schema -json` into the discovery
+// surface terrapod-query exposes: the set of data sources a caller can run to
+// find existing resources, and — for each — the arguments it accepts to narrow
+// the search.
+//
+// This is deliverable D1 of #823. It decides nothing about strategy (that is
+// #824's AI) and holds no hardcoded per-resource knowledge (unlike a fixed
+// provider allowlist) — every fact comes from the provider's own schema, so a
+// new provider or a new data source is understood for free.
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Schema is the top-level `providers schema -json` document.
+type Schema struct {
+	FormatVersion   string              `json:"format_version"`
+	ProviderSchemas map[string]Provider `json:"provider_schemas"`
+}
+
+// Provider holds one provider's resource and data-source schemas. The map key
+// in ProviderSchemas is the fully-qualified source address, e.g.
+// "registry.opentofu.org/hashicorp/aws".
+type Provider struct {
+	DataSourceSchemas map[string]ResourceSchema `json:"data_source_schemas"`
+	ResourceSchemas   map[string]ResourceSchema `json:"resource_schemas"`
+}
+
+// ResourceSchema is the schema of a single resource or data source.
+type ResourceSchema struct {
+	Version int64 `json:"version"`
+	Block   Block `json:"block"`
+}
+
+// Block is a configuration block: a set of scalar attributes plus nested
+// blocks (block_types).
+type Block struct {
+	Attributes map[string]Attribute `json:"attributes"`
+	BlockTypes map[string]BlockType `json:"block_types"`
+}
+
+// Attribute is a single argument/attribute. Optional (and not Computed) means
+// the caller can set it — i.e. it is a query input. Computed-only attributes
+// are outputs the data source returns.
+type Attribute struct {
+	// Type is left as raw JSON: it may be a string ("string") or a nested
+	// array (["list","string"]), and D1 doesn't need to interpret it.
+	Type        json.RawMessage `json:"type"`
+	Description string          `json:"description"`
+	Required    bool            `json:"required"`
+	Optional    bool            `json:"optional"`
+	Computed    bool            `json:"computed"`
+}
+
+// BlockType is a nested block (e.g. a repeatable `filter {}` block).
+type BlockType struct {
+	NestingMode string `json:"nesting_mode"`
+	Block       Block  `json:"block"`
+}
+
+// Parse decodes a `providers schema -json` document.
+func Parse(b []byte) (*Schema, error) {
+	var s Schema
+	if err := json.Unmarshal(b, &s); err != nil {
+		return nil, fmt.Errorf("parse providers schema: %w", err)
+	}
+	return &s, nil
+}
+
+// DataSource describes one data source as a discovery candidate: which narrowing
+// signals it exposes and what a query can constrain on. It is the unit #824's AI
+// reasons over when choosing what to try.
+type DataSource struct {
+	// Provider is the fully-qualified provider source address.
+	Provider string `json:"provider"`
+	// Name is the data-source type, e.g. "aws_vpcs".
+	Name string `json:"name"`
+	// HasFilter is true when the data source exposes a `filter {}` block — the
+	// canonical EC2-style narrowing mechanism.
+	HasFilter bool `json:"has_filter"`
+	// HasTags is true when the data source accepts a settable `tags` argument.
+	HasTags bool `json:"has_tags"`
+	// ReturnsList is true when the data source returns multiple results (a
+	// plural/list source, detected by a computed `ids` output).
+	ReturnsList bool `json:"returns_list"`
+	// Inputs are the settable (Optional or Required, non-Computed) argument
+	// names — attributes and nested blocks — a query can constrain on, sorted.
+	Inputs []string `json:"inputs"`
+	// RequiredInputs are the subset of Inputs that are Required (must be set
+	// for the data source to read), sorted. A data source whose only required
+	// input is an exact id is a poor discovery candidate on its own.
+	RequiredInputs []string `json:"required_inputs"`
+}
+
+// Queryable reports whether the data source has a strong, unambiguous discovery
+// signal: a filter block, a tags argument, or a plural/list return. These are
+// the high-confidence surface. Data sources that only accept, say, an optional
+// name still appear in Catalogue (with their Inputs) so #824 can consider them,
+// but they are not asserted as strong candidates here.
+func (d DataSource) Queryable() bool {
+	return d.HasFilter || d.HasTags || d.ReturnsList
+}
+
+// Catalogue returns every data source across every provider, classified, sorted
+// by provider then name — the complete discovery surface derived from the
+// schema. Use QueryableDataSources for just the strong-signal subset.
+func (s *Schema) Catalogue() []DataSource {
+	var out []DataSource
+	for provider, ps := range s.ProviderSchemas {
+		for name, ds := range ps.DataSourceSchemas {
+			out = append(out, classify(provider, name, ds))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// QueryableDataSources returns the Catalogue filtered to data sources with a
+// strong discovery signal (see DataSource.Queryable).
+func (s *Schema) QueryableDataSources() []DataSource {
+	all := s.Catalogue()
+	out := all[:0:0]
+	for _, d := range all {
+		if d.Queryable() {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// classify derives the discovery signals for one data source from its block.
+func classify(provider, name string, ds ResourceSchema) DataSource {
+	d := DataSource{Provider: provider, Name: name}
+	blk := ds.Block
+
+	if _, ok := blk.BlockTypes["filter"]; ok {
+		d.HasFilter = true
+	}
+	// A settable `tags` argument (not a computed-only tags output).
+	if a, ok := blk.Attributes["tags"]; ok && !a.Computed {
+		d.HasTags = true
+	}
+	// Plural/list sources expose a computed `ids` list of matched resources.
+	if a, ok := blk.Attributes["ids"]; ok && a.Computed {
+		d.ReturnsList = true
+	}
+
+	// Settable inputs: optional/required non-computed attributes, plus nested
+	// blocks (a block a caller can populate, e.g. `filter`).
+	for aname, a := range blk.Attributes {
+		if a.Computed && !a.Optional && !a.Required {
+			continue // pure output
+		}
+		d.Inputs = append(d.Inputs, aname)
+		if a.Required {
+			d.RequiredInputs = append(d.RequiredInputs, aname)
+		}
+	}
+	for bname := range blk.BlockTypes {
+		d.Inputs = append(d.Inputs, bname)
+	}
+	sort.Strings(d.Inputs)
+	sort.Strings(d.RequiredInputs)
+	return d
+}

--- a/query/internal/schema/schema_test.go
+++ b/query/internal/schema/schema_test.go
@@ -1,0 +1,127 @@
+package schema
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func loadFixture(t *testing.T) *Schema {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "sample-schema.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	s, err := Parse(b)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return s
+}
+
+func find(cat []DataSource, name string) (DataSource, bool) {
+	for _, d := range cat {
+		if d.Name == name {
+			return d, true
+		}
+	}
+	return DataSource{}, false
+}
+
+func TestCatalogueCoversEveryProviderAndDataSource(t *testing.T) {
+	cat := loadFixture(t).Catalogue()
+	if len(cat) != 4 {
+		t.Fatalf("expected 4 data sources across both providers, got %d", len(cat))
+	}
+	// Sorted by provider then name: aws_* before google_*.
+	if cat[0].Provider != "registry.opentofu.org/hashicorp/aws" {
+		t.Errorf("catalogue not sorted by provider: first is %q", cat[0].Provider)
+	}
+	if _, ok := find(cat, "google_compute_instance"); !ok {
+		t.Error("second provider's data source missing from catalogue")
+	}
+}
+
+func TestClassifyFilterTagsAndListSignals(t *testing.T) {
+	cat := loadFixture(t).Catalogue()
+
+	vpcs, ok := find(cat, "aws_vpcs")
+	if !ok {
+		t.Fatal("aws_vpcs missing")
+	}
+	if !vpcs.HasFilter || !vpcs.HasTags || !vpcs.ReturnsList {
+		t.Errorf("aws_vpcs should have filter+tags+list, got %+v", vpcs)
+	}
+	if !vpcs.Queryable() {
+		t.Error("aws_vpcs should be queryable")
+	}
+	// Settable inputs are the filter block + tags; the computed `ids` output is
+	// not an input.
+	assertEqualSet(t, "aws_vpcs.Inputs", vpcs.Inputs, []string{"filter", "tags"})
+	if len(vpcs.RequiredInputs) != 0 {
+		t.Errorf("aws_vpcs has no required inputs, got %v", vpcs.RequiredInputs)
+	}
+}
+
+func TestComputedOnlyTagsIsNotAnInput(t *testing.T) {
+	// aws_vpc's `tags` is computed-only → not HasTags, not an input. But it has
+	// a filter block, so it's still queryable.
+	vpc, ok := find(loadFixture(t).Catalogue(), "aws_vpc")
+	if !ok {
+		t.Fatal("aws_vpc missing")
+	}
+	if vpc.HasTags {
+		t.Error("aws_vpc tags is computed-only; HasTags should be false")
+	}
+	if !vpc.HasFilter || !vpc.Queryable() {
+		t.Error("aws_vpc has a filter block; should be queryable")
+	}
+	for _, in := range vpc.Inputs {
+		if in == "tags" {
+			t.Error("computed-only tags leaked into Inputs")
+		}
+	}
+}
+
+func TestNonDiscoveryDataSourceExcludedFromStrongSubset(t *testing.T) {
+	s := loadFixture(t)
+
+	// aws_caller_identity has no filter/tags/ids — appears in the full
+	// catalogue but not in the strong queryable subset.
+	if ci, ok := find(s.Catalogue(), "aws_caller_identity"); !ok {
+		t.Error("aws_caller_identity should be in the full catalogue")
+	} else if ci.Queryable() {
+		t.Error("aws_caller_identity has no discovery signal; should not be queryable")
+	}
+
+	// google_compute_instance only accepts an optional name/project/zone — a
+	// soft candidate: catalogued with inputs, but not a strong signal.
+	gci, ok := find(s.Catalogue(), "google_compute_instance")
+	if !ok {
+		t.Fatal("google_compute_instance missing")
+	}
+	if gci.Queryable() {
+		t.Error("google_compute_instance has no filter/tags/list; not a strong candidate")
+	}
+	assertEqualSet(t, "google_compute_instance.Inputs", gci.Inputs, []string{"name", "project", "zone"})
+
+	// The strong subset is exactly {aws_vpc, aws_vpcs}.
+	q := s.QueryableDataSources()
+	if len(q) != 2 {
+		t.Fatalf("expected 2 strong candidates, got %d: %+v", len(q), q)
+	}
+}
+
+func assertEqualSet(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+		return
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s = %v, want %v", label, got, want)
+			return
+		}
+	}
+}

--- a/query/internal/schema/testdata/sample-schema.json
+++ b/query/internal/schema/testdata/sample-schema.json
@@ -1,0 +1,75 @@
+{
+  "format_version": "1.0",
+  "provider_schemas": {
+    "registry.opentofu.org/hashicorp/aws": {
+      "data_source_schemas": {
+        "aws_vpcs": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "ids": { "type": ["list", "string"], "computed": true },
+              "tags": { "type": ["map", "string"], "optional": true }
+            },
+            "block_types": {
+              "filter": {
+                "nesting_mode": "set",
+                "block": {
+                  "attributes": {
+                    "name": { "type": "string", "required": true },
+                    "values": { "type": ["list", "string"], "required": true }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "aws_vpc": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "id": { "type": "string", "optional": true, "computed": true },
+              "cidr_block": { "type": "string", "optional": true, "computed": true },
+              "tags": { "type": ["map", "string"], "computed": true }
+            },
+            "block_types": {
+              "filter": {
+                "nesting_mode": "set",
+                "block": {
+                  "attributes": {
+                    "name": { "type": "string", "required": true },
+                    "values": { "type": ["list", "string"], "required": true }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "aws_caller_identity": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "account_id": { "type": "string", "computed": true },
+              "arn": { "type": "string", "computed": true },
+              "id": { "type": "string", "computed": true }
+            }
+          }
+        }
+      }
+    },
+    "registry.opentofu.org/hashicorp/google": {
+      "data_source_schemas": {
+        "google_compute_instance": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "name": { "type": "string", "optional": true },
+              "project": { "type": "string", "optional": true },
+              "zone": { "type": "string", "optional": true },
+              "id": { "type": "string", "computed": true }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/query/internal/tofu/tofu.go
+++ b/query/internal/tofu/tofu.go
@@ -65,3 +65,22 @@ func (r *Runner) Init(ctx context.Context) error {
 func (r *Runner) ProvidersSchema(ctx context.Context) ([]byte, error) {
 	return r.run(ctx, "providers", "schema", "-json")
 }
+
+// Apply reads the configuration in the working directory and writes the result
+// to local state. terrapod-query only ever applies a data-source-only
+// configuration (a `data` block plus an `output`), which issues provider
+// read/`Describe` calls and makes NO changes to infrastructure — it is the
+// tofu-native way to force the data source to be read and its result to be
+// materialised for `output -json`. There are no managed `resource` blocks in a
+// discovery configuration, so nothing can be created, changed, or destroyed.
+func (r *Runner) Apply(ctx context.Context) error {
+	_, err := r.run(ctx, "apply", "-auto-approve", "-input=false", "-no-color")
+	return err
+}
+
+// OutputJSON returns the JSON-encoded value of a named output via
+// `tofu output -json <name>`. The value is the data source's attributes — the
+// structured result the query package parses (no text scraping).
+func (r *Runner) OutputJSON(ctx context.Context, name string) ([]byte, error) {
+	return r.run(ctx, "output", "-json", name)
+}

--- a/query/internal/tofu/tofu.go
+++ b/query/internal/tofu/tofu.go
@@ -1,0 +1,67 @@
+// Package tofu is a thin orchestration wrapper around the OpenTofu CLI.
+//
+// terrapod-query deliberately drives the `tofu` binary rather than speaking the
+// provider plugin protocol directly. OpenTofu already exposes everything the
+// discovery engine needs — schema introspection (`providers schema -json`),
+// data-source execution (a `data` block plus `output -json`), and config
+// generation (`plan -generate-config-out`) — so reimplementing a plugin client
+// would rebuild a wheel tofu already turns. This package is that orchestration
+// seam: it shells tofu in a caller-supplied working directory and returns the
+// raw bytes for the caller to parse.
+package tofu
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// Runner shells a specific `tofu` binary in a specific working directory. The
+// working directory is expected to already contain the ephemeral configuration
+// (and, for schema/query, to have been through `Init`) the caller wants to act
+// on. Runner holds no run state — it is a stateless launcher.
+type Runner struct {
+	// Bin is the path to the tofu executable. Empty means "tofu" on PATH.
+	Bin string
+	// Dir is the working directory tofu runs in.
+	Dir string
+}
+
+// bin resolves the executable name, defaulting to "tofu" on PATH.
+func (r *Runner) bin() string {
+	if r.Bin != "" {
+		return r.Bin
+	}
+	return "tofu"
+}
+
+// run executes tofu with the given arguments and returns stdout. On failure it
+// returns an error that carries stderr, since tofu writes diagnostics there.
+func (r *Runner) run(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, r.bin(), args...)
+	cmd.Dir = r.Dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("tofu %v: %w: %s", args, err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
+// Init runs `tofu init` so the provider plugins are installed and the schema is
+// resolvable. Discovery is read-only, so no backend is configured; init only
+// needs the providers.
+func (r *Runner) Init(ctx context.Context) error {
+	_, err := r.run(ctx, "init", "-input=false", "-no-color")
+	return err
+}
+
+// ProvidersSchema returns the raw `tofu providers schema -json` output. The
+// working directory must have been initialised first (Init) so the providers
+// are present. The bytes are the machine-readable schema of every provider,
+// resource, and data source — the input the schema package parses.
+func (r *Runner) ProvidersSchema(ctx context.Context) ([]byte, error) {
+	return r.run(ctx, "providers", "schema", "-json")
+}


### PR DESCRIPTION
Closes #823.

Adds **`terrapod-query`**, the tofu-native discovery engine for onboarding
existing, unmanaged cloud resources into IaC — the mechanical primitive the AI
onboarding workflow (#824) will drive. New 5th root Go module (`query/`), MPL,
**no BUSL Terraform binary and no bespoke provider-plugin client** — everything
rides the `tofu` CLI.

## What's in this PR (the engine + its build/release/docs)

- **D1 — schema** (`schema` subcommand): `tofu providers schema -json` → the
  discovery surface (which data sources accept `filter`/`tags`/name args),
  entirely schema-driven, zero hardcoded per-resource knowledge.
- **D2 — query** (`query` subcommand): a `data` block + `tofu output -json` →
  structured results. Read-only (data-source-only config → provider reads, no
  changes).
- **D3 — import** (`import` subcommand): results → candidate `import {}` blocks,
  with best-effort id derivation that **fails safe** (a wrong id shows as
  create/replace in the plan, not an import, so the operator doesn't merge it).
- **CI + images + release**: `build-query` compiles linux amd64+arm64 **once**
  → artifacts, reused by both the image bake and the release (no double
  compile). Baked into the **api** image (with pinned **OpenTofu 1.12.4** for
  credential-less schema introspection) and the **runner** image. `release-query`
  attaches all 6 platform archives + a GPG-signed SHA256SUMS to the Release,
  wired into all six release-job sites. `query-lint`/`query-test` join CI;
  Tiltfile/Makefile build the binary locally in a golang container.
- **Docs**: `docs/terrapod-query.md` + llms.txt / docs/index.md / AGENTS.md.

## Design decisions

- **Maximal-tofu, not a plugin client.** tofu already exposes schema
  introspection, data-source execution, and config-gen; we orchestrate it.
- **Split on the credential boundary.** Schema introspection is credential-less
  and provider-version-stable → runs in the **API** (responsive, no runner Job).
  Query execution hits the cloud with the workspace identity → runs in the
  **runner**. Same split as every plan/apply.
- **`release-query` is bespoke, not GoReleaser** — GoReleaser's `prebuilt`
  builder (to reuse the linux artifacts) is Pro-only, caught by `goreleaser
  check`. The job tars the exact build-query linux binaries and only compiles
  darwin/windows, so linux is still built once.

## Deferred to #824 (the consumption layer)

The engine is complete and shipped as a binary but **inert** until a consumer
invokes it. Per scope, these move to #824: the API-side schema-cache *service*
(shell the binary → cache per provider-version → endpoint), the runner
discovery-*mode* invocation, the AI loop + `generate-config-out` + config
cleanup + reviewed VCS PR, and the live-AWS behavioural smoke.

## Verification

`go vet`/`build`/`test ./...` green (schema/query/importblock unit-tested;
query/import hermetically via a fake-tofu stub — no cloud in CI). The full
tofu-native loop was validated end-to-end against a real dev AWS account
(read-only) in the spike: import block → import-only plan (0 add / 0 destroy)
holds. ci.yml is valid YAML; the tofu download+sha logic and the 6-platform
release packaging were dry-run locally. The api/runner image builds and the tag
pipeline validate on this PR's CI / first tag.