### PR TITLE
test(cost): differential-oracle CI job — native engine vs real oiq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,52 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/test.sh python -- ${{ matrix.slice.pytest_args }} ${{ matrix.slice.paths }}
 
+  # ── Cost Differential Oracle (#871) ───────────────────
+  # Correctness backstop for the native, OpenInfraQuote-compatible cost engine:
+  # run the REAL `oiq` binary over the committed plan/state corpus and assert
+  # our pure-Python engine agrees bit-exact on the SAME pricesheet. The binary
+  # lives ONLY here as an oracle — it is never shipped in any image (Terrapod
+  # carries no third-party cost binary; that's the whole point of the port).
+  # The engine is pure stdlib, so this needs no DB/Redis/S3 — just Python + the
+  # binary + a pricesheet. In the normal `make test` shards the same test file
+  # SKIPS (no OIQ_BINARY/OIQ_PRICESHEET set), so it is never double-run.
+  cost-differential:
+    name: Cost Differential
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    env:
+      # Pin the oracle binary version; bump deliberately (a new oiq could change
+      # pricing semantics — that's exactly what this job is here to catch).
+      OIQ_VERSION: v1.10.0
+      OIQ_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+      - run: pip install pytest
+      - name: Fetch the real oiq binary (oracle only — never shipped)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o oiq.tar.gz \
+            "https://github.com/terrateamio/openinfraquote/releases/download/${OIQ_VERSION}/oiq-linux-amd64-${OIQ_VERSION}.tar.gz"
+          tar xzf oiq.tar.gz
+          chmod +x oiq
+          ./oiq --version
+      - name: Fetch the published pricesheet (same sheet fed to both engines)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o prices.csv.gz https://oiq.terrateam.io/prices.csv.gz
+          gunzip -f prices.csv.gz
+          wc -l prices.csv
+      - name: Differential — native engine vs oiq
+        working-directory: services
+        env:
+          OIQ_BINARY: ${{ github.workspace }}/oiq
+          OIQ_PRICESHEET: ${{ github.workspace }}/prices.csv
+        run: PYTHONPATH=. python -m pytest tests/services/test_cost_differential.py -v
+
   # ── Migration smoke (#544) ────────────────────────────
   # The Python test tiers build the schema with `Base.metadata.create_all`, so
   # the migration files are never executed by any test. This one-shot job runs
@@ -2105,6 +2151,7 @@ jobs:
       - mcp-test
       - build-query
       - python-test
+      - cost-differential
       - migration-check
       - python-audit
       - npm-audit
@@ -2152,6 +2199,7 @@ jobs:
             "${{ needs.mcp-test.result }}"
             "${{ needs.build-query.result }}"
             "${{ needs.python-test.result }}"
+            "${{ needs.cost-differential.result }}"
             "${{ needs.migration-check.result }}"
             "${{ needs.python-audit.result }}"
             "${{ needs.npm-audit.result }}"

