### PR TITLE
fix(web): close the md–lg (768–1023px) responsive dead-zone (#839)

### DIFF
--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -375,3 +375,39 @@ test.describe('Responsive harness (phone viewport)', () => {
     await expectNoHorizontalPageScroll(page);
   });
 });
+
+/**
+ * Tablet-width guard for the md–lg dead-zone (#839).
+ *
+ * The phone `responsive` project runs below md and the desktop projects run
+ * well above lg, so the 768–1023px band — where the desktop nav used to render
+ * (at md) but not fit until lg, wrapping into a tall sticky bar that shoved page
+ * content (incl. the run/workspace tab bar) out of view — was tested by NEITHER
+ * side. This block pins that band: the nav must still be its compact hamburger
+ * form (desktop link row is `hidden lg:flex`, so it must NOT show here), and no
+ * page must scroll horizontally — including the ≤11-tab workspace-detail strip,
+ * which now scrolls within itself (`overflow-x-auto`) instead of overflowing the
+ * page. One DRY viewport-driven UI, verified at the seam.
+ */
+test.describe('Tablet width (md–lg dead-zone, #839)', () => {
+  test.use({ viewport: { width: 900, height: 900 }, isMobile: false });
+
+  test('nav stays a compact hamburger, no page h-scroll', async ({ page }) => {
+    await page.goto('/workspaces');
+    // Below lg the mobile hamburger is the nav; the desktop link row is hidden.
+    await expect(page.getByRole('button', { name: /open menu/i })).toBeVisible();
+    await expectNoHorizontalPageScroll(page);
+  });
+
+  test('workspace-detail tab strip scrolls within itself, no page h-scroll', async ({ page }) => {
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('e2e-tabstrip-tablet'));
+
+    await page.goto(`/workspaces/${wsId}`);
+    // At ≥md the desktop tab bar renders (not the mobile <select>).
+    await expect(page.getByRole('button', { name: 'Overview' })).toBeVisible({ timeout: 15_000 });
+    // The ~11-tab strip must not push the page into horizontal scroll — it is
+    // contained by overflow-x-auto on its wrapper (the #839 fix).
+    await expectNoHorizontalPageScroll(page);
+  });
+});

--- a/web/src/app/admin/agent-pools/[id]/page.tsx
+++ b/web/src/app/admin/agent-pools/[id]/page.tsx
@@ -362,8 +362,8 @@ export default function AgentPoolDetailPage() {
         )}
 
         {/* Tabs */}
