### PR TITLE
feat(pricegen): stream-filter the EC2 offer → add aws_instance + aws_ebs_volume

### DIFF
--- a/.github/workflows/pricesheet.yml
+++ b/.github/workflows/pricesheet.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
-      - run: pip install pyyaml
+      - run: pip install pyyaml ijson # ijson stream-filters the large AmazonEC2 offer
 
       - name: Fetch offers from the official cloud pricing APIs
         env:

--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -90,8 +90,13 @@ covers; a future deterministic resolver is a `services/…/cost` enhancement.
 
 ## Running it
 
-Requires `pyyaml`. Offer files are large (one EC2 region ≈ 458 MB) — cached
-under `.cache/` (gitignored).
+Requires `pyyaml` (and `ijson` for the large AmazonEC2 offer). Offer files are
+large (one EC2 region ≈ 458 MB) — cached under `.cache/` (gitignored). The
+fetcher **stream-filters** big offers with ijson to just the families a recipe
+needs, so RAM stays flat (~50 MB) regardless of offer size instead of the
+~2.5 GB a whole-file `json.load` would take; the full 9-recipe publish peaks
+around 270 MB. Recipes whose `fetch:` block has a `families` key take the
+streaming path; the shared EC2 download is cached across recipes in one run.
 
 ```sh
 # fetch one AWS region offer (public, no credentials)

--- a/pricegen/fetch_offers.py
+++ b/pricegen/fetch_offers.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import sys
+import tempfile
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -31,6 +33,9 @@ import yaml
 HERE = Path(__file__).parent
 _UA = {"User-Agent": "terrapod-pricegen/0.1"}
 _AWS_BULK = "https://pricing.us-east-1.amazonaws.com"
+# Within one run, a large offer (e.g. AmazonEC2) is downloaded once and reused
+# across recipes that read different families of it (aws_instance + aws_ebs_volume).
+_BIG_OFFER_CACHE: dict[str, str] = {}
 
 
 def _get_json(url: str) -> dict:
@@ -40,12 +45,79 @@ def _get_json(url: str) -> dict:
         return json.load(resp)
 
 
+def _keep(prod: dict, families: set, keep_attrs: dict) -> bool:
+    """A product is kept if its family is wanted and every ``keep_attrs`` filter
+    passes: a filter matches when the attribute is ABSENT (mirrors the recipe's
+    canonical "apply only where present") or its value is in the allowed set."""
+    if prod.get("productFamily") not in families:
+        return False
+    attrs = prod.get("attributes", {})
+    for key, allowed in keep_attrs.items():
+        v = attrs.get(key)
+        if v is not None and v not in allowed:
+            return False
+    return True
+
+
+def _stream_filter_aws(region_url: str, families: list, keep_attrs: dict) -> dict:
+    """Stream a large AWS offer with ijson, keeping only products in ``families``
+    that pass ``keep_attrs`` (and their OnDemand terms) — so a 450 MB offer never
+    lands in RAM. The offer is streamed to a temp file (constant memory), then
+    parsed incrementally; only the small filtered subset is held. Applying the
+    recipe's canonical/select as ``keep_attrs`` here keeps that subset tiny
+    (~2k products for EC2 instances vs ~106k) so ``generate`` stays light too."""
+    import ijson  # heavy dep, only needed for the big-offer path
+
+    fams = set(families)
+    keep = {k: set(v) for k, v in keep_attrs.items()}
+    tmp = _BIG_OFFER_CACHE.get(region_url)
+    if tmp is None:
+        fd, tmp = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        with (
+            urllib.request.urlopen(  # noqa: S310 — trusted pinned host
+                urllib.request.Request(region_url, headers=_UA)
+            ) as resp,
+            open(tmp, "wb") as out,
+        ):
+            shutil.copyfileobj(resp, out)  # stream to disk, low RAM
+        _BIG_OFFER_CACHE[region_url] = tmp
+    products: dict = {}
+    with open(tmp, "rb") as f:
+        for sku, prod in ijson.kvitems(f, "products"):
+            if _keep(prod, fams, keep):
+                products[sku] = prod
+    terms: dict = {}
+    with open(tmp, "rb") as f:
+        for sku, term in ijson.kvitems(f, "terms.OnDemand"):
+            if sku in products:
+                terms[sku] = term
+    return {"products": products, "terms": {"OnDemand": terms}}
+
+
+def _cleanup_big_offers() -> None:
+    """Remove the cached big-offer temp files at end of run."""
+    for path in _BIG_OFFER_CACHE.values():
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    _BIG_OFFER_CACHE.clear()
+
+
 def fetch_aws(fetch: dict) -> dict:
-    """AWS Price List Bulk API: region_index → the region's index.json."""
+    """AWS Price List Bulk API: region_index → the region's offer.
+
+    Small offers load whole. Large ones (a ``families`` filter in the fetch
+    block, e.g. AmazonEC2) are stream-filtered with ijson to just the needed
+    families + ``keep_attrs``, so RAM stays flat regardless of offer size."""
     svc, region = fetch["service_code"], fetch["region"]
     idx = _get_json(f"{_AWS_BULK}/offers/v1.0/aws/{svc}/current/region_index.json")
-    region_url = idx["regions"][region]["currentVersionUrl"]
-    return _get_json(_AWS_BULK + region_url)
+    region_url = _AWS_BULK + idx["regions"][region]["currentVersionUrl"]
+    families = fetch.get("families")
+    if families:
+        return _stream_filter_aws(region_url, families, fetch.get("keep_attrs", {}))
+    return _get_json(region_url)
 
 
 def fetch_azure(fetch: dict) -> dict:
@@ -97,27 +169,30 @@ def main() -> int:
     args = ap.parse_args()
 
     config = yaml.safe_load(args.config.read_text())
-    for cfg in config["recipes"]:
-        provider = cfg["provider"]
-        if args.only and provider != args.only:
-            continue
-        fetch = cfg.get("fetch")
-        if not fetch:
-            print(
-                f"  {provider}/{cfg['recipe']}: no fetch block, skipping",
-                file=sys.stderr,
+    try:
+        for cfg in config["recipes"]:
+            provider = cfg["provider"]
+            if args.only and provider != args.only:
+                continue
+            fetch = cfg.get("fetch")
+            if not fetch:
+                print(
+                    f"  {provider}/{cfg['recipe']}: no fetch block, skipping",
+                    file=sys.stderr,
+                )
+                continue
+            out = cfg["offer"]
+            out = Path(out) if Path(out).is_absolute() else HERE / out
+            out.parent.mkdir(parents=True, exist_ok=True)
+            print(f"  fetching {provider}/{cfg['recipe']} → {out} …", file=sys.stderr)
+            offer = _FETCHERS[provider](fetch)
+            size = len(
+                offer.get("skus") or offer.get("Items") or offer.get("products") or {}
             )
-            continue
-        out = cfg["offer"]
-        out = Path(out) if Path(out).is_absolute() else HERE / out
-        out.parent.mkdir(parents=True, exist_ok=True)
-        print(f"  fetching {provider}/{cfg['recipe']} → {out} …", file=sys.stderr)
-        offer = _FETCHERS[provider](fetch)
-        size = len(
-            offer.get("skus") or offer.get("Items") or offer.get("products") or {}
-        )
-        out.write_text(json.dumps(offer))
-        print(f"    {size} items", file=sys.stderr)
+            out.write_text(json.dumps(offer))
+            print(f"    {size} items", file=sys.stderr)
+    finally:
+        _cleanup_big_offers()
     return 0
 
 

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -36,3 +36,28 @@ recipes:
     recipe: aws_dynamodb_table
     offer: .cache/ddb-us-east-1.json
     fetch: { service_code: AmazonDynamoDB, region: us-east-1 }
+  # EC2 + EBS come from the ~450 MB AmazonEC2 offer, so their fetch blocks carry
+  # `families` (+ `keep_attrs` for the huge Compute Instance family) — fetch_offers
+  # stream-filters the offer with ijson to a small compact offer at flat RAM, and
+  # the shared download is cached so the 450 MB is pulled once for both.
+  - provider: aws
+    recipe: aws_instance
+    offer: .cache/ec2-instance-us-east-1.json
+    fetch:
+      service_code: AmazonEC2
+      region: us-east-1
+      families: [Compute Instance]
+      keep_attrs:
+        operatingSystem: [Linux, Windows]
+        tenancy: [Shared]
+        capacitystatus: [Used]
+        marketoption: [OnDemand]
+        preInstalledSw: ["NA"]
+        licenseModel: ["No License required"]
+  - provider: aws
+    recipe: aws_ebs_volume
+    offer: .cache/ec2-ebs-us-east-1.json
+    fetch:
+      service_code: AmazonEC2
+      region: us-east-1
+      families: [Storage, System Operation]

--- a/pricegen/tests/test_fetch_offers.py
+++ b/pricegen/tests/test_fetch_offers.py
@@ -1,0 +1,44 @@
+"""Unit tests for the offer fetcher's stream-filter predicate (#893).
+
+`_keep` is the pure filter applied while streaming a large AWS offer (e.g. the
+~450 MB AmazonEC2 offer) so only the needed products land in RAM. Its semantics
+mirror the recipe's canonical/select: an attribute filter passes when the attr
+is ABSENT (canonical "apply only where present") or its value is allowed.
+"""
+
+from __future__ import annotations
+
+from pricegen.fetch_offers import _keep
+
+_FAMS = {"Compute Instance"}
+_KEEP = {
+    "operatingSystem": {"Linux", "Windows"},
+    "tenancy": {"Shared"},
+    "marketoption": {"OnDemand"},
+}
+
+
+def _p(family="Compute Instance", **attrs):
+    return {"productFamily": family, "attributes": attrs}
+
+
+def test_wrong_family_dropped():
+    assert not _keep(_p(family="Storage"), _FAMS, _KEEP)
+
+
+def test_matching_product_kept():
+    assert _keep(_p(operatingSystem="Linux", tenancy="Shared"), _FAMS, _KEEP)
+
+
+def test_disallowed_value_dropped():
+    assert not _keep(_p(operatingSystem="RHEL", tenancy="Shared"), _FAMS, _KEEP)
+    assert not _keep(_p(operatingSystem="Linux", tenancy="Dedicated"), _FAMS, _KEEP)
+
+
+def test_absent_attr_is_kept_mirrors_canonical():
+    # marketoption absent on some SKUs -> kept (canonical applies only where present).
+    assert _keep(_p(operatingSystem="Linux", tenancy="Shared"), _FAMS, _KEEP)
+
+
+def test_no_keep_attrs_keeps_any_in_family():
+    assert _keep(_p(family="Storage", volumeApiName="gp3"), {"Storage"}, {})

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -72,6 +72,9 @@ _ROWS = [
     "AmazonDynamoDB,Amazon DynamoDB PayPerRequest Throughput,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&request_type=read&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.0000001250,o,USD",
     "AmazonDynamoDB,Amazon DynamoDB PayPerRequest Throughput,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&request_type=write&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.0000006250,o,USD",
     "AmazonDynamoDB,Database Storage,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.2500000000,d,USD",
+    # EBS gp3 storage — priced a=values.size. From the ~450 MB EC2 offer, now in
+    # the published sheet via the ijson stream-filter (#893).
+    "AmazonEC2,Storage,type=aws_ebs_volume&values.type=gp3,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage,0.0800000000,a=values.size,USD",
 ]
 
 
@@ -449,6 +452,24 @@ def test_dynamodb_table_read_write_storage():
     expected = 80_000_000 * 0.000000125 + 16_000_000 * 0.000000625 + 80 * 0.25
     assert est.resources[0].monthly_min == pytest.approx(expected, abs=0.01)  # $40.00
     assert est.unpriced == []
+
+
+def test_ebs_gp3_volume_prices_by_size():
+    """aws_ebs_volume gp3 storage is priced a=values.size (rate x the volume's
+    size attr). Now in the published sheet via the EC2-offer stream-filter."""
+    plan = _plan(
+        [
+            {
+                "address": "aws_ebs_volume.d",
+                "type": "aws_ebs_volume",
+                "name": "d",
+                "mode": "managed",
+                "values": {"type": "gp3", "size": 100, "region": "us-east-1"},
+            }
+        ]
+    )
+    est = estimate(plan, _sheet())
+    assert est.resources[0].monthly_min == pytest.approx(100 * 0.08, abs=0.01)  # $8.00
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
Closes #956. Part of #893. **Closes the biggest gap — EC2 instances (the #1 resource) + EBS are now in the published sheet.**

## The problem you flagged
`aws_instance`/`aws_ebs_volume` had working recipes but weren't published: their offer is the ~450 MB AmazonEC2 file, which `json.load`s to **~2.5 GB RAM** — too much for a free CI runner.

## The fix — stream-filter, no credentials
The AWS Query API can return a subset but needs **credentials**; instead we keep the credential-free public **Bulk** API (consistent with Azure/GCP) and **stream-filter it with ijson**:
- Stream the offer to a temp file (curl-style, constant RAM), parse incrementally, and keep only the product **families** a recipe needs. A `keep_attrs` allowlist (mirroring the recipe's canonical/select — Linux/Windows, Shared, OnDemand…) shrinks the huge Compute Instance family from **~106k → ~2k** products.
- The shared 450 MB download is **cached within a run**, so both EC2 recipes pull it once.
- `fetch:` blocks gain optional `families`/`keep_attrs`; `ijson` added to the workflow.

## Memory (measured)
| step | before | after |
|---|---|---|
| EC2 fetch | ~2.5 GB | **~52 MB** |
| full 9-recipe publish | — | **~268 MB** |

## Result
Published sheet: **7 → 9 recipes / 7134 products** (incl. **2077 EC2 instance types** + EBS). Verified prices: m5.large=$0.096, c5.xlarge=$0.17, t3.micro=$0.0104, EBS gp3=$0.08/GB. 42 pricegen + 15 contract tests green.

This is also the pattern for any future large-offer resource (NAT Gateway, EIP — same EC2 offer, just more families).