--- a/docs/cost-estimation.md
+++ b/docs/cost-estimation.md
@@ -46,6 +46,16 @@ Full request/response shapes are in the [API reference](api-reference.md#cost-es
 - **AI agents (MCP)** — the [`terrapod-mcp`](mcp.md) server exposes `terrapod_run_cost` and `terrapod_workspace_cost` read-only tools, so an agent can reason about the price of a change alongside its plan JSON.
 - **Go SDK** — [`go-terrapod`](terraform-provider.md) exposes `GetRunCostEstimate` and `GetWorkspaceCostEstimate`.
 
+## Correctness — proven against the real oiq
+
+The estimates are **deterministic data**, and Terrapod proves the ported engine
+is faithful: a CI **differential oracle** runs the genuine `oiq` binary over a
+committed plan/state corpus and asserts the native engine agrees bit-exact on
+the *same* pricesheet. Because the assertion is engine-agreement (not a fixed
+dollar figure), a daily pricesheet refresh moves both engines together and the
+test stays valid. The binary lives only in CI as the oracle — no third-party
+cost binary is ever shipped in a Terrapod image.
+
 ## AI enhancement (separate, optional)
 
 The figures above are always **authoritative oiq-derived data**. An optional AI *enhancement* — a plain-language narrative plus savings advisories (Savings Plans / reserved-instance / spot) — rides the existing [plan-analysis AI switch](ai-plan-summary.md) and renders alongside the data, always flagged distinctly. AI dollar figures are marked `source: ai-estimate` and are **never** blended into the authoritative total and never a gate. With AI disabled, only the data view is shown.

--- a/services/tests/services/cost_corpus/README.md
+++ b/services/tests/services/cost_corpus/README.md
@@ -1,0 +1,42 @@
+# Cost differential-oracle corpus
+
+`terraform show -json` plan/state fixtures fed to **both** the native cost
+engine (`terrapod.services.cost`) and the real `oiq` binary by
+[`../test_cost_differential.py`](../test_cost_differential.py). The oracle
+asserts the two agree bit-exact on the same pricesheet — the correctness
+backstop for the ported engine.
+
+## Hard invariant: every fixture is single-region
+
+The differential prices the whole corpus against **one** region (the
+`OIQ_REGION` env, default `us-east-1`). oiq prices a plan against a per-plan
+`--region` flag; Terrapod's engine resolves region **per resource** (a
+deliberate divergence — a plan can span regions, #871). To keep the oracle an
+apples-to-apples test of the shared matcher + pricer (not of Terrapod's
+region-resolution extension, which is unit-tested separately in
+`../test_cost_engine.py`):
+
+- **No fixture carries a per-resource region attribute** (`values.region`,
+  `values.location`) or a provider-config region. Region comes solely from the
+  flag/default, so both engines price identically.
+- A fixture that needs a non-default region prices the *whole* file in that
+  region; the test runs the corpus at one region per invocation.
+
+## What the corpus exercises
+
+| Fixture | Covers |
+|---|---|
+| `state_ec2_rds_ebs.json` | A multi-service **state** (current cost): EC2 (`Per_time`), RDS (`Per_time`), EBS gp3 (`Per_data` storage). Every resource priced, `diff` zero. |
+| `plan_add_remove_noop.json` | A **plan** with an add, a remove, and a noop — pins the `price`/`prev_price`/`price_diff` (total/previous/delta) semantics. |
+| `state_s3_lambda_iam.json` | Usage-driven pricing (S3, Lambda) **plus** an unpriced resource (`aws_iam_role`) that nothing in the pricesheet matches — exercises the unpriced bucket. |
+
+## Regenerating / adding a fixture
+
+1. Produce a `terraform show -json` of a plan or state (or hand-author one in
+   the shape above), scrubbing any real account IDs / names. Keep it
+   single-region (no region attrs).
+2. **Verify it agrees before committing** — run the fixture through both
+   engines on a real pricesheet and confirm the totals match. Only fixtures
+   that already agree belong here; a mismatch is a *native-engine bug to fix*,
+   never a fixture to tweak until it passes.
+3. The oracle picks up any `*.json` in this directory automatically.

--- a/services/tests/services/cost_corpus/plan_add_remove_noop.json
+++ b/services/tests/services/cost_corpus/plan_add_remove_noop.json
@@ -1,0 +1,46 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web",
+          "values": { "instance_type": "m5.large" }
+        },
+        {
+          "address": "aws_instance.new",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "new",
+          "values": { "instance_type": "m5.xlarge" }
+        }
+      ]
+    }
+  },
+  "prior_state": {
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_instance.web",
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "web",
+            "values": { "instance_type": "m5.large" }
+          },
+          {
+            "address": "aws_instance.old",
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "old",
+            "values": { "instance_type": "m5.large" }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/services/tests/services/cost_corpus/state_ec2_rds_ebs.json
+++ b/services/tests/services/cost_corpus/state_ec2_rds_ebs.json
@@ -1,0 +1,31 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.9.0",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web",
+          "values": { "instance_type": "m5.large" }
+        },
+        {
+          "address": "aws_db_instance.db",
+          "mode": "managed",
+          "type": "aws_db_instance",
+          "name": "db",
+          "values": { "instance_class": "db.t3.medium", "engine": "postgres", "multi_az": false }
+        },
+        {
+          "address": "aws_ebs_volume.data",
+          "mode": "managed",
+          "type": "aws_ebs_volume",
+          "name": "data",
+          "values": { "size": 100, "type": "gp3" }
+        }
+      ]
+    }
+  }
+}

--- a/services/tests/services/cost_corpus/state_s3_lambda_iam.json
+++ b/services/tests/services/cost_corpus/state_s3_lambda_iam.json
@@ -1,0 +1,31 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.9.0",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.assets",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "assets",
+          "values": { "bucket": "assets" }
+        },
+        {
+          "address": "aws_lambda_function.fn",
+          "mode": "managed",
+          "type": "aws_lambda_function",
+          "name": "fn",
+          "values": { "memory_size": 512, "architectures": ["x86_64"] }
+        },
+        {
+          "address": "aws_iam_role.r",
+          "mode": "managed",
+          "type": "aws_iam_role",
+          "name": "r",
+          "values": { "name": "r" }
+        }
+      ]
+    }
+  }
+}

