### PR TITLE
fix(cost): raise conservative usage-band highs to honest busy-resource levels (#971)

### DIFF
--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -18,7 +18,7 @@
       "unit": "requests/month",
       "low": 100000,
       "typical": 4000000,
-      "high": 100000000
+      "high": 1000000000
     }
   },
   {
@@ -33,7 +33,7 @@
       "unit": "requests/month",
       "low": 1000000,
       "typical": 50000000,
-      "high": 1000000000
+      "high": 10000000000
     }
   },
   {
@@ -48,7 +48,7 @@
       "unit": "GB-month",
       "low": 50,
       "typical": 900,
-      "high": 10000
+      "high": 500000
     }
   },
   {
@@ -88,7 +88,7 @@
       "unit": "requests/month",
       "low": 1000000,
       "typical": 50000000,
-      "high": 5000000000
+      "high": 50000000000
     }
   },
   {
@@ -103,7 +103,7 @@
       "unit": "requests/month",
       "low": 1000000,
       "typical": 100000000,
-      "high": 10000000000
+      "high": 50000000000
     }
   },
   {
@@ -118,7 +118,7 @@
       "unit": "GB-seconds/month",
       "low": 100000,
       "typical": 1000000,
-      "high": 100000000
+      "high": 1000000000
     }
   },
   {
@@ -133,7 +133,7 @@
       "unit": "GB-seconds/month",
       "low": 100000,
       "typical": 1000000,
-      "high": 100000000
+      "high": 1000000000
     }
   },
   {
@@ -159,7 +159,7 @@
       "unit": "GB-month",
       "low": 5,
       "typical": 80,
-      "high": 5000
+      "high": 50000
     }
   },
   {
@@ -174,7 +174,7 @@
       "unit": "GB-month",
       "low": 5,
       "typical": 80,
-      "high": 5000
+      "high": 50000
     }
   },
   {
@@ -189,7 +189,7 @@
       "unit": "RRU/month",
       "low": 1000000,
       "typical": 80000000,
-      "high": 10000000000
+      "high": 50000000000
     }
   },
   {
@@ -204,7 +204,7 @@
       "unit": "WRU/month",
       "low": 500000,
       "typical": 16000000,
-      "high": 2000000000
+      "high": 10000000000
     }
   },
   {


### PR DESCRIPTION
## What

Raises the `high` bound of each usage-assumption band so the **honest raw upper cost** (`cost_high`, now surfaced per-item after #968/#970) reflects a genuinely busy resource rather than a token value.

With bands now visible to operators with the AI off, a too-conservative `high` reads as a false ceiling — exactly the failure the "honest raw" mandate exists to prevent (a `high` that only looks right after AI tailoring is wrong).

| Resource / dimension | old high | new high | rationale |
|---|---|---|---|
| S3 tier-1 requests | 100M | 1B | ~385 writes/s busy ingestion |
| S3 tier-2 requests | 1B | 10B | ~3.9k reads/s hot origin |
| S3 storage | 10 TB | 500 TB | a real data lake |
| SQS requests | 5B | 50B | large event system |
| Lambda invocations | 10B | 50B | ~19k/s hyperscale |
| Lambda duration (ARM+x86) | 100M GB-s | 1B GB-s | compute-heavy fleet |
| DynamoDB storage | 5 TB | 50 TB | large table |
| DynamoDB read | 10B RRU | 50B RRU | busy table |
| DynamoDB write | 2B WRU | 10B WRU | busy write table |

NAT data (50 TB) was already honest — unchanged. Every high stays **finite** (never infinity). `typical`/`low` untouched — `typical` must remain the actual usage point the `monthly` figure folds in.

## Verification

- Data-only change to `usage_defaults.json` band highs; the pricer's per-item `cost_high` now re-prices at these levels.
- `./scripts/test.sh python -- -k "cost or usage or pricer"` — 125 pass (contract tests assert bounds relationally, so they still hold).

Part of #962. Closes #971.
