### PR TITLE
feat(846): MCP write/CRUD tools (workspace + variable) + consumer contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,15 +143,28 @@ Per-surface verification before you push (lint alone is **not** enough):
 ## The API ↔ Consumer contract (hard)
 
 Terrapod's API has several classes of consumer, each with its own contract.
-**Every API change must update every consumer it affects.**
+**Every API change must update every consumer it affects — whether it consumes
+the API *directly* (its own HTTP calls) or *transitively* (through go-terrapod).**
+A change is not done when the server compiles; it is done when every consumer
+that surfaces the changed thing has been carried along with it.
 
-- **Web UI** (`web/`) — SSR fetches + client `fetch()` calls.
+- **Web UI** (`web/`) — **direct** consumer: SSR fetches + client `fetch()` calls.
 - **go-terrapod** (`go-terrapod/`) — the canonical Go SDK; the source of
-  truth for the Go-side shape of every resource.
-- **terraform-provider-terrapod** (`provider/`) — imports go-terrapod for
-  every API call; holds only Terraform-plugin-framework code.
+  truth for the Go-side shape of every resource. Every other Go consumer below
+  goes through it, so an API change lands in go-terrapod **first** and then
+  fans out to all of them.
+- **terraform-provider-terrapod** (`provider/`) — **transitive** (via
+  go-terrapod); holds only Terraform-plugin-framework code.
 - **terrapod-migrate** (`migrate/`) and **terrapod-publish** (`publish/`) —
-  both import go-terrapod for every Terrapod-side write.
+  **transitive**; both import go-terrapod for every Terrapod-side write.
+- **terrapod-mcp** (`mcp/`) — **transitive**; the MCP server exposes curated
+  `terrapod_*` tools to AI agents, each backed by a go-terrapod call. It is a
+  first-class consumer: **when you add or change an endpoint, a go-terrapod
+  method, or a JSON:API attribute that an MCP tool surfaces (or should surface),
+  update the MCP tool + its `tool_catalogue.json` golden in the same change.**
+  A new capability an agent should be able to observe or drive is not complete
+  until it has a tool. Its tools inherit the API's RBAC (they act as the user's
+  `tofu login` identity), so no tool may widen access beyond what the API grants.
 
 The workflow when extending the API:
 
@@ -159,14 +172,19 @@ The workflow when extending the API:
    CLI-surface list; otherwise `/api/terrapod/v1/`).
 2. Add a typed method to **go-terrapod** + a test (the shape matches the
    JSON:API response).
-3. Add the consumer code that needs it (provider resource, frontend page,
-   migration/publish writer).
+3. Add the consumer code for **every** surface the change touches — directly or
+   transitively: the provider resource, the frontend page, the
+   migration/publish writer, **and the MCP tool** (with its catalogue golden).
+   If a surface genuinely isn't affected, that's fine — but the default is that
+   it is, and skipping one silently is the failure this contract exists to
+   prevent.
 
 When a JSON:API attribute name changes, update go-terrapod's struct
 field/tag, the provider's matching attribute, every frontend `fetch` that
-references it, and the migration tool if it touches that field. go-terrapod is
-the single source of truth for the Go-side view; the provider and migration
-tools do not carry their own JSON:API marshaling.
+references it, the migration tool if it touches that field, and any MCP tool
+that returns it. go-terrapod is the single source of truth for the Go-side
+view; the provider, migration tools, and MCP do not carry their own JSON:API
+marshaling — they read the changed shape off go-terrapod.
 
 ## The Code ↔ Tests contract (hard)
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -100,9 +100,20 @@ Every tool is namespaced `terrapod_*` and carries a safety annotation
 | `terrapod_run_discard` | — | Discard a planned run without applying. |
 | `terrapod_run_cancel` | — | Cancel a non-terminal run. |
 
