### PR TITLE
feat(pricegen): aws_rds_cluster_instance — Aurora instance hours (standard mode) (#985)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -127,7 +127,7 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 
 - [x] Provider-agnostic architecture (adapter → Unit → shared engine)
 - [x] AWS adapter + `aws_instance` (parity) + `aws_ebs_volume` (composite, exceptions)
-- [x] AWS RDS (`aws_db_instance`): instance + storage + io1/io2 provisioned IOPS, all validated end-to-end
+- [x] AWS RDS (`aws_db_instance`): instance + storage + io1/io2 provisioned IOPS, all validated end-to-end; Aurora (`aws_rds_cluster_instance`) instance hours (standard mode, 90 classes)
 - [x] End-to-end pricing validation (real consumer engine, not just row-parity) + generator drift diagnostics
 - [x] Azure adapter + `azurerm_linux_virtual_machine` (regex select, validated end-to-end) — second cloud proven
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**

--- a/pricegen/health.yaml
+++ b/pricegen/health.yaml
@@ -12,6 +12,7 @@ min_rows:
   aws_db_instance: 1000
   azurerm_linux_virtual_machine: 500
   google_compute_instance: 50
+  aws_rds_cluster_instance: 50
 
 # WARN if a recipe's row count moves more than this fraction vs the last publish.
 row_delta_fraction: 0.5

--- a/pricegen/providers/aws/recipes/aws_rds_cluster_instance.yaml
+++ b/pricegen/providers/aws/recipes/aws_rds_cluster_instance.yaml
@@ -1,0 +1,26 @@
+# Aurora -> aws_rds_cluster_instance (the cluster's compute; aws_rds_cluster is
+# the storage/cluster). Priced per instance-hour, deterministic (an instance is
+# always-on). Aurora MySQL and PostgreSQL price identically, so we match only
+# instance_class (engine omitted; the redundant per-engine SKUs dedup to one
+# row). We select STANDARD-mode pricing (`InstanceUsage:`, NOT
+# `InstanceUsageIOOptimized:`) — the common default; the I/O-Optimized mode is
+# set on the parent aws_rds_cluster (storage_type=aurora-iopt1), not visible on
+# the instance resource, so it's a natural follow-up. From the cached AmazonRDS
+# offer. Serverless v2 (db.serverless, ACU-priced) is out of scope here.
+resource_type: aws_rds_cluster_instance
+service: AmazonRDS
+
+components:
+  - product_family: "^Database Instance$"
+    service_class: instance
+    select:
+      databaseEngine: { regex: "^Aurora" }
+      usagetype: { regex: "InstanceUsage:" }
+      # RDS reports "No license required" (lowercase l); the shared canonical uses
+      # EC2's "No License required" (capital L) — AWS is inconsistent across
+      # services — so override to match, exactly as aws_db_instance does.
+      licenseModel: No license required
+    match:
+      instance_class: { attr: instanceType }
+    price: { type: t, unit: Hrs }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -97,3 +97,7 @@ recipes:
     recipe: aws_efs_file_system
     offer: .cache/efs-us-east-1.json
     fetch: { service_code: AmazonEFS, region: us-east-1 }
+  - provider: aws
+    recipe: aws_rds_cluster_instance
+    offer: .cache/rds-us-east-1.json
+    fetch: { service_code: AmazonRDS, region: us-east-1 }

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -330,5 +330,12 @@
       "typical": 100,
       "high": 50000
     }
