### PR TITLE
feat(846): MCP Ground tools — registry modules/providers + module interface

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -111,6 +111,16 @@ Every tool is namespaced `terrapod_*` and carries a safety annotation
 | `terrapod_variable_set` | — | Upsert a variable by key (terraform or env; `hcl` for non-string values). |
 | `terrapod_variable_delete` | destructive | Delete a variable by key. |
 
+### Ground (read-only) — write correct config against *your* estate
+
+| Tool | What it does |
+|---|---|
+| `terrapod_registry_module_list` | List the private registry modules published here (name, provider, VCS, status). |
+| `terrapod_registry_module_get` | One module by name + provider — source, status, owner, labels. |
+| `terrapod_registry_module_interface` | A module version's **inputs + outputs** — the exact surface to author a correct `module` block against it, instead of guessing variable names. |
+| `terrapod_registry_provider_list` | List the private registry providers published here. |
+| `terrapod_registry_provider_get` | One provider by name — namespace, owner, labels. |
+
 Nothing bypasses the platform: applies obey the workspace's VCS/auto-apply/lock
 rules and OPA policy, config changes apply on the next run, and every action is
 bounded by your Terrapod RBAC — a read-only token cannot mutate.
@@ -135,12 +145,10 @@ warns you through the agent.
 
 ## Roadmap (additive)
 
-Observe + gated Act + workspace/variable **Manage** have landed. Continuing
-additively (no breaking changes): the rest of management **CRUD** (VCS
-connections, roles, agent pools, run tasks, notifications, execution hooks, …),
-the **Ground** tools (private registry modules + their input/output interface,
-provider schemas) so an agent writes correct config against *your* estate, and
-the tofu-native **`discover`** tool (folding in
+Observe + gated Act + workspace/variable **Manage** + registry **Ground** have
+landed. Continuing additively (no breaking changes): the rest of management
+**CRUD** (VCS connections, roles, agent pools, run tasks, notifications,
+execution hooks, …), and the tofu-native **`discover`** tool (folding in
 [`terrapod-query`](terrapod-query.md)) for onboarding existing resources.
 
 ## See also

--- a/go-terrapod/registry_modules.go
+++ b/go-terrapod/registry_modules.go
@@ -29,6 +29,14 @@ type RegistryModule struct {
 	UpdatedAt       string            `json:"updated-at,omitempty"`
 }
 
+// ModuleInterface is a published module version's input/output surface —
+// what an agent needs to author a correct `module` block against it.
+type ModuleInterface struct {
+	Version string           `json:"version"`
+	Inputs  []map[string]any `json:"inputs"`
+	Outputs []map[string]any `json:"outputs"`
+}
+
 // CreateRegistryModuleRequest registers a new module.
 type CreateRegistryModuleRequest struct {
 	Name            string
@@ -71,6 +79,56 @@ func (c *Client) GetRegistryModule(ctx context.Context, name, providerName strin
 		return nil, err
 	}
 	return parseRegistryModule(data)
+}
+
+// ListRegistryModules returns every module in the registry (the
+// management list — not the CLI download protocol). Slices the
+// server's JSON:API list through the same per-resource projector the
+// single-resource Get uses.
+func (c *Client) ListRegistryModules(ctx context.Context) ([]RegistryModule, error) {
+	data, err := c.Get(ctx, "/api/terrapod/v1/registry-modules")
+	if err != nil {
+		return nil, err
+	}
+	resources, err := ParseResourceList(data)
+	if err != nil {
+		return nil, err
+	}
+	modules := make([]RegistryModule, 0, len(resources))
+	for i := range resources {
+		modules = append(modules, *registryModuleFromResource(&resources[i]))
+	}
+	return modules, nil
+}
+
+// GetModuleInterface reads a published module version's input/output
+// surface — the inputs an agent must supply and the outputs it can
+// consume when authoring a `module` block. Returns *NotFoundError when
+// interface extraction is disabled for the module or the version is
+// unknown.
+func (c *Client) GetModuleInterface(ctx context.Context, name, provider, version string) (*ModuleInterface, error) {
+	path := fmt.Sprintf("/api/terrapod/v1/registry-modules/private/default/%s/%s/%s/interface",
+		url.PathEscape(name), url.PathEscape(provider), url.PathEscape(version))
+	data, err := c.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	res, err := ParseResource(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse module-interface response: %w", err)
+	}
+	iface := &ModuleInterface{Version: GetStringAttr(res, "version")}
+	if raw, ok := res.Attributes["inputs"]; ok && len(raw) > 0 && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &iface.Inputs); err != nil {
+			return nil, fmt.Errorf("parse module-interface inputs: %w", err)
+		}
+	}
+	if raw, ok := res.Attributes["outputs"]; ok && len(raw) > 0 && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &iface.Outputs); err != nil {
+			return nil, fmt.Errorf("parse module-interface outputs: %w", err)
+		}
+	}
+	return iface, nil
 }
 
 // UpdateRegistryModule patches a module identified by (name, provider).

