### PR TITLE
feat(pricegen): drift guardrail (manifest diff, blocks collapsed publish) — #922

### DIFF
--- a/pricegen/drift.py
+++ b/pricegen/drift.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Drift guardrail for the scheduled publish job (#922).
+
+A **self-generated** pricesheet is exposed to a failure mode a hosted feed hides
+from us: a cloud provider quietly renames a product family, adds an enum value
+(a new engine / volume type / machine family), or restructures its API — and our
+recipes then silently emit **fewer rows, or wrong ones**. This diffs the run's
+drift **manifest** (from ``publish.py``) against the **last published** manifest
+and decides whether the new sheet is safe to publish:
+
+* **BLOCK** — a recipe vanished, or its row count fell below its floor
+  (``min_rows`` in ``health.yaml``): the family regex / select almost certainly
+  stopped matching. The scheduled job must NOT publish the collapsed sheet over
+  the good one, and should open/refresh an issue.
+* **WARN** — a new unmapped value the recipe doesn't cover (and isn't on the
+  expected-drop allowlist), a large row-count move, or a price swing. Surfaced,
+  not blocking.
+
+Runs only on the weekly schedule (it needs two manifests across runs), never
+per-PR. Pure logic (``check_drift``) so it is unit tested with synthetic
+manifests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).parent
+
+
+@dataclass
+class Finding:
+    severity: str  # "block" | "warn"
+    recipe: str
+    message: str
+
+
+@dataclass
+class DriftReport:
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def blocked(self) -> bool:
+        return any(f.severity == "block" for f in self.findings)
+
+    def issue_body(self) -> str:
+        """A deterministic markdown body for the drift issue (stable title →
+        update-in-place, no duplicate spam)."""
+        if not self.findings:
+            return "No pricesheet drift detected."
+        blocks = [f for f in self.findings if f.severity == "block"]
+        warns = [f for f in self.findings if f.severity == "warn"]
+        lines = ["## pricegen drift detected", ""]
+        if blocks:
+            lines.append("### 🛑 Blocking — sheet NOT published")
+            lines += [f"- **{f.recipe}**: {f.message}" for f in blocks]
+            lines.append("")
+        if warns:
+            lines.append("### ⚠️ Warnings")
+            lines += [f"- **{f.recipe}**: {f.message}" for f in warns]
+        return "\n".join(lines)
+
+
+def _by_recipe(manifest: dict) -> dict[str, dict]:
+    return {r["recipe"]: r for r in manifest.get("recipes", [])}
+
+
+def check_drift(prev: dict, curr: dict, health: dict) -> DriftReport:
+    """Diff ``curr`` manifest against ``prev`` under ``health`` thresholds."""
+    report = DriftReport()
+    prev_by, curr_by = _by_recipe(prev), _by_recipe(curr)
+    floors = health.get("min_rows", {})
+    allow = health.get("known_unmapped", {})
+    swing = float(health.get("price_swing_factor", 10))
+    band = float(health.get("row_delta_fraction", 0.5))
+
+    # A recipe present last publish but gone now — hard block.
+    for name, prev_r in prev_by.items():
+        if name not in curr_by:
+            report.findings.append(
+                Finding(
+                    "block",
+                    name,
+                    f"vanished from the sheet (was {prev_r['rows']} rows)",
+                )
+            )
+
+    for name, cur in curr_by.items():
+        prev_r = prev_by.get(name)
+        floor = floors.get(name, 1)
+        if cur["rows"] < floor:
+            report.findings.append(
+                Finding(
+                    "block",
+                    name,
+                    f"produced {cur['rows']} rows (< floor {floor}) — the product-family "
+                    "regex / select likely stopped matching (renamed family?)",
+                )
+            )
+        elif prev_r and prev_r["rows"] > 0:
+            frac = abs(cur["rows"] - prev_r["rows"]) / prev_r["rows"]
+            if frac > band:
+                report.findings.append(
+                    Finding(
+                        "warn",
+                        name,
+                        f"row count moved {prev_r['rows']} → {cur['rows']} ({frac:.0%})",
+                    )
+                )
+
+        # New unmapped values not on the allowlist and not seen last publish.
+        patterns = {
+            f: [re.compile(p) for p in ps] for f, ps in allow.get(name, {}).items()
+        }
+        prev_unmapped = (prev_r or {}).get("unmapped", {})
+        for fieldname, values in cur.get("unmapped", {}).items():
+            known_prev = set(prev_unmapped.get(fieldname, {}))
+            for value in values:
+                if value in known_prev:
+                    continue
+                if any(rx.search(value) for rx in patterns.get(fieldname, [])):
+                    continue
+                report.findings.append(
+                    Finding(
+                        "warn",
+                        name,
+                        f"new unmapped {fieldname}={value!r} — a value the feed added "
+                        "that the recipe doesn't cover (map/regex may need an update)",
+                    )
+                )
+
+        # Price anomaly on the top of the range.
+        pmax_prev, pmax_cur = (prev_r or {}).get("price_max"), cur.get("price_max")
+        if prev_r and pmax_prev and pmax_cur:
+            ratio = pmax_cur / pmax_prev
+            if ratio > swing or ratio < 1 / swing:
+                report.findings.append(
+                    Finding("warn", name, f"max price swung {pmax_prev} → {pmax_cur}")
+                )
+
+    return report
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--prev", type=Path, required=True, help="last published manifest.json"
+    )
+    ap.add_argument("--curr", type=Path, required=True, help="this run's manifest.json")
+    ap.add_argument("--health", type=Path, default=HERE / "health.yaml")
+    ap.add_argument(
+        "--issue-body", type=Path, help="write the markdown issue body here"
+    )
+    args = ap.parse_args()
+
+    prev = json.loads(args.prev.read_text())
+    curr = json.loads(args.curr.read_text())
+    health = yaml.safe_load(args.health.read_text())
+    report = check_drift(prev, curr, health)
+
+    print(report.issue_body(), file=sys.stderr)
+    if args.issue_body:
+        args.issue_body.write_text(report.issue_body())
+    # Exit non-zero on a blocking finding so the workflow refuses to publish.
+    return 1 if report.blocked else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pricegen/health.yaml
+++ b/pricegen/health.yaml
@@ -1,0 +1,36 @@
+# Drift-guardrail thresholds for the scheduled publish job (#922).
+#
+# The guardrail (pricegen/drift.py) diffs each run's manifest against the last
+# PUBLISHED manifest and blocks a publish (or opens an issue) when a recipe's
+# coverage collapses or the feed grew a value the recipe doesn't cover — the
+# "the cloud changed its API and our logic needs an update" signal. These
+# knobs keep intentional drops from paging us.
+
+# Hard floor per recipe: fewer rows than this ⇒ BLOCK (the family regex / select
+# almost certainly stopped matching — e.g. a renamed product family).
+min_rows:
+  aws_db_instance: 1000
+  azurerm_linux_virtual_machine: 500
+  google_compute_instance: 50
+
+# WARN if a recipe's row count moves more than this fraction vs the last publish.
+row_delta_fraction: 0.5
+
+# WARN if a recipe's max price swings by more than this factor vs last publish
+# (a ×10 jump or →0 usually means a unit/parse error, not a real price change).
+price_swing_factor: 10
+
+# Expected-unmapped allowlist: an unmapped value MATCHING any of these regexes
+# (per recipe, per field) is a deliberate drop and does NOT warn. A genuinely
+# NEW unmapped value — one that matches nothing here and wasn't unmapped last
+# publish — is the actionable drift signal and warns.
+known_unmapped:
+  aws_db_instance:
+    match.engine:
+      - "Aurora" # separate aws_rds_cluster_instance recipe
+      - "Db2" # not yet mapped (deliberate)
+      - "Outpost" # RDS on Outposts — out of scope
+      - "Developer" # SQL Server Developer edition
+      - "Express" # SQL Server Express edition
+    match.storage_type:
+      - "Aurora" # Aurora volume types -> aws_rds_cluster_instance

