### PR TITLE
fix(898): runner cost phase sent a malformed Authorization header → cost estimation silently dead on every agent run

### DIFF
--- a/services/terrapod/runner/phases/cost.py
+++ b/services/terrapod/runner/phases/cost.py
@@ -105,7 +105,7 @@ def _fetch_pricesheet(cfg: RunnerConfig) -> bool:
     to a presigned storage URL that ``download_to_file`` follows.
     """
     url = f"{cfg.api_url}{_PRICESHEET_PATH}"
-    headers = {"Authorization": cfg.auth_header} if cfg.auth_token else {}
+    headers = {"Authorization": f"Bearer {cfg.auth_token}"} if cfg.auth_token else {}
     result = download_to_file(
         url,
         _PRICESHEET_CSV,

--- a/services/terrapod/runner/runner_config.py
+++ b/services/terrapod/runner/runner_config.py
@@ -180,7 +180,3 @@ class RunnerConfig:
         ``phase`` — the run is plan-phase for all infra; only the entrypoint's
         behaviour branch differs."""
         return bool(self.onboard_session_id)
-
-    @property
-    def auth_header(self) -> str:
-        return f"Authorization: Bearer {self.auth_token}"

--- a/services/tests/runner/test_phase_cost.py
+++ b/services/tests/runner/test_phase_cost.py
@@ -116,3 +116,35 @@ def test_no_api_skips(tmp_path, monkeypatch):
     with patch.object(cost, "download_to_file", side_effect=AssertionError("no fetch")):
         out = cost.estimate_cost(cfg, plan)
     assert out is None
+
+
+def test_pricesheet_request_sends_well_formed_bearer_header(tmp_path, monkeypatch):
+    """Regression: the pricesheet fetch must send a valid ``Authorization: Bearer
+    <token>`` header — NOT a doubled ``Authorization: Authorization: Bearer ...``.
+
+    The cost phase once built the header value from ``cfg.auth_header`` (which was
+    the *entire* header line ``"Authorization: Bearer <tok>"``) under the
+    ``Authorization`` key, so the runner sent ``Authorization: Authorization:
+    Bearer <tok>`` and every agent-run pricesheet fetch 401'd — cost estimation
+    silently skipped on every server-side run. Only surfaced live (a real runner
+    against a real API); the prior tests stubbed the download without asserting
+    the header. Pin the exact header the request carries.
+    """
+    _redirect_paths(tmp_path, monkeypatch)
+    plan = tmp_path / "plan.json"
+    plan.write_text(json.dumps(_PLAN))
+
+    seen: dict[str, str] = {}
+
+    def capture_download(url, output_path, headers=None, **_kw):
+        seen.update(headers or {})
+        output_path.write_text(_SHEET)
+        return DownloadResult(ok=True, status=200)
+
+    with patch.object(cost, "download_to_file", side_effect=capture_download):
+        out = cost.estimate_cost(_cfg(TP_AUTH_TOKEN="tok"), plan)
+
+    assert out is not None
+    assert seen.get("Authorization") == "Bearer tok"
+    # Belt-and-braces: the value must not itself contain the header name.
+    assert "Authorization:" not in seen.get("Authorization", "")


### PR DESCRIPTION
## Problem

Cost estimation (deterministic **and** AI) was silently non-functional on **every agent-mode run**. The runner Job log showed:

```
pricesheet download failed  status=401  url=…/api/terrapod/v1/cost-estimation/pricesheet
pricesheet unavailable — skipping cost estimation
```

## Root cause

`runner/phases/cost.py` built its headers as `{"Authorization": cfg.auth_header}`, but `RunnerConfig.auth_header` returned the **entire header line** `"Authorization: Bearer <token>"` — so the runner sent:

```
Authorization: Authorization: Bearer <token>
```

`get_current_user` can't parse that → 401. Because the cost phase is (correctly) best-effort, the run still succeeded and the failure was silent: `has_cost_estimate` stayed false, `GET /runs/{id}/cost-estimate` 404'd, and the AI-cost-summary chain (gated on the cost artifact) never fired. The sibling `binary.py` phase does it correctly; the cost phase was the sole consumer of the `auth_header` property.

## Fix

- `cost.py`: `{"Authorization": f"Bearer {cfg.auth_token}"}` (the house pattern).
- Remove the `RunnerConfig.auth_header` property — a footgun (whole-header-line return, one broken caller).
- Regression test pinning the exact header the pricesheet request carries. The prior cost-phase tests stubbed the download **without asserting headers**, which is why this shipped.

## Verification

- `make`-tier runner tests green (38 passed, incl. the new regression + all runner_config tests after the property removal).
- **Live Tilt F-gate** (real runner → real API, real Bedrock): a plan with 1 oiq-priceable EC2 ($70.08/mo) + 3 unpriced resources (kinesis/efs/mq). Post-fix, the deterministic estimate is produced ($70.08 + 3 unpriced), and the AI cost summary estimated all 3 unpriced resources (each `source: ai-estimate`, shown separately, never summed into the oiq total). Found by this F-gate; not reproducible by the mocked unit tests.

Closes #898