### PR TITLE
feat(pricegen): aws_nat_gateway (deterministic hours + usage-driven data band)

### DIFF
--- a/pricegen/providers/aws/recipes/aws_nat_gateway.yaml
+++ b/pricegen/providers/aws/recipes/aws_nat_gateway.yaml
@@ -1,0 +1,24 @@
+# NAT Gateway -> aws_nat_gateway. Two charges: the always-on gateway HOUR
+# ($0.045/hr — deterministic, the resource exists so it runs 730h) and per-GB
+# DATA processed ($0.045/GB — usage-driven, a traffic guess). Net-new vs oiq, so
+# it needs paired usage entries; the data entry carries a low/typical/high band
+# (#962) so the estimate flags it as an assumption and the AI can refine it (NAT
+# data cost can dwarf the fixed hour cost, so this matters). From the large
+# AmazonEC2 offer via the ijson stream-filter (families: [NAT Gateway]), sharing
+# the cached EC2 download. Standard NatGateway-* usagetypes only (not Regional /
+# Prvd-Gbps); the $0 provisioned-bytes SKU is dropped by the adapter's $0-skip.
+resource_type: aws_nat_gateway
+service: AmazonEC2
+
+components:
+  - product_family: "^NAT Gateway$"
+    service_class: hours
+    select: { usagetype: NatGateway-Hours }
+    price: { type: t, unit: Hrs }
+    tier: usage
+
+  - product_family: "^NAT Gateway$"
+    service_class: data
+    select: { usagetype: NatGateway-Bytes }
+    price: { type: d, unit: GB }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -61,3 +61,10 @@ recipes:
       service_code: AmazonEC2
       region: us-east-1
       families: [Storage, System Operation]
+  - provider: aws
+    recipe: aws_nat_gateway
+    offer: .cache/ec2-nat-us-east-1.json
+    fetch:
+      service_code: AmazonEC2
+      region: us-east-1
+      families: [NAT Gateway]

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -227,5 +227,27 @@
     "usage": {
       "time": 730
     }
+  },
+  {
+    "description": "NAT Gateway hours (always-on)",
+    "match_query": "type = aws_nat_gateway and service_class = hours",
+    "usage": {
+      "time": 730
+    }
+  },
+  {
+    "description": "NAT Gateway data processed",
+    "match_query": "type = aws_nat_gateway and service_class = data",
+    "usage": {
+      "data": 100
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "data processed",
+      "unit": "GB/month",
+      "low": 10,
+      "typical": 100,
+      "high": 5000
+    }
   }
 ]

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -247,7 +247,7 @@
       "unit": "GB/month",
       "low": 10,
       "typical": 100,
-      "high": 5000
+      "high": 50000
     }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -271,7 +271,7 @@ def test_default_usage_catalogue_loads():
     entries = default_entries()
     # 18 vendored from OpenInfraQuote + Terrapod additions: RDS provisioned IOPS
     # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933).
-    assert len(entries) == 21
+    assert len(entries) == 23
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -75,6 +75,9 @@ _ROWS = [
     # EBS gp3 storage — priced a=values.size. From the ~450 MB EC2 offer, now in
     # the published sheet via the ijson stream-filter (#893).
     "AmazonEC2,Storage,type=aws_ebs_volume&values.type=gp3,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage,0.0800000000,a=values.size,USD",
+    # NAT gateway — deterministic always-on hours + usage-driven data processed.
+    "AmazonEC2,NAT Gateway,type=aws_nat_gateway,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0450000000,t,USD",
+    "AmazonEC2,NAT Gateway,type=aws_nat_gateway,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=data&start_usage_amount=0&end_usage_amount=Inf,0.0450000000,d,USD",
 ]
 
 
@@ -504,6 +507,30 @@ def test_usage_assumptions_flagged_with_bands_for_usage_driven_resources():
     assert inv["unit"] and inv["description"]
     # deterministic EC2 instance: no usage assumptions, field omitted.
     assert "usage_assumptions" not in by_addr["aws_instance.web"]
+
+
+def test_nat_gateway_deterministic_hours_plus_usage_driven_data():
+    """NAT gateway: the always-on hour is deterministic (confident), the data
+    processed is usage-driven and flagged with a band — the full #962 loop on a
+    net-new resource. (#893/#962)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_nat_gateway.n",
+                "type": "aws_nat_gateway",
+                "name": "n",
+                "mode": "managed",
+                "values": {"region": "us-east-1"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    # hours 730*0.045=32.85 (deterministic) + data 100*0.045=4.50 (typical)
+    assert r["monthly"]["min"] == pytest.approx(730 * 0.045 + 100 * 0.045, abs=0.01)
+    dims = {ua["dimension"]: ua for ua in r["usage_assumptions"]}
+    assert set(dims) == {"data processed"}  # only data is an assumption, not hours
+    assert dims["data processed"]["low"] < dims["data processed"]["high"]
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
feat(pricegen): aws_nat_gateway — deterministic hours + usage-driven data band

First resource built on the #962 usage-band model. NAT gateway has two
charges:
- always-on HOUR ($0.045/hr → 730h): deterministic, confident.
- DATA processed ($0.045/GB): usage-driven, flagged as an assumption with a
  low/typical/high band (10 / 100 / 5000 GB) so the user sees it's a guess and
  the AI can refine it — NAT data cost can dwarf the fixed hour cost.

From the ~450 MB AmazonEC2 offer via the ijson stream-filter
(families: [NAT Gateway]), sharing the cached EC2 download.

Validated E2E: $37.35 typical ($32.85 hours + $4.50 data); the cost result
exposes only the data component as a usage assumption (hours deterministic).
usage-catalogue count 21->23. 46 services + 42 pricegen tests green.

Part of #893, part of #962.