--- a/services/tests/services/test_cost_differential.py
+++ b/services/tests/services/test_cost_differential.py
@@ -2,25 +2,33 @@
 
 This is the correctness backstop for the ported engine. It runs the genuine
 OpenInfraQuote binary over a plan/state corpus and asserts our native Python
-engine agrees within tolerance. **The binary is never shipped** — it lives only
-here, in CI, as an oracle: production carries no third-party cost binary.
+engine agrees bit-exact (within a cent of float noise). **The binary is never
+shipped** — it lives only here, in CI, as an oracle: production carries no
+third-party cost binary.
 
 The test skips unless both are available in the environment:
 
-* ``OIQ_BINARY``   — path to (or name on ``PATH`` of) the ``oiq`` executable.
+* ``OIQ_BINARY``    — path to (or name on ``PATH`` of) the ``oiq`` executable.
 * ``OIQ_PRICESHEET`` — path to a ``prices.csv`` for the binary to price against
-  (the same sheet is fed to the native engine).
+  (the *same* sheet is fed to the native engine, so the assertion is engine
+  agreement, not agreement with a fixed dollar figure — the corpus never pins
+  amounts, so a daily pricesheet refresh moves both engines together).
+* ``OIQ_REGION`` (optional, default ``us-east-1``) — the single region the
+  whole corpus is priced against. See ``cost_corpus/README.md``: oiq prices a
+  plan against a per-plan ``--region``, whereas Terrapod resolves region
+  per-resource, so the corpus is single-region to keep this an apples-to-apples
+  test of the shared matcher + pricer.
 
-The dedicated CI job sets both. Locally and in the default test container they
-are unset, so this skips — the hand-verified fixtures in ``test_cost_engine.py``
-cover the offline path. Corpus fixtures live under
-``services/tests/services/cost_corpus/`` (``*.json`` terraform show output);
-the directory is optional until the corpus lands.
+The dedicated CI job (``Cost Differential``) sets these. Locally and in the
+default test container they are unset, so this skips — the hand-verified
+fixtures in ``test_cost_engine.py`` cover the offline path.
 
