### PR TITLE
feat(pricegen): aws_dynamodb_table recipe (PayPerRequest read/write + storage)

### DIFF
--- a/pricegen/providers/aws/recipes/aws_dynamodb_table.yaml
+++ b/pricegen/providers/aws/recipes/aws_dynamodb_table.yaml
@@ -1,0 +1,45 @@
+# DynamoDB -> aws_dynamodb_table (on-demand / PayPerRequest, Standard class).
+# Three cost dimensions: read request units, write request units, and per-GB
+# storage. Each correlates with its existing usage entry via literal pricing
+# dimensions (request_type=read/write, table_class=standard). Only the common
+# PayPerRequest + Standard table class is covered; Infrequent Access (the *IA
+# groups), global-table ReplicatedWrite, PITR storage, and provisioned capacity
+# are follow-ups. The exact `group`/`usagetype` selects keep IA/Replicated/PITR
+# out (they're distinct SKUs, not attributes on these).
+resource_type: aws_dynamodb_table
+service: AmazonDynamoDB
+
+components:
+  # Read request units (PayPerRequest, Standard).
+  - product_family: "^Amazon DynamoDB PayPerRequest Throughput$"
+    service_class: requests
+    select: { group: DDB-ReadUnits }
+    pricing: { request_type: read, table_class: standard }
+    price: { type: o, unit: ReadRequestUnits }
+    tier: usage
+
+  # Write request units.
+  - product_family: "^Amazon DynamoDB PayPerRequest Throughput$"
+    service_class: requests
+    select: { group: DDB-WriteUnits }
+    pricing: { request_type: write, table_class: standard }
+    price: { type: o, unit: WriteRequestUnits }
+    tier: usage
+
+  # Storage — per GB-month at $0.25. The offer tiers this 0-25 GB @ $0 (the
+  # account-wide 25 GB free tier) then 25-Inf @ $0.25. We do NOT apply that free
+  # tier per-table: it's an account-wide one-off, and applying it per-resource
+  # would under-estimate (and be inconsistent with Lambda, whose free tier we
+  # also drop). `tier_bounds` forces the billable range to start at 0 so a table
+  # is billed for its full storage. (The $0 free-tier row is already dropped by
+  # the adapter's $0-skip; this pins the remaining rate's start to 0.)
+  - product_family: "^Database Storage$"
+    service_class: storage
+    select: { usagetype: TimedStorage-ByteHrs }
+    pricing: { table_class: standard }
+    price: { type: d, unit: GB-Mo }
+    tier: usage
+    tier_bounds:
+      - when: { usagetype: TimedStorage-ByteHrs }
+        start: "0"
+        end: Inf

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -32,3 +32,7 @@ recipes:
     recipe: aws_s3_bucket
     offer: .cache/s3-us-east-1.json
     fetch: { service_code: AmazonS3, region: us-east-1 }
+  - provider: aws
+    recipe: aws_dynamodb_table
+    offer: .cache/ddb-us-east-1.json
+    fetch: { service_code: AmazonDynamoDB, region: us-east-1 }

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -66,6 +66,12 @@ _ROWS = [
     "AmazonS3,Storage,type=aws_s3_bucket,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&storage_class=general_purpose&start_usage_amount=0&end_usage_amount=51200,0.0230000000,d,USD",
     "AmazonS3,API Request,type=aws_s3_bucket,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&tier=1&start_usage_amount=0&end_usage_amount=Inf,0.0000050000,o,USD",
     "AmazonS3,API Request,type=aws_s3_bucket,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&tier=2&start_usage_amount=0&end_usage_amount=Inf,0.0000004000,o,USD",
+    # DynamoDB (PayPerRequest, Standard) — read + write request units + storage.
+    # Storage starts at 0 (the 25 GB account-wide free tier is NOT applied
+    # per-table), so a table is billed for its full storage.
+    "AmazonDynamoDB,Amazon DynamoDB PayPerRequest Throughput,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&request_type=read&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.0000001250,o,USD",
+    "AmazonDynamoDB,Amazon DynamoDB PayPerRequest Throughput,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&request_type=write&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.0000006250,o,USD",
+    "AmazonDynamoDB,Database Storage,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.2500000000,d,USD",
 ]
 
 
@@ -420,6 +426,28 @@ def test_s3_bucket_storage_plus_request_tiers():
     # usage defaults: 900 GB storage + 4M Tier-1 + 50M Tier-2 requests.
     expected = 900 * 0.023 + 4_000_000 * 0.000005 + 50_000_000 * 0.0000004
     assert est.resources[0].monthly_min == pytest.approx(expected, abs=0.01)  # $60.70
+    assert est.unpriced == []
+
+
+def test_dynamodb_table_read_write_storage():
+    """DynamoDB PayPerRequest table: read + write request units + full storage
+    (the 25 GB account-wide free tier is deliberately NOT applied per-table, so
+    it's consistent with Lambda and doesn't under-estimate). (#893)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_dynamodb_table.t",
+                "type": "aws_dynamodb_table",
+                "name": "t",
+                "mode": "managed",
+                "values": {"region": "us-east-1", "billing_mode": "PAY_PER_REQUEST"},
+            }
+        ]
+    )
+    est = estimate(plan, _sheet())
+    # usage defaults: 80M reads + 16M writes + 80 GB storage (billed from 0).
+    expected = 80_000_000 * 0.000000125 + 16_000_000 * 0.000000625 + 80 * 0.25
+    assert est.resources[0].monthly_min == pytest.approx(expected, abs=0.01)  # $40.00
     assert est.unpriced == []
 
 


### PR DESCRIPTION
Closes #953. Part of #893. **Fourth breadth resource.**

DynamoDB (PayPerRequest / on-demand, Standard class): **read** request units + **write** request units + per-GB **storage**, each correlated with its usage entry via literal pricing dims (`request_type=read/write`, `table_class=standard`).

**Free-tier decision:** the offer tiers storage 0-25 GB @ $0 (the account-wide 25 GB free tier) then 25-Inf @ $0.25. We do **not** apply that free tier per-table (`tier_bounds` pins the billable start to 0) — it's an account-wide one-off, applying it per-resource under-estimates, and it keeps us consistent with Lambda (whose free tier we also drop).

IA / global-table ReplicatedWrite / PITR / provisioned capacity are follow-ups.

Validated E2E: a PayPerRequest table at the usage defaults (80M reads + 16M writes + 80 GB) = **$40/mo** ($10 + $10 + $20). 37 pricegen + 14 contract tests green; ruff clean.