### PR TITLE
fix(onboarding): owner-execute only on downloaded binaries (least privilege)

### DIFF
--- a/services/terrapod/runner/phases/terragrunt.py
+++ b/services/terrapod/runner/phases/terragrunt.py
@@ -178,7 +178,10 @@ def write_wrappers(
     )
     for path, src in ((tf_wrapper, tf_src), (tg_wrapper, tg_src)):
         path.write_text(src)
-        path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        # Owner-execute only (S_IEXEC == S_IXUSR) — these wrappers live in the
+        # runner Job's private working dir and are exec'd solely by the Job's own
+        # user; group/other execute is needless (insecure-file-permissions SAST).
+        path.chmod(path.stat().st_mode | stat.S_IEXEC)
     logger.info("terragrunt wrappers written", tg=str(tg_wrapper), tf=str(tf_wrapper))
     return tg_wrapper
 

--- a/services/terrapod/services/onboarding_service.py
+++ b/services/terrapod/services/onboarding_service.py
@@ -367,7 +367,15 @@ async def _download_engine_binary(db: AsyncSession, engine: str, version: str) -
 
 
 def _unzip_engine(zip_path: str, dest: str, engine: str) -> None:
-    """Extract the engine binary from a release zip to ``dest`` and mark it +x."""
+    """Extract the engine binary from a release zip to ``dest`` and mark it
+    owner-executable.
+
+    Only the OWNER execute bit is set (``S_IXUSR``) — not group/other. The binary
+    lives in a private ``mkdtemp`` directory (mode 0700) on the pod's ephemeral
+    storage and is executed only by this pod's own user; granting group/other
+    execute would be needlessly permissive (flagged by the insecure-file-
+    permissions SAST rule).
+    """
     import zipfile
 
     with zipfile.ZipFile(zip_path) as zf:
@@ -376,7 +384,7 @@ def _unzip_engine(zip_path: str, dest: str, engine: str) -> None:
             raise RuntimeError(f"{engine} binary not found in release archive")
         with zf.open(member) as src, open(dest, "wb") as out:
             shutil.copyfileobj(src, out)
-    os.chmod(dest, os.stat(dest).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    os.chmod(dest, os.stat(dest).st_mode | stat.S_IXUSR)
 
 
 def _discover_surface_blocking(


### PR DESCRIPTION
Resolves the **insecure-file-permissions** Semgrep code-scanning alert ([code-scanning/344](https://github.com/mattrobinsonsre/terrapod/security/code-scanning/344)).

## What
Two spots chmod a freshly-downloaded/written executable for **user + group + other**:

- `services/terrapod/services/onboarding_service.py` — the D1 discovery engine binary (`tofu`/`terraform`) extracted from its release zip.
- `services/terrapod/runner/phases/terragrunt.py` — the terragrunt `TF`/`TG` wrapper scripts.

Both files live in **private `mkdtemp` / Job working directories (mode 0700)** on ephemeral pod storage and are executed **solely by the pod's / Job's own user**. Granting group/other execute is needless excess (least-privilege).

## Change
Restrict both to **owner-execute only** (`S_IXUSR` / `S_IEXEC`). No functional change — the single-user exec path is unaffected; no test pinned the removed bits.