### PR TITLE
feat(web): offer language choice on the login screen (#835)

### DIFF
--- a/e2e/tests/i18n.spec.ts
+++ b/e2e/tests/i18n.spec.ts
@@ -96,3 +96,36 @@ test.describe('i18n language switcher', () => {
     expect(intlErrors, `next-intl errors: ${intlErrors.join('\n')}`).toEqual([]);
   });
 });
+
+// The login page is the one authenticated users never see, so the nav-bar globe
+// switcher isn't available there — an unauthenticated visitor would otherwise
+// have no way to pick a language before signing in (#835). The login page mounts
+// its own LocaleSwitcher; prove it flips the pre-sign-in copy through the BFF
+// with no session.
+test.describe('i18n language switcher on the login page', () => {
+  // Drop the admin storageState — the login page only renders unauthenticated.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('an unauthenticated visitor can choose a language before signing in', async ({ page, context }) => {
+    const intlErrors = guardIntlErrors(page);
+
+    await page.goto('/login');
+    // English baseline — the sign-in subtitle above the card.
+    await expect(page.getByText('Sign in to manage your infrastructure')).toBeVisible();
+
+    // The switcher is present pre-auth and flips the copy to German.
+    await switchLocale(page, /Change language/i, 'Deutsch');
+
+    await expect(
+      page.getByText('Melden Sie sich an, um Ihre Infrastruktur zu verwalten'),
+    ).toBeVisible();
+    await expect(page.getByText('Sign in to manage your infrastructure')).toHaveCount(0);
+
+    // The server layout reads NEXT_LOCALE — set even without a session.
+    const cookies = await context.cookies();
+    expect(cookies.find((c) => c.name === 'NEXT_LOCALE')?.value).toBe('de');
+
+    await expect(page.locator('body')).not.toContainText('MISSING_MESSAGE');
+    expect(intlErrors, `next-intl errors: ${intlErrors.join('\n')}`).toEqual([]);
+  });
+});

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
+import { LocaleSwitcher } from '@/components/locale-switcher'
 import { setAuth } from '@/lib/auth'
 import { STORAGE_AUTH_STATE, STORAGE_PKCE_VERIFIER, STORAGE_REDIRECT_AFTER_LOGIN } from '@/lib/constants'
 import { generatePKCE, generateState } from '@/lib/pkce'
@@ -15,13 +16,22 @@ interface Provider {
 export default function LoginPage() {
   const t = useTranslations('auth')
   return (
-    <Suspense fallback={
-      <main className="h-dvh flex items-center justify-center p-4">
-        <div className="text-slate-500">{t('loading')}</div>
-      </main>
-    }>
-      <LoginContent />
-    </Suspense>
+    <>
+      {/* Language chooser — always visible, before sign-in (the nav-bar
+          switcher isn't shown to unauthenticated users). Writes the
+          NEXT_LOCALE cookie + refreshes, re-rendering the login page in the
+          chosen locale. */}
+      <div className="absolute top-4 right-4 z-10">
+        <LocaleSwitcher />
+      </div>
+      <Suspense fallback={
+        <main className="h-dvh flex items-center justify-center p-4">
+          <div className="text-slate-500">{t('loading')}</div>
+        </main>
+      }>
+        <LoginContent />
+      </Suspense>
+    </>
   )
 }
 


### PR DESCRIPTION
The nav-bar globe switcher is only rendered to authenticated users, so an unauthenticated visitor at `/login` had no way to pick a language before signing in. This mounts a `LocaleSwitcher` on the login page (top-right, outside the Suspense boundary so it shows during provider load), writing the same `NEXT_LOCALE` cookie + `router.refresh()` as the nav switcher.

## Changes
- `web/src/app/login/page.tsx` — wrap the login content in a fragment with a top-right `LocaleSwitcher`.
- `e2e/tests/i18n.spec.ts` — unauthenticated spec (no session storageState) proving the switcher flips the pre-sign-in subtitle to German through the BFF and sets the cookie.

## Verification
- `npm run build` — clean (login route prerenders).
- `npm run lint` — 0 errors.
- `npm run i18n:lint` / `i18n:check` — pass (no new strings; the switcher reuses the existing `switcher.*` catalog).

closes #835