### PR TITLE
fix(884): stream /api/* through the BFF so large uploads work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,19 @@ Per-surface verification before you push (lint alone is **not** enough):
    Every feature — including SSE and streaming — must work through the full
    proxy chain. New SSE endpoints must be added to the `headers()` config in
    `web/next.config.js` with `Content-Encoding: none`, or SSE silently fails
-   through the BFF.
+   through the BFF. **The `/api/*` proxy MUST stream request bodies — it is a
+   Route Handler (`web/src/app/api/[...path]/route.ts`) that forwards
+   `request.body` unbuffered via `fetch(..., { duplex: 'half' })`, NOT Next.js
+   middleware.** Middleware buffers the whole request body and caps it at
+   `middlewareClientMaxBodySize` (10 MB), which silently truncates large uploads
+   (config-version tarballs, state blobs, provider binaries are tens–hundreds of
+   MB) and kills the proxied request with a `socket hang up` — a 500 with no run
+   ever created, and it defeats the API's careful direct-to-storage streaming
+   (rule 14 / #884). The route handler reads `process.env.API_URL` per request,
+   so it keeps runtime config too. The small-body prefixes (`/.well-known`,
+   `/oauth`, `/v1`) may stay on the middleware. Never raise the middleware body
+   cap as a "fix" — that still buffers the whole body in the web pod (OOM risk)
+   and doesn't stream.
 9. **Single organization (hard requirement)** — Terrapod does **not** support
    multiple organizations at any level. There is no `org_name` column
    anywhere. The literal organization name is always `default` — in code,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -110,6 +110,14 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
     },
     {
+      // #884: a >10MB upload must stream through the BFF proxy chain (the
+      // streaming Route Handler, not the body-capping middleware). Drives raw
+      // HTTP through BASE_URL, so no browser storageState is needed.
+      name: 'large-upload',
+      testMatch: 'large-upload.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
       name: 'estate',
       testMatch: 'estate.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },

--- a/e2e/tests/large-upload.spec.ts
+++ b/e2e/tests/large-upload.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Large config-version upload through the BFF (#884).
+ *
+ * Regression guard for the config-version upload path. Uploads (config-version
+ * tarballs, state blobs, provider binaries) flow client → BFF → API, and the
+ * API streams them straight to object storage. The bug: the BFF proxied /api/*
+ * via Next.js *middleware*, which buffers the request body and caps it at
+ * `middlewareClientMaxBodySize` (10 MB). Any upload over that was truncated and
+ * the proxied PUT died with a `socket hang up` → 500 → no run ever created, so
+ * CLI-driven runs were impossible for any real repo (a monorepo config slug is
+ * tens of MB once modules are bundled).
+ *
+ * The fix moves the /api/* proxy to a streaming Route Handler
+ * (web/src/app/api/[...path]/route.ts) that forwards `request.body` unbuffered.
+ * This spec proves it end-to-end through the REAL BFF proxy chain: a body
+ * comfortably over the old 10 MB cap must upload with a 200 and the CV must
+ * actually reach `uploaded` (bytes landed, not truncated). It would fail on the
+ * pre-fix middleware and passes on the route handler.
+ *
+ * The upload PUT MUST target BASE_URL (the BFF web tier), not API_URL — routing
+ * it straight at the API would bypass exactly the layer under test.
+ */
+import { test, expect } from '@playwright/test'
+import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000'
+const API_URL = process.env.API_URL || 'http://localhost:8000'
+
+test.describe('Large upload through BFF', () => {
+  test('a >10MB config tarball uploads through the BFF (not capped/buffered)', async () => {
+    const token = getStoredToken()
+    const wsId = await createWorkspace(token, uniqueName('e2e-bigupload'))
+
+    // Create a configuration version (small request — API-direct setup is fine).
+    const cvRes = await fetch(`${API_URL}/api/v2/workspaces/${wsId}/configuration-versions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/vnd.api+json',
+      },
+      body: JSON.stringify({
+        data: {
+          type: 'configuration-versions',
+          attributes: { 'auto-queue-runs': false, speculative: true },
+        },
+      }),
+    })
+    expect(cvRes.status).toBe(201)
+    const cvId = (await cvRes.json()).data.id as string
+
+    // 12 MB — deliberately over the old 10 MB middleware body cap. The upload
+    // endpoint doesn't parse the tarball (that happens at run time), so opaque
+    // bytes are a valid body: it only needs to be non-empty and land whole.
+    const body = Buffer.alloc(12 * 1024 * 1024, 7)
+
+    // THROUGH THE BFF (BASE_URL) — the layer under test.
+    const upRes = await fetch(`${BASE_URL}/api/v2/configuration-versions/${cvId}/upload`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body,
+    })
+    expect(upRes.status).toBe(200)
+
+    // The CV actually reached `uploaded` — proves the full body landed in
+    // storage, not a truncated first 10 MB.
+    const showRes = await fetch(`${API_URL}/api/v2/configuration-versions/${cvId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(showRes.status).toBe(200)
+    expect((await showRes.json()).data.attributes.status).toBe('uploaded')
+  })
+})

--- a/web/src/app/api/[...path]/route.ts
+++ b/web/src/app/api/[...path]/route.ts
@@ -1,0 +1,125 @@
+// Streaming BFF proxy for /api/* (issue #884).
+//
+// The BFF forwards every /api/* request to the API service. This MUST stream
+// the request body — it must never buffer it. Config-version tarballs, state
+// blobs, and provider binaries are tens to hundreds of MB, and the API is
+// carefully written to stream them straight to object storage (rule 14). If the
+// BFF buffers first, that streaming is defeated.
+//
+// Why a Route Handler and not middleware: Next.js middleware buffers the whole
+// request body and caps it at `middlewareClientMaxBodySize` (10 MB default), so
+// any upload over that silently truncates and the proxied request dies with a
+// `socket hang up` (a 500 the client sees as "error connecting to the cloud
+// backend", with no run ever created). A Route Handler has no such cap: it
+// reads `request.body` as a ReadableStream and forwards it with fetch's
+// `duplex: 'half'`, so bytes flow client → BFF → API → storage without ever
+// being fully held in the web pod's memory.
+//
+// Why not `next.config` rewrites (which also stream): those bake the
+// destination at build time, so the Helm-injected runtime `API_URL` is ignored
+// (#47 — the reason the proxy moved to middleware in the first place). A Route
+// Handler reads `process.env.API_URL` per request, so it gets BOTH runtime
+// config AND streaming — the two properties #47 and #884 each needed.
+//
+// SSE responses (…/events) stream back the same way: we return the upstream
+// `Response.body` stream unbuffered. The `Content-Encoding: none` headers in
+// next.config.js still apply by path and keep Next from gzip-buffering them.
+
+import { type NextRequest } from 'next/server'
+
+// Force dynamic + Node runtime: this is a per-request proxy, never statically
+// optimised, and streaming request bodies via fetch needs the Node runtime.
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+// Hop-by-hop / framing headers we must not forward verbatim — undici sets the
+// host and manages transfer framing itself; forwarding a stale content-length
+// alongside a streamed body desyncs the upstream request.
+const STRIP_REQUEST_HEADERS = new Set([
+  'host',
+  'connection',
+  'keep-alive',
+  'proxy-connection',
+  'transfer-encoding',
+  'upgrade',
+  'content-length',
+  'expect',
+])
+
+// Response framing headers undici/Next re-derive for the streamed body.
+const STRIP_RESPONSE_HEADERS = new Set([
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+])
+
+function apiBase(): string {
+  // Read at request time so the Helm-injected env var is respected (#47).
+  return process.env.API_URL || 'http://localhost:8001'
+}
+
+async function proxy(request: NextRequest): Promise<Response> {
+  const incoming = new URL(request.url)
+  const target = new URL(apiBase())
+  target.pathname = incoming.pathname
+  target.search = incoming.search
+
+  const headers = new Headers()
+  request.headers.forEach((value, key) => {
+    if (!STRIP_REQUEST_HEADERS.has(key.toLowerCase())) {
+      headers.set(key, value)
+    }
+  })
+
+  const method = request.method.toUpperCase()
+  const hasBody = method !== 'GET' && method !== 'HEAD'
+
+  const init: RequestInit & { duplex?: 'half' } = {
+    method,
+    headers,
+    redirect: 'manual',
+    cache: 'no-store',
+    signal: request.signal,
+  }
+  if (hasBody) {
+    // Stream the request body straight through — never buffer it. `duplex:
+    // 'half'` is required to send a streaming body with fetch (Node/undici).
+    init.body = request.body
+    init.duplex = 'half'
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(target, init)
+  } catch (err) {
+    // Client aborts surface as an AbortError — that's not a proxy failure.
+    if (err instanceof Error && err.name === 'AbortError') {
+      return new Response(null, { status: 499 }) // client closed request
+    }
+    return new Response('Bad Gateway', { status: 502 })
+  }
+
+  const responseHeaders = new Headers()
+  upstream.headers.forEach((value, key) => {
+    if (!STRIP_RESPONSE_HEADERS.has(key.toLowerCase())) {
+      responseHeaders.set(key, value)
+    }
+  })
+
+  // Stream the upstream body back unbuffered (preserves SSE + large downloads).
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  })
+}
+
+export const GET = proxy
+export const POST = proxy
+export const PUT = proxy
+export const PATCH = proxy
+export const DELETE = proxy
+export const HEAD = proxy
+export const OPTIONS = proxy

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,6 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const PROXY_PREFIXES = ['/api/', '/.well-known/', '/oauth/', '/v1/']
+// `/api/*` is proxied by the streaming Route Handler at app/api/[...path]/
+// route.ts — NOT here. Middleware buffers the request body and caps it at
+// `middlewareClientMaxBodySize` (10 MB), which truncates large uploads
+// (config-version tarballs, state blobs, provider binaries) and breaks them
+// with a `socket hang up` (#884). The remaining prefixes only ever carry small
+// request bodies (service discovery, the OAuth token exchange, the registry
+// CLI protocol), so the middleware rewrite is fine for them. Both this
+// middleware and the route handler run inside the BFF (web) tier — all traffic
+// still flows client → BFF → API (rule 8); only the /api proxy mechanism
+// differs so it can stream.
+const PROXY_PREFIXES = ['/.well-known/', '/oauth/', '/v1/']
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -30,5 +40,7 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/api/:path*', '/.well-known/:path*', '/oauth/:path*', '/v1/:path*'],
+  // `/api/:path*` is intentionally absent — the streaming Route Handler owns it
+  // (see PROXY_PREFIXES note above). Keep the matcher in sync with it.
+  matcher: ['/.well-known/:path*', '/oauth/:path*', '/v1/:path*'],
 }


