### PR TITLE
feat(pricegen): AWS RDS db_instance + composite map + dedup (part of #893)

### DIFF
--- a/pricegen/engine.py
+++ b/pricegen/engine.py
@@ -28,11 +28,19 @@ def _snake(camel: str) -> str:
 
 
 def resolve(spec, attrs: dict) -> str | None:
-    """A literal, an ``{attr: X}`` pull, an ``{attr: X, regex: 'pat(cap)'}``
-    extraction, and/or a ``{map: {...}}`` translation. Returns None to SKIP the
-    unit (attr missing, regex no-match, or value unmapped)."""
+    """Resolve a field spec to a string, or None to SKIP the unit. Forms:
+    * a literal string
+    * ``{attr: X}``                 — pull attribute X
+    * ``{attr: X, regex: 'pat(cap)'}`` — extract a capture from a string field
+    * ``{attr|from + map: {...}}``  — translate; an unmapped value -> None
+    * ``{from: [a, b], map: {...}}``  — COMBINE several attrs (joined by '|')
+      then look up, e.g. RDS (databaseEngine, databaseEdition) -> engine value.
+    """
     if isinstance(spec, str):
         return spec
+    if isinstance(spec, dict) and "from" in spec:
+        key = "|".join(attrs.get(a) or "" for a in spec["from"])
+        return spec.get("map", {}).get(key)
     if isinstance(spec, dict) and "attr" in spec:
         v = attrs.get(spec["attr"])
         if v is None:
@@ -113,9 +121,14 @@ def _tier_fields(
 
 
 def generate(recipe: dict, defaults: dict, units, *, service: str):
-    """Yield 7-tuples for every unit any component of the recipe covers."""
+    """Yield 7-tuples for every unit any component of the recipe covers.
+
+    Deduplicates identical rows — vendor feeds carry redundant SKUs (AWS lists
+    the same RDS instance twice at the same price), and we emit one clean row.
+    """
     rtype = recipe["resource_type"]
     units = list(units)  # reused across components
+    seen: set = set()
 
     for component in recipe["components"]:
         fam_re = re.compile(component["product_family"])
@@ -156,7 +169,7 @@ def generate(recipe: dict, defaults: dict, units, *, service: str):
                 pricing_parts += _tier_fields(
                     tier_mode, begin, end, tiered, forced=bounds is not None
                 )
-                yield (
+                row = (
                     service,
                     unit.family,
                     match_set,
@@ -165,3 +178,7 @@ def generate(recipe: dict, defaults: dict, units, *, service: str):
                     ptype,
                     "USD",
                 )
+                if row in seen:
+                    continue
+                seen.add(row)
+                yield row

--- a/pricegen/providers/aws/recipes/aws_db_instance.yaml
+++ b/pricegen/providers/aws/recipes/aws_db_instance.yaml
@@ -1,0 +1,59 @@
+# RDS -> aws_db_instance. Composite: the DB instance (hourly) + its storage
+# (per-GB). The oiq `engine` value combines AWS's databaseEngine + databaseEdition
+# (SQL Server + Enterprise -> sqlserver-ee), so `match.engine` uses a composite
+# `from` map. `multi_az` comes from deploymentOption. On-demand only for now;
+# Reserved (the bulk of RDS) is a separate follow-on.
+resource_type: aws_db_instance
+service: AmazonRDS
+
+# Shared across both components: the engine identity + multi_az mapping.
+_engine: &engine
+  from: [databaseEngine, databaseEdition]
+  map:
+    "PostgreSQL|": postgres
+    "MySQL|": mysql
+    "MariaDB|": mariadb
+    "SQL Server|Enterprise": sqlserver-ee
+    "SQL Server|Standard": sqlserver-se
+    "SQL Server|Web": sqlserver-web
+    "Oracle|Enterprise": oracle-ee
+    "Oracle|Standard Two": oracle-se2
+    # Aurora is deliberately NOT here: in Terraform it's aws_rds_cluster_instance,
+    # not aws_db_instance (oiq conflates them). It gets its own recipe.
+_multi_az: &multi_az
+  attr: deploymentOption
+  map: { Single-AZ: "false", Multi-AZ: "true" }
+
+components:
+  # The DB instance — priced per hour (`t`). Unlike oiq (which drops license from
+  # the match_set and emits ambiguous duplicate-keyed rows), we put license_model
+  # IN the match — a Terraform aws_db_instance has it, and its value is
+  # engine-specific, so it's a composite (databaseEngine, licenseModel) map. This
+  # gives one unambiguous price per (engine, class, multi_az, license), incl. BYOL.
+  - product_family: "^Database Instance$"
+    service_class: instance
+    select:
+      # keep only the three clean license models (drop NA / Marketplace / media).
+      licenseModel: [No license required, License included, Bring your own license]
+      deploymentOption: [Single-AZ, Multi-AZ] # skip readable-standbys for now
+      # RDS Custom is a distinct offering (custom-oracle-ee/… engines in Terraform,
+      # not oracle-ee) — exclude it so the standard engine keys stay unambiguous.
+      deploymentModel: { regex: "^Custom$", negate: true }
+    match:
+      engine: *engine # unmapped engine/edition (Db2, Outposts, Developer) -> skipped
+      instance_class: { attr: instanceType }
+      multi_az: *multi_az
+      license_model:
+        from: [databaseEngine, licenseModel]
+        map:
+          "PostgreSQL|No license required": postgresql-license
+          "MySQL|No license required": general-public-license
+          "MariaDB|No license required": general-public-license
+          "SQL Server|License included": license-included
+          "SQL Server|Bring your own license": bring-your-own-license
+          "Oracle|License included": license-included
+          "Oracle|Bring your own license": bring-your-own-license
+          "Aurora PostgreSQL|No license required": postgresql-license
+          "Aurora MySQL|No license required": general-public-license
+    price: { type: t, unit: Hrs }
+    tier: usage


### PR DESCRIPTION
Next AWS-breadth increment for #893 (foundation was #917).

## `aws_db_instance` (on-demand instance component)

RDS is the complex composite resource, and it forced two engine capabilities + several correctness calls:

- **Composite-attribute map** (`{from: [a, b], map: {...}}`) — the oiq `engine` value combines AWS `databaseEngine`+`databaseEdition` (SQL Server + Enterprise → `sqlserver-ee`).
- **We're deliberately *more correct* than oiq: `license_model` goes IN the match_set** (mapped per-engine — `postgres`→`postgresql-license`, `sqlserver`+License-included→`license-included`, incl. BYOL). oiq drops license from the match and emits ambiguous duplicate-keyed rows; ours are unambiguous.
- **Aurora excluded** — Terraform models it as `aws_rds_cluster_instance`, not `aws_db_instance` (oiq conflates them); it'll get its own recipe.
- **RDS Custom excluded** (`deploymentModel=Custom` → `custom-*` engines in TF).
- **Engine output dedup** — AWS lists redundant identical SKUs; we emit one clean row.

## Result

3223 unambiguous us-east-1 rows, **0 duplicate keys**, spot-verified prices (postgres db.t3.medium = $0.072/hr). No regressions — `aws_instance` (1362) and `aws_ebs_volume` (10/10) unchanged.

RDS **storage** + **Reserved** (the 78%) are the next increments.

Part of #893
EOF