### PR TITLE
test(873): fix flaky i18n language-switcher E2E (menu-open race)

### DIFF
--- a/e2e/tests/i18n.spec.ts
+++ b/e2e/tests/i18n.spec.ts
@@ -30,13 +30,25 @@ function guardIntlErrors(page: import('@playwright/test').Page) {
 }
 
 async function switchLocale(page: import('@playwright/test').Page, triggerName: RegExp, itemName: string) {
-  await page.getByRole('button', { name: triggerName }).first().click();
+  const trigger = page.getByRole('button', { name: triggerName }).first();
+  const menu = page.getByRole('menu');
+  // Open the menu robustly. The Radix trigger can be clicked before React has
+  // hydrated its onClick handler (far more likely under CI/host load), so a
+  // single click sometimes no-ops and the menu never opens — the dominant cause
+  // of this spec's flake (#873). Retry the click until the menu is actually
+  // visible, guarding against a toggle-close by only clicking when it isn't
+  // already open.
+  await expect(async () => {
+    if (!(await menu.isVisible())) {
+      await trigger.click();
+    }
+    await expect(menu).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 15000 });
   // Exact match: several native names are substrings of others (e.g. "English"
   // ⊂ "English (UK)"), so a loose name match is ambiguous across 30+ locales.
-  const item = page.getByRole('menuitem', { name: itemName, exact: true });
+  const item = menu.getByRole('menuitem', { name: itemName, exact: true });
   // The switcher is a max-h-[70vh] scroll container; the bottom locales (the
-  // joke set) sit well below the fold, and Playwright's implicit click-scroll
-  // is unreliable inside this Radix scroll region — scroll it in explicitly.
+  // joke set) sit below the fold, so scroll the item into view before clicking.
   await item.scrollIntoViewIfNeeded();
   await item.click();
 }


### PR DESCRIPTION
The `i18n language switcher` spec was **the single most common cause of E2E-shard reruns** — a hard failure on run 29685527853 plus repeated attempt-2 reruns across recent PRs (it's what forced the rerun on the cost-engine PR #872).

## Root cause (from the captured failure DOM, not assumed)

The accessibility tree at failure was the full nav with **zero `menu`/`menuitem`** and the trigger still showing "EN" — **the dropdown never opened**. The Radix trigger was sometimes clicked *before React hydrated its onClick handler*, so the click no-opped. `scrollIntoViewIfNeeded` timing out was only the *symptom* (waiting on a menuitem that never appeared). It's load-sensitive: ~25% on CI, **~70% locally under load**.

## Fix

`switchLocale` now opens the menu robustly — retrying the trigger click until `role=menu` is actually visible, guarded by an `isVisible()` check so it never toggle-closes an already-open menu — then the existing scroll+click. **Product code unchanged; test-only.**

## Verification (real e2e stack, `--repeat-each`)

- The `1337` test: **14/20 failing** on the old helper → **20/20 passing** with the fix.
- Full switcher describe (German/Spanish/1337/unauthenticated): **20/20** (×5), no regression on the top-of-list locales.

Closes #873.