+### Manage (gated) — shape the estate
+
+| Tool | Safety | What it does |
+|---|---|---|
+| `terrapod_workspace_create` | — | Create a workspace (name required; execution mode, VCS wiring, agent pool, labels, …). |
+| `terrapod_workspace_update` | — | Update a workspace's settings (only the fields you pass change; applies on its next run). |
+| `terrapod_workspace_delete` | destructive | Delete a workspace + its Terrapod records. Does **not** destroy the tracked infra — queue a destroy run first. Catalog-managed workspaces are refused. |
+| `terrapod_variable_list` | read-only | List a workspace's variables (sensitive values masked). |
+| `terrapod_variable_set` | — | Upsert a variable by key (terraform or env; `hcl` for non-string values). |
+| `terrapod_variable_delete` | destructive | Delete a variable by key. |
+
 Nothing bypasses the platform: applies obey the workspace's VCS/auto-apply/lock
-rules and OPA policy, and every action is bounded by your Terrapod RBAC — a
-read-only token cannot mutate.
+rules and OPA policy, config changes apply on the next run, and every action is
+bounded by your Terrapod RBAC — a read-only token cannot mutate.
 
 ## Safety model, in short
 
@@ -124,13 +135,13 @@ warns you through the agent.
 
 ## Roadmap (additive)
 
-The foundation ships Observe + gated Act. Landing next, additively (no breaking
-changes): full management **CRUD** (workspaces, variables, VCS connections,
-roles, agent pools, run tasks, notifications, execution hooks, …), the **Ground**
-tools (private registry modules + their input/output interface, provider schemas)
-so an agent writes correct config against *your* estate, and the tofu-native
-**`discover`** tool (folding in [`terrapod-query`](terrapod-query.md)) for
-onboarding existing resources.
+Observe + gated Act + workspace/variable **Manage** have landed. Continuing
+additively (no breaking changes): the rest of management **CRUD** (VCS
+connections, roles, agent pools, run tasks, notifications, execution hooks, …),
+the **Ground** tools (private registry modules + their input/output interface,
+provider schemas) so an agent writes correct config against *your* estate, and
+the tofu-native **`discover`** tool (folding in
+[`terrapod-query`](terrapod-query.md)) for onboarding existing resources.
 
 ## See also
 