### PR DESCRIPTION
Closes #884.

## The bug

`terraform`/`tofu` runs against a real repo hang forever at *"Preparing the remote plan…"* and **no run is ever created** — CLI-driven runs are impossible for any workspace whose config slug is more than ~10 MB (a monorepo slug is tens of MB once `.terraform/modules` is bundled).

## Root cause (proven live, not theorised)

The original issue blamed filesystem `put_stream` throughput. **That was wrong.** Isolating each layer against an 18 MB slug in Tilt (1 web + 1 api):

| path | result |
|---|---|
| **through the BFF** | `500`, **0.6 MB/s**, 31 s |
| **direct to the API** | `200`, **109 MB/s**, **0.17 s** |

So it's **not** the API/storage (18 MB in 0.17 s even on the filesystem backend) and **not** pod-jump/multi-replica (reproduces at 1+1; prod is shared S3 anyway). The BFF proxies `/api/*` via **Next.js middleware**, which **buffers the request body and caps it at `middlewareClientMaxBodySize` (10 MB)**. The web pod logs it:

```
Request body exceeded 10MB … middlewareClientMaxBodySize
Failed to proxy … Error: socket hang up
```

Over 10 MB → truncated → `socket hang up` → 500 → no run. All traffic goes through the BFF, so this **defeats the API's careful direct-to-storage streaming** (rule 14). The proxy moved from `next.config` rewrites → middleware in `baab56e` to get the runtime `API_URL` (#47); that move introduced the cap.