--- a/go-terrapod/registry_modules_test.go
+++ b/go-terrapod/registry_modules_test.go
@@ -1,6 +1,7 @@
 package terrapod
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -89,5 +90,81 @@ func TestDeleteRegistryModule(t *testing.T) {
 	c := newRegModFixture(t)
 	if err := c.DeleteRegistryModule(t.Context(), "vpc", "aws"); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestListRegistryModules(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/terrapod/v1/registry-modules" {
+			http.Error(w, "unhandled", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":[
+		  {"id":"mod-aaa","type":"registry-modules","attributes":{"name":"vpc","provider":"aws"}},
+		  {"id":"mod-bbb","type":"registry-modules","attributes":{"name":"eks","provider":"aws"}}
+		]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mods, err := c.ListRegistryModules(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mods) != 2 {
+		t.Fatalf("expected 2 modules, got %d", len(mods))
+	}
+	if mods[0].Name != "vpc" || mods[1].Name != "eks" {
+		t.Errorf("modules: %+v", mods)
+	}
+}
+
+func TestGetModuleInterface(t *testing.T) {
+	const ifacePath = "/api/terrapod/v1/registry-modules/private/default/vpc/aws/1.2.3/interface"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "unhandled", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		if r.URL.Path == ifacePath {
+			_, _ = w.Write([]byte(`{"data":{"type":"module-interface","id":"modver-xyz","attributes":{
+			  "version":"1.2.3",
+			  "inputs":[{"name":"cidr","type":"string","required":true},{"name":"tags","type":"map"}],
+			  "outputs":[{"name":"vpc_id"}]
+			}}}`))
+			return
+		}
+		// Any other version → 404 (extraction disabled or unknown version).
+		http.Error(w, `{"errors":[{"status":"404","title":"Not Found"}]}`, http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	iface, err := c.GetModuleInterface(t.Context(), "vpc", "aws", "1.2.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if iface.Version != "1.2.3" {
+		t.Errorf("version: %q", iface.Version)
+	}
+	if len(iface.Inputs) != 2 || len(iface.Outputs) != 1 {
+		t.Fatalf("inputs=%d outputs=%d", len(iface.Inputs), len(iface.Outputs))
+	}
+	if iface.Inputs[0]["name"] != "cidr" {
+		t.Errorf("input[0] name: %v", iface.Inputs[0]["name"])
+	}
+
+	// A missing/extraction-disabled version surfaces as *NotFoundError.
+	_, err = c.GetModuleInterface(t.Context(), "vpc", "aws", "9.9.9")
+	var nf *NotFoundError
+	if !errors.As(err, &nf) {
+		t.Errorf("expected *NotFoundError, got %v", err)
 	}
 }

--- a/go-terrapod/registry_providers.go
+++ b/go-terrapod/registry_providers.go
@@ -59,6 +59,26 @@ func (c *Client) GetRegistryProvider(ctx context.Context, name string) (*Registr
 	return parseRegistryProvider(data)
 }
 
+// ListRegistryProviders returns every provider in the registry (the
+// management list — not the CLI download protocol). Slices the
+// server's JSON:API list through the same per-resource projector the
+// single-resource Get uses.
+func (c *Client) ListRegistryProviders(ctx context.Context) ([]RegistryProvider, error) {
+	data, err := c.Get(ctx, "/api/terrapod/v1/registry-providers")
+	if err != nil {
+		return nil, err
+	}
+	resources, err := ParseResourceList(data)
+	if err != nil {
+		return nil, err
+	}
+	providers := make([]RegistryProvider, 0, len(resources))
+	for i := range resources {
+		providers = append(providers, *registryProviderFromResource(&resources[i]))
+	}
+	return providers, nil
+}
+
 // UpdateRegistryProvider patches a provider by name.
 func (c *Client) UpdateRegistryProvider(ctx context.Context, name string, req UpdateRegistryProviderRequest) (*RegistryProvider, error) {
 	attrs := map[string]any{}

--- a/go-terrapod/registry_providers_test.go
+++ b/go-terrapod/registry_providers_test.go
@@ -82,3 +82,32 @@ func TestDeleteRegistryProvider(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestListRegistryProviders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/terrapod/v1/registry-providers" {
+			http.Error(w, "unhandled", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":[
+		  {"id":"prov-aaa","type":"registry-providers","attributes":{"name":"acme"}},
+		  {"id":"prov-bbb","type":"registry-providers","attributes":{"name":"widgets"}}
+		]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provs, err := c.ListRegistryProviders(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(provs) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(provs))
+	}
+	if provs[0].Name != "acme" || provs[1].Name != "widgets" {
+		t.Errorf("providers: %+v", provs)
+	}
+}

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -292,6 +292,9 @@ field ListMeta.CurrentPage int `json:"current-page"`
 field ListMeta.PageSize int `json:"page-size"`
 field ListMeta.TotalCount int `json:"total-count"`
 field ListMeta.TotalPages int `json:"total-pages"`
+field ModuleInterface.Inputs []map[string]any `json:"inputs"`
+field ModuleInterface.Outputs []map[string]any `json:"outputs"`
+field ModuleInterface.Version string `json:"version"`
 field ModuleWorkspaceLink.CreatedAt string `json:"created-at,omitempty"`
 field ModuleWorkspaceLink.CreatedBy string `json:"created-by,omitempty"`
 field ModuleWorkspaceLink.ID string `json:"id"`
@@ -896,6 +899,7 @@ method (*Client) GetEncryptionStatus(ctx context.Context) (*EncryptionStatus, er
 method (*Client) GetEstateGraph(ctx context.Context) (*EstateGraph, error)
 method (*Client) GetExecutionHook(ctx context.Context, id string) (*ExecutionHook, error)
 method (*Client) GetGPGKey(ctx context.Context, id string) (*GPGKey, error)
+method (*Client) GetModuleInterface(ctx context.Context, name, provider, version string) (*ModuleInterface, error)
 method (*Client) GetModuleWorkspaceLink(ctx context.Context, moduleName, moduleProvider, linkID string) (*ModuleWorkspaceLink, error)
 method (*Client) GetNotificationConfiguration(ctx context.Context, id string) (*NotificationConfiguration, error)
 method (*Client) GetOnboardingAvailability(ctx context.Context) (*OnboardingAvailability, error)
@@ -948,6 +952,8 @@ method (*Client) ListOutboundRunTriggers(ctx context.Context, workspaceID string
 method (*Client) ListPlanSummaryMessages(ctx context.Context, runID string) ([]*PlanSummaryMessage, error)
 method (*Client) ListPolicySets(ctx context.Context) ([]PolicySet, error)
 method (*Client) ListProviderTemplates(ctx context.Context) ([]ProviderTemplate, error)
+method (*Client) ListRegistryModules(ctx context.Context) ([]RegistryModule, error)
+method (*Client) ListRegistryProviders(ctx context.Context) ([]RegistryProvider, error)
 method (*Client) ListRemoteStateConsumers(ctx context.Context, producerWorkspaceID string) ([]RemoteStateConsumer, error)
 method (*Client) ListRoleAssignments(ctx context.Context) ([]RoleAssignment, error)
 method (*Client) ListRoleAssignmentsForIdentity(ctx context.Context, providerName, email string) ([]RoleAssignment, error)
@@ -1069,6 +1075,7 @@ type LabelEntity struct
 type LabelKey struct
 type LabelValue struct
 type ListMeta struct
+type ModuleInterface struct
 type ModuleWorkspaceLink struct
 type NotFoundError struct
 type NotificationConfiguration struct

--- a/mcp/internal/mcpserver/ground.go
+++ b/mcp/internal/mcpserver/ground.go
@@ -1,0 +1,110 @@
+package mcpserver
+
+import (
+	"context"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerGround adds the read-only "Ground" tools — the private-registry
+// context an agent needs to write CORRECT config against *this* estate: which
+// modules/providers exist here, and (the load-bearing one) a module version's
+// input/output interface so the agent authors a valid `module` block instead of
+// guessing variable names. All read-only; bounded by the caller's registry RBAC.
+func registerGround(s *mcp.Server, c *terrapod.Client) {
+	// ── terrapod_registry_module_list ────────────────────────────────
+	type moduleListOut struct {
+		Count   int                       `json:"count"`
+		Modules []terrapod.RegistryModule `json:"modules"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_registry_module_list",
+		Description: "List the private registry modules published on this instance (name, provider, VCS wiring, status). Use to discover what modules are available before authoring config.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, moduleListOut, error) {
+		mods, err := c.ListRegistryModules(ctx)
+		if err != nil {
+			return errResult(err), moduleListOut{}, nil
+		}
+		return nil, moduleListOut{Count: len(mods), Modules: mods}, nil
+	})
+
+	// ── terrapod_registry_module_get ─────────────────────────────────
+	type moduleGetIn struct {
+		Name     string `json:"name" jsonschema:"the module name"`
+		Provider string `json:"provider" jsonschema:"the module's provider (e.g. aws)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_registry_module_get",
+		Description: "Get one private registry module by name + provider — its VCS source, status, owner, labels. To see a version's inputs/outputs, use terrapod_registry_module_interface.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in moduleGetIn) (*mcp.CallToolResult, *terrapod.RegistryModule, error) {
+		if in.Name == "" || in.Provider == "" {
+			return errText("name and provider are required"), nil, nil
+		}
+		mod, err := c.GetRegistryModule(ctx, in.Name, in.Provider)
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, mod, nil
+	})
+
+	// ── terrapod_registry_module_interface ───────────────────────────
+	type moduleInterfaceIn struct {
+		Name     string `json:"name" jsonschema:"the module name"`
+		Provider string `json:"provider" jsonschema:"the module's provider (e.g. aws)"`
+		Version  string `json:"version" jsonschema:"the module version (e.g. 1.2.3)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "terrapod_registry_module_interface",
+		Description: "Get a module version's input variables and outputs — the exact surface to author a correct `module` block against it (variable names, types, whether required, defaults; and what it returns). " +
+			"Prefer this over guessing a module's inputs. Returns 404 if interface extraction is disabled on this instance or the version doesn't exist.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in moduleInterfaceIn) (*mcp.CallToolResult, *terrapod.ModuleInterface, error) {
+		if in.Name == "" || in.Provider == "" || in.Version == "" {
+			return errText("name, provider and version are required"), nil, nil
+		}
+		iface, err := c.GetModuleInterface(ctx, in.Name, in.Provider, in.Version)
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, iface, nil
+	})
+
+	// ── terrapod_registry_provider_list ──────────────────────────────
+	type providerListOut struct {
+		Count     int                         `json:"count"`
+		Providers []terrapod.RegistryProvider `json:"providers"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_registry_provider_list",
+		Description: "List the private registry providers published on this instance (name, namespace, owner, labels). Use to discover which internal providers are available.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, providerListOut, error) {
+		provs, err := c.ListRegistryProviders(ctx)
+		if err != nil {
+			return errResult(err), providerListOut{}, nil
+		}
+		return nil, providerListOut{Count: len(provs), Providers: provs}, nil
+	})
+
+	// ── terrapod_registry_provider_get ───────────────────────────────
+	type providerGetIn struct {
+		Name string `json:"name" jsonschema:"the provider name"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_registry_provider_get",
+		Description: "Get one private registry provider by name — namespace, owner, labels.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in providerGetIn) (*mcp.CallToolResult, *terrapod.RegistryProvider, error) {
+		if in.Name == "" {
+			return errText("name is required"), nil, nil
+		}
+		prov, err := c.GetRegistryProvider(ctx, in.Name)
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, prov, nil
+	})
+}

--- a/mcp/internal/mcpserver/server.go
+++ b/mcp/internal/mcpserver/server.go
@@ -86,6 +86,7 @@ func New(cfg Config) (*mcp.Server, *terrapod.Client, error) {
 	registerObserve(srv, client)
 	registerAct(srv, client)
 	registerCRUD(srv, client)
+	registerGround(srv, client)
 
 	return srv, client, nil
 }

--- a/mcp/internal/mcpserver/tool_catalogue.json
+++ b/mcp/internal/mcpserver/tool_catalogue.json
@@ -1,5 +1,87 @@
 [
   {
+    "name": "terrapod_registry_module_get",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "the module name",
+          "type": "string"
+        },
+        "provider": {
+          "description": "the module's provider (e.g. aws)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "provider"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_registry_module_interface",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "the module name",
+          "type": "string"
+        },
+        "provider": {
+          "description": "the module's provider (e.g. aws)",
+          "type": "string"
+        },
+        "version": {
+          "description": "the module version (e.g. 1.2.3)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "provider",
+        "version"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_registry_module_list",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_registry_provider_get",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "the provider name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_registry_provider_list",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  {
     "name": "terrapod_run_apply",
     "destructive": true,
     "input_schema": {


### PR DESCRIPTION
Part of #846 — the **Ground** tranche after Manage/CRUD (#865). The read-rich context an agent needs to write *correct* config against **this** estate rather than guess it. All read-only, bounded by the caller's registry RBAC.

## go-terrapod (SDK-first, per the consumer contract)
Additive methods, then the MCP tools on top:
- `ListRegistryModules` / `ListRegistryProviders` (management list endpoints)
- `GetModuleInterface(name, provider, version)` → new `ModuleInterface{Version, Inputs, Outputs}` over `.../{name}/{provider}/{version}/interface`

httptest coverage (list + interface + 404→`*NotFoundError`); exported-surface golden regenerated (additions only: 3 methods + the type).

## MCP Ground tools (5, read-only)
- `terrapod_registry_module_list` / `terrapod_registry_module_get`
- **`terrapod_registry_module_interface`** — a module version's inputs + outputs, the exact surface to author a valid `module` block (the load-bearing one; stops the agent guessing variable names).
- `terrapod_registry_provider_list` / `terrapod_registry_provider_get`

## Verification
- go-terrapod + mcp `go build && go vet && go test` green.
- Catalogue golden regenerated — **20 tools** (was 15), additive.
- `docs/mcp.md` Ground table + roadmap updated.

Next: `discover` tool (terrapod-query), then MCP release-artifact wiring.