### PR TITLE
feat(cost): reorient AI cost layer to estimate what oiq can't price

### DIFF
--- a/alembic/versions/d321124f68ee_cost_summary_estimated_resources.py
+++ b/alembic/versions/d321124f68ee_cost_summary_estimated_resources.py
@@ -1,0 +1,39 @@
+"""cost_summaries.estimated_resources — AI estimates for what oiq can't price (#871)
+
+The cost AI's PRIMARY output: the model's own monthly estimate for resources the
+deterministic oiq engine could not price (the unpriced bucket + providers oiq
+doesn't cover + usage-driven dimensions it omits). Each entry is tagged
+`source: "ai-estimate"`, shown as a separate overlay, and never summed into the
+authoritative oiq total.
+
+Purely additive: a JSONB column with a `[]` server default, no backfill.
+
+Revision ID: d321124f68ee
+Revises: 05af36ae12f9
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "d321124f68ee"
+down_revision = "05af36ae12f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cost_summaries",
+        sa.Column(
+            "estimated_resources",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("cost_summaries", "estimated_resources")

--- a/go-terrapod/cost_estimate.go
+++ b/go-terrapod/cost_estimate.go
@@ -178,24 +178,40 @@ type CostAdvisory struct {
 	Source        string     `json:"source"`         // always "ai-estimate"
 }
 
-// CostSummary is the optional AI *enhancement* of a run's cost estimate (#871):
-// a plain-language narrative plus savings advisories. It rides the plan-analysis
-// AI switch and holds AI polish ONLY — the authoritative monthly figures live on
-// CostEstimate (GetRunCostEstimate) and are never restated here.
+// CostEstimatedResource is an AI monthly estimate for a resource the
+// deterministic oiq engine could NOT price (#871) — the PRIMARY output of the
+// cost AI. Monthly is always an ESTIMATE (Source == "ai-estimate"), shown as a
+// separate overlay and never summed into the authoritative oiq total; Basis is
+// the model's one-line justification/assumption.
+type CostEstimatedResource struct {
+	Address string    `json:"address"`
+	Type    string    `json:"type"`
+	Monthly CostRange `json:"monthly"`
+	Basis   string    `json:"basis"`
+	Source  string    `json:"source"` // always "ai-estimate"
+}
+
+// CostSummary is the optional AI *enhancement* of a run's cost estimate (#871).
+// Its PRIMARY value is EstimatedResources — the model pricing what oiq couldn't
+// (the unpriced set + providers oiq doesn't cover + usage-driven costs). The
+// narrative + advisories are the secondary, human-readable bonus. Everything
+// here is AI estimate/polish — the authoritative figures live on CostEstimate
+// (GetRunCostEstimate) and are never restated.
 type CostSummary struct {
 	// ID is the prefixed resource id ("cost-summary-<uuid>"); RunID is the bare
 	// run UUID resolved from the `run` relationship.
-	ID           string         `json:"-"`
-	RunID        string         `json:"-"`
-	Status       string         `json:"status"` // pending|ready|errored|skipped
-	Narrative    string         `json:"narrative"`
-	Advisories   []CostAdvisory `json:"advisories"`
-	Model        string         `json:"model"`
-	InputTokens  int            `json:"input-tokens"`
-	OutputTokens int            `json:"output-tokens"`
-	ErrorMessage string         `json:"error-message"`
-	CreatedAt    string         `json:"created-at"`
-	UpdatedAt    string         `json:"updated-at"`
+	ID                 string                  `json:"-"`
+	RunID              string                  `json:"-"`
+	Status             string                  `json:"status"` // pending|ready|errored|skipped
+	EstimatedResources []CostEstimatedResource `json:"estimated-resources"`
+	Narrative          string                  `json:"narrative"`
+	Advisories         []CostAdvisory          `json:"advisories"`
+	Model              string                  `json:"model"`
+	InputTokens        int                     `json:"input-tokens"`
+	OutputTokens       int                     `json:"output-tokens"`
+	ErrorMessage       string                  `json:"error-message"`
+	CreatedAt          string                  `json:"created-at"`
+	UpdatedAt          string                  `json:"updated-at"`
 }
 
 func costSummaryFromResource(res *Resource) *CostSummary {
@@ -210,6 +226,9 @@ func costSummaryFromResource(res *Resource) *CostSummary {
 		ErrorMessage: GetStringAttr(res, "error-message"),
 		CreatedAt:    GetStringAttr(res, "created-at"),
 		UpdatedAt:    GetStringAttr(res, "updated-at"),
+	}
+	if raw, ok := res.Attributes["estimated-resources"]; ok {
+		_ = json.Unmarshal(raw, &s.EstimatedResources)
 	}
 	if raw, ok := res.Attributes["advisories"]; ok {
 		_ = json.Unmarshal(raw, &s.Advisories)

--- a/go-terrapod/cost_estimate_test.go
+++ b/go-terrapod/cost_estimate_test.go
@@ -158,6 +158,9 @@ func TestGetWorkspaceCostEstimateEmptyID(t *testing.T) {
 const costSummaryBody = `{"data":{"id":"cost-summary-abc","type":"cost-summaries",
   "attributes":{
     "status":"ready",
+    "estimated-resources":[
+      {"address":"azurerm_linux_virtual_machine.web","type":"azurerm_linux_virtual_machine","monthly":{"min":70.0,"max":90.0},"basis":"Standard_D2s_v5, West Europe, 730h","source":"ai-estimate"}
+    ],
     "narrative":"Roughly $219/mo, dominated by aws_instance.eu.",
     "advisories":[
       {"kind":"reserved","title":"RI aws_instance.eu","detail":"On-demand 24/7; a 1yr RI cuts it.","monthly_saving":{"min":40.0,"max":60.0},"source":"ai-estimate"},
@@ -179,6 +182,16 @@ func TestGetRunCostSummary(t *testing.T) {
 	}
 	if s.Status != "ready" || s.Narrative == "" {
 		t.Errorf("status/narrative not decoded: %+v", s)
+	}
+	if len(s.EstimatedResources) != 1 {
+		t.Fatalf("estimated_resources=%d, want 1", len(s.EstimatedResources))
+	}
+	er := s.EstimatedResources[0]
+	if er.Address != "azurerm_linux_virtual_machine.web" || er.Source != "ai-estimate" {
+		t.Errorf("estimated resource not decoded / provenance lost: %+v", er)
+	}
+	if er.Monthly.Min != 70.0 || er.Basis == "" {
+		t.Errorf("estimated resource monthly/basis not decoded: %+v", er)
 	}
 	if len(s.Advisories) != 2 {
 		t.Fatalf("advisories=%d, want 2", len(s.Advisories))

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -80,6 +80,11 @@ field CostEstimate.Resources []CostResource `json:"resources"`
 field CostEstimate.RunID string `json:"-"`
 field CostEstimate.Total CostRange `json:"total"`
 field CostEstimate.Unpriced []UnpricedResource `json:"unpriced"`
+field CostEstimatedResource.Address string `json:"address"`
+field CostEstimatedResource.Basis string `json:"basis"`
+field CostEstimatedResource.Monthly CostRange `json:"monthly"`
+field CostEstimatedResource.Source string `json:"source"`
+field CostEstimatedResource.Type string `json:"type"`
 field CostRange.Max float64 `json:"max"`
 field CostRange.Min float64 `json:"min"`
 field CostResource.Address string `json:"address"`
@@ -93,6 +98,7 @@ field CostStateVersion.Serial int `json:"serial"`
 field CostSummary.Advisories []CostAdvisory `json:"advisories"`
 field CostSummary.CreatedAt string `json:"created-at"`
 field CostSummary.ErrorMessage string `json:"error-message"`
+field CostSummary.EstimatedResources []CostEstimatedResource `json:"estimated-resources"`
 field CostSummary.ID string `json:"-"`
 field CostSummary.InputTokens int `json:"input-tokens"`
 field CostSummary.Model string `json:"model"`
@@ -1083,6 +1089,7 @@ type Client struct
 type ConflictError struct
 type CostAdvisory struct
 type CostEstimate struct
+type CostEstimatedResource struct
 type CostRange struct
 type CostResource struct
 type CostStateVersion struct

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1149,9 +1149,13 @@ def _cost_summary_json(run_id, summary: CostSummary) -> dict:
             "type": "cost-summaries",
             "attributes": {
                 "status": summary.status,
+                # PRIMARY (#871): the model's estimates for what oiq couldn't
+                # price. Each carries source="ai-estimate" (stamped server-side);
+                # the UI renders these as a separate overlay, never summed into
+                # the authoritative oiq total.
+                "estimated-resources": summary.estimated_resources,
                 "narrative": summary.narrative,
-                # Every advisory carries source="ai-estimate" (stamped server-side);
-                # the UI renders these distinctly from the authoritative figures.
+                # Advisories also carry source="ai-estimate".
                 "advisories": summary.advisories,
                 "model": summary.model,
                 "input-tokens": summary.input_tokens,
@@ -1229,6 +1233,7 @@ async def regenerate_cost_summary(
         "run_id": run.id,
         "status": "pending",
         "model": settings.ai_summary.model,
+        "estimated_resources": [],
         "narrative": "",
         "advisories": [],
         "input_tokens": 0,
@@ -1241,6 +1246,7 @@ async def regenerate_cost_summary(
         set_={
             "status": stmt.excluded.status,
             "model": stmt.excluded.model,
+            "estimated_resources": stmt.excluded.estimated_resources,
             "narrative": stmt.excluded.narrative,
             "advisories": stmt.excluded.advisories,
             "input_tokens": stmt.excluded.input_tokens,

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -2268,7 +2268,18 @@ class CostSummary(Base):
 
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
 
-    # Model fields — populated when status == "ready"
+    # Model fields — populated when status == "ready".
+    #
+    # estimated_resources is the PRIMARY output (#871 reframe): the model's own
+    # monthly estimate for resources the deterministic oiq engine could NOT
+    # price — the "unpriced" bucket (unmapped types, and providers oiq doesn't
+    # cover, e.g. Azure/GCP) plus usage-driven dimensions it omits. Each carries
+    # `source: "ai-estimate"` (stamped server-side), is shown as a separate
+    # overlay beside the authoritative oiq figures, and is NEVER summed into the
+    # oiq total. narrative + advisories are the secondary, human-readable bonus.
+    estimated_resources: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, default=list, nullable=False
+    )
     narrative: Mapped[str] = mapped_column(Text, nullable=False, default="")
     advisories: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, default=list, nullable=False)
 

--- a/services/terrapod/services/cost_summariser.py
+++ b/services/terrapod/services/cost_summariser.py
@@ -6,14 +6,20 @@ per-workspace mode) and reuses the plan summariser's model plumbing — the
 LiteLLM tool-calling call (:func:`summariser._call_model`), the shared daily
 token budget, and the per-workspace run-events SSE channel.
 
-**Provenance is a hard invariant (the whole reason cost is data-first).** This
-service produces AI *polish* only — a plain-language narrative of the estimate
-plus optional savings advisories — stored in ``cost_summaries``. It NEVER
-computes, restates, or overrides the authoritative figures: those come from the
-runner-produced ``cost_estimate.json`` artifact (oiq-derived) and are served by
-the data-only ``/runs/{id}/cost-estimate`` endpoint. Every advisory dollar
-amount is stamped ``source: "ai-estimate"`` **server-side here**, regardless of
-what the model returns, and is never a gate.
+**Its PRIMARY job is to price what oiq can't (#871 reframe).** The deterministic
+engine prices what its pricesheet covers; this service uses the model's own cost
+knowledge to ESTIMATE the resources oiq could NOT price — the ``unpriced`` bucket
+(unmapped types, and providers oiq doesn't cover, e.g. Azure/GCP) plus obviously
+usage-driven costs it omits. Those estimates are the ``estimated_resources``
+primary output. A human-readable ``narrative`` + savings ``advisories`` are the
+secondary bonus.
+
+**Provenance is a hard invariant.** Every figure this service stores — each
+estimated resource and each advisory — is tagged ``source: "ai-estimate"``
+**server-side here**, regardless of what the model returns. It is shown as a
+separate overlay, NEVER summed into or substituted for the authoritative oiq
+total (which stays on the data-only ``/runs/{id}/cost-estimate`` endpoint), and
+is never a gate.
 
 The only input fed to the model is the ``cost_estimate.json`` artifact — a
 derived, non-sensitive aggregate (resource addresses, types, monthly ranges).
@@ -59,6 +65,7 @@ async def _upsert_cost_summary(
     *,
     run_id: uuid.UUID,
     status: str,
+    estimated_resources: list[dict] | None = None,
     narrative: str = "",
     advisories: list[dict] | None = None,
     model: str = "",
@@ -69,7 +76,7 @@ async def _upsert_cost_summary(
     """Idempotent upsert keyed on (run_id); never downgrades a 'ready' row.
 
     Mirrors ``summariser._upsert_summary`` so a transient errored retry can't
