### PR TITLE
feat(pricegen): aws_lb — ALB + NLB (deterministic hour + usage-driven LCU band) (#977)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -133,6 +133,6 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)
-- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip` (deterministic + usage-driven, with low/typical/high cost bands)
-- [ ] More AWS breadth (load balancers, …) + all-regions + a row-parity CI gate
+- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB, hour + LCU band) (deterministic + usage-driven, with low/typical/high cost bands)
+- [ ] More AWS breadth (classic `aws_elb`, EBS snapshots, Route53, …) + all-regions + a row-parity CI gate
 - [ ] Broaden GCP families/regions; Azure managed disks / Windows

--- a/pricegen/providers/aws/recipes/aws_lb.yaml
+++ b/pricegen/providers/aws/recipes/aws_lb.yaml
@@ -1,0 +1,40 @@
+# Application/Network Load Balancer -> aws_lb (aws_alb is an alias). Two charges
+# per LB: the always-on HOUR ($0.0225/hr — deterministic) and per-LCU-hour
+# capacity ($0.008 ALB / $0.006 NLB — usage-driven, a traffic guess with a
+# band). ALB and NLB are SEPARATE product families in the AmazonEC2 offer, so
+# each is its own pair of components, keyed by `values.load_balancer_type`
+# (stamped via `const`). aws_lb's load_balancer_type has a schema Default of
+# "application", so a `terraform plan` always carries it (unlike license_model,
+# #924) — matching on it is safe. From the large AmazonEC2 offer via the ijson
+# stream-filter, sharing the cached EC2 download.
+resource_type: aws_lb
+service: AmazonEC2
+
+components:
+  # ── Application Load Balancer ──────────────────────────────────────────────
+  - product_family: "^Load Balancer-Application$"
+    service_class: hours
+    select: { usagetype: LoadBalancerUsage }
+    match: { load_balancer_type: { const: application } }
+    price: { type: t, unit: Hrs }
+    tier: usage
+  - product_family: "^Load Balancer-Application$"
+    service_class: lcu
+    select: { usagetype: LCUUsage }
+    match: { load_balancer_type: { const: application } }
+    price: { type: t, unit: LCU-Hrs }
+    tier: usage
+
+  # ── Network Load Balancer ──────────────────────────────────────────────────
+  - product_family: "^Load Balancer-Network$"
+    service_class: hours
+    select: { usagetype: LoadBalancerUsage }
+    match: { load_balancer_type: { const: network } }
+    price: { type: t, unit: Hrs }
+    tier: usage
+  - product_family: "^Load Balancer-Network$"
+    service_class: lcu
+    select: { usagetype: LCUUsage }
+    match: { load_balancer_type: { const: network } }
+    price: { type: t, unit: LCU-Hrs }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -72,3 +72,10 @@ recipes:
     recipe: aws_eip
     offer: .cache/vpc-us-east-1.json
     fetch: { service_code: AmazonVPC, region: us-east-1 }
+  - provider: aws
+    recipe: aws_lb
+    offer: .cache/ec2-lb-us-east-1.json
+    fetch:
+      service_code: AmazonEC2
+      region: us-east-1
+      families: [Load Balancer-Application, Load Balancer-Network]

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -243,6 +243,28 @@
     }
   },
   {
+    "description": "Load balancer hours (always-on)",
+    "match_query": "type = aws_lb and service_class = hours",
+    "usage": {
+      "time": 730
+    }
+  },
+  {
+    "description": "Load balancer capacity units (LCU-hours)",
+    "match_query": "type = aws_lb and service_class = lcu",
+    "usage": {
+      "time": 1460
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "capacity units",
+      "unit": "LCU-hours/month",
+      "low": 730,
+      "typical": 1460,
+      "high": 30000
+    }
+  },
+  {
     "description": "NAT Gateway data processed",
     "match_query": "type = aws_nat_gateway and service_class = data",
     "usage": {

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -271,8 +271,9 @@ def test_default_usage_catalogue_loads():
     entries = default_entries()
     # 18 vendored from OpenInfraQuote + Terrapod additions: RDS provisioned IOPS
     # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933) +
-    # NAT gateway hours+data (#966) + Elastic IP hours (#973).
-    assert len(entries) == 24
+    # NAT gateway hours+data (#966) + Elastic IP hours (#973) + load balancer
+    # hours+LCU (#977).
+    assert len(entries) == 26
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -82,6 +82,13 @@ _ROWS = [
     # is a deterministic always-on charge (from the AmazonVPC offer; the product's
     # empty productFamily falls back to the `group`).
     "AmazonVPC,VPCPublicIPv4Address,type=aws_eip,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0050000000,t,USD",
+    # Load balancers — ALB + NLB, each a deterministic hour + a usage-driven LCU
+    # (capacity units) band. load_balancer_type is stamped (schema Default, so a
+    # plan always carries it). ALB LCU $0.008, NLB LCU $0.006.
+    "AmazonEC2,Load Balancer-Application,type=aws_lb&values.load_balancer_type=application,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0225000000,t,USD",
+    "AmazonEC2,Load Balancer-Application,type=aws_lb&values.load_balancer_type=application,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=lcu&start_usage_amount=0&end_usage_amount=Inf,0.0080000000,t,USD",
+    "AmazonEC2,Load Balancer-Network,type=aws_lb&values.load_balancer_type=network,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0225000000,t,USD",
+    "AmazonEC2,Load Balancer-Network,type=aws_lb&values.load_balancer_type=network,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=lcu&start_usage_amount=0&end_usage_amount=Inf,0.0060000000,t,USD",
 ]
 
 
@@ -570,6 +577,53 @@ def test_eip_deterministic_hourly_public_ipv4():
     assert r["monthly"]["max"] == pytest.approx(730 * 0.005, abs=0.01)
     # Deterministic — no usage band, field omitted entirely.
     assert "usage_assumptions" not in r
+
+
+def test_alb_hours_plus_lcu_band():
+    """aws_lb (application): deterministic hour ($0.0225 * 730) + usage-driven
+    LCU capacity band. load_balancer_type is stamped, so the ALB rows match and
+    the NLB rows don't. (#893/#977)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_lb.app",
+                "type": "aws_lb",
+                "name": "app",
+                "mode": "managed",
+                "values": {"region": "us-east-1", "load_balancer_type": "application"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    # hours 730*0.0225 = 16.425 + LCU typical 1460*0.008 = 11.68 -> 28.105
+    assert r["monthly"]["max"] == pytest.approx(730 * 0.0225 + 1460 * 0.008, abs=0.01)
+    dims = {ua["dimension"]: ua for ua in r["usage_assumptions"]}
+    assert set(dims) == {"capacity units"}  # LCU is the assumption, not the hour
+    lcu = dims["capacity units"]
+    assert lcu["cost_typical"] == pytest.approx(1460 * 0.008, abs=0.01)
+    assert lcu["cost_high"] == pytest.approx(30000 * 0.008, abs=0.01)  # honest busy high
+
+
+def test_nlb_prices_at_the_network_lcu_rate():
+    """aws_lb (network) picks the NLB family rows (LCU $0.006, not the ALB
+    $0.008) via the stamped load_balancer_type. (#977)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_lb.net",
+                "type": "aws_lb",
+                "name": "net",
+                "mode": "managed",
+                "values": {"region": "us-east-1", "load_balancer_type": "network"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    assert r["monthly"]["max"] == pytest.approx(730 * 0.0225 + 1460 * 0.006, abs=0.01)
+    lcu = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["capacity units"]
+    assert lcu["cost_typical"] == pytest.approx(1460 * 0.006, abs=0.01)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

Adds `aws_lb` (Application + Network Load Balancer; `aws_alb` is an alias) to pricegen.

Two charges per LB, both from the AmazonEC2 offer:
- **hour** — $0.0225/hr, **deterministic** (the LB is always-on), like the NAT gateway hour.
- **LCU capacity** — **usage-driven** ($0.008/LCU-hr ALB, $0.006/LCU-hr NLB), so it carries a low/typical/high **cost band** (#962).

ALB and NLB are **separate product families** (`Load Balancer-Application` / `Load Balancer-Network`), so each is its own hour+LCU pair, keyed by `values.load_balancer_type` stamped via `const`. `load_balancer_type` has a schema **Default** of `application`, so a `terraform plan` always carries it — matching on it is safe (unlike the license_model trap in #924).

## Changes

- **recipe `aws_lb`** — 4 components (ALB/NLB × hours/LCU).
- **manifest** — fetches the two LB families from the EC2 offer via the ijson stream-filter (shares the cached EC2 download).
- **consumer** — 2 usage entries: hours (deterministic, 730) + LCU (banded, 730/1460/30000 LCU-hours/month).
- **contract tests** — ALB $28.11/mo + LCU cost band; NLB picks the $0.006 network rate.

## Verification

- `python3 -m pricegen.generate --recipe aws_lb` → 4 clean rows (ALB/NLB hours $0.0225, ALB LCU $0.008, NLB LCU $0.006).
- E2E probe through the real consumer: **ALB $28.11/mo** (band $5.84–$240), **NLB $25.19/mo** (band $4.38–$180).
- `./scripts/test.sh python -- -k "cost or usage or pricer or catalogue"` — 128 pass (incl. the catalogue count 24→26 and both new LB tests). `pytest pricegen/tests/` — 42 pass.

Classic `aws_elb` (hours + data-processed band) is a natural follow-up.

Part of #893. Closes #977.
