### PR TITLE
test(896): stabilise flaky responsive nav e2e (sheet-close race)

### DIFF
--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -65,7 +65,17 @@ test.describe('Responsive harness (phone viewport)', () => {
 
     // Account has its own trigger + drawer (personal/session items + log out).
     await menu.getByRole('button', { name: /close menu/i }).click();
-    await page.getByRole('button', { name: 'Open account menu' }).click();
+    // Wait for the nav sheet to fully close before opening the account drawer.
+    // The open sheet is a full-screen `fixed … z-40` overlay covering the account
+    // trigger in the top bar; closing it unmounts the drawer via a React state
+    // update. Driving the account-open click before that unmount completes lets
+    // the click miss (the overlay still intercepts) so the account drawer never
+    // opens — the intermittent "element(s) not found" flake (#896). Gate on the
+    // sheet being gone, then on the trigger being actionable, before clicking.
+    await expect(menu).toBeHidden();
+    const accountTrigger = page.getByRole('button', { name: 'Open account menu' });
+    await expect(accountTrigger).toBeVisible();
+    await accountTrigger.click();
     const account = page.locator('#mobile-account-menu');
     await expect(account).toBeVisible();
     await expect(account.getByRole('link', { name: 'API Tokens' })).toBeVisible();


### PR DESCRIPTION
## Problem

`responsive.spec.ts › nav adapts to mobile: hamburger shown, grouped sheet` intermittently fails with `expect(locator).toBeVisible() — element(s) not found` (seen on unrelated PR CI runs).

## Root cause

The spec closes the mobile nav sheet, then **immediately** clicks the `Open account menu` trigger. The open nav sheet (`MobileDrawer`) is a full-screen `fixed … z-40` overlay covering that trigger in the top bar. Closing it unmounts the drawer via a React state update; the account-open click can land before the unmount completes, so the click misses the (still-covered) trigger and the account drawer never opens — the following `toBeVisible()` then finds no element. CI load widens the race.

## Fix

Between closing the nav sheet and opening the account drawer, wait for the sheet to be hidden (`expect(menu).toBeHidden()`) and for the account trigger to be actionable (`expect(accountTrigger).toBeVisible()`) before clicking. Correctness improvement — don't drive the next interaction until the previous overlay is gone — not a blind timeout bump.

Test-only; no product code change.

Closes #896