-    clobber a good narrative.
+    clobber a good result.
     """
     existing = (
         await db.execute(select(CostSummary).where(CostSummary.run_id == run_id))
@@ -81,6 +88,7 @@ async def _upsert_cost_summary(
         "id": uuid.uuid4(),
         "run_id": run_id,
         "status": status,
+        "estimated_resources": estimated_resources or [],
         "narrative": narrative,
         "advisories": advisories or [],
         "model": model,
@@ -94,6 +102,7 @@ async def _upsert_cost_summary(
         index_elements=["run_id"],
         set_={
             "status": stmt.excluded.status,
+            "estimated_resources": stmt.excluded.estimated_resources,
             "narrative": stmt.excluded.narrative,
             "advisories": stmt.excluded.advisories,
             "model": stmt.excluded.model,
@@ -104,6 +113,40 @@ async def _upsert_cost_summary(
         },
     )
     await db.execute(stmt)
+
+
+def _normalise_estimated_resources(raw: object) -> list[dict]:
+    """Coerce the model's per-resource estimates into the stored shape.
+
+    The PRIMARY output (#871): AI estimates for resources oiq couldn't price.
+    Each becomes ``{address, type, monthly: {min, max}, basis, source:
+    "ai-estimate"}``. ``source`` is forced here — the model can never claim a
+    computed figure. Entries missing a numeric range or an address are dropped.
+    """
+    if not isinstance(raw, list):
+        return []
+    out: list[dict] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        address = item.get("address")
+        lo = item.get("monthly_min")
+        hi = item.get("monthly_max")
+        if not isinstance(address, str) or not address:
+            continue
+        if not isinstance(lo, int | float) or not isinstance(hi, int | float):
+            continue
+        basis = item.get("basis")
+        out.append(
+            {
+                "address": address,
+                "type": item.get("type") if isinstance(item.get("type"), str) else "",
+                "monthly": {"min": float(lo), "max": float(hi)},
+                "basis": basis[:400] if isinstance(basis, str) else "",
+                "source": "ai-estimate",  # HARD provenance — always an estimate
+            }
+        )
+    return out
 
 
 def _normalise_advisories(raw: object) -> list[dict]:
@@ -236,26 +279,32 @@ async def handle_ai_cost_summary(payload: dict) -> None:
             await _emit_summary_event("cost_summary_errored", ws.id, run_id)
             return
 
-        narrative = args.get("narrative") if isinstance(args, dict) else None
-        advisories = _normalise_advisories(
-            args.get("advisories") if isinstance(args, dict) else None
-        )
-        if not isinstance(narrative, str) or not narrative.strip():
+        # A non-dict tool result is the only genuine failure — the model
+        # returned something unusable. Empty estimates/advisories/narrative are
+        # ALL legitimate "ready" states (oiq priced everything; nothing for the
+        # AI to add), so we don't error on them.
+        if not isinstance(args, dict):
             await _upsert_cost_summary(
                 db,
                 run_id=run_id,
                 status="errored",
                 model=cfg.model,
-                error_message="model returned no narrative",
+                error_message="model returned no structured result",
             )
             await db.commit()
             await _emit_summary_event("cost_summary_errored", ws.id, run_id)
             return
 
+        estimated_resources = _normalise_estimated_resources(args.get("estimated_resources"))
+        advisories = _normalise_advisories(args.get("advisories"))
+        narrative = args.get("narrative")
+        narrative = narrative if isinstance(narrative, str) else ""
+
         await _upsert_cost_summary(
             db,
             run_id=run_id,
             status="ready",
+            estimated_resources=estimated_resources,
             narrative=narrative,
             advisories=advisories,
             model=cfg.model,

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -126,18 +126,54 @@ FAILURE_ANALYSIS_TOOL: dict = {
 COST_SUMMARY_JSON_SCHEMA: dict = {
     "type": "object",
     "additionalProperties": False,
-    "required": ["narrative", "advisories"],
+    "required": ["estimated_resources", "advisories"],
     "properties": {
+        "estimated_resources": {
+            "type": "array",
+            "description": (
+                "YOUR PRIMARY JOB. From your own knowledge, estimate the monthly "
+                "cost of resources the deterministic pricing engine could NOT "
+                "price — the ones listed under UNPRICED (unmapped types, or "
+                "providers/regions the pricesheet doesn't cover, e.g. Azure/GCP) "
+                "— plus any usage-driven cost the priced figures obviously omit "
+                "(data egress, request volumes, cross-AZ). Do NOT re-estimate or "
+                "restate resources that are ALREADY priced deterministically — "
+                "those numbers are authoritative and shown separately. One entry "
+                "per resource you can put a number on; omit ones you genuinely "
+                "cannot estimate. Empty array is fine if nothing is estimable."
+            ),
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["address", "monthly_min", "monthly_max", "basis"],
+                "properties": {
+                    "address": {
+                        "type": "string",
+                        "description": "Terraform address of the resource being estimated.",
+                    },
+                    "type": {"type": "string", "description": "Terraform resource type."},
+                    "monthly_min": {"type": "number", "description": "Low end, monthly, USD."},
+                    "monthly_max": {"type": "number", "description": "High end, monthly, USD."},
+                    "basis": {
+                        "type": "string",
+                        "maxLength": 400,
+                        "description": (
+                            "One line on how you arrived at the estimate + the "
+                            "key assumption (region, tier, usage), so the reader "
+                            "can judge it. This is an estimate, not a quote."
+                        ),
+                    },
+                },
+            },
+        },
         "narrative": {
             "type": "string",
             "description": (
-                "Plain-language explanation of the cost estimate: what drives "
-                "the monthly cost, which resources dominate, and how a change "
-                "moves the bill. Up to ~350 words. Refer to resources by their "
-                "terraform address. Do NOT restate the authoritative monthly "
-                "total as if you computed it — it is given to you and shown "
-                "separately; describe and contextualise it, never replace it. "
-                "No chain-of-thought, no preamble."
+                "OPTIONAL, secondary. A brief plain-language read of the overall "
+                "cost picture — up to ~200 words, resources by terraform address. "
+                "Do NOT restate the authoritative deterministic total as if you "
+                "computed it (it is given + shown separately). Empty string is "
+                "fine; the estimates above are the point, not this prose."
             ),
         },
         "advisories": {
@@ -184,9 +220,10 @@ COST_SUMMARY_TOOL: dict = {
     "function": {
         "name": "submit_cost_summary",
         "description": (
-            "Submit the structured cost summary. Call this tool exactly once "
-            "with the narrative and any savings advisories. Never restate the "
-            "authoritative monthly total as your own computation."
+            "Submit your cost estimates. Call this tool exactly once. The "
+            "primary field is estimated_resources — YOUR estimate for what the "
+            "deterministic engine could not price. Never restate an "
+            "already-priced figure as your own computation."
         ),
         "parameters": COST_SUMMARY_JSON_SCHEMA,
     },
@@ -622,26 +659,32 @@ def render_prompt(
 
 # --- Cost summary prompt (#871) ---------------------------------------------
 COST_SUMMARY_SKILL_PROMPT = """\
-You are a senior cloud FinOps reviewer. You are given an ALREADY-COMPUTED, \
-authoritative monthly cost estimate for a Terraform/OpenTofu plan (produced by \
-a deterministic pricing engine, OpenInfraQuote). Your job is to EXPLAIN and \
-CONTEXTUALISE it and, where obvious, suggest concrete savings — never to \
-recompute or override it.
+You are a senior cloud FinOps engineer. A deterministic pricing engine \
+(OpenInfraQuote) has ALREADY priced the resources it has data for; those \
+figures are authoritative and shown to the user separately. Some resources it \
+could NOT price — they are listed under UNPRICED (unmapped types, or \
+providers/regions its pricesheet doesn't cover, e.g. Azure/GCP).
+
+YOUR PRIMARY JOB is to fill that gap: from your own cost knowledge, ESTIMATE the \
+monthly cost of the unpriced resources — that is the whole point of this task, \
+not writing prose.
 
 Hard rules:
-- The authoritative monthly total and every per-resource figure are DATA. They \
-are given to you and shown to the user separately. Describe them, group them, \
-explain what drives them — but never present a different total as if you \
-computed it, and never contradict the given figures.
-- Any monthly_saving you put on an advisory is YOUR ESTIMATE, not a computed \
-number. Keep advisories practical and specific to what is actually in the \
-plan (e.g. a long-lived on-demand instance → a Savings Plan / reserved \
-instance; a fault-tolerant batch workload → spot; an over-provisioned \
-instance class → rightsizing). Do not invent resources that are not present.
-- Be concise and factual. Refer to resources by their terraform address. No \
-chain-of-thought, no preamble, no restating these instructions.
-- If the estimate is trivial or nothing obvious can be saved, say so briefly \
-and return an empty advisories array.\
+- estimated_resources is the main output. Estimate monthly cost ONLY for the \
+UNPRICED resources (and any obviously-omitted usage-driven cost — egress, \
+requests, cross-AZ). NEVER re-estimate or restate a resource that is already \
+priced deterministically; those numbers are authoritative and yours would only \
+add noise. Give each estimate a one-line `basis` stating your key assumption \
+(region, tier, usage) so the reader can judge it. Omit anything you genuinely \
+cannot estimate; an empty array is fine if nothing is estimable.
+- Everything you output is an ESTIMATE (the API tags it `source: ai-estimate`) \
+— it is shown as a separate overlay, never merged into the authoritative total, \
+never a gate. Do not present a different authoritative total.
+- Advisories (savings) are secondary and specific to what is present (long-lived \
+on-demand → Savings Plan/RI; fault-tolerant batch → spot; oversized → \
+rightsizing). Their monthly_saving is also your estimate.
+- narrative is optional and secondary — a brief read of the picture, or empty. \
+Refer to resources by terraform address. No chain-of-thought, no preamble.\
 """
 
 
@@ -686,11 +729,18 @@ def render_cost_prompt(
         user_parts.append(f"FLEET_CONTEXT:\n{fleet_context.strip()}")
     if workspace_context.strip():
         user_parts.append(f"WORKSPACE_CONTEXT:\n{workspace_context.strip()}")
-    user_parts.append(f"COST_ESTIMATE (authoritative, oiq-derived):\n```json\n{estimate_json}\n```")
+    user_parts.append(
+        "DETERMINISTIC_COST_ESTIMATE (authoritative — priced resources are in "
+        "`resources`; the ones the engine could NOT price are in `unpriced`, and "
+        "THOSE are what you estimate):\n"
+        f"```json\n{estimate_json}\n```"
+    )
     if plan_json.strip():
         user_parts.append(f"PLAN_JSON (context):\n```json\n{plan_json}\n```")
     user_parts.append(
-        "Now call the `submit_cost_summary` tool exactly once with your structured answer."
+        "Now call the `submit_cost_summary` tool exactly once: estimate the "
+        "UNPRICED resources in `estimated_resources` (the primary output), then "
+        "any savings advisories, then an optional brief narrative."
     )
 
     user_message = "\n\n".join(user_parts)

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -411,6 +411,7 @@
     "advisories",
     "created-at",
     "error-message",
+    "estimated-resources",
     "input-tokens",
     "model",
     "narrative",

--- a/services/tests/api/test_cost_summary.py
+++ b/services/tests/api/test_cost_summary.py
@@ -57,6 +57,19 @@ def _mock_cost_summary(run_id, status="ready"):
     s.id = uuid.uuid4()
     s.run_id = run_id
     s.status = status
+    s.estimated_resources = (
+        [
+            {
+                "address": "azurerm_storage_account.a",
+                "type": "azurerm_storage_account",
+                "monthly": {"min": 5.0, "max": 8.0},
+                "basis": "LRS, hot tier, ~100GB",
+                "source": "ai-estimate",
+            }
+        ]
+        if status == "ready"
+        else []
+    )
     s.narrative = "Roughly $73/mo." if status == "ready" else ""
     s.advisories = (
         [
@@ -113,6 +126,9 @@ class TestGetCostSummary:
         assert resp.status_code == 200
         attrs = resp.json()["data"]["attributes"]
         assert attrs["status"] == "ready"
+        # PRIMARY output surfaced with provenance intact.
+        assert attrs["estimated-resources"][0]["address"] == "azurerm_storage_account.a"
+        assert attrs["estimated-resources"][0]["source"] == "ai-estimate"
         assert attrs["narrative"].startswith("Roughly")
         assert attrs["advisories"][0]["source"] == "ai-estimate"  # provenance surfaced
 

--- a/services/tests/services/test_cost_summariser.py
+++ b/services/tests/services/test_cost_summariser.py
@@ -77,6 +77,39 @@ class TestNormaliseAdvisories:
         assert len(out[0]["detail"]) == 600
 
 
+class TestNormaliseEstimatedResources:
+    def test_stamps_source_and_coerces_range(self):
+        out = cost_summariser._normalise_estimated_resources(
+            [
+                {
+                    "address": "google_compute_instance.x",
+                    "type": "google_compute_instance",
+                    "monthly_min": 12,
+                    "monthly_max": 15.5,
+                    "basis": "e2-medium us-central1",
+                    "source": "computed",  # lie
+                }
+            ]
+        )
+        assert len(out) == 1
+        assert out[0]["source"] == "ai-estimate"
+        assert out[0]["monthly"] == {"min": 12.0, "max": 15.5}
+        assert out[0]["address"] == "google_compute_instance.x"
+
+    def test_drops_entries_without_address_or_numeric_range(self):
+        out = cost_summariser._normalise_estimated_resources(
+            [
+                {"type": "x", "monthly_min": 1, "monthly_max": 2},  # no address
+                {"address": "a.b", "monthly_min": "n/a", "monthly_max": 2},  # non-numeric
+                {"address": "a.b", "monthly_min": 1, "monthly_max": 2, "basis": "ok"},  # valid
+            ]
+        )
+        assert [e["address"] for e in out] == ["a.b"]
+
+    def test_non_list_returns_empty(self):
+        assert cost_summariser._normalise_estimated_resources(None) == []
+
+
 # ---------------------------------------------------------------------------
 # No state leakage — hard invariant (Code ↔ Tests contract)
 # ---------------------------------------------------------------------------
@@ -156,6 +189,16 @@ async def test_ready_path_stamps_advisories_and_emits(monkeypatch):
     call_model = AsyncMock(
         return_value=(
             {
+                "estimated_resources": [
+                    {
+                        "address": "azurerm_storage_account.a",
+                        "type": "azurerm_storage_account",
+                        "monthly_min": 5,
+                        "monthly_max": 8,
+                        "basis": "LRS hot ~100GB",
+                        "source": "computed",  # model lie — must be overwritten
+                    },
+                ],
                 "narrative": "Roughly $73/mo, driven by aws_instance.web.",
                 "advisories": [
                     {
@@ -187,10 +230,15 @@ async def test_ready_path_stamps_advisories_and_emits(monkeypatch):
         sess.return_value.__aexit__ = AsyncMock(return_value=False)
         await cost_summariser.handle_ai_cost_summary({"run_id": str(run.id)})
 
-    # The terminal upsert is status="ready" with a stamped advisory.
+    # The terminal upsert is status="ready" with the PRIMARY estimated
+    # resources (provenance forced) + a stamped advisory.
     ready = [c for c in upsert.await_args_list if c.kwargs.get("status") == "ready"]
     assert ready, "expected a ready upsert"
     kw = ready[-1].kwargs
+    er = kw["estimated_resources"][0]
+    assert er["address"] == "azurerm_storage_account.a"
+    assert er["monthly"] == {"min": 5.0, "max": 8.0}
+    assert er["source"] == "ai-estimate"  # the model's "computed" was overwritten
     assert kw["narrative"].startswith("Roughly")
     assert kw["advisories"][0]["source"] == "ai-estimate"
     assert kw["advisories"][0]["monthly_saving"] == {"min": 20.0, "max": 30.0}


### PR DESCRIPTION
Part of #871 — the design correction we settled on: **the AI's job is to price what the deterministic oiq engine cannot, flagged as estimate, alongside the authoritative figures.** Narrating oiq's numbers was the wrong emphasis; **estimation is the point, human-readable narrative is a bonus.**

## What changed
- **`cost_summaries.estimated_resources`** (new JSONB column, additive migration) — the model's monthly estimate for resources oiq couldn't price: the `unpriced` bucket (unmapped types + providers oiq doesn't cover, e.g. **Azure/GCP**) + obviously usage-driven costs it omits. Each is `{address, type, monthly:{min,max}, basis, source}`.
- **Prompt + schema reoriented** — `estimated_resources` is now the primary, *required* output. The model is instructed to estimate **only the UNPRICED resources** (never restate an already-priced figure), each with a one-line `basis` (its key assumption, so the reader can judge it). Narrative is demoted to optional/secondary.
- **Service** — `_normalise_estimated_resources` stamps `source: "ai-estimate"` **server-side** (the model can never claim a computed figure) and drops entries lacking an address or numeric range. An all-empty result is now a valid `ready` (oiq covered everything, nothing for the AI to add) — the old "no narrative → errored" gate is gone.
- **API** — `estimated-resources` on the cost-summary response (attribute contract regen, additive); regenerate resets it.
- **go-terrapod** — `CostEstimatedResource` + `CostSummary.EstimatedResources` (surface golden regen, additive), provenance-preserving decode + test.

## Provenance stays hard
Every AI figure — each estimated resource and each advisory — is `source: "ai-estimate"`, shown as a **separate overlay**, **never summed into or substituted for the authoritative oiq total**, never a gate.

**Verified:** cost service + router + migration-contract (24 passing), `go test ./...`, attribute + surface contracts additive, ruff clean.

Next: **Slice C** = the Cost-tab UI, built around AI *estimates beside* the oiq data (for your visual review).