### PR TITLE
feat(pricegen): aws_sqs_queue recipe (fixes oiq's inverted FIFO/Standard mapping)

### DIFF
--- a/pricegen/providers/aws/recipes/aws_sqs_queue.yaml
+++ b/pricegen/providers/aws/recipes/aws_sqs_queue.yaml
@@ -1,0 +1,32 @@
+# SQS -> aws_sqs_queue (on-demand). Per-API-request pricing, tiered by monthly
+# request volume. AWS's `queueType` maps to the Terraform `fifo_queue` bool.
+#
+# NB we map queueType->fifo_queue CORRECTLY, unlike oiq, which has it inverted:
+# AWS charges Standard $0.40/M requests and FIFO $0.50/M (FIFO is pricier), but
+# oiq's rows tag the $0.50 rate as fifo_queue=false and $0.40 as fifo_queue=true
+# — backwards. Matching oiq's rows by parity would copy that bug; we map by the
+# real AWS meaning instead (Standard->false, FIFO->true). The "Fair" and "Any"
+# queueTypes (a promo tier and the $0 first-1M free tier) are unmapped -> skipped.
+#
+# Uses the existing usage entry `type = aws_sqs_queue and service_class =
+# requests` (50M requests/mo) — which lands in the first tier.
+resource_type: aws_sqs_queue
+service: AWSQueueService
+
+components:
+  - product_family: "^API Request$"
+    service_class: requests
+    match:
+      # queueType is "Standard" or "FIFO (first-in, first-out)" — extract the
+      # leading word, then map. "Fair"/"Any" (a promo tier + the free first-1M
+      # tier) don't match -> skipped.
+      fifo_queue:
+        attr: queueType
+        regex: "^(Standard|FIFO)"
+        map:
+          Standard: "false"
+          FIFO: "true"
+    # per-request (`o`); the 3 volume tiers come from the offer's priceDimensions
+    # (0-100B / 100B-200B / 200B-Inf), emitted as start/end_usage_amount.
+    price: { type: o, unit: Requests }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -20,3 +20,7 @@ recipes:
     recipe: google_compute_instance
     offer: .cache/gcp-compute.json
     fetch: { service_id: "6F81-5844-456A" } # Compute Engine
+  - provider: aws
+    recipe: aws_sqs_queue
+    offer: .cache/sqs-us-east-1.json
+    fetch: { service_code: AWSQueueService, region: us-east-1 }

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -50,6 +50,11 @@ _ROWS = [
     # per-vCPU-core + per-GiB-RAM rates (n2-standard-4 = 4*core + 16*ram). Region
     # is derived from the resource's `zone`.
     "Compute Engine,Compute Instance,type=google_compute_instance&values.machine_type=n2-standard-4,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=instance&start_usage_amount=0&end_usage_amount=Inf,0.1942360000,t,USD",
+    # SQS — first request tier for a standard (fifo=false) and a FIFO queue. The
+    # CORRECT mapping: FIFO is pricier ($0.50/M) than Standard ($0.40/M); oiq has
+    # these inverted, so this row set deliberately does NOT match oiq.
+    "AWSQueueService,API Request,type=aws_sqs_queue&values.fifo_queue=false,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&start_usage_amount=0&end_usage_amount=100000000000,0.0000004000,o,USD",
+    "AWSQueueService,API Request,type=aws_sqs_queue&values.fifo_queue=true,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&start_usage_amount=0&end_usage_amount=100000000000,0.0000005000,o,USD",
 ]
 
 
@@ -308,6 +313,42 @@ def test_gcp_compute_instance_prices_with_zone_derived_region():
     # 0.194236/hr * 730 = 141.79
     assert est.resources[0].monthly_min == pytest.approx(0.194236 * 730, abs=0.01)
     assert est.unpriced == []
+
+
+def test_sqs_queue_fifo_is_pricier_than_standard():
+    """SQS request pricing, and the correctness check: FIFO ($0.50/M) costs more
+    than Standard ($0.40/M). oiq has these inverted; we map by the real AWS
+    meaning, so this asserts the RIGHT answer, not oiq's (#893)."""
+    plan = {
+        "format_version": "1.2",
+        "terraform_version": "1.9.0",
+        "planned_values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "aws_sqs_queue.std",
+                        "type": "aws_sqs_queue",
+                        "name": "std",
+                        "mode": "managed",
+                        "values": {"fifo_queue": False, "region": "us-east-1"},
+                    },
+                    {
+                        "address": "aws_sqs_queue.fifo",
+                        "type": "aws_sqs_queue",
+                        "name": "fifo",
+                        "mode": "managed",
+                        "values": {"fifo_queue": True, "region": "us-east-1"},
+                    },
+                ]
+            }
+        },
+    }
+    est = estimate(plan, _sheet())
+    costs = {r.address: r.monthly_min for r in est.resources}
+    # 50M requests/mo (the usage default) in the first tier.
+    assert costs["aws_sqs_queue.std"] == pytest.approx(50_000_000 * 0.0000004, abs=0.01)
+    assert costs["aws_sqs_queue.fifo"] == pytest.approx(50_000_000 * 0.0000005, abs=0.01)
+    assert costs["aws_sqs_queue.fifo"] > costs["aws_sqs_queue.std"]  # FIFO pricier
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
Closes #947. Part of #893. **First coverage-breadth addition beyond compute/storage.**

`aws_sqs_queue` — per-API-request pricing, tiered by monthly request volume (3 tiers straight from the offer's priceDimensions), matched on `fifo_queue`. Uses the existing `service_class = requests` usage entry (50M req/mo), so recipe-only.

## More correct than oiq
AWS charges **Standard $0.40/M** and **FIFO $0.50/M** (FIFO pricier — correct). oiq's rows have the mapping **inverted** (`fifo_queue=false`→$0.50, `fifo_queue=true`→$0.40). We map `queueType`→`fifo_queue` by the real AWS meaning (regex-extract the leading word: Standard→false, FIFO→true; the "Fair"/"Any" promo+free tiers are skipped). **Row-parity against oiq would have copied the bug** — caught only because we validate end-to-end pricing, not row shape.

## Validated E2E
| queue | cost (50M req/mo, first tier) |
|---|---|
| Standard (`fifo_queue=false`) | **$20.00** |
| FIFO (`fifo_queue=true`) | **$25.00** |

FIFO correctly pricier. The contract test asserts `fifo > standard`, locking in the correct (non-oiq) mapping. 35 pricegen + 11 contract tests green; ruff clean.