### PR TITLE
feat(pricegen): combined publish producer (gzipped-YAML sheet + drift manifest)

### DIFF
--- a/pricegen/publish.py
+++ b/pricegen/publish.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Combine every recipe into one published Terrapod pricesheet (#893).
+
+Runs each entry in ``recipes.yaml`` through the engine, then writes two
+artifacts:
+
+* ``prices.yaml.gz`` — the combined pricesheet in Terrapod's own **YAML** schema
+  (``schema: terrapod-pricesheet/v1``), gzipped. This is what a Terrapod instance
+  consumes (via ``cost_estimation.prices_url``), replacing the dependency on
+  OpenInfraQuote's hosted CSV. YAML (not CSV) because it is self-describing,
+  versioned, and extensible; gzip because the row set, while far smaller and more
+  targeted than a 200k-row flat CSV, still compresses well.
+* ``manifest.json`` — the aggregated per-recipe **drift diagnostics** (row
+  counts, price ranges, and the unmapped-value signal). The scheduled publish
+  workflow diffs this against the last published manifest to detect that a cloud
+  changed its API and a recipe needs updating, and refuses to publish a
+  collapsed sheet over a good one (#922).
+
+The ``combine`` function is pure (results -> sheet + manifest) so it is unit
+tested without any offer files; ``main`` wires in offer loading + the engine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+from pricegen import engine
+
+HERE = Path(__file__).parent
+SCHEMA = "terrapod-pricesheet/v1"
+
+
+def _row_to_product(row: tuple) -> dict:
+    service, family, match_set, pricing_match_set, price, price_type, _ccy = row
+    return {
+        "service": service,
+        "family": family,
+        "match": match_set,
+        "pricing": pricing_match_set,
+        "price": price,
+        "price_type": price_type,
+    }
+
+
+def combine(
+    results: list[tuple[dict, list[tuple], engine.RecipeStats]],
+) -> tuple[dict, dict]:
+    """Combine per-recipe (config, rows, stats) into (sheet_dict, manifest_dict).
+
+    Pure — no I/O. ``results`` is one tuple per recipe. Currency is assumed USD
+    (every adapter emits USD today); a mixed-currency sheet would carry it
+    per-product instead.
+    """
+    products: list[dict] = []
+    recipes: list[dict] = []
+    for cfg, rows, stats in results:
+        products.extend(_row_to_product(r) for r in rows)
+        recipes.append(
+            {
+                "provider": cfg["provider"],
+                "recipe": cfg["recipe"],
+                "resource_type": rows[0][2].split("&", 1)[0].removeprefix("type=")
+                if rows
+                else cfg["recipe"],
+                "rows": stats.rows,
+                "units_in_family": stats.units_total,
+                "skipped": {
+                    "select": stats.skipped_select,
+                    "absent": stats.skipped_absent,
+                    "unmapped": stats.skipped_unmapped,
+                },
+                "unmapped": {f: dict(c) for f, c in sorted(stats.unmapped.items())},
+                "price_min": stats.price_min,
+                "price_max": stats.price_max,
+            }
+        )
+    sheet = {"schema": SCHEMA, "currency": "USD", "products": products}
+    manifest = {
+        "schema": SCHEMA,
+        "total_products": len(products),
+        "recipes": recipes,
+    }
+    return sheet, manifest
+
+
+def _run_one(cfg: dict) -> tuple[dict, list[tuple], engine.RecipeStats]:
+    pdir = HERE / "providers" / cfg["provider"]
+    adapter = importlib.import_module(f"pricegen.providers.{cfg['provider']}.adapter")
+    defaults = yaml.safe_load((pdir / "defaults.yaml").read_text())
+    recipe = yaml.safe_load((pdir / "recipes" / f"{cfg['recipe']}.yaml").read_text())
+    offer_path = cfg["offer"]
+    if not Path(offer_path).is_absolute():
+        offer_path = HERE / offer_path
+    offer = adapter.load(offer_path)
+    units = adapter.iter_units(offer, term=defaults.get("price_term", "OnDemand"))
+    stats = engine.RecipeStats()
+    if "computed" in recipe:
+        rows = list(
+            engine.generate_computed(
+                recipe, defaults, list(units), service=recipe["service"], stats=stats
+            )
+        )
+    else:
+        rows = list(
+            engine.generate(
+                recipe, defaults, units, service=recipe["service"], stats=stats
+            )
+        )
+    print(f"  {cfg['provider']}/{cfg['recipe']}: {stats.rows} rows", file=sys.stderr)
+    return cfg, rows, stats
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", type=Path, default=HERE / "recipes.yaml")
+    ap.add_argument("--out", type=Path, default=Path("prices.yaml.gz"))
+    ap.add_argument("--manifest", type=Path, default=Path("manifest.json"))
+    args = ap.parse_args()
+
+    config = yaml.safe_load(args.config.read_text())
+    results = [_run_one(cfg) for cfg in config["recipes"]]
+    sheet, manifest = combine(results)
+
+    with gzip.open(args.out, "wt") as f:
+        yaml.safe_dump(sheet, f, sort_keys=False)
+    args.manifest.write_text(json.dumps(manifest, indent=2))
+    print(
+        f"wrote {args.out} ({manifest['total_products']} products) + {args.manifest}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -1,0 +1,17 @@
+# The set of recipes the published Terrapod pricesheet includes (#893).
+#
+# Each entry names a provider, a recipe, and the offer file it reads. In CI the
+# offers are fetched fresh (a later phase); locally they come from the gitignored
+# `.cache/` (see the fetch snippets in the provider adapters' module docs). The
+# `publish` generator runs every entry through the engine, combines the rows into
+# one gzipped-YAML pricesheet, and aggregates the per-recipe drift manifests.
+recipes:
+  - provider: aws
+    recipe: aws_db_instance
+    offer: .cache/rds-us-east-1.json
+  - provider: azure
+    recipe: azurerm_linux_virtual_machine
+    offer: .cache/azure-vm-eastus.json
+  - provider: gcp
+    recipe: google_compute_instance
+    offer: .cache/gcp-compute.json

--- a/pricegen/tests/test_publish.py
+++ b/pricegen/tests/test_publish.py
@@ -1,0 +1,86 @@
+"""Unit tests for the publish combiner (#893).
+
+`combine` is pure — it takes per-recipe (config, rows, stats) and returns the
+YAML sheet dict + the aggregated drift manifest — so it's tested with synthetic
+data, no offer files.
+"""
+
+from __future__ import annotations
+
+from pricegen.engine import RecipeStats
+from pricegen.publish import SCHEMA, combine
+
+
+def _row(service, rtype, price, ptype="t"):
+    return (
+        service,
+        "Fam",
+        f"type={rtype}&values.x=1",
+        "region=us-east-1&service_class=instance",
+        price,
+        ptype,
+        "USD",
+    )
+
+
+def _stats(rows, **kw):
+    s = RecipeStats()
+    s.rows = rows
+    s.units_total = kw.get("units", rows)
+    s.price_min = kw.get("pmin")
+    s.price_max = kw.get("pmax")
+    for f, vals in kw.get("unmapped", {}).items():
+        for v, n in vals.items():
+            for _ in range(n):
+                s._note_unmapped(f, v)
+    return s
+
+
+def test_combine_aggregates_products_and_metadata():
+    results = [
+        (
+            {"provider": "aws", "recipe": "r1"},
+            [_row("AmazonEC2", "aws_instance", "0.1")],
+            _stats(1, pmin=0.1, pmax=0.1),
+        ),
+        (
+            {"provider": "gcp", "recipe": "r2"},
+            [_row("Compute Engine", "google_compute_instance", "0.2")],
+            _stats(1, pmin=0.2, pmax=0.2),
+        ),
+    ]
+    sheet, manifest = combine(results)
+    assert sheet["schema"] == SCHEMA and sheet["currency"] == "USD"
+    assert len(sheet["products"]) == 2
+    p = sheet["products"][0]
+    assert set(p) == {"service", "family", "match", "pricing", "price", "price_type"}
+    assert p["service"] == "AmazonEC2" and p["price"] == "0.1"
+    assert manifest["total_products"] == 2
+    assert {r["provider"] for r in manifest["recipes"]} == {"aws", "gcp"}
+    assert manifest["recipes"][0]["resource_type"] == "aws_instance"
+
+
+def test_combine_surfaces_unmapped_drift_in_manifest():
+    stats = _stats(
+        1, pmin=1.0, pmax=1.0, unmapped={"match.engine": {"Db2|Standard": 3}}
+    )
+    _, manifest = combine(
+        [
+            (
+                {"provider": "aws", "recipe": "r"},
+                [_row("S", "aws_db_instance", "1.0")],
+                stats,
+            )
+        ]
+    )
+    rec = manifest["recipes"][0]
+    assert rec["skipped"]["unmapped"] == 3
+    assert rec["unmapped"]["match.engine"]["Db2|Standard"] == 3
+
+
+def test_combine_handles_empty_recipe_rows():
+    # a recipe that produced zero rows (e.g. feed collapse) still records a
+    # manifest entry — that's exactly the drift signal the guardrail acts on.
+    _, manifest = combine([({"provider": "aws", "recipe": "r"}, [], _stats(0))])
+    assert manifest["total_products"] == 0
+    assert manifest["recipes"][0]["rows"] == 0


### PR DESCRIPTION
Closes #939. Part of #893. **Phase 1 of the publish vertical.**

`pricegen/publish.py` runs every recipe in `recipes.yaml` through the engine and combines them into the two published artifacts:

- **`prices.yaml.gz`** — the combined pricesheet in Terrapod's own YAML schema (`terrapod-pricesheet/v1`), gzipped. YAML (not CSV) because it's self-describing, versioned, and extensible; this becomes what a Terrapod instance consumes (`cost_estimation.prices_url`), replacing the OpenInfraQuote-CSV dependency.
- **`manifest.json`** — aggregated per-recipe **drift diagnostics** (rows, price ranges, the unmapped-value signal). The scheduled workflow will diff this against the last published manifest to detect a cloud changing its API and refuse to publish a collapsed sheet (#922).

`combine` is **pure** (results → sheet + manifest), unit-tested with synthetic data (no offer files). Validated locally across all three clouds: **5024 products** (AWS RDS + Azure VM + GCP compute) → **45 KB gzipped**.

## Next phases
- Consumer reads the Terrapod YAML sheet (alongside oiq CSV).
- Scheduled CI workflow: fetch offers → generate → **drift guardrail** (manifest diff → fail/open-issue) → rolling GitHub Release + manifest asset.
- Flip `cost_estimation.prices_url` default to the rolling release.

26 pricegen tests green; ruff clean.