--- a/pricegen/tests/test_drift.py
+++ b/pricegen/tests/test_drift.py
@@ -1,0 +1,114 @@
+"""Unit tests for the drift guardrail (#922).
+
+check_drift is pure — synthetic prev/curr manifests + a small health config,
+no offer files. It's the scheduled-job logic that decides whether a freshly
+generated sheet is safe to publish over the last good one.
+"""
+
+from __future__ import annotations
+
+from pricegen.drift import check_drift
+
+
+def _recipe(name, rows, unmapped=None, pmax=100.0):
+    return {
+        "recipe": name,
+        "rows": rows,
+        "unmapped": unmapped or {},
+        "price_min": 0.1,
+        "price_max": pmax,
+    }
+
+
+def _manifest(*recipes):
+    return {"recipes": list(recipes)}
+
+
+_HEALTH = {
+    "min_rows": {"aws_db_instance": 1000, "gcp": 50},
+    "row_delta_fraction": 0.5,
+    "price_swing_factor": 10,
+    "known_unmapped": {"aws_db_instance": {"match.engine": ["Aurora", "Db2"]}},
+}
+
+
+def test_no_drift_is_clean():
+    m = _manifest(_recipe("aws_db_instance", 3200))
+    r = check_drift(m, m, _HEALTH)
+    assert not r.blocked and r.findings == []
+
+
+def test_coverage_collapse_below_floor_blocks():
+    prev = _manifest(_recipe("aws_db_instance", 3200))
+    curr = _manifest(_recipe("aws_db_instance", 0))  # family regex stopped matching
+    r = check_drift(prev, curr, _HEALTH)
+    assert r.blocked
+    assert "floor" in r.findings[0].message
+
+
+def test_recipe_vanished_blocks():
+    prev = _manifest(_recipe("aws_db_instance", 3200), _recipe("gcp", 90))
+    curr = _manifest(_recipe("aws_db_instance", 3200))
+    r = check_drift(prev, curr, _HEALTH)
+    assert r.blocked
+    assert any(f.recipe == "gcp" and "vanished" in f.message for f in r.findings)
+
+
+def test_new_unmapped_value_warns():
+    prev = _manifest(_recipe("aws_db_instance", 3200))
+    curr = _manifest(
+        _recipe("aws_db_instance", 3200, unmapped={"match.engine": {"Neptune|": 5}})
+    )
+    r = check_drift(prev, curr, _HEALTH)
+    assert not r.blocked  # a warn, not a block
+    assert any("Neptune" in f.message and f.severity == "warn" for f in r.findings)
+
+
+def test_known_unmapped_value_is_allowed():
+    prev = _manifest(_recipe("aws_db_instance", 3200))
+    # Aurora + Db2 are on the allowlist -> no warning.
+    curr = _manifest(
+        _recipe(
+            "aws_db_instance",
+            3200,
+            unmapped={"match.engine": {"Aurora MySQL|": 3, "Db2|Standard": 2}},
+        )
+    )
+    r = check_drift(prev, curr, _HEALTH)
+    assert r.findings == []
+
+
+def test_unmapped_value_seen_last_publish_does_not_re_warn():
+    prev = _manifest(
+        _recipe("aws_db_instance", 3200, unmapped={"match.engine": {"Weird|": 1}})
+    )
+    curr = _manifest(
+        _recipe("aws_db_instance", 3200, unmapped={"match.engine": {"Weird|": 1}})
+    )
+    r = check_drift(prev, curr, _HEALTH)
+    assert r.findings == []  # not new -> no warn
+
+
+def test_large_row_move_warns():
+    prev = _manifest(_recipe("aws_db_instance", 3200))
+    curr = _manifest(_recipe("aws_db_instance", 1500))  # -53%, above floor but big move
+    r = check_drift(prev, curr, _HEALTH)
+    assert not r.blocked
+    assert any("row count moved" in f.message for f in r.findings)
+
+
+def test_price_swing_warns():
+    prev = _manifest(_recipe("aws_db_instance", 3200, pmax=100.0))
+    curr = _manifest(_recipe("aws_db_instance", 3200, pmax=2000.0))  # 20x
+    r = check_drift(prev, curr, _HEALTH)
+    assert any("price swung" in f.message for f in r.findings)
+
+
+def test_issue_body_groups_by_severity():
+    prev = _manifest(_recipe("aws_db_instance", 3200), _recipe("gcp", 90))
+    curr = _manifest(
+        _recipe("aws_db_instance", 0, unmapped={"match.engine": {"Neptune|": 1}})
+    )
+    body = check_drift(prev, curr, _HEALTH).issue_body()
+    assert "Blocking" in body and "Warnings" in body
+    assert "gcp" in body and "aws_db_instance" in body


