### PR TITLE
feat(871): workspace state-cost API + go-terrapod method

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3319,6 +3319,98 @@ The raw D2 query results + the import-only verdict (JSON object; non-JSON or non
 
 > **Import run is always plan-only:** the confirmed import step is a gated, **import-only** run (plan-only) through the normal run gate — never an auto-apply.
 
+## Cost Estimation
+
+Terrapod estimates the monthly cost of Terraform/OpenTofu-managed infrastructure using a **native, pure-Python reader engine that is compatible with — and consumes the published pricesheet of — [OpenInfraQuote](https://github.com/terrateamio/openinfraquote) (oiq, by Terrateam, MPL-2.0)**. Terrapod ships **no binary and shells out to nothing**; it downloads oiq's `prices.csv` and matches plan/state resources against it. The pricing data and matcher/pricer design are OpenInfraQuote's; Terrapod credits them wherever cost is shown.
+
+Every figure returned here is **data** (oiq-derived) — no AI is involved. (An optional AI *enhancement* — narrative + savings advisories — is a separate surface that rides the plan-analysis AI switch and is always flagged distinctly; it never blends into these authoritative numbers.)
+
+Cost estimation is **on by default** (Helm: `api.config.cost_estimation.enabled`, default `true`); when disabled the endpoints below return `404`. The pricesheet is a **pull-through cache** (mirrored into object storage on demand, no schedule) — air-gapped deployments pre-seed the cached object or point `cost_estimation.prices_url` at an internal mirror. `cost_estimation.default_region` is only the fallback for a resource whose region can't be resolved from its own attributes or provider config (region is resolved **per resource**).
+
+There are two cost views: a **run** view (the monthly cost *delta* a plan introduces) and a **workspace** view (the *current* monthly cost of the workspace's managed infrastructure, priced from its latest state version).
+
+### Show Run Cost Estimate
+
+```
+GET /api/terrapod/v1/runs/{run_id}/cost-estimate
+```
+
+Requires `run:read` on the run's workspace. Returns the runner-produced estimate of the plan's monthly cost delta (`404` when the run produced no estimate — errored before plan, cost estimation disabled, or the artifact aged out).
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "cost-estimate-<run-uuid>",
+    "type": "cost-estimates",
+    "attributes": {
+      "currency": "USD",
+      "total": { "min": 219.0, "max": 219.0 },
+      "previous": { "min": 73.0, "max": 73.0 },
+      "diff": { "min": 146.0, "max": 146.0 },
+      "resources": [
+        { "address": "aws_instance.eu", "type": "aws_instance", "name": "eu", "change": "add", "monthly": { "min": 146.0, "max": 146.0 } }
+      ],
+      "unpriced": [ { "address": "random_pet.name", "type": "random_pet", "change": "add" } ]
+    },
+    "relationships": { "run": { "data": { "id": "run-<uuid>", "type": "runs" } } }
+  }
+}
+```
+
+| Attribute | Description |
+|---|---|
+| `currency` | Pricesheet currency (typically `USD`). |
+| `total` | Projected monthly spend of the planned state (min/max range). |
+| `previous` | Projected monthly spend of the prior state (`total − diff`). |
+| `diff` | Monthly delta this run introduces (adds positive, removes negative). |
+| `resources[]` | Per-resource cost; `change` is `add` / `remove` / `noop`. |
+| `unpriced[]` | Resources nothing in the pricesheet matched (unmapped/free type, or a provider the data doesn't cover). |
+
+### Show Workspace Cost Estimate
+
+```
+GET /api/terrapod/v1/workspaces/{id}/cost-estimate
+```
+
+Requires `state:read` on the workspace (the estimate is derived server-side from the secret-bearing state blob, though only non-sensitive aggregates are returned). Runs the workspace's **latest state version** through the cost engine to report the current monthly cost of its managed infrastructure — the state analogue of the run delta above. Because state carries no change, every resource is a `noop`, `diff` is zero, and `total` is the current monthly spend.
+
+A workspace with **no state yet** (or a state-version row whose bytes haven't landed / were swept) returns a zeroed estimate with `state-version: null` rather than an error. `503` when no pricesheet is available (upstream fetch failed and nothing is cached).
+
+**Response:**
+```json
+{
+  "data": {
+    "id": "workspace-cost-<workspace-uuid>",
+    "type": "workspace-cost-estimates",
+    "attributes": {
+      "currency": "USD",
+      "total": { "min": 292.0, "max": 292.0 },
+      "previous": { "min": 292.0, "max": 292.0 },
+      "diff": { "min": 0.0, "max": 0.0 },
+      "resources": [
+        { "address": "aws_instance.web", "type": "aws_instance", "name": "web", "change": "noop", "monthly": { "min": 73.0, "max": 73.0 } }
+      ],
+      "unpriced": [],
+      "state-version": { "id": "sv-<uuid>", "serial": 7, "created-at": "2026-01-01T00:00:00Z" }
+    },
+    "relationships": { "workspace": { "data": { "id": "ws-<uuid>", "type": "workspaces" } } }
+  }
+}
+```
+
+The attributes match the run estimate, plus `state-version` naming the priced version (`null` when the workspace has no state).
+
+### Pricesheet (runner + admin)
+
+```
+GET  /api/terrapod/v1/cost-estimation/pricesheet             # 302 → presigned cached CSV (any authenticated caller; consumed by runner Jobs)
+GET  /api/terrapod/v1/cost-estimation/pricesheet/status      # admin: enabled + cached?
+POST /api/terrapod/v1/cost-estimation/pricesheet/refresh     # admin: force re-fetch from upstream
+```
+
+The download endpoint is pull-through: a cold or stale cache is fetched from `cost_estimation.prices_url` on demand, and a stale copy is served if a refresh fails (a transient upstream outage never breaks a run). `404` when cost estimation is disabled or nothing is cached; the returned presigned URL needs no auth. `refresh` returns `502` on an upstream/decompress failure.
+
 ## Service Catalog
 
 No-code self-service provisioning over the private module registry. A *catalog item* blesses a registry module; provisioning it creates an agent-mode, non-VCS, catalog-managed workspace whose configuration is a server-generated wrapper. See [Service Catalog](service-catalog.md) for the full feature doc.

--- a/go-terrapod/cost_estimate.go
+++ b/go-terrapod/cost_estimate.go
@@ -93,3 +93,74 @@ func (c *Client) GetRunCostEstimate(ctx context.Context, runID string) (*CostEst
 	}
 	return e, nil
 }
+
+// CostStateVersion identifies the state version a workspace cost estimate was
+// derived from. Nil on a WorkspaceCostEstimate when the workspace has no state.
+type CostStateVersion struct {
+	ID        string `json:"id"`     // prefixed "sv-<uuid>"
+	Serial    int    `json:"serial"`
+	CreatedAt string `json:"created-at"`
+}
+
+// WorkspaceCostEstimate is the native OpenInfraQuote-port estimate of a
+// workspace's CURRENT managed infrastructure, derived server-side from its
+// latest Terraform state (#871). It is the state analogue of CostEstimate's
+// plan-delta view: Total is the current projected monthly spend, Diff is zero
+// (state carries no change), and every resource is a "noop".
+//
+// Every figure is DATA (oiq-derived) — no AI involved. Credit: pricing data +
+// matcher/pricer design are OpenInfraQuote's (by Terrateam).
+type WorkspaceCostEstimate struct {
+	// WorkspaceID is the bare workspace UUID (the "ws-" prefix is stripped),
+	// resolved from the `workspace` relationship.
+	WorkspaceID string             `json:"-"`
+	Currency    string             `json:"currency"`
+	Total       CostRange          `json:"total"`
+	Previous    CostRange          `json:"previous"`
+	Diff        CostRange          `json:"diff"`
+	Resources   []CostResource     `json:"resources"`
+	Unpriced    []UnpricedResource `json:"unpriced"`
+	// StateVersion names the priced state version; nil when the workspace has
+	// no state yet (Total is zero in that case).
+	StateVersion *CostStateVersion `json:"state-version"`
+}
+
+// GetWorkspaceCostEstimate fetches the current managed-infrastructure cost
+// estimate for a workspace, computed from its latest state version.
+//
+// workspaceID accepts either a bare workspace UUID or the prefixed "ws-<uuid>"
+// form. A workspace with no state returns a zeroed estimate with a nil
+// StateVersion (not an error). Returns *NotFoundError when cost estimation is
+// disabled globally.
+func (c *Client) GetWorkspaceCostEstimate(ctx context.Context, workspaceID string) (*WorkspaceCostEstimate, error) {
+	if workspaceID == "" {
+		return nil, errors.New("workspace id is required")
+	}
+	id := workspaceID
+	if len(id) < 3 || id[:3] != "ws-" {
+		id = "ws-" + id
+	}
+	data, err := c.Get(ctx, "/api/terrapod/v1/workspaces/"+url.PathEscape(id)+"/cost-estimate")
+	if err != nil {
+		return nil, err
+	}
+	res, err := ParseResource(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse workspace cost estimate response: %w", err)
+	}
+	e := &WorkspaceCostEstimate{WorkspaceID: strings.TrimPrefix(GetRelationshipID(res, "workspace"), "ws-")}
+	for key, dst := range map[string]any{
+		"currency":      &e.Currency,
+		"total":         &e.Total,
+		"previous":      &e.Previous,
+		"diff":          &e.Diff,
+		"resources":     &e.Resources,
+		"unpriced":      &e.Unpriced,
+		"state-version": &e.StateVersion,
+	} {
+		if raw, ok := res.Attributes[key]; ok {
+			_ = json.Unmarshal(raw, dst)
+		}
+	}
+	return e, nil
+}

--- a/go-terrapod/cost_estimate_test.go
+++ b/go-terrapod/cost_estimate_test.go
@@ -81,3 +81,76 @@ func TestGetRunCostEstimateEmptyID(t *testing.T) {
 		t.Fatal("want error for empty run id")
 	}
 }
+
+const workspaceCostBody = `{"data":{"id":"workspace-cost-ws1","type":"workspace-cost-estimates",
+  "attributes":{
+    "currency":"USD",
+    "total":{"min":292.0,"max":292.0},
+    "previous":{"min":292.0,"max":292.0},
+    "diff":{"min":0.0,"max":0.0},
+    "resources":[
+      {"address":"aws_instance.web","type":"aws_instance","name":"web","change":"noop","monthly":{"min":73.0,"max":73.0}},
+      {"address":"aws_db_instance.main","type":"aws_db_instance","name":"main","change":"noop","monthly":{"min":219.0,"max":219.0}}
+    ],
+    "unpriced":[
+      {"address":"random_pet.name","type":"random_pet","change":"noop"}
+    ],
+    "state-version":{"id":"sv-xyz","serial":7,"created-at":"2026-07-20T09:00:00Z"}
+  },
+  "relationships":{"workspace":{"data":{"id":"ws-ws1","type":"workspaces"}}}}}`
+
+const workspaceCostEmptyBody = `{"data":{"id":"workspace-cost-ws1","type":"workspace-cost-estimates",
+  "attributes":{
+    "currency":"USD",
+    "total":{"min":0.0,"max":0.0},
+    "previous":{"min":0.0,"max":0.0},
+    "diff":{"min":0.0,"max":0.0},
+    "resources":[],
+    "unpriced":[],
+    "state-version":null
+  },
+  "relationships":{"workspace":{"data":{"id":"ws-ws1","type":"workspaces"}}}}}`
+
+func TestGetWorkspaceCostEstimate(t *testing.T) {
+	c := newCostEstimateFixture(t, http.StatusOK, workspaceCostBody)
+	e, err := c.GetWorkspaceCostEstimate(t.Context(), "ws1") // bare UUID → "ws-ws1"
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.WorkspaceID != "ws1" {
+		t.Errorf("WorkspaceID = %q, want ws1 (prefix stripped)", e.WorkspaceID)
+	}
+	if e.Total.Max != 292.0 || e.Diff.Max != 0.0 {
+		t.Errorf("ranges not decoded: total=%+v diff=%+v", e.Total, e.Diff)
+	}
+	if len(e.Resources) != 2 || len(e.Unpriced) != 1 {
+		t.Fatalf("resources=%d unpriced=%d, want 2/1", len(e.Resources), len(e.Unpriced))
+	}
+	if e.Resources[0].Change != "noop" {
+		t.Errorf("state resources must be noop, got %q", e.Resources[0].Change)
+	}
+	if e.StateVersion == nil || e.StateVersion.ID != "sv-xyz" || e.StateVersion.Serial != 7 {
+		t.Errorf("state-version not decoded: %+v", e.StateVersion)
+	}
+}
+
+func TestGetWorkspaceCostEstimateNoState(t *testing.T) {
+	c := newCostEstimateFixture(t, http.StatusOK, workspaceCostEmptyBody)
+	e, err := c.GetWorkspaceCostEstimate(t.Context(), "ws-ws1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.StateVersion != nil {
+		t.Errorf("want nil StateVersion for a workspace with no state, got %+v", e.StateVersion)
+	}
+	if e.Total.Max != 0.0 || len(e.Resources) != 0 {
+		t.Errorf("want zeroed empty estimate, got total=%+v resources=%d", e.Total, len(e.Resources))
+	}
+}
+
+func TestGetWorkspaceCostEstimateEmptyID(t *testing.T) {
+	c := newCostEstimateFixture(t, http.StatusOK, workspaceCostBody)
+	if _, err := c.GetWorkspaceCostEstimate(t.Context(), ""); err == nil {
+		t.Fatal("want error for empty workspace id")
+	}
+}

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -82,6 +82,9 @@ field CostResource.Change string `json:"change"`
 field CostResource.Monthly CostRange `json:"monthly"`
 field CostResource.Name string `json:"name"`
 field CostResource.Type string `json:"type"`
+field CostStateVersion.CreatedAt string `json:"created-at"`
+field CostStateVersion.ID string `json:"id"`
+field CostStateVersion.Serial int `json:"serial"`
 field CreateAPITokenRequest.Description string
 field CreateAPITokenRequest.Kind string
 field CreateAPITokenRequest.LifespanHours int64
@@ -788,6 +791,14 @@ field Workspace.WorkingDirectory string `json:"working-directory,omitempty"`
 field WorkspaceChange.Diff map[string]any `json:"diff,omitempty"`
 field WorkspaceChange.ID string `json:"id"`
 field WorkspaceChange.Name string `json:"name"`
+field WorkspaceCostEstimate.Currency string `json:"currency"`
+field WorkspaceCostEstimate.Diff CostRange `json:"diff"`
+field WorkspaceCostEstimate.Previous CostRange `json:"previous"`
+field WorkspaceCostEstimate.Resources []CostResource `json:"resources"`
+field WorkspaceCostEstimate.StateVersion *CostStateVersion `json:"state-version"`
+field WorkspaceCostEstimate.Total CostRange `json:"total"`
+field WorkspaceCostEstimate.Unpriced []UnpricedResource `json:"unpriced"`
+field WorkspaceCostEstimate.WorkspaceID string `json:"-"`
 field WorkspaceFilter.AgentPoolID string `json:"agent_pool_id,omitempty"`
 field WorkspaceFilter.All bool `json:"all,omitempty"`
 field WorkspaceFilter.DriftStatus string `json:"drift_status,omitempty"`
@@ -944,6 +955,7 @@ method (*Client) GetVariableSet(ctx context.Context, id string) (*VariableSet, e
 method (*Client) GetVarsetVariable(ctx context.Context, varsetID, varID string) (*VariableSetVariable, error)
 method (*Client) GetWorkspace(ctx context.Context, id string) (*Workspace, error)
 method (*Client) GetWorkspaceByName(ctx context.Context, name string) (*Workspace, error)
+method (*Client) GetWorkspaceCostEstimate(ctx context.Context, workspaceID string) (*WorkspaceCostEstimate, error)
 method (*Client) IsWorkspaceAssignedToExecutionHook(ctx context.Context, hookID, workspaceID string) (bool, error)
 method (*Client) IsWorkspaceAssignedToVarset(ctx context.Context, varsetID, workspaceID string) (bool, error)
 method (*Client) ListAgentPoolTokens(ctx context.Context, poolID string) ([]AgentPoolToken, error)
@@ -1054,6 +1066,7 @@ type ConflictError struct
 type CostEstimate struct
 type CostRange struct
 type CostResource struct
+type CostStateVersion struct
 type CreateAPITokenRequest struct
 type CreateAgentPoolRequest struct
 type CreateAgentPoolTokenRequest struct
@@ -1158,6 +1171,7 @@ type WarmProviderEntry struct
 type WarmResult struct
 type Workspace struct
 type WorkspaceChange struct
+type WorkspaceCostEstimate struct
 type WorkspaceFilter struct
 type WorkspaceList struct
 type WorkspaceListOptions struct

--- a/services/terrapod/api/routers/cost_estimation.py
+++ b/services/terrapod/api/routers/cost_estimation.py
@@ -11,12 +11,14 @@ Cost estimates are powered by OpenInfraQuote
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import RedirectResponse
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from fastapi.responses import JSONResponse, RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user, require_admin
 from terrapod.config import settings
-from terrapod.services import cost_pricesheet_service
+from terrapod.db.session import get_db
+from terrapod.services import cost_pricesheet_service, workspace_cost_service
 from terrapod.storage import get_storage
 from terrapod.storage.protocol import ObjectStore
 
@@ -44,6 +46,47 @@ async def download_pricesheet(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_CACHED_DETAIL)
     url = await cost_pricesheet_service.pricesheet_download_url(storage)
     return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
+
+
+@router.get("/workspaces/{workspace_id}/cost-estimate")
+async def show_workspace_cost_estimate(
+    workspace_id: str = Path(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Current monthly cost of a workspace's managed infrastructure (#871).
+
+    Terrapod-native. Runs the workspace's latest state version through the native
+    OpenInfraQuote-port cost engine server-side and returns the estimate — the
+    *state* analogue of the run Cost tab's plan-*delta* estimate. Same
+    ``currency/total/previous/diff/resources/unpriced`` shape, plus a
+    ``state-version`` meta naming the priced version (null when the workspace has
+    no state yet). Every figure is **data** (`oiq`-derived); no AI is involved.
+    Gated on ``state:read`` (the estimate derives from the state blob). 404 when
+    cost estimation is disabled; 503 when no pricesheet is available.
+    """
+    if not settings.cost_estimation.enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_DISABLED_DETAIL)
+    try:
+        attrs = await workspace_cost_service.estimate_workspace_cost(db, user, workspace_id)
+    except workspace_cost_service.PricesheetUnavailable as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
+
+    ws_short = workspace_id.removeprefix("ws-")
+    return JSONResponse(
+        content={
+            "data": {
+                "id": f"workspace-cost-{ws_short}",
+                "type": "workspace-cost-estimates",
+                "attributes": attrs,
+                "relationships": {
+                    "workspace": {"data": {"id": f"ws-{ws_short}", "type": "workspaces"}},
+                },
+            }
+        }
+    )
 
 
 @router.get("/cost-estimation/pricesheet/status")

--- a/services/terrapod/services/cost_pricesheet_service.py
+++ b/services/terrapod/services/cost_pricesheet_service.py
@@ -175,3 +175,31 @@ async def pricesheet_download_url(storage: ObjectStore) -> str:
 def pricesheet_stream(storage: ObjectStore) -> AsyncIterator[bytes]:
     """Stream the cached pricesheet's bytes (for the API state/workspace path)."""
     return storage.get_stream(cost_pricesheet_key())
+
+
+def _safe_unlink(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+async def download_cached_to_file(storage: ObjectStore) -> str:
+    """Stream the cached pricesheet CSV to a PVC tempfile; return its path.
+
+    For the API's state/workspace cost path: the native engine reads the sheet
+    as a local text file, and it's ~20 MB decompressed, so it lands on the
+    attached PVC (rule 14), streamed off the event loop (rule 13). The caller
+    owns the returned path and MUST unlink it. Raises ``ObjectNotFoundError`` if
+    no sheet is cached (call :func:`ensure_pricesheet` first).
+    """
+    tmpdir = _resolve_ephemeral_tmpdir()
+    fd, path = await asyncio.to_thread(tempfile.mkstemp, suffix=".csv", dir=tmpdir)
+    await asyncio.to_thread(os.close, fd)
+    try:
+        async for chunk in storage.get_stream(cost_pricesheet_key()):
+            await asyncio.to_thread(_append_chunk, path, chunk)
+    except BaseException:
+        await asyncio.to_thread(_safe_unlink, path)
+        raise
+    return path

--- a/services/terrapod/services/workspace_cost_service.py
+++ b/services/terrapod/services/workspace_cost_service.py
@@ -1,0 +1,156 @@
+"""Workspace state-cost service (#871).
+
+Prices a workspace's **current managed infrastructure** by running its latest
+Terraform state through the native OpenInfraQuote-port cost engine
+(:mod:`terrapod.services.cost`) — the state analogue of the runner's plan-cost
+phase (:mod:`terrapod.runner.phases.cost`), which prices a plan *delta*. This
+powers the workspace cost card (current monthly managed-infra cost).
+
+Gated on ``state:read`` (the same as the state graph): the estimate is derived
+from the secret-bearing state blob, even though only non-sensitive aggregates
+(resource addresses, types, monthly cost) are returned. The heavy work — state
+decrypt + parse, and streaming a ~200k-row pricesheet — runs via
+``asyncio.to_thread`` (rule 13); the pricesheet lands on the attached PVC, never
+``/tmp`` (rule 14). A workspace with no state yet is a normal condition, not an
+error: it returns a zeroed estimate with ``state_version = None``.
+
+Credit: the pricing data and matcher/pricer design are OpenInfraQuote's (by
+Terrateam); Terrapod ships a native reader engine and consumes their prices.csv.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
+from terrapod.config import settings
+from terrapod.db.models import StateVersion, Workspace
+from terrapod.services import cost_pricesheet_service
+from terrapod.services.workspace_rbac_service import resolve_workspace_capabilities_for
+from terrapod.storage import get_storage
+from terrapod.storage.keys import state_key
+
+logger = structlog.get_logger(__name__)
+
+
+class PricesheetUnavailable(Exception):
+    """No cost pricesheet is cached and an on-demand fetch failed."""
+
+
+def _rfc3339(dt) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _empty_attrs(state_version: dict | None = None) -> dict[str, Any]:
+    """A well-formed, zeroed estimate — used when the workspace has no state."""
+    zero = {"min": 0.0, "max": 0.0}
+    return {
+        "currency": "USD",
+        "total": dict(zero),
+        "previous": dict(zero),
+        "diff": dict(zero),
+        "resources": [],
+        "unpriced": [],
+        "state-version": state_version,
+    }
+
+
+def _run_engine(state_bytes: bytes, pricesheet_path: str, default_region: str) -> dict[str, Any]:
+    """Parse state + run the cost engine (sync — called via ``to_thread``)."""
+    from terrapod.services.cost import estimate
+
+    tf_json = json.loads(state_bytes)
+    with open(pricesheet_path) as sheet:
+        result = estimate(tf_json, sheet, default_region=default_region)
+    return result.to_dict()
+
+
+async def estimate_workspace_cost(db: AsyncSession, user, workspace_id: str) -> dict[str, Any]:
+    """Estimate the current monthly cost of a workspace's managed infrastructure.
+
+    Resolves the workspace, enforces ``state:read``, runs its latest state
+    version through the cost engine, and returns the estimate attributes (the
+    same ``currency/total/previous/diff/resources/unpriced`` shape the run cost
+    tab uses, plus a ``state-version`` meta identifying the priced version).
+
+    A workspace with no state (or a state-version row whose bytes haven't landed
+    or were swept) returns a zeroed estimate with ``state-version = None`` rather
+    than erroring. Raises :class:`PricesheetUnavailable` when no pricesheet is
+    cached and an on-demand refresh fails, and ``HTTPException(403)`` when the
+    caller lacks ``state:read``.
+    """
+    from terrapod.api.routers.tfe_v2 import _get_workspace_by_id
+
+    ws: Workspace = await _get_workspace_by_id(workspace_id, db)
+
+    caps = await resolve_workspace_capabilities_for(db, user, ws)
+    if not has_capability(caps, cap.STATE_READ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Requires state:read permission on workspace",
+        )
+
+    sv = (
+        await db.execute(
+            select(StateVersion)
+            .where(StateVersion.workspace_id == ws.id)
+            .order_by(StateVersion.serial.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    # No state yet, or a version row written before its /content PUT landed.
+    if sv is None or sv.state_size == 0:
+        return _empty_attrs(None)
+
+    sv_meta = {
+        "id": f"sv-{sv.id}",
+        "serial": sv.serial,
+        "created-at": _rfc3339(sv.created_at),
+    }
+
+    storage = get_storage()
+    try:
+        raw = await storage.get(state_key(str(ws.id), str(sv.id)))
+    except Exception:  # noqa: BLE001 - metadata row without a backing object
+        logger.warning("workspace_cost_state_blob_missing", state_version_id=str(sv.id))
+        return _empty_attrs(sv_meta)
+
+    from terrapod.crypto.state import decrypt_state_bytes
+
+    state_bytes = await decrypt_state_bytes(raw)
+
+    # A cold/stale cache is fetched on demand here (pull-through); a total
+    # failure with nothing cached is surfaced honestly rather than silently
+    # pricing everything as $0.
+    if not await cost_pricesheet_service.ensure_pricesheet(storage):
+        raise PricesheetUnavailable(
+            "Cost pricesheet is not available (upstream fetch failed and nothing cached)"
+        )
+
+    pricesheet_path = await cost_pricesheet_service.download_cached_to_file(storage)
+    try:
+        default_region = settings.cost_estimation.default_region
+        attrs = await asyncio.to_thread(_run_engine, state_bytes, pricesheet_path, default_region)
+    finally:
+        await asyncio.to_thread(cost_pricesheet_service._safe_unlink, pricesheet_path)
+
+    attrs["state-version"] = sv_meta
+    logger.info(
+        "workspace_cost_estimated",
+        workspace_id=str(ws.id),
+        state_version_id=str(sv.id),
+        currency=attrs.get("currency"),
+        monthly_max=round(attrs.get("total", {}).get("max", 0.0), 2),
+        priced=len(attrs.get("resources", [])),
+        unpriced=len(attrs.get("unpriced", [])),
+    )
+    return attrs

--- a/services/tests/api/api_route_contract.json
+++ b/services/tests/api/api_route_contract.json
@@ -131,6 +131,7 @@
   "GET /api/terrapod/v1/vcs-connections",
   "GET /api/terrapod/v1/vcs-connections/{connection_id}",
   "GET /api/terrapod/v1/workspace-events",
+  "GET /api/terrapod/v1/workspaces/{workspace_id}/cost-estimate",
   "GET /api/terrapod/v1/workspaces/{workspace_id}/notification-configurations",
   "GET /api/terrapod/v1/workspaces/{workspace_id}/onboarding-sessions",
   "GET /api/terrapod/v1/workspaces/{workspace_id}/remote-state-consumers ?filter_type",

--- a/services/tests/api/test_cost_estimation.py
+++ b/services/tests/api/test_cost_estimation.py
@@ -19,7 +19,9 @@ _AUTH = {"Authorization": "Bearer dummy"}
 _DL = "/api/terrapod/v1/cost-estimation/pricesheet"
 _STATUS = "/api/terrapod/v1/cost-estimation/pricesheet/status"
 _REFRESH = "/api/terrapod/v1/cost-estimation/pricesheet/refresh"
+_WS_COST = "/api/terrapod/v1/workspaces/ws-abc123/cost-estimate"
 _SVC = "terrapod.services.cost_pricesheet_service"
+_WSVC = "terrapod.services.workspace_cost_service"
 
 
 def _user(roles=None):
@@ -124,3 +126,78 @@ class TestAdminSurfaces:
             with patch.object(settings.cost_estimation, "enabled", True):
                 resp = await c.post(_REFRESH, headers=_AUTH)
         assert resp.status_code == 502
+
+
+@patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+@patch("terrapod.api.app.init_redis")
+@patch("terrapod.api.app.init_db")
+class TestWorkspaceCostEstimate:
+    """The workspace state-cost endpoint (#871) — the RBAC + engine work lives
+    in workspace_cost_service (unit-tested separately); the router is thin."""
+
+    async def test_disabled_returns_404(self, *mocks):
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            with patch.object(settings.cost_estimation, "enabled", False):
+                resp = await c.get(_WS_COST, headers=_AUTH)
+        assert resp.status_code == 404
+
+    @patch(f"{_WSVC}.estimate_workspace_cost", new_callable=AsyncMock)
+    async def test_happy_path(self, mock_estimate, *mocks):
+        mock_estimate.return_value = {
+            "currency": "USD",
+            "total": {"min": 292.0, "max": 292.0},
+            "previous": {"min": 292.0, "max": 292.0},
+            "diff": {"min": 0.0, "max": 0.0},
+            "resources": [
+                {
+                    "address": "aws_instance.web",
+                    "type": "aws_instance",
+                    "name": "web",
+                    "change": "noop",
+                    "monthly": {"min": 73.0, "max": 73.0},
+                }
+            ],
+            "unpriced": [],
+            "state-version": {"id": "sv-xyz", "serial": 7, "created-at": "2026-07-20T09:00:00Z"},
+        }
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            with patch.object(settings.cost_estimation, "enabled", True):
+                resp = await c.get(_WS_COST, headers=_AUTH)
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["type"] == "workspace-cost-estimates"
+        assert data["id"] == "workspace-cost-abc123"
+        assert data["relationships"]["workspace"]["data"]["id"] == "ws-abc123"
+        assert data["attributes"]["total"]["max"] == 292.0
+        assert data["attributes"]["state-version"]["serial"] == 7
+
+    @patch(f"{_WSVC}.estimate_workspace_cost", new_callable=AsyncMock)
+    async def test_no_state_returns_zeroed_estimate(self, mock_estimate, *mocks):
+        mock_estimate.return_value = {
+            "currency": "USD",
+            "total": {"min": 0.0, "max": 0.0},
+            "previous": {"min": 0.0, "max": 0.0},
+            "diff": {"min": 0.0, "max": 0.0},
+            "resources": [],
+            "unpriced": [],
+            "state-version": None,
+        }
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            with patch.object(settings.cost_estimation, "enabled", True):
+                resp = await c.get(_WS_COST, headers=_AUTH)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attributes"]["state-version"] is None
+
+    @patch(f"{_WSVC}.estimate_workspace_cost", new_callable=AsyncMock)
+    async def test_pricesheet_unavailable_returns_503(self, mock_estimate, *mocks):
+        from terrapod.services.workspace_cost_service import PricesheetUnavailable
+
+        mock_estimate.side_effect = PricesheetUnavailable("no sheet")
+        app = _make_app(_user(roles=["everyone"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            with patch.object(settings.cost_estimation, "enabled", True):
+                resp = await c.get(_WS_COST, headers=_AUTH)
+        assert resp.status_code == 503

--- a/services/tests/services/test_workspace_cost_service.py
+++ b/services/tests/services/test_workspace_cost_service.py
@@ -1,0 +1,174 @@
+"""Tests for workspace_cost_service — workspace state-cost path (#871).
+
+The cost engine itself is covered by test_cost_engine.py; here we exercise the
+service's orchestration: the state:read gate, the no-state / missing-blob empty
+paths, the pricesheet-unavailable failure, and that the priced result carries
+the state-version meta. The engine call is mocked (don't test past the layer).
+"""
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from terrapod.auth import capabilities as cap
+from terrapod.services import workspace_cost_service as svc
+
+WS = uuid.uuid4()
+SV = uuid.uuid4()
+
+_ENGINE_RESULT = {
+    "currency": "USD",
+    "total": {"min": 292.0, "max": 292.0},
+    "previous": {"min": 292.0, "max": 292.0},
+    "diff": {"min": 0.0, "max": 0.0},
+    "resources": [
+        {
+            "address": "aws_instance.web",
+            "type": "aws_instance",
+            "name": "web",
+            "change": "noop",
+            "monthly": {"min": 73.0, "max": 73.0},
+        }
+    ],
+    "unpriced": [{"address": "random_pet.name", "type": "random_pet", "change": "noop"}],
+}
+
+
+def _ws():
+    return SimpleNamespace(id=WS, name="prod", owner_email="o@x.io", labels={})
+
+
+def _sv(state_size=1234):
+    return SimpleNamespace(
+        id=SV,
+        workspace_id=WS,
+        serial=7,
+        state_size=state_size,
+        created_at=datetime(2026, 7, 20, 9, 0, 0, tzinfo=UTC),
+    )
+
+
+def _db_returning(sv):
+    """AsyncMock db whose single execute(...).scalar_one_or_none() yields sv."""
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=sv)))
+    return db
+
+
+def _user():
+    return SimpleNamespace(email="u@x.io", roles=["everyone"])
+
+
+def _patches(caps, sv, *, state_bytes=b"{}", engine=_ENGINE_RESULT):
+    """Stack the service's collaborators; caller supplies caps + state version."""
+    storage = AsyncMock()
+    storage.get = AsyncMock(return_value=state_bytes)
+    return [
+        patch("terrapod.api.routers.tfe_v2._get_workspace_by_id", AsyncMock(return_value=_ws())),
+        patch.object(svc, "resolve_workspace_capabilities_for", AsyncMock(return_value=caps)),
+        patch.object(svc, "get_storage", return_value=storage),
+        patch("terrapod.crypto.state.decrypt_state_bytes", AsyncMock(side_effect=lambda b: b)),
+        patch.object(
+            svc.cost_pricesheet_service, "ensure_pricesheet", AsyncMock(return_value=True)
+        ),
+        patch.object(
+            svc.cost_pricesheet_service,
+            "download_cached_to_file",
+            AsyncMock(return_value="/tmp/prices.csv"),
+        ),
+        patch.object(svc.cost_pricesheet_service, "_safe_unlink", MagicMock()),
+        patch.object(svc, "_run_engine", MagicMock(return_value=dict(engine))),
+    ]
+
+
+class _Ctx:
+    def __init__(self, patches):
+        self._patches = patches
+
+    def __enter__(self):
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patches:
+            p.stop()
+
+
+async def test_denied_without_state_read():
+    with _Ctx(_patches(frozenset(), _sv())):
+        with pytest.raises(HTTPException) as ei:
+            await svc.estimate_workspace_cost(_db_returning(_sv()), _user(), "ws-" + str(WS))
+    assert ei.value.status_code == 403
+
+
+async def test_no_state_returns_zeroed_empty():
+    with _Ctx(_patches(frozenset({cap.STATE_READ}), None)):
+        attrs = await svc.estimate_workspace_cost(_db_returning(None), _user(), str(WS))
+    assert attrs["state-version"] is None
+    assert attrs["total"] == {"min": 0.0, "max": 0.0}
+    assert attrs["resources"] == [] and attrs["unpriced"] == []
+
+
+async def test_unlanded_state_version_is_empty():
+    sv = _sv(state_size=0)
+    with _Ctx(_patches(frozenset({cap.STATE_READ}), sv)):
+        attrs = await svc.estimate_workspace_cost(_db_returning(sv), _user(), str(WS))
+    # A row that exists before its /content PUT landed → empty, not an error.
+    assert attrs["state-version"] is None
+    assert attrs["total"]["max"] == 0.0
+
+
+async def test_missing_blob_is_empty_with_sv_meta():
+    sv = _sv()
+    patches = _patches(frozenset({cap.STATE_READ}), sv)
+    # Override storage.get to raise (metadata row, no backing object).
+    storage = AsyncMock()
+    storage.get = AsyncMock(side_effect=RuntimeError("gone"))
+    patches[2] = patch.object(svc, "get_storage", return_value=storage)
+    with _Ctx(patches):
+        attrs = await svc.estimate_workspace_cost(_db_returning(sv), _user(), str(WS))
+    # Blob gone → zeroed, but the state-version meta is still surfaced.
+    assert attrs["state-version"]["id"] == f"sv-{SV}"
+    assert attrs["total"]["max"] == 0.0
+
+
+async def test_pricesheet_unavailable_raises():
+    sv = _sv()
+    patches = _patches(frozenset({cap.STATE_READ}), sv)
+    patches[4] = patch.object(
+        svc.cost_pricesheet_service, "ensure_pricesheet", AsyncMock(return_value=False)
+    )
+    with _Ctx(patches):
+        with pytest.raises(svc.PricesheetUnavailable):
+            await svc.estimate_workspace_cost(_db_returning(sv), _user(), str(WS))
+
+
+async def test_happy_path_prices_and_attaches_sv_meta():
+    sv = _sv()
+    with _Ctx(_patches(frozenset({cap.STATE_READ}), sv)):
+        attrs = await svc.estimate_workspace_cost(_db_returning(sv), _user(), str(WS))
+    assert attrs["total"]["max"] == 292.0
+    assert attrs["resources"][0]["change"] == "noop"
+    assert attrs["state-version"] == {
+        "id": f"sv-{SV}",
+        "serial": 7,
+        "created-at": "2026-07-20T09:00:00Z",
+    }
+
+
+async def test_pricesheet_tempfile_is_always_unlinked():
+    """The PVC pricesheet tempfile is cleaned up even when the engine raises."""
+    sv = _sv()
+    patches = _patches(frozenset({cap.STATE_READ}), sv)
+    unlink = MagicMock()
+    patches[6] = patch.object(svc.cost_pricesheet_service, "_safe_unlink", unlink)
+    patches[7] = patch.object(svc, "_run_engine", MagicMock(side_effect=ValueError("bad state")))
+    with _Ctx(patches):
+        with pytest.raises(ValueError):
+            await svc.estimate_workspace_cost(_db_returning(sv), _user(), str(WS))
+    unlink.assert_called_once_with("/tmp/prices.csv")


### PR DESCRIPTION
Part of #871 (cost estimation). The **workspace** counterpart to the run Cost tab: prices a workspace's *current* managed infrastructure from its latest state, where the run tab prices a plan's *delta*.

## What

`GET /api/terrapod/v1/workspaces/{id}/cost-estimate` — runs the workspace's latest state version through the native OpenInfraQuote-port cost engine **server-side** and returns the current monthly cost. Same `currency/total/previous/diff/resources/unpriced` shape as the run estimate (consumers reuse the types), plus a `state-version` meta naming the priced version. Because state carries no change, every resource is a `noop`, `diff` is zero, and `total` is the current monthly spend.

- **`workspace_cost_service.py`** — `state:read` gate (mirrors the state-graph service; the estimate derives from the secret-bearing blob, but only non-sensitive aggregates are returned), latest-state fetch + decrypt, engine run via `asyncio.to_thread` (rule 13). A workspace with **no state** (or an unlanded/swept blob) returns a zeroed estimate with `state-version: null` — a normal condition, not an error. `503` when no pricesheet is available.
- **`cost_pricesheet_service.download_cached_to_file`** — streams the cached ~20 MB pricesheet to a **PVC tempfile** for the API path (rule 14), off the event loop; caller unlinks (always, even on engine raise).
- **go-terrapod** `GetWorkspaceCostEstimate` + `WorkspaceCostEstimate` type, reusing the shared `CostRange`/`CostResource`/`UnpricedResource` shapes.
- **docs/api-reference.md** — new Cost Estimation section (run + workspace reads + pricesheet endpoints), crediting OpenInfraQuote.

Every figure is **data** (oiq-derived); no AI is involved.

## Contract

Additive route → route-contract snapshot regenerated (one line). No attribute/wire/config/migration snapshot change. All five contract gates pass.

## Tests

- **services** (`test_workspace_cost_service.py`): RBAC deny, no-state / unlanded / missing-blob → empty, pricesheet-unavailable → raise, happy path attaches state-version meta, PVC tempfile always unlinked (even on engine raise).
- **services-api** (`test_cost_estimation.py`): disabled → 404, happy, no-state, pricesheet-unavailable → 503.
- **go-terrapod** httptest: decode + noop assertion, no-state → nil StateVersion, empty-id error.

`make lint` + `make test` (contract gates + cost + api) green; go-terrapod `go test` green.

## Not in this PR (later #871 slices)

- Workspace **cost card** UI (needs visual review) + provider/MCP fan-out for cost.
- AI enhancement (rides the plan-analysis AI switch).
- Full feature-catalogue / llms.txt / getting-started (H-gate deliverable).