### PR TITLE
feat(cost): usage-assumption bands surfaced to the AI (foundation for #962)

### DIFF
--- a/services/terrapod/services/cost/engine.py
+++ b/services/terrapod/services/cost/engine.py
@@ -40,6 +40,10 @@ class ResourceCost:
     change: Change
     monthly_min: float
     monthly_max: float
+    # Usage-driven components whose quantity was assumed, each a
+    # {description, dimension, unit, low, typical, high} — so the estimate can
+    # flag them and the AI can refine them per-resource (#962).
+    usage_assumptions: list[dict] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -75,6 +79,10 @@ class CostEstimate:
                     "name": r.name,
                     "change": r.change,
                     "monthly": {"min": r.monthly_min, "max": r.monthly_max},
+                    # Additive (#962): usage-driven line items whose quantity was
+                    # assumed, with low/typical/high bands. Omitted when empty so
+                    # deterministic resources' payload is unchanged.
+                    **({"usage_assumptions": r.usage_assumptions} if r.usage_assumptions else {}),
                 }
                 for r in self.resources
             ],
@@ -129,6 +137,7 @@ def estimate(
             change=pr.change,
             monthly_min=pr.price.min,
             monthly_max=pr.price.max,
+            usage_assumptions=pr.usage_assumptions,
         )
         for pr in result.resources
     ]

--- a/services/terrapod/services/cost/pricer.py
+++ b/services/terrapod/services/cost/pricer.py
@@ -14,7 +14,7 @@ filter of the upstream CLI is not needed by Terrapod and is omitted.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from terrapod.services.cost import usage as usage_mod
 from terrapod.services.cost.match_set import MatchSet
@@ -53,6 +53,12 @@ class PricedResource:
     change: Change
     price: Range[float]
     products: list[PricedProduct]
