### PR TITLE
fix(pricegen): don't require license_model to match an RDS instance

### DIFF
--- a/pricegen/providers/aws/recipes/aws_db_instance.yaml
+++ b/pricegen/providers/aws/recipes/aws_db_instance.yaml
@@ -25,11 +25,18 @@ _multi_az: &multi_az
   map: { Single-AZ: "false", Multi-AZ: "true" }
 
 components:
-  # The DB instance — priced per hour (`t`). Unlike oiq (which drops license from
-  # the match_set and emits ambiguous duplicate-keyed rows), we put license_model
-  # IN the match — a Terraform aws_db_instance has it, and its value is
-  # engine-specific, so it's a composite (databaseEngine, licenseModel) map. This
-  # gives one unambiguous price per (engine, class, multi_az, license), incl. BYOL.
+  # The DB instance — priced per hour (`t`). We match on (engine, instance_class,
+  # multi_az) and DELIBERATELY do NOT put license_model in the match: it's an
+  # Optional+Computed attribute that a `terraform plan` for a new DB emits as
+  # null/absent (the common estimate case), so a row that required it would fail
+  # to match — proven by running the consumer engine against a plan without it.
+  # The `select` still keeps the three clean license models as SEPARATE priced
+  # rows; under the consumer's SUBSET matching that means postgres/mysql (one
+  # license) price to a single value, while SQL Server / Oracle (License-included
+  # vs BYOL, different prices, same key) price to a min..max RANGE — the honest
+  # answer when the plan doesn't pin the license. (oiq's "ambiguous duplicate"
+  # rows are the same thing; under subset matching a range is correct, not a bug,
+  # which is why the earlier attempt to disambiguate via license_model was wrong.)
   - product_family: "^Database Instance$"
     service_class: instance
     select:
@@ -43,18 +50,6 @@ components:
       engine: *engine # unmapped engine/edition (Db2, Outposts, Developer) -> skipped
       instance_class: { attr: instanceType }
       multi_az: *multi_az
-      license_model:
-        from: [databaseEngine, licenseModel]
-        map:
-          "PostgreSQL|No license required": postgresql-license
-          "MySQL|No license required": general-public-license
-          "MariaDB|No license required": general-public-license
-          "SQL Server|License included": license-included
-          "SQL Server|Bring your own license": bring-your-own-license
-          "Oracle|License included": license-included
-          "Oracle|Bring your own license": bring-your-own-license
-          "Aurora PostgreSQL|No license required": postgresql-license
-          "Aurora MySQL|No license required": general-public-license
     price: { type: t, unit: Hrs }
     tier: usage
 


### PR DESCRIPTION
Closes #924. Part of #893.

## The bug (found by *running* the consumer, not reasoning)
The RDS **instance** component (#919) put `license_model` in the match_set. But `license_model` is an **Optional+Computed** AWS attribute — a `terraform plan` for a *new* DB emits it null/absent — so under the consumer's **subset matching** a row requiring `values.license_model=…` is not a subset of the resource, and **the instance never prices**. That's the single most common estimate case (a new postgres/mysql DB) silently losing its instance cost.

### Proof (consumer engine, synthetic plan)
| plan | before | after |
|---|---|---|
| postgres db.t3.medium, **no** `license_model` (100 GB gp2) | **$12.50** (storage only — instance dropped!) | **$64.06** ✓ |
| same, `license_model=postgresql-license` present | $65.06 | $65.06 |

## The fix
Match on `(engine, instance_class, multi_az)` only. The `select` still keeps the three clean license models as **separate priced rows**, so under subset matching:
- **postgres/mysql/mariadb** (one license) → a single **exact** value.
- **SQL Server / Oracle** (License-included vs BYOL, different prices, same key) → a **min..max range** — the honest answer when the plan doesn't pin the license.

The #919 rationale (oiq's license-less rows are 'ambiguous duplicates' to be disambiguated) was wrong for a subset-matching consumer: multiple matched products is a *price range*, not a bug.

## Validation
Instance rows carry **no** `license_model`; postgres db.t3.medium = one $0.072/hr row; the **96** same-key-multi-price rows are **all** SQL Server/Oracle license pairs (**0** others); re-probe prices the license-less postgres plan at the correct **$64.06**.