### PR DESCRIPTION
Closes #941. Delivers **#922**. Part of #893. **Phase 2 of the publish vertical** — the CI-alerting you asked for.

A **self-generated** pricesheet is exposed to a failure mode a hosted feed hides: a cloud quietly renames a product family / adds an enum value / restructures its API, and our recipes silently emit fewer or wrong rows. `pricegen/drift.py` diffs a publish run's **manifest** against the **last published** one:

- **🛑 BLOCK** (exit 1 — sheet NOT published, open/refresh an issue): a recipe vanished, or its row count fell below its `health.yaml` floor (the family regex/select stopped matching — a renamed family).
- **⚠️ WARN**: a new unmapped value the recipe doesn't cover (not on the expected-drop allowlist), a large row-count move, or a price swing.

`health.yaml` carries per-recipe floors, the row-delta band, the price-swing factor, and a **regex allowlist of expected-unmapped values** (Aurora/Db2/Outposts/…) so intentional drops don't page us. `check_drift` is pure (synthetic manifests → report) with a deterministic markdown issue body (stable title → update-in-place, no dupes).

Smoke-validated on the real manifest: clean run → **exit 0**; a simulated `aws_db_instance`→0 collapse → **BLOCK exit 1** ("sheet NOT published"). Runs only on the weekly schedule (needs two manifests across runs), never per-PR.

## Next
The scheduled CI workflow: fetch offers → `publish` → `drift` (vs last release's manifest) → publish to a rolling GitHub Release (or open the drift issue).

9 new drift tests (35 pricegen total); ruff clean.