### PR TITLE
feat(pricegen): scheduled publish workflow (fetch → publish → drift → rolling release)

### DIFF
--- a/.github/workflows/pricesheet.yml
+++ b/.github/workflows/pricesheet.yml
@@ -1,0 +1,90 @@
+name: Pricesheet
+
+# Weekly regeneration of the self-generated cost pricesheet (#893) from the
+# official cloud pricing APIs, published to a rolling GitHub Release. Runs ONLY
+# on a schedule (or manual dispatch) — never on PRs — because it fetches live
+# pricing data and publishes an artifact. The drift guardrail (#922) diffs this
+# run's manifest against the last published one and REFUSES to publish a
+# collapsed sheet, opening an issue instead.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # publish the rolling release
+  issues: write # open/refresh the drift issue
+
+env:
+  RELEASE_TAG: pricesheet
+  DRIFT_TITLE: "pricegen: pricesheet drift detected"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v5.0.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+      - run: pip install pyyaml
+
+      - name: Fetch offers from the official cloud pricing APIs
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+        run: python -m pricegen.fetch_offers
+
+      - name: Generate the pricesheet + drift manifest
+        run: python -m pricegen.publish --out prices.yaml.gz --manifest manifest.json
+
+      - name: Download the last published manifest (if any)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p prev
+          if gh release download "$RELEASE_TAG" --pattern manifest.json --dir prev 2>/dev/null; then
+            echo "have_prev=true" >> "$GITHUB_ENV"
+          else
+            echo "have_prev=false" >> "$GITHUB_ENV"
+            echo "No previous release — first publish, skipping drift check."
+          fi
+
+      - name: Drift guardrail
+        id: drift
+        if: env.have_prev == 'true'
+        run: |
+          set +e
+          python -m pricegen.drift --prev prev/manifest.json --curr manifest.json \
+            --issue-body drift-body.md
+          echo "blocked=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Open/refresh drift issue and fail (blocking drift)
+        if: steps.drift.outputs.blocked == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list --state open --search "$DRIFT_TITLE in:title" \
+            --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file drift-body.md
+            echo "Refreshed drift issue #$existing"
+          else
+            gh issue create --title "$DRIFT_TITLE" --body-file drift-body.md
+          fi
+          echo "::error::Pricesheet drift is blocking — the collapsed sheet was NOT published."
+          exit 1
+
+      - name: Publish to the rolling release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --title "Terrapod cost pricesheet (rolling)" \
+              --notes "Auto-generated weekly from official cloud pricing APIs (#893). The \`prices.yaml.gz\` asset is a stable URL for \`cost_estimation.prices_url\`; \`manifest.json\` is the drift manifest." \
+              --latest=false
+          fi
+          gh release upload "$RELEASE_TAG" prices.yaml.gz manifest.json --clobber
+          echo "Published $(du -h prices.yaml.gz | cut -f1) pricesheet to the '$RELEASE_TAG' release."