--- a/mcp/internal/mcpserver/crud.go
+++ b/mcp/internal/mcpserver/crud.go
@@ -1,0 +1,236 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerCRUD adds the workspace + variable management tools — the config
+// surface an agent needs to *shape* the estate, distinct from the run-lifecycle
+// Act tools. Everything is an ordinary go-terrapod call bounded by the user's
+// RBAC: a create/update/delete only succeeds if the token's capabilities allow
+// it. Mutating tools that remove config or infrastructure carry the
+// `destructive` hint so an MCP host prompts for confirmation, mirroring the
+// UI's confirm-on-destructive-action policy.
+func registerCRUD(s *mcp.Server, c *terrapod.Client) {
+	// ── terrapod_workspace_create ────────────────────────────────────
+	type workspaceCreateIn struct {
+		Name             string            `json:"name" jsonschema:"the workspace name (unique within the org)"`
+		ExecutionMode    string            `json:"execution_mode,omitempty" jsonschema:"local or agent (default: server default)"`
+		ExecutionBackend string            `json:"execution_backend,omitempty" jsonschema:"tofu or terraform (default: server default)"`
+		TerraformVersion string            `json:"terraform_version,omitempty" jsonschema:"partial version like 1.15 (means 1.15.*); no HCL operators"`
+		AutoApply        *bool             `json:"auto_apply,omitempty" jsonschema:"auto-apply successful plans (default false)"`
+		AgentPoolID      string            `json:"agent_pool_id,omitempty" jsonschema:"agent pool id (apool-...) for agent execution mode"`
+		WorkingDirectory string            `json:"working_directory,omitempty" jsonschema:"subdirectory within the repo"`
+		VCSConnectionID  string            `json:"vcs_connection_id,omitempty" jsonschema:"VCS connection id to wire this workspace to a repo"`
+		VCSRepoURL       string            `json:"vcs_repo_url,omitempty" jsonschema:"git repo URL (requires vcs_connection_id)"`
+		VCSBranch        string            `json:"vcs_branch,omitempty" jsonschema:"tracked branch (empty = repo default)"`
+		OwnerEmail       string            `json:"owner_email,omitempty" jsonschema:"workspace owner email (defaults to the caller)"`
+		Labels           map[string]string `json:"labels,omitempty" jsonschema:"key/value labels for RBAC + filtering (reserved keys rejected)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "terrapod_workspace_create",
+		Description: "Create a workspace. Only `name` is required; everything else falls back to the instance default. " +
+			"For agent execution set execution_mode=agent + agent_pool_id; for VCS-driven runs set vcs_connection_id + vcs_repo_url. Returns the created workspace.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in workspaceCreateIn) (*mcp.CallToolResult, *terrapod.Workspace, error) {
+		if in.Name == "" {
+			return errText("name is required"), nil, nil
+		}
+		ws, err := c.CreateWorkspace(ctx, terrapod.CreateWorkspaceRequest{
+			Name:             in.Name,
+			ExecutionMode:    in.ExecutionMode,
+			ExecutionBackend: in.ExecutionBackend,
+			TerraformVersion: in.TerraformVersion,
+			AutoApply:        in.AutoApply,
+			AgentPoolID:      in.AgentPoolID,
+			WorkingDirectory: in.WorkingDirectory,
+			VCSConnectionID:  in.VCSConnectionID,
+			VCSRepoURL:       in.VCSRepoURL,
+			VCSBranch:        in.VCSBranch,
+			OwnerEmail:       in.OwnerEmail,
+			Labels:           in.Labels,
+		})
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, ws, nil
+	})
+
+	// ── terrapod_workspace_update ────────────────────────────────────
+	type workspaceUpdateIn struct {
+		WorkspaceID      string            `json:"workspace_id" jsonschema:"the workspace id (ws-...) to update"`
+		Name             string            `json:"name,omitempty" jsonschema:"rename the workspace (empty = leave)"`
+		ExecutionMode    string            `json:"execution_mode,omitempty" jsonschema:"local or agent"`
+		ExecutionBackend string            `json:"execution_backend,omitempty" jsonschema:"tofu or terraform"`
+		TerraformVersion string            `json:"terraform_version,omitempty" jsonschema:"partial version like 1.15"`
+		AutoApply        *bool             `json:"auto_apply,omitempty" jsonschema:"auto-apply successful plans"`
+		AgentPoolID      string            `json:"agent_pool_id,omitempty" jsonschema:"agent pool id (apool-...)"`
+		WorkingDirectory string            `json:"working_directory,omitempty" jsonschema:"subdirectory within the repo"`
+		Labels           map[string]string `json:"labels,omitempty" jsonschema:"replace the label set (reserved keys rejected)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "terrapod_workspace_update",
+		Description: "Update a workspace's settings. Only the fields you pass change; omitted fields are left alone. " +
+			"This is a config change (the new settings apply on the workspace's next run) — it does not itself queue a run.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in workspaceUpdateIn) (*mcp.CallToolResult, *terrapod.Workspace, error) {
+		if in.WorkspaceID == "" {
+			return errText("workspace_id is required"), nil, nil
+		}
+		ws, err := c.UpdateWorkspace(ctx, in.WorkspaceID, terrapod.UpdateWorkspaceRequest{
+			Name:             in.Name,
+			ExecutionMode:    in.ExecutionMode,
+			ExecutionBackend: in.ExecutionBackend,
+			TerraformVersion: in.TerraformVersion,
+			AutoApply:        in.AutoApply,
+			AgentPoolID:      in.AgentPoolID,
+			WorkingDirectory: in.WorkingDirectory,
+			Labels:           in.Labels,
+		})
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, ws, nil
+	})
+
+	// ── terrapod_workspace_delete ────────────────────────────────────
+	type workspaceDeleteIn struct {
+		WorkspaceID string `json:"workspace_id" jsonschema:"the workspace id (ws-...) to delete"`
+	}
+	type deleteOut struct {
+		Deleted bool   `json:"deleted"`
+		ID      string `json:"id"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_workspace_delete",
+		Description: "Delete a workspace and its Terrapod-side records (variables, run history, state versions). This does NOT destroy the real infrastructure the state tracks — to tear that down, queue a destroy run first (terrapod_run_create is_destroy=true) and apply it. Catalog-managed workspaces are rejected (409); destroy the catalog instance instead. Irreversible — confirm with the user.",
+		Annotations: destructive,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in workspaceDeleteIn) (*mcp.CallToolResult, *deleteOut, error) {
+		if in.WorkspaceID == "" {
+			return errText("workspace_id is required"), nil, nil
+		}
+		if err := c.DeleteWorkspace(ctx, in.WorkspaceID); err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, &deleteOut{Deleted: true, ID: in.WorkspaceID}, nil
+	})
+
+	// ── terrapod_variable_list ───────────────────────────────────────
+	type variableListIn struct {
+		WorkspaceID string `json:"workspace_id" jsonschema:"the workspace id (ws-...) whose variables to list"`
+	}
+	type variableListOut struct {
+		Count     int                 `json:"count"`
+		Variables []terrapod.Variable `json:"variables"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_variable_list",
+		Description: "List a workspace's variables (terraform + env). Sensitive values are masked by the server (never returned). Use to inspect config before a run or before setting a variable.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in variableListIn) (*mcp.CallToolResult, variableListOut, error) {
+		if in.WorkspaceID == "" {
+			return errText("workspace_id is required"), variableListOut{}, nil
+		}
+		vars, err := c.ListAllVariables(ctx, in.WorkspaceID)
+		if err != nil {
+			return errResult(err), variableListOut{}, nil
+		}
+		return nil, variableListOut{Count: len(vars), Variables: vars}, nil
+	})
+
+	// ── terrapod_variable_set ────────────────────────────────────────
+	type variableSetIn struct {
+		WorkspaceID string `json:"workspace_id" jsonschema:"the workspace id (ws-...)"`
+		Key         string `json:"key" jsonschema:"the variable key"`
+		Value       string `json:"value,omitempty" jsonschema:"the value (empty is legal, e.g. flag-shaped env vars)"`
+		Category    string `json:"category,omitempty" jsonschema:"terraform or env (default terraform)"`
+		HCL         *bool  `json:"hcl,omitempty" jsonschema:"the value is a raw HCL expression (lists/objects); default false"`
+		Sensitive   *bool  `json:"sensitive,omitempty" jsonschema:"mark sensitive — masked at rest and in responses; default false"`
+		Description string `json:"description,omitempty" jsonschema:"optional human description"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "terrapod_variable_set",
+		Description: "Set a workspace variable — creates it if the key is new, updates it in place if it exists (an upsert keyed on `key`). " +
+			"category defaults to terraform; set category=env for an environment variable. Set hcl=true for non-string values (lists/objects/numbers). Returns the variable.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in variableSetIn) (*mcp.CallToolResult, *terrapod.Variable, error) {
+		if in.WorkspaceID == "" || in.Key == "" {
+			return errText("workspace_id and key are required"), nil, nil
+		}
+		category := in.Category
+		if category == "" {
+			category = "terraform"
+		}
+		// Upsert: look the key up; update if present, else create. A NotFound on
+		// the lookup is the create path, not an error.
+		existing, err := c.GetVariableByKey(ctx, in.WorkspaceID, in.Key)
+		switch {
+		case err == nil && existing != nil:
+			v, uerr := c.UpdateVariable(ctx, in.WorkspaceID, existing.ID, terrapod.UpdateVariableRequest{
+				Value:       &in.Value,
+				Category:    category,
+				HCL:         in.HCL,
+				Sensitive:   in.Sensitive,
+				Description: strPtrOrNil(in.Description),
+			})
+			if uerr != nil {
+				return errResult(uerr), nil, nil
+			}
+			return nil, v, nil
+		case err != nil && !isNotFound(err):
+			return errResult(err), nil, nil
+		}
+		v, cerr := c.CreateVariable(ctx, in.WorkspaceID, terrapod.CreateVariableRequest{
+			Key:         in.Key,
+			Value:       in.Value,
+			Category:    category,
+			HCL:         boolOrFalse(in.HCL),
+			Sensitive:   boolOrFalse(in.Sensitive),
+			Description: in.Description,
+		})
+		if cerr != nil {
+			return errResult(cerr), nil, nil
+		}
+		return nil, v, nil
+	})
+
+	// ── terrapod_variable_delete ─────────────────────────────────────
+	type variableDeleteIn struct {
+		WorkspaceID string `json:"workspace_id" jsonschema:"the workspace id (ws-...)"`
+		Key         string `json:"key" jsonschema:"the variable key to delete"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_variable_delete",
+		Description: "Delete a workspace variable by key. Irreversible (the value, if not sensitive, is gone) and it changes what the next run sees — confirm with the user.",
+		Annotations: destructive,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in variableDeleteIn) (*mcp.CallToolResult, *deleteOut, error) {
+		if in.WorkspaceID == "" || in.Key == "" {
+			return errText("workspace_id and key are required"), nil, nil
+		}
+		existing, err := c.GetVariableByKey(ctx, in.WorkspaceID, in.Key)
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		if err := c.DeleteVariable(ctx, in.WorkspaceID, existing.ID); err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, &deleteOut{Deleted: true, ID: existing.ID}, nil
+	})
+}
+
+// isNotFound reports whether err is a go-terrapod not-found (the upsert
+// create-path signal), without conflating it with auth/other errors.
+func isNotFound(err error) bool {
+	var nf *terrapod.NotFoundError
+	return errors.As(err, &nf)
+}
+
+func boolOrFalse(b *bool) bool { return b != nil && *b }
+
+func strPtrOrNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/mcp/internal/mcpserver/server.go
+++ b/mcp/internal/mcpserver/server.go
@@ -7,6 +7,18 @@
 // namespace tools per server, so an agent configured with a dev server and a
 // prod server gets two clearly-labelled tool sets, and a server bound to dev
 // literally cannot touch prod (it holds no prod token/host).