+    # The usage assumptions folded into this resource's cost — each a
+    # {description, dimension, unit, low, typical, high} for a usage-driven
+    # component (requests, data, duration) whose quantity was guessed, not read
+    # from the plan. Empty for a fully-deterministic resource. Surfaced so the
+    # UI can flag assumptions and the AI can refine them per-resource (#962).
+    usage_assumptions: list[dict] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -258,6 +264,15 @@ def price(
             for pp in priced_products:
                 summed = append(lambda a, b: a + b, summed, pp.price)
             resource_price = Range(sign * summed.min, sign * summed.max)
+            # Collect the usage assumptions that fed this resource's cost (one per
+            # dimension) — the usage-driven entries that matched its products.
+            assumptions: list[dict] = []
+            seen_dims: set = set()
+            for used_entry in entry_by_key.values():
+                ua = used_entry.usage_assumption()
+                if ua is not None and ua["dimension"] not in seen_dims:
+                    assumptions.append(ua)
+                    seen_dims.add(ua["dimension"])
             priced_resources.append(
                 PricedResource(
                     address=resource.address,
@@ -266,6 +281,7 @@ def price(
                     change=change,
                     price=resource_price,
                     products=priced_products,
+                    usage_assumptions=assumptions,
                 )
             )
         else:

--- a/services/terrapod/services/cost/usage.py
+++ b/services/terrapod/services/cost/usage.py
@@ -62,9 +62,33 @@ class Entry:
     divisor: int | None
     match_query: MatchQuery
     usage: Usage | None
+    # A component priced through this entry is a USAGE ASSUMPTION (its quantity
+    # is a guess about runtime traffic — requests, data processed, duration —
+    # not something the plan tells us) when ``assumption`` is set. ``bands`` then
+    # carries our low/typical/high judgement so the estimate can flag the
+    # assumption and the AI layer can refine it per-resource (#962). Deterministic
+    # entries (always-on hours, storage from the resource's own size attr) leave
+    # both unset. ``bands`` shape: {dimension, unit, low, typical, high}.
+    assumption: bool = False
+    bands: dict[str, Any] | None = None
 
     def with_usage(self, usage: Usage) -> Entry:
         return replace(self, usage=usage)
+
+    def usage_assumption(self) -> dict[str, Any] | None:
+        """This entry's usage-assumption descriptor for the cost result, or None
+        if it's a deterministic entry."""
+        if not self.assumption:
+            return None
+        b = self.bands or {}
+        return {
+            "description": self.description,
+            "dimension": b.get("dimension"),
+            "unit": b.get("unit"),
+            "low": b.get("low"),
+            "typical": b.get("typical"),
+            "high": b.get("high"),
+        }
 
 
 # Accessors for the three usage dimensions (get/set a Range on a Usage).
@@ -114,6 +138,8 @@ def _entry_from_obj(obj: dict[str, Any]) -> Entry:
         divisor=obj.get("divisor"),
         match_query=MatchQuery.of_string(obj["match_query"]),
         usage=_parse_usage(obj.get("usage")),
+        assumption=bool(obj.get("assumption", False)),
+        bands=obj.get("bands"),
     )
 
 

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -11,6 +11,14 @@
     "match_query": "type = aws_s3_bucket and tier = 1 and purchase_option = on_demand",
     "usage": {
       "operations": 4000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "tier-1 requests",
+      "unit": "requests/month",
+      "low": 100000,
+      "typical": 4000000,
+      "high": 100000000
     }
   },
   {
@@ -18,6 +26,14 @@
     "match_query": "type = aws_s3_bucket and tier = 2 and purchase_option = on_demand",
     "usage": {
       "operations": 50000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "tier-2 requests",
+      "unit": "requests/month",
+      "low": 1000000,
+      "typical": 50000000,
+      "high": 1000000000
     }
   },
   {
@@ -25,6 +41,14 @@
     "match_query": "type = aws_s3_bucket and service_class = storage and purchase_option = on_demand and storage_class = general_purpose",
     "usage": {
       "data": 900
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "storage",
+      "unit": "GB-month",
+      "low": 50,
+      "typical": 900,
+      "high": 10000
     }
   },
   {
@@ -42,7 +66,7 @@
     }
   },
   {
-    "description": "AWS RDS provisioned IOPS (io1/io2/gp3) — quantity read from the resource's iops attr; usage-less. Must stay AFTER the storage_type=standard entry above (first match wins) so magnetic keeps the per-request entry.",
+    "description": "AWS RDS provisioned IOPS (io1/io2/gp3) \u2014 quantity read from the resource's iops attr; usage-less. Must stay AFTER the storage_type=standard entry above (first match wins) so magnetic keeps the per-request entry.",
     "match_query": "type = aws_db_instance and service_class = iops"
   },
   {
@@ -57,6 +81,14 @@
     "match_query": "type = aws_sqs_queue and service_class = requests",
     "usage": {
       "operations": 50000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "API requests",
+      "unit": "requests/month",
+      "low": 1000000,
+      "typical": 50000000,
+      "high": 5000000000
     }
   },
   {
@@ -64,6 +96,14 @@
     "match_query": "type = aws_lambda_function and service_class = requests",
     "usage": {
       "operations": 100000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "invocations",
+      "unit": "requests/month",
+      "low": 1000000,
+      "typical": 100000000,
+      "high": 10000000000
     }
   },
   {
@@ -71,6 +111,14 @@
     "match_query": "type = aws_lambda_function and service_class = duration and values.architectures=arm64 and arch=arm64",
     "usage": {
       "time": 1000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "duration",
+      "unit": "GB-seconds/month",
+      "low": 100000,
+      "typical": 1000000,
+      "high": 100000000
     }
   },
   {
@@ -78,6 +126,14 @@
     "match_query": "type = aws_lambda_function and service_class = duration and (not values.architectures or values.architectures=x86) and arch=x86",
     "usage": {
       "time": 1000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "duration",
+      "unit": "GB-seconds/month",
+      "low": 100000,
+      "typical": 1000000,
+      "high": 100000000
     }
   },
   {
@@ -96,6 +152,14 @@
     "match_query": "type = aws_dynamodb_table and service_class = storage",
     "usage": {
       "data": 80
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "storage",
+      "unit": "GB-month",
+      "low": 5,
+      "typical": 80,
+      "high": 5000
     }
   },
   {
@@ -103,6 +167,14 @@
     "match_query": "type = aws_dynamodb_table and service_class = storage and ((table_class = ia and values.table_class = STANDARD_INFREQUENT_ACCESS) or ((not values.table_class or values.table_class = STANDARD or values.table_class = null) and table_class = standard))",
     "usage": {
       "data": 80
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "storage",
+      "unit": "GB-month",
+      "low": 5,
+      "typical": 80,
+      "high": 5000
     }
   },
   {
@@ -110,6 +182,14 @@
     "match_query": "type = aws_dynamodb_table and service_class = requests and request_type = read and ((table_class = ia and values.table_class = STANDARD_INFREQUENT_ACCESS) or ((not values.table_class or values.table_class = STANDARD or values.table_class = null) and table_class = standard))",
     "usage": {
       "operations": 80000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "read request units",
+      "unit": "RRU/month",
+      "low": 1000000,
+      "typical": 80000000,
+      "high": 10000000000
     }
   },
   {
@@ -117,6 +197,14 @@
     "match_query": "type = aws_dynamodb_table and service_class = requests and request_type = write and ((table_class = ia and values.table_class = STANDARD_INFREQUENT_ACCESS) or ((not values.table_class or values.table_class = STANDARD or values.table_class = null) and table_class = standard))",
     "usage": {
       "operations": 16000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "write request units",
+      "unit": "WRU/month",
+      "low": 500000,
+      "typical": 16000000,
+      "high": 2000000000
     }
   },
   {

--- a/services/terrapod/services/summariser_prompt.py
+++ b/services/terrapod/services/summariser_prompt.py
@@ -732,7 +732,11 @@ def render_cost_prompt(
     user_parts.append(
         "DETERMINISTIC_COST_ESTIMATE (authoritative — priced resources are in "
         "`resources`; the ones the engine could NOT price are in `unpriced`, and "
-        "THOSE are what you estimate):\n"
+        "THOSE are what you estimate). A priced resource may carry "
+        "`usage_assumptions`: usage-driven line items (requests, data processed, "
+        "duration) priced at a TYPICAL guess, each with low/typical/high bands — "
+        "so its real cost can swing across that band with traffic, and the priced "
+        "figure is only the typical point:\n"
         f"```json\n{estimate_json}\n```"
     )
     if plan_json.strip():
@@ -740,7 +744,12 @@ def render_cost_prompt(
     user_parts.append(
         "Now call the `submit_cost_summary` tool exactly once: estimate the "
         "UNPRICED resources in `estimated_resources` (the primary output), then "
-        "any savings advisories, then an optional brief narrative."
+        "any savings advisories, then an optional brief narrative. Where a priced "
+        "resource carries `usage_assumptions`, use them: in the narrative/"
+        "advisories, flag the usage-driven items that dominate its cost, and — "
+        "only where the resource's own context (name, config, workspace) clearly "
+        "suggests it — say whether its real usage sits toward the low or high end "
+        "of the band. Do not restate the deterministic figures as your own."
     )
 
     user_message = "\n\n".join(user_parts)

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -472,6 +472,40 @@ def test_ebs_gp3_volume_prices_by_size():
     assert est.resources[0].monthly_min == pytest.approx(100 * 0.08, abs=0.01)  # $8.00
 
 
+def test_usage_assumptions_flagged_with_bands_for_usage_driven_resources():
+    """A usage-driven resource (Lambda) exposes usage_assumptions with
+    low/typical/high bands so the AI/UI can flag + refine them; a deterministic
+    resource (an EC2 instance — always-on hours) exposes none (#962)."""
+    plan = _plan(
+        [
+            {
+                "address": "aws_lambda_function.f",
+                "type": "aws_lambda_function",
+                "name": "f",
+                "mode": "managed",
+                "values": {"region": "us-east-1", "memory_size": 512},
+            },
+            {
+                "address": "aws_instance.web",
+                "type": "aws_instance",
+                "name": "web",
+                "mode": "managed",
+                "values": {"instance_type": "m5.large", "region": "us-east-1"},
+            },
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    by_addr = {r["address"]: r for r in d["resources"]}
+    lam = by_addr["aws_lambda_function.f"]
+    dims = {ua["dimension"]: ua for ua in lam["usage_assumptions"]}
+    assert "invocations" in dims and "duration" in dims
+    inv = dims["invocations"]
+    assert inv["low"] < inv["typical"] < inv["high"]  # a real band
+    assert inv["unit"] and inv["description"]
+    # deterministic EC2 instance: no usage assumptions, field omitted.
+    assert "usage_assumptions" not in by_addr["aws_instance.web"]
+
+
 def test_ec2_instance_prices():
     plan = {
         "format_version": "1.2",


### PR DESCRIPTION
Part of #962 — the first slice: **make usage-driven cost assumptions first-class and put them in front of the AI**, per the steer that the AI should refine low/typical/high usage per-resource and it can only do that if it *has* the information.

## The problem
For usage-driven components (requests, data processed, duration) the engine baked one assumed number and folded it into a single figure — false precision. A NAT / Lambda / S3 / DynamoDB resource's real cost swings widely with traffic, and the user saw no signal it was a guess.

## What this adds
- **`usage.Entry` gains `assumption` + `bands`** (low/typical/high); `usage_defaults.json` annotates the **11 genuinely usage-driven entries** (S3 storage/requests, Lambda invocations/duration, SQS, DynamoDB read/write/storage) with a documented band. Deterministic entries (always-on hours, attr-priced storage from the resource's own `size`) stay flat.
- **The pricer collects, per resource, the usage assumptions that fed its cost** (one per dimension); `ResourceCost` + `to_dict` expose them as `usage_assumptions = [{description, dimension, unit, low, typical, high}]`. **Additive and omitted when empty**, so deterministic resources' payload and existing consumers are unchanged.
- **The cost-summary prompt uses them:** the AI is told to flag the usage-driven items that dominate a resource's cost and — only where the resource's own context clearly suggests it — place its real usage in the band.

The bands are **Terrapod's documented judgement, not model-invented facts** (the AI reasons over them; consistent with the no-model-training-for-facts rule).

## Verified
A Lambda estimate exposes its two usage bands; a deterministic EC2 instance exposes none. **45 cost tests green.**

## Next slices (of #962)
go-terrapod struct + provider/UI presentation ("typical, range low–high", assumptions marked), and evolving the engine to emit per-item **cost** bands (not just quantity bands).
