### PR TITLE
fix(880): terrapod-mcp re-reads the token on 401 (in-session `tofu login` refresh)

### DIFF
--- a/mcp/cmd/terrapod-mcp/main.go
+++ b/mcp/cmd/terrapod-mcp/main.go
@@ -46,13 +46,17 @@ func main() {
 		fmt.Fprintln(os.Stderr, "terrapod-mcp:", err)
 		os.Exit(1)
 	}
+	// A token from the credentials file can be refreshed live on a 401 (a
+	// `tofu login` re-write); an explicit --token / $TERRAPOD_TOKEN is static.
+	refreshFromFile := *token == "" && os.Getenv("TERRAPOD_TOKEN") == ""
 
 	srv, client, err := mcpserver.New(mcpserver.Config{
-		Host:          *host,
-		Name:          *name,
-		Token:         tok,
-		EnvHint:       *envHint,
-		SkipTLSVerify: *skipTLS,
+		Host:                 *host,
+		Name:                 *name,
+		Token:                tok,
+		EnvHint:              *envHint,
+		SkipTLSVerify:        *skipTLS,
+		RefreshTokenFromFile: refreshFromFile,
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "terrapod-mcp:", err)

--- a/mcp/internal/mcpserver/server.go
+++ b/mcp/internal/mcpserver/server.go
@@ -50,6 +50,11 @@ type Config struct {
 	EnvHint string
 	// SkipTLSVerify disables certificate verification (local/dev only).
 	SkipTLSVerify bool
+	// RefreshTokenFromFile is true when Token was resolved from the credentials
+	// file (not an explicit --token / $TERRAPOD_TOKEN). It lets the client
+	// re-read the file and retry once on a 401, so an in-session `tofu login`
+	// refresh is picked up without reconnecting the MCP (issue #880).
+	RefreshTokenFromFile bool
 }
 
 // New builds the go-terrapod client for the configured instance and an MCP
@@ -65,10 +70,14 @@ func New(cfg Config) (*mcp.Server, *terrapod.Client, error) {
 	// MCP-built-against version to what the server advertises.
 	terrapod.SDKVersion = Version
 
+	// Inject an http.Client that refreshes the token on a 401 (issue #880) so an
+	// in-session `tofu login` refresh is picked up without reconnecting. It owns
+	// the TLS config now, so SkipTLSVerify is passed to it, not to go-terrapod
+	// (which ignores its own SkipTLSVerify once an HTTPClient is supplied).
 	client, err := terrapod.NewClient(terrapod.Options{
-		BaseURL:       cfg.Host,
-		Token:         cfg.Token,
-		SkipTLSVerify: cfg.SkipTLSVerify,
+		BaseURL:    cfg.Host,
+		Token:      cfg.Token,
+		HTTPClient: newHTTPClient(cfg.Host, cfg.Token, cfg.RefreshTokenFromFile, cfg.SkipTLSVerify),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("build terrapod client: %w", err)

--- a/mcp/internal/mcpserver/transport.go
+++ b/mcp/internal/mcpserver/transport.go
@@ -1,0 +1,99 @@
+package mcpserver
+
+import (
+	"crypto/tls"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// refreshTransport re-resolves the API token from the credentials file when a
+// request comes back 401, then retries the request once with the fresh token
+// (issue #880).
+//
+// Without this, terrapod-mcp reads the token once at startup and reuses it for
+// the life of the process: when the token expires and the operator refreshes it
+// with `tofu login <host>` (or edits the credentials file), the running server
+// keeps sending the stale token and every tool call fails with "Invalid or
+// expired token" until the MCP is reconnected — even though the file now holds
+// a valid token. This transport makes an in-session refresh transparent.
+//
+// Only a file-sourced token is refreshed. An explicit --token / $TERRAPOD_TOKEN
+// is static (refresh is nil), so a genuinely-bad explicit token surfaces its
+// 401 immediately instead of looping.
+type refreshTransport struct {
+	base http.RoundTripper
+	// refresh re-resolves the token (reads the credentials file for the bound
+	// host). nil when the token is fixed (flag/env) and must not be re-read.
+	refresh func() string
+
+	mu    sync.RWMutex
+	token string // best-known current token (starts at the startup token)
+}
+
+func (t *refreshTransport) current() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.token
+}
+
+func (t *refreshTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Send our best-known token. After a refresh this is fresher than the value
+	// the go-terrapod client re-sets from its startup token on every request, so
+	// subsequent calls succeed on the first attempt instead of 401→refresh→retry.
+	// Clone first — a RoundTripper must not mutate the caller's request.
+	first := req.Clone(req.Context())
+	if cur := t.current(); cur != "" {
+		first.Header.Set("Authorization", "Bearer "+cur)
+	}
+	resp, err := t.base.RoundTrip(first)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized || t.refresh == nil {
+		return resp, err
+	}
+
+	fresh := t.refresh()
+	if fresh == "" || fresh == t.current() {
+		return resp, err // no newer token to try — surface the 401
+	}
+
+	// Build a replayable retry. A body is only safe to resend when net/http gave
+	// us a GetBody (it does for the bytes.Reader bodies go-terrapod sends).
+	retry := req.Clone(req.Context())
+	if req.Body != nil {
+		if req.GetBody == nil {
+			return resp, err
+		}
+		body, gErr := req.GetBody()
+		if gErr != nil {
+			return resp, err
+		}
+		retry.Body = body
+	}
+	retry.Header.Set("Authorization", "Bearer "+fresh)
+
+	_ = resp.Body.Close() // discard the 401 so the connection can be reused
+	t.mu.Lock()
+	t.token = fresh
+	t.mu.Unlock()
+	return t.base.RoundTrip(retry)
+}
+
+// newHTTPClient builds the http.Client go-terrapod uses, wrapping its transport
+// with token-refresh-on-401 (issue #880). When refreshable is true the token is
+// re-read from the credentials file for host on a 401; when false (explicit
+// --token / $TERRAPOD_TOKEN) the token is pinned. skipTLSVerify mirrors what
+// go-terrapod would do for a self-signed dev instance (go-terrapod ignores its
+// own SkipTLSVerify once an HTTPClient is injected, so we set it here).
+func newHTTPClient(host, token string, refreshable, skipTLSVerify bool) *http.Client {
+	base := &http.Transport{
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS13}, //nolint:gosec
+	}
+	if skipTLSVerify {
+		base.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec
+	}
+	rt := &refreshTransport{base: base, token: token}
+	if refreshable {
+		rt.refresh = func() string { return tokenFromCredentialsFile(host) }
+	}
+	return &http.Client{Transport: rt, Timeout: 30 * time.Second}
+}

--- a/mcp/internal/mcpserver/transport_test.go
+++ b/mcp/internal/mcpserver/transport_test.go
@@ -1,0 +1,145 @@
+package mcpserver
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// A file-sourced token that has rotated: the first (stale) call 401s, the MCP
+// re-reads the credentials file, and the retry with the fresh token succeeds —
+// no reconnect needed (issue #880).
+func TestRefreshTransportRetriesOn401WithFreshToken(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Header.Get("Authorization") != "Bearer new" { // server only accepts the fresh token
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rt := &refreshTransport{base: http.DefaultTransport, token: "old", refresh: func() string { return "new" }}
+	client := &http.Client{Transport: rt}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer old") // what the go-terrapod client sets from its startup token
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want 200 after refresh+retry", resp.StatusCode)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("calls=%d, want 2 (stale 401 + fresh retry)", got)
+	}
+	if rt.current() != "new" {
+		t.Fatalf("cached token=%q, want new", rt.current())
+	}
+
+	// Subsequent requests use the cached fresh token on the FIRST attempt, even
+	// though the client keeps setting the stale startup token.
+	calls.Store(0)
+	req2, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req2.Header.Set("Authorization", "Bearer old")
+	resp2, err := client.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want 200", resp2.StatusCode)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls=%d, want 1 (proactive fresh token, no re-401)", got)
+	}
+}
+
+// A POST body is replayed on the retry (net/http gives GetBody for the
+// bytes/strings readers go-terrapod sends).
+func TestRefreshTransportReplaysBodyOnRetry(t *testing.T) {
+	var gotBody atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer new" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		gotBody.Store(string(b))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rt := &refreshTransport{base: http.DefaultTransport, token: "old", refresh: func() string { return "new" }}
+	client := &http.Client{Transport: rt}
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(`{"payload":1}`))
+	req.Header.Set("Authorization", "Bearer old")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+	if got, _ := gotBody.Load().(string); got != `{"payload":1}` {
+		t.Fatalf("retry body=%q, want the original payload replayed", got)
+	}
+}
+
+// An explicit token (--token / $TERRAPOD_TOKEN → refresh == nil) is never
+// re-read: a genuinely-bad explicit token surfaces its 401 immediately.
+func TestRefreshTransportFixedTokenDoesNotRetry(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	rt := &refreshTransport{base: http.DefaultTransport, token: "bad", refresh: nil}
+	client := &http.Client{Transport: rt}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status=%d, want 401 passthrough", resp.StatusCode)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls=%d, want 1 (no retry for a fixed token)", got)
+	}
+}
+
+// When the re-resolved token is unchanged (the file hasn't actually rotated),
+// don't loop — surface the 401 once.
+func TestRefreshTransportNoRetryWhenTokenUnchanged(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	rt := &refreshTransport{base: http.DefaultTransport, token: "same", refresh: func() string { return "same" }}
+	client := &http.Client{Transport: rt}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls=%d, want 1 (no retry when re-resolved token is unchanged)", got)
+	}
+}


