### PR TITLE
feat(pricegen): aws_eip — deterministic public-IPv4 hourly charge (#973)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -132,6 +132,7 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] Azure adapter + `azurerm_linux_virtual_machine` (regex select, validated end-to-end) — second cloud proven
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
-- [ ] Consumer reads the Terrapod YAML sheet + flip `cost_estimation.prices_url` default to the rolling release
-- [ ] AWS breadth (LB, NAT, EIP, S3, …) + all-regions + a row-parity CI gate
+- [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)
+- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip` (deterministic + usage-driven, with low/typical/high cost bands)
+- [ ] More AWS breadth (load balancers, …) + all-regions + a row-parity CI gate
 - [ ] Broaden GCP families/regions; Azure managed disks / Windows

--- a/pricegen/providers/aws/adapter.py
+++ b/pricegen/providers/aws/adapter.py
@@ -51,6 +51,10 @@ def iter_units(offer: dict, *, term: str = "OnDemand"):
                 )
         if not prices:
             continue
-        yield Unit(
-            product.get("productFamily", ""), product.get("attributes", {}), prices
-        )
+        attrs = product.get("attributes", {})
+        # Some priced products carry an EMPTY productFamily (e.g. VPC public-IPv4
+        # address charges). Fall back to the attribute `group` so a recipe has a
+        # stable family to match on. No existing recipe matches an empty family,
+        # so this only enables new coverage — it never re-routes a matched SKU.
+        family = product.get("productFamily") or attrs.get("group", "")
+        yield Unit(family, attrs, prices)

--- a/pricegen/providers/aws/recipes/aws_eip.yaml
+++ b/pricegen/providers/aws/recipes/aws_eip.yaml
@@ -1,0 +1,18 @@
+# Elastic IP -> aws_eip. Since 2024-02-01 AWS charges $0.005/hr for EVERY public
+# IPv4 address, attached or idle, so an aws_eip is a DETERMINISTIC always-on
+# charge (~$3.65/mo) — like the NAT gateway HOUR, not a usage guess. Priced from
+# the small AmazonVPC offer. The product carries an EMPTY productFamily, so the
+# adapter falls back to the attribute `group` (VPCPublicIPv4Address), which this
+# recipe matches. We match the In-use rate (an EIP is normally attached; the
+# Idle rate is identical anyway). The region-prefixed usagetype
+# (`USE1-PublicIPv4:InUseAddress`) is matched by regex so the recipe stays
+# region-portable.
+resource_type: aws_eip
+service: AmazonVPC
+
+components:
+  - product_family: "^VPCPublicIPv4Address$"
+    service_class: hours
+    select: { usagetype: { regex: "PublicIPv4:InUseAddress$" } }
+    price: { type: t, unit: Hrs }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -68,3 +68,7 @@ recipes:
       service_code: AmazonEC2
       region: us-east-1
       families: [NAT Gateway]
+  - provider: aws
+    recipe: aws_eip
+    offer: .cache/vpc-us-east-1.json
+    fetch: { service_code: AmazonVPC, region: us-east-1 }

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -236,6 +236,13 @@
     }
   },
   {
+    "description": "Elastic IP hours (always-on public IPv4 charge)",
+    "match_query": "type = aws_eip and service_class = hours",
+    "usage": {
+      "time": 730
+    }
+  },
+  {
     "description": "NAT Gateway data processed",
     "match_query": "type = aws_nat_gateway and service_class = data",
     "usage": {

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -270,8 +270,9 @@ def test_resources_from_state_v4_lifts_attributes():
 def test_default_usage_catalogue_loads():
     entries = default_entries()
     # 18 vendored from OpenInfraQuote + Terrapod additions: RDS provisioned IOPS
-    # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933).
-    assert len(entries) == 23
+    # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933) +
+    # NAT gateway hours+data (#966) + Elastic IP hours (#973).
+    assert len(entries) == 24
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -78,6 +78,10 @@ _ROWS = [
     # NAT gateway — deterministic always-on hours + usage-driven data processed.
     "AmazonEC2,NAT Gateway,type=aws_nat_gateway,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0450000000,t,USD",
     "AmazonEC2,NAT Gateway,type=aws_nat_gateway,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=data&start_usage_amount=0&end_usage_amount=Inf,0.0450000000,d,USD",
+    # Elastic IP — every public IPv4 is $0.005/hr since 2024-02-01, so an aws_eip
+    # is a deterministic always-on charge (from the AmazonVPC offer; the product's
+    # empty productFamily falls back to the `group`).
+    "AmazonVPC,VPCPublicIPv4Address,type=aws_eip,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0050000000,t,USD",
 ]
 
 
@@ -543,6 +547,29 @@ def test_nat_gateway_deterministic_hours_plus_usage_driven_data():
     # The headline monthly stays at typical (hours + typical data), NOT the
     # widened band — so workspace totals don't balloon on the high bound.
     assert r["monthly"]["max"] == pytest.approx(730 * 0.045 + data["cost_typical"], abs=0.01)
+
+
+def test_eip_deterministic_hourly_public_ipv4():
+    """aws_eip: since 2024-02-01 every public IPv4 is billed $0.005/hr whether
+    attached or idle, so an Elastic IP is a deterministic always-on charge with
+    NO usage assumption (like the NAT hour). 0.005*730 = $3.65/mo. (#893)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_eip.nat",
+                "type": "aws_eip",
+                "name": "nat",
+                "mode": "managed",
+                "values": {"region": "us-east-1", "domain": "vpc"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    assert r["monthly"]["min"] == pytest.approx(730 * 0.005, abs=0.01)
+    assert r["monthly"]["max"] == pytest.approx(730 * 0.005, abs=0.01)
+    # Deterministic — no usage band, field omitted entirely.
+    assert "usage_assumptions" not in r
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

Adds `aws_eip` (Elastic IP) to pricegen. Since **2024-02-01** AWS bills **$0.005/hr for every public IPv4 address** — attached or idle — so an `aws_eip` is a **deterministic always-on** charge (~$3.65/mo), like the NAT gateway hour, not a usage assumption.

## Findings (verified by inspecting the offers, not assuming)

- Public IPv4 pricing is **not** in the AmazonEC2 offer (no "IP Address" family), and there is **no** standalone `AWSPublicIPv4Address` service in the Bulk index. It lives in the small **AmazonVPC** offer: usagetypes `…PublicIPv4:InUseAddress` (attached) and `:IdleAddress` (idle), both `$0.005/hr`.
- Those products carry an **empty `productFamily`**. So the AWS adapter now falls back to the attribute `group` (here `VPCPublicIPv4Address`) when `productFamily` is empty. No existing recipe matches an empty family, so this only enables new coverage — it never re-routes a matched SKU.

## Changes

- **adapter** — empty-`productFamily` → `group` fallback.
- **recipe `aws_eip`** — matches `VPCPublicIPv4Address`, selects the In-use rate via a region-portable regex (the Idle rate is identical).
- **manifest** — fetches the whole small AmazonVPC offer (no stream-filter needed).
- **consumer usage entry** — `type = aws_eip and service_class = hours`, `time: 730`, deterministic (no band).
- **contract test** — asserts $3.65/mo and that no `usage_assumptions` is emitted.

## Verification

- `python3 -m pricegen.generate --recipe aws_eip` → 1 clean row, `$0.005`, In-use selected (Idle skipped).
- `./scripts/test.sh python -- tests/services/test_cost_pricegen_contract.py` — 18 pass (incl. new EIP test).
- `pytest pricegen/tests/` — 42 pass (adapter fallback doesn't regress existing recipes).

Part of #893. Closes #973.