+//
+// # Consumer contract (see AGENTS.md → "The API ↔ Consumer contract")
+//
+// terrapod-mcp is a first-class, *transitive* consumer of the Terrapod API: every
+// tool here is backed by a go-terrapod call and reads the JSON:API shape off
+// go-terrapod — it carries no marshaling of its own. So a change to an endpoint,
+// a go-terrapod method, or a JSON:API attribute that a tool surfaces (or should
+// surface) is not complete until the tool + its tool_catalogue.json golden are
+// updated in the same change. New agent-observable/-drivable capability is not
+// done until it has a tool. Tools never widen access: they inherit the caller's
+// `tofu login` RBAC, and mutating tools that remove config or infrastructure
+// carry the `destructive` hint so the host confirms.
 package mcpserver
 
 import (
@@ -73,6 +85,7 @@ func New(cfg Config) (*mcp.Server, *terrapod.Client, error) {
 
 	registerObserve(srv, client)
 	registerAct(srv, client)
+	registerCRUD(srv, client)
 
 	return srv, client, nil
 }

--- a/mcp/internal/mcpserver/tool_catalogue.json
+++ b/mcp/internal/mcpserver/tool_catalogue.json
@@ -150,6 +150,175 @@
     }
   },
   {
+    "name": "terrapod_variable_delete",
+    "destructive": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "description": "the variable key to delete",
+          "type": "string"
+        },
+        "workspace_id": {
+          "description": "the workspace id (ws-...)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_id",
+        "key"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_variable_list",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "workspace_id": {
+          "description": "the workspace id (ws-...) whose variables to list",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_id"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_variable_set",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "description": "terraform or env (default terraform)",
+          "type": "string"
+        },
+        "description": {
+          "description": "optional human description",
+          "type": "string"
+        },
+        "hcl": {
+          "description": "the value is a raw HCL expression (lists/objects); default false",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "key": {
+          "description": "the variable key",
+          "type": "string"
+        },
+        "sensitive": {
+          "description": "mark sensitive — masked at rest and in responses; default false",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "value": {
+          "description": "the value (empty is legal, e.g. flag-shaped env vars)",
+          "type": "string"
+        },
+        "workspace_id": {
+          "description": "the workspace id (ws-...)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_id",
+        "key"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_workspace_create",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "agent_pool_id": {
+          "description": "agent pool id (apool-...) for agent execution mode",
+          "type": "string"
+        },
+        "auto_apply": {
+          "description": "auto-apply successful plans (default false)",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "execution_backend": {
+          "description": "tofu or terraform (default: server default)",
+          "type": "string"
+        },
+        "execution_mode": {
+          "description": "local or agent (default: server default)",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "key/value labels for RBAC + filtering (reserved keys rejected)",
+          "type": "object"
+        },
+        "name": {
+          "description": "the workspace name (unique within the org)",
+          "type": "string"
+        },
+        "owner_email": {
+          "description": "workspace owner email (defaults to the caller)",
+          "type": "string"
+        },
+        "terraform_version": {
+          "description": "partial version like 1.15 (means 1.15.*); no HCL operators",
+          "type": "string"
+        },
+        "vcs_branch": {
+          "description": "tracked branch (empty = repo default)",
+          "type": "string"
+        },
+        "vcs_connection_id": {
+          "description": "VCS connection id to wire this workspace to a repo",
+          "type": "string"
+        },
+        "vcs_repo_url": {
+          "description": "git repo URL (requires vcs_connection_id)",
+          "type": "string"
+        },
+        "working_directory": {
+          "description": "subdirectory within the repo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_workspace_delete",
+    "destructive": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "workspace_id": {
+          "description": "the workspace id (ws-...) to delete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_id"
+      ],
+      "type": "object"
+    }
+  },
+  {
     "name": "terrapod_workspace_get",
     "read_only": true,
     "input_schema": {
@@ -181,6 +350,60 @@
           "type": "string"
         }
       },
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_workspace_update",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "agent_pool_id": {
+          "description": "agent pool id (apool-...)",
+          "type": "string"
+        },
+        "auto_apply": {
+          "description": "auto-apply successful plans",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "execution_backend": {
+          "description": "tofu or terraform",
+          "type": "string"
+        },
+        "execution_mode": {
+          "description": "local or agent",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "replace the label set (reserved keys rejected)",
+          "type": "object"
+        },
+        "name": {
+          "description": "rename the workspace (empty = leave)",
+          "type": "string"
+        },
+        "terraform_version": {
+          "description": "partial version like 1.15",
+          "type": "string"
+        },
+        "working_directory": {
+          "description": "subdirectory within the repo",
+          "type": "string"
+        },
+        "workspace_id": {
+          "description": "the workspace id (ws-...) to update",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_id"
+      ],
       "type": "object"
     }
   }


