### PR TITLE
feat(846): MCP discover/onboard tools — bring existing resources under management

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -121,6 +121,20 @@ Every tool is namespaced `terrapod_*` and carries a safety annotation
 | `terrapod_registry_provider_list` | List the private registry providers published here. |
 | `terrapod_registry_provider_get` | One provider by name — namespace, owner, labels. |
 
+### Discover (gated) — onboard existing resources
+
+Tofu-native resource discovery: bring existing cloud resources under management.
+These tools only **discover and generate** — they produce reviewable `import {}`
+blocks + config for the human to adopt; **they never apply an import themselves**.
+
+| Tool | Safety | What it does |
+|---|---|---|
+| `terrapod_onboard_availability` | read-only | Is the AI-assisted onboarding path available (its own switch + model)? |
+| `terrapod_onboard_start` | — | Start a discovery session for a workspace + provider; kicks off credential-less schema discovery. |
+| `terrapod_onboard_list` | read-only | A workspace's discovery sessions. |
+| `terrapod_onboard_get` | read-only | One session — status, discovery surface (importable data sources), and the generated config + `import {}` blocks. |
+| `terrapod_onboard_discover` | — | Run discovery over chosen data-source types → generated config + import blocks (imports nothing). |
+
 Nothing bypasses the platform: applies obey the workspace's VCS/auto-apply/lock
 rules and OPA policy, config changes apply on the next run, and every action is
 bounded by your Terrapod RBAC — a read-only token cannot mutate.
@@ -145,11 +159,11 @@ warns you through the agent.
 
 ## Roadmap (additive)
 
-Observe + gated Act + workspace/variable **Manage** + registry **Ground** have
-landed. Continuing additively (no breaking changes): the rest of management
-**CRUD** (VCS connections, roles, agent pools, run tasks, notifications,
-execution hooks, …), and the tofu-native **`discover`** tool (folding in
-[`terrapod-query`](terrapod-query.md)) for onboarding existing resources.
+Observe + gated Act + workspace/variable **Manage** + registry **Ground** +
+resource **Discover** have landed. Continuing additively (no breaking changes):
+the rest of management **CRUD** (VCS connections, roles, agent pools, run tasks,
+notifications, execution hooks, …), and — once the gated import-only apply lands
+— an `onboard_apply` tool to adopt the generated import blocks.
 
 ## See also
 

--- a/mcp/internal/mcpserver/discover.go
+++ b/mcp/internal/mcpserver/discover.go
@@ -1,0 +1,124 @@
+package mcpserver
+
+import (
+	"context"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerDiscover adds the resource-discovery ("onboard") tools — the
+// tofu-native flow that brings *existing* cloud resources under Terrapod
+// management: discover a provider's importable data sources (credential-less D1
+// schema), run discovery over the chosen types (D2/D3), and read back the
+// generated config + matching `import {}` blocks for the user to review.
+//
+// These tools only DISCOVER and GENERATE — they never apply an import
+// themselves (that is a separate gated import-only run). They produce reviewable
+// artifacts; the human decides whether to adopt them. All are bounded by the
+// caller's `workspace:onboard` capability.
+func registerDiscover(s *mcp.Server, c *terrapod.Client) {
+	// ── terrapod_onboard_availability ────────────────────────────────
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_onboard_availability",
+		Description: "Report whether the optional AI-assisted onboarding path is available on this instance (its own switch + a configured model). The deterministic discovery flow works regardless; this only affects the AI-polished config view.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, *terrapod.OnboardingAvailability, error) {
+		avail, err := c.GetOnboardingAvailability(ctx)
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, avail, nil
+	})
+
+	// ── terrapod_onboard_start ───────────────────────────────────────
+	type onboardStartIn struct {
+		WorkspaceID     string `json:"workspace_id" jsonschema:"the workspace id (ws-...) to onboard resources into"`
+		Provider        string `json:"provider" jsonschema:"lowercase terraform provider name (e.g. aws)"`
+		ProviderVersion string `json:"provider_version,omitempty" jsonschema:"optional provider version constraint (e.g. ~> 5.0)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "terrapod_onboard_start",
+		Description: "Start a resource-discovery session for a workspace + provider. Kicks off credential-less schema discovery (which of the provider's data sources are importable). " +
+			"Poll terrapod_onboard_get until status is `schema_ready`, then read the discovery surface and call terrapod_onboard_discover with the types you want. Non-destructive — nothing is imported.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in onboardStartIn) (*mcp.CallToolResult, *terrapod.OnboardingSession, error) {
+		if in.WorkspaceID == "" || in.Provider == "" {
+			return errText("workspace_id and provider are required"), nil, nil
+		}
+		sess, err := c.CreateOnboardingSession(ctx, terrapod.CreateOnboardingSessionRequest{
+			WorkspaceID:     in.WorkspaceID,
+			Provider:        in.Provider,
+			ProviderVersion: in.ProviderVersion,
+		})
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, sess, nil
+	})
+
+	// ── terrapod_onboard_list ────────────────────────────────────────
+	type onboardListIn struct {
+		WorkspaceID string `json:"workspace_id" jsonschema:"the workspace id (ws-...) whose discovery sessions to list"`
+	}
+	type onboardListOut struct {
+		Count    int                          `json:"count"`
+		Sessions []terrapod.OnboardingSession `json:"sessions"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_onboard_list",
+		Description: "List a workspace's resource-discovery sessions (status, provider, engine). The full discovery surface is omitted here — read one session with terrapod_onboard_get for it.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in onboardListIn) (*mcp.CallToolResult, onboardListOut, error) {
+		if in.WorkspaceID == "" {
+			return errText("workspace_id is required"), onboardListOut{}, nil
+		}
+		sessions, err := c.ListOnboardingSessions(ctx, in.WorkspaceID)
+		if err != nil {
+			return errResult(err), onboardListOut{}, nil
+		}
+		return nil, onboardListOut{Count: len(sessions), Sessions: sessions}, nil
+	})
+
+	// ── terrapod_onboard_get ─────────────────────────────────────────
+	type onboardGetIn struct {
+		SessionID string `json:"session_id" jsonschema:"the onboarding session id"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "terrapod_onboard_get",
+		Description: "Get one discovery session — its status plus (when ready) the discovery surface (importable data sources), and the generated config + `import {}` blocks. " +
+			"Statuses progress: discovering schema → schema_ready (surface available) → discovering (after terrapod_onboard_discover) → config_ready (generated-config + import-blocks available). Present these to the user to review before adopting.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in onboardGetIn) (*mcp.CallToolResult, *terrapod.OnboardingSession, error) {
+		if in.SessionID == "" {
+			return errText("session_id is required"), nil, nil
+		}
+		sess, err := c.GetOnboardingSession(ctx, in.SessionID)
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, sess, nil
+	})
+
+	// ── terrapod_onboard_discover ────────────────────────────────────
+	type onboardDiscoverIn struct {
+		SessionID     string   `json:"session_id" jsonschema:"the schema_ready session id"`
+		SelectedTypes []string `json:"selected_types" jsonschema:"a non-empty subset of the session's discovery-surface data-source types to query"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "terrapod_onboard_discover",
+		Description: "Run discovery over the chosen data-source types for a `schema_ready` session — dispatches the discovery run that produces the generated config + `import {}` blocks. selected_types must be a non-empty subset of the session's discovery surface. " +
+			"Non-destructive: it queries and generates config, it does NOT import anything. Poll terrapod_onboard_get until config_ready, then review the output with the user.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in onboardDiscoverIn) (*mcp.CallToolResult, *terrapod.OnboardingSession, error) {
+		if in.SessionID == "" {
+			return errText("session_id is required"), nil, nil
+		}
+		if len(in.SelectedTypes) == 0 {
+			return errText("selected_types must be a non-empty subset of the discovery surface"), nil, nil
+		}
+		sess, err := c.StartOnboardingDiscovery(ctx, in.SessionID, in.SelectedTypes)
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, sess, nil
+	})
+}