## Fix

A **streaming Route Handler** (`web/src/app/api/[...path]/route.ts`) that:
- reads `process.env.API_URL` **per request** (keeps the #47 runtime-config fix), and
- forwards `request.body` **unbuffered** via `fetch(..., { duplex: 'half' })` — no buffer, no cap.

The middleware keeps the small-body prefixes (`/.well-known`, `/oauth`, `/v1`). **Still 100% through the BFF (rule 8)** — only the `/api` proxy mechanism changed. Raising the middleware cap was rejected: it still buffers the whole body in the web pod (OOM on hundreds-of-MB slugs) and doesn't stream.

## Verified live (Tilt, through the BFF)

| | before | after |
|---|---|---|
| 18 MB config upload | `500`, 0.6 MB/s, 31 s | **`200`, 48.7 MB/s, 0.39 s** |
| 150 MB upload | (fails) | **`200`, 87.8 MB/s, 1.79 s** |
| SSE (`workspace-events`) | streams | **still streams** (`content-encoding: none`) |
| small GETs / login | 200 | 200 |

## Tests / docs

- **E2E** (`large-upload.spec.ts`): a >10 MB body PUT **through the BFF** (`BASE_URL`) asserts `200` + CV `uploaded` — fails on the pre-fix middleware, passes on the route handler.
- **AGENTS.md** rule 8: the `/api` proxy MUST be a streaming route handler (not middleware); never raise the middleware cap as a "fix".
- `npm run build` passes (`ƒ /api/[...path]` dynamic route registered); tsc + eslint clean.

**No Python changed** — the API already streams correctly; the disproven filesystem-throughput "fix" from the issue is deliberately not made.