### PR DESCRIPTION
Fixes #880.

## Problem

`terrapod-mcp` resolved the API token **once at startup** and reused it for the life of the process. When the token expired and the operator refreshed it with `tofu login <host>` (or edited the credentials file), the running server kept sending the stale token and every tool call failed with `Invalid or expired token` — until the MCP was reconnected — even though the file already held a valid token.

## Fix

Inject an `http.Client` (via go-terrapod's `Options.HTTPClient`) whose transport:
- on a **401**, re-resolves the token from the credentials file and **retries the request once** with the fresh token;
- **proactively** uses the refreshed token on subsequent requests, so there's no repeated `401 → refresh → retry` round-trip after a rotation;
- only refreshes a **file-sourced** token — an explicit `--token` / `$TERRAPOD_TOKEN` is static, so a genuinely-bad explicit token surfaces its 401 immediately (no loop);
- **replays request bodies** via `net/http`'s `GetBody`, so POST/PATCH/DELETE tools retry safely.

The whole change lives in the MCP layer — **no go-terrapod surface change**, so no SDK contract impact.

## Tests

`transport_test.go` covers: refresh-on-401 succeeds; the refreshed token is reused proactively (no second 401); POST body replayed on retry; fixed (`--token`) token never retries; unchanged re-resolved token does not loop.

## Operator note

After this lands + a release, the local `~/go/bin/terrapod-mcp` needs the usual post-release rebuild to pick it up; from then on a `tofu login` refresh is honoured live without reconnecting the MCP.