### PR TITLE
feat(pricegen): aws_lambda_function recipe (per-arch duration + requests)

### DIFF
--- a/pricegen/engine.py
+++ b/pricegen/engine.py
@@ -60,6 +60,11 @@ def _resolve2(spec, attrs: dict) -> tuple[str | None, str | None, str | None]:
     """
     if isinstance(spec, str):
         return spec, None, None
+    if isinstance(spec, dict) and "const" in spec:
+        # a fixed literal to STAMP on the row (e.g. values.architectures=arm64 on
+        # the ARM-duration component) — distinct from a bare string in a `match`,
+        # which _match_set reads as an attribute NAME.
+        return spec["const"], None, None
     if isinstance(spec, dict) and "from" in spec:
         vals = [attrs.get(a) for a in spec["from"]]
         key = "|".join(v or "" for v in vals)
@@ -154,7 +159,9 @@ def _match_set(
     """Return ``(match_set, miss)`` where miss is ``(field, reason, value)`` for
     the first field that didn't resolve, or None when the whole set resolved."""
     parts = [f"type={rtype}"]
-    match = component["match"]
+    # A component with no `match` constrains only the resource type (matches all
+    # of that type) — e.g. Lambda requests apply to every lambda.
+    match = component.get("match", {})
     items = (
         {_snake(a): {"attr": a} for a in match} if isinstance(match, list) else match
     )

--- a/pricegen/providers/aws/adapter.py
+++ b/pricegen/providers/aws/adapter.py
@@ -36,7 +36,10 @@ def iter_units(offer: dict, *, term: str = "OnDemand"):
         for t in offer_terms.values():
             for pd in t.get("priceDimensions", {}).values():
                 usd = pd.get("pricePerUnit", {}).get("USD")
