### PR TITLE
feat(provider): terrapod_workspace_cost data source (part of #871)

### DIFF
--- a/docs/terraform-provider.md
+++ b/docs/terraform-provider.md
@@ -33,8 +33,23 @@ otherwise click through in the web UI or call over the API, expressed as HCL:
 | Service catalog | `terrapod_catalog_item`, `terrapod_catalog_instance`, `terrapod_provider_template` |
 
 **Data sources** (`terrapod_*`): `terrapod_workspace`, `terrapod_workspaces`,
-`terrapod_agent_pool`, `terrapod_role`, `terrapod_user`,
-`terrapod_vcs_connection`, `terrapod_catalog_instances`.
+`terrapod_workspace_cost`, `terrapod_agent_pool`, `terrapod_role`,
+`terrapod_user`, `terrapod_vcs_connection`, `terrapod_catalog_instances`.
+
+`terrapod_workspace_cost` reports a workspace's current monthly managed-infra
+cost (from its latest state, via the native OpenInfraQuote-port engine) — useful
+for budget guardrails and reporting. Example:
+
+```hcl
+data "terrapod_workspace_cost" "app" {
+  workspace_id = terrapod_workspace.app.id
+}
+
+# e.g. gate something on the estimate, or surface it as an output
+output "app_monthly_cost" {
+  value = data.terrapod_workspace_cost.app.total_max
+}
+```
 
 Under the hood the provider is a thin, typed wrapper over the canonical Go SDK
 [`go-terrapod`](../go-terrapod): the SDK owns every API call shape, and the

--- a/provider/internal/datasources/workspace_cost/data_source.go
+++ b/provider/internal/datasources/workspace_cost/data_source.go
@@ -1,0 +1,213 @@
+// Package workspace_cost implements the terrapod_workspace_cost data source (#871).
+//
+// API Contract: GET /api/terrapod/v1/workspaces/{id}/cost-estimate
+// Reports the current monthly cost of a workspace's managed infrastructure,
+// computed server-side from its latest state version by the native
+// OpenInfraQuote-port engine. Data only — no AI. Useful in config for budget
+// guardrails, reporting, or feeding a threshold into an alert.
+//
+// A workspace with no state yet returns a zeroed estimate with a null
+// state_version (not an error).
+package workspace_cost
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/mattrobinsonsre/terrapod/provider/internal/client"
+)
+
+var _ datasource.DataSource = &workspaceCostDataSource{}
+
+type workspaceCostDataSource struct {
+	tc *terrapod.Client
+}
+
+type workspaceCostDataSourceModel struct {
+	WorkspaceID           types.String  `tfsdk:"workspace_id"`
+	Currency              types.String  `tfsdk:"currency"`
+	TotalMin              types.Float64 `tfsdk:"total_min"`
+	TotalMax              types.Float64 `tfsdk:"total_max"`
+	PreviousMin           types.Float64 `tfsdk:"previous_min"`
+	PreviousMax           types.Float64 `tfsdk:"previous_max"`
+	DiffMin               types.Float64 `tfsdk:"diff_min"`
+	DiffMax               types.Float64 `tfsdk:"diff_max"`
+	Resources             types.List    `tfsdk:"resources"`
+	Unpriced              types.List    `tfsdk:"unpriced"`
+	StateVersionID        types.String  `tfsdk:"state_version_id"`
+	StateVersionSerial    types.Int64   `tfsdk:"state_version_serial"`
+	StateVersionCreatedAt types.String  `tfsdk:"state_version_created_at"`
+}
+
+type costResourceObj struct {
+	Address    types.String  `tfsdk:"address"`
+	Type       types.String  `tfsdk:"type"`
+	Name       types.String  `tfsdk:"name"`
+	Change     types.String  `tfsdk:"change"`
+	MonthlyMin types.Float64 `tfsdk:"monthly_min"`
+	MonthlyMax types.Float64 `tfsdk:"monthly_max"`
+}
+
+type unpricedObj struct {
+	Address types.String `tfsdk:"address"`
+	Type    types.String `tfsdk:"type"`
+	Change  types.String `tfsdk:"change"`
+}
+
+var costResourceAttrTypes = map[string]attr.Type{
+	"address":     types.StringType,
+	"type":        types.StringType,
+	"name":        types.StringType,
+	"change":      types.StringType,
+	"monthly_min": types.Float64Type,
+	"monthly_max": types.Float64Type,
+}
+
+var unpricedAttrTypes = map[string]attr.Type{
+	"address": types.StringType,
+	"type":    types.StringType,
+	"change":  types.StringType,
+}
+
+// NewDataSource returns a new workspace-cost data source.
+func NewDataSource() datasource.DataSource {
+	return &workspaceCostDataSource{}
+}
+
+func (d *workspaceCostDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_workspace_cost"
+}
+
+func (d *workspaceCostDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Current monthly cost of a workspace's managed infrastructure, computed " +
+			"from its latest state by the native OpenInfraQuote-port engine (data only, no AI). " +
+			"Useful for budget guardrails and reporting. A workspace with no state returns a " +
+			"zeroed estimate with a null state_version.",
+		Attributes: map[string]schema.Attribute{
+			"workspace_id": schema.StringAttribute{
+				Description: "Workspace ID (ws-… or a bare UUID) to estimate.",
+				Required:    true,
+			},
+			"currency":     schema.StringAttribute{Description: "ISO currency code (e.g. USD).", Computed: true},
+			"total_min":    schema.Float64Attribute{Description: "Current monthly total, lower bound.", Computed: true},
+			"total_max":    schema.Float64Attribute{Description: "Current monthly total, upper bound (equals total_min for deterministic prices).", Computed: true},
+			"previous_min": schema.Float64Attribute{Description: "Prior monthly total, lower bound (equals total for a state estimate).", Computed: true},
+			"previous_max": schema.Float64Attribute{Description: "Prior monthly total, upper bound.", Computed: true},
+			"diff_min":     schema.Float64Attribute{Description: "Monthly delta, lower bound (zero for a state estimate).", Computed: true},
+			"diff_max":     schema.Float64Attribute{Description: "Monthly delta, upper bound (zero for a state estimate).", Computed: true},
+			"resources": schema.ListNestedAttribute{
+				Description: "Per-resource priced breakdown. Every resource is a `noop` for a state estimate.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"address":     schema.StringAttribute{Description: "Resource address.", Computed: true},
+						"type":        schema.StringAttribute{Description: "Resource type.", Computed: true},
+						"name":        schema.StringAttribute{Description: "Resource name.", Computed: true},
+						"change":      schema.StringAttribute{Description: "noop | add | remove.", Computed: true},
+						"monthly_min": schema.Float64Attribute{Description: "Monthly cost, lower bound.", Computed: true},
+						"monthly_max": schema.Float64Attribute{Description: "Monthly cost, upper bound.", Computed: true},
+					},
+				},
+			},
+			"unpriced": schema.ListNestedAttribute{
+				Description: "Resources the pricing data couldn't price (unmapped type, no direct cost, or an uncovered provider).",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"address": schema.StringAttribute{Description: "Resource address.", Computed: true},
+						"type":    schema.StringAttribute{Description: "Resource type.", Computed: true},
+						"change":  schema.StringAttribute{Description: "noop | add | remove.", Computed: true},
+					},
+				},
+			},
+			"state_version_id":         schema.StringAttribute{Description: "ID of the priced state version (sv-…); null when the workspace has no state.", Computed: true},
+			"state_version_serial":     schema.Int64Attribute{Description: "Serial of the priced state version; 0 when no state.", Computed: true},
+			"state_version_created_at": schema.StringAttribute{Description: "Creation timestamp of the priced state version; null when no state.", Computed: true},
+		},
+	}
+}
+
+func (d *workspaceCostDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client, got %T", req.ProviderData))
+		return
+	}
+	tc, err := terrapod.NewClient(terrapod.Options{BaseURL: c.BaseURL, Token: c.Token})
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to build go-terrapod client", err.Error())
+		return
+	}
+	d.tc = tc
+}
+
+func (d *workspaceCostDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config workspaceCostDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	est, err := d.tc.GetWorkspaceCostEstimate(ctx, config.WorkspaceID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read workspace cost estimate", err.Error())
+		return
+	}
+
+	config.Currency = types.StringValue(est.Currency)
+	config.TotalMin = types.Float64Value(est.Total.Min)
+	config.TotalMax = types.Float64Value(est.Total.Max)
+	config.PreviousMin = types.Float64Value(est.Previous.Min)
+	config.PreviousMax = types.Float64Value(est.Previous.Max)
+	config.DiffMin = types.Float64Value(est.Diff.Min)
+	config.DiffMax = types.Float64Value(est.Diff.Max)
+
+	resources := make([]costResourceObj, 0, len(est.Resources))
+	for _, r := range est.Resources {
+		resources = append(resources, costResourceObj{
+			Address:    types.StringValue(r.Address),
+			Type:       types.StringValue(r.Type),
+			Name:       types.StringValue(r.Name),
+			Change:     types.StringValue(r.Change),
+			MonthlyMin: types.Float64Value(r.Monthly.Min),
+			MonthlyMax: types.Float64Value(r.Monthly.Max),
+		})
+	}
+	resList, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: costResourceAttrTypes}, resources)
+	resp.Diagnostics.Append(diags...)
+	config.Resources = resList
+
+	unpriced := make([]unpricedObj, 0, len(est.Unpriced))
+	for _, u := range est.Unpriced {
+		unpriced = append(unpriced, unpricedObj{
+			Address: types.StringValue(u.Address),
+			Type:    types.StringValue(u.Type),
+			Change:  types.StringValue(u.Change),
+		})
+	}
+	unpricedList, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: unpricedAttrTypes}, unpriced)
+	resp.Diagnostics.Append(diags...)
+	config.Unpriced = unpricedList
+
+	if est.StateVersion != nil {
+		config.StateVersionID = types.StringValue(est.StateVersion.ID)
+		config.StateVersionSerial = types.Int64Value(int64(est.StateVersion.Serial))
+		config.StateVersionCreatedAt = types.StringValue(est.StateVersion.CreatedAt)
+	} else {
+		config.StateVersionID = types.StringNull()
+		config.StateVersionSerial = types.Int64Value(0)
+		config.StateVersionCreatedAt = types.StringNull()
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}