--- a/mcp/internal/mcpserver/server.go
+++ b/mcp/internal/mcpserver/server.go
@@ -87,6 +87,7 @@ func New(cfg Config) (*mcp.Server, *terrapod.Client, error) {
 	registerAct(srv, client)
 	registerCRUD(srv, client)
 	registerGround(srv, client)
+	registerDiscover(srv, client)
 
 	return srv, client, nil
 }

--- a/mcp/internal/mcpserver/tool_catalogue.json
+++ b/mcp/internal/mcpserver/tool_catalogue.json
@@ -1,5 +1,99 @@
 [
   {
+    "name": "terrapod_onboard_availability",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_onboard_discover",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "selected_types": {
+          "description": "a non-empty subset of the session's discovery-surface data-source types to query",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "null",
+            "array"
+          ]
+        },
+        "session_id": {
+          "description": "the schema_ready session id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "session_id",
+        "selected_types"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_onboard_get",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "session_id": {
+          "description": "the onboarding session id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "session_id"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_onboard_list",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "workspace_id": {
+          "description": "the workspace id (ws-...) whose discovery sessions to list",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_id"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "name": "terrapod_onboard_start",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "description": "lowercase terraform provider name (e.g. aws)",
+          "type": "string"
+        },
+        "provider_version": {
+          "description": "optional provider version constraint (e.g. ~\u003e 5.0)",
+          "type": "string"
+        },
+        "workspace_id": {
+          "description": "the workspace id (ws-...) to onboard resources into",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_id",
+        "provider"
+      ],
+      "type": "object"
+    }
+  },
+  {
     "name": "terrapod_registry_module_get",
     "read_only": true,
     "input_schema": {


### PR DESCRIPTION
Part of #846 — the **Discover** tranche after Ground (#866). The tofu-native resource-discovery flow as MCP tools, over the existing go-terrapod onboarding surface (no SDK expansion needed).

**Discover + generate only** — these tools produce reviewable `import {}` blocks + config for the human to adopt; they **never apply an import themselves** (that stays a separate gated import-only run; when #383 lands, an `onboard_apply` tool follows per the contract).

## Tools (5), bounded by `workspace:onboard` RBAC
- `terrapod_onboard_availability` (read-only) — is the AI-polish path available.
- `terrapod_onboard_start` — create a session; kicks off credential-less **D1** schema discovery (which of a provider's data sources are importable).
- `terrapod_onboard_list` / `terrapod_onboard_get` (read-only) — sessions + one session's status, discovery surface, `generated-config`, `import-blocks`.
- `terrapod_onboard_discover` — run **D2/D3** over chosen data-source types → generated config + import blocks (imports nothing).

Typical agent flow: `start` → poll `get` to `schema_ready` → `discover(selected_types)` → poll `get` to `config_ready` → present the import blocks/config to the user.

## Verification
- mcp `go build && go vet && go test` green.
- Catalogue golden regenerated — **25 tools** (was 20), additive.
- `docs/mcp.md` Discover table + roadmap updated.

Next: MCP release-artifact wiring (goreleaser + `release-mcp` job) — the last tranche.