### PR TITLE
feat(pricegen): Azure adapter + azurerm_linux_virtual_machine (2nd cloud)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -32,7 +32,7 @@ pricegen/
   generate.py            # CLI: pick provider, run engine, (AWS) row-parity vs oiq
   providers/
     aws/   { adapter.py, defaults.yaml, recipes/*.yaml }
-    azure/ { adapter.py, defaults.yaml, recipes/*.yaml }   # WIP
+    azure/ { adapter.py, defaults.yaml, recipes/*.yaml }   # VM proven
     gcp/   { adapter.py, defaults.yaml, recipes/*.yaml }   # WIP
 ```
 
@@ -122,7 +122,9 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 
 - [x] Provider-agnostic architecture (adapter → Unit → shared engine)
 - [x] AWS adapter + `aws_instance` (parity) + `aws_ebs_volume` (composite, exceptions)
-- [ ] AWS breadth (RDS, LB, NAT, EIP, S3, …) + all-regions + a row-parity CI gate
-- [ ] Azure adapter + recipes
+- [x] AWS RDS (`aws_db_instance`): instance + storage + io1/io2 provisioned IOPS, all validated end-to-end
+- [x] End-to-end pricing validation (real consumer engine, not just row-parity) + generator drift diagnostics
+- [x] Azure adapter + `azurerm_linux_virtual_machine` (regex select, validated end-to-end) — second cloud proven
+- [ ] AWS breadth (LB, NAT, EIP, S3, …) + all-regions + a row-parity CI gate
 - [ ] GCP computed-component engine + machine-type catalog + adapter + recipes
 - [ ] Publish job (gzipped-YAML rolling release) + engine reads YAML + `prices_url` default

--- a/pricegen/providers/azure/adapter.py
+++ b/pricegen/providers/azure/adapter.py
@@ -1,0 +1,57 @@
+"""Azure Retail Prices API adapter (#893).
+
+Normalizes an Azure retail-prices offer (a flat ``Items[]`` array) into ``Unit``s.
+Azure is the *string-embedded* case: unlike AWS's structured attribute dict, the
+variant we need (OS, Spot/Low-Priority) lives inside free-text fields
+(``productName``, ``skuName``), so the recipes lean on the engine's regex
+resolution rather than clean attributes.
+
+The offer is fetched from the official public Azure Retail Prices API
+(``prices.azure.com/api/retail/prices``, no credentials, paginated via
+``NextPageLink``). Each item is already a flat dict — its keys (``armSkuName``,
+``productName``, ``skuName``, ``meterName``, ``type``, ``armRegionName``,
+``unitPrice``, ``unitOfMeasure`` …) become the Unit's attrs verbatim, and the
+Unit's *family* is the ``serviceName`` (e.g. ``Virtual Machines``) that a
+recipe's ``product_family`` regex matches.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+from pricegen.models import Price, Unit
+
+
+def load(path: Path) -> dict:
+    opener = gzip.open if str(path).endswith(".gz") else open
+    with opener(path, "rt") as f:
+        return json.load(f)
+
+
+def iter_units(offer: dict, *, term: str = "Consumption"):
+    """Yield one Unit per retail-price item.
+
+    ``term`` is accepted for adapter-interface symmetry with AWS but Azure's
+    Consumption/Reservation distinction lives in each item's ``type`` field, so
+    it's filtered by the recipe's canonical dimension (``type: Consumption``),
+    not here — every priced item is yielded and the engine selects.
+    """
+    for item in offer.get("Items", []):
+        usd = item.get("unitPrice")
+        # A $0 retail price is a feed placeholder (e.g. not-yet-GA meters), not a
+        # genuinely free resource — skip it so it can't zero out or drag down a
+        # size's price. Mirrors the AWS adapter skipping items with no USD price.
+        if usd is None or usd == 0:
+            continue
+        # tierMinimumUnits is a float (0.0, 51200.0, …); the consumer parses tier
+        # bounds with int(), so normalize to an int-string ("0.0" would crash it).
+        begin = str(int(float(item.get("tierMinimumUnits", 0) or 0)))
+        price = Price(
+            usd=str(usd),
+            begin=begin,
+            end="Inf",
+            unit=item.get("unitOfMeasure", ""),
+        )
+        yield Unit(item.get("serviceName", ""), item, [price])

--- a/pricegen/providers/azure/defaults.yaml
+++ b/pricegen/providers/azure/defaults.yaml
@@ -1,0 +1,20 @@
+# Azure provider defaults (#893). Shared across every Azure recipe.
+#
+# canonical: the one dimension that's a clean attribute — the retail-price
+# `type`. We price on-demand (Consumption); Reservation / DevTestConsumption
+# rows are filtered out here (applied only where the attr is present). The
+# Spot/Low-Priority variants live in skuName, NOT type, so each recipe excludes
+# them with a regex select — not here.
+canonical:
+  type: Consumption
+
+# pricing_common: the billing dimensions every Azure row carries. region comes
+# from armRegionName; the consumer resolves an azurerm resource's region from
+# its `location` attribute and filters to matching rows (#871).
+pricing_common:
+  service_provider: azure
+  purchase_option: on_demand
+  region: { attr: armRegionName }
+
+# Azure's Consumption meters are the on-demand equivalent of AWS OnDemand.
+price_term: Consumption

--- a/pricegen/providers/azure/recipes/azurerm_linux_virtual_machine.yaml
+++ b/pricegen/providers/azure/recipes/azurerm_linux_virtual_machine.yaml
@@ -1,0 +1,29 @@
+# Azure VM -> azurerm_linux_virtual_machine (on-demand / Consumption).
+#
+# Azure prices the base compute rate under the Linux SKU: a productName carries
+# "Windows" ONLY for Windows images (which add the license premium); the Linux /
+# base-compute meter is everything that is NOT Windows. So we select the base
+# rate by EXCLUDING "Windows" from productName, and exclude the Spot / Low
+# Priority variants (which live in skuName). The Terraform `size` attribute is
+# armSkuName verbatim (e.g. "Standard_D2s_v5"). Needs the paired usage entry
+# `type = azurerm_linux_virtual_machine and service_class = instance` (time:730).
+resource_type: azurerm_linux_virtual_machine
+service: Virtual Machines
+
+components:
+  - product_family: "^Virtual Machines$" # the Unit family = Azure serviceName
+    service_class: instance
+    select:
+      # base compute rate = NOT the Windows-licensed meter…
+      # base compute rate = NOT the Windows-licensed meter, and NOT the classic
+      # "Cloud Services" (PaaS) meters that also carry serviceName=Virtual
+      # Machines at a different rate (not azurerm_linux_virtual_machine).
+      productName: { regex: "Windows|Cloud ?Services", negate: true }
+      # …and NOT the discounted Spot / Low-Priority variants.
+      skuName: { regex: "Spot|Low Priority", negate: true }
+    match:
+      size: { attr: armSkuName } # Terraform azurerm_linux_virtual_machine.size
+    pricing:
+      os: linux
+    price: { type: t, unit: "1 Hour" } # per-hour; engine ×730 for monthly
+    tier: usage

--- a/pricegen/tests/test_azure_adapter.py
+++ b/pricegen/tests/test_azure_adapter.py
@@ -1,0 +1,70 @@
+"""Unit tests for the Azure Retail Prices adapter (#893).
+
+Deterministic — a tiny in-memory ``Items[]`` offer, no network. Covers the two
+normalizations the adapter does that the AWS one didn't need: skipping $0
+placeholder meters, and coercing Azure's float ``tierMinimumUnits`` to an
+int-string (the consumer parses tier bounds with ``int()``, so "0.0" would
+crash it).
+"""
+
+from __future__ import annotations
+
+from pricegen.providers.azure import adapter
+
+
+def _offer(items):
+    return {"Items": items}
+
+
+def _item(**kw):
+    base = {
+        "serviceName": "Virtual Machines",
+        "armSkuName": "Standard_D2s_v5",
+        "productName": "Virtual Machines Dsv5 Series",
+        "skuName": "Standard_D2s_v5",
+        "type": "Consumption",
+        "armRegionName": "eastus",
+        "unitPrice": 0.096,
+        "unitOfMeasure": "1 Hour",
+        "tierMinimumUnits": 0.0,
+    }
+    base.update(kw)
+    return base
+
+
+def test_family_is_service_name_and_attrs_are_the_item():
+    units = list(adapter.iter_units(_offer([_item()])))
+    assert len(units) == 1
+    u = units[0]
+    assert u.family == "Virtual Machines"
+    assert u.attrs["armSkuName"] == "Standard_D2s_v5"
+    assert u.prices[0].usd == "0.096"
+    assert u.prices[0].unit == "1 Hour"
+
+
+def test_zero_price_meters_are_skipped():
+    units = list(
+        adapter.iter_units(_offer([_item(unitPrice=0.0), _item(unitPrice=0.096)]))
+    )
+    assert len(units) == 1  # the $0 placeholder dropped
+    assert units[0].prices[0].usd == "0.096"
+
+
+def test_none_price_skipped():
+    units = list(adapter.iter_units(_offer([_item(unitPrice=None)])))
+    assert units == []
+
+
+def test_tier_minimum_units_float_coerced_to_int_string():
+    # 0.0 -> "0"; a tiered boundary like 51200.0 -> "51200" (consumer int()-parses).
+    u0 = next(adapter.iter_units(_offer([_item(tierMinimumUnits=0.0)])))
+    assert u0.prices[0].begin == "0"
+    u1 = next(adapter.iter_units(_offer([_item(tierMinimumUnits=51200.0)])))
+    assert u1.prices[0].begin == "51200"
+
+
+def test_missing_tier_minimum_units_defaults_to_zero():
+    item = _item()
+    del item["tierMinimumUnits"]
+    u = next(adapter.iter_units(_offer([item])))
+    assert u.prices[0].begin == "0"

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -125,5 +125,12 @@
     "usage": {
       "operations": 0
     }
+  },
+  {
+    "description": "Azure Linux VM instance hours (Terrapod addition)",
+    "match_query": "type = azurerm_linux_virtual_machine and service_class = instance",
+    "usage": {
+      "time": 730
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -225,9 +225,9 @@ def test_resources_from_state_v4_lifts_attributes():
 
 def test_default_usage_catalogue_loads():
     entries = default_entries()
-    # 18 vendored from OpenInfraQuote + 1 Terrapod addition (RDS provisioned
-    # IOPS io1/io2, #928 — the usage-less service_class=iops entry).
-    assert len(entries) == 19
+    # 18 vendored from OpenInfraQuote + Terrapod additions: RDS provisioned IOPS
+    # io1/io2 (#928, usage-less service_class=iops) + Azure Linux VM hours (#931).
+    assert len(entries) == 20
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -43,6 +43,9 @@ _ROWS = [
     "AmazonRDS,Provisioned IOPS,type=aws_db_instance&values.storage_type=io1&values.multi_az=false,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=iops,0.1000000000,a=values.iops,USD",
     # EC2 for breadth.
     "AmazonEC2,Compute Instance,type=aws_instance&values.instance_type=m5.large,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=instance&os=linux&start_usage_amount=0&end_usage_amount=Inf,0.0960000000,t,USD",
+    # Azure Linux VM (#931) — proves the second cloud prices through the same
+    # engine. size = armSkuName; region resolved from the resource's `location`.
+    "Virtual Machines,Virtual Machines,type=azurerm_linux_virtual_machine&values.size=Standard_D2s_v5,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=instance&os=linux&start_usage_amount=0&end_usage_amount=Inf,0.096,t,USD",
 ]
 
 
@@ -243,6 +246,33 @@ def test_rds_gp3_default_iops_is_free_baseline():
 
 
 # --- EC2 breadth + the unpriced bucket -------------------------------------
+
+
+def test_azure_linux_vm_prices_through_the_same_engine():
+    """A second cloud: azurerm_linux_virtual_machine prices via size=armSkuName,
+    with region resolved from the resource's `location`. Proves the provider-
+    agnostic sheet + engine work beyond AWS (#931)."""
+    plan = {
+        "format_version": "1.2",
+        "terraform_version": "1.9.0",
+        "planned_values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "azurerm_linux_virtual_machine.a",
+                        "type": "azurerm_linux_virtual_machine",
+                        "name": "a",
+                        "mode": "managed",
+                        "values": {"size": "Standard_D2s_v5", "location": "eastus"},
+                    }
+                ]
+            }
+        },
+    }
+    est = estimate(plan, _sheet())
+    # 0.096/hr * 730 = 70.08
+    assert est.resources[0].monthly_min == pytest.approx(0.096 * 730, abs=0.01)
+    assert est.unpriced == []
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
Closes #931. Part of #893. **Proves the provider-agnostic architecture on a second cloud, end-to-end.**

## Azure adapter (`pricegen/providers/azure/adapter.py`)
Normalizes the public **Azure Retail Prices API** (`prices.azure.com`, no key, paginated `Items[]`) into `Unit`s. Azure is the *string-embedded* case — OS + Spot/Low-Priority live in `productName`/`skuName` free-text, handled by the engine's regex select. Two normalizations the AWS adapter didn't need:
- **Skip $0 placeholder meters** (not-yet-GA meters priced $0 in the feed).
- **Coerce float `tierMinimumUnits` → int-string** — the consumer `int()`-parses tier bounds, so "0.0" crashed it (caught by *running*, not reasoning).

## Recipe (`azurerm_linux_virtual_machine`)
Match `size` = `armSkuName`; select the base compute rate by excluding **Windows** (the licensed meter), **`Cloud ?Services`** (classic PaaS meters that also carry `serviceName=Virtual Machines` at a different rate), and **Spot/Low-Priority**. Result: **1697 sizes, exactly one price each, zero ambiguity, no $0**.

## Consumer
Usage entry `type = azurerm_linux_virtual_machine and service_class = instance` → 730 hrs. The consumer already resolves an Azure resource's region from its `location` (#871).

## Validated end-to-end
`Standard_D2s_v5` in eastus prices at **$70.08** (0.096 × 730) through the real `estimate()` engine. Adds 5 pricegen adapter unit tests + an Azure case in the pricing-contract test; usage-catalogue count 19→20.

Windows VMs, Azure managed disks, and other regions are follow-ups. 35 services + 16 pricegen tests green; ruff clean.