### PR TITLE
feat(pricegen): GCP computed engine + google_compute_instance (3rd/final CSP)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -33,7 +33,7 @@ pricegen/
   providers/
     aws/   { adapter.py, defaults.yaml, recipes/*.yaml }
     azure/ { adapter.py, defaults.yaml, recipes/*.yaml }   # VM proven
-    gcp/   { adapter.py, defaults.yaml, recipes/*.yaml }   # WIP
+    gcp/   { adapter.py, defaults.yaml, recipes/*.yaml }   # compute proven
 ```
 
 - **Adapter** — normalizes the vendor feed into `Unit`s. AWS joins `products`+`terms`;
@@ -125,6 +125,7 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] AWS RDS (`aws_db_instance`): instance + storage + io1/io2 provisioned IOPS, all validated end-to-end
 - [x] End-to-end pricing validation (real consumer engine, not just row-parity) + generator drift diagnostics
 - [x] Azure adapter + `azurerm_linux_virtual_machine` (regex select, validated end-to-end) — second cloud proven
+- [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
 - [ ] AWS breadth (LB, NAT, EIP, S3, …) + all-regions + a row-parity CI gate
-- [ ] GCP computed-component engine + machine-type catalog + adapter + recipes
+- [ ] Broaden GCP families/regions; Azure managed disks / Windows
 - [ ] Publish job (gzipped-YAML rolling release) + engine reads YAML + `prices_url` default

--- a/pricegen/engine.py
+++ b/pricegen/engine.py
@@ -10,12 +10,16 @@ value we need often lives inside a string field (Azure's OS/tier in
 ``productName``/``skuName``; GCP's machine family in ``description``) rather than
 a clean attribute like AWS's ``instanceType``.
 
-Two component kinds:
-  * direct   — match a unit, emit its price (AWS, Azure).
-  * computed — assemble a row from several units × an external catalog (GCP
-    machine_type -> Σ vCPU-core + RAM-GB). Not implemented yet; the direct kind
-    is what the AWS/Azure recipes use. The seam is here so GCP slots in without
-    an engine rewrite.
+Two recipe kinds:
+  * direct   — ``components:`` — match a unit, emit its price (AWS, Azure). Run
+    by :func:`generate`.
+  * computed — ``computed:`` — assemble a row from several units by arithmetic
+    (GCP prices per vCPU-core hour + per GiB-RAM hour separately, so a machine
+    type costs ``vCPU × core-rate + RAM_GiB × ram-rate``). Run by
+    :func:`generate_computed`, which enumerates machine types from a compact
+    per-family shape catalog in the recipe and pre-computes each total, so the
+    emitted rows match ``values.machine_type`` like any other instance — no
+    consumer arithmetic needed.
 
 Diagnostics (#922): ``generate`` optionally records a :class:`RecipeStats` — row
 counts and, crucially, the *reason* each unit was dropped. The high-signal
@@ -272,4 +276,95 @@ def generate(recipe: dict, defaults: dict, units, *, service: str, stats=None):
                 if stats is not None:
                     stats.rows += 1
                     stats._note_price(p.usd)
+                yield row
+
+
+# --- computed kind (GCP compute: Σ vCPU-core + RAM-GiB) ---------------------
+
+
+def generate_computed(recipe: dict, defaults: dict, units, *, service: str, stats=None):
+    """Yield rows for a ``computed:`` recipe (GCP Compute Engine).
+
+    GCP prices compute per **vCPU-core hour** and per **GiB-RAM hour** as
+    separate SKUs (e.g. "N2 Instance Core running in Americas" / "... Ram ..."),
+    so a machine type's hourly cost is ``vCPU × core-rate + RAM_GiB × ram-rate``.
+    We read each family's Core+Ram rate from the units, then enumerate machine
+    types from a compact per-family shape catalog and pre-compute each total —
+    emitting one ``values.machine_type=<type>`` row per type, matched by the
+    consumer exactly like an AWS/Azure instance (no consumer arithmetic).
+
+    Recipe ``computed`` block::
+
+        computed:
+          region: us-central1                 # match units in this region
+          family_regex: '^(\\w+)(?: Predefined)? Instance (Core|Ram) running in'
+          vcpus: [1, 2, 4, 8, 16, 32, 64, 96]
+          families:                            # key = machine prefix (lowercased
+            n2: { standard: 4, highmem: 8, highcpu: 1 }   # token); shape -> GiB/vCPU
+            e2: { standard: 4, highmem: 8, highcpu: 1 }
+
+    Custom machine types (``n2-custom-…``) aren't enumerable and are left
+    unpriced (a documented gap); over-enumerated sizes that don't exist are
+    harmless (they never match a real plan).
+    """
+    spec = recipe["computed"]
+    rtype = recipe["resource_type"]
+    region = spec["region"]
+    fam_re = re.compile(spec["family_regex"])
+    canon = defaults.get("canonical", {})
+
+    # 1. Collect each family's Core/Ram rate from the OnDemand, in-region units.
+    rates: dict[str, dict[str, float]] = {}
+    for unit in units:
+        a = unit.attrs
+        if a.get("region") != region:
+            continue
+        if any(a.get(dim) != c for dim, c in canon.items() if dim in a):
+            continue
+        m = fam_re.match(a.get("description", ""))
+        if not m:
+            continue
+        fam, kind = m.group(1).lower(), m.group(2)
+        if unit.prices:
+            rates.setdefault(fam, {})[kind] = float(unit.prices[0].usd)
+
+    # 2. Enumerate machine types and pre-compute each total.
+    base = dict(defaults.get("pricing_common", {}))
+    base.pop("region", None)  # region is per-computed-spec, emitted below
+    base["service_class"] = "instance"
+    base["region"] = region
+    pricing = "&".join(
+        [f"{k}={v}" for k, v in base.items()]
+        + ["start_usage_amount=0", "end_usage_amount=Inf"]
+    )
+    seen: set = set()
+    for fam, shapes in spec["families"].items():
+        fam_rates = rates.get(fam)
+        if not fam_rates or "Core" not in fam_rates or "Ram" not in fam_rates:
+            if stats is not None:
+                stats._note_unmapped("family", fam)  # rates missing -> drift signal
+            continue
+        core, ram = fam_rates["Core"], fam_rates["Ram"]
+        for shape, gib_per_vcpu in shapes.items():
+            for vcpu in spec["vcpus"]:
+                machine_type = f"{fam}-{shape}-{vcpu}"
+                ram_gib = vcpu * gib_per_vcpu
+                hourly = vcpu * core + ram_gib * ram
+                match_set = f"type={rtype}&values.machine_type={machine_type}"
+                row = (
+                    service,
+                    "Compute Instance",
+                    match_set,
+                    pricing,
+                    f"{hourly:.10f}",
+                    "t",
+                    "USD",
+                )
+                if row in seen:
+                    continue
+                seen.add(row)
+                if stats is not None:
+                    stats.rows += 1
+                    stats.units_total += 1
+                    stats._note_price(f"{hourly:.10f}")
                 yield row

--- a/pricegen/generate.py
+++ b/pricegen/generate.py
@@ -142,9 +142,18 @@ def main() -> int:
     offer = adapter.load(args.offer)
     units = adapter.iter_units(offer, term=defaults.get("price_term", "OnDemand"))
     stats = engine.RecipeStats()
-    rows = list(
-        engine.generate(recipe, defaults, units, service=recipe["service"], stats=stats)
-    )
+    # A recipe is either `components:` (direct match, AWS/Azure) or `computed:`
+    # (arithmetic assembly, GCP compute). generate_computed consumes the unit
+    # stream once, so materialize it for that path.
+    if "computed" in recipe:
+        gen = engine.generate_computed(
+            recipe, defaults, list(units), service=recipe["service"], stats=stats
+        )
+    else:
+        gen = engine.generate(
+            recipe, defaults, units, service=recipe["service"], stats=stats
+        )
+    rows = list(gen)
     print(f"generated {len(rows)} rows for {recipe['resource_type']}", file=sys.stderr)
     _report_stats(stats, recipe["resource_type"])
     if args.manifest:

--- a/pricegen/providers/gcp/adapter.py
+++ b/pricegen/providers/gcp/adapter.py
@@ -1,0 +1,69 @@
+"""GCP Cloud Billing Catalog adapter (#893).
+
+Normalizes a GCP service's SKU list into ``Unit``s. GCP is the *computed* case:
+Compute Engine doesn't price a machine type directly — it prices **per vCPU-core
+hour** and **per GiB-RAM hour** separately (e.g. "N2 Instance Core running in
+Americas", "N2 Instance Ram running in Americas"), and a machine type's cost is
+``vCPU × core-rate + RAM_GiB × ram-rate``. The recipe's ``computed`` block (run
+by ``engine.generate_computed``) does that assembly; this adapter just surfaces
+each SKU's rate.
+
+The offer is fetched from the public Cloud Billing Catalog API
+(``cloudbilling.googleapis.com/v1/services/{id}/skus``) which needs a free
+read-only API key. Each SKU can apply to several ``serviceRegions``; we expand
+to **one Unit per (SKU, region)** so ``region`` is a scalar attr the recipe can
+match, mirroring how AWS/Azure carry a single region per Unit. The Unit family
+is the SKU ``description`` (the recipe extracts the machine family + Core/Ram
+kind from it by regex).
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+from pricegen.models import Price, Unit
+
+
+def load(path: Path) -> dict:
+    opener = gzip.open if str(path).endswith(".gz") else open
+    with opener(path, "rt") as f:
+        return json.load(f)
+
+
+def _rate(sku: dict) -> str | None:
+    infos = sku.get("pricingInfo") or []
+    if not infos:
+        return None
+    tiers = infos[0].get("pricingExpression", {}).get("tieredRates") or []
+    if not tiers:
+        return None
+    up = tiers[0].get("unitPrice", {})
+    units = int(up.get("units", "0") or 0)
+    nanos = up.get("nanos", 0)
+    return f"{units + nanos / 1e9:.10f}"
+
+
+def iter_units(offer: dict, *, term: str = "OnDemand"):
+    """Yield one Unit per (SKU, serviceRegion).
+
+    ``term`` is accepted for interface symmetry; GCP's OnDemand/Commitment split
+    is in each SKU's ``category.usageType``, filtered by the recipe's canonical
+    dimension, not here.
+    """
+    for sku in offer.get("skus", []):
+        usd = _rate(sku)
+        if usd is None:
+            continue
+        cat = sku.get("category", {})
+        pe = (sku.get("pricingInfo") or [{}])[0].get("pricingExpression", {})
+        base = {
+            "description": sku.get("description", ""),
+            "resource_group": cat.get("resourceGroup", ""),
+            "usage_type": cat.get("usageType", ""),
+            "usage_unit": pe.get("usageUnit", ""),
+        }
+        price = Price(usd=usd, begin="0", end="Inf", unit=base["usage_unit"])
+        for region in sku.get("serviceRegions", []) or [""]:
+            yield Unit(base["description"], {**base, "region": region}, [price])

--- a/pricegen/providers/gcp/defaults.yaml
+++ b/pricegen/providers/gcp/defaults.yaml
@@ -1,0 +1,14 @@
+# GCP provider defaults (#893). Shared across every GCP recipe.
+#
+# canonical: price on-demand — GCP's OnDemand vs Commitment/Reserved distinction
+# is the SKU's category.usageType. Applied only where the attr is present.
+canonical:
+  usage_type: OnDemand
+
+# pricing_common: the billing dimensions every GCP row carries. region is set
+# per-recipe (the computed compute recipe pins a single region per run).
+pricing_common:
+  service_provider: gcp
+  purchase_option: on_demand
+
+price_term: OnDemand

--- a/pricegen/providers/gcp/recipes/google_compute_instance.yaml
+++ b/pricegen/providers/gcp/recipes/google_compute_instance.yaml
@@ -1,0 +1,28 @@
+# GCP Compute Engine -> google_compute_instance (computed).
+#
+# GCP prices compute per vCPU-core hour + per GiB-RAM hour SEPARATELY (e.g.
+# "N2 Instance Core running in Americas" + "N2 Instance Ram running in
+# Americas"), so a machine type's cost is vCPU x core-rate + RAM_GiB x ram-rate.
+# generate_computed reads each family's Core+Ram rate, then enumerates machine
+# types from the per-family shape catalog below and pre-computes each total,
+# emitting one values.machine_type=<type> row per type (matched by the consumer
+# like any instance — no consumer arithmetic).
+#
+# The `families` keys are the Terraform machine prefix (n2 -> n2-standard-4),
+# matched to the Core/Ram SKU family by `family_regex` (which lowercases the
+# extracted token: "N2 Instance Core" -> n2, "N1 Predefined Instance Core" ->
+# n1). Each shape maps to its GiB-per-vCPU ratio. Custom machine types
+# (n2-custom-*) aren't enumerable -> left unpriced (documented gap); over-
+# enumerated sizes that a family doesn't offer are harmless (never matched).
+resource_type: google_compute_instance
+service: Compute Engine
+
+computed:
+  region: us-central1
+  family_regex: '^(\w+)(?: Predefined)? Instance (Core|Ram) running in'
+  vcpus: [1, 2, 4, 8, 16, 32, 48, 64, 96, 128]
+  families:
+    # ratios = GiB RAM per vCPU for each shape (GCP's fixed shape definitions).
+    n1: { standard: 3.75, highmem: 6.5, highcpu: 0.9 }
+    n2: { standard: 4, highmem: 8, highcpu: 1 }
+    e2: { standard: 4, highmem: 8, highcpu: 1 }

--- a/pricegen/tests/test_computed_engine.py
+++ b/pricegen/tests/test_computed_engine.py
@@ -1,0 +1,122 @@
+"""Unit tests for the GCP computed-engine path (#933).
+
+Deterministic — in-memory Core/Ram Units, no network. generate_computed reads
+each family's per-vCPU-core + per-GiB-RAM rate and pre-computes each machine
+type's total (vCPU x core + RAM_GiB x ram), emitting one values.machine_type
+row per type.
+"""
+
+from __future__ import annotations
+
+from pricegen.engine import RecipeStats, generate_computed
+from pricegen.models import Price, Unit
+
+
+def _core(fam, region, usd):
+    return Unit(
+        f"{fam} Instance Core running in Americas",
+        {
+            "description": f"{fam} Instance Core running in Americas",
+            "usage_type": "OnDemand",
+            "region": region,
+        },
+        [Price(usd=str(usd))],
+    )
+
+
+def _ram(fam, region, usd):
+    return Unit(
+        f"{fam} Instance Ram running in Americas",
+        {
+            "description": f"{fam} Instance Ram running in Americas",
+            "usage_type": "OnDemand",
+            "region": region,
+        },
+        [Price(usd=str(usd))],
+    )
+
+
+_DEFAULTS = {
+    "canonical": {"usage_type": "OnDemand"},
+    "pricing_common": {"service_provider": "gcp", "purchase_option": "on_demand"},
+}
+
+
+def _recipe():
+    return {
+        "resource_type": "google_compute_instance",
+        "service": "Compute Engine",
+        "computed": {
+            "region": "us-central1",
+            "family_regex": r"^(\w+)(?: Predefined)? Instance (Core|Ram) running in",
+            "vcpus": [1, 4],
+            "families": {"n2": {"standard": 4, "highmem": 8}},
+        },
+    }
+
+
+def _rows(units, stats=None):
+    return list(
+        generate_computed(
+            _recipe(), _DEFAULTS, units, service="Compute Engine", stats=stats
+        )
+    )
+
+
+def test_computed_total_is_core_plus_ram():
+    units = [_core("N2", "us-central1", 0.031611), _ram("N2", "us-central1", 0.004237)]
+    rows = _rows(units)
+    by_mt = {r[2].split("machine_type=")[1]: float(r[4]) for r in rows}
+    # n2-standard-4 = 4*0.031611 + 16*0.004237 = 0.194236
+    assert abs(by_mt["n2-standard-4"] - (4 * 0.031611 + 16 * 0.004237)) < 1e-9
+    # n2-highmem-4 = 4*0.031611 + 32*0.004237
+    assert abs(by_mt["n2-highmem-4"] - (4 * 0.031611 + 32 * 0.004237)) < 1e-9
+    # n2-standard-1 = 1 core + 4 GiB
+    assert abs(by_mt["n2-standard-1"] - (1 * 0.031611 + 4 * 0.004237)) < 1e-9
+    # 2 shapes x 2 vcpus = 4 rows
+    assert len(rows) == 4
+    for r in rows:
+        assert r[5] == "t" and r[6] == "USD"
+        assert "service_provider=gcp" in r[3] and "region=us-central1" in r[3]
+
+
+def test_computed_skips_other_regions_and_commitment():
+    units = [
+        _core("N2", "europe-west1", 0.9),  # wrong region
+        _ram("N2", "europe-west1", 0.9),
+        _core("N2", "us-central1", 0.031611),
+        _ram("N2", "us-central1", 0.004237),
+    ]
+    rows = _rows(units)
+    # only the us-central1 rates used
+    n2s4 = next(float(r[4]) for r in rows if "n2-standard-4" in r[2])
+    assert abs(n2s4 - (4 * 0.031611 + 16 * 0.004237)) < 1e-9
+
+
+def test_computed_missing_family_rates_recorded_as_drift():
+    # only Core present for n2 -> can't compute -> family flagged unmapped.
+    stats = RecipeStats()
+    rows = _rows([_core("N2", "us-central1", 0.031611)], stats=stats)
+    assert rows == []
+    assert stats.unmapped["family"]["n2"] == 1
+
+
+def test_computed_ignores_custom_instance_meters():
+    # "N2 Custom Instance Core" must not match the family_regex.
+    units = [
+        Unit(
+            "N2 Custom Instance Core running in Americas",
+            {
+                "description": "N2 Custom Instance Core running in Americas",
+                "usage_type": "OnDemand",
+                "region": "us-central1",
+            },
+            [Price(usd="0.033")],
+        ),
+        _core("N2", "us-central1", 0.031611),
+        _ram("N2", "us-central1", 0.004237),
+    ]
+    rows = _rows(units)
+    # standard core rate used (0.031611), not the custom 0.033
+    n2s1 = next(float(r[4]) for r in rows if "n2-standard-1" in r[2])
+    assert abs(n2s1 - (0.031611 + 4 * 0.004237)) < 1e-9

--- a/pricegen/tests/test_gcp_adapter.py
+++ b/pricegen/tests/test_gcp_adapter.py
@@ -1,0 +1,51 @@
+"""Unit tests for the GCP Cloud Billing Catalog adapter (#933)."""
+
+from __future__ import annotations
+
+from pricegen.providers.gcp import adapter
+
+
+def _sku(
+    desc, units="0", nanos=0, regions=("us-central1",), rg="CPU", usage="OnDemand"
+):
+    return {
+        "description": desc,
+        "category": {"resourceGroup": rg, "usageType": usage},
+        "serviceRegions": list(regions),
+        "pricingInfo": [
+            {
+                "pricingExpression": {
+                    "usageUnit": "h",
+                    "tieredRates": [{"unitPrice": {"units": units, "nanos": nanos}}],
+                }
+            }
+        ],
+    }
+
+
+def test_rate_units_and_nanos_combined():
+    units = list(
+        adapter.iter_units(
+            {"skus": [_sku("N2 Instance Core", units="0", nanos=31611000)]}
+        )
+    )
+    assert units[0].prices[0].usd == "0.0316110000"
+    assert units[0].attrs["description"] == "N2 Instance Core"
+    assert units[0].attrs["usage_type"] == "OnDemand"
+
+
+def test_multi_region_sku_expands_to_one_unit_per_region():
+    sku = _sku("N2 Instance Ram", nanos=4237000, regions=("us-central1", "us-east1"))
+    units = list(adapter.iter_units({"skus": [sku]}))
+    assert {u.attrs["region"] for u in units} == {"us-central1", "us-east1"}
+    assert all(u.prices[0].usd == "0.0042370000" for u in units)
+
+
+def test_sku_without_pricing_skipped():
+    bad = {
+        "description": "x",
+        "category": {},
+        "serviceRegions": ["us-central1"],
+        "pricingInfo": [],
+    }
+    assert list(adapter.iter_units({"skus": [bad]})) == []

--- a/services/terrapod/services/cost/tf.py
+++ b/services/terrapod/services/cost/tf.py
@@ -20,6 +20,7 @@ same ``{type, values.*}`` shape falls out either way.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -231,13 +232,22 @@ def provider_regions(plan_json: dict[str, Any]) -> dict[str, str]:
 
 
 def resolve_region(resource: Resource, provider_region_map: dict[str, str], default: str) -> str:
-    """Resolve a resource's region: own attribute → provider config → default."""
+    """Resolve a resource's region: own attribute → provider config → default.
+
+    A GCP ``google_compute_instance`` carries a ``zone`` (``us-central1-a``), not
+    a ``region`` — the region is the zone with its trailing ``-<letter>`` removed.
+    (AWS uses ``availability_zone``, not ``zone``, so keying on ``zone`` is
+    GCP-safe.)
+    """
     values = resource.data.get("values")
     if isinstance(values, dict):
         for key in _REGION_ATTR_KEYS:
             val = values.get(key)
             if isinstance(val, str) and val:
                 return val
+        zone = values.get("zone")
+        if isinstance(zone, str) and zone:
+            return re.sub(r"-[a-z]$", "", zone)
     provider = resource.data.get("provider_name")
     if isinstance(provider, str) and provider in provider_region_map:
         return provider_region_map[provider]

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -132,5 +132,12 @@
     "usage": {
       "time": 730
     }
+  },
+  {
+    "description": "GCP Compute Engine instance hours (Terrapod addition)",
+    "match_query": "type = google_compute_instance and service_class = instance",
+    "usage": {
+      "time": 730
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -226,8 +226,8 @@ def test_resources_from_state_v4_lifts_attributes():
 def test_default_usage_catalogue_loads():
     entries = default_entries()
     # 18 vendored from OpenInfraQuote + Terrapod additions: RDS provisioned IOPS
-    # io1/io2 (#928, usage-less service_class=iops) + Azure Linux VM hours (#931).
-    assert len(entries) == 20
+    # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933).
+    assert len(entries) == 21
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),
@@ -382,6 +382,23 @@ def test_resolve_region_from_provider_config():
 def test_resolve_region_falls_back_to_default():
     r = _resource("aws_instance.web", "aws_instance", {"instance_type": "m5.large"})
     assert resolve_region(r, {}, "us-east-1") == "us-east-1"
+
+
+def test_resolve_region_derives_from_gcp_zone():
+    # a google_compute_instance carries `zone`, not `region` (#933).
+    r = _resource(
+        "google_compute_instance.a",
+        "google_compute_instance",
+        {"machine_type": "n2-standard-4", "zone": "us-central1-a"},
+    )
+    assert resolve_region(r, {}, "us-east-1") == "us-central1"
+    # an explicit region attribute still wins over zone.
+    r2 = _resource(
+        "google_compute_instance.b",
+        "google_compute_instance",
+        {"region": "europe-west1", "zone": "us-central1-a"},
+    )
+    assert resolve_region(r2, {}, "us-east-1") == "europe-west1"
 
 
 def test_provider_regions_extracts_constant_only():

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -46,6 +46,10 @@ _ROWS = [
     # Azure Linux VM (#931) — proves the second cloud prices through the same
     # engine. size = armSkuName; region resolved from the resource's `location`.
     "Virtual Machines,Virtual Machines,type=azurerm_linux_virtual_machine&values.size=Standard_D2s_v5,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=instance&os=linux&start_usage_amount=0&end_usage_amount=Inf,0.096,t,USD",
+    # GCP compute (#933) — the computed kind: this row is pre-assembled from the
+    # per-vCPU-core + per-GiB-RAM rates (n2-standard-4 = 4*core + 16*ram). Region
+    # is derived from the resource's `zone`.
+    "Compute Engine,Compute Instance,type=google_compute_instance&values.machine_type=n2-standard-4,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=instance&start_usage_amount=0&end_usage_amount=Inf,0.1942360000,t,USD",
 ]
 
 
@@ -272,6 +276,37 @@ def test_azure_linux_vm_prices_through_the_same_engine():
     est = estimate(plan, _sheet())
     # 0.096/hr * 730 = 70.08
     assert est.resources[0].monthly_min == pytest.approx(0.096 * 730, abs=0.01)
+    assert est.unpriced == []
+
+
+def test_gcp_compute_instance_prices_with_zone_derived_region():
+    """Third cloud: google_compute_instance prices via a pre-computed
+    machine_type row, with region DERIVED from the resource's `zone`
+    (us-central1-a -> us-central1). Proves the computed kind + zone handling
+    end-to-end (#933)."""
+    plan = {
+        "format_version": "1.2",
+        "terraform_version": "1.9.0",
+        "planned_values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "google_compute_instance.a",
+                        "type": "google_compute_instance",
+                        "name": "a",
+                        "mode": "managed",
+                        "values": {
+                            "machine_type": "n2-standard-4",
+                            "zone": "us-central1-a",
+                        },
+                    }
+                ]
+            }
+        },
+    }
+    est = estimate(plan, _sheet())
+    # 0.194236/hr * 730 = 141.79
+    assert est.resources[0].monthly_min == pytest.approx(0.194236 * 730, abs=0.01)
     assert est.unpriced == []
 
 


### PR DESCRIPTION
Closes #933. Part of #893. **The computed recipe kind — GCP's hardest case — completing all three clouds end-to-end.**

## Computed engine (`engine.generate_computed`)
GCP prices compute per **vCPU-core hour** + per **GiB-RAM hour** as *separate* SKUs ("N2 Instance Core running in Americas" / "... Ram ..."), so a machine type costs `vCPU × core-rate + RAM_GiB × ram-rate`. The engine reads each family's Core+Ram rate, enumerates machine types from a compact **per-family shape catalog**, and **pre-computes each total** — emitting one `values.machine_type=<type>` row per type, matched by the consumer like any instance (**no consumer arithmetic**). Kept separate from the direct `generate` path so AWS/Azure are untouched.

## GCP adapter
Public **Cloud Billing Catalog API** (free read-only key), expanding multi-region SKUs to one Unit per (SKU, region).

## Consumer: zone→region
A `google_compute_instance` carries **`zone`** (us-central1-a), not `region` — added zone→region derivation to `resolve_region` (strip trailing `-<letter>`; AWS uses `availability_zone`, so it's GCP-safe), plus the usage entry.

## Formulaic catalog
machine-type→(vCPU,RAM) is **formulaic** (standard = 4 GiB/vCPU, highmem = 8, highcpu = 1; per-family ratios in the recipe) — no external catalog. Custom types (`n2-custom-*`) left unpriced (documented gap); over-enumerated sizes are harmless (never matched).

## Validated end-to-end
`google_compute_instance{machine_type=n2-standard-4, zone=us-central1-a}` = **$141.79/mo** (0.194236/hr = 4×0.031611 + 16×0.004237) through the real `estimate()` engine. n2/e2/n1/highmem/highcpu all compute exactly.

Broader GCP families/regions are follow-ups. 37 services + 23 pricegen tests green (computed-engine, GCP-adapter, zone-region, and E2E cases added); usage-catalogue count 20→21.