### PR DESCRIPTION
Part of #846 — the first of the MCP tool tranches after the foundation (#861).

## Consumer contract — MCP is now a first-class transitive consumer
Expands the **API↔Consumer contract** (AGENTS.md) so an API change carries a requirement to update **everything that consumes it, directly or transitively**. The MCP reads the JSON:API shape off go-terrapod (it carries no marshaling of its own), so an endpoint / go-terrapod method / JSON:API attribute change that a tool surfaces isn't done until the **tool + its `tool_catalogue.json` golden** are updated in the same change. Documented in AGENTS.md (direct-vs-transitive consumer list + workflow) and in the `mcpserver` package doc comment.

## New "Manage" tools (6)
All backed by existing go-terrapod methods, bounded by the caller's `tofu login` RBAC:

| Tool | Safety | |
|---|---|---|
| `terrapod_workspace_create` | — | name required; execution mode, VCS wiring, agent pool, labels, … |
| `terrapod_workspace_update` | — | partial update; applies on the next run (doesn't queue one) |
| `terrapod_workspace_delete` | destructive | removes Terrapod records only — **not** the tracked infra (queue a destroy run first); catalog-managed workspaces refused (409) |
| `terrapod_variable_list` | read-only | sensitive values masked |
| `terrapod_variable_set` | — | upsert by key (terraform/env; `hcl` for non-string values) |
| `terrapod_variable_delete` | destructive | by key |

Destructive tools carry the `destructive` hint so the MCP host confirms, mirroring the UI's confirm-on-destructive policy. Nothing widens access — a read-only token still can't mutate.

## Verification
- `mcp` module `go build && go vet && go test` green.
- Catalogue golden regenerated — **15 tools** (was 9), additive only (the CI tool-catalogue gate treats additions as safe).
- `docs/mcp.md` updated (Manage table + roadmap).

Next tranches (separate PRs): remaining CRUD (VCS connections, roles, agent pools, run tasks, notifications, hooks), the Ground tools (registry interfaces + provider schemas), the tofu-native `discover` tool, and MCP release-artifact wiring.