+  },
+  {
+    "description": "Aurora cluster instance hours (always-on)",
+    "match_query": "type = aws_rds_cluster_instance and service_class = instance",
+    "usage": {
+      "time": 730
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -273,8 +273,8 @@ def test_default_usage_catalogue_loads():
     # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933) +
     # NAT gateway hours+data (#966) + Elastic IP hours (#973) + load balancer
     # hours+LCU (#977) + classic ELB hours+data (#979) + EBS snapshot storage
-    # (#981) + EFS storage (#983).
-    assert len(entries) == 30
+    # (#981) + EFS storage (#983) + Aurora cluster instance hours (#985).
+    assert len(entries) == 31
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -96,6 +96,10 @@ _ROWS = [
     "AmazonEC2,Storage Snapshot,type=aws_ebs_snapshot,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&start_usage_amount=0&end_usage_amount=Inf,0.0500000000,d,USD",
     # EFS — usage-driven General Purpose stored size at $0.30/GB-month.
     "AmazonEFS,Storage,type=aws_efs_file_system,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&start_usage_amount=0&end_usage_amount=Inf,0.3000000000,d,USD",
+    # Aurora cluster instance (aws_rds_cluster_instance) — deterministic per-hour,
+    # standard mode. r6g.large $0.26 (MySQL/PostgreSQL price identically -> one
+    # deduped row keyed on instance_class only).
+    "AmazonRDS,Database Instance,type=aws_rds_cluster_instance&values.instance_class=db.r6g.large,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=instance&start_usage_amount=0&end_usage_amount=Inf,0.2600000000,t,USD",
 ]
 
 
@@ -701,6 +705,31 @@ def test_efs_usage_driven_storage_band():
     data = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["stored size"]
     assert data["cost_typical"] == pytest.approx(100 * 0.30, abs=0.01)
     assert data["cost_high"] == pytest.approx(50000 * 0.30, abs=0.01)
+
+
+def test_aurora_cluster_instance_prices_deterministically():
+    """aws_rds_cluster_instance (Aurora): deterministic per-hour, standard mode.
+    Matched on instance_class only (engine omitted — MySQL/PostgreSQL price the
+    same and dedup to one row). No usage band. (#893/#985)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_rds_cluster_instance.writer",
+                "type": "aws_rds_cluster_instance",
+                "name": "writer",
+                "mode": "managed",
+                "values": {
+                    "region": "us-east-1",
+                    "instance_class": "db.r6g.large",
+                    "engine": "aurora-postgresql",
+                },
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    assert r["monthly"]["max"] == pytest.approx(730 * 0.26, abs=0.01)  # $189.80
+    assert "usage_assumptions" not in r  # deterministic
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

Adds `aws_rds_cluster_instance` (Aurora compute) — the companion to `aws_db_instance`, which deliberately excludes Aurora (in Terraform, Aurora instances are `aws_rds_cluster_instance`, not `aws_db_instance`).

Priced per instance-hour, **deterministic** (always-on). **Standard-mode** pricing (`InstanceUsage:`, not `InstanceUsageIOOptimized:` — I/O-Optimized is set on the parent `aws_rds_cluster`, not visible on the instance; a follow-up). Aurora MySQL and PostgreSQL price identically, so we match only `instance_class` and let the redundant per-engine SKUs dedup → **90 instance classes**.

## Snag found + fixed (why the drift floor)

The select initially generated **0 rows**: RDS reports `licenseModel="No license required"` (lowercase l), but the shared canonical uses EC2's `"No License required"` (capital L) — **AWS is inconsistent across services**. The select now overrides it, exactly as `aws_db_instance` does. Added a `min_rows: 50` drift floor to `health.yaml` so a future select break (like this one) is caught by the scheduled guardrail instead of silently publishing an empty recipe.

## Changes

- **recipe `aws_rds_cluster_instance`** + manifest (cached AmazonRDS offer) + usage entry (730, no band).
- **health.yaml** — `min_rows: 50` drift floor.
- **contract test** — db.r6g.large $189.80/mo, deterministic (no usage band).

## Verification

- `python3 -m pricegen.generate --recipe aws_rds_cluster_instance` → 90 rows, price range $0.041–$29.95/hr.
- E2E probe: db.r6g.large = **$189.80/mo** (730 × $0.26).
- `./scripts/test.sh python -- -k "cost or usage or pricer or catalogue"` — 132 pass (catalogue 30→31 + new test). `pytest pricegen/tests/` — 42 pass.

Part of #893. Closes #985.