--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -126,6 +126,7 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] End-to-end pricing validation (real consumer engine, not just row-parity) + generator drift diagnostics
 - [x] Azure adapter + `azurerm_linux_virtual_machine` (regex select, validated end-to-end) — second cloud proven
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
+- [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
+- [ ] Consumer reads the Terrapod YAML sheet + flip `cost_estimation.prices_url` default to the rolling release
 - [ ] AWS breadth (LB, NAT, EIP, S3, …) + all-regions + a row-parity CI gate
 - [ ] Broaden GCP families/regions; Azure managed disks / Windows
-- [ ] Publish job (gzipped-YAML rolling release) + engine reads YAML + `prices_url` default

--- a/pricegen/fetch_offers.py
+++ b/pricegen/fetch_offers.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Fetch each recipe's pricing offer from the official cloud API (#893).
+
+Config-driven downloader for the scheduled publish job: for every entry in
+``recipes.yaml`` it fetches that recipe's offer to the path the recipe expects
+(``.cache/…``), so ``publish.py`` can then run over fresh data. All three
+sources are official first-class APIs — no third-party pricing product:
+
+* **AWS** — Price List Bulk API: the service's ``region_index.json`` → the
+  region's ``index.json`` (public, no credentials).
+* **Azure** — Retail Prices API, paginated via ``NextPageLink`` (public).
+* **GCP** — Cloud Billing Catalog ``skus`` list, paginated (needs a free
+  read-only API key in ``GCP_BILLING_API_KEY``).
+
+Each ``recipes.yaml`` entry carries a ``fetch:`` block describing its source.
+Run: ``python -m pricegen.fetch_offers`` (add ``--only aws`` to limit).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).parent
+_UA = {"User-Agent": "terrapod-pricegen/0.1"}
+_AWS_BULK = "https://pricing.us-east-1.amazonaws.com"
+
+
+def _get_json(url: str) -> dict:
+    with urllib.request.urlopen(  # noqa: S310 — trusted pinned cloud hosts
+        urllib.request.Request(url, headers=_UA)
+    ) as resp:
+        return json.load(resp)
+
+
+def fetch_aws(fetch: dict) -> dict:
+    """AWS Price List Bulk API: region_index → the region's index.json."""
+    svc, region = fetch["service_code"], fetch["region"]
+    idx = _get_json(f"{_AWS_BULK}/offers/v1.0/aws/{svc}/current/region_index.json")
+    region_url = idx["regions"][region]["currentVersionUrl"]
+    return _get_json(_AWS_BULK + region_url)
+
+
+def fetch_azure(fetch: dict) -> dict:
+    """Azure Retail Prices API — page through every Consumption item."""
+    name, region = fetch["service_name"], fetch["region"]
+    flt = (
+        f"serviceName eq '{name}' and armRegionName eq '{region}' "
+        "and priceType eq 'Consumption'"
+    )
+    url = "https://prices.azure.com/api/retail/prices?" + urllib.parse.urlencode(
+        {"$filter": flt}
+    )
+    items: list[dict] = []
+    while url:
+        d = _get_json(url)
+        items.extend(d.get("Items", []))
+        url = d.get("NextPageLink")
+    return {"Items": items}
+
+
+def fetch_gcp(fetch: dict) -> dict:
+    """GCP Cloud Billing Catalog — page through a service's SKUs (needs a key)."""
+    key = os.environ.get("GCP_BILLING_API_KEY")
+    if not key:
+        raise SystemExit("GCP_BILLING_API_KEY not set — required to fetch GCP offers")
+    svc = fetch["service_id"]
+    skus: list[dict] = []
+    tok = ""
+    while True:
+        url = (
+            f"https://cloudbilling.googleapis.com/v1/services/{svc}/skus"
+            f"?key={key}&pageSize=5000" + (f"&pageToken={tok}" if tok else "")
+        )
+        d = _get_json(url)
+        skus.extend(d.get("skus", []))
+        tok = d.get("nextPageToken")
+        if not tok:
+            break
+    return {"skus": skus}
+
+
+_FETCHERS = {"aws": fetch_aws, "azure": fetch_azure, "gcp": fetch_gcp}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", type=Path, default=HERE / "recipes.yaml")
+    ap.add_argument("--only", help="fetch only this provider (aws|azure|gcp)")
+    args = ap.parse_args()
+
+    config = yaml.safe_load(args.config.read_text())
+    for cfg in config["recipes"]:
+        provider = cfg["provider"]
+        if args.only and provider != args.only:
+            continue
+        fetch = cfg.get("fetch")
+        if not fetch:
+            print(
+                f"  {provider}/{cfg['recipe']}: no fetch block, skipping",
+                file=sys.stderr,
+            )
+            continue
+        out = cfg["offer"]
+        out = Path(out) if Path(out).is_absolute() else HERE / out
+        out.parent.mkdir(parents=True, exist_ok=True)
+        print(f"  fetching {provider}/{cfg['recipe']} → {out} …", file=sys.stderr)
+        offer = _FETCHERS[provider](fetch)
+        size = len(
+            offer.get("skus") or offer.get("Items") or offer.get("products") or {}
+        )
+        out.write_text(json.dumps(offer))
+        print(f"    {size} items", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -1,17 +1,22 @@
 # The set of recipes the published Terrapod pricesheet includes (#893).
 #
-# Each entry names a provider, a recipe, and the offer file it reads. In CI the
-# offers are fetched fresh (a later phase); locally they come from the gitignored
-# `.cache/` (see the fetch snippets in the provider adapters' module docs). The
-# `publish` generator runs every entry through the engine, combines the rows into
-# one gzipped-YAML pricesheet, and aggregates the per-recipe drift manifests.
+# Each entry names a provider, a recipe, the offer file it reads, and a `fetch:`
+# block describing how to download that offer from the official cloud pricing
+# API. `python -m pricegen.fetch_offers` populates the offers (from the API); the
+# `publish` generator then runs every entry through the engine, combines the rows
+# into one gzipped-YAML pricesheet, and aggregates the per-recipe drift manifests.
+# Locally the offers live in the gitignored `.cache/`; in CI the scheduled
+# pricesheet workflow fetches them fresh each run.
 recipes:
   - provider: aws
     recipe: aws_db_instance
     offer: .cache/rds-us-east-1.json
+    fetch: { service_code: AmazonRDS, region: us-east-1 }
   - provider: azure
     recipe: azurerm_linux_virtual_machine
     offer: .cache/azure-vm-eastus.json
+    fetch: { service_name: "Virtual Machines", region: eastus }
   - provider: gcp
     recipe: google_compute_instance
     offer: .cache/gcp-compute.json
+    fetch: { service_id: "6F81-5844-456A" } # Compute Engine


### PR DESCRIPTION
Closes #943. Part of #893. **Phase 3 of the publish vertical** — ties the producer (#940) and drift guardrail (#942/#922) into a weekly automated pipeline.

## `pricegen/fetch_offers.py`
Config-driven offer downloader from the **official** APIs — AWS Price List Bulk (region-index → region index.json), Azure Retail Prices (paginated), GCP Cloud Billing Catalog (paginated, free read-only key). Each `recipes.yaml` entry gains a `fetch:` block. **Validated end-to-end** by re-fetching all three: RDS 6048 products (postgres $0.072), Azure VM D2s_v5 $0.096, GCP 31728 SKUs.

## `.github/workflows/pricesheet.yml`
Scheduled **weekly** (+ manual dispatch, **never on PRs**):
`fetch_offers` → `publish` → download last release's manifest → `drift` guardrail → **on block: open/refresh the drift issue and FAIL** (the collapsed sheet is NOT published over the good one); **on pass: upload `prices.yaml.gz` + `manifest.json`** to the rolling `pricesheet` GitHub Release (clobber). Same SHA-pinned actions + `gh release` pattern as `ci.yml`; `GCP_BILLING_API_KEY` from secrets.

Same GitHub-hosted delivery story as the images (GHCR) + chart (OCI): the `prices.yaml.gz` asset is a stable URL for `cost_estimation.prices_url`.

Full pipeline smoke green (fetch cached → publish 5024 products → drift exit 0). 35 pricegen tests green; ruff clean; workflow YAML valid. The workflow is CI-only (can't run on this PR); it's runnable via **workflow_dispatch** to validate live.

## Next
Consumer reads the Terrapod YAML sheet; flip `cost_estimation.prices_url` default to the rolling release.