### PR TITLE
fix(go-terrapod): add native run + plan-JSON SDK methods (contract gap)

### DIFF
--- a/go-terrapod/runs.go
+++ b/go-terrapod/runs.go
@@ -1,0 +1,379 @@
+package terrapod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// RunActions reports which lifecycle transitions a run currently permits. It
+// mirrors the server's `actions` attribute block — the same signals the UI keys
+// its buttons off — so an agent can decide what it may do next without
+// re-deriving it from Status.
+type RunActions struct {
+	IsConfirmable bool `json:"is-confirmable"`
+	IsDiscardable bool `json:"is-discardable"`
+	IsCancelable  bool `json:"is-cancelable"`
+	IsRetryable   bool `json:"is-retryable"`
+}
+
+// RunStatusTimestamps records when the run entered each phase (RFC3339 with a
+// trailing Z, or empty if not reached). Useful for an agent narrating progress.
+type RunStatusTimestamps struct {
+	PlanQueuedAt string `json:"plan-queued-at,omitempty"`
+	PlanningAt   string `json:"planning-at,omitempty"`
+	PlannedAt    string `json:"planned-at,omitempty"`
+	ApplyingAt   string `json:"applying-at,omitempty"`
+	AppliedAt    string `json:"applied-at,omitempty"`
+}
+
+// Run is the decoded form of one Terrapod run. Field tags mirror the JSON:API
+// attribute names.
+//
+// The struct deliberately carries Terrapod-native fields that a generic TFE
+// client does not model — HasJSONOutput, HasChanges, IsDriftDetection, the
+// resource profile (PeakMemoryBytes / RunnerExit*), Terragrunt*, and
+// StateDiverged — because the whole point of the native SDK is to surface what
+// Terrapod actually reports about a run.
+//
+// Nullable fields use pointers where nil is meaningful and distinct from the
+// zero value: HasChanges (unknown until planned), PeakMemoryBytes / PeakCPUUsec /
+// RunnerExitCode (unset until the Job reports a profile), and
+// VCSPullRequestNumber (nil for branch/CLI runs).
+type Run struct {
+	ID               string `json:"id"`
+	Status           string `json:"status"`
+	Message          string `json:"message,omitempty"`
+	DiscardReason    string `json:"discard-reason,omitempty"`
+	IsDestroy        bool   `json:"is-destroy"`
+	AutoApply        bool   `json:"auto-apply"`
+	PlanOnly         bool   `json:"plan-only"`
+	Source           string `json:"source,omitempty"`
+	ExecutionBackend string `json:"execution-backend,omitempty"`
+	TerraformVersion string `json:"terraform-version,omitempty"`
+	// Terragrunt* echo the workspace's terragrunt wrapping for this run.
+	TerragruntEnabled bool   `json:"terragrunt-enabled"`
+	TerragruntVersion string `json:"terragrunt-version,omitempty"`
+	ResourceCPU       string `json:"resource-cpu,omitempty"`
+	ResourceMemory    string `json:"resource-memory,omitempty"`
+	// Resource profile — populated once the Job reports it. Nil until then.
+	PeakMemoryBytes  *int64 `json:"peak-memory-bytes,omitempty"`
+	PeakCPUUsec      *int64 `json:"peak-cpu-usec,omitempty"`
+	RunnerExitCode   *int64 `json:"runner-exit-code,omitempty"`
+	RunnerExitReason string `json:"runner-exit-reason,omitempty"`
+	RunnerExitStatus string `json:"runner-exit-status,omitempty"`
+	ErrorMessage     string `json:"error-message,omitempty"`
+	// Run options this run was created with (echoed back).
+	TargetAddrs     []string `json:"target-addrs,omitempty"`
+	ReplaceAddrs    []string `json:"replace-addrs,omitempty"`
+	RefreshOnly     bool     `json:"refresh-only"`
+	Refresh         bool     `json:"refresh"`
+	AllowEmptyApply bool     `json:"allow-empty-apply"`
+	// Terrapod-native observability the MCP most needs.
+	IsDriftDetection bool  `json:"is-drift-detection"`
+	HasChanges       *bool `json:"has-changes,omitempty"`
+	HasJSONOutput    bool  `json:"has-json-output"`
+	StateDiverged    bool  `json:"state-diverged"`
+	// Workspace context.
+	WorkspaceID   string `json:"workspace-id,omitempty"` // from the `workspace` relationship
+	WorkspaceName string `json:"workspace-name,omitempty"`
+	// VCS metadata (empty / nil for CLI runs).
+	VCSCommitSHA         string `json:"vcs-commit-sha,omitempty"`
+	VCSBranch            string `json:"vcs-branch,omitempty"`
+	VCSPullRequestNumber *int64 `json:"vcs-pull-request-number,omitempty"`
+	CreatedBy            string `json:"created-by,omitempty"`
+	CreatedAt            string `json:"created-at,omitempty"`
+	UpdatedAt            string `json:"updated-at,omitempty"`
+	// Nested blocks.
+	Actions          RunActions          `json:"actions"`
+	StatusTimestamps RunStatusTimestamps `json:"status-timestamps"`
+}
+
+// CreateRunRequest describes a run to queue against a workspace. WorkspaceID is
+// required; everything else is optional and follows the server defaults when
+// unset.
+//
+// PlanOnly is the key intent signal (a speculative plan vs. a plan+apply run).
+// AutoApply and Refresh are pointers because nil means "use the workspace/server
+// default" (workspace auto-apply setting; refresh defaults true) — distinct from
+// an explicit false.
+type CreateRunRequest struct {
+	WorkspaceID            string
+	ConfigurationVersionID string
+	Message                string
+	PlanOnly               bool
+	IsDestroy              bool
+	AutoApply              *bool
+	TerraformVersion       string
+	TargetAddrs            []string
+	ReplaceAddrs           []string
+	RefreshOnly            bool
+	Refresh                *bool
+	AllowEmptyApply        bool
+	// VCSRef plans against an arbitrary branch/tag/SHA. The server forces such a
+	// run plan-only regardless of PlanOnly.
+	VCSRef string
+}
+
+// CreateRun queues a run. See CreateRunRequest for the intent signals. Returns
+// *ValidationError (422) when the workspace/CLI policy rejects the run (e.g. a
+// CLI apply on a VCS-connected workspace).
+func (c *Client) CreateRun(ctx context.Context, req CreateRunRequest) (*Run, error) {
+	if req.WorkspaceID == "" {
+		return nil, fmt.Errorf("workspace id is required")
+	}
+	attrs := map[string]any{"plan-only": req.PlanOnly}
+	if req.Message != "" {
+		attrs["message"] = req.Message
+	}
+	if req.IsDestroy {
+		attrs["is-destroy"] = true
+	}
+	if req.AutoApply != nil {
+		attrs["auto-apply"] = *req.AutoApply
+	}
+	if req.TerraformVersion != "" {
+		attrs["terraform-version"] = req.TerraformVersion
+	}
+	if len(req.TargetAddrs) > 0 {
+		attrs["target-addrs"] = req.TargetAddrs
+	}
+	if len(req.ReplaceAddrs) > 0 {
+		attrs["replace-addrs"] = req.ReplaceAddrs
+	}
+	if req.RefreshOnly {
+		attrs["refresh-only"] = true
+	}
+	if req.Refresh != nil {
+		attrs["refresh"] = *req.Refresh
+	}
+	if req.AllowEmptyApply {
+		attrs["allow-empty-apply"] = true
+	}
+	if req.VCSRef != "" {
+		attrs["vcs-ref"] = req.VCSRef
+	}
+	rels := map[string]any{
+		"workspace": map[string]any{
+			"data": map[string]any{"id": req.WorkspaceID, "type": "workspaces"},
+		},
+	}
+	if req.ConfigurationVersionID != "" {
+		rels["configuration-version"] = map[string]any{
+			"data": map[string]any{"id": req.ConfigurationVersionID, "type": "configuration-versions"},
+		}
+	}
+	body, err := MarshalResource("runs", attrs, rels)
+	if err != nil {
+		return nil, fmt.Errorf("marshal create run: %w", err)
+	}
+	data, err := c.Post(ctx, "/api/v2/runs", body)
+	if err != nil {
+		return nil, err
+	}
+	return parseRun(data)
+}
+
+// GetRun reads a run by id. Accepts a bare UUID or the prefixed "run-<uuid>"
+// form.
+func (c *Client) GetRun(ctx context.Context, runID string) (*Run, error) {
+	id, err := runIDPath(runID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := c.Get(ctx, "/api/v2/runs/"+id)
+	if err != nil {
+		return nil, err
+	}
+	return parseRun(data)
+}
+
+// ListWorkspaceRuns returns a workspace's runs, newest first. pageNumber and
+// pageSize are 1-based; pass 0 for either to use the server defaults (page 1,
+// size 20).
+func (c *Client) ListWorkspaceRuns(ctx context.Context, workspaceID string, pageNumber, pageSize int) ([]Run, error) {
+	if workspaceID == "" {
+		return nil, fmt.Errorf("workspace id is required")
+	}
+	path := fmt.Sprintf("/api/v2/workspaces/%s/runs", url.PathEscape(workspaceID))
+	q := url.Values{}
+	if pageNumber > 0 {
+		q.Set("page[number]", strconv.Itoa(pageNumber))
+	}
+	if pageSize > 0 {
+		q.Set("page[size]", strconv.Itoa(pageSize))
+	}
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	data, err := c.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	resources, err := ParseResourceList(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse runs list: %w", err)
+	}
+	out := make([]Run, 0, len(resources))
+	for i := range resources {
+		out = append(out, *runFromResource(&resources[i]))
+	}
+	return out, nil
+}
+
+// ApplyRun confirms a planned run, moving it to apply. Returns *ValidationError
+// (422) or *ConflictError (409) when the run/workspace state forbids it (e.g. a
+// CLI confirm on a VCS-connected workspace, or a manually-locked workspace).
+func (c *Client) ApplyRun(ctx context.Context, runID string) (*Run, error) {
+	return c.runAction(ctx, runID, "apply")
+}
+
+// DiscardRun discards a planned run without applying it.
+func (c *Client) DiscardRun(ctx context.Context, runID string) (*Run, error) {
+	return c.runAction(ctx, runID, "discard")
+}
+
+// CancelRun cancels a non-terminal run.
+func (c *Client) CancelRun(ctx context.Context, runID string) (*Run, error) {
+	return c.runAction(ctx, runID, "cancel")
+}
+
+// GetRunPlanJSON returns the structured JSON plan output for a run (the
+// `tofu show -json` document). Plan ids share the run's UUID, so this accepts a
+// run id in any form (bare, "run-<uuid>", or "plan-<uuid>"). The endpoint 302s
+// to a presigned storage URL; the client follows it and returns the raw JSON
+// bytes. Returns *NotFoundError when the run produced no JSON plan output (never
+// planned, an engine/version that didn't emit it, or the artifact expired).
+func (c *Client) GetRunPlanJSON(ctx context.Context, runID string) ([]byte, error) {
+	id := strings.TrimPrefix(strings.TrimPrefix(runID, "plan-"), "run-")
+	if id == "" {
+		return nil, fmt.Errorf("run id is required")
+	}
+	// Raw JSON body (not JSON:API) — return the bytes as-is for the caller to
+	// decode into whatever plan shape it needs.
+	return c.Get(ctx, "/api/v2/plans/"+url.PathEscape(id)+"/json-output")
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────
+
+// runAction POSTs one of the actions/{apply,discard,cancel} endpoints (no body)
+// and returns the updated run.
+func (c *Client) runAction(ctx context.Context, runID, action string) (*Run, error) {
+	id, err := runIDPath(runID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := c.Post(ctx, "/api/v2/runs/"+id+"/actions/"+action, nil)
+	if err != nil {
+		return nil, err
+	}
+	return parseRun(data)
+}
+
+// runIDPath normalises a run id to the "run-<uuid>" form the run endpoints
+// expect and path-escapes it.
+func runIDPath(runID string) (string, error) {
+	if runID == "" {
+		return "", fmt.Errorf("run id is required")
+	}
+	id := runID
+	if !strings.HasPrefix(id, "run-") {
+		id = "run-" + strings.TrimPrefix(id, "plan-")
+	}
+	return url.PathEscape(id), nil
+}
+
+func parseRun(body []byte) (*Run, error) {
+	res, err := ParseResource(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse run response: %w", err)
+	}
+	return runFromResource(res), nil
+}
+
+func runFromResource(res *Resource) *Run {
+	r := &Run{
+		ID:                res.ID,
+		Status:            GetStringAttr(res, "status"),
+		Message:           GetStringAttr(res, "message"),
+		DiscardReason:     GetStringAttr(res, "discard-reason"),
+		IsDestroy:         GetBoolAttr(res, "is-destroy"),
+		AutoApply:         GetBoolAttr(res, "auto-apply"),
+		PlanOnly:          GetBoolAttr(res, "plan-only"),
+		Source:            GetStringAttr(res, "source"),
+		ExecutionBackend:  GetStringAttr(res, "execution-backend"),
+		TerraformVersion:  GetStringAttr(res, "terraform-version"),
+		TerragruntEnabled: GetBoolAttr(res, "terragrunt-enabled"),
+		TerragruntVersion: GetStringAttr(res, "terragrunt-version"),
+		ResourceCPU:       GetStringAttr(res, "resource-cpu"),
+		ResourceMemory:    GetStringAttr(res, "resource-memory"),
+		RunnerExitReason:  GetStringAttr(res, "runner-exit-reason"),
+		RunnerExitStatus:  GetStringAttr(res, "runner-exit-status"),
+		ErrorMessage:      GetStringAttr(res, "error-message"),
+		TargetAddrs:       GetListAttr(res, "target-addrs"),
+		ReplaceAddrs:      GetListAttr(res, "replace-addrs"),
+		RefreshOnly:       GetBoolAttr(res, "refresh-only"),
+		Refresh:           GetBoolAttr(res, "refresh"),
+		AllowEmptyApply:   GetBoolAttr(res, "allow-empty-apply"),
+		IsDriftDetection:  GetBoolAttr(res, "is-drift-detection"),
+		HasJSONOutput:     GetBoolAttr(res, "has-json-output"),
+		StateDiverged:     GetBoolAttr(res, "state-diverged"),
+		WorkspaceName:     GetStringAttr(res, "workspace-name"),
+		VCSCommitSHA:      GetStringAttr(res, "vcs-commit-sha"),
+		VCSBranch:         GetStringAttr(res, "vcs-branch"),
+		CreatedBy:         GetStringAttr(res, "created-by"),
+		CreatedAt:         GetStringAttr(res, "created-at"),
+		UpdatedAt:         GetStringAttr(res, "updated-at"),
+	}
+	if v := GetRelationshipID(res, "workspace"); v != "" {
+		r.WorkspaceID = v
+	}
+	r.PeakMemoryBytes = nullableInt(res, "peak-memory-bytes")
+	r.PeakCPUUsec = nullableInt(res, "peak-cpu-usec")
+	r.RunnerExitCode = nullableInt(res, "runner-exit-code")
+	r.VCSPullRequestNumber = nullableInt(res, "vcs-pull-request-number")
+	r.HasChanges = nullableBool(res, "has-changes")
+	unmarshalAttr(res, "actions", &r.Actions)
+	unmarshalAttr(res, "status-timestamps", &r.StatusTimestamps)
+	return r
+}
+
+// nullableInt returns a *int64 for an attribute that may be JSON null / absent.
+func nullableInt(res *Resource, key string) *int64 {
+	raw, ok := res.Attributes[key]
+	if !ok || len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var n int64
+	if json.Unmarshal(raw, &n) != nil {
+		return nil
+	}
+	return &n
+}
+
+// nullableBool returns a *bool for an attribute that may be JSON null / absent
+// (distinguishing "unknown" from an explicit false).
+func nullableBool(res *Resource, key string) *bool {
+	raw, ok := res.Attributes[key]
+	if !ok || len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var b bool
+	if json.Unmarshal(raw, &b) != nil {
+		return nil
+	}
+	return &b
+}
+
+// unmarshalAttr decodes a nested-object attribute into dst, leaving dst at its
+// zero value when the attribute is absent / null / unparsable.
+func unmarshalAttr(res *Resource, key string, dst any) {
+	raw, ok := res.Attributes[key]
+	if !ok || len(raw) == 0 || string(raw) == "null" {
+		return
+	}
+	_ = json.Unmarshal(raw, dst)
+}

--- a/go-terrapod/runs_test.go
+++ b/go-terrapod/runs_test.go
@@ -1,0 +1,234 @@
+package terrapod
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// runAttrs is a representative planned-run payload with the Terrapod-native
+// fields, nested action/timestamp blocks, and a mix of null + present nullables.
+const runAttrs = `{
+  "status":"planned","message":"nightly","is-destroy":false,"auto-apply":false,
+  "plan-only":false,"source":"tfe-api","execution-backend":"tofu",
+  "terraform-version":"1.9.0","terragrunt-enabled":false,
+  "target-addrs":["aws_vpc.main"],"replace-addrs":[],
+  "refresh-only":false,"refresh":true,"allow-empty-apply":false,
+  "is-drift-detection":false,"has-changes":true,"has-json-output":true,
+  "state-diverged":false,
+  "peak-memory-bytes":536870912,"peak-cpu-usec":null,"runner-exit-code":0,
+  "runner-exit-reason":"","workspace-name":"app",
+  "vcs-commit-sha":"abc123","vcs-branch":"main","vcs-pull-request-number":null,
+  "created-by":"alice@example.com",
+  "created-at":"2026-07-17T10:00:00Z","updated-at":"2026-07-17T10:05:00Z",
+  "actions":{"is-confirmable":true,"is-discardable":true,"is-cancelable":true,"is-retryable":false},
+  "status-timestamps":{"plan-queued-at":"2026-07-17T10:00:00Z","planned-at":"2026-07-17T10:03:00Z"}
+}`
+
+func runPayload(id string) string {
+	return `{"data":{"id":"` + id + `","type":"runs","attributes":` + runAttrs +
+		`,"relationships":{"workspace":{"data":{"id":"ws-app","type":"workspaces"}}}}}`
+}
+
+func newRunsFixture(t *testing.T) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody []byte
+		if r.Body != nil {
+			reqBody, _ = io.ReadAll(r.Body)
+			_ = r.Body.Close()
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		p := r.URL.Path
+		switch {
+		case r.Method == http.MethodPost && p == "/api/v2/runs":
+			var doc struct {
+				Data struct {
+					Attributes    map[string]any `json:"attributes"`
+					Relationships map[string]any `json:"relationships"`
+				} `json:"data"`
+			}
+			_ = json.Unmarshal(reqBody, &doc)
+			if _, ok := doc.Data.Attributes["plan-only"]; !ok {
+				http.Error(w, "missing plan-only", http.StatusUnprocessableEntity)
+				return
+			}
+			if doc.Data.Relationships["workspace"] == nil {
+				http.Error(w, "missing workspace", http.StatusUnprocessableEntity)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(runPayload("run-aaaa")))
+
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/runs") && strings.Contains(p, "/workspaces/"):
+			_, _ = w.Write([]byte(`{"data":[` +
+				`{"id":"run-aaaa","type":"runs","attributes":` + runAttrs + `}]}`))
+
+		case r.Method == http.MethodGet && strings.Contains(p, "/api/v2/runs/"):
+			_, _ = w.Write([]byte(runPayload("run-aaaa")))
+
+		case r.Method == http.MethodPost && strings.HasSuffix(p, "/actions/apply"):
+			if strings.Contains(p, "run-locked") {
+				http.Error(w, `{"errors":[{"status":"409","title":"Conflict","detail":"workspace is locked"}]}`, http.StatusConflict)
+				return
+			}
+			_, _ = w.Write([]byte(runPayload("run-aaaa")))
+		case r.Method == http.MethodPost && (strings.HasSuffix(p, "/actions/discard") || strings.HasSuffix(p, "/actions/cancel")):
+			_, _ = w.Write([]byte(runPayload("run-aaaa")))
+
+		// Plan JSON: 302 to a presigned URL that serves the raw JSON bytes.
+		case r.Method == http.MethodGet && strings.HasSuffix(p, "/json-output"):
+			if strings.Contains(p, "nooutput") {
+				http.Error(w, `{"errors":[{"status":"404","title":"Not Found","detail":"JSON plan output not available"}]}`, http.StatusNotFound)
+				return
+			}
+			http.Redirect(w, r, "/presigned/plan.json", http.StatusFound)
+		case r.Method == http.MethodGet && p == "/presigned/plan.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"format_version":"1.2","resource_changes":[]}`))
+
+		default:
+			http.Error(w, "unhandled "+r.Method+" "+p, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestCreateRun(t *testing.T) {
+	c := newRunsFixture(t)
+	yes := true
+	run, err := c.CreateRun(t.Context(), CreateRunRequest{
+		WorkspaceID: "ws-app",
+		PlanOnly:    false,
+		AutoApply:   &yes,
+		Message:     "nightly",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.ID != "run-aaaa" || run.Status != "planned" {
+		t.Errorf("run: %+v", run)
+	}
+}
+
+func TestCreateRunRequiresWorkspace(t *testing.T) {
+	c := newRunsFixture(t)
+	if _, err := c.CreateRun(t.Context(), CreateRunRequest{PlanOnly: true}); err == nil {
+		t.Fatal("expected error for missing workspace id")
+	}
+}
+
+func TestGetRunParsesNativeFields(t *testing.T) {
+	c := newRunsFixture(t)
+	run, err := c.GetRun(t.Context(), "run-aaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Workspace comes from the relationship.
+	if run.WorkspaceID != "ws-app" {
+		t.Errorf("workspace id: %q", run.WorkspaceID)
+	}
+	// Terrapod-native fields go-tfe can't model.
+	if !run.HasJSONOutput {
+		t.Error("expected has-json-output true")
+	}
+	if run.HasChanges == nil || !*run.HasChanges {
+		t.Errorf("has-changes: %+v", run.HasChanges)
+	}
+	if run.PeakMemoryBytes == nil || *run.PeakMemoryBytes != 536870912 {
+		t.Errorf("peak-memory-bytes: %+v", run.PeakMemoryBytes)
+	}
+	// Present-but-zero nullable stays non-nil; null stays nil.
+	if run.RunnerExitCode == nil || *run.RunnerExitCode != 0 {
+		t.Errorf("runner-exit-code: %+v", run.RunnerExitCode)
+	}
+	if run.PeakCPUUsec != nil || run.VCSPullRequestNumber != nil {
+		t.Errorf("expected nil for null nullables: cpu=%+v pr=%+v", run.PeakCPUUsec, run.VCSPullRequestNumber)
+	}
+	// Nested blocks.
+	if !run.Actions.IsConfirmable || !run.Actions.IsCancelable || run.Actions.IsRetryable {
+		t.Errorf("actions: %+v", run.Actions)
+	}
+	if run.StatusTimestamps.PlannedAt != "2026-07-17T10:03:00Z" {
+		t.Errorf("status-timestamps: %+v", run.StatusTimestamps)
+	}
+	if len(run.TargetAddrs) != 1 || run.TargetAddrs[0] != "aws_vpc.main" {
+		t.Errorf("target-addrs: %+v", run.TargetAddrs)
+	}
+}
+
+func TestListWorkspaceRuns(t *testing.T) {
+	c := newRunsFixture(t)
+	runs, err := c.ListWorkspaceRuns(t.Context(), "ws-app", 1, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 || runs[0].Status != "planned" {
+		t.Errorf("runs: %+v", runs)
+	}
+}
+
+func TestRunActions(t *testing.T) {
+	c := newRunsFixture(t)
+	for _, tc := range []struct {
+		name string
+		fn   func() (*Run, error)
+	}{
+		{"apply", func() (*Run, error) { return c.ApplyRun(t.Context(), "run-aaaa") }},
+		{"discard", func() (*Run, error) { return c.DiscardRun(t.Context(), "run-aaaa") }},
+		{"cancel", func() (*Run, error) { return c.CancelRun(t.Context(), "run-aaaa") }},
+	} {
+		run, err := tc.fn()
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if run.ID != "run-aaaa" {
+			t.Errorf("%s: %+v", tc.name, run)
+		}
+	}
+}
+
+func TestApplyRunConflict(t *testing.T) {
+	c := newRunsFixture(t)
+	_, err := c.ApplyRun(t.Context(), "run-locked")
+	if err == nil {
+		t.Fatal("expected conflict")
+	}
+	if _, ok := err.(*ConflictError); !ok {
+		t.Errorf("expected *ConflictError, got %T: %v", err, err)
+	}
+}
+
+func TestGetRunPlanJSONFollowsRedirect(t *testing.T) {
+	c := newRunsFixture(t)
+	// Accepts a run id in any form; server strips the prefix.
+	raw, err := c.GetRunPlanJSON(t.Context(), "run-aaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		FormatVersion string `json:"format_version"`
+	}
+	if json.Unmarshal(raw, &doc) != nil || doc.FormatVersion != "1.2" {
+		t.Errorf("plan json: %s", raw)
+	}
+}
+
+func TestGetRunPlanJSONNotFound(t *testing.T) {
+	c := newRunsFixture(t)
+	_, err := c.GetRunPlanJSON(t.Context(), "nooutput")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := err.(*NotFoundError); !ok {
+		t.Errorf("expected *NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -138,6 +138,19 @@ field CreateRoleRequest.Name string
 field CreateRoleRequest.PoolPermission string
 field CreateRoleRequest.RegistryPermission string
 field CreateRoleRequest.WorkspacePermission string
+field CreateRunRequest.AllowEmptyApply bool
+field CreateRunRequest.AutoApply *bool
+field CreateRunRequest.ConfigurationVersionID string
+field CreateRunRequest.IsDestroy bool
+field CreateRunRequest.Message string
+field CreateRunRequest.PlanOnly bool
+field CreateRunRequest.Refresh *bool
+field CreateRunRequest.RefreshOnly bool
+field CreateRunRequest.ReplaceAddrs []string
+field CreateRunRequest.TargetAddrs []string
+field CreateRunRequest.TerraformVersion string
+field CreateRunRequest.VCSRef string
+field CreateRunRequest.WorkspaceID string
 field CreateRunTaskRequest.Enabled *bool
 field CreateRunTaskRequest.EnforcementLevel string
 field CreateRunTaskRequest.HMACKey string
@@ -442,6 +455,54 @@ field RoleAssignment.CreatedAt string `json:"created-at,omitempty"`
 field RoleAssignment.Email string `json:"email"`
 field RoleAssignment.ProviderName string `json:"provider-name"`
 field RoleAssignment.RoleName string `json:"role-name"`
+field Run.Actions RunActions `json:"actions"`
+field Run.AllowEmptyApply bool `json:"allow-empty-apply"`
+field Run.AutoApply bool `json:"auto-apply"`
+field Run.CreatedAt string `json:"created-at,omitempty"`
+field Run.CreatedBy string `json:"created-by,omitempty"`
+field Run.DiscardReason string `json:"discard-reason,omitempty"`
+field Run.ErrorMessage string `json:"error-message,omitempty"`
+field Run.ExecutionBackend string `json:"execution-backend,omitempty"`
+field Run.HasChanges *bool `json:"has-changes,omitempty"`
+field Run.HasJSONOutput bool `json:"has-json-output"`
+field Run.ID string `json:"id"`
+field Run.IsDestroy bool `json:"is-destroy"`
+field Run.IsDriftDetection bool `json:"is-drift-detection"`
+field Run.Message string `json:"message,omitempty"`
+field Run.PeakCPUUsec *int64 `json:"peak-cpu-usec,omitempty"`
+field Run.PeakMemoryBytes *int64 `json:"peak-memory-bytes,omitempty"`
+field Run.PlanOnly bool `json:"plan-only"`
+field Run.Refresh bool `json:"refresh"`
+field Run.RefreshOnly bool `json:"refresh-only"`
+field Run.ReplaceAddrs []string `json:"replace-addrs,omitempty"`
+field Run.ResourceCPU string `json:"resource-cpu,omitempty"`
+field Run.ResourceMemory string `json:"resource-memory,omitempty"`
+field Run.RunnerExitCode *int64 `json:"runner-exit-code,omitempty"`
+field Run.RunnerExitReason string `json:"runner-exit-reason,omitempty"`
+field Run.RunnerExitStatus string `json:"runner-exit-status,omitempty"`
+field Run.Source string `json:"source,omitempty"`
+field Run.StateDiverged bool `json:"state-diverged"`
+field Run.Status string `json:"status"`
+field Run.StatusTimestamps RunStatusTimestamps `json:"status-timestamps"`
+field Run.TargetAddrs []string `json:"target-addrs,omitempty"`
+field Run.TerraformVersion string `json:"terraform-version,omitempty"`
+field Run.TerragruntEnabled bool `json:"terragrunt-enabled"`
+field Run.TerragruntVersion string `json:"terragrunt-version,omitempty"`
+field Run.UpdatedAt string `json:"updated-at,omitempty"`
+field Run.VCSBranch string `json:"vcs-branch,omitempty"`
+field Run.VCSCommitSHA string `json:"vcs-commit-sha,omitempty"`
+field Run.VCSPullRequestNumber *int64 `json:"vcs-pull-request-number,omitempty"`
+field Run.WorkspaceID string `json:"workspace-id,omitempty"`
+field Run.WorkspaceName string `json:"workspace-name,omitempty"`
+field RunActions.IsCancelable bool `json:"is-cancelable"`
+field RunActions.IsConfirmable bool `json:"is-confirmable"`
+field RunActions.IsDiscardable bool `json:"is-discardable"`
+field RunActions.IsRetryable bool `json:"is-retryable"`
+field RunStatusTimestamps.AppliedAt string `json:"applied-at,omitempty"`
+field RunStatusTimestamps.ApplyingAt string `json:"applying-at,omitempty"`
+field RunStatusTimestamps.PlanQueuedAt string `json:"plan-queued-at,omitempty"`
+field RunStatusTimestamps.PlannedAt string `json:"planned-at,omitempty"`
+field RunStatusTimestamps.PlanningAt string `json:"planning-at,omitempty"`
 field RunTask.CreatedAt string `json:"created-at,omitempty"`
 field RunTask.Enabled bool `json:"enabled"`
 field RunTask.EnforcementLevel string `json:"enforcement-level"`
@@ -758,9 +819,11 @@ method (*AuthenticationError) Error() string
 method (*AuthorizationError) Error() string
 method (*Client) AddPolicy(ctx context.Context, policySetID string, req AddPolicyRequest) (*Policy, error)
 method (*Client) AddRoleToIdentity(ctx context.Context, providerName, email, roleName string) error
+method (*Client) ApplyRun(ctx context.Context, runID string) (*Run, error)
 method (*Client) AssignWorkspaceToExecutionHook(ctx context.Context, hookID, workspaceID string) error
 method (*Client) AssignWorkspaceToVarset(ctx context.Context, varsetID, workspaceID string) error
 method (*Client) BulkUpdateWorkspaces( ctx context.Context, filter WorkspaceFilter, update map[string]any, dryRun bool, ) (*BulkUpdateResult, error)
+method (*Client) CancelRun(ctx context.Context, runID string) (*Run, error)
 method (*Client) ConfirmCatalogInstanceRun(ctx context.Context, wsID string) (*CatalogRunRef, error)
 method (*Client) CreateAPIToken(ctx context.Context, userID string, req CreateAPITokenRequest) (*APIToken, error)
 method (*Client) CreateAgentPool(ctx context.Context, req CreateAgentPoolRequest) (*AgentPool, error)
@@ -779,6 +842,7 @@ method (*Client) CreateRegistryModule(ctx context.Context, req CreateRegistryMod
 method (*Client) CreateRegistryProvider(ctx context.Context, req CreateRegistryProviderRequest) (*RegistryProvider, error)
 method (*Client) CreateRemoteStateConsumer(ctx context.Context, req CreateRemoteStateConsumerRequest) (*RemoteStateConsumer, error)
 method (*Client) CreateRole(ctx context.Context, req CreateRoleRequest) (*Role, error)
+method (*Client) CreateRun(ctx context.Context, req CreateRunRequest) (*Run, error)
 method (*Client) CreateRunTask(ctx context.Context, workspaceID string, req CreateRunTaskRequest) (*RunTask, error)
 method (*Client) CreateRunTrigger(ctx context.Context, req CreateRunTriggerRequest) (*RunTrigger, error)
 method (*Client) CreateStateVersion(ctx context.Context, workspaceID string, req CreateStateVersionRequest) (*StateVersion, error)
@@ -816,6 +880,7 @@ method (*Client) DeleteWithBody(ctx context.Context, path string, payload []byte
 method (*Client) DeleteWorkspace(ctx context.Context, id string) error
 method (*Client) DestroyCatalogInstance(ctx context.Context, wsID string, attrs map[string]any) (*CatalogRunRef, error)
 method (*Client) DiscardCatalogInstanceRun(ctx context.Context, wsID string) (*CatalogRunRef, error)
+method (*Client) DiscardRun(ctx context.Context, runID string) (*Run, error)
 method (*Client) Get(ctx context.Context, path string) ([]byte, error)
 method (*Client) GetAPIToken(ctx context.Context, tokenID string) (*APIToken, error)
 method (*Client) GetAgentPool(ctx context.Context, id string) (*AgentPool, error)
@@ -841,7 +906,9 @@ method (*Client) GetRegistryProvider(ctx context.Context, name string) (*Registr
 method (*Client) GetRemoteStateConsumer(ctx context.Context, id string) (*RemoteStateConsumer, error)
 method (*Client) GetRole(ctx context.Context, name string) (*Role, error)
 method (*Client) GetRoleAssignment(ctx context.Context, providerName, email, roleName string) (*RoleAssignment, error)
+method (*Client) GetRun(ctx context.Context, runID string) (*Run, error)
 method (*Client) GetRunImpactGraph(ctx context.Context, runID string) (*ImpactGraph, error)
+method (*Client) GetRunPlanJSON(ctx context.Context, runID string) ([]byte, error)
 method (*Client) GetRunTask(ctx context.Context, id string) (*RunTask, error)
 method (*Client) GetRunTrigger(ctx context.Context, id string) (*RunTrigger, error)
 method (*Client) GetStateGraph(ctx context.Context, workspaceID, stateVersionID string) (*StateGraph, error)
@@ -885,6 +952,7 @@ method (*Client) ListVCSConnections(ctx context.Context) ([]VCSConnection, error
 method (*Client) ListVariableSets(ctx context.Context) ([]VariableSet, error)
 method (*Client) ListVariables(ctx context.Context, workspaceID string) ([]Variable, error)
 method (*Client) ListVarsetVariables(ctx context.Context, varsetID string) ([]VariableSetVariable, error)
+method (*Client) ListWorkspaceRuns(ctx context.Context, workspaceID string, pageNumber, pageSize int) ([]Run, error)
 method (*Client) ListWorkspaces(ctx context.Context, opts WorkspaceListOptions) (*WorkspaceList, error)
 method (*Client) OrphanCatalogInstance(ctx context.Context, wsID string) error
 method (*Client) Patch(ctx context.Context, path string, payload []byte) ([]byte, error)
@@ -965,6 +1033,7 @@ type CreateRegistryModuleRequest struct
 type CreateRegistryProviderRequest struct
 type CreateRemoteStateConsumerRequest struct
 type CreateRoleRequest struct
+type CreateRunRequest struct
 type CreateRunTaskRequest struct
 type CreateRunTriggerRequest struct
 type CreateStateVersionRequest struct
@@ -1014,6 +1083,9 @@ type RemoteStateConsumer struct
 type Resource struct
 type Role struct
 type RoleAssignment struct
+type Run struct
+type RunActions struct
+type RunStatusTimestamps struct
 type RunTask struct
 type RunTrigger struct
 type SearchWorkspacesResult struct


### PR DESCRIPTION
## What

Adds native **run + plan-JSON** methods to go-terrapod. The SDK already covered
the `/api/v2` CLI surface natively (workspaces, variables, variable-sets,
state-versions, plan-summaries) — runs and the plan-JSON output were the
conspicuous gap, the same class of coverage breach as the onboarding one
(#851/#852). No Go consumer could drive or observe a run through go-terrapod.

Leaning on go-tfe for runs was considered and rejected — its `Run` struct can't
model Terrapod-native run fields (`has-json-output`, `has-changes`,
`is-drift-detection`, the peak-memory / runner-exit resource profile,
terragrunt, `state-diverged`), and it drags in a client whose model
(multi-org/teams/projects/Sentinel) is broader than Terrapod's. Native methods
expose exactly what Terrapod reports and keep the SDK to a single client.

## Methods added (`go-terrapod/runs.go`)

| SDK method | Endpoint |
|---|---|
| `CreateRun` | `POST /api/v2/runs` |
| `GetRun` | `GET /api/v2/runs/{id}` |
| `ListWorkspaceRuns` | `GET /api/v2/workspaces/{id}/runs` (paginated) |
| `ApplyRun` | `POST /api/v2/runs/{id}/actions/apply` |
| `DiscardRun` | `POST /api/v2/runs/{id}/actions/discard` |
| `CancelRun` | `POST /api/v2/runs/{id}/actions/cancel` |
| `GetRunPlanJSON` | `GET /api/v2/plans/{id}/json-output` (plan id == run id; follows the 302 to the presigned URL, returns raw JSON bytes) |

Typed `Run` carries the Terrapod-native fields + nested `Actions` /
`StatusTimestamps`, and pointer-nullables where nil is meaningful
(`HasChanges`, the resource-profile ints, `VCSPullRequestNumber`).
`CreateRunRequest` uses `*bool` for `AutoApply` / `Refresh` so "unset →
workspace/server default" is distinct from an explicit false.

## Tests (`go-terrapod/runs_test.go`)

Every method against an httptest fixture: create (+ the missing-workspace
guard), get (asserting the native fields, pointer-nullables, and nested
`Actions`/`StatusTimestamps` parse), list, all three actions, a **409** conflict
(`*ConflictError`), and the plan-JSON **redirect-follow** + **404**
(`*NotFoundError`) paths.

## Backward compatibility (#550)

Exported-surface golden regenerated; the diff is **purely additive** — no
removals/renames. `go build/vet/test ./...` + `golangci-lint` all green.

Closes #853. Sibling of #851. Found while auditing SDK coverage for the MCP (#846).
