### PR TITLE
feat(cost): AI cost-narrative backend — data-first, gated, provenance-safe

### DIFF
--- a/alembic/versions/05af36ae12f9_cost_summaries.py
+++ b/alembic/versions/05af36ae12f9_cost_summaries.py
@@ -1,0 +1,59 @@
+"""cost_summaries: AI cost-narrative enhancement, one-to-one with runs (#871)
+
+Adds the ``cost_summaries`` table backing the optional AI *enhancement* of a
+run's cost estimate. It rides the plan-analysis AI switch (``ai_summary.enabled``
++ the per-workspace mode) and holds AI *polish* only — a plain-language
+narrative of the oiq-derived estimate plus optional savings advisories. It never
+holds, restates, or replaces the authoritative oiq figures (those stay in the
+``cost_estimate.json`` artifact + the ``runs`` cost columns); any dollar amount
+in ``advisories`` is an AI estimate tagged ``source: "ai-estimate"``.
+
+Stored separately from ``runs`` (same rationale as ``plan_summaries``): a
+per-run, some-deployments-only feature must not grow the column footprint of a
+large table, and the narrative text must not bloat cold reads. One-to-one with
+Run via a unique ``run_id``; CASCADE on run delete.
+
+Purely additive — a new table, no changes to existing tables, no backfill.
+
+Revision ID: 05af36ae12f9
+Revises: 238c16839feb
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "05af36ae12f9"
+down_revision = "238c16839feb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cost_summaries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("narrative", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "advisories",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column("model", sa.String(length=255), nullable=False, server_default=""),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_message", sa.Text(), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["run_id"], ["runs.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", name="uq_cost_summaries_run"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("cost_summaries")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -942,6 +942,8 @@ Returns the AI-generated plan summary (or failure analysis on errored plans) whe
 
 All five payloads carry `{run_id, workspace_id}` at minimum. The UI re-fetches the summary on any of them. For VCS-driven runs, the per-workspace PR/MR status comment is edited in place to include the summary content when it lands.
 
+The **AI cost narrative** (#871 — the optional enhancement over the data-only cost estimate, riding this same `ai_summary.enabled` switch + per-workspace mode) emits its own lifecycle events on the same per-workspace channel: `cost_summary_pending`, `cost_summary_ready`, `cost_summary_errored`, and `cost_summary_skipped` (workspace opted out / daily budget hit / no estimate). Each carries `{run_id, workspace_id}`. These are AI *polish* only — the authoritative figures stay on the data-only cost-estimate endpoint; every advisory dollar amount is tagged `source: "ai-estimate"`.
+
 ### Regenerate Plan Summary
 
 ```

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -289,6 +289,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             description="Summarise plan changes or analyse plan failures via LLM",
         )
 
+        # AI cost narrative (#871) — the optional enhancement over the
+        # deterministic oiq cost estimate. Rides this same switch.
+        from terrapod.services.cost_summariser import handle_ai_cost_summary
+
+        register_trigger_handler(
+            "ai_cost_summary",
+            handler=handle_ai_cost_summary,
+            description="Narrate a run's cost estimate + suggest savings via LLM",
+        )
+
     # Run reconciler (drives run state transitions based on Job outcomes)
     from terrapod.services.run_reconciler import reconcile_runs
 

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -476,6 +476,22 @@ async def upload_cost_estimate(
                 workspace_id=str(run.workspace_id),
             )
         await db.commit()
+        # AI cost narrative (#871) — enqueue the enhancement now that the
+        # estimate is in storage and the flag is committed. Rides the same
+        # switch as the plan summary; best-effort, deduped per run. The handler
+        # re-checks the flag + workspace mode, so a disabled workspace no-ops.
+        if settings.ai_summary.enabled:
+            try:
+                from terrapod.services.scheduler import enqueue_trigger
+
+                await enqueue_trigger(
+                    "ai_cost_summary",
+                    {"run_id": str(run.id)},
+                    dedup_key=f"aicost:{run.id}",
+                    dedup_ttl=300,
+                )
+            except Exception as e:
+                logger.debug("Failed to enqueue ai_cost_summary after upload", error=str(e))
         return Response(status_code=204)
     finally:
         try:

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -2228,6 +2228,66 @@ class PlanSummaryMessage(Base):
     )
 
 
+class CostSummary(Base):
+    """LLM-generated *enhancement* of a run's cost estimate (#871).
+
+    One-to-one with Run, keyed by (run_id). Rides the same switch as the
+    plan summary (``ai_summary.enabled`` + the per-workspace mode) and is
+    stored separately from ``runs`` for the same reasons ``plan_summaries``
+    is (footprint + cold-read bloat).
+
+    **Provenance is a hard invariant.** This row holds AI *polish* only —
+    a plain-language narrative of the oiq-derived cost estimate plus
+    optional savings *advisories* (Savings Plans / reserved / spot /
+    rightsizing). It NEVER holds, restates, or replaces the authoritative
+    oiq figures: those live in the ``cost_estimate.json`` artifact and the
+    ``runs`` cost columns, and are served by the data-only cost-estimate
+    endpoint. Any dollar amount an advisory carries is an AI *estimate*,
+    tagged ``source: "ai-estimate"`` in the ``advisories`` JSON, is never a
+    gate, and is always rendered distinctly from the data figures.
+
+    ``advisories`` is a list of ``{kind, title, detail, monthly_saving:
+    {min, max}, source}`` objects (``kind`` ∈ savings_plan / reserved /
+    spot / rightsizing / other; ``source`` is always ``"ai-estimate"``).
+
+    Status values mirror PlanSummary: pending / ready / skipped / errored.
+    The handler upserts on (run_id) so retries are idempotent and a
+    ``ready`` row is never overwritten by a later errored attempt.
+    """
+
+    __tablename__ = "cost_summaries"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=generate_uuid7
+    )
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+
+    # Model fields — populated when status == "ready"
+    narrative: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    advisories: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, default=list, nullable=False)
+
+    # Telemetry / debugging
+    model: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    error_message: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=now_utc, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=now_utc, onupdate=now_utc, nullable=False
+    )
+
+    __table_args__ = (sa.UniqueConstraint("run_id", name="uq_cost_summaries_run"),)
+
+
 # Onboarding session lifecycle (#824 P2). A session is workspace-scoped and
 # discovers existing, unmanaged cloud resources, then generates copy-pasteable
 # ``resource`` + ``import {}`` config. The stages map onto where each runs:

--- a/services/terrapod/services/cost_summariser.py
+++ b/services/terrapod/services/cost_summariser.py
@@ -1,0 +1,267 @@
+"""AI *enhancement* of a run's cost estimate (#871).
+
+This is the optional AI layer over the deterministic, oiq-derived cost estimate.
+It rides the SAME switch as the plan summary (``ai_summary.enabled`` + the
+per-workspace mode) and reuses the plan summariser's model plumbing — the
+LiteLLM tool-calling call (:func:`summariser._call_model`), the shared daily
+token budget, and the per-workspace run-events SSE channel.
+
+**Provenance is a hard invariant (the whole reason cost is data-first).** This
+service produces AI *polish* only — a plain-language narrative of the estimate
+plus optional savings advisories — stored in ``cost_summaries``. It NEVER
+computes, restates, or overrides the authoritative figures: those come from the
+runner-produced ``cost_estimate.json`` artifact (oiq-derived) and are served by
+the data-only ``/runs/{id}/cost-estimate`` endpoint. Every advisory dollar
+amount is stamped ``source: "ai-estimate"`` **server-side here**, regardless of
+what the model returns, and is never a gate.
+
+The only input fed to the model is the ``cost_estimate.json`` artifact — a
+derived, non-sensitive aggregate (resource addresses, types, monthly ranges).
+It deliberately does NOT read Terraform state or the plan JSON, so no sensitive
+value can leak through this path (asserted by ``TestCostNoStateLeakage``).
+
+Enqueued as an ``ai_cost_summary`` trigger when the runner uploads
+``cost_estimate.json`` (``run_artifacts.py``), only when the feature is globally
+enabled. Multi-replica safe: any replica runs the handler; the upsert is
+idempotent on ``run_id``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from terrapod.config import settings
+from terrapod.db.models import CostSummary, Run, Workspace, now_utc
+from terrapod.db.session import get_db_session
+from terrapod.logging_config import get_logger
+from terrapod.services.summariser import (
+    _budget_charge,
+    _budget_remaining,
+    _call_model,
+    _emit_summary_event,
+    _resolve_workspace_mode,
+)
+from terrapod.services.summariser_prompt import render_cost_prompt
+from terrapod.storage import get_storage
+from terrapod.storage.keys import cost_estimate_key
+from terrapod.storage.protocol import ObjectNotFoundError
+
+logger = get_logger(__name__)
+
+_VALID_ADVISORY_KINDS = {"savings_plan", "reserved", "spot", "rightsizing", "other"}
+
+
+async def _upsert_cost_summary(
+    db,
+    *,
+    run_id: uuid.UUID,
+    status: str,
+    narrative: str = "",
+    advisories: list[dict] | None = None,
+    model: str = "",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    error_message: str = "",
+) -> None:
+    """Idempotent upsert keyed on (run_id); never downgrades a 'ready' row.
+
+    Mirrors ``summariser._upsert_summary`` so a transient errored retry can't
+    clobber a good narrative.
+    """
+    existing = (
+        await db.execute(select(CostSummary).where(CostSummary.run_id == run_id))
+    ).scalar_one_or_none()
+    if existing is not None and existing.status == "ready" and status != "ready":
+        return
+
+    values = {
+        "id": uuid.uuid4(),
+        "run_id": run_id,
+        "status": status,
+        "narrative": narrative,
+        "advisories": advisories or [],
+        "model": model,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "error_message": error_message,
+        "updated_at": now_utc(),
+    }
+    stmt = pg_insert(CostSummary).values(**values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["run_id"],
+        set_={
+            "status": stmt.excluded.status,
+            "narrative": stmt.excluded.narrative,
+            "advisories": stmt.excluded.advisories,
+            "model": stmt.excluded.model,
+            "input_tokens": stmt.excluded.input_tokens,
+            "output_tokens": stmt.excluded.output_tokens,
+            "error_message": stmt.excluded.error_message,
+            "updated_at": stmt.excluded.updated_at,
+        },
+    )
+    await db.execute(stmt)
+
+
+def _normalise_advisories(raw: object) -> list[dict]:
+    """Coerce the model's advisories into the stored shape, stamping provenance.
+
+    Each advisory becomes ``{kind, title, detail, monthly_saving: {min, max} |
+    None, source: "ai-estimate"}``. ``source`` is forced here — the model can't
+    claim a computed figure. Malformed entries are dropped rather than trusted.
+    """
+    if not isinstance(raw, list):
+        return []
+    out: list[dict] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        kind = item.get("kind")
+        title = item.get("title")
+        detail = item.get("detail")
+        if (
+            kind not in _VALID_ADVISORY_KINDS
+            or not isinstance(title, str)
+            or not isinstance(detail, str)
+        ):
+            continue
+        lo = item.get("monthly_saving_min")
+        hi = item.get("monthly_saving_max")
+        saving = None
+        if isinstance(lo, int | float) and isinstance(hi, int | float):
+            saving = {"min": float(lo), "max": float(hi)}
+        out.append(
+            {
+                "kind": kind,
+                "title": title[:120],
+                "detail": detail[:600],
+                "monthly_saving": saving,
+                "source": "ai-estimate",  # HARD provenance — never trust the model
+            }
+        )
+    return out
+
+
+async def handle_ai_cost_summary(payload: dict) -> None:
+    """Triggered handler: generate the AI cost narrative for a run.
+
+    Payload: ``{"run_id": "<uuid>"}``. Enqueued when ``cost_estimate.json``
+    lands, only when ``ai_summary.enabled``. Every exit path settles the
+    ``cost_summaries`` row to a terminal state (ready / skipped / errored) and
+    emits the matching SSE event so the run-page Cost tab updates live.
+    """
+    cfg = settings.ai_summary
+    if not cfg.enabled:
+        return
+
+    try:
+        run_id = uuid.UUID(payload["run_id"])
+    except (KeyError, ValueError):
+        logger.warning("Invalid ai_cost_summary payload", payload=payload)
+        return
+
+    async with get_db_session() as db:
+        run = (await db.execute(select(Run).where(Run.id == run_id))).scalar_one_or_none()
+        if run is None or not run.has_cost_estimate:
+            return
+        ws = (
+            await db.execute(select(Workspace).where(Workspace.id == run.workspace_id))
+        ).scalar_one_or_none()
+        if ws is None:
+            return
+
+        # Per-workspace mode gate (global × workspace). OFF → record 'skipped'
+        # so the UI shows a deliberate skipped state, not a spinner.
+        if not _resolve_workspace_mode(ws):
+            await _upsert_cost_summary(db, run_id=run_id, status="skipped", model=cfg.model)
+            await db.commit()
+            await _emit_summary_event("cost_summary_skipped", ws.id, run_id)
+            return
+
+        await _upsert_cost_summary(db, run_id=run_id, status="pending", model=cfg.model)
+        await db.commit()
+        await _emit_summary_event("cost_summary_pending", ws.id, run_id)
+
+        # Budget gate — shared daily output-token budget with the plan summary.
+        remaining = await _budget_remaining()
+        if remaining is not None and remaining <= 0:
+            await _upsert_cost_summary(db, run_id=run_id, status="skipped", model=cfg.model)
+            await db.commit()
+            await _emit_summary_event("cost_summary_skipped", ws.id, run_id)
+            return
+
+        # Read the authoritative estimate — the ONLY model input (derived,
+        # non-sensitive; no state, no plan JSON).
+        storage = get_storage()
+        key = cost_estimate_key(str(run.workspace_id), str(run.id))
+        try:
+            raw = await storage.get(key)
+        except ObjectNotFoundError:
+            await _upsert_cost_summary(db, run_id=run_id, status="skipped", model=cfg.model)
+            await db.commit()
+            await _emit_summary_event("cost_summary_skipped", ws.id, run_id)
+            return
+        estimate_json = raw.decode() if isinstance(raw, bytes) else str(raw)
+
+        ctx = cfg.context
+        system_message, user_message = render_cost_prompt(
+            estimate_json=estimate_json,
+            fleet_context=ctx.fleet_context,
+            workspace_context=ws.ai_summary_context or "",
+            prompt_prefix=ctx.prompt_prefix,
+            prompt_suffix=ctx.prompt_suffix,
+            output_language=cfg.summary_language,
+        )
+
+        try:
+            args, input_tokens, output_tokens = await _call_model(
+                kind="cost_summary",
+                system_message=system_message,
+                user_message=user_message,
+                max_output_tokens=cfg.max_output_tokens,
+            )
+        except Exception as e:  # noqa: BLE001 — any model/HTTP/parse failure
+            logger.info("cost summary model call failed", run_id=str(run_id), error=str(e))
+            await _upsert_cost_summary(
+                db,
+                run_id=run_id,
+                status="errored",
+                model=cfg.model,
+                error_message=str(e)[:2000],
+            )
+            await db.commit()
+            await _emit_summary_event("cost_summary_errored", ws.id, run_id)
+            return
+
+        narrative = args.get("narrative") if isinstance(args, dict) else None
+        advisories = _normalise_advisories(
+            args.get("advisories") if isinstance(args, dict) else None
+        )
+        if not isinstance(narrative, str) or not narrative.strip():
+            await _upsert_cost_summary(
+                db,
+                run_id=run_id,
+                status="errored",
+                model=cfg.model,
+                error_message="model returned no narrative",
+            )
+            await db.commit()
+            await _emit_summary_event("cost_summary_errored", ws.id, run_id)
+            return
+
+        await _upsert_cost_summary(
+            db,
+            run_id=run_id,
+            status="ready",
+            narrative=narrative,
+            advisories=advisories,
+            model=cfg.model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+        await db.commit()
+        await _budget_charge(output_tokens)
+        await _emit_summary_event("cost_summary_ready", ws.id, run_id)

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -116,12 +116,91 @@ FAILURE_ANALYSIS_TOOL: dict = {
 }
 
 
+# --- Cost summary (#871) -----------------------------------------------------
+# The AI *enhancement* of a run's cost estimate: a plain-language narrative of
+# the (authoritative, oiq-derived) figures + optional savings advisories. HARD
+# provenance: the model is told never to restate/override the oiq total, and
+# every advisory dollar amount is an AI ESTIMATE (the API stamps
+# `source: "ai-estimate"` on each advisory server-side; the schema does not let
+# the model claim otherwise).
+COST_SUMMARY_JSON_SCHEMA: dict = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["narrative", "advisories"],
+    "properties": {
+        "narrative": {
+            "type": "string",
+            "description": (
+                "Plain-language explanation of the cost estimate: what drives "
+                "the monthly cost, which resources dominate, and how a change "
+                "moves the bill. Up to ~350 words. Refer to resources by their "
+                "terraform address. Do NOT restate the authoritative monthly "
+                "total as if you computed it — it is given to you and shown "
+                "separately; describe and contextualise it, never replace it. "
+                "No chain-of-thought, no preamble."
+            ),
+        },
+        "advisories": {
+            "type": "array",
+            "description": (
+                "Optional cost-savings suggestions, ordered biggest-impact "
+                "first. Empty array is fine when nothing obvious applies. Each "
+                "monthly_saving is YOUR ESTIMATE, not a computed figure."
+            ),
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["kind", "title", "detail"],
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "enum": [
+                            "savings_plan",
+                            "reserved",
+                            "spot",
+                            "rightsizing",
+                            "other",
+                        ],
+                    },
+                    "title": {"type": "string", "maxLength": 120},
+                    "detail": {"type": "string", "maxLength": 600},
+                    "monthly_saving_min": {
+                        "type": "number",
+                        "description": "Estimated low end of monthly saving (same currency).",
+                    },
+                    "monthly_saving_max": {
+                        "type": "number",
+                        "description": "Estimated high end of monthly saving (same currency).",
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+COST_SUMMARY_TOOL: dict = {
+    "type": "function",
+    "function": {
+        "name": "submit_cost_summary",
+        "description": (
+            "Submit the structured cost summary. Call this tool exactly once "
+            "with the narrative and any savings advisories. Never restate the "
+            "authoritative monthly total as your own computation."
+        ),
+        "parameters": COST_SUMMARY_JSON_SCHEMA,
+    },
+}
+
+
 def tool_for_kind(kind: str) -> dict:
     """Return the LiteLLM tool definition matching this summariser kind."""
     if kind == "plan_summary":
         return PLAN_SUMMARY_TOOL
     if kind == "failure_analysis":
         return FAILURE_ANALYSIS_TOOL
+    if kind == "cost_summary":
+        return COST_SUMMARY_TOOL
     raise ValueError(f"unknown summariser kind: {kind!r}")
 
 
@@ -536,6 +615,83 @@ def render_prompt(
 
     tool_name = "submit_plan_summary" if kind == "plan_summary" else "submit_failure_analysis"
     user_parts.append(f"Now call the `{tool_name}` tool exactly once with your structured answer.")
+
+    user_message = "\n\n".join(user_parts)
+    return system_message, user_message
+
+
+# --- Cost summary prompt (#871) ---------------------------------------------
+COST_SUMMARY_SKILL_PROMPT = """\
+You are a senior cloud FinOps reviewer. You are given an ALREADY-COMPUTED, \
+authoritative monthly cost estimate for a Terraform/OpenTofu plan (produced by \
+a deterministic pricing engine, OpenInfraQuote). Your job is to EXPLAIN and \
+CONTEXTUALISE it and, where obvious, suggest concrete savings — never to \
+recompute or override it.
+
+Hard rules:
+- The authoritative monthly total and every per-resource figure are DATA. They \
+are given to you and shown to the user separately. Describe them, group them, \
+explain what drives them — but never present a different total as if you \
+computed it, and never contradict the given figures.
+- Any monthly_saving you put on an advisory is YOUR ESTIMATE, not a computed \
+number. Keep advisories practical and specific to what is actually in the \
+plan (e.g. a long-lived on-demand instance → a Savings Plan / reserved \
+instance; a fault-tolerant batch workload → spot; an over-provisioned \
+instance class → rightsizing). Do not invent resources that are not present.
+- Be concise and factual. Refer to resources by their terraform address. No \
+chain-of-thought, no preamble, no restating these instructions.
+- If the estimate is trivial or nothing obvious can be saved, say so briefly \
+and return an empty advisories array.\
+"""
+
+
+def render_cost_prompt(
+    *,
+    estimate_json: str,
+    plan_json: str = "",
+    fleet_context: str = "",
+    workspace_context: str = "",
+    prompt_prefix: str = "",
+    prompt_suffix: str = "",
+    output_language: str = "",
+) -> tuple[str, str]:
+    """Render the (system, user) messages for the cost-summary request.
+
+    ``estimate_json`` is the authoritative oiq cost estimate (the
+    ``cost_estimate.json`` artifact body). ``plan_json`` is optional extra
+    context (the structured plan) — pass "" to omit it. The output contract is
+    the ``submit_cost_summary`` tool; provenance guardrails live in the skill
+    prompt above and are re-asserted server-side (advisories are stamped
+    ``source: "ai-estimate"`` regardless of what the model returns).
+    """
+    parts: list[str] = []
+    if prompt_prefix.strip():
+        parts.append(prompt_prefix.strip())
+    parts.append(COST_SUMMARY_SKILL_PROMPT)
+    if prompt_suffix.strip():
+        parts.append(prompt_suffix.strip())
+    if output_language.strip() and output_language.strip().lower() != "english":
+        parts.append(
+            f"OUTPUT_LANGUAGE: Write every natural-language field you emit — the "
+            f"narrative and each advisory's title and detail — in "
+            f"{output_language.strip()}. Keep all identifiers verbatim and "
+            f"untranslated: resource addresses, provider and module names, HCL "
+            f"keywords, CLI flags, file paths, currency codes, and anything "
+            f"inside backticks."
+        )
+    system_message = "\n\n".join(parts)
+
+    user_parts: list[str] = []
+    if fleet_context.strip():
+        user_parts.append(f"FLEET_CONTEXT:\n{fleet_context.strip()}")
+    if workspace_context.strip():
+        user_parts.append(f"WORKSPACE_CONTEXT:\n{workspace_context.strip()}")
+    user_parts.append(f"COST_ESTIMATE (authoritative, oiq-derived):\n```json\n{estimate_json}\n```")
+    if plan_json.strip():
+        user_parts.append(f"PLAN_JSON (context):\n```json\n{plan_json}\n```")
+    user_parts.append(
+        "Now call the `submit_cost_summary` tool exactly once with your structured answer."
+    )
 
     user_message = "\n\n".join(user_parts)
     return system_message, user_message

--- a/services/tests/services/test_cost_summariser.py
+++ b/services/tests/services/test_cost_summariser.py
@@ -1,0 +1,255 @@
+"""Tests for the AI cost-narrative enhancement (#871).
+
+Covers the two things that matter most for this feature:
+
+  * **Provenance** — advisories are always stamped ``source: "ai-estimate"``
+    server-side and the model can never smuggle a computed figure through
+    (``_normalise_advisories``).
+  * **No state leakage** — the cost summariser reads ONLY the derived,
+    non-sensitive ``cost_estimate.json`` artifact, never Terraform state or
+    the plan JSON. Pinned at module-source level (hard-invariant tier) so a
+    future "let the AI see the state too" change fails CI loudly.
+
+Plus the gating + happy-path behaviour of the trigger handler.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from terrapod.services import cost_summariser
+
+# ---------------------------------------------------------------------------
+# Provenance — the whole point of the data-first design
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseAdvisories:
+    def test_stamps_ai_estimate_source_always(self):
+        # Even if the model tries to claim a different source, we overwrite it.
+        out = cost_summariser._normalise_advisories(
+            [{"kind": "reserved", "title": "t", "detail": "d", "source": "computed"}]
+        )
+        assert len(out) == 1
+        assert out[0]["source"] == "ai-estimate"
+
+    def test_coerces_monthly_saving_range(self):
+        out = cost_summariser._normalise_advisories(
+            [
+                {
+                    "kind": "savings_plan",
+                    "title": "t",
+                    "detail": "d",
+                    "monthly_saving_min": 10,
+                    "monthly_saving_max": 25.5,
+                }
+            ]
+        )
+        assert out[0]["monthly_saving"] == {"min": 10.0, "max": 25.5}
+
+    def test_missing_saving_is_none(self):
+        out = cost_summariser._normalise_advisories([{"kind": "spot", "title": "t", "detail": "d"}])
+        assert out[0]["monthly_saving"] is None
+
+    def test_drops_invalid_kind_and_malformed(self):
+        out = cost_summariser._normalise_advisories(
+            [
+                {"kind": "not_a_kind", "title": "t", "detail": "d"},  # bad kind
+                {"kind": "rightsizing", "title": "t"},  # missing detail
+                {"kind": "other", "title": "t", "detail": "d"},  # valid
+                "garbage",  # not a dict
+            ]
+        )
+        assert [a["kind"] for a in out] == ["other"]
+
+    def test_non_list_returns_empty(self):
+        assert cost_summariser._normalise_advisories(None) == []
+        assert cost_summariser._normalise_advisories({"kind": "spot"}) == []
+
+    def test_truncates_long_fields(self):
+        out = cost_summariser._normalise_advisories(
+            [{"kind": "other", "title": "x" * 500, "detail": "y" * 1000}]
+        )
+        assert len(out[0]["title"]) == 120
+        assert len(out[0]["detail"]) == 600
+
+
+# ---------------------------------------------------------------------------
+# No state leakage — hard invariant (Code ↔ Tests contract)
+# ---------------------------------------------------------------------------
+
+
+class TestCostNoStateLeakage:
+    """The cost narrative MUST read only the derived cost estimate — never
+    Terraform state or the plan JSON (both can carry sensitive values).
+
+    Pinned at module-source level: any future change that pulls state or
+    plan JSON into the cost prompt fails CI here.
+    """
+
+    @staticmethod
+    def _source() -> str:
+        import inspect
+
+        return inspect.getsource(cost_summariser)
+
+    def test_reads_only_the_cost_estimate_artifact(self):
+        src = self._source()
+        assert "cost_estimate_key" in src, "cost summariser must read the cost estimate artifact"
+
+    def test_no_state_key_helpers(self):
+        src = self._source()
+        for helper in ("state_key", "state_index_key", "state_backup_key"):
+            assert helper not in src, f"cost summariser must not reference {helper!r}"
+
+    def test_no_state_version_or_plan_json_references(self):
+        src = self._source()
+        for name in (
+            "StateVersion",
+            "state_versions",
+            "state_version_id",
+            "json_output_key",  # the plan-JSON artifact key — not for cost
+            "before_sensitive",
+            "after_sensitive",
+        ):
+            assert name not in src, f"cost summariser must not reference {name!r}"
+
+
+# ---------------------------------------------------------------------------
+# Handler gating + happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_globally_is_noop():
+    with patch.object(cost_summariser.settings.ai_summary, "enabled", False):
+        with patch("terrapod.services.cost_summariser.get_db_session") as sess:
+            await cost_summariser.handle_ai_cost_summary({"run_id": str(uuid.uuid4())})
+            sess.assert_not_called()
+
+
+def _db_returning(run, ws):
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=ws)),
+        ]
+    )
+    db.commit = AsyncMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_ready_path_stamps_advisories_and_emits(monkeypatch):
+    run = MagicMock(id=uuid.uuid4(), workspace_id=uuid.uuid4(), has_cost_estimate=True)
+    ws = MagicMock(id=uuid.uuid4(), ai_summary_context="")
+    db = _db_returning(run, ws)
+
+    storage = MagicMock()
+    storage.get = AsyncMock(return_value=b'{"currency":"USD","total":{"min":73,"max":73}}')
+    upsert = AsyncMock()
+    emit = AsyncMock()
+    call_model = AsyncMock(
+        return_value=(
+            {
+                "narrative": "Roughly $73/mo, driven by aws_instance.web.",
+                "advisories": [
+                    {
+                        "kind": "reserved",
+                        "title": "RI the box",
+                        "detail": "d",
+                        "monthly_saving_min": 20,
+                        "monthly_saving_max": 30,
+                    },
+                ],
+            },
+            120,
+            60,
+        )
+    )
+
+    monkeypatch.setattr(cost_summariser.settings.ai_summary, "enabled", True)
+    with (
+        patch("terrapod.services.cost_summariser.get_db_session") as sess,
+        patch("terrapod.services.cost_summariser._resolve_workspace_mode", return_value=True),
+        patch("terrapod.services.cost_summariser._budget_remaining", AsyncMock(return_value=None)),
+        patch("terrapod.services.cost_summariser._budget_charge", AsyncMock()),
+        patch("terrapod.services.cost_summariser.get_storage", return_value=storage),
+        patch("terrapod.services.cost_summariser._call_model", call_model),
+        patch("terrapod.services.cost_summariser._upsert_cost_summary", upsert),
+        patch("terrapod.services.cost_summariser._emit_summary_event", emit),
+    ):
+        sess.return_value.__aenter__ = AsyncMock(return_value=db)
+        sess.return_value.__aexit__ = AsyncMock(return_value=False)
+        await cost_summariser.handle_ai_cost_summary({"run_id": str(run.id)})
+
+    # The terminal upsert is status="ready" with a stamped advisory.
+    ready = [c for c in upsert.await_args_list if c.kwargs.get("status") == "ready"]
+    assert ready, "expected a ready upsert"
+    kw = ready[-1].kwargs
+    assert kw["narrative"].startswith("Roughly")
+    assert kw["advisories"][0]["source"] == "ai-estimate"
+    assert kw["advisories"][0]["monthly_saving"] == {"min": 20.0, "max": 30.0}
+    # A ready SSE event fired.
+    assert any(c.args and c.args[0] == "cost_summary_ready" for c in emit.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_workspace_mode_disabled_skips(monkeypatch):
+    run = MagicMock(id=uuid.uuid4(), workspace_id=uuid.uuid4(), has_cost_estimate=True)
+    ws = MagicMock(id=uuid.uuid4(), ai_summary_context="")
+    db = _db_returning(run, ws)
+    upsert = AsyncMock()
+    emit = AsyncMock()
+    call_model = AsyncMock()
+
+    monkeypatch.setattr(cost_summariser.settings.ai_summary, "enabled", True)
+    with (
+        patch("terrapod.services.cost_summariser.get_db_session") as sess,
+        patch("terrapod.services.cost_summariser._resolve_workspace_mode", return_value=False),
+        patch("terrapod.services.cost_summariser._call_model", call_model),
+        patch("terrapod.services.cost_summariser._upsert_cost_summary", upsert),
+        patch("terrapod.services.cost_summariser._emit_summary_event", emit),
+    ):
+        sess.return_value.__aenter__ = AsyncMock(return_value=db)
+        sess.return_value.__aexit__ = AsyncMock(return_value=False)
+        await cost_summariser.handle_ai_cost_summary({"run_id": str(run.id)})
+
+    call_model.assert_not_awaited()  # never calls the model when workspace is off
+    assert [c.kwargs.get("status") for c in upsert.await_args_list] == ["skipped"]
+    assert any(c.args and c.args[0] == "cost_summary_skipped" for c in emit.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_missing_artifact_skips(monkeypatch):
+    from terrapod.storage.protocol import ObjectNotFoundError
+
+    run = MagicMock(id=uuid.uuid4(), workspace_id=uuid.uuid4(), has_cost_estimate=True)
+    ws = MagicMock(id=uuid.uuid4(), ai_summary_context="")
+    db = _db_returning(run, ws)
+    storage = MagicMock()
+    storage.get = AsyncMock(side_effect=ObjectNotFoundError("gone"))
+    upsert = AsyncMock()
+    emit = AsyncMock()
+    call_model = AsyncMock()
+
+    monkeypatch.setattr(cost_summariser.settings.ai_summary, "enabled", True)
+    with (
+        patch("terrapod.services.cost_summariser.get_db_session") as sess,
+        patch("terrapod.services.cost_summariser._resolve_workspace_mode", return_value=True),
+        patch("terrapod.services.cost_summariser._budget_remaining", AsyncMock(return_value=None)),
+        patch("terrapod.services.cost_summariser.get_storage", return_value=storage),
+        patch("terrapod.services.cost_summariser._call_model", call_model),
+        patch("terrapod.services.cost_summariser._upsert_cost_summary", upsert),
+        patch("terrapod.services.cost_summariser._emit_summary_event", emit),
+    ):
+        sess.return_value.__aenter__ = AsyncMock(return_value=db)
+        sess.return_value.__aexit__ = AsyncMock(return_value=False)
+        await cost_summariser.handle_ai_cost_summary({"run_id": str(run.id)})
+
+    call_model.assert_not_awaited()
+    assert upsert.await_args_list[-1].kwargs["status"] == "skipped"


### PR DESCRIPTION
Part of #871 — **Slice A** of the cost AI enhancement (narrative + savings advisories). Chat is a later slice; the UI + go-terrapod method + view-time i18n come in follow-up slices (this is backend-only, no new route yet).

It **rides the same switch as the plan summary** (`ai_summary.enabled` + the per-workspace mode) and reuses its model plumbing — the LiteLLM tool-calling call, the shared daily token budget, and the per-workspace SSE channel. AI **off → the data-only cost view is unchanged.**

## Hard provenance (the whole reason cost is data-first)
- New `cost_summaries` table (one-to-one with runs) holds a **narrative + savings advisories only**. The authoritative oiq figures stay on the data-only `/runs/{id}/cost-estimate` endpoint and are **never restated** here.
- Every advisory dollar amount is stamped **`source: "ai-estimate"` server-side** in `_normalise_advisories`, regardless of what the model returns; malformed advisories are dropped, never trusted. It is **never a gate.**
- The **only** model input is the derived, non-sensitive `cost_estimate.json` artifact — **never** Terraform state or the plan JSON. Pinned by a source-level hard-invariant test (`TestCostNoStateLeakage`), mirroring the plan summariser's `TestNoStateLeakage`.

## Wiring
`handle_ai_cost_summary` is registered as an `ai_cost_summary` trigger (only when enabled) and enqueued when the runner uploads `cost_estimate.json`, deduped per run. It emits `cost_summary_pending/ready/errored/skipped` on the per-workspace channel (added to the api-reference SSE table).

## Tests
Provenance units (`_normalise_advisories` stamps source, drops junk, coerces the saving range), the no-state-leakage introspection invariant, and the gated handler paths (globally-disabled no-op, workspace-off → skipped, missing-artifact → skipped, ready → stamped advisories + `cost_summary_ready`). Migration is additive + reversible (contract gate green).

**Verified:** `make test` on the cost + migration-contract + touched-module suites (16 + 140 passing), ruff clean.