### PR TITLE
chore(security): suppress false-positive PGP-key scan alert in sign_test

### DIFF
--- a/publish/internal/sign/sign_test.go
+++ b/publish/internal/sign/sign_test.go
@@ -97,7 +97,14 @@ func TestLoadPrivateKeyRejectsPublicKey(t *testing.T) {
 // fixture. Tracked as a follow-up rather than an in-memory quick win.
 
 func TestLoadPrivateKeyRejectsGarbage(t *testing.T) {
-	if _, err := LoadPrivateKey("-----BEGIN PGP PRIVATE KEY BLOCK-----\nnot base64\n-----END PGP PRIVATE KEY BLOCK-----\n", ""); err == nil {
+	// Deliberately-malformed armored input: the PGP markers wrap the literal
+	// text "not base64" — there is NO key material here. It exists only to
+	// prove LoadPrivateKey rejects bad armor. The secret scanner matches the
+	// marker text, not a real key (every real test key is generated at runtime
+	// via openpgp.NewEntity), so this is a false positive.
+	// nosemgrep: generic.secrets.security.detected-pgp-private-key-block
+	const malformedArmor = "-----BEGIN PGP PRIVATE KEY BLOCK-----\nnot base64\n-----END PGP PRIVATE KEY BLOCK-----\n"
+	if _, err := LoadPrivateKey(malformedArmor, ""); err == nil {
 		t.Fatal("expected error on malformed armor")
 	}
 	if _, err := LoadPrivateKey("not armored at all", ""); err == nil {


### PR DESCRIPTION
Resolves code-scanning **alert #345** (Semgrep OSS `detected-pgp-private-key-block`, severity error) on `publish/internal/sign/sign_test.go:100`.

## Assessment: false positive

`TestLoadPrivateKeyRejectsGarbage` feeds `LoadPrivateKey` a **deliberately-malformed** armored string — the literal text `not base64` wrapped in `-----BEGIN/END PGP PRIVATE KEY BLOCK-----` markers — to assert the reject path. There is **no key material**; every real test key in the file is generated at runtime via `openpgp.NewEntity`. The scanner matches the marker text, not a secret.

## Fix

Extract the malformed literal to a named `const` with a documented `// nosemgrep: generic.secrets.security.detected-pgp-private-key-block` directive and a rationale comment — suppressing the finding at source (matching the project's convention for scanner false positives) rather than letting it linger as an open alert or a silent allowlist entry.

Test unchanged in behaviour; `go test ./internal/sign/` passes.