### PR TITLE
feat(pricegen): aws_ebs_snapshot — usage-driven incremental storage band (#981)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -133,6 +133,6 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)
-- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB, hour + LCU band), `aws_elb` (classic, hour + data band) (deterministic + usage-driven, with low/typical/high cost bands)
-- [ ] More AWS breadth (EBS snapshots, Route53, ElastiCache, …) + all-regions + a row-parity CI gate
+- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB, hour + LCU band), `aws_elb` (classic, hour + data band), `aws_ebs_snapshot` (storage band) (deterministic + usage-driven, with low/typical/high cost bands)
+- [ ] More AWS breadth (Route53, ElastiCache, EFS, SNS, …) + all-regions + a row-parity CI gate
 - [ ] Broaden GCP families/regions; Azure managed disks / Windows

--- a/pricegen/providers/aws/recipes/aws_ebs_snapshot.yaml
+++ b/pricegen/providers/aws/recipes/aws_ebs_snapshot.yaml
@@ -1,0 +1,16 @@
+# EBS snapshot -> aws_ebs_snapshot. Standard snapshot storage at $0.05/GB-month.
+# The billed size is the INCREMENTAL (changed-block) size, which the plan can't
+# tell us (aws_ebs_snapshot.volume_size is the source volume size, not the
+# incremental stored size, and is Computed anyway), so it's usage-driven with a
+# band (#962). We match only the plain `EBS:SnapshotUsage` SKU — NOT the archive
+# tier (SnapshotArchive*), outposts (.outposts), or the UnderBilling variant.
+# From the cached AmazonEC2 offer (Storage Snapshot family).
+resource_type: aws_ebs_snapshot
+service: AmazonEC2
+
+components:
+  - product_family: "^Storage Snapshot$"
+    service_class: storage
+    select: { usagetype: { regex: "EBS:SnapshotUsage$" } }
+    price: { type: d, unit: GB-Mo }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -86,3 +86,10 @@ recipes:
       service_code: AmazonEC2
       region: us-east-1
       families: [Load Balancer]
+  - provider: aws
+    recipe: aws_ebs_snapshot
+    offer: .cache/ec2-snapshot-us-east-1.json
+    fetch:
+      service_code: AmazonEC2
+      region: us-east-1
+      families: [Storage Snapshot]

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -300,5 +300,20 @@
       "typical": 100,
       "high": 50000
     }
+  },
+  {
+    "description": "EBS snapshot stored size (incremental)",
+    "match_query": "type = aws_ebs_snapshot and service_class = storage",
+    "usage": {
+      "data": 100
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "stored size",
+      "unit": "GB-month",
+      "low": 8,
+      "typical": 100,
+      "high": 16000
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -272,8 +272,9 @@ def test_default_usage_catalogue_loads():
     # 18 vendored from OpenInfraQuote + Terrapod additions: RDS provisioned IOPS
     # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933) +
     # NAT gateway hours+data (#966) + Elastic IP hours (#973) + load balancer
-    # hours+LCU (#977) + classic ELB hours+data (#979).
-    assert len(entries) == 28
+    # hours+LCU (#977) + classic ELB hours+data (#979) + EBS snapshot storage
+    # (#981).
+    assert len(entries) == 29
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -92,6 +92,8 @@ _ROWS = [
     # Classic ELB (aws_elb) — deterministic hour + usage-driven data processed.
     "AmazonEC2,Load Balancer,type=aws_elb,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0250000000,t,USD",
     "AmazonEC2,Load Balancer,type=aws_elb,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=data&start_usage_amount=0&end_usage_amount=Inf,0.0080000000,d,USD",
+    # EBS snapshot — usage-driven incremental stored size at $0.05/GB-month.
+    "AmazonEC2,Storage Snapshot,type=aws_ebs_snapshot,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&start_usage_amount=0&end_usage_amount=Inf,0.0500000000,d,USD",
 ]
 
 
@@ -652,6 +654,29 @@ def test_classic_elb_hours_plus_data_band():
     data = dims["data processed"]
     assert data["cost_typical"] == pytest.approx(500 * 0.008, abs=0.01)
     assert data["cost_high"] == pytest.approx(50000 * 0.008, abs=0.01)
+
+
+def test_ebs_snapshot_usage_driven_storage_band():
+    """aws_ebs_snapshot: the billed incremental size is unknowable from the plan,
+    so it's a usage-driven storage band at $0.05/GB-month. (#893/#981)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_ebs_snapshot.s",
+                "type": "aws_ebs_snapshot",
+                "name": "s",
+                "mode": "managed",
+                "values": {"region": "us-east-1"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    # typical 100 GB * 0.05 = $5.00
+    assert r["monthly"]["max"] == pytest.approx(100 * 0.05, abs=0.01)
+    data = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["stored size"]
+    assert data["cost_typical"] == pytest.approx(100 * 0.05, abs=0.01)
+    assert data["cost_high"] == pytest.approx(16000 * 0.05, abs=0.01)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

Adds `aws_ebs_snapshot` to pricegen — standard snapshot storage at **$0.05/GB-month** (`Storage Snapshot` family, `EBS:SnapshotUsage`, excluding the archive tier / outposts / under-billing variants).

The billed size is the **incremental (changed-block)** size, which the plan can't tell us (`volume_size` is the *source volume* size, not the stored size, and is Computed), so it's **usage-driven** with a low/typical/high **cost band** (#962).

## Changes

- **recipe `aws_ebs_snapshot`** — 1 storage component, regex-selecting the exact `EBS:SnapshotUsage` SKU.
- **manifest** — fetches the `Storage Snapshot` family from the EC2 offer (stream-filtered).
- **consumer** — usage entry banded 8 / 100 / 16000 GB-month.
- **contract test** — $5.00/mo typical + cost band $0.40–$800.

## Verification

- `python3 -m pricegen.generate --recipe aws_ebs_snapshot` → 1 clean row ($0.05/GB-Mo; 5 archive/outposts variants correctly skipped).
- E2E probe: $5.00/mo typical (100 GB), band $0.40–$800.
- `./scripts/test.sh python -- -k "cost or usage or pricer or catalogue"` — 130 pass (catalogue 28→29 + new test). `pytest pricegen/tests/` — 42 pass.

Part of #893. Closes #981.
