### PR TITLE
feat(pricegen): aws_elb — classic ELB (deterministic hour + usage-driven data band) (#979)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -133,6 +133,6 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)
-- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB, hour + LCU band) (deterministic + usage-driven, with low/typical/high cost bands)
-- [ ] More AWS breadth (classic `aws_elb`, EBS snapshots, Route53, …) + all-regions + a row-parity CI gate
+- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB, hour + LCU band), `aws_elb` (classic, hour + data band) (deterministic + usage-driven, with low/typical/high cost bands)
+- [ ] More AWS breadth (EBS snapshots, Route53, ElastiCache, …) + all-regions + a row-parity CI gate
 - [ ] Broaden GCP families/regions; Azure managed disks / Windows

--- a/pricegen/providers/aws/recipes/aws_elb.yaml
+++ b/pricegen/providers/aws/recipes/aws_elb.yaml
@@ -1,0 +1,19 @@
+# Classic Load Balancer -> aws_elb. The legacy ELB (distinct from aws_lb's
+# ALB/NLB). Two charges from the AmazonEC2 offer's `Load Balancer` family: the
+# always-on HOUR ($0.025/hr — deterministic) and per-GB DATA processed
+# ($0.008/GB — usage-driven, a traffic guess with a band). Shares the cached EC2
+# download via the ijson stream-filter.
+resource_type: aws_elb
+service: AmazonEC2
+
+components:
+  - product_family: "^Load Balancer$"
+    service_class: hours
+    select: { usagetype: LoadBalancerUsage }
+    price: { type: t, unit: Hrs }
+    tier: usage
+  - product_family: "^Load Balancer$"
+    service_class: data
+    select: { usagetype: DataProcessing-Bytes }
+    price: { type: d, unit: GB }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -79,3 +79,10 @@ recipes:
       service_code: AmazonEC2
       region: us-east-1
       families: [Load Balancer-Application, Load Balancer-Network]
+  - provider: aws
+    recipe: aws_elb
+    offer: .cache/ec2-elb-us-east-1.json
+    fetch:
+      service_code: AmazonEC2
+      region: us-east-1
+      families: [Load Balancer]

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -265,6 +265,28 @@
     }
   },
   {
+    "description": "Classic load balancer hours (always-on)",
+    "match_query": "type = aws_elb and service_class = hours",
+    "usage": {
+      "time": 730
+    }
+  },
+  {
+    "description": "Classic load balancer data processed",
+    "match_query": "type = aws_elb and service_class = data",
+    "usage": {
+      "data": 500
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "data processed",
+      "unit": "GB/month",
+      "low": 50,
+      "typical": 500,
+      "high": 50000
+    }
+  },
+  {
     "description": "NAT Gateway data processed",
     "match_query": "type = aws_nat_gateway and service_class = data",
     "usage": {

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -272,8 +272,8 @@ def test_default_usage_catalogue_loads():
     # 18 vendored from OpenInfraQuote + Terrapod additions: RDS provisioned IOPS
     # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933) +
     # NAT gateway hours+data (#966) + Elastic IP hours (#973) + load balancer
-    # hours+LCU (#977).
-    assert len(entries) == 26
+    # hours+LCU (#977) + classic ELB hours+data (#979).
+    assert len(entries) == 28
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -89,6 +89,9 @@ _ROWS = [
     "AmazonEC2,Load Balancer-Application,type=aws_lb&values.load_balancer_type=application,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=lcu&start_usage_amount=0&end_usage_amount=Inf,0.0080000000,t,USD",
     "AmazonEC2,Load Balancer-Network,type=aws_lb&values.load_balancer_type=network,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0225000000,t,USD",
     "AmazonEC2,Load Balancer-Network,type=aws_lb&values.load_balancer_type=network,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=lcu&start_usage_amount=0&end_usage_amount=Inf,0.0060000000,t,USD",
+    # Classic ELB (aws_elb) — deterministic hour + usage-driven data processed.
+    "AmazonEC2,Load Balancer,type=aws_elb,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0250000000,t,USD",
+    "AmazonEC2,Load Balancer,type=aws_elb,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=data&start_usage_amount=0&end_usage_amount=Inf,0.0080000000,d,USD",
 ]
 
 
@@ -624,6 +627,31 @@ def test_nlb_prices_at_the_network_lcu_rate():
     assert r["monthly"]["max"] == pytest.approx(730 * 0.0225 + 1460 * 0.006, abs=0.01)
     lcu = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["capacity units"]
     assert lcu["cost_typical"] == pytest.approx(1460 * 0.006, abs=0.01)
+
+
+def test_classic_elb_hours_plus_data_band():
+    """aws_elb (classic): deterministic hour ($0.025 * 730) + usage-driven data
+    processed band ($0.008/GB). (#893/#979)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_elb.legacy",
+                "type": "aws_elb",
+                "name": "legacy",
+                "mode": "managed",
+                "values": {"region": "us-east-1"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    # hours 730*0.025 = 18.25 + data typical 500*0.008 = 4.0 -> 22.25
+    assert r["monthly"]["max"] == pytest.approx(730 * 0.025 + 500 * 0.008, abs=0.01)
+    dims = {ua["dimension"]: ua for ua in r["usage_assumptions"]}
+    assert set(dims) == {"data processed"}
+    data = dims["data processed"]
+    assert data["cost_typical"] == pytest.approx(500 * 0.008, abs=0.01)
+    assert data["cost_high"] == pytest.approx(50000 * 0.008, abs=0.01)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

Adds `aws_elb` (classic/legacy Load Balancer) to pricegen — the companion to `aws_lb` (ALB/NLB, #977).

Two charges from the AmazonEC2 offer's `Load Balancer` family:
- **hour** — $0.025/hr, **deterministic** (always-on).
- **data processed** — $0.008/GB, **usage-driven**, so it carries a low/typical/high **cost band** (#962).

## Changes

- **recipe `aws_elb`** — 2 components (hours + data).
- **manifest** — fetches the `Load Balancer` family from the EC2 offer (stream-filtered, shares the cached download).
- **consumer** — 2 usage entries: hours (deterministic, 730) + data (banded, 50/500/50000 GB/month).
- **contract test** — $22.25/mo (hours $18.25 + data typical $4.00) + data cost band $0.40–$400.

## Verification

- `python3 -m pricegen.generate --recipe aws_elb` → 2 clean rows (hours $0.025, data $0.008).
- `./scripts/test.sh python -- -k "cost or usage or pricer or catalogue"` — 129 pass (catalogue count 26→28 + new ELB test). `pytest pricegen/tests/` — 42 pass.

Part of #893. Closes #979.
