### PR TITLE
fix(ci): Eval Boot (k3d) — local registry instead of k3d image import; fail fast (#975)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,13 +953,27 @@ jobs:
             kind create cluster --name terrapod-eval --wait 120s
             for img in $imgs; do kind load docker-image "$img" --name terrapod-eval; done
           else
-            k3d cluster create terrapod-eval --wait --timeout 120s
-            # Import ALL images in ONE call. Separate per-image `k3d image import`
-            # calls race on their temp tarball ("ctr: open …tar: no such file or
-            # directory") and k3d masks that with exit 0 — which silently left the
-            # listener image unimported (ImagePullBackOff → run stuck queued). One
-            # call = one tarball = no race.
-            k3d image import $imgs -c terrapod-eval
+            # A k3d-managed local registry, NOT `k3d image import`. The import
+            # reports "Successfully imported" but leaves images unresolvable by
+            # the kubelet under their own ref, so pods fall back to pulling from
+            # ghcr.io (nothing pushed there on PRs) → ImagePullBackOff → the
+            # pre-install migration hook hangs the whole boot for 10 min. A real
+            # registry pull is deterministic and works identically on PR + branch
+            # builds. #975.
+            reg_port=5111
+            k3d registry create eval-registry.localhost --port "$reg_port"
+            k3d cluster create terrapod-eval \
+              --registry-use "k3d-eval-registry.localhost:${reg_port}" \
+              --wait --timeout 120s
+            for i in terrapod-api terrapod-web terrapod-migrations terrapod-listener terrapod-runner; do
+              # Push over localhost:PORT (docker auto-treats localhost as an
+              # insecure registry — no daemon config needed); pods pull the same
+              # repo path in-cluster via k3d-eval-registry.localhost:PORT, which
+              # the chart's global.imageRegistry override points them at.
+              dst="localhost:${reg_port}/mattrobinsonsre/${i}:sha-${sha}-amd64"
+              docker tag "$REGISTRY/${i}:sha-${sha}-amd64" "$dst"
+              docker push "$dst"
+            done
           fi
       - name: make eval (install into the cluster)
         env:
@@ -971,6 +985,13 @@ jobs:
           # this the k3d matrix job would auto-detect kind and the smoke step's
           # k3d-pinned context lookup would miss.
           TERRAPOD_EVAL_TOOL: ${{ matrix.tool }}
+          # k3d pulls every image from the local registry created above (kind
+          # loads images straight into the node, so it needs no override). #975.
+          TERRAPOD_EVAL_IMAGE_REGISTRY: ${{ matrix.tool == 'k3d' && 'k3d-eval-registry.localhost:5111' || '' }}
+          # Fail fast: a healthy boot is ~50s, so cap the install wait at 5 min so
+          # a genuine image/scheduling problem surfaces quickly with pod
+          # diagnostics instead of a ~10-min silent hang. #975.
+          TERRAPOD_EVAL_HELM_TIMEOUT: 300s
         run: scripts/eval.sh up
       - name: Smoke the running stack
         run: |

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -99,6 +99,15 @@ up() {
   restore_ctx
 
   log "Installing Terrapod (${RELEASE}) into namespace '${NS}' using image tag '${VERSION}'…"
+  # Optional image-registry override. When set (e.g. CI's k3d leg points every
+  # image at a k3d-managed local registry, which is a deterministic pull instead
+  # of the flaky `k3d image import`), redirect all five images via
+  # global.imageRegistry. Empty by default, so a normal `make eval` — which loads
+  # images straight into the node — is unaffected.
+  local reg_args=()
+  if [[ -n "${TERRAPOD_EVAL_IMAGE_REGISTRY:-}" ]]; then
+    reg_args+=(--set "global.imageRegistry=${TERRAPOD_EVAL_IMAGE_REGISTRY}")
+  fi
   # `--wait` blocks until every Deployment — including the runner listener — is
   # ready. The listener only reports ready once it has JOINED the agent pool, and
   # the pool is created by the bootstrap job, which is a PRE-install hook (see
@@ -108,6 +117,7 @@ up() {
   helm --kube-context "$ctx" upgrade --install "$RELEASE" "$CHART_DIR" \
     --namespace "$NS" --create-namespace \
     -f "${CHART_DIR}/values-eval.yaml" \
+    "${reg_args[@]}" \
     --set "api.image.tag=${VERSION}" \
     --set "web.image.tag=${VERSION}" \
     --set "migrations.image.tag=${VERSION}" \


### PR DESCRIPTION
## Problem

`Eval Boot (k3d)` hangs ~11 min and fails with `timed out waiting for the condition`; the `kind` leg of the same matrix passes.

**Root cause:** the job loads the 5 locally-built images with `k3d image import`, which prints *"Successfully imported 5 image(s)"* — but the images aren't reliably registered in k3s's containerd under their own ref, so the kubelet falls back to *pulling* `ghcr.io/mattrobinsonsre/terrapod-migrations:sha-…-amd64`. PRs push nothing to GHCR (images travel as build artifacts), so the pull fails → `ImagePullBackOff`. The migration Job is a Helm **pre-install hook** run with `--wait`, so Helm blocks on it for its full 10-min timeout, then fails the whole boot. `kind load docker-image` writes straight into the node's containerd deterministically, which is why only k3d flakes.

## Fix

**1. Local registry instead of `k3d image import`.** Create a `k3d registry`, `docker push` the five images to it, and drive the chart's existing `global.imageRegistry` so every pod does a normal, deterministic registry pull — identical on PR and branch builds. `eval.sh` gains an optional `TERRAPOD_EVAL_IMAGE_REGISTRY` override (empty by default → a normal `make eval` and the kind leg are unchanged; images still load straight into the node there).

**3. Fail fast.** Cap the eval install wait at `300s` (a healthy boot is ~50s, so 6× headroom) so any genuine image/scheduling problem surfaces quickly with pod diagnostics instead of a ~10-min silent hang. Uses `eval.sh`'s existing `TERRAPOD_EVAL_HELM_TIMEOUT` knob.

kind keeps `kind load docker-image` (reliable).

## Verification

- `bash -n scripts/eval.sh` clean.
- `helm template … --set global.imageRegistry=k3d-eval-registry.localhost:5111` confirms **all five** images (api/web/migrations/listener as `image:`, runner as the ConfigMap `repository:`) resolve to the local registry — push path `localhost:5111/mattrobinsonsre/<img>` and in-cluster pull path `k3d-eval-registry.localhost:5111/mattrobinsonsre/<img>` share the same repo path on the same registry container.
- The real proof is this PR's own `Eval Boot (k3d)` leg going green deterministically.

Closes #975.