-NOTE: the exact ``oiq`` CLI invocation + output shape is pinned by the CI job
-that first runs this against a real binary; the parsing below targets the
-documented ``match | price`` pipeline and fails loudly (not silently) if the
-observed shape differs, so the oracle can be corrected rather than rubber-stamp.
+The ``oiq`` invocation and JSON shape below were pinned against the real
+``oiq v1.10.0`` binary (``oiq match --pricesheet S FILE | oiq price
+--format json --region R``); ``price`` emits ``{price, prev_price,
+price_diff}`` each a ``{min, max}`` range plus a per-resource ``resources[]``.
+The parsing fails loudly (not silently) if a future ``oiq`` changes that shape,
+so the oracle can be corrected rather than rubber-stamp.
 """
 
 from __future__ import annotations
@@ -34,7 +42,8 @@ from pathlib import Path
 import pytest
 
 _CORPUS = Path(__file__).parent / "cost_corpus"
-_TOLERANCE = 0.01  # absolute USD tolerance on monthly min/max
+_TOLERANCE = 0.01  # absolute USD tolerance on monthly min/max (float noise only)
+_REGION = os.environ.get("OIQ_REGION", "us-east-1")
 
 
 def _oiq_binary() -> str | None:
@@ -59,38 +68,65 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _oiq_price(plan_path: Path) -> tuple[float, float]:
-    """Run ``oiq match | oiq price`` and return the monthly (min, max) total."""
+def _oiq_price(plan_path: Path) -> dict[str, tuple[float, float]]:
+    """Run ``oiq match | oiq price`` and return the total/prev/diff ranges.
+
+    Returns a dict of ``{"total"|"prev"|"diff": (min, max)}`` — the whole-plan
+    figures the native engine's ``CostEstimate`` mirrors.
+    """
     assert _BINARY and _PRICESHEET
-    match = subprocess.run(
+    matched = subprocess.run(
         [_BINARY, "match", "--pricesheet", _PRICESHEET, str(plan_path)],
         capture_output=True,
         text=True,
         check=True,
     )
     priced = subprocess.run(
-        [_BINARY, "price"],
-        input=match.stdout,
+        # --format json: the default is a human "summary"; --region: sugar for
+        # 'not region or region=R', pricing the plan in one region (see module
+        # docstring + corpus README on why the corpus is single-region).
+        [_BINARY, "price", "--format", "json", "--region", _REGION],
+        input=matched.stdout,
         capture_output=True,
         text=True,
         check=True,
     )
     data = json.loads(priced.stdout)
-    price = data["price"]
-    return (float(price["min"]), float(price["max"]))
+    # Fail loudly if the pinned shape ever drifts, rather than silently passing.
+    for key in ("price", "prev_price", "price_diff"):
+        if key not in data or "min" not in data[key] or "max" not in data[key]:
+            raise AssertionError(
+                f"oiq price JSON shape changed: missing {key}.min/max in {sorted(data)}"
+            )
+    return {
+        "total": (float(data["price"]["min"]), float(data["price"]["max"])),
+        "prev": (float(data["prev_price"]["min"]), float(data["prev_price"]["max"])),
+        "diff": (float(data["price_diff"]["min"]), float(data["price_diff"]["max"])),
+    }
 
 
 @pytest.mark.parametrize("plan_path", _corpus_files(), ids=lambda p: p.name)
 def test_native_engine_matches_oiq(plan_path: Path):
     from terrapod.services.cost import estimate
 
-    oiq_min, oiq_max = _oiq_price(plan_path)
+    oiq = _oiq_price(plan_path)
     with plan_path.open() as fp:
         tf_json = json.load(fp)
     with open(_PRICESHEET) as sheet:  # type: ignore[arg-type]
-        est = estimate(tf_json, sheet)
-    assert est.total_min == pytest.approx(oiq_min, abs=_TOLERANCE), plan_path.name
-    assert est.total_max == pytest.approx(oiq_max, abs=_TOLERANCE), plan_path.name
+        est = estimate(tf_json, sheet, default_region=_REGION)
+
+    native = {
+        "total": (est.total_min, est.total_max),
+        "prev": (est.prev_min, est.prev_max),
+        "diff": (est.diff_min, est.diff_max),
+    }
+    for field in ("total", "prev", "diff"):
+        assert native[field][0] == pytest.approx(oiq[field][0], abs=_TOLERANCE), (
+            f"{plan_path.name}: {field}.min native={native[field][0]} oiq={oiq[field][0]}"
+        )
+        assert native[field][1] == pytest.approx(oiq[field][1], abs=_TOLERANCE), (
+            f"{plan_path.name}: {field}.max native={native[field][1]} oiq={oiq[field][1]}"
+        )
 
 
 def test_corpus_present_when_oracle_enabled():


### PR DESCRIPTION
Part of #871. Delivers the correctness backstop that certifies the **deterministic** cost engine: without it we could not be sure the OpenInfraQuote port is faithful.

## What it does
A new **`Cost Differential`** CI job runs the genuine `oiq` binary (pinned `v1.10.0`) over a committed plan/state corpus and asserts the native pure-Python engine agrees **bit-exact on the same pricesheet**. The binary lives only in CI as an oracle — it is **never shipped** in any Terrapod image (the whole point of the port).

The assertion is *engine-agreement*, not a fixed dollar figure, so the daily pricesheet refresh moves both engines together and the test stays valid.

## Pinned against the real binary (not guessed)
The scaffold from #872 guessed the `oiq` invocation. I ran the real `oiq v1.10.0` to pin it:
- `oiq match --pricesheet S FILE | oiq price --format json --region R` — the scaffold omitted `--format json` (default is a human summary) and `--region`.
- `price` emits `{price, prev_price, price_diff}` (each `{min,max}`) + `resources[]`. The test now compares **total, prev, AND diff**, and fails loudly if that shape ever drifts.

## Corpus (all single-region by invariant)
`oiq` prices a plan against a per-plan `--region`; Terrapod resolves region **per-resource** (a deliberate #871 divergence, unit-tested separately). So the corpus holds region constant to keep the oracle apples-to-apples on the shared matcher+pricer:
- `state_ec2_rds_ebs.json` — multi-service state (`Per_time` + `Per_data`).
- `plan_add_remove_noop.json` — pins the plan total/prev/diff semantics.
- `state_s3_lambda_iam.json` — usage-driven pricing + an unpriced resource.

## Lean, no-double-run
The engine is pure stdlib, so the job needs no DB/Redis/S3 — `setup-python` + fetch oiq + pricesheet + pytest. Wired into `ci-pass`. In the normal `make test` shards the same file **skips** (no `OIQ_BINARY`/`OIQ_PRICESHEET`), so it never runs twice.

## Verified locally
Against the real `v1.10.0` binary + full published pricesheet: every fixture agrees exactly (EC2/RDS/EBS = **$130.64** on both engines; the add/remove/noop plan = **140.16 / 70.08 / 70.08** on both), across us-east-1 / eu-west-1 / ap-southeast-2. Skips cleanly in Docker without the env (4 skipped, 26 engine tests pass).