### PR TITLE
feat(cost): view-time translation of the AI cost estimate (Slice D1, part of #871)

### DIFF
--- a/go-terrapod/cost_estimate.go
+++ b/go-terrapod/cost_estimate.go
@@ -210,8 +210,13 @@ type CostSummary struct {
 	InputTokens        int                     `json:"input-tokens"`
 	OutputTokens       int                     `json:"output-tokens"`
 	ErrorMessage       string                  `json:"error-message"`
-	CreatedAt          string                  `json:"created-at"`
-	UpdatedAt          string                  `json:"updated-at"`
+	// Language is the canonical language the prose is stored in; Translated is
+	// true when the served narrative/basis/advisory text was translated on view
+	// for a reader locale (#871). Request a locale via GetRunCostSummaryLocale.
+	Language     string `json:"-"`
+	Translated   bool   `json:"-"`
+	CreatedAt    string `json:"created-at"`
+	UpdatedAt    string `json:"updated-at"`
 }
 
 func costSummaryFromResource(res *Resource) *CostSummary {
@@ -224,6 +229,8 @@ func costSummaryFromResource(res *Resource) *CostSummary {
 		InputTokens:  int(GetIntAttr(res, "input-tokens")),
 		OutputTokens: int(GetIntAttr(res, "output-tokens")),
 		ErrorMessage: GetStringAttr(res, "error-message"),
+		Language:     GetStringAttr(res, "language"),
+		Translated:   GetBoolAttr(res, "translated"),
 		CreatedAt:    GetStringAttr(res, "created-at"),
 		UpdatedAt:    GetStringAttr(res, "updated-at"),
 	}

--- a/go-terrapod/cost_estimate_test.go
+++ b/go-terrapod/cost_estimate_test.go
@@ -167,6 +167,7 @@ const costSummaryBody = `{"data":{"id":"cost-summary-abc","type":"cost-summaries
       {"kind":"rightsizing","title":"Downsize us","detail":"Idle most of the day.","monthly_saving":null,"source":"ai-estimate"}
     ],
     "model":"bedrock/claude","input-tokens":120,"output-tokens":60,"error-message":"",
+    "language":"en","translated":true,
     "created-at":"2026-01-01T00:00:00Z","updated-at":"2026-01-01T00:01:00Z"
   },
   "relationships":{"run":{"data":{"id":"run-abc","type":"runs"}}}}}`
@@ -182,6 +183,9 @@ func TestGetRunCostSummary(t *testing.T) {
 	}
 	if s.Status != "ready" || s.Narrative == "" {
 		t.Errorf("status/narrative not decoded: %+v", s)
+	}
+	if s.Language != "en" || !s.Translated {
+		t.Errorf("language/translated not decoded: lang=%q translated=%v", s.Language, s.Translated)
 	}
 	if len(s.EstimatedResources) != 1 {
 		t.Fatalf("estimated_resources=%d, want 1", len(s.EstimatedResources))

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -101,11 +101,13 @@ field CostSummary.ErrorMessage string `json:"error-message"`
 field CostSummary.EstimatedResources []CostEstimatedResource `json:"estimated-resources"`
 field CostSummary.ID string `json:"-"`
 field CostSummary.InputTokens int `json:"input-tokens"`
+field CostSummary.Language string `json:"-"`
 field CostSummary.Model string `json:"model"`
 field CostSummary.Narrative string `json:"narrative"`
 field CostSummary.OutputTokens int `json:"output-tokens"`
 field CostSummary.RunID string `json:"-"`
 field CostSummary.Status string `json:"status"`
+field CostSummary.Translated bool `json:"-"`
 field CostSummary.UpdatedAt string `json:"updated-at"`
 field CreateAPITokenRequest.Description string
 field CreateAPITokenRequest.Kind string

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -1141,8 +1141,22 @@ async def show_cost_estimate(
     )
 
 
-def _cost_summary_json(run_id, summary: CostSummary) -> dict:
-    """JSON:API body for a cost-summary row."""
+def _cost_summary_json(
+    run_id,
+    summary: CostSummary,
+    *,
+    estimated_resources: list | None = None,
+    narrative: str | None = None,
+    advisories: list | None = None,
+    translated: bool = False,
+    language: str = "",
+) -> dict:
+    """JSON:API body for a cost-summary row.
+
+    The natural-language fields default to the stored (canonical-language)
+    values; pass translated overrides (with ``translated=True`` + the canonical
+    ``language``) to serve a reader-locale view (#871).
+    """
     return {
         "data": {
             "id": f"cost-summary-{summary.id}",
@@ -1153,14 +1167,20 @@ def _cost_summary_json(run_id, summary: CostSummary) -> dict:
                 # price. Each carries source="ai-estimate" (stamped server-side);
                 # the UI renders these as a separate overlay, never summed into
                 # the authoritative oiq total.
-                "estimated-resources": summary.estimated_resources,
-                "narrative": summary.narrative,
+                "estimated-resources": estimated_resources
+                if estimated_resources is not None
+                else summary.estimated_resources,
+                "narrative": narrative if narrative is not None else summary.narrative,
                 # Advisories also carry source="ai-estimate".
-                "advisories": summary.advisories,
+                "advisories": advisories if advisories is not None else summary.advisories,
                 "model": summary.model,
                 "input-tokens": summary.input_tokens,
                 "output-tokens": summary.output_tokens,
                 "error-message": summary.error_message,
+                # Canonical language the summary is stored in; `translated` is
+                # true when the served prose was translated on view (#871/#767).
+                "language": language,
+                "translated": translated,
                 "created-at": _rfc3339(summary.created_at),
                 "updated-at": _rfc3339(summary.updated_at),
             },
@@ -1174,21 +1194,26 @@ def _cost_summary_json(run_id, summary: CostSummary) -> dict:
 @extensions_router.get("/runs/{run_id}/cost-summary")
 async def show_cost_summary(
     run_id: str = Path(...),
+    locale: str | None = Query(None),
     user: AuthenticatedUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """AI cost narrative + savings advisories for a run (#871).
+    """AI cost estimate + savings advisories for a run (#871).
 
     Terrapod-native; the optional AI *enhancement* over the data-only cost
-    estimate, riding the plan-analysis AI switch. AI *polish* only — the
-    authoritative oiq figures live on the data-only `/runs/{id}/cost-estimate`
-    endpoint and are never restated here; every advisory dollar amount is
-    tagged `source: "ai-estimate"`.
+    estimate, riding the plan-analysis AI switch. Its estimates price what oiq
+    couldn't; the authoritative oiq figures live on the data-only
+    `/runs/{id}/cost-estimate` endpoint and are never restated here. Every AI
+    dollar amount is tagged `source: "ai-estimate"`.
 
-    404 when no cost narrative exists yet — the UI uses this as the "not
-    generated" signal (vs a `pending` row, which means "in flight"). The
-    narrative is stored in the deployment's `ai_summary.summary_language`;
-    view-time translation for a reader `?locale=` is a follow-up (#871).
+    404 when no cost estimate exists yet — the UI uses this as the "not
+    generated" signal (vs a `pending` row, which means "in flight"). The prose
+    is stored in the deployment's `ai_summary.summary_language`; when the caller
+    passes a `?locale=` for a different real language, the narrative + each
+    estimate's `basis` + each advisory's `title`/`detail` are translated on view
+    (Redis-cached, 7-day sliding TTL, best-effort) and `translated`/`language`
+    reflect that. On failure or budget exhaustion the canonical text is served
+    with `translated=false`.
     """
     run = await _get_run(run_id, db)
     await _require_run_ws_capability(run, cap.RUN_READ, user, db)
@@ -1197,9 +1222,33 @@ async def show_cost_summary(
         await db.execute(select(CostSummary).where(CostSummary.run_id == run.id))
     ).scalar_one_or_none()
     if summary is None:
-        raise HTTPException(status_code=404, detail="no cost narrative for this run")
+        raise HTTPException(status_code=404, detail="no cost estimate for this run")
 
-    return JSONResponse(content=_cost_summary_json(run.id, summary))
+    canonical_language = settings.ai_summary.summary_language
+    if summary.status == "ready" and locale:
+        from terrapod.services import summary_translation
+
+        result = await summary_translation.translate_cost_summary(
+            summary_id=str(summary.id),
+            narrative=summary.narrative,
+            estimated_resources=summary.estimated_resources,
+            advisories=summary.advisories,
+            reader_locale=locale,
+        )
+        if result is not None:
+            return JSONResponse(
+                content=_cost_summary_json(
+                    run.id,
+                    summary,
+                    estimated_resources=result["estimated_resources"],
+                    narrative=result["narrative"],
+                    advisories=result["advisories"],
+                    translated=True,
+                    language=canonical_language,
+                )
+            )
+
+    return JSONResponse(content=_cost_summary_json(run.id, summary, language=canonical_language))
 
 
 @extensions_router.post("/runs/{run_id}/cost-summary/regenerate")

--- a/services/terrapod/services/summary_translation.py
+++ b/services/terrapod/services/summary_translation.py
@@ -324,6 +324,91 @@ async def translate_summary(
     }
 
 
+async def translate_cost_summary(
+    *,
+    summary_id: str,
+    narrative: str,
+    estimated_resources: list[dict[str, Any]],
+    advisories: list[dict[str, Any]],
+    reader_locale: str | None,
+) -> dict[str, Any] | None:
+    """Translate a ready cost summary's prose into the reader's locale, or None.
+
+    The cost analogue of :func:`translate_summary` (#871). Returns
+    ``{"narrative": str, "estimated_resources": [...], "advisories": [...]}`` with
+    only the natural-language fields translated — the narrative, each estimated
+    resource's ``basis``, and each advisory's ``title``/``detail``. Every other
+    field (``address``/``type``/``monthly``/``source`` on estimates;
+    ``kind``/``monthly_saving``/``source`` on advisories) is preserved verbatim.
+    Returns None when no translation applies (locale not a target, same language,
+    budget exhausted, or the model call fails) — the caller then serves canonical.
+    """
+    target = target_language(reader_locale, settings.ai_summary.summary_language)
+    if target is None:
+        return None
+    if not (narrative or estimated_resources or advisories):
+        return None
+
+    # Only the translatable natural-language fields go into the cache key + call.
+    est_min = [{"basis": e.get("basis", "")} for e in estimated_resources]
+    adv_min = [{"title": a.get("title", ""), "detail": a.get("detail", "")} for a in advisories]
+    canonical = json.dumps(
+        {"narrative": narrative, "estimated": est_min, "advisories": adv_min},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    key = _cache_key("cost_summary", summary_id, target, _hash(canonical))
+
+    cached = await _cache_get(key)
+    if cached is None:
+        if not await _budget_ok():
+            logger.info("cost_translation_skipped_budget", summary_id=summary_id, target=target)
+            return None
+        try:
+            raw, out_tok = await _translate_call(
+                _TRANSLATE_JSON_SYSTEM.format(target=target),
+                canonical,
+                max_tokens=settings.ai_summary.max_output_tokens,
+            )
+            await _charge(out_tok)
+            cached = _strip_json_fence(raw)
+            json.loads(cached)  # validate before caching
+            await _cache_set(key, cached)
+        except Exception as exc:  # noqa: BLE001 — never break the view
+            logger.warning(
+                "cost_translation_failed", summary_id=summary_id, target=target, error=str(exc)
+            )
+            return None
+
+    try:
+        payload = json.loads(cached)
+    except (ValueError, TypeError):
+        return None
+
+    te = payload.get("estimated", [])
+    out_est: list[dict[str, Any]] = []
+    for i, orig in enumerate(estimated_resources):
+        merged = dict(orig)
+        if i < len(te) and isinstance(te[i], dict):
+            merged["basis"] = te[i].get("basis", orig.get("basis", ""))
+        out_est.append(merged)
+
+    ta = payload.get("advisories", [])
+    out_adv: list[dict[str, Any]] = []
+    for i, orig in enumerate(advisories):
+        merged = dict(orig)
+        if i < len(ta) and isinstance(ta[i], dict):
+            merged["title"] = ta[i].get("title", orig.get("title", ""))
+            merged["detail"] = ta[i].get("detail", orig.get("detail", ""))
+        out_adv.append(merged)
+
+    return {
+        "narrative": payload.get("narrative", narrative),
+        "estimated_resources": out_est,
+        "advisories": out_adv,
+    }
+
+
 async def translate_message(
     *, message_id: str, content: str, reader_locale: str | None
 ) -> str | None:

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -413,10 +413,12 @@
     "error-message",
     "estimated-resources",
     "input-tokens",
+    "language",
     "model",
     "narrative",
     "output-tokens",
     "status",
+    "translated",
     "updated-at"
   ],
   "runs._plan_json": [

--- a/services/tests/api/api_route_contract.json
+++ b/services/tests/api/api_route_contract.json
@@ -116,7 +116,7 @@
   "GET /api/terrapod/v1/runs/{run_id}/artifacts/plan-file",
   "GET /api/terrapod/v1/runs/{run_id}/artifacts/state",
   "GET /api/terrapod/v1/runs/{run_id}/cost-estimate",
-  "GET /api/terrapod/v1/runs/{run_id}/cost-summary",
+  "GET /api/terrapod/v1/runs/{run_id}/cost-summary ?locale",
   "GET /api/terrapod/v1/runs/{run_id}/impact-graph",
   "GET /api/terrapod/v1/runs/{run_id}/plan",
   "GET /api/terrapod/v1/runs/{run_id}/plan-summary ?locale",

--- a/services/tests/api/test_cost_summary.py
+++ b/services/tests/api/test_cost_summary.py
@@ -136,6 +136,65 @@ class TestGetCostSummary:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    async def test_translated_on_locale(self, mock_resolve, *_):
+        # ?locale= translates the prose on view; data fields stay verbatim, and
+        # translated/language reflect the translation (#871).
+        mock_resolve.return_value = caps_for_level("read")
+        run = _mock_run()
+        ws = _mock_ws(run.workspace_id)
+        summary = _mock_cost_summary(run.id)
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=run)),
+                MagicMock(scalar_one_or_none=MagicMock(return_value=summary)),
+            ]
+        )
+        mock_db.get = AsyncMock(return_value=ws)
+
+        translated = {
+            "narrative": "Zusammenfassung DE",
+            "estimated_resources": [
+                {
+                    "address": "azurerm_storage_account.a",
+                    "type": "azurerm_storage_account",
+                    "monthly": {"min": 5.0, "max": 8.0},
+                    "basis": "Grundlage DE",
+                    "source": "ai-estimate",
+                }
+            ],
+            "advisories": [
+                {"kind": "reserved", "title": "Titel DE", "detail": "d", "source": "ai-estimate"}
+            ],
+        }
+
+        app = _make_app(_user(), mock_db)
+        with (
+            patch(
+                "terrapod.services.summary_translation.translate_cost_summary",
+                AsyncMock(return_value=translated),
+            ),
+            patch("terrapod.api.routers.runs.settings.ai_summary.summary_language", "en"),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+                resp = await c.get(
+                    f"/api/terrapod/v1/runs/run-{run.id}/cost-summary?locale=de", headers=_AUTH
+                )
+
+        assert resp.status_code == 200
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["translated"] is True
+        assert attrs["language"] == "en"
+        assert attrs["narrative"] == "Zusammenfassung DE"
+        assert attrs["estimated-resources"][0]["basis"] == "Grundlage DE"
+        # Provenance + numbers preserved through translation.
+        assert attrs["estimated-resources"][0]["source"] == "ai-estimate"
+        assert attrs["estimated-resources"][0]["monthly"] == {"min": 5.0, "max": 8.0}
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
     async def test_404_when_absent(self, mock_resolve, *_):
         mock_resolve.return_value = caps_for_level("read")
         run = _mock_run()

--- a/services/tests/services/test_summary_translation.py
+++ b/services/tests/services/test_summary_translation.py
@@ -159,6 +159,95 @@ async def test_translate_summary_model_failure_falls_back(_no_cache):
     assert out is None  # caller serves canonical text
 
 
+# ── translate_cost_summary (#871) ────────────────────────────────────────────
+
+
+async def test_translate_cost_summary_skips_untranslatable_locale(_no_cache):
+    with patch.object(st.settings.ai_summary, "summary_language", "en"):
+        out = await st.translate_cost_summary(
+            summary_id="c1",
+            narrative="hi",
+            estimated_resources=[],
+            advisories=[],
+            reader_locale="en-x-leet",
+        )
+    assert out is None
+
+
+async def test_translate_cost_summary_translates_prose_preserves_data(_no_cache):
+    # Only narrative + estimate.basis + advisory.title/detail are translated;
+    # address/type/monthly/source + kind/monthly_saving/source stay verbatim.
+    translated_json = json.dumps(
+        {
+            "narrative": "Zusammenfassung auf Deutsch",
+            "estimated": [{"basis": "Grundlage DE"}],
+            "advisories": [{"title": "Titel DE", "detail": "Detail DE"}],
+        }
+    )
+    with (
+        patch.object(st.settings.ai_summary, "summary_language", "en"),
+        patch.object(st, "_translate_call", AsyncMock(return_value=(translated_json, 42))),
+    ):
+        out = await st.translate_cost_summary(
+            summary_id="c1",
+            narrative="English narrative",
+            estimated_resources=[
+                {
+                    "address": "azurerm_storage_account.a",
+                    "type": "azurerm_storage_account",
+                    "monthly": {"min": 5.0, "max": 8.0},
+                    "basis": "LRS hot ~100GB",
+                    "source": "ai-estimate",
+                }
+            ],
+            advisories=[
+                {
+                    "kind": "reserved",
+                    "title": "T",
+                    "detail": "D",
+                    "monthly_saving": {"min": 10.0, "max": 20.0},
+                    "source": "ai-estimate",
+                }
+            ],
+            reader_locale="de",
+        )
+    assert out["narrative"] == "Zusammenfassung auf Deutsch"
+    e = out["estimated_resources"][0]
+    assert e["basis"] == "Grundlage DE"
+    # non-prose fields preserved untouched
+    assert e["address"] == "azurerm_storage_account.a"
+    assert e["monthly"] == {"min": 5.0, "max": 8.0}
+    assert e["source"] == "ai-estimate"
+    a = out["advisories"][0]
+    assert a["title"] == "Titel DE" and a["detail"] == "Detail DE"
+    assert a["kind"] == "reserved"
+    assert a["monthly_saving"] == {"min": 10.0, "max": 20.0}
+    assert a["source"] == "ai-estimate"
+
+
+async def test_translate_cost_summary_empty_is_none(_no_cache):
+    with patch.object(st.settings.ai_summary, "summary_language", "en"):
+        out = await st.translate_cost_summary(
+            summary_id="c1", narrative="", estimated_resources=[], advisories=[], reader_locale="de"
+        )
+    assert out is None
+
+
+async def test_translate_cost_summary_model_failure_falls_back(_no_cache):
+    with (
+        patch.object(st.settings.ai_summary, "summary_language", "en"),
+        patch.object(st, "_translate_call", AsyncMock(side_effect=RuntimeError("boom"))),
+    ):
+        out = await st.translate_cost_summary(
+            summary_id="c1",
+            narrative="x",
+            estimated_resources=[],
+            advisories=[{"kind": "other", "title": "t", "detail": "d", "monthly_saving": None}],
+            reader_locale="de",
+        )
+    assert out is None  # caller serves canonical text
+
+
 # ── normalize_to_system_language (3b helper) ─────────────────────────────────
 
 

--- a/web/src/components/cost-ai-summary.tsx
+++ b/web/src/components/cost-ai-summary.tsx
@@ -17,7 +17,7 @@
  */
 
 import type React from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslations, useLocale } from 'next-intl'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -61,6 +61,10 @@ interface CostSummary {
     'input-tokens': number
     'output-tokens': number
     'error-message': string
+    /** Canonical language the prose is stored in (#871). */
+    language?: string
+    /** True when the served prose was translated on view for the reader. */
+    translated?: boolean
     'created-at': string
     'updated-at': string
   }
@@ -83,6 +87,9 @@ const ADVISORY_BADGE: Record<AdvisoryKind, string> = {
 
 export function CostAiSummary({ runId, refreshKey = 0 }: Props) {
   const t = useTranslations('runDetail')
+  // "Translating…" + the translated note are the same concept as the plan
+  // summary; reuse its already-translated strings rather than duplicate keys.
+  const tp = useTranslations('planSummary')
   const locale = useLocale()
   const [summary, setSummary] = useState<CostSummary | null>(null)
   const [missing, setMissing] = useState(false)
@@ -90,14 +97,27 @@ export function CostAiSummary({ runId, refreshKey = 0 }: Props) {
   const [transportError, setTransportError] = useState<string | null>(null)
   const [regenerating, setRegenerating] = useState(false)
   const [regenerateError, setRegenerateError] = useState<string | null>(null)
+  // True while a locale change re-fetches the translated view — keep the
+  // previous (stale-language) content on screen under a spinner (#871/#767).
+  const [translating, setTranslating] = useState(false)
+  const hasContentRef = useRef(false)
   const isTouch = useIsTouch()
 
   const load = useCallback(async () => {
+    // A re-fetch while we already have content means the reader switched
+    // language — show the translating spinner and keep the old content visible.
+    if (hasContentRef.current) setTranslating(true)
     try {
-      const res = await apiFetch(`/api/terrapod/v1/runs/run-${runId}/cost-summary`)
+      // Pass the reader's locale so the API translates the canonical-language
+      // prose on view (#871). Re-fetches when the locale changes (load is keyed
+      // on it).
+      const res = await apiFetch(
+        `/api/terrapod/v1/runs/run-${runId}/cost-summary?locale=${encodeURIComponent(locale)}`,
+      )
       if (res.status === 404) {
         setMissing(true)
         setSummary(null)
+        hasContentRef.current = false
         return
       }
       if (!res.ok) {
@@ -106,14 +126,16 @@ export function CostAiSummary({ runId, refreshKey = 0 }: Props) {
       }
       const data = await res.json()
       setSummary(data.data as CostSummary)
+      hasContentRef.current = true
       setMissing(false)
       setTransportError(null)
     } catch (e) {
       setTransportError(e instanceof Error ? e.message : String(e))
     } finally {
       setLoading(false)
+      setTranslating(false)
     }
-  }, [runId, t])
+  }, [runId, t, locale])
 
   useEffect(() => {
     load()
@@ -171,6 +193,12 @@ export function CostAiSummary({ runId, refreshKey = 0 }: Props) {
           <Sparkles className="h-4 w-4 text-brand-400" aria-hidden="true" />
           <h3 className="text-sm font-medium text-slate-200">{t('costAi.heading')}</h3>
           <span className="hidden text-xs text-slate-500 md:inline">{t('costAi.aiGenerated')}</span>
+          {translating && (
+            <span className="flex items-center gap-1.5 text-xs text-brand-400">
+              <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
+              {tp('translating')}
+            </span>
+          )}
         </div>
         {attrs && attrs.status !== 'pending' && (
           <button
@@ -322,6 +350,10 @@ export function CostAiSummary({ runId, refreshKey = 0 }: Props) {
                 </ReactMarkdown>
               </div>
             </div>
+          )}
+
+          {attrs.translated && (
+            <p className="text-xs italic text-slate-500">{tp('translatedNote')}</p>
           )}
 
           {/* Provenance + model footer. */}


### PR DESCRIPTION
## What

Brings the AI cost estimate to **i18n parity with the plan analysis** (#767): its AI-generated prose (narrative, each estimate's `basis`, each advisory's `title`/`detail`) is translated on view for the reader's locale. Data fields — `address`/`type`/`monthly`/`source` on estimates, `kind`/`monthly_saving`/`source` on advisories — are preserved verbatim, so provenance and numbers never change through translation.

## How

- **`summary_translation.translate_cost_summary`** — the cost analogue of `translate_summary`, reusing the same target-language resolution, Redis cache (7-day sliding TTL), model-call, and daily-budget plumbing. Best-effort: on model failure or budget exhaustion the canonical text is served with `translated=false`.
- **`GET /runs/{id}/cost-summary?locale=`** — translates when the row is `ready` and a real target locale is passed; adds `translated`/`language` attributes. **No `?locale=` → behaviour unchanged** (additive, MINOR-safe).
- **go-terrapod** `CostSummary.Language`/`Translated` decode. The SDK doesn't request a locale (view-time translation is a browser concern) — matching the plan-summary SDK.
- **Web `CostAiSummary`** passes `?locale=`, re-fetches on locale change under a "Translating…" spinner, and shows a translated note. Reuses the plan-summary's already-translated `translating`/`translatedNote` strings — **no new catalog keys, so no 32-locale refill**.

## Verification

- Python: 59 passing (translation unit tests preserving structure + provenance; router `?locale=` test asserting `translated`/`language` + verbatim data).
- go-terrapod: full suite green (new fields decoded).
- `npm run build` + `i18n:lint` (0 new hardcoded) + full `make lint` (ruff + tsc) green.
- Additive **attribute** + **go-terrapod surface** contract snapshots regenerated (`language`, `translated`; `CostSummary.Language/Translated`) — both are additions, MINOR-safe.

Part of #871