--- a/provider/internal/provider/provider.go
+++ b/provider/internal/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	userDS "github.com/mattrobinsonsre/terrapod/provider/internal/datasources/user"
 	vcsConnectionDS "github.com/mattrobinsonsre/terrapod/provider/internal/datasources/vcs_connection"
 	workspaceDS "github.com/mattrobinsonsre/terrapod/provider/internal/datasources/workspace"
+	workspaceCostDS "github.com/mattrobinsonsre/terrapod/provider/internal/datasources/workspace_cost"
 	workspacesDS "github.com/mattrobinsonsre/terrapod/provider/internal/datasources/workspaces"
 	agentPoolRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/agent_pool"
 	agentPoolTokenRes "github.com/mattrobinsonsre/terrapod/provider/internal/resources/agent_pool_token"
@@ -174,6 +175,7 @@ func (p *terrapodProvider) Resources(_ context.Context) []func() resource.Resour
 func (p *terrapodProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		workspaceDS.NewDataSource,
+		workspaceCostDS.NewDataSource,
 		workspacesDS.NewDataSource,
 		roleDS.NewDataSource,
 		agentPoolDS.NewDataSource,

--- a/provider/internal/provider/schema.golden
+++ b/provider/internal/provider/schema.golden
@@ -82,6 +82,19 @@ data terrapod_workspace.vcs_last_error_at required=false optional=false computed
 data terrapod_workspace.vcs_last_polled_at required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.vcs_repo_url required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.working_directory required=false optional=false computed=true sensitive=false type=basetypes.StringType
+data terrapod_workspace_cost.currency required=false optional=false computed=true sensitive=false type=basetypes.StringType
+data terrapod_workspace_cost.diff_max required=false optional=false computed=true sensitive=false type=basetypes.Float64Type
+data terrapod_workspace_cost.diff_min required=false optional=false computed=true sensitive=false type=basetypes.Float64Type
+data terrapod_workspace_cost.previous_max required=false optional=false computed=true sensitive=false type=basetypes.Float64Type
+data terrapod_workspace_cost.previous_min required=false optional=false computed=true sensitive=false type=basetypes.Float64Type
+data terrapod_workspace_cost.resources required=false optional=false computed=true sensitive=false type=types.ListType[types.ObjectType["address":basetypes.StringType, "change":basetypes.StringType, "monthly_max":basetypes.Float64Type, "monthly_min":basetypes.Float64Type, "name":basetypes.StringType, "type":basetypes.StringType]]
+data terrapod_workspace_cost.state_version_created_at required=false optional=false computed=true sensitive=false type=basetypes.StringType
+data terrapod_workspace_cost.state_version_id required=false optional=false computed=true sensitive=false type=basetypes.StringType
+data terrapod_workspace_cost.state_version_serial required=false optional=false computed=true sensitive=false type=basetypes.Int64Type
+data terrapod_workspace_cost.total_max required=false optional=false computed=true sensitive=false type=basetypes.Float64Type
+data terrapod_workspace_cost.total_min required=false optional=false computed=true sensitive=false type=basetypes.Float64Type
+data terrapod_workspace_cost.unpriced required=false optional=false computed=true sensitive=false type=types.ListType[types.ObjectType["address":basetypes.StringType, "change":basetypes.StringType, "type":basetypes.StringType]]
+data terrapod_workspace_cost.workspace_id required=true optional=false computed=false sensitive=false type=basetypes.StringType
 data terrapod_workspaces.search required=false optional=true computed=false sensitive=false type=basetypes.StringType
 data terrapod_workspaces.workspaces required=false optional=false computed=true sensitive=false type=types.ListType[types.ObjectType["execution_mode":basetypes.StringType, "id":basetypes.StringType, "locked":basetypes.BoolType, "name":basetypes.StringType]]
 resource terrapod_agent_pool.created_at required=false optional=false computed=true sensitive=false type=basetypes.StringType


### PR DESCRIPTION
The one worthwhile follow-up after the #871 cost feature shipped.

## What

A `terrapod_workspace_cost` **data source** exposing a workspace's *current* monthly managed-infrastructure cost — the deterministic OpenInfraQuote-port state estimate — usable in config for budget guardrails, reporting, or feeding a threshold into an alert.

```hcl
data "terrapod_workspace_cost" "app" {
  workspace_id = terrapod_workspace.app.id
}
output "app_monthly_cost" { value = data.terrapod_workspace_cost.app.total_max }
```

**Workspace-scoped, not run-scoped** (per the design discussion): a run's cost is a transient plan-delta; a workspace's current-state cost is the durable, config-useful figure.

## How

Thin wrapper over the existing go-terrapod `GetWorkspaceCostEstimate` — **no new SDK or API work**. Exposes `currency`, `total_/previous_/diff_{min,max}`, the per-resource priced breakdown (`resources`) + `unpriced` list, and the priced `state_version_*` (null when the workspace has no state).

## Verification

- `go build` + full provider `go test` green.
- Additive **provider schema-contract** golden regenerated (`UPDATE_SCHEMA=1`) — every attribute captured incl. the nested `resources`/`unpriced` object shapes.
- Provider docs data-source list + example updated.

Closes #914
Part of #871