-        <div className="border-b border-slate-700/50 mb-6">
-          <div className="flex gap-1 -mb-px">
+        <div className="border-b border-slate-700/50 mb-6 overflow-x-auto">
+          <div className="flex gap-1 -mb-px whitespace-nowrap">
             {tabs.map((tab) => (
               <button
                 key={tab.key}

--- a/web/src/app/admin/execution-hooks/[id]/page.tsx
+++ b/web/src/app/admin/execution-hooks/[id]/page.tsx
@@ -250,8 +250,8 @@ export default function ExecutionHookDetailPage() {
         )}
 
         {/* Tabs */}
-        <div className="border-b border-slate-700/50 mb-6">
-          <div className="flex gap-1 -mb-px">
+        <div className="border-b border-slate-700/50 mb-6 overflow-x-auto">
+          <div className="flex gap-1 -mb-px whitespace-nowrap">
             {tabs.map((tab) => (
               <button
                 key={tab.key}

--- a/web/src/app/admin/roles/page.tsx
+++ b/web/src/app/admin/roles/page.tsx
@@ -644,8 +644,8 @@ export default function RolesPage() {
         )}
 
         {/* Tabs */}
-        <div className="border-b border-slate-700/50 mb-6">
-          <div className="flex gap-1 -mb-px">
+        <div className="border-b border-slate-700/50 mb-6 overflow-x-auto">
+          <div className="flex gap-1 -mb-px whitespace-nowrap">
             {tabs.map((tab) => (
               <button
                 key={tab.key}

--- a/web/src/app/admin/variable-sets/[id]/page.tsx
+++ b/web/src/app/admin/variable-sets/[id]/page.tsx
@@ -393,8 +393,8 @@ export default function VariableSetDetailPage() {
         )}
 
         {/* Tabs */}
-        <div className="border-b border-slate-700/50 mb-6">
-          <div className="flex gap-1 -mb-px">
+        <div className="border-b border-slate-700/50 mb-6 overflow-x-auto">
+          <div className="flex gap-1 -mb-px whitespace-nowrap">
             {tabs.map((tab) => (
               <button
                 key={tab.key}

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1718,8 +1718,8 @@ function WorkspaceDetailContent() {
             ))}
           </select>
         </div>
-        <div className="hidden border-b border-slate-700/50 mb-6 md:block">
-          <div className="flex gap-1 -mb-px">
+        <div className="hidden border-b border-slate-700/50 mb-6 md:block overflow-x-auto">
+          <div className="flex gap-1 -mb-px whitespace-nowrap">
             {tabs.map((tab) => (
               <button
                 key={tab.key}

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -1171,8 +1171,8 @@ function RunDetailPageInner() {
             ))}
           </select>
         </div>
-        <div className="hidden border-b border-slate-700/50 mb-6 md:block">
-          <div className="flex gap-1 -mb-px">
+        <div className="hidden border-b border-slate-700/50 mb-6 md:block overflow-x-auto">
+          <div className="flex gap-1 -mb-px whitespace-nowrap">
             {tabs.map(([v, label]) => (
               <button
                 key={v}

--- a/web/src/components/nav-bar.tsx
+++ b/web/src/components/nav-bar.tsx
@@ -302,7 +302,7 @@ function MobileDrawer({
   return (
     <div
       id={id}
-      className="md:hidden fixed top-0 left-0 right-0 h-dvh z-40 bg-slate-900 flex flex-col"
+      className="lg:hidden fixed top-0 left-0 right-0 h-dvh z-40 bg-slate-900 flex flex-col"
     >
       <div className="flex items-center justify-between h-14 px-4 border-b border-slate-800 flex-shrink-0">
         <span className="font-bold text-lg text-slate-100">{title}</span>
@@ -394,8 +394,12 @@ export default function NavBar() {
       <TokenExpiryBanner />
       <nav className="border-b border-slate-800 bg-slate-900/80 backdrop-blur-sm sticky top-0 z-10">
         <div className="px-4 sm:px-6 lg:px-8">
-          {/* Desktop nav */}
-          <div className="hidden md:flex items-center gap-1 py-2">
+          {/* Desktop nav — enabled at `lg`, not `md`: the full horizontal nav
+              (logo + 5 primary items + admin + locale + help + a long account
+              email) doesn't fit until ~1024, so below `lg` it would wrap into a
+              tall, ugly multi-row bar that (being sticky) also covers page
+              content beneath it. Below `lg` we use the clean hamburger instead. */}
+          <div className="hidden lg:flex items-center gap-1 py-2">
             <Link href="/" className="flex items-center gap-2 mr-3 flex-shrink-0">
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>
@@ -437,8 +441,8 @@ export default function NavBar() {
             />
           </div>
 
-          {/* Mobile top bar — logo + Account trigger + hamburger */}
-          <div className="md:hidden flex items-center justify-between h-14">
+          {/* Mobile top bar — logo + Account trigger + hamburger (below `lg`) */}
+          <div className="lg:hidden flex items-center justify-between h-14">
             <Link href="/" className="flex items-center gap-2">
               <img src="/logo.svg" alt="Terrapod" className="w-7 h-7" />
               <span className="font-bold text-lg text-slate-100">Terrapod</span>


### PR DESCRIPTION
Closes #839.

## The symptom

At viewport widths in the **768–1023px** band (e.g. a 962px window / small tablet), the workspace-detail and run pages showed **neither the mobile `<select>` picker nor the desktop tab bar**, and the top nav looked broken. Reported with a screenshot at 962px.

## Root cause — two distinct bugs, verified live (not theorised)

I reproduced this in a real browser against the local stack at 962px, measuring the DOM before/after (I'd initially mis-diagnosed the tab/select switch as fine and stopped there — it *is* consistent at `md`; the real causes were elsewhere):

**1. Nav renders its desktop bar too early (`md`, 768) but doesn't fit until ~1024.**
The full horizontal nav (logo + 5 primary items + Admin/Help/Account dropdowns + locale switcher + a long account email) can't fit below ~1024px, so in the 768–1023 band it **wrapped into a 3-row, 173px-tall sticky bar**. Because it's `sticky`, that tall bar shoved page content down far enough to push the tab bar **out of the visible area** — hence "no tabs". (The `<select>` is *correctly* hidden ≥768; `select=md:hidden` and `tabs=hidden md:block` are exact complements, so there is no width where both CSS-hide — the tabs were merely pushed below the fold.)
→ **Fix:** gate the desktop nav at `lg` and the hamburger below `lg`. The 768–1023 band now gets the clean **57px** hamburger.

**2. The tab strip had no overflow handling.**
`<div className="flex gap-1 -mb-px">` with ~11 tabs (workspace-detail) overflowed by 415px and forced **391px of horizontal *page* scroll** at 962 — a hard-rule violation, with some tabs unreachable.
→ **Fix:** `overflow-x-auto` + `whitespace-nowrap` on all **six** tab-strip wrappers (2 workspace pages + 4 admin detail pages) so the strip scrolls within itself.

## Evidence (measured at 962px, live)

| | nav sticky height | page horizontal scroll |
|---|---|---|
| **before (main)** | **173px** (wrapped 3 rows) | **391px** |
| **after** | **57px** (single hamburger row) | **0px** |

## Thorough sweep (per "check for similar problems")

- Audited every responsive view-toggle in `web/src`. The nav was the **only** true mobile↔desktop view-toggle with mismatched breakpoints. The admin list pages are **not** affected — they use one responsive table with `overflow-x-auto` + progressive column disclosure (`hidden sm/md/lg:table-cell`) + `md:hidden` reflow badges, not a card/table swap.
- Swept 390 / 768 / 900 / 962px across nav / list / detail pages: **no other dead-zone or page-h-scroll** remains.

## Tests

Added a **tablet-width (900px)** block to the responsive Playwright suite (`e2e/tests/responsive.spec.ts`) — the exact seam that neither the phone `responsive` project (<768) nor the desktop projects (≥1280) covered. It asserts the nav stays a compact hamburger and no page scrolls horizontally, incl. the workspace-detail tab strip.

`npm run build` passes.