### PR TITLE
docs(824): v1.1.0 pre-release audit — document onboarding API + close coverage gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Everything below is implemented and shipped today.
 | Estate topology | Whole-estate dependency graph — workspaces + modules wired by run-triggers, remote-state, and module links; group by any label / pool / name prefix; RBAC-filtered; accessible table fallback |
 | State resource graph | Per-workspace resource dependency graph from Terraform state — resources wired by `depends-on`; current state version by default with an older-version picker; group by type / module / provider / mode; accessible table fallback |
 | Workspace health | Per-workspace health conditions, VCS polling status, drift detection indicators |
+| Internationalization | Web UI translated into **24 languages** (next-intl) — European + Asian — with the locale resolved per-request (`NEXT_LOCALE` cookie → `Accept-Language` → `en`), selectable on the login screen and via a nav switcher. AI plan summaries are translated at view time; two CI gates keep every offered language 100% complete (no partial locales) and block untranslated UI strings |
 
 ### Migration & onboarding
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3131,6 +3131,158 @@ Records the runner's policy-evaluation outcomes for the run. Persisted via Postg
 
 ---
 
+## Onboarding / Resource Discovery
+
+Discover existing, unmanaged cloud resources and generate copy-pasteable `resource {}` + `import {}` blocks, then bring them under management with a single gated import run. A session drives a discovery engine: **D1 schema** discovery runs credential-lessly in the API; **D2 query** + **D3 generate/clean** run on the runner; the only mutating step is an operator-confirmed, plan-only import run through the normal run gate.
+
+Onboarding has **no feature flag** — it is gated per workspace by the `workspace:onboard` capability (see [Roles](#roles)). Every session endpoint requires `workspace:onboard` on the workspace, returning `403` otherwise. The optional **AI mode** (natural-language selection + config cleanup) is the only part behind a switch (`api.config.ai_onboarding.enabled`); it never alters an attribute value or an import id.
+
+### Availability Probe
+
+```
+GET /api/terrapod/v1/onboarding
+```
+
+Any authenticated user. Reports whether the optional AI mode is available, so the UI can offer the conversational path when it is configured. Onboarding itself is always present — actual access is decided per-workspace by the `workspace:onboard` capability on the real endpoints.
+
+**Response:**
+```json
+{
+  "data": {
+    "type": "onboarding-availability",
+    "attributes": {
+      "ai-available": true,
+      "ai-model-configured": true
+    }
+  }
+}
+```
+
+| Attribute | Description |
+|---|---|
+| `ai-available` | Whether the AI mode switch (`ai_onboarding.enabled`) is on. |
+| `ai-model-configured` | Whether AI mode is on **and** a model is configured. |
+
+### Create Onboarding Session
+
+```
+POST /api/terrapod/v1/workspaces/{id}/onboarding-sessions
+```
+
+Requires `workspace:onboard`. Starts a session and kicks off credential-less D1 schema discovery on a scheduler trigger (off the request thread). The client polls the session (below) until `status == "schema_ready"`, then reads the discovery surface and selects the data-source types to query.
+
+**Request body:**
+```json
+{
+  "data": {
+    "type": "onboarding-sessions",
+    "attributes": {
+      "provider": "aws",
+      "provider-version": "< 6.0"
+    }
+  }
+}
+```
+
+| Attribute | Description |
+|---|---|
+| `provider` | The terraform/tofu provider to onboard, lowercase (e.g. `aws`). One provider per session; onboard several by running several sessions. Invalid → `422`. |
+| `provider-version` | Optional provider version *constraint* pinned in the generated `providers.tf` (e.g. `< 6.0`, `~> 5.0`). Empty = unconstrained (latest). Must be a valid terraform version constraint or → `422`. |
+
+Returns `201` with the serialized session (below).
+
+### List Onboarding Sessions
+
+```
+GET /api/terrapod/v1/workspaces/{id}/onboarding-sessions
+```
+
+Requires `workspace:onboard`. Returns the workspace's sessions. The (large, per-session) discovery surface is **omitted** from the list — fetch a single session for it.
+
+### Show Onboarding Session
+
+```
+GET /api/terrapod/v1/onboarding-sessions/{id}
+```
+
+Requires `workspace:onboard` on the session's workspace. Returns the session **including** its `discovery-surface` (served from a time-limited Redis cache — never persisted per-session; an expired session simply re-runs discovery). Once `status == "config_ready"`, the generated config and import blocks are present.
+
+### Start Discovery (D2/D3)
+
+```
+POST /api/terrapod/v1/onboarding-sessions/{id}/discover
+```
+
+Requires `workspace:onboard`. Dispatches the runner discovery run for a `schema_ready` session, querying the selected subset of the session's discovery surface. A session not in `schema_ready` → `422`.
+
+**Request body:**
+```json
+{
+  "data": {
+    "type": "onboarding-sessions",
+    "attributes": {
+      "selected-types": ["aws_vpcs", "aws_subnets"]
+    }
+  }
+}
+```
+
+| Attribute | Description |
+|---|---|
+| `selected-types` | The data-source types (a subset of the session's discovery surface) to query. Must be a list of strings or → `422`. |
+
+Returns the serialized session (now with `discovery-run-id` set).
+
+### Session Attributes
+
+The `onboarding-sessions` JSON:API resource the UI consumes:
+
+| Attribute | Description |
+|---|---|
+| `workspace-id` | The owning workspace. |
+| `status` | Session lifecycle state, one of `pending`, `schema_ready`, `querying`, `config_ready`, `run_created`, `errored`, `canceled`. |
+| `provider` | The provider being onboarded (e.g. `aws`). |
+| `provider-version` | The provider version constraint pinned in the generated `providers.tf`; empty = unconstrained. |
+| `engine` | The engine D1 ran with (`terraform` / `tofu`). |
+| `engine-version` | The resolved engine version D1 ran with. |
+| `selected-types` | The data-source types selected for the D2 query. |
+| `ai-assisted` | Whether the optional AI mode assisted this session (naming, cleanup, chat). True iff the polished view exists. |
+| `discovery-surface` | The D1 provider-schema surface (from the Redis cache). Present only on the **show** (detail) read; `null` on list. |
+| `data-source-count` | Count derived from the discovery surface (`null` when the surface isn't included). |
+| `generated-config` | D3 output — the cleaned, import-only `resource {}` config (null/empty ConflictsWith attributes pruned so it plans). Present once `status == config_ready`. |
+| `import-blocks` | D3 output — the candidate `import {}` blocks. Present once `status == config_ready`. |
+| `polished-config` | Optional AI-polished view of `generated-config` (resources renamed from tags, grouped, commented). **Never alters a value or import id** (enforced by a value-preservation check). `null` until the polish lands or if rejected / AI disabled. |
+| `polished-import-blocks` | The polished counterpart to `import-blocks`; renames are mirrored deterministically into the `to = <addr>` targets. |
+| `paired-config` | **Derived presentation view** (computed at serialize time, never stored): each `import {}` interleaved directly above the resource it targets, over the canonical `generated-config`/`import-blocks`. Ids/values untouched. `null` until config exists. |
+| `paired-polished-config` | The same derived pairing over the polished halves. `null` until the polished config exists. |
+| `discovery-run-id` | The runner discovery run that produced the query results + config (D2/D3), or `null`. |
+| `result-run-id` | The resulting gated import-only run, or `null`. |
+| `error` | Human-readable failure detail when `status == "errored"`. |
+| `created-by` | The user who started the session. |
+| `created-at` | RFC3339 timestamp. |
+| `updated-at` | RFC3339 timestamp. |
+
+### Runner Discovery Artifacts
+
+The runner discovery Job uploads its generated artifacts to these endpoints. Auth is a **runner token scoped to the discovery run** — each endpoint resolves the owning session via its `discovery_run_id` (== this run), so a Job can only ever write to its own session. Bodies are capped (`413` if too large).
+
+```
+PUT  /api/terrapod/v1/runs/{run_id}/artifacts/onboarding-config
+```
+The cleaned, import-only generated `resource {}` config (D3 + clean). Body is `.tf` text; stored on the session's `generated-config`. Returns `204`.
+
+```
+PUT  /api/terrapod/v1/runs/{run_id}/artifacts/onboarding-imports
+```
+The candidate `import {}` blocks (D3). Body is `.tf` text; stored on the session's `import-blocks`. Returns `204`.
+
+```
+POST /api/terrapod/v1/runs/{run_id}/artifacts/onboarding-query-results
+```
+The raw D2 query results + the import-only verdict (JSON object; non-JSON or non-object → `422`). Stored on the session. Returns `204`.
+
+> **Import run is always plan-only:** the confirmed import step is a gated, **import-only** run (plan-only) through the normal run gate — never an auto-apply.
+
 ## Service Catalog
 
 No-code self-service provisioning over the private module registry. A *catalog item* blesses a registry module; provisioning it creates an agent-mode, non-VCS, catalog-managed workspace whose configuration is a server-generated wrapper. See [Service Catalog](service-catalog.md) for the full feature doc.
@@ -3373,7 +3525,7 @@ Queues an `is_destroy` run with source **`catalog-lifecycle`**. On a **successfu
 
 Returns a reference to the queued destroy run. **Required permission:** catalog `use`.
 
-> **Run sources:** catalog runs carry `source = "catalog"` (provision / reconfigure) or `source = "catalog-lifecycle"` (destroy → archive). These appear on the run object alongside the existing sources (`tfe-api`, `vcs`, `drift-detection`, `autodiscovery-lifecycle`, `module-test`, `module-publish`).
+> **Run sources:** catalog runs carry `source = "catalog"` (provision / reconfigure) or `source = "catalog-lifecycle"` (destroy → archive). These appear on the run object alongside the existing sources (`tfe-api`, `vcs`, `drift-detection`, `autodiscovery-lifecycle`, `module-test`, `module-publish`, `onboarding-discovery`).
 
 ### Confirm / Discard a Catalog Instance Run
 

--- a/docs/internationalization.md
+++ b/docs/internationalization.md
@@ -30,6 +30,10 @@ Resolved per-request, with no `/<locale>/` URL segment:
 The switcher writes the cookie and refreshes; the server layout re-runs
 `src/i18n/request.ts` and re-provides messages — no reload, no URL change.
 
+The same picker is also offered **pre-auth on the login screen** (#836), so an
+operator can choose their language before signing in; it writes the same
+`NEXT_LOCALE` cookie, so the choice carries through to the authenticated app.
+
 `en` (US English) is the **source** catalog. Every other locale deep-merges
 over `en`, so a missing key can never render `MISSING_KEY` — but see the
 completeness gate below: a *partial* locale is never actually offered.

--- a/services/terrapod/api/routers/onboarding.py
+++ b/services/terrapod/api/routers/onboarding.py
@@ -86,9 +86,24 @@ async def _require_onboard(ws: Workspace, user: AuthenticatedUser, db: AsyncSess
         )
 
 
-def _session_json(s: OnboardingSession, surface: dict | None = None) -> dict:
-    """Serialize a session. ``surface`` (from the Redis cache) is included only on
-    the detail read — it's never stored on the row, so callers fetch it."""
+def _session_json(
+    s: OnboardingSession, surface: dict | None = None, *, detail: bool = False
+) -> dict:
+    """Serialize a session. ``surface`` (from the Redis cache) and the derived
+    ``paired-*`` views are included only on the **detail** read — the surface is
+    never stored on the row, and the paired views are a regex reflow over the full
+    config, so computing them per-row in the list handler (an ``async def``) would
+    be sync work on the event loop (Rule 13). The list omits both."""
+    paired_config = (
+        onboarding_polish.pair_config_and_imports(s.generated_config, s.import_blocks or "")
+        if detail and s.generated_config
+        else None
+    )
+    paired_polished = (
+        onboarding_polish.pair_config_and_imports(s.polished_config, s.polished_import_blocks or "")
+        if detail and s.polished_config
+        else None
+    )
     return {
         "type": "onboarding-sessions",
         "id": str(s.id),
@@ -117,18 +132,8 @@ def _session_json(s: OnboardingSession, surface: dict | None = None) -> dict:
             # directly above the resource it targets (import ids/values untouched;
             # the split fields above stay canonical). Computed at serialize time —
             # never stored. Null until config exists.
-            "paired-config": (
-                onboarding_polish.pair_config_and_imports(s.generated_config, s.import_blocks or "")
-                if s.generated_config
-                else None
-            ),
-            "paired-polished-config": (
-                onboarding_polish.pair_config_and_imports(
-                    s.polished_config, s.polished_import_blocks or ""
-                )
-                if s.polished_config
-                else None
-            ),
+            "paired-config": paired_config,
+            "paired-polished-config": paired_polished,
             "discovery-run-id": str(s.discovery_run_id) if s.discovery_run_id else None,
             "result-run-id": str(s.result_run_id) if s.result_run_id else None,
             "created-by": s.created_by,
@@ -225,7 +230,7 @@ async def get_onboarding_session(
         raise HTTPException(status_code=404, detail="Workspace not found")
     await _require_onboard(ws, user, db)
     surface = await onboarding_service.get_session_surface(session)
-    return {"data": _session_json(session, surface=surface)}
+    return {"data": _session_json(session, surface=surface, detail=True)}
 
 
 @router.post("/onboarding-sessions/{session_id}/discover")
@@ -264,4 +269,4 @@ async def start_onboarding_discovery(
     await db.commit()
 
     surface = await onboarding_service.get_session_surface(session)
-    return {"data": _session_json(session, surface=surface)}
+    return {"data": _session_json(session, surface=surface, detail=True)}

--- a/services/tests/api/test_onboarding.py
+++ b/services/tests/api/test_onboarding.py
@@ -127,6 +127,7 @@ import datetime as _dt  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
 from terrapod.auth.capabilities import WORKSPACE_ONBOARD  # noqa: E402
+from terrapod.services import onboarding_service  # noqa: E402
 
 _ONB = "terrapod.api.routers.onboarding"
 
@@ -305,3 +306,77 @@ class TestOnboardingSessions:
                     headers=_AUTH,
                 )
         assert resp.status_code == 404
+
+    # --- POST /onboarding-sessions/{id}/discover (D2/D3 dispatch) ---
+    _DISCOVER = "/api/terrapod/v1/onboarding-sessions/22222222-2222-2222-2222-222222222222/discover"
+
+    async def test_discover_requires_onboard_capability(self, *mocks):
+        with (
+            patch(
+                f"{_ONB}.onboarding_service.get_session",
+                AsyncMock(return_value=_fake_session(status="schema_ready")),
+            ),
+            patch(
+                f"{_ONB}.resolve_workspace_capabilities_for", AsyncMock(return_value=frozenset())
+            ),
+        ):
+            async with await self._client() as c:
+                resp = await c.post(
+                    self._DISCOVER,
+                    json={"data": {"attributes": {"selected-types": ["aws_vpcs"]}}},
+                    headers=_AUTH,
+                )
+        assert resp.status_code == 403
+
+    async def test_discover_rejects_non_list_selected_types(self, *mocks):
+        with (
+            patch(
+                f"{_ONB}.onboarding_service.get_session",
+                AsyncMock(return_value=_fake_session(status="schema_ready")),
+            ),
+            patch(
+                f"{_ONB}.resolve_workspace_capabilities_for",
+                AsyncMock(return_value=frozenset({WORKSPACE_ONBOARD})),
+            ),
+        ):
+            async with await self._client() as c:
+                resp = await c.post(
+                    self._DISCOVER,
+                    json={"data": {"attributes": {"selected-types": "aws_vpcs"}}},
+                    headers=_AUTH,
+                )
+        assert resp.status_code == 422
+
+    async def test_discover_bad_uuid_is_404(self, *mocks):
+        async with await self._client() as c:
+            resp = await c.post(
+                "/api/terrapod/v1/onboarding-sessions/not-a-uuid/discover",
+                json={"data": {"attributes": {"selected-types": []}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 404
+
+    async def test_discover_maps_onboarding_error_to_422(self, *mocks):
+        with (
+            patch(
+                f"{_ONB}.onboarding_service.get_session",
+                AsyncMock(return_value=_fake_session(status="pending")),
+            ),
+            patch(
+                f"{_ONB}.resolve_workspace_capabilities_for",
+                AsyncMock(return_value=frozenset({WORKSPACE_ONBOARD})),
+            ),
+            patch(
+                f"{_ONB}.onboarding_service.start_discovery",
+                AsyncMock(
+                    side_effect=onboarding_service.OnboardingError("session is not schema_ready")
+                ),
+            ),
+        ):
+            async with await self._client() as c:
+                resp = await c.post(
+                    self._DISCOVER,
+                    json={"data": {"attributes": {"selected-types": ["aws_vpcs"]}}},
+                    headers=_AUTH,
+                )
+        assert resp.status_code == 422

--- a/services/tests/services/test_onboarding_service.py
+++ b/services/tests/services/test_onboarding_service.py
@@ -78,6 +78,25 @@ def test_is_valid_version_constraint(value, ok):
     assert svc.is_valid_version_constraint(value) is ok
 
 
+@pytest.mark.parametrize(
+    ("value", "ok"),
+    [
+        ("aws", True),
+        ("google", True),
+        ("azurerm", True),
+        ("aws-cc", True),  # hyphen allowed inside the name
+        ("", False),  # empty rejected
+        ("AWS", False),  # uppercase rejected (interpolated into `provider "<name>"`)
+        ("1aws", False),  # must start with a letter
+        ('aws" }\nmalicious', False),  # can't break out of the HCL string literal
+        ("aws provider", False),  # no whitespace
+        ("a" * 65, False),  # over length cap
+    ],
+)
+def test_is_valid_provider(value, ok):
+    assert svc.is_valid_provider(value) is ok
+
+
 def test_local_platform_is_linux():
     os_, arch = svc._local_platform()
     assert os_ == "linux"


### PR DESCRIPTION
Pre-release audit fixes for **v1.1.0** (the first minor since the v1.0.0 no-breaking-changes commitment). Found by the mandatory third-party completeness review over `v1.0.0..main`.

## Gate A (docs completeness) — the blocker
- **`docs/api-reference.md`**: adds the missing **"Onboarding / Resource Discovery"** section — the 9 onboarding endpoints (session lifecycle + the 3 runner artifact uploads) and the `onboarding-sessions` JSON:API attribute table the UI consumes. The onboarding surface shipped across #834/#841/#843 with no api-reference entry, violating the API↔UX contract.
- Adds `onboarding-discovery` to the **Run sources** enumeration.
- **`docs/internationalization.md`**: documents the pre-auth login-screen language picker (#836).

## Gate C (coverage) + Rule 13
- **Rule 13 tidy**: the derived `paired-*` views (a regex reflow over the full config) are now computed only on the **detail** read, never per-row in the `async def` list handler.
- **Tests**: the `/onboarding-sessions/{id}/discover` router endpoint had no router test — added RBAC 403, non-list 422, bad-UUID 404, and OnboardingError→422. Added a parametrized `is_valid_provider` unit test (the injection guard interpolated into `provider "<name>"`, previously only exercised indirectly).

## Backward-compat (gate I)
Confirmed clean across the whole release range: **no** route/attribute/wire/config/helm removal or rename since v1.0.0; the only "route contract" delta is an **optional** `?locale` query param added to the existing plan-summary endpoints (a lagging client is unaffected). All new surface is additive → MINOR-safe.

Targeted onboarding suite (70) + ruff green.