### PR TITLE
fix(web): self-heal ChunkLoadError after deploy (custom global-error boundary)

### DIFF
--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { isChunkError } from '@/lib/chunk-error';
+
+// Next.js renders this (replacing the root layout) when an error escapes every
+// nested boundary — including a failed chunk/RSC fetch after a new deploy, where
+// the browser still holds the previous build's chunk hashes (see #847). In that
+// case a full reload pulls the current build and self-heals, so we reload once —
+// guarded against a loop — instead of dead-ending on Next's default error page.
+//
+// This component renders OUTSIDE the app's providers and global CSS (it replaces
+// the root layout), so it cannot use next-intl and must inline its styles. The
+// English copy is the deliberate last-resort fallback (only seen if the one-shot
+// reload guard trips); the user-facing literals carry `i18n-ignore`.
+
+const RELOAD_GUARD_KEY = 'tp:chunk-reload-at';
+const RELOAD_WINDOW_MS = 10_000;
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (!isChunkError(error)) return;
+    // Reload at most once per short window: if the chunk is genuinely gone
+    // (not just a stale-deploy race) a blind reload would loop forever.
+    try {
+      const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) || 0);
+      if (Date.now() - last > RELOAD_WINDOW_MS) {
+        sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+        window.location.reload();
+      }
+    } catch {
+      // sessionStorage unavailable (private mode / disabled) — fall through to
+      // the manual reload UI rather than risk a loop.
+    }
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100dvh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0f172a',
+          color: '#e2e8f0',
+          fontFamily:
+            'Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+        }}
+      >
+        <div style={{ textAlign: 'center', padding: '2rem', maxWidth: 420 }}>
+          <div style={{ fontSize: 40, lineHeight: 1, marginBottom: 16 }} aria-hidden>
+            {'⚠'}
+          </div>
+          <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 8px' }}>
+            This page couldn&rsquo;t load{/* i18n-ignore: renders outside next-intl */}
+          </h1>
+          <p style={{ fontSize: 14, color: '#94a3b8', margin: '0 0 24px' }}>
+            Reload to try again, or go back.{/* i18n-ignore: renders outside next-intl */}
+          </p>
+          <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
+            <button
+              onClick={() => window.location.reload()}
+              style={{
+                padding: '8px 16px',
+                borderRadius: 8,
+                border: 'none',
+                background: '#e2e8f0',
+                color: '#0f172a',
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              Reload{/* i18n-ignore: renders outside next-intl */}
+            </button>
+            <button
+              onClick={() => window.history.back()}
+              style={{
+                padding: '8px 16px',
+                borderRadius: 8,
+                border: '1px solid #334155',
+                background: 'transparent',
+                color: '#e2e8f0',
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: 'pointer',
+              }}
+            >
+              Back{/* i18n-ignore: renders outside next-intl */}
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/src/lib/chunk-error.ts
+++ b/web/src/lib/chunk-error.ts
@@ -1,0 +1,17 @@
+// Detect a failed JS/CSS chunk or dynamic-import load. After a new web build is
+// deployed, a browser still holding the previous build's chunk hashes will 404
+// on the next lazy chunk/RSC fetch (e.g. a route transition or a language
+// switch), surfacing as a `ChunkLoadError`. That's a deploy-transient: a full
+// reload pulls the current build and self-heals. `global-error.tsx` uses this to
+// reload once instead of dead-ending on an error screen. Kept as a tiny pure
+// predicate so the match set is reviewable in one place.
+
+const CHUNK_ERROR_RE =
+  /ChunkLoadError|Loading chunk [\d]+ failed|Loading CSS chunk|(dynamically )?imported module|importing a module script failed/i;
+
+export function isChunkError(error: unknown): boolean {
+  if (!error) return false;
+  const e = error as { name?: unknown; message?: unknown };
+  if (e.name === 'ChunkLoadError') return true;
+  return typeof e.message === 'string' && CHUNK_ERROR_RE.test(e.message);
+}


### PR DESCRIPTION
Closes #847.

## Problem
Observed on the markup **1.1.0** deploy: switching UI language showed **"This page couldn't load — Reload to try again, or go back."**; a manual full reload (logout→login) fixed it.

That screen is **Next.js's built-in `global-error`** — Terrapod ships no custom `app/global-error.tsx` or root `app/error.tsx`, so Next's default catches escaped errors. When a browser on the *previous* build lazy-loads a chunk/RSC segment the new build renamed (or a rolling deploy briefly serves mixed pods), the fetch 404s → `ChunkLoadError` → the default page, which has no self-heal. It's a deploy-transient, unrelated to i18n or the no-breaking-changes guarantee.

## Fix
- **`app/global-error.tsx`** — detects a chunk-load / dynamic-import failure and **auto-reloads once** (sessionStorage-guarded to a 10s window, so a genuinely-missing chunk can't loop), pulling the current build and self-healing. Otherwise renders a **Terrapod-branded** inline-styled fallback (Reload / Back), replacing Next's generic default.
- **`lib/chunk-error.ts`** — `isChunkError()`, a small pure predicate (matches `ChunkLoadError`, `Loading chunk … failed`, dynamic-import failures), kept separate so the match set is reviewable.

global-error renders **outside** the next-intl provider + global CSS (it replaces the root layout), so its copy is English by necessity — the deliberate last-resort fallback, only seen if the one-shot reload guard trips — and inline-styled; the literals carry `i18n-ignore` (documented exception to the hardcoded-string gate).

Self-heals the dead-end on **every** future deploy, not just language switching.

## Verification / test note
`i18n:lint` (suppressions accepted, 0 new) + `npm run build` green. Honest coverage caveat: there's **no JS unit runner** in `web/`, and a real `ChunkLoadError` can't be E2E-simulated (it requires a live stale-deploy chunk 404) — so `isChunkError` is a deliberately-trivial pure predicate and the reload path is verified by reasoning, not a test. Existing e2e proves no regression to normal rendering.