### PR TITLE
fix(862): honour page[size] on list endpoints + optional-pagination convention (Stage 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,6 +374,44 @@ multi-language implementation ships in the same PR**:
   `UPDATE_API_CONTRACT=1 pytest tests/api/test_route_contract.py` — a conscious,
   reviewed act so new surface never slips in silently. (More of the "no breaking
   changes" program lands under #550.)
+- **List endpoints — optional pagination (convention)** — every list/collection
+  endpoint supports **optional** paging and always returns a `meta.pagination`
+  block. Use the shared helper `services/terrapod/api/pagination.py::paginate(
+  items, request)`, which reads the params off the raw `Request` and slices the
+  already-materialised list. Rules:
+  - **`page[size]` >= 1** (with optional `page[number]`, 1-indexed) → return
+    that page, size capped at `MAX_PAGE_SIZE` (100).
+  - **`page[size]=0` OR no paging params** → return the **full list** as a single
+    page. Both are the "non-paged" signal. This preserves the pre-pagination
+    behaviour, so no caller that omits paging changes — which is what makes
+    adding pagination **additive / MINOR-safe** rather than breaking.
+  - **Always emit `meta.pagination`** with Terrapod's four keys —
+    `current-page`, `page-size`, `total-count`, `total-pages`. This is
+    **Terrapod's own shape, used uniformly on both `/api/v2` and
+    `/api/terrapod/v1`** — do not model non-TFE endpoints on TFE's key set
+    (no `prev-page`/`next-page`). On `/api/v2` the shape still matches what a
+    `go-tfe` client parses; that compatibility is incidental, not a constraint
+    the native surface bends to.
+  - **RBAC-filtered lists slice AFTER the permission filter** — pass the visible
+    list to `paginate()` so pages are full and `total-count` is the visible
+    count, never the pre-filter row count.
+  - **Contract-safe:** because params are read off `Request` (no `Query()`
+    declarations) and `meta` is a top-level sibling of `data`, the route,
+    attribute, wire, config, and migration snapshots are all untouched — this
+    change needs **no snapshot regen**. Adding declared `Query(alias="page[size]")`
+    params instead would change the route signature and require a conscious route
+    snapshot regen, so prefer the `Request`-based helper.
+  - **The one exception is unbounded-history collections** (workspace **runs**):
+    they keep a sensible bounded default page (20) instead of "absent → all",
+    since returning the entire run history on every request is a perf hazard.
+    They still honour `page[size]` and emit `meta.pagination` so a client can
+    page the full history.
+  - **Clients page + loop to fetch a whole collection** rather than relying on
+    the "absent → all" default — it's more robust across version/skew. go-terrapod
+    exposes single-page `List*` (returns `meta` on the typed list result) plus
+    `ListAll*` loop helpers; the web UI, which deliberately shows whole lists and
+    filters client-side (**no page-through UX**), fetches via `fetchAllPages()`
+    in `web/src/lib/api.ts`.
 - **The config-channel contract (hard requirement)** — a three-way contract
   binding the **config code**, the **Helm chart**, and the **chart tests**:
   the in-code config models (the API's Pydantic `Settings`, the listener's

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,6 +80,38 @@ Responses use `application/json` (accepted by `go-tfe`).
 
 Terrapod is single-organization. The literal organization name `default` is the only valid value; every API path that contains an organization segment uses `organizations/default/` verbatim. Requests to any other organization name return 404.
 
+### Pagination
+
+List (collection `GET`) endpoints support **optional** pagination and always return a `meta.pagination` block:
+
+| Query param | Meaning |
+|---|---|
+| `page[size]` | Items per page. `>= 1` returns that page (capped at **100**). **`0` — or omitting paging entirely — returns the full list** as a single page. |
+| `page[number]` | 1-indexed page to return (default `1`). Only meaningful with `page[size] >= 1`. A page past the end returns an empty `data` array, not an error. |
+
+Every list response carries pagination metadata in Terrapod's four-key shape:
+
+```json
+{
+  "data": [ /* ... */ ],
+  "meta": {
+    "pagination": {
+      "current-page": 1,
+      "page-size": 100,
+      "total-count": 250,
+      "total-pages": 3
+    }
+  }
+}
+```
+
+Notes:
+
+- **Absent params → full list.** Omitting `page[size]` (or sending `page[size]=0`) returns every item, so a client that just wants the whole collection can ignore paging entirely. This is a deliberate Terrapod behaviour; on `/api/v2/` the `meta.pagination` shape still matches what a `go-tfe` client expects.
+- **To fetch everything robustly, page and loop** rather than relying on the absent-params default — request `page[size]=100`, then `page[number]=1,2,…` until `total-pages` is reached. go-terrapod exposes `ListAll*` helpers that do this; the web UI uses `fetchAllPages()`.
+- **Unbounded-history collections are the one exception:** the runs list (`GET /api/v2/workspaces/{id}/runs`) keeps a **bounded default page (20)** instead of returning all history, but still honours `page[size]` and emits `meta.pagination` so you can page the full history.
+- `total-count` is the size of the whole (RBAC-filtered) collection, not the returned page.
+
 ---
 
 ## Health Check Endpoints
@@ -217,6 +249,8 @@ Returns feature flags (all enabled for Terrapod).
 ```
 GET /api/v2/organizations/default/workspaces
 ```
+
+Supports optional [pagination](#pagination) (`page[size]`/`page[number]`; absent or `page[size]=0` returns the full list) and filtering by `search[name]` and cloud-block tags (`filter[tagged][...]`). Results are scoped to workspaces the caller can read.
 
 ### Get Workspace by Name
 
@@ -699,6 +733,8 @@ GET /api/v2/runs/{run_id}
 ```
 GET /api/v2/workspaces/{id}/runs
 ```
+
+Newest first. Because run history grows without bound, this endpoint keeps a **bounded default page** (`page[size]` default 20, max 100) rather than returning everything — the one exception to the "absent → full list" [pagination](#pagination) convention. It honours `page[size]`/`page[number]` and always returns `meta.pagination`, so you can page the full history.
 
 ### Confirm Run (Approve Apply)
 

--- a/go-terrapod/jsonapi.go
+++ b/go-terrapod/jsonapi.go
@@ -232,6 +232,7 @@ func GetRelationshipID(r *Resource, name string) string {
 // returns WorkspaceList with CurrentPage/TotalPages/TotalCount).
 type ListMeta struct {
 	CurrentPage int `json:"current-page"`
+	PageSize    int `json:"page-size"`
 	TotalPages  int `json:"total-pages"`
 	TotalCount  int `json:"total-count"`
 }

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -289,6 +289,7 @@ field LabelKey.ValueCount int `json:"value-count"`
 field LabelValue.EntityCounts map[string]int `json:"entity-counts"`
 field LabelValue.Value string `json:"value"`
 field ListMeta.CurrentPage int `json:"current-page"`
+field ListMeta.PageSize int `json:"page-size"`
 field ListMeta.TotalCount int `json:"total-count"`
 field ListMeta.TotalPages int `json:"total-pages"`
 field ModuleWorkspaceLink.CreatedAt string `json:"created-at,omitempty"`
@@ -783,6 +784,7 @@ field WorkspaceFilter.VCSConnectionID string `json:"vcs_connection_id,omitempty"
 field WorkspaceFilter.WorkspaceIDs []string `json:"workspace_ids,omitempty"`
 field WorkspaceList.CurrentPage int
 field WorkspaceList.Items []Workspace
+field WorkspaceList.PageSize int
 field WorkspaceList.TotalCount int
 field WorkspaceList.TotalPages int
 field WorkspaceListOptions.PageNumber int
@@ -925,6 +927,7 @@ method (*Client) IsWorkspaceAssignedToVarset(ctx context.Context, varsetID, work
 method (*Client) ListAgentPoolTokens(ctx context.Context, poolID string) ([]AgentPoolToken, error)
 method (*Client) ListAgentPools(ctx context.Context) ([]AgentPool, error)
 method (*Client) ListAllAPITokens(ctx context.Context, kind string) ([]APIToken, error)
+method (*Client) ListAllWorkspaces(ctx context.Context, opts WorkspaceListOptions) ([]Workspace, error)
 method (*Client) ListCatalogInstances(ctx context.Context, itemID string) ([]CatalogInstance, error)
 method (*Client) ListCatalogItems(ctx context.Context) ([]CatalogItem, error)
 method (*Client) ListExecutionHooks(ctx context.Context) ([]ExecutionHook, error)

--- a/go-terrapod/workspaces.go
+++ b/go-terrapod/workspaces.go
@@ -213,6 +213,7 @@ type WorkspaceListOptions struct {
 type WorkspaceList struct {
 	Items       []Workspace
 	CurrentPage int
+	PageSize    int
 	TotalPages  int
 	TotalCount  int
 }
@@ -328,10 +329,52 @@ func (c *Client) ListWorkspaces(ctx context.Context, opts WorkspaceListOptions) 
 	// separately so the resource-list parse stays clean.
 	if meta, err := parseListMeta(data); err == nil {
 		list.CurrentPage = meta.CurrentPage
+		list.PageSize = meta.PageSize
 		list.TotalPages = meta.TotalPages
 		list.TotalCount = meta.TotalCount
 	}
 	return list, nil
+}
+
+// ListAllWorkspaces fetches every workspace matching opts, paging through
+// the whole collection so the caller doesn't have to. It is the robust way
+// to "get all workspaces": it loops on the server's meta.total-pages rather
+// than relying on any single-response default, so it stays correct even if
+// the server imposes a page size. opts.PageNumber is ignored (paging starts
+// at 1); opts.PageSize sets the per-request page (defaults to 100 here to
+// keep round-trips down), and opts.Search still filters.
+//
+// Prefer this over ListWorkspaces when you want the complete set; use
+// ListWorkspaces when you genuinely want a single page (e.g. surfacing
+// total-count to a user without pulling everything).
+func (c *Client) ListAllWorkspaces(ctx context.Context, opts WorkspaceListOptions) ([]Workspace, error) {
+	pageSize := opts.PageSize
+	if pageSize <= 0 {
+		pageSize = 100
+	}
+	var all []Workspace
+	for page := 1; ; page++ {
+		list, err := c.ListWorkspaces(ctx, WorkspaceListOptions{
+			PageNumber: page,
+			PageSize:   pageSize,
+			Search:     opts.Search,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, list.Items...)
+		// Stop when we've collected every page. TotalPages is authoritative;
+		// fall back to "a short page means the end" if the server omitted meta
+		// (older server, or a non-paginating collection).
+		if list.TotalPages > 0 {
+			if page >= list.TotalPages {
+				break
+			}
+		} else if len(list.Items) < pageSize {
+			break
+		}
+	}
+	return all, nil
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────

--- a/go-terrapod/workspaces_test.go
+++ b/go-terrapod/workspaces_test.go
@@ -326,6 +326,89 @@ func TestListWorkspaces_PaginationMeta(t *testing.T) {
 	}
 }
 
+func TestListWorkspaces_SurfacesPageSize(t *testing.T) {
+	f := newWorkspaceFixtureServer(t)
+	f.listHandler = func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+		  "data": [],
+		  "meta": {"pagination": {"current-page": 1, "page-size": 25, "total-pages": 1, "total-count": 0}}
+		}`))
+	}
+	c := f.client()
+	list, err := c.ListWorkspaces(t.Context(), WorkspaceListOptions{})
+	if err != nil {
+		t.Fatalf("ListWorkspaces: %v", err)
+	}
+	if list.PageSize != 25 {
+		t.Errorf("PageSize = %d, want 25", list.PageSize)
+	}
+}
+
+func TestListAllWorkspaces_LoopsAllPages(t *testing.T) {
+	// The server returns 3 pages of 2 (total 5). ListAllWorkspaces must loop
+	// until total-pages is reached and return every workspace.
+	pages := map[string]string{
+		"1": `{"data":[
+		  {"id":"ws-a","type":"workspaces","attributes":{"name":"a"}},
+		  {"id":"ws-b","type":"workspaces","attributes":{"name":"b"}}],
+		  "meta":{"pagination":{"current-page":1,"page-size":2,"total-pages":3,"total-count":5}}}`,
+		"2": `{"data":[
+		  {"id":"ws-c","type":"workspaces","attributes":{"name":"c"}},
+		  {"id":"ws-d","type":"workspaces","attributes":{"name":"d"}}],
+		  "meta":{"pagination":{"current-page":2,"page-size":2,"total-pages":3,"total-count":5}}}`,
+		"3": `{"data":[
+		  {"id":"ws-e","type":"workspaces","attributes":{"name":"e"}}],
+		  "meta":{"pagination":{"current-page":3,"page-size":2,"total-pages":3,"total-count":5}}}`,
+	}
+	f := newWorkspaceFixtureServer(t)
+	var requested []string
+	f.listHandler = func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page[number]")
+		requested = append(requested, page)
+		if got := r.URL.Query().Get("page[size]"); got != "2" {
+			t.Errorf("page size = %q, want 2", got)
+		}
+		body, ok := pages[page]
+		if !ok {
+			t.Fatalf("unexpected page request: %q", page)
+		}
+		_, _ = w.Write([]byte(body))
+	}
+	c := f.client()
+	all, err := c.ListAllWorkspaces(t.Context(), WorkspaceListOptions{PageSize: 2})
+	if err != nil {
+		t.Fatalf("ListAllWorkspaces: %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("got %d workspaces, want 5: %+v", len(all), all)
+	}
+	if all[0].ID != "ws-a" || all[4].ID != "ws-e" {
+		t.Errorf("wrong order/content: %+v", all)
+	}
+	if len(requested) != 3 {
+		t.Errorf("requested pages %v, want exactly 3", requested)
+	}
+}
+
+func TestListAllWorkspaces_StopsOnShortPageWithoutMeta(t *testing.T) {
+	// A server that omits total-pages (older/non-paginating) must still
+	// terminate: a page shorter than the requested size means the end.
+	f := newWorkspaceFixtureServer(t)
+	f.listHandler = func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[
+		  {"id":"ws-a","type":"workspaces","attributes":{"name":"a"}}],
+		  "meta":{"pagination":{}}}`))
+	}
+	c := f.client()
+	all, err := c.ListAllWorkspaces(t.Context(), WorkspaceListOptions{PageSize: 100})
+	if err != nil {
+		t.Fatalf("ListAllWorkspaces: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("got %d, want 1 (single short page terminates)", len(all))
+	}
+}
+
 func TestListWorkspaces_SearchFilter(t *testing.T) {
 	f := newWorkspaceFixtureServer(t)
 	f.listHandler = func(w http.ResponseWriter, r *http.Request) {

--- a/services/terrapod/api/pagination.py
+++ b/services/terrapod/api/pagination.py
@@ -1,0 +1,91 @@
+"""Shared JSON:API pagination for list endpoints.
+
+The Terrapod convention (see AGENTS.md → "List endpoints — optional
+pagination"): every list endpoint accepts optional ``page[size]`` +
+``page[number]`` (the TFE / JSON:API wire shape, so `go-tfe` / go-terrapod
+clients paginate normally) and always returns a ``meta.pagination`` block.
+
+**Non-paged** — signalled by an explicit ``page[size]=0`` **or** the absence of
+any paging params — returns the **full result set** as a single page. This keeps
+bulk-fetch clients (and the web UI, which fetches the whole list and filters
+client-side) working unchanged, so adding pagination is an additive,
+backward-compatible change rather than a breaking one. **Paged** — ``page[size]``
+>= 1 — returns that page (capped at ``MAX_PAGE_SIZE``).
+
+The meta shape matches the already-paginated endpoints (audit/users/runs) and
+what go-terrapod's ``parseListMeta`` decodes: ``current-page``, ``page-size``,
+``total-count``, ``total-pages``.
+
+For RBAC-filtered lists, slice **after** the permission filter (pass the visible
+list here) so pages are full and counts are correct.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Request
+
+# Upper bound on an explicitly-requested page size, to cap the work a single
+# paged request can ask for. Does not apply to the non-paged (absent-params)
+# path, which returns the caller's full result set by design.
+MAX_PAGE_SIZE = 100
+
+
+def parse_page_params(request: Request | None) -> tuple[int, int | None]:
+    """Return ``(page_number, page_size)`` from JSON:API ``page[*]`` query params.
+
+    ``page_size`` is ``None`` when the client requested no pagination (so the
+    caller should return the full list). ``page_number`` defaults to 1.
+    """
+
+    def _int(key: str) -> int | None:
+        raw = request.query_params.get(key) if request is not None else None
+        try:
+            return int(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    size = _int("page[size]")
+    if size is not None and size < 1:
+        size = None
+    number = _int("page[number]") or 1
+    if number < 1:
+        number = 1
+    return number, size
+
+
+def paginate(items: list[Any], request: Request | None) -> tuple[list[Any], dict]:
+    """Apply optional JSON:API pagination to an already-materialised list.
+
+    - ``page[size]`` present → return that page (size capped at ``MAX_PAGE_SIZE``);
+      a ``page[number]`` past the end yields an empty page (not an error).
+    - ``page[size]`` absent → return the whole list as a single page.
+
+    Returns ``(page_items, meta)`` where ``meta`` is ``{"pagination": {...}}``.
+    """
+    total = len(items)
+    number, size = parse_page_params(request)
+
+    if size is None:
+        page_items = items
+        page_size = total or 1
+        page_number = 1
+        total_pages = 1
+    else:
+        size = min(size, MAX_PAGE_SIZE)
+        start = (number - 1) * size
+        page_items = items[start : start + size]
+        page_size = size
+        page_number = number
+        total_pages = (total + size - 1) // size if total > 0 else 0
+
+    meta = {
+        "pagination": {
+            "current-page": page_number,
+            "page-size": page_size,
+            "total-count": total,
+            "total-pages": total_pages,
+        }
+    }
+    return page_items, meta

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -603,14 +603,34 @@ async def list_workspace_runs(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Requires read permission on workspace",
         )
+    # Runs are the one deliberate exception to the "absent → full list"
+    # convention: run history grows without bound, so this endpoint keeps a
+    # sensible bounded default page (20) rather than returning everything.
+    # It honours page[size]/page[number] and always emits meta.pagination so
+    # clients can page through the full history. (See pagination.py.)
+    if page_size < 1:
+        page_size = 20
+    page_size = min(page_size, 100)
+    if page_number < 1:
+        page_number = 1
+
     runs = await run_service.list_workspace_runs(db, ws.id, page_number, page_size)
+    total = await run_service.count_workspace_runs(db, ws.id)
     has_vcs = ws.vcs_connection_id is not None
     return JSONResponse(
         content={
             "data": [
                 _run_json(r, workspace_name=ws.name, workspace_has_vcs=has_vcs)["data"]
                 for r in runs
-            ]
+            ],
+            "meta": {
+                "pagination": {
+                    "current-page": page_number,
+                    "page-size": page_size,
+                    "total-count": total,
+                    "total-pages": (total + page_size - 1) // page_size if total > 0 else 0,
+                }
+            },
         }
     )
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -53,6 +53,7 @@ from terrapod.api.dependencies import (
     require_non_runner,
 )
 from terrapod.api.labels import validate_labels
+from terrapod.api.pagination import paginate
 from terrapod.auth import capabilities as cap
 from terrapod.auth.capabilities import has_capability
 from terrapod.db.models import (
@@ -868,8 +869,14 @@ async def list_workspaces(
         if caps:
             visible.append(_workspace_json(ws, caps, latest_run=latest_runs.get(ws.id))["data"])
 
+    # Optional JSON:API pagination (TFE wire shape). page[size]>=1 returns that
+    # page; page[size]=0 or absent params return the full RBAC-filtered list as a
+    # single page. meta is always emitted so paginating clients (go-terrapod,
+    # the provider, go-tfe) can loop, while bulk-fetch callers stay unaffected.
+    page_items, meta = paginate(visible, request)
+
     return JSONResponse(
-        content={"data": visible},
+        content={"data": page_items, "meta": meta},
         headers=_tfe_headers(),
     )
 
@@ -1645,10 +1652,14 @@ async def list_state_versions(
     )
     state_versions = result.scalars().all()
 
+    # Optional JSON:API pagination (see pagination.paginate): page[size]>=1 →
+    # that page; page[size]=0 or absent → full list. go-tfe paginates this
+    # endpoint, so meta is always emitted.
+    items = [_state_version_json(sv, request)["data"] for sv in state_versions]
+    page_items, meta = paginate(items, request)
+
     return JSONResponse(
-        content={
-            "data": [_state_version_json(sv, request)["data"] for sv in state_versions],
-        },
+        content={"data": page_items, "meta": meta},
         headers=_tfe_headers(),
     )
 

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -3,7 +3,7 @@
 import json
 import uuid
 
-from sqlalchemy import and_, not_, or_, select
+from sqlalchemy import and_, func, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
@@ -1473,6 +1473,14 @@ async def list_workspace_runs(
         .limit(page_size)
     )
     return list(result.scalars().all())
+
+
+async def count_workspace_runs(db: AsyncSession, workspace_id: uuid.UUID) -> int:
+    """Total run count for a workspace (for pagination meta.total-count)."""
+    result = await db.execute(
+        select(func.count()).select_from(Run).where(Run.workspace_id == workspace_id)
+    )
+    return int(result.scalar_one())
 
 
 async def claim_next_run(

--- a/services/tests/api/test_pagination.py
+++ b/services/tests/api/test_pagination.py
@@ -1,0 +1,145 @@
+"""Unit tests for the shared list-pagination helper.
+
+Exercises the whole convention matrix directly on the pure helper (no DB, no
+HTTP): absent params → full list, page[size]=0 → full list, page[size]>=1 →
+that page, page[number] windowing, past-the-end empty page, MAX_PAGE_SIZE cap,
+and that meta.pagination always carries the four Terrapod keys.
+"""
+
+from types import SimpleNamespace
+
+from terrapod.api.pagination import MAX_PAGE_SIZE, paginate, parse_page_params
+
+
+def _req(params: dict | None):
+    """A minimal stand-in for a Starlette Request exposing query_params.get."""
+    return SimpleNamespace(query_params=params or {})
+
+
+def _items(n: int) -> list[int]:
+    return list(range(n))
+
+
+# ── parse_page_params ────────────────────────────────────────────────────
+
+
+class TestParsePageParams:
+    def test_absent_is_non_paged(self):
+        number, size = parse_page_params(_req({}))
+        assert number == 1
+        assert size is None  # None → "return the full list"
+
+    def test_size_zero_is_non_paged(self):
+        # Explicit page[size]=0 is the second "give me everything" signal.
+        _, size = parse_page_params(_req({"page[size]": "0"}))
+        assert size is None
+
+    def test_negative_size_is_non_paged(self):
+        _, size = parse_page_params(_req({"page[size]": "-5"}))
+        assert size is None
+
+    def test_size_present(self):
+        number, size = parse_page_params(_req({"page[size]": "25"}))
+        assert (number, size) == (1, 25)
+
+    def test_number_present(self):
+        number, size = parse_page_params(_req({"page[number]": "3", "page[size]": "10"}))
+        assert (number, size) == (3, 10)
+
+    def test_number_below_one_clamps(self):
+        number, _ = parse_page_params(_req({"page[number]": "0", "page[size]": "10"}))
+        assert number == 1
+
+    def test_garbage_values_ignored(self):
+        number, size = parse_page_params(_req({"page[size]": "abc", "page[number]": "x"}))
+        assert (number, size) == (1, None)
+
+    def test_none_request(self):
+        number, size = parse_page_params(None)
+        assert (number, size) == (1, None)
+
+
+# ── paginate: non-paged (full list) ──────────────────────────────────────
+
+
+class TestPaginateNonPaged:
+    def test_absent_returns_full_list_single_page(self):
+        items = _items(37)
+        page, meta = paginate(items, _req({}))
+        assert page == items  # every element, one page
+        assert meta["pagination"] == {
+            "current-page": 1,
+            "page-size": 37,
+            "total-count": 37,
+            "total-pages": 1,
+        }
+
+    def test_size_zero_returns_full_list(self):
+        items = _items(5)
+        page, meta = paginate(items, _req({"page[size]": "0"}))
+        assert page == items
+        assert meta["pagination"]["total-pages"] == 1
+        assert meta["pagination"]["total-count"] == 5
+
+    def test_empty_list_non_paged(self):
+        page, meta = paginate([], _req({}))
+        assert page == []
+        # page-size falls back to 1 so a client never divides by zero
+        assert meta["pagination"] == {
+            "current-page": 1,
+            "page-size": 1,
+            "total-count": 0,
+            "total-pages": 1,
+        }
+
+
+# ── paginate: paged ──────────────────────────────────────────────────────
+
+
+class TestPaginatePaged:
+    def test_first_page(self):
+        items = _items(10)
+        page, meta = paginate(items, _req({"page[size]": "3"}))
+        assert page == [0, 1, 2]
+        assert meta["pagination"] == {
+            "current-page": 1,
+            "page-size": 3,
+            "total-count": 10,
+            "total-pages": 4,  # ceil(10/3)
+        }
+
+    def test_second_page(self):
+        items = _items(10)
+        page, meta = paginate(items, _req({"page[size]": "3", "page[number]": "2"}))
+        assert page == [3, 4, 5]
+        assert meta["pagination"]["current-page"] == 2
+
+    def test_last_partial_page(self):
+        items = _items(10)
+        page, _ = paginate(items, _req({"page[size]": "3", "page[number]": "4"}))
+        assert page == [9]  # only one element left
+
+    def test_page_past_end_is_empty_not_error(self):
+        items = _items(10)
+        page, meta = paginate(items, _req({"page[size]": "3", "page[number]": "99"}))
+        assert page == []
+        assert meta["pagination"]["total-count"] == 10  # count still truthful
+
+    def test_size_capped_at_max(self):
+        items = _items(500)
+        page, meta = paginate(items, _req({"page[size]": str(MAX_PAGE_SIZE + 50)}))
+        assert len(page) == MAX_PAGE_SIZE
+        assert meta["pagination"]["page-size"] == MAX_PAGE_SIZE
+        assert meta["pagination"]["total-count"] == 500
+
+    def test_exact_multiple_total_pages(self):
+        items = _items(9)
+        _, meta = paginate(items, _req({"page[size]": "3"}))
+        assert meta["pagination"]["total-pages"] == 3  # 9/3 exact
+
+    def test_total_count_reflects_full_input_not_page(self):
+        # total-count must be the whole collection, not the returned slice —
+        # this is what a looping client keys off to know it's done.
+        items = _items(10)
+        _, meta = paginate(items, _req({"page[size]": "3"}))
+        assert meta["pagination"]["total-count"] == 10

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -1519,3 +1519,97 @@ class TestGranularCapabilityEnforcement:
             )
         assert resp.status_code == 403
         assert "run:apply" in resp.json()["detail"]
+
+
+# ── List workspace runs: pagination meta (#862) ─────────────────────────
+
+
+def _ws_lookup_db(ws):
+    """Mock DB whose _get_workspace execute() returns ws."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = ws
+    db = AsyncMock()
+    db.execute.return_value = result
+    return db
+
+
+class TestListRunsPagination:
+    """Runs are the deliberate exception to 'absent → full list': run history
+    grows unbounded, so this endpoint keeps a bounded default page but now
+    always emits meta.pagination so a client can page the full history.
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.count_workspace_runs")
+    @patch("terrapod.api.routers.runs.run_service.list_workspace_runs")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_list_emits_meta(self, mock_resolve, mock_list, mock_count, *mocks):
+        mock_resolve.return_value = caps_for_level("read")
+        ws = _mock_workspace()
+        mock_list.return_value = [_mock_run(ws_id=ws.id) for _ in range(2)]
+        mock_count.return_value = 45  # more than one page exists
+
+        app, _ = _make_app(_user(), mock_db=_ws_lookup_db(ws))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                f"/api/v2/workspaces/ws-{ws.id}/runs?page[size]=2&page[number]=3",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["data"]) == 2
+        assert body["meta"]["pagination"] == {
+            "current-page": 3,
+            "page-size": 2,
+            "total-count": 45,
+            "total-pages": 23,  # ceil(45/2)
+        }
+        # The service was asked for page 3 at size 2.
+        assert mock_list.await_args.args[2:] == (3, 2)
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.count_workspace_runs")
+    @patch("terrapod.api.routers.runs.run_service.list_workspace_runs")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_default_page_size_is_bounded(self, mock_resolve, mock_list, mock_count, *mocks):
+        mock_resolve.return_value = caps_for_level("read")
+        ws = _mock_workspace()
+        mock_list.return_value = []
+        mock_count.return_value = 0
+
+        app, _ = _make_app(_user(), mock_db=_ws_lookup_db(ws))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}/runs", headers=_AUTH)
+
+        assert resp.status_code == 200, resp.text
+        # Absent params → bounded default of 20 (NOT the full history).
+        assert mock_list.await_args.args[2:] == (1, 20)
+        assert resp.json()["meta"]["pagination"]["page-size"] == 20
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.run_service.count_workspace_runs")
+    @patch("terrapod.api.routers.runs.run_service.list_workspace_runs")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_page_size_zero_falls_back_to_default(
+        self, mock_resolve, mock_list, mock_count, *mocks
+    ):
+        # Unlike the bounded-collection endpoints, page[size]=0 here must NOT
+        # dump all history — it clamps to the default page.
+        mock_resolve.return_value = caps_for_level("read")
+        ws = _mock_workspace()
+        mock_list.return_value = []
+        mock_count.return_value = 0
+
+        app, _ = _make_app(_user(), mock_db=_ws_lookup_db(ws))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/workspaces/ws-{ws.id}/runs?page[size]=0", headers=_AUTH)
+
+        assert resp.status_code == 200, resp.text
+        assert mock_list.await_args.args[2:] == (1, 20)

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -1084,3 +1084,137 @@ class TestVcsWorkflowAttributes:
         assert resp.status_code == 200, resp.text
         assert ws.auto_merge is True
         assert ws.auto_merge_strategy == "squash"
+
+
+# ── List Workspaces: pagination wiring ──────────────────────────────────
+
+
+def _list_db(workspaces):
+    """A mock DB whose two execute() calls return workspaces then no runs."""
+    ws_result = MagicMock()
+    ws_result.scalars.return_value.all.return_value = workspaces
+    runs_result = MagicMock()
+    runs_result.scalars.return_value.all.return_value = []
+    db = AsyncMock()
+    db.execute.side_effect = [ws_result, runs_result]
+    return db
+
+
+class TestListWorkspacesPagination:
+    """The #862 bug fix: /api/v2 workspace list honours page[size] and always
+    emits meta.pagination, while absent params / page[size]=0 return the full
+    list (so the whole-list-fetch web UI and go-tfe bulk clients are unchanged).
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_absent_params_returns_full_list_with_meta(self, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("read")
+        wss = [_mock_workspace(name=f"ws-{i}") for i in range(3)]
+        app, _ = _make_app(_user(), mock_db=_list_db(wss))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get("/api/v2/organizations/default/workspaces", headers=_AUTH)
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["data"]) == 3  # full list, no truncation
+        assert body["meta"]["pagination"] == {
+            "current-page": 1,
+            "page-size": 3,
+            "total-count": 3,
+            "total-pages": 1,
+        }
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_page_size_zero_returns_full_list(self, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("read")
+        wss = [_mock_workspace(name=f"ws-{i}") for i in range(3)]
+        app, _ = _make_app(_user(), mock_db=_list_db(wss))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                "/api/v2/organizations/default/workspaces?page[size]=0", headers=_AUTH
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["data"]) == 3
+        assert body["meta"]["pagination"]["total-pages"] == 1
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_first_page_honours_page_size(self, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("read")
+        wss = [_mock_workspace(name=f"ws-{i}") for i in range(5)]
+        app, _ = _make_app(_user(), mock_db=_list_db(wss))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                "/api/v2/organizations/default/workspaces?page[size]=2", headers=_AUTH
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["data"]) == 2  # only the first page
+        assert body["meta"]["pagination"] == {
+            "current-page": 1,
+            "page-size": 2,
+            "total-count": 5,
+            "total-pages": 3,
+        }
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_second_page(self, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("read")
+        wss = [_mock_workspace(name=f"ws-{i}") for i in range(5)]
+        app, _ = _make_app(_user(), mock_db=_list_db(wss))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                "/api/v2/organizations/default/workspaces?page[size]=2&page[number]=3",
+                headers=_AUTH,
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["data"]) == 1  # last, partial page (5 items, size 2)
+        assert body["meta"]["pagination"]["current-page"] == 3
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_page_slices_after_rbac_filter(self, mock_resolve, *mocks):
+        # Two of four workspaces are invisible (no caps). total-count must be 2
+        # (the visible set), and a page[size]=1 returns exactly one visible ws —
+        # proving the slice happens AFTER the permission filter, not before.
+        wss = [_mock_workspace(name=f"ws-{i}") for i in range(4)]
+        visible_names = {wss[0].name, wss[2].name}
+
+        async def _caps(_db, _user, ws):
+            return caps_for_level("read") if ws.name in visible_names else set()
+
+        mock_resolve.side_effect = _caps
+        app, _ = _make_app(_user(), mock_db=_list_db(wss))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(
+                "/api/v2/organizations/default/workspaces?page[size]=1", headers=_AUTH
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["data"]) == 1
+        assert body["meta"]["pagination"]["total-count"] == 2  # visible only
+        assert body["meta"]["pagination"]["total-pages"] == 2

--- a/web/src/app/admin/execution-hooks/[id]/page.tsx
+++ b/web/src/app/admin/execution-hooks/[id]/page.tsx
@@ -11,7 +11,7 @@ import { ErrorBanner } from '@/components/error-banner'
 import { EmptyState } from '@/components/empty-state'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { useConfirm } from '@/lib/use-confirm'
-import { apiFetch } from '@/lib/api'
+import { apiFetch, fetchAllPages } from '@/lib/api'
 import { usePollingInterval } from '@/lib/use-polling-interval'
 
 const HOOK_POINTS = ['pre_init', 'pre_plan', 'post_plan', 'pre_apply', 'post_apply'] as const
@@ -103,11 +103,8 @@ export default function ExecutionHookDetailPage() {
   async function loadAllWorkspaces() {
     setWsLoading(true)
     try {
-      const res = await apiFetch('/api/v2/organizations/default/workspaces')
-      if (res.ok) {
-        const data = await res.json()
-        setAllWorkspaces(data.data || [])
-      }
+      // Page through the whole list so every workspace is attachable.
+      setAllWorkspaces(await fetchAllPages<WorkspaceRef>('/api/v2/organizations/default/workspaces'))
     } catch {
       // Non-critical
     } finally {

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -14,7 +14,7 @@ import { SortableHeader } from '@/components/sortable-header'
 import { useSortable } from '@/lib/use-sortable'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { useConfirm } from '@/lib/use-confirm'
-import { apiFetch } from '@/lib/api'
+import { apiFetch, fetchAllPages } from '@/lib/api'
 import { useFormat } from '@/lib/format'
 import { usePollingInterval } from '@/lib/use-polling-interval'
 
@@ -302,10 +302,9 @@ export default function UsersPage() {
 
   async function loadUsers() {
     try {
-      const res = await apiFetch('/api/terrapod/v1/users?page[size]=100')
-      if (!res.ok) throw new Error(t('errors.load'))
-      const data = await res.json()
-      setUsers(data.data || [])
+      // Page through all users (previously capped at page[size]=100, which
+      // silently truncated deployments with more than 100 users).
+      setUsers(await fetchAllPages<UserRecord>('/api/terrapod/v1/users'))
     } catch (err) {
       setError(err instanceof Error ? err.message : t('errors.load'))
     } finally {

--- a/web/src/app/admin/variable-sets/[id]/page.tsx
+++ b/web/src/app/admin/variable-sets/[id]/page.tsx
@@ -12,7 +12,7 @@ import { EmptyState } from '@/components/empty-state'
 import { SensitiveValueInput } from '@/components/sensitive-value-input'
 import { getAuthState, isAdmin } from '@/lib/auth'
 import { useConfirm } from '@/lib/use-confirm'
-import { apiFetch } from '@/lib/api'
+import { apiFetch, fetchAllPages } from '@/lib/api'
 import { usePollingInterval } from '@/lib/use-polling-interval'
 
 interface VarsetAttrs {
@@ -162,10 +162,8 @@ export default function VariableSetDetailPage() {
 
   async function loadAllWorkspaces() {
     try {
-      const res = await apiFetch('/api/v2/organizations/default/workspaces')
-      if (!res.ok) return
-      const data = await res.json()
-      setAllWorkspaces(data.data || [])
+      // Page through the whole list so every workspace is assignable.
+      setAllWorkspaces(await fetchAllPages<WorkspaceRef>('/api/v2/organizations/default/workspaces'))
     } catch {
       // Non-critical
     }

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -15,7 +15,7 @@ import { SortableHeader } from '@/components/sortable-header'
 import { WorkspaceStatusBadges } from '@/components/workspace-status-badges'
 import { StatChip } from '@/components/stat-chip'
 import { getAuthState } from '@/lib/auth'
-import { apiFetch } from '@/lib/api'
+import { apiFetch, fetchAllPages } from '@/lib/api'
 import { useSortable } from '@/lib/use-sortable'
 import { useWorkspaceListEvents } from '@/lib/use-workspace-list-events'
 import {
@@ -460,10 +460,10 @@ function WorkspacesPageInner() {
 
   async function loadWorkspaces() {
     try {
-      const res = await apiFetch('/api/v2/organizations/default/workspaces')
-      if (!res.ok) throw new Error(t('loadFailed'))
-      const data = await res.json()
-      setWorkspaces(data.data || [])
+      // Fetch the whole list (paging through internally) and filter/sort
+      // client-side — the workspace list is deliberately not page-through UI.
+      const items = await fetchAllPages<Workspace>('/api/v2/organizations/default/workspaces')
+      setWorkspaces(items)
     } catch (err) {
       setError(err instanceof Error ? err.message : t('loadFailed'))
     } finally {

--- a/web/src/components/workspace-picker.tsx
+++ b/web/src/components/workspace-picker.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Search } from 'lucide-react'
 import { useTranslations } from 'next-intl'
-import { apiFetch } from '@/lib/api'
+import { fetchAllPages } from '@/lib/api'
 
 export interface WorkspaceOption {
   id: string
@@ -51,15 +51,13 @@ export function WorkspacePicker({
     let active = true
     ;(async () => {
       try {
-        const res = await apiFetch('/api/v2/organizations/default/workspaces')
-        if (res.ok && active) {
-          const data = await res.json()
-          setAll(
-            (data.data || []).map((ws: { id: string; attributes: { name: string } }) => ({
-              id: ws.id,
-              name: ws.attributes.name,
-            }))
-          )
+        // Page through the whole list so the picker can find any workspace,
+        // not just the first server page.
+        const items = await fetchAllPages<{ id: string; attributes: { name: string } }>(
+          '/api/v2/organizations/default/workspaces'
+        )
+        if (active) {
+          setAll(items.map((ws) => ({ id: ws.id, name: ws.attributes.name })))
         }
       } catch {
         // best-effort; empty list renders "No workspaces found"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -96,6 +96,49 @@ export async function apiFetch(path: string, init?: RequestInit): Promise<Respon
 }
 
 /**
+ * Fetch EVERY item from a paginated list endpoint by looping the pages.
+ *
+ * Terrapod list endpoints support optional pagination: they return the full
+ * list when no page params are sent, but they honour `page[size]`/`page[number]`
+ * and always emit `meta.pagination` (see docs/api-reference.md and the #862
+ * convention). The web UI deliberately shows whole lists and filters/sorts
+ * client-side — it does NOT page-through in the UI. To fetch the whole list
+ * *robustly* (rather than relying on the server's absent-params default), this
+ * helper pages through with a fixed page size and concatenates `data`, so it
+ * stays correct regardless of any server-side default page.
+ *
+ * It stops on `meta.pagination.total-pages` (authoritative); if the server
+ * omits meta, a page shorter than the page size ends the loop. Returns the
+ * combined `data` array. Throws (via parseApiError) on any non-OK page.
+ *
+ * `path` may already carry a query string (e.g. a search filter); the page
+ * params are appended with the correct separator.
+ */
+export async function fetchAllPages<T = unknown>(path: string, pageSize = 100): Promise<T[]> {
+  const sep = path.includes('?') ? '&' : '?'
+  const all: T[] = []
+  for (let page = 1; ; page++) {
+    const url = `${path}${sep}page[size]=${pageSize}&page[number]=${page}`
+    const res = await apiFetch(url)
+    if (!res.ok) {
+      throw new Error(await parseApiError(res, 'Failed to load list'))
+    }
+    const body = await res.json()
+    const items: T[] = Array.isArray(body?.data) ? body.data : []
+    all.push(...items)
+
+    const totalPages = Number(body?.meta?.pagination?.['total-pages'] ?? 0)
+    if (totalPages > 0) {
+      if (page >= totalPages) break
+    } else if (items.length < pageSize) {
+      // No meta (older server / non-paginating collection): a short page ends it.
+      break
+    }
+  }
+  return all
+}
+
+/**
  * Extract a human-readable message from a failed API response.
  *
  * Handles the shapes the API actually returns — JSON:API `{ errors: [{ detail }] }`,


### PR DESCRIPTION
Closes the first stage of #862.

## The bug
`GET /api/v2/organizations/default/workspaces` accepted `page[size]`/`page[number]` but **ignored** them — returning the whole visible set with no `meta.pagination`. go-terrapod's `ListWorkspaces` sends the params and the `terrapod_workspaces` provider data source loops on `TotalPages`; both got zeros because the server emitted no meta. Surfaced while building the MCP (`workspace_list` `page_size` had no effect). It was benign only because every consumer wanted the whole list, which the return-everything endpoint happened to give them.

## The convention (this PR establishes it)
Shared `services/terrapod/api/pagination.py::paginate(items, request)`:
- `page[size]` >= 1 (with optional `page[number]`) → that page, capped at 100.
- **`page[size]=0` or absent params → the full list** (single page) — preserves today's behaviour, so nothing that omits paging changes.
- **Always emits `meta.pagination`** with Terrapod's own 4-key shape (`current-page`, `page-size`, `total-count`, `total-pages`), uniform on `/api/v2` and `/api/terrapod/v1`. Params are read off the `Request` and `meta` is a top-level sibling of `data`, so **no contract snapshot changes** — purely additive / MINOR-safe.

## Scope — the workspace family
- **Server:** `list_workspaces` + `list_state_versions` use `paginate()`; `list_workspace_runs` emits `meta` but keeps a **bounded default page (20)** — the one documented exception to "absent → all", since run history is unbounded.
- **go-terrapod:** `ListMeta.PageSize` + `WorkspaceList.PageSize` + a `ListAllWorkspaces` loop helper (fetch every page robustly).
- **web:** shared `fetchAllPages()`; the workspace list + the three workspace pickers + the users page fetch-all by paging internally instead of one unbounded request (fixes `admin/users` truncating at `page[size]=100`). The UI still shows whole lists and filters client-side — **no page-through UX introduced**.
- **docs:** AGENTS.md convention + `api-reference.md` Pagination section.

## Verification
- `make test` — pagination unit matrix + workspace/state-version/runs endpoint tests pass.
- go-terrapod `go test ./...` — single-page + `ListAll` loop tests pass; exported-surface golden regenerated (additive: +2 fields, +1 method).
- `npm run build` (web) passes.
- **All five #550 contract snapshots pass unchanged** (route/attribute/wire/config/migration) — confirms additive.

## Follow-up (Stage 2, separate PR)
The remaining ~22 native list endpoints + their go-terrapod methods + web callers + provider/migrate find-by-name loops get the same treatment, endpoint-family by family, once this lands. Tracked in #862.