### PR TITLE
feat(pricegen): generator drift diagnostics (manifest + skip-reason counters)

### DIFF
--- a/pricegen/engine.py
+++ b/pricegen/engine.py
@@ -16,43 +16,108 @@ Two component kinds:
     machine_type -> Σ vCPU-core + RAM-GB). Not implemented yet; the direct kind
     is what the AWS/Azure recipes use. The seam is here so GCP slots in without
     an engine rewrite.
+
+Diagnostics (#922): ``generate`` optionally records a :class:`RecipeStats` — row
+counts and, crucially, the *reason* each unit was dropped. The high-signal
+reason is **unmapped**: a value the feed carries for a mapped field that our
+``map:`` doesn't cover (a new ``volumeType``/``databaseEdition``/machine family).
+That's the canonical "the cloud changed and our recipe logic needs an update"
+signal — the scheduled generator surfaces it so drift is alerted, not silently
+dropped. An "absent" miss (the source attr simply isn't on this unit) is the
+expected, low-signal case and is counted separately.
 """
 
 from __future__ import annotations
 
 import re
+from collections import Counter
+from dataclasses import dataclass, field
 
 
 def _snake(camel: str) -> str:
     return re.sub(r"(?<!^)(?=[A-Z])", "_", camel).lower()
 
 
-def resolve(spec, attrs: dict) -> str | None:
-    """Resolve a field spec to a string, or None to SKIP the unit. Forms:
-    * a literal string
-    * ``{attr: X}``                 — pull attribute X
+def _resolve2(spec, attrs: dict) -> tuple[str | None, str | None, str | None]:
+    """Resolve a field spec to ``(value, miss, offending)``.
+
+    ``miss`` is ``None`` when resolved, ``"absent"`` when the source attribute
+    isn't present on the unit (expected — this unit just isn't for us), or
+    ``"unmapped"`` when the source IS present but our ``map:``/``regex`` doesn't
+    cover its value (**actionable drift** — ``offending`` carries that value).
+
+    Forms:
+    * a literal string                 — always resolves
+    * ``{attr: X}``                    — pull attribute X
     * ``{attr: X, regex: 'pat(cap)'}`` — extract a capture from a string field
-    * ``{attr|from + map: {...}}``  — translate; an unmapped value -> None
-    * ``{from: [a, b], map: {...}}``  — COMBINE several attrs (joined by '|')
+    * ``{attr: X, map: {...}}``        — translate; unmapped value -> miss
+    * ``{from: [a, b], map: {...}}``   — COMBINE several attrs (joined by '|')
       then look up, e.g. RDS (databaseEngine, databaseEdition) -> engine value.
     """
     if isinstance(spec, str):
-        return spec
+        return spec, None, None
     if isinstance(spec, dict) and "from" in spec:
-        key = "|".join(attrs.get(a) or "" for a in spec["from"])
-        return spec.get("map", {}).get(key)
+        vals = [attrs.get(a) for a in spec["from"]]
+        key = "|".join(v or "" for v in vals)
+        mapping = spec.get("map", {})
+        if key in mapping:
+            return mapping[key], None, None
+        # all source attrs empty -> genuinely absent; else an uncovered combo.
+        if all(v is None for v in vals):
+            return None, "absent", None
+        return None, "unmapped", key
     if isinstance(spec, dict) and "attr" in spec:
         v = attrs.get(spec["attr"])
         if v is None:
-            return None
+            return None, "absent", None
+        raw = v
         if "regex" in spec:
             m = re.search(spec["regex"], v)
             if not m:
-                return None
+                return None, "unmapped", raw
             v = m.group(1) if m.groups() else m.group(0)
         mapping = spec.get("map")
-        return mapping.get(v) if mapping is not None else v
+        if mapping is not None:
+            if v not in mapping:
+                return None, "unmapped", raw
+            return mapping[v], None, None
+        return v, None, None
     raise ValueError(f"bad field spec: {spec!r}")
+
+
+def resolve(spec, attrs: dict) -> str | None:
+    """Resolve a field spec to a string, or None to SKIP the unit."""
+    return _resolve2(spec, attrs)[0]
+
+
+@dataclass
+class RecipeStats:
+    """Per-recipe diagnostics for one generate() run (#922).
+
+    ``unmapped`` is the drift signal: ``field -> {offending_value: count}`` for
+    values the feed carried that our recipe's map/regex didn't cover.
+    """
+
+    rows: int = 0
+    units_total: int = 0
+    skipped_select: int = 0
+    skipped_absent: int = 0
+    skipped_unmapped: int = 0
+    unmapped: dict[str, Counter] = field(default_factory=dict)
+    price_min: float | None = None
+    price_max: float | None = None
+
+    def _note_unmapped(self, fieldname: str, value: str) -> None:
+        self.skipped_unmapped += 1
+        self.unmapped.setdefault(fieldname, Counter())[value] += 1
+
+    def _note_price(self, usd: str) -> None:
+        try:
+            v = float(usd)
+        except (TypeError, ValueError):
+            return
+        self.price_min = v if self.price_min is None else min(self.price_min, v)
+        self.price_max = v if self.price_max is None else max(self.price_max, v)
 
 
 def _requirement_ok(want, got: str | None) -> bool:
@@ -79,7 +144,11 @@ def _passes(component: dict, defaults: dict, attrs: dict) -> bool:
     return all(_requirement_ok(want, attrs.get(dim)) for dim, want in select.items())
 
 
-def _match_set(component: dict, rtype: str, attrs: dict) -> str | None:
+def _match_set(
+    component: dict, rtype: str, attrs: dict
+) -> tuple[str | None, tuple[str, str, str] | None]:
+    """Return ``(match_set, miss)`` where miss is ``(field, reason, value)`` for
+    the first field that didn't resolve, or None when the whole set resolved."""
     parts = [f"type={rtype}"]
     match = component["match"]
     items = (
@@ -88,11 +157,11 @@ def _match_set(component: dict, rtype: str, attrs: dict) -> str | None:
     for tf_key, spec in items.items():
         if isinstance(spec, str):
             spec = {"attr": spec}
-        v = resolve(spec, attrs)
+        v, miss, offending = _resolve2(spec, attrs)
         if v is None:
-            return None
+            return None, (tf_key, miss or "absent", offending or "")
         parts.append(f"values.{tf_key}={v}")
-    return "&".join(parts)
+    return "&".join(parts), None
 
 
 def _tier_bounds(component: dict, attrs: dict) -> tuple[str, str] | None:
@@ -120,11 +189,14 @@ def _tier_fields(
     return []
 
 
-def generate(recipe: dict, defaults: dict, units, *, service: str):
+def generate(recipe: dict, defaults: dict, units, *, service: str, stats=None):
     """Yield 7-tuples for every unit any component of the recipe covers.
 
     Deduplicates identical rows — vendor feeds carry redundant SKUs (AWS lists
     the same RDS instance twice at the same price), and we emit one clean row.
+
+    When ``stats`` (a :class:`RecipeStats`) is passed, records row counts and the
+    reason each unit was dropped — the drift-diagnostics foundation for #922.
     """
     rtype = recipe["resource_type"]
     units = list(units)  # reused across components
@@ -140,10 +212,21 @@ def generate(recipe: dict, defaults: dict, units, *, service: str):
         for unit in units:
             if not fam_re.search(unit.family):
                 continue
+            # Unit is in-family for this component — now it counts toward stats.
+            if stats is not None:
+                stats.units_total += 1
             if not _passes(component, defaults, unit.attrs):
+                if stats is not None:
+                    stats.skipped_select += 1
                 continue
-            match_set = _match_set(component, rtype, unit.attrs)
+            match_set, miss = _match_set(component, rtype, unit.attrs)
             if match_set is None:
+                if stats is not None:
+                    fieldname, reason, value = miss  # type: ignore[misc]
+                    if reason == "unmapped":
+                        stats._note_unmapped(f"match.{fieldname}", value)
+                    else:
+                        stats.skipped_absent += 1
                 continue
 
             base = dict(defaults.get("pricing_common", {}))
@@ -152,8 +235,13 @@ def generate(recipe: dict, defaults: dict, units, *, service: str):
             resolved: dict[str, str] = {}
             skip = False
             for k, spec in base.items():
-                v = resolve(spec, unit.attrs)
+                v, miss_reason, offending = _resolve2(spec, unit.attrs)
                 if v is None:
+                    if stats is not None:
+                        if miss_reason == "unmapped":
+                            stats._note_unmapped(f"pricing.{k}", offending or "")
+                        else:
+                            stats.skipped_absent += 1
                     skip = True
                     break
                 resolved[k] = v
@@ -181,4 +269,7 @@ def generate(recipe: dict, defaults: dict, units, *, service: str):
                 if row in seen:
                     continue
                 seen.add(row)
+                if stats is not None:
+                    stats.rows += 1
+                    stats._note_price(p.usd)
                 yield row

--- a/pricegen/generate.py
+++ b/pricegen/generate.py
@@ -22,6 +22,7 @@ import argparse
 import csv
 import gzip
 import importlib
+import json
 import sys
 import urllib.request
 from pathlib import Path
@@ -74,6 +75,44 @@ def fetch_oiq_rows(rtype: str, region: str) -> list[list[str]]:
     return out
 
 
+def _manifest(stats: engine.RecipeStats, recipe: dict) -> dict:
+    """The per-recipe drift-diagnostics record the scheduled generator persists
+    and diffs across runs (#922). ``unmapped`` is the actionable signal: values
+    the feed carried for a mapped field that our recipe didn't cover."""
+    return {
+        "resource_type": recipe["resource_type"],
+        "service": recipe["service"],
+        "rows": stats.rows,
+        "units_in_family": stats.units_total,
+        "skipped": {
+            "select": stats.skipped_select,
+            "absent": stats.skipped_absent,
+            "unmapped": stats.skipped_unmapped,
+        },
+        "unmapped": {f: dict(c) for f, c in sorted(stats.unmapped.items())},
+        "price_min": stats.price_min,
+        "price_max": stats.price_max,
+    }
+
+
+def _report_stats(stats: engine.RecipeStats, rtype: str) -> None:
+    print(f"=== diagnostics ({rtype}) ===", file=sys.stderr)
+    print(
+        f"  {stats.rows} rows from {stats.units_total} in-family units "
+        f"(skipped: select={stats.skipped_select} absent={stats.skipped_absent} "
+        f"unmapped={stats.skipped_unmapped})",
+        file=sys.stderr,
+    )
+    if stats.price_min is not None:
+        print(f"  price range: {stats.price_min} … {stats.price_max}", file=sys.stderr)
+    if stats.unmapped:
+        # The drift signal — a value the feed carries that our recipe drops.
+        print("  UNMAPPED (recipe may need an update):", file=sys.stderr)
+        for fieldname, counter in sorted(stats.unmapped.items()):
+            for value, n in counter.most_common(10):
+                print(f"    {fieldname}={value!r} ({n})", file=sys.stderr)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--provider", default="aws", help="aws | azure | gcp")
@@ -83,6 +122,12 @@ def main() -> int:
         "--out", type=Path, help="write rows here (gzip if .gz); default stdout"
     )
     ap.add_argument("--compare-oiq", metavar="REGION")
+    ap.add_argument(
+        "--manifest",
+        type=Path,
+        help="write a drift-diagnostics manifest (JSON) here — the artifact the "
+        "scheduled generator diffs across runs to alert on feed/logic drift (#922)",
+    )
     args = ap.parse_args()
 
     pdir = HERE / "providers" / args.provider
@@ -96,8 +141,15 @@ def main() -> int:
     print(f"loading {args.provider} offer {args.offer} …", file=sys.stderr)
     offer = adapter.load(args.offer)
     units = adapter.iter_units(offer, term=defaults.get("price_term", "OnDemand"))
-    rows = list(engine.generate(recipe, defaults, units, service=recipe["service"]))
+    stats = engine.RecipeStats()
+    rows = list(
+        engine.generate(recipe, defaults, units, service=recipe["service"], stats=stats)
+    )
     print(f"generated {len(rows)} rows for {recipe['resource_type']}", file=sys.stderr)
+    _report_stats(stats, recipe["resource_type"])
+    if args.manifest:
+        args.manifest.write_text(json.dumps(_manifest(stats, recipe), indent=2))
+        print(f"wrote manifest {args.manifest}", file=sys.stderr)
 
     if args.out:
         opener = gzip.open if args.out.suffix == ".gz" else open

--- a/pricegen/tests/test_engine.py
+++ b/pricegen/tests/test_engine.py
@@ -1,0 +1,182 @@
+"""Unit tests for the shared recipe engine (#893).
+
+Deterministic — they build ``Unit``s directly, no cloud feed. They cover the
+pure logic: field resolution + miss classification, select filtering, dedup,
+tier bounds, and the drift-diagnostics counters (#922). The *drift guardrail*
+itself (diffing manifests across scheduled runs, opening an issue) is a property
+of the scheduled publish workflow, not of this engine — these only assert that
+the engine emits the right signal for that workflow to act on.
+"""
+
+from __future__ import annotations
+
+from pricegen.engine import RecipeStats, _resolve2, generate
+from pricegen.models import Price, Unit
+
+
+# --- field resolution + miss classification --------------------------------
+
+
+def test_resolve_literal():
+    assert _resolve2("linux", {}) == ("linux", None, None)
+
+
+def test_resolve_attr_present_and_absent():
+    assert _resolve2({"attr": "instanceType"}, {"instanceType": "m5.large"}) == (
+        "m5.large",
+        None,
+        None,
+    )
+    assert _resolve2({"attr": "instanceType"}, {}) == (None, "absent", None)
+
+
+def test_resolve_map_hit_and_unmapped():
+    spec = {"attr": "operatingSystem", "map": {"Linux": "linux"}}
+    assert _resolve2(spec, {"operatingSystem": "Linux"}) == ("linux", None, None)
+    # present but not in the map -> the actionable drift signal, carries value.
+    assert _resolve2(spec, {"operatingSystem": "Haiku"}) == (None, "unmapped", "Haiku")
+    # attr absent -> expected, not drift.
+    assert _resolve2(spec, {}) == (None, "absent", None)
+
+
+def test_resolve_regex_extract_and_miss():
+    spec = {"attr": "meterName", "regex": r"^(\w+) IOPS"}
+    assert _resolve2(spec, {"meterName": "gp3 IOPS charge"}) == ("gp3", None, None)
+    # string present but pattern didn't match -> unmapped, carries the raw value.
+    assert _resolve2(spec, {"meterName": "flat rate"}) == (
+        None,
+        "unmapped",
+        "flat rate",
+    )
+
+
+def test_resolve_from_composite_map():
+    spec = {
+        "from": ["databaseEngine", "databaseEdition"],
+        "map": {"SQL Server|Enterprise": "sqlserver-ee"},
+    }
+    attrs = {"databaseEngine": "SQL Server", "databaseEdition": "Enterprise"}
+    assert _resolve2(spec, attrs) == ("sqlserver-ee", None, None)
+    # a real combo we didn't map -> unmapped, carries the joined key.
+    assert _resolve2(
+        spec, {"databaseEngine": "Db2", "databaseEdition": "Standard"}
+    ) == (
+        None,
+        "unmapped",
+        "Db2|Standard",
+    )
+    # nothing present -> absent.
+    assert _resolve2(spec, {}) == (None, "absent", None)
+
+
+# --- generate: rows, dedup, diagnostics ------------------------------------
+
+
+def _recipe():
+    return {
+        "resource_type": "aws_instance",
+        "service": "AmazonEC2",
+        "components": [
+            {
+                "product_family": "^Compute Instance",
+                "service_class": "instance",
+                "match": {"instance_type": {"attr": "instanceType"}},
+                "select": {},
+                "pricing": {
+                    "os": {"attr": "operatingSystem", "map": {"Linux": "linux"}}
+                },
+                "price": {"type": "t", "unit": "Hrs"},
+                "tier": "usage",
+            }
+        ],
+    }
+
+
+def _defaults():
+    return {"pricing_common": {"region": "us-east-1"}, "canonical": {}}
+
+
+def _unit(itype, os="Linux", usd="0.10"):
+    return Unit(
+        family="Compute Instance",
+        attrs={"instanceType": itype, "operatingSystem": os},
+        prices=[Price(usd=usd, unit="Hrs")],
+    )
+
+
+def test_generate_emits_expected_row():
+    stats = RecipeStats()
+    rows = list(
+        generate(
+            _recipe(),
+            _defaults(),
+            [_unit("m5.large")],
+            service="AmazonEC2",
+            stats=stats,
+        )
+    )
+    assert len(rows) == 1
+    service, fam, ms, pms, price, ptype, ccy = rows[0]
+    assert ms == "type=aws_instance&values.instance_type=m5.large"
+    assert "os=linux" in pms and "region=us-east-1" in pms
+    assert "start_usage_amount=0" in pms and "end_usage_amount=Inf" in pms
+    assert price == "0.10" and ptype == "t" and ccy == "USD"
+    assert stats.rows == 1 and stats.units_total == 1
+
+
+def test_generate_dedups_identical_units():
+    # two feed SKUs, same coordinates + price -> one row (AWS carries dupes).
+    units = [_unit("m5.large"), _unit("m5.large")]
+    stats = RecipeStats()
+    rows = list(
+        generate(_recipe(), _defaults(), units, service="AmazonEC2", stats=stats)
+    )
+    assert len(rows) == 1
+    assert stats.units_total == 2 and stats.rows == 1
+
+
+def test_generate_records_unmapped_pricing_value_as_drift():
+    # an OS the pricing map doesn't cover -> dropped, surfaced as drift signal.
+    stats = RecipeStats()
+    rows = list(
+        generate(
+            _recipe(),
+            _defaults(),
+            [_unit("m5.large", os="Plan9")],
+            service="AmazonEC2",
+            stats=stats,
+        )
+    )
+    assert rows == []
+    assert stats.skipped_unmapped == 1
+    assert stats.unmapped["pricing.os"]["Plan9"] == 1
+
+
+def test_generate_price_range_tracked():
+    units = [_unit("a", usd="0.05"), _unit("b", usd="0.40")]
+    stats = RecipeStats()
+    list(generate(_recipe(), _defaults(), units, service="AmazonEC2", stats=stats))
+    assert stats.price_min == 0.05 and stats.price_max == 0.40
+
+
+def test_generate_select_filter_counts_separately():
+    recipe = _recipe()
+    recipe["components"][0]["select"] = {"operatingSystem": ["Linux"]}
+    stats = RecipeStats()
+    units = [_unit("m5.large", os="Linux"), _unit("m5.large", os="Windows")]
+    rows = list(generate(recipe, _defaults(), units, service="AmazonEC2", stats=stats))
+    assert len(rows) == 1  # only the Linux unit
+    assert stats.skipped_select == 1  # the Windows unit, via select not unmapped
+
+
+def test_generate_tier_bounds_override():
+    recipe = _recipe()
+    comp = recipe["components"][0]
+    comp["tier"] = "provision"
+    comp["price"] = {"type": "o", "unit": "Hrs"}
+    comp["tier_bounds"] = [
+        {"when": {"instanceType": "m5.large"}, "start": "3000", "end": "Inf"}
+    ]
+    rows = list(generate(recipe, _defaults(), [_unit("m5.large")], service="AmazonEC2"))
+    assert "start_provision_amount=3000" in rows[0][3]
+    assert "end_provision_amount=Inf" in rows[0][3]


### PR DESCRIPTION
Part of #893. **Part of #922** (does not close it — this is the *foundation*; the scheduled guardrail that acts on the manifest is the rest of #922, and by design runs only on the weekly schedule, not per-PR).

## Why
A **self-generated** pricesheet is exposed to a failure mode a hosted feed hides: the cloud provider quietly renames a product family, adds an enum value (a new `volumeType`/`databaseEdition`/machine family), or restructures the API — and our recipes then silently emit **fewer rows, or wrong ones**. This adds the signal that makes that drift *detectable* so the scheduled job can alert on it (#922).

## What
- **`engine.RecipeStats` + `_resolve2`** now return `(value, miss, offending)`; `generate()` takes an optional `stats` collector. It records why each in-family unit is dropped, distinguishing:
  - **`absent`** — the source attr isn't on this unit (expected, low signal).
  - **`unmapped`** — the source value IS present but our `map:`/`regex` doesn't cover it (**actionable drift** — carries the offending value).
- Behaviour-preserving when `stats is None`: `resolve()` is unchanged and RDS still emits the identical **3233 rows**.
- **`generate.py`** prints a per-recipe diagnostics summary (rows, skip breakdown, the UNMAPPED values) and writes a **`--manifest` JSON** — the artifact the scheduled publish workflow diffs across runs to alert on drift and refuse to publish a collapsed sheet.
- **`pricegen/tests/test_engine.py`** — first pricegen test suite (11 tests): miss classification, dedup, select-vs-unmapped counting, tier bounds, price-range/manifest counters.

## It immediately earned its keep
Running it over RDS surfaced that **`SQL Server|Express`** (`sqlserver-ex`, a real Terraform engine) is **unmapped** in the instance recipe — a genuine coverage gap to fix next — alongside the *expected* drops (Aurora → its own recipe, Outposts → out of scope, Db2 → not yet mapped). Exactly the "your logic needs an update" signal, working.

```
=== diagnostics (aws_db_instance) ===
  3233 rows from 5621 in-family units (skipped: select=1378 absent=0 unmapped=817)
  UNMAPPED (recipe may need an update):
    match.engine='SQL Server|Express' (8)
    match.engine='Db2|Advanced' (160)
    match.storage_type='IO Optimized-Aurora' (4)
    ...
```