### PR TITLE
feat(pricegen): aws_efs_file_system — General Purpose storage band (#983)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -133,6 +133,6 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)
-- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB, hour + LCU band), `aws_elb` (classic, hour + data band), `aws_ebs_snapshot` (storage band) (deterministic + usage-driven, with low/typical/high cost bands)
-- [ ] More AWS breadth (Route53, ElastiCache, EFS, SNS, …) + all-regions + a row-parity CI gate
+- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB, hour + LCU band), `aws_elb` (classic, hour + data band), `aws_ebs_snapshot` (storage band), `aws_efs_file_system` (storage band) (deterministic + usage-driven, with low/typical/high cost bands)
+- [ ] More AWS breadth (Route53, ElastiCache, SNS, …) + all-regions + a row-parity CI gate
 - [ ] Broaden GCP families/regions; Azure managed disks / Windows

--- a/pricegen/providers/aws/recipes/aws_efs_file_system.yaml
+++ b/pricegen/providers/aws/recipes/aws_efs_file_system.yaml
@@ -1,0 +1,15 @@
+# EFS -> aws_efs_file_system. Standard General Purpose regional storage at
+# $0.30/GB-month. The stored size is usage-driven (EFS grows/shrinks with the
+# data written; not a plan attribute), so it's a band (#962). We select the
+# General Purpose storage class explicitly, so the One Zone ($0.16), Infrequent
+# Access, and Archive tiers are excluded (each a distinct storageClass — natural
+# follow-ups). From the small AmazonEFS offer.
+resource_type: aws_efs_file_system
+service: AmazonEFS
+
+components:
+  - product_family: "^Storage$"
+    service_class: storage
+    select: { storageClass: "General Purpose" }
+    price: { type: d, unit: GB-Mo }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -93,3 +93,7 @@ recipes:
       service_code: AmazonEC2
       region: us-east-1
       families: [Storage Snapshot]
+  - provider: aws
+    recipe: aws_efs_file_system
+    offer: .cache/efs-us-east-1.json
+    fetch: { service_code: AmazonEFS, region: us-east-1 }

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -315,5 +315,20 @@
       "typical": 100,
       "high": 16000
     }
+  },
+  {
+    "description": "EFS stored size (General Purpose)",
+    "match_query": "type = aws_efs_file_system and service_class = storage",
+    "usage": {
+      "data": 100
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "stored size",
+      "unit": "GB-month",
+      "low": 10,
+      "typical": 100,
+      "high": 50000
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -273,8 +273,8 @@ def test_default_usage_catalogue_loads():
     # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933) +
     # NAT gateway hours+data (#966) + Elastic IP hours (#973) + load balancer
     # hours+LCU (#977) + classic ELB hours+data (#979) + EBS snapshot storage
-    # (#981).
-    assert len(entries) == 29
+    # (#981) + EFS storage (#983).
+    assert len(entries) == 30
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -94,6 +94,8 @@ _ROWS = [
     "AmazonEC2,Load Balancer,type=aws_elb,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=data&start_usage_amount=0&end_usage_amount=Inf,0.0080000000,d,USD",
     # EBS snapshot — usage-driven incremental stored size at $0.05/GB-month.
     "AmazonEC2,Storage Snapshot,type=aws_ebs_snapshot,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&start_usage_amount=0&end_usage_amount=Inf,0.0500000000,d,USD",
+    # EFS — usage-driven General Purpose stored size at $0.30/GB-month.
+    "AmazonEFS,Storage,type=aws_efs_file_system,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&start_usage_amount=0&end_usage_amount=Inf,0.3000000000,d,USD",
 ]
 
 
@@ -677,6 +679,28 @@ def test_ebs_snapshot_usage_driven_storage_band():
     data = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["stored size"]
     assert data["cost_typical"] == pytest.approx(100 * 0.05, abs=0.01)
     assert data["cost_high"] == pytest.approx(16000 * 0.05, abs=0.01)
+
+
+def test_efs_usage_driven_storage_band():
+    """aws_efs_file_system: General Purpose stored size is usage-driven ($0.30/
+    GB-month) — EFS grows with the data written, not a plan attribute. (#983)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_efs_file_system.fs",
+                "type": "aws_efs_file_system",
+                "name": "fs",
+                "mode": "managed",
+                "values": {"region": "us-east-1"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    assert r["monthly"]["max"] == pytest.approx(100 * 0.30, abs=0.01)  # typical 100 GB
+    data = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["stored size"]
+    assert data["cost_typical"] == pytest.approx(100 * 0.30, abs=0.01)
+    assert data["cost_high"] == pytest.approx(50000 * 0.30, abs=0.01)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

Adds `aws_efs_file_system` — standard **General Purpose** regional storage at **$0.30/GB-month** (`Storage` family, selected by `storageClass=General Purpose`).

Stored size grows with the data written and isn't a plan attribute, so it's **usage-driven** with a low/typical/high **cost band** (#962). One Zone ($0.16), Infrequent Access, and Archive tiers are distinct storage classes — natural follow-ups.

## Changes

- **recipe `aws_efs_file_system`** — 1 storage component.
- **manifest** — fetches the small AmazonEFS offer.
- **consumer** — usage entry banded 10 / 100 / 50000 GB-month.
- **contract test** — $30/mo typical + cost band $3–$15000.

## Verification

- `python3 -m pricegen.generate --recipe aws_efs_file_system` → 1 clean row ($0.30/GB-Mo; 12 One-Zone/IA/Archive/throughput variants skipped).
- `./scripts/test.sh python -- -k "cost or usage or pricer or catalogue"` — 131 pass (catalogue 29→30 + new test). `pytest pricegen/tests/` — 42 pass.

Part of #893. Closes #983.