-                if usd is None:
+                # Skip $0 dimensions — they're AWS Free Tier / promotional SKUs
+                # (e.g. Lambda's free duration tier, often carrying an empty
+                # region), not a real charge. Mirrors the Azure adapter.
+                if usd is None or float(usd) == 0:
                     continue
                 prices.append(
                     Price(

--- a/pricegen/providers/aws/recipes/aws_lambda_function.yaml
+++ b/pricegen/providers/aws/recipes/aws_lambda_function.yaml
@@ -1,0 +1,41 @@
+# Lambda -> aws_lambda_function (on-demand). Two cost dimensions: per-request
+# (arch-independent) and per-GB-second duration (x86 vs arm64 differ). The
+# consumer correlates the architecture via an `arch` pricing dimension + the
+# resource's `architectures` list, so we stamp both: the ARM duration rows carry
+# `values.architectures=arm64` (via `const`) + pricing `arch=arm64`; the x86 rows
+# carry no architectures constraint (matching the default-x86 case) + `arch=x86`.
+# A default lambda (no `architectures`) matches the x86 rows; an arm64 lambda
+# (`architectures=["arm64"]` -> flattens to values.architectures=arm64) matches
+# the ARM rows and NOT the x86 ones (the usage entries gate on arch). Uses the
+# existing aws_lambda_function usage entries (requests + duration by arch).
+resource_type: aws_lambda_function
+service: AWSLambda
+
+components:
+  # Requests — arch-independent, per request. (Only the plural-unit "Requests"
+  # SKU is the real charge; the group filter + unit keep it unambiguous.)
+  - product_family: "^Serverless$"
+    service_class: requests
+    select: { group: AWS-Lambda-Requests }
+    price: { type: o, unit: Requests }
+    tier: usage
+
+  # Duration x86 — GB-second, tiered by monthly volume. `arch=x86` in pricing;
+  # no architectures constraint so it prices the default (x86) lambda.
+  - product_family: "^Serverless$"
+    service_class: duration
+    select: { group: AWS-Lambda-Duration }
+    pricing: { arch: x86 }
+    price: { type: t, unit: Lambda-GB-Second }
+    tier: usage
+
+  # Duration arm64 — stamps values.architectures=arm64 (const) so it only prices
+  # an arm64 lambda, and arch=arm64 so the arm64 usage entry selects it.
+  - product_family: "^Serverless$"
+    service_class: duration
+    select: { group: AWS-Lambda-Duration-ARM }
+    match:
+      architectures: { const: arm64 }
+    pricing: { arch: arm64 }
+    price: { type: t, unit: Lambda-GB-Second }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -24,3 +24,7 @@ recipes:
     recipe: aws_sqs_queue
     offer: .cache/sqs-us-east-1.json
     fetch: { service_code: AWSQueueService, region: us-east-1 }
+  - provider: aws
+    recipe: aws_lambda_function
+    offer: .cache/lambda-us-east-1.json
+    fetch: { service_code: AWSLambda, region: us-east-1 }

--- a/pricegen/tests/test_engine.py
+++ b/pricegen/tests/test_engine.py
@@ -180,3 +180,16 @@ def test_generate_tier_bounds_override():
     rows = list(generate(recipe, _defaults(), [_unit("m5.large")], service="AmazonEC2"))
     assert "start_provision_amount=3000" in rows[0][3]
     assert "end_provision_amount=Inf" in rows[0][3]
+
+
+def test_resolve_const_literal():
+    # a `const` in a match stamps a fixed value (not read as an attr name).
+    assert _resolve2({"const": "arm64"}, {}) == ("arm64", None, None)
+    assert _resolve2({"const": "arm64"}, {"arm64": "x"}) == ("arm64", None, None)
+
+
+def test_generate_component_without_match_constrains_only_type():
+    recipe = _recipe()
+    del recipe["components"][0]["match"]  # no match -> matches all of the type
+    rows = list(generate(recipe, _defaults(), [_unit("m5.large")], service="AmazonEC2"))
+    assert rows[0][2] == "type=aws_instance"  # only the type constraint

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -55,6 +55,12 @@ _ROWS = [
     # these inverted, so this row set deliberately does NOT match oiq.
     "AWSQueueService,API Request,type=aws_sqs_queue&values.fifo_queue=false,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&start_usage_amount=0&end_usage_amount=100000000000,0.0000004000,o,USD",
     "AWSQueueService,API Request,type=aws_sqs_queue&values.fifo_queue=true,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&start_usage_amount=0&end_usage_amount=100000000000,0.0000005000,o,USD",
+    # Lambda — requests (arch-independent) + duration first tier, x86 and arm64.
+    # x86 duration carries no architectures constraint (default lambda); arm64
+    # carries values.architectures=arm64. arch pricing dim gates the usage entry.
+    "AWSLambda,Serverless,type=aws_lambda_function,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&start_usage_amount=0&end_usage_amount=Inf,0.0000002000,o,USD",
+    "AWSLambda,Serverless,type=aws_lambda_function,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=duration&arch=x86&start_usage_amount=0&end_usage_amount=6000000000,0.0000166667,t,USD",
+    "AWSLambda,Serverless,type=aws_lambda_function&values.architectures=arm64,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=duration&arch=arm64&start_usage_amount=0&end_usage_amount=7500000000,0.0000133334,t,USD",
 ]
 
 
@@ -349,6 +355,45 @@ def test_sqs_queue_fifo_is_pricier_than_standard():
     assert costs["aws_sqs_queue.std"] == pytest.approx(50_000_000 * 0.0000004, abs=0.01)
     assert costs["aws_sqs_queue.fifo"] == pytest.approx(50_000_000 * 0.0000005, abs=0.01)
     assert costs["aws_sqs_queue.fifo"] > costs["aws_sqs_queue.std"]  # FIFO pricier
+
+
+def test_lambda_x86_and_arm64_price_by_architecture():
+    """A default (x86) lambda and an arm64 lambda price their duration at the
+    right per-arch rate — the `arch` pricing dimension + `values.architectures`
+    correlate correctly (arm64 is cheaper). Requests are arch-independent (#893)."""
+
+    def fn(addr, arch=None):
+        v = {"region": "us-east-1", "memory_size": 512}
+        if arch:
+            v["architectures"] = [arch]
+        return {
+            "address": addr,
+            "type": "aws_lambda_function",
+            "name": addr.split(".")[-1],
+            "mode": "managed",
+            "values": v,
+        }
+
+    plan = {
+        "format_version": "1.2",
+        "terraform_version": "1.9.0",
+        "planned_values": {
+            "root_module": {
+                "resources": [fn("aws_lambda_function.d"), fn("aws_lambda_function.a", "arm64")]
+            }
+        },
+    }
+    est = estimate(plan, _sheet())
+    costs = {r.address: r.monthly_min for r in est.resources}
+    # usage defaults: 100M requests + 1M GB-s duration.
+    reqs = 100_000_000 * 0.0000002
+    assert costs["aws_lambda_function.d"] == pytest.approx(
+        reqs + 1_000_000 * 0.0000166667, abs=0.01
+    )
+    assert costs["aws_lambda_function.a"] == pytest.approx(
+        reqs + 1_000_000 * 0.0000133334, abs=0.01
+    )
+    assert costs["aws_lambda_function.a"] < costs["aws_lambda_function.d"]  # arm64 cheaper
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
Closes #949. Part of #893. **Second breadth resource.**

Lambda: per-request (arch-independent) + per-GB-second duration (x86 vs arm64 differ), matched via the consumer's `arch` pricing dimension + the resource's `architectures` list.

## Small, general engine additions
- **`{const: X}` field form** — stamps a fixed literal in a match set (the ARM-duration rows carry `values.architectures=arm64`); a bare string in a `match` is read as an attr *name*, so a literal needed its own form.
- **`match` is now optional** — a component with no `match` constrains only the resource type (Lambda requests apply to every lambda).
- **AWS adapter skips $0 dimensions** — AWS Free Tier / promo SKUs (Lambda's free duration tier, empty region) are placeholders, not charges (mirrors the Azure adapter). No effect on existing recipes (RDS still 3237 rows).

## Validated E2E (100M req + 1M GB-s duration usage defaults)
| lambda | cost |
|---|---|
| default (x86) | **$36.67/mo** |
| arm64 | **$33.33/mo** |

arm64 correctly cheaper; the `arch` pricing dim + `values.architectures` correlate so each arch prices its own duration rate. Uses the existing Lambda usage entries. 37 pricegen + 12 contract tests green; ruff clean.