### PR TITLE
feat(pricegen): aws_s3_bucket recipe (Standard storage + Tier-1/Tier-2 requests)

### DIFF
--- a/pricegen/providers/aws/recipes/aws_s3_bucket.yaml
+++ b/pricegen/providers/aws/recipes/aws_s3_bucket.yaml
@@ -1,0 +1,33 @@
+# S3 -> aws_s3_bucket (on-demand). Three cost dimensions for the common Standard
+# (General Purpose) class: per-GB-month storage (tiered) + Tier-1 requests
+# (PUT/POST/LIST) + Tier-2 requests (GET/etc). Each correlates with an existing
+# usage entry via a literal pricing dimension: storage_class=general_purpose,
+# tier=1, tier=2. Only Standard storage is covered here; Infrequent Access /
+# Glacier / One Zone (SIA/GIR/XZ groups) are follow-ups.
+resource_type: aws_s3_bucket
+service: AmazonS3
+
+components:
+  # Standard storage — per GB-month, tiered (0-51200 / 51200-512000 / 512000-Inf).
+  - product_family: "^Storage$"
+    service_class: storage
+    select: { volumeType: Standard }
+    pricing: { storage_class: general_purpose }
+    price: { type: d, unit: GB-Mo }
+    tier: usage
+
+  # Tier-1 requests (PUT / POST / LIST) — the pricier request class.
+  - product_family: "^API Request$"
+    service_class: requests
+    select: { group: S3-API-Tier1 }
+    pricing: { tier: "1" }
+    price: { type: o, unit: Requests }
+    tier: usage
+
+  # Tier-2 requests (GET / SELECT / others).
+  - product_family: "^API Request$"
+    service_class: requests
+    select: { group: S3-API-Tier2 }
+    pricing: { tier: "2" }
+    price: { type: o, unit: Requests }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -28,3 +28,7 @@ recipes:
     recipe: aws_lambda_function
     offer: .cache/lambda-us-east-1.json
     fetch: { service_code: AWSLambda, region: us-east-1 }
+  - provider: aws
+    recipe: aws_s3_bucket
+    offer: .cache/s3-us-east-1.json
+    fetch: { service_code: AmazonS3, region: us-east-1 }

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -61,6 +61,11 @@ _ROWS = [
     "AWSLambda,Serverless,type=aws_lambda_function,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&start_usage_amount=0&end_usage_amount=Inf,0.0000002000,o,USD",
     "AWSLambda,Serverless,type=aws_lambda_function,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=duration&arch=x86&start_usage_amount=0&end_usage_amount=6000000000,0.0000166667,t,USD",
     "AWSLambda,Serverless,type=aws_lambda_function&values.architectures=arm64,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=duration&arch=arm64&start_usage_amount=0&end_usage_amount=7500000000,0.0000133334,t,USD",
+    # S3 — Standard storage (first GB tier) + Tier-1 (PUT/LIST) + Tier-2 (GET)
+    # requests, each correlated with a usage entry via a literal pricing dim.
+    "AmazonS3,Storage,type=aws_s3_bucket,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&storage_class=general_purpose&start_usage_amount=0&end_usage_amount=51200,0.0230000000,d,USD",
+    "AmazonS3,API Request,type=aws_s3_bucket,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&tier=1&start_usage_amount=0&end_usage_amount=Inf,0.0000050000,o,USD",
+    "AmazonS3,API Request,type=aws_s3_bucket,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&tier=2&start_usage_amount=0&end_usage_amount=Inf,0.0000004000,o,USD",
 ]
 
 
@@ -394,6 +399,28 @@ def test_lambda_x86_and_arm64_price_by_architecture():
         reqs + 1_000_000 * 0.0000133334, abs=0.01
     )
     assert costs["aws_lambda_function.a"] < costs["aws_lambda_function.d"]  # arm64 cheaper
+
+
+def test_s3_bucket_storage_plus_request_tiers():
+    """S3 prices its three dimensions — Standard storage (per-GB, first tier) +
+    Tier-1 and Tier-2 requests — each correlated to its usage entry by a literal
+    pricing dimension (storage_class / tier). (#893)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_s3_bucket.b",
+                "type": "aws_s3_bucket",
+                "name": "b",
+                "mode": "managed",
+                "values": {"region": "us-east-1"},
+            }
+        ]
+    )
+    est = estimate(plan, _sheet())
+    # usage defaults: 900 GB storage + 4M Tier-1 + 50M Tier-2 requests.
+    expected = 900 * 0.023 + 4_000_000 * 0.000005 + 50_000_000 * 0.0000004
+    assert est.resources[0].monthly_min == pytest.approx(expected, abs=0.01)  # $60.70
+    assert est.unpriced == []
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
Closes #951. Part of #893. **Third breadth resource.**

S3: per-GB-month **Standard storage** (tiered) + **Tier-1** (PUT/POST/LIST) + **Tier-2** (GET/etc) requests, each correlated with its existing usage entry via a literal pricing dimension (`storage_class=general_purpose`, `tier=1`, `tier=2`). Standard (General Purpose) class only; Infrequent Access / Glacier / One Zone are follow-ups.

Validated E2E: a bucket at the usage defaults (900 GB + 4M Tier-1 + 50M Tier-2) = **$60.70/mo** (storage $20.70 + $20 + $20). 37 pricegen + 13 contract tests green; ruff clean.