### PR TITLE
test(902): fix pre-hydration lost-click flake on responsive nav open

### DIFF
--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -52,9 +52,18 @@ test.describe('Responsive harness (phone viewport)', () => {
     // Opening it reveals the grouped sheet: primary links plus labelled
     // sections (Registry / Help, + Admin for admins). Account is NOT here — it
     // has its own trigger + drawer.
-    await hamburger.click();
+    //
+    // The nav is a client component: right after navigation the hamburger is
+    // SSR-rendered and visible, but a click can land BEFORE React hydrates and
+    // wires its onClick — the click is swallowed, `menuOpen` never flips, and
+    // #mobile-nav-menu never mounts (the pre-hydration lost-click flake, #902).
+    // Retry the click until the sheet actually opens, clicking only while it's
+    // still closed so a late-hydrated handler can't toggle it back shut.
     const menu = page.locator('#mobile-nav-menu');
-    await expect(menu).toBeVisible();
+    await expect(async () => {
+      if (!(await menu.isVisible())) await hamburger.click();
+      await expect(menu).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 15000 });
     await expect(menu.getByRole('link', { name: 'Workspaces' })).toBeVisible();
     await expect(menu.getByText('Registry', { exact: true })).toBeVisible();
     await expect(menu.getByText('Help', { exact: true })).toBeVisible();


### PR DESCRIPTION
## Problem

Follow-up to #896/#897. Those hardened the *close→account* sequence (sheet-teardown race). A **second, distinct** race remained at the sheet **open**: `responsive.spec.ts:57` `expect(menu).toBeVisible()` intermittently failed with `element(s) not found` right after `hamburger.click()` (line 55) — it flaked on #895 and again on #899's rebased run.

## Root cause

The nav is a client component. After `page.goto('/workspaces')` the hamburger is SSR-rendered and visible, so Playwright's auto-wait clicks it **before React hydrates and wires its `onClick`**. The click is swallowed, `menuOpen` never flips, `#mobile-nav-menu` never mounts, and the assertion fails (even on retry, since each attempt re-navigates).

## Fix

Wrap the open in `expect(...).toPass()`, clicking the hamburger only while the sheet is still closed, so a swallowed pre-hydration click is retried until the sheet mounts — and a late-hydrated handler can't toggle it back shut. Test-only; `tsc` clean.

Closes #902