### PR TITLE
feat(pricegen): RDS provisioned IOPS for io1/io2

### DIFF
--- a/pricegen/providers/aws/recipes/aws_db_instance.yaml
+++ b/pricegen/providers/aws/recipes/aws_db_instance.yaml
@@ -86,3 +86,34 @@ components:
       multi_az: *multi_az
     price: { type: "a=values.allocated_storage" }
     tier: none
+
+  # Provisioned IOPS — priced per provisioned IOPS-month, read from the real
+  # `iops` attr (`a=`). Like storage, the rate is engine-independent, so we match
+  # on (storage_type, multi_az) only. Verified against the offer: RDS PIOPS rates
+  # are FLAT, not graduated (io1/io2 $0.10) — so `a=values.iops` prices io1 AND
+  # io2 EXACTLY, and both ALWAYS carry an `iops` attr in Terraform (no missing-
+  # attr edge). io1/io2 have NO free baseline: you pay for every provisioned IOPS.
+  #
+  # gp3 is deliberately EXCLUDED: gp3 includes 3000 free provisioned IOPS, and the
+  # consumer's provision model can FILTER to a tier but can't SUBTRACT a baseline
+  # (verified — a gp3 at exactly 3000 IOPS billed the full 3000). Including gp3
+  # would spuriously bill the free baseline on the common case. gp3-above-3000 is
+  # a minor, opt-in line item; leaving it $0 (a bounded under-estimate) is more
+  # honest than a baseline over-charge until the consumer gains baseline
+  # subtraction (#926/#929). Default gp3 (no explicit iops) is correctly $0
+  # anyway. Needs the paired usage-less `service_class=iops` entry in
+  # usage_defaults.json to price at all.
+  - product_family: "^Provisioned IOPS$"
+    service_class: iops
+    select:
+      deploymentOption: [Single-AZ, Multi-AZ] # skip Mirror / readable-standbys / RAC
+    match:
+      storage_type:
+        attr: volumeType
+        map:
+          Provisioned IOPS (SSD): io1
+          Provisioned IOPS-IO2: io2
+          # General Purpose-GP3 deliberately absent -> unmapped -> skipped (see above).
+      multi_az: *multi_az
+    price: { type: "a=values.iops" }
+    tier: none

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -42,6 +42,10 @@
     }
   },
   {
+    "description": "AWS RDS provisioned IOPS (io1/io2/gp3) — quantity read from the resource's iops attr; usage-less. Must stay AFTER the storage_type=standard entry above (first match wins) so magnetic keeps the per-request entry.",
+    "match_query": "type = aws_db_instance and service_class = iops"
+  },
+  {
     "description": "Default AWS RDS Instance hours",
     "match_query": "type = aws_db_instance and service_class = instance and purchase_option = on_demand",
     "usage": {

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -225,7 +225,9 @@ def test_resources_from_state_v4_lifts_attributes():
 
 def test_default_usage_catalogue_loads():
     entries = default_entries()
-    assert len(entries) == 18  # vendored from OpenInfraQuote
+    # 18 vendored from OpenInfraQuote + 1 Terrapod addition (RDS provisioned
+    # IOPS io1/io2, #928 — the usage-less service_class=iops entry).
+    assert len(entries) == 19
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -38,6 +38,9 @@ _ROWS = [
     "AmazonRDS,Database Storage,type=aws_db_instance&values.storage_type=gp2&values.multi_az=false,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage,0.1150000000,a=values.allocated_storage,USD",
     # gp2 storage multi-AZ — double rate.
     "AmazonRDS,Database Storage,type=aws_db_instance&values.storage_type=gp2&values.multi_az=true,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage,0.2300000000,a=values.allocated_storage,USD",
+    # io1 storage + io1 provisioned IOPS — both priced from the resource's attrs.
+    "AmazonRDS,Database Storage,type=aws_db_instance&values.storage_type=io1&values.multi_az=false,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage,0.1250000000,a=values.allocated_storage,USD",
+    "AmazonRDS,Provisioned IOPS,type=aws_db_instance&values.storage_type=io1&values.multi_az=false,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=iops,0.1000000000,a=values.iops,USD",
     # EC2 for breadth.
     "AmazonEC2,Compute Instance,type=aws_instance&values.instance_type=m5.large,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=instance&os=linux&start_usage_amount=0&end_usage_amount=Inf,0.0960000000,t,USD",
 ]
@@ -187,6 +190,56 @@ def test_rds_storage_multi_az_doubles():
     # multi-AZ storage 100*0.23=23.00; instance has no multi_az=true row here,
     # so only storage prices -> 23.00 (guards the multi_az storage discriminator).
     assert est.resources[0].monthly_min == pytest.approx(23.00, abs=0.01)
+
+
+# --- provisioned IOPS: io1/io2 priced exactly from the iops attr (#928) -----
+
+
+def test_rds_io1_provisioned_iops_prices_exactly():
+    """io1 has no free baseline — every provisioned IOPS is billed. a=values.iops
+    reads the real count, so io1 (and io2, same flat rate) price exactly. Before
+    #928 this was $0 (no usage entry matched io1 iops)."""
+    plan = _plan(
+        [
+            _rds(
+                "aws_db_instance.io1",
+                {
+                    "engine": "postgres",
+                    "instance_class": "db.t3.medium",
+                    "multi_az": False,
+                    "storage_type": "io1",
+                    "allocated_storage": 100,
+                    "iops": 5000,
+                },
+            )
+        ]
+    )
+    est = estimate(plan, _sheet())
+    # instance 52.56 + io1 storage 100*0.125=12.50 + iops 5000*0.10=500 = 565.06
+    assert est.resources[0].monthly_min == pytest.approx(52.56 + 12.50 + 500.0, abs=0.01)
+
+
+def test_rds_gp3_default_iops_is_free_baseline():
+    """A gp3 volume with no explicit iops must NOT be charged for provisioned
+    IOPS (its 3000 baseline is free). gp3 is excluded from the iops component,
+    and a missing iops attr is caught — either way, no spurious IOPS charge."""
+    plan = _plan(
+        [
+            _rds(
+                "aws_db_instance.gp3",
+                {
+                    "engine": "postgres",
+                    "instance_class": "db.t3.medium",
+                    "multi_az": False,
+                    "storage_type": "gp3",
+                    "allocated_storage": 100,
+                },
+            )
+        ]
+    )
+    est = estimate(plan, _sheet())
+    # no gp3 storage row in this fixture -> instance-only 52.56; crucially no iops.
+    assert est.resources[0].monthly_min == pytest.approx(52.56, abs=0.01)
 
 
 # --- EC2 breadth + the unpriced bucket -------------------------------------


### PR DESCRIPTION
Closes #928. Part of #893.

io1/io2 provisioned IOPS was silently **$0** (no usage entry matched it — proven earlier: an io1 volume priced storage-only). Two coupled legs:

## Recipe
A `^Provisioned IOPS$` component on `aws_db_instance`, matched on `(storage_type, multi_az)` only (engine-independent, like storage), priced **`a=values.iops`**. Verified against the offer that RDS PIOPS rates are **flat, not graduated** (io1/io2 $0.10), so `a=values.iops` prices **io1 and io2 exactly**, and both always carry an `iops` attr in Terraform (no missing-attr edge).

## Consumer
A broad **usage-less** `type = aws_db_instance and service_class = iops` entry in `usage_defaults.json`, placed **after** the `storage_type=standard` entry (first-match wins) so magnetic keeps its per-request entry and io1/io2 fall through to the ATTR-filled one.

## gp3 deliberately excluded
gp3 has a 3000 free-IOPS baseline, and the consumer's provision model can *filter* to a tier but can't *subtract* a baseline (verified — a gp3 at exactly 3000 IOPS billed the full 3000). Including gp3 would spuriously bill the free baseline on the common case; leaving gp3-above-3000 at $0 (a bounded under-estimate of a minor, opt-in line item) is more honest until the consumer gains baseline subtraction (#926/#929). **Default gp3 (no explicit iops) is correctly $0 either way.**

## Validation (E2E through the real consumer)
| resource | cost |
|---|---|
| io1, 100 GB, 5000 IOPS | **$565.06** (52.56 instance + 12.50 storage + **500 IOPS**) exact |
| io1/io2, 10000 IOPS | **$1065.06** exact |
| gp3, default (no iops) | **$52.56** — no spurious IOPS charge |

Extends the pricing-contract test with io1-exact + gp3-free-baseline cases; bumps the usage-catalogue count 18→19. EBS has the same gap but is coupled to an EC2-offer re-download + `o`→`a=` switch (#929).

34 services tests + 11 pricegen tests green; ruff clean.