### PR TITLE
fix(cost): render run Cost tab + fix 2 semgrep FP suppressions

### DIFF
--- a/publish/internal/sign/sign_test.go
+++ b/publish/internal/sign/sign_test.go
@@ -102,8 +102,9 @@ func TestLoadPrivateKeyRejectsGarbage(t *testing.T) {
 	// prove LoadPrivateKey rejects bad armor. The secret scanner matches the
 	// marker text, not a real key (every real test key is generated at runtime
 	// via openpgp.NewEntity), so this is a false positive.
-	// nosemgrep: generic.secrets.security.detected-pgp-private-key-block
-	const malformedArmor = "-----BEGIN PGP PRIVATE KEY BLOCK-----\nnot base64\n-----END PGP PRIVATE KEY BLOCK-----\n"
+	// Full check-id (registry rules carry a doubled leaf; the single-id form did
+	// not match, so the suppression never took — GitHub code-scanning alert).
+	const malformedArmor = "-----BEGIN PGP PRIVATE KEY BLOCK-----\nnot base64\n-----END PGP PRIVATE KEY BLOCK-----\n" // nosemgrep: generic.secrets.security.detected-pgp-private-key-block.detected-pgp-private-key-block
 	if _, err := LoadPrivateKey(malformedArmor, ""); err == nil {
 		t.Fatal("expected error on malformed armor")
 	}

--- a/services/tests/services/test_cost_differential.py
+++ b/services/tests/services/test_cost_differential.py
@@ -75,7 +75,13 @@ def _oiq_price(plan_path: Path) -> dict[str, tuple[float, float]]:
     figures the native engine's ``CostEstimate`` mirrors.
     """
     assert _BINARY and _PRICESHEET
+    # nosemgrep (both calls): list-form (no shell=True → no shell injection),
+    # CI-only test running the oracle binary whose path/pricesheet come from the
+    # trusted CI job's own env, never an end user. The comment sits on the sink
+    # (subprocess.run) line — ruff-format-stable — with the full doubled check-id
+    # (registry rules carry a doubled leaf) so the suppression actually matches.
     matched = subprocess.run(
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
         [_BINARY, "match", "--pricesheet", _PRICESHEET, str(plan_path)],
         capture_output=True,
         text=True,
@@ -83,8 +89,9 @@ def _oiq_price(plan_path: Path) -> dict[str, tuple[float, float]]:
     )
     priced = subprocess.run(
         # --format json: the default is a human "summary"; --region: sugar for
-        # 'not region or region=R', pricing the plan in one region (see module
-        # docstring + corpus README on why the corpus is single-region).
+        # 'not region or region=R', pricing the plan in one region. The nosemgrep
+        # line must sit directly above the args (the finding line).
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
         [_BINARY, "price", "--format", "json", "--region", _REGION],
         input=matched.stdout,
         capture_output=True,

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -1313,6 +1313,10 @@ function RunDetailPageInner() {
             view; the tab only appears when the run produced a JSON plan. */}
         {view === 'impact' && <ImpactGraph runId={runId.replace(/^run-/, '')} />}
 
+        {/* Cost tab (#871) — data-only oiq monthly cost breakdown; the tab only
+            appears when the run produced a cost estimate (has-cost-estimate). */}
+        {view === 'cost' && <CostPanel runId={runId.replace(/^run-/, '')} />}
+
         {view === 'details' && (
         <>
         {/* Resource usage panel (#430) — peak memory/CPU alongside the


### PR DESCRIPTION
Closes #890 — clears the 4 open code-scanning alerts.

| Alert | Tool | What it was | Fix |
|---|---|---|---|
| #348 | CodeQL | `CostPanel` imported on the run page but **never rendered** — the run Cost tab showed nothing (regression from #882; the tab + import were there but no `view === 'cost'` block) | Add the render, mirroring the Impact tab + the workspace Cost tab (same component). |
| #347, #349 | Semgrep | `subprocess.run([...])` in the differential-oracle test flagged as tainted-env command injection — a false positive (list-form, no `shell=True`, CI-only, args from the trusted CI job env) | Standalone `nosemgrep` line directly above the args (the finding line; ruff-format-stable), full doubled check-id. |
| #346 | Semgrep | Test-fixture string `"not base64"` wrapped in PGP markers (no key material). Existing `nosemgrep` used the **single**-form rule id while the real check-id carries a **doubled leaf**, so it never matched | Corrected to the full doubled check-id. |

**Why E2E did not catch #348:** `e2e/tests/cost-tab.spec.ts` documents that the CI stack has no runner pool, so a seeded run never produces a cost estimate and the panel is unreachable in CI (verified on live Tilt, same as the Impact tab). CodeQL's unused-variable was the only automated signal — which is exactly why this alert mattered.

**Verified** (per "verify by running"): re-ran the real `semgrep 1.117` image → **0 findings** on both files (before/after `ruff format`); the differential test still passes vs the real `oiq` binary; `ruff format` leaves the test unchanged; `npm run build` + `i18n:lint` pass. The alerts auto-close on the next `main` SAST/CodeQL scan (no manual dismissal).