### PR TITLE
feat(pricegen): KMS + Secrets Manager (flat fee) + SNS topic (#987)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -133,6 +133,6 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)
-- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB, hour + LCU band), `aws_elb` (classic, hour + data band), `aws_ebs_snapshot` (storage band), `aws_efs_file_system` (storage band) (deterministic + usage-driven, with low/typical/high cost bands)
-- [ ] More AWS breadth (Route53, ElastiCache, SNS, …) + all-regions + a row-parity CI gate
+- [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB), `aws_elb`, `aws_ebs_snapshot`, `aws_efs_file_system`, `aws_kms_key` ($1 flat), `aws_secretsmanager_secret` ($0.40 flat), `aws_sns_topic` (publishes band) (deterministic + usage-driven, with low/typical/high cost bands)
+- [ ] More AWS breadth (Route53 + CloudFront [global offers], ElastiCache [needs node-count engine feature], CloudWatch) + all-regions + a row-parity CI gate
 - [ ] Broaden GCP families/regions; Azure managed disks / Windows

--- a/pricegen/providers/aws/recipes/aws_kms_key.yaml
+++ b/pricegen/providers/aws/recipes/aws_kms_key.yaml
@@ -1,0 +1,13 @@
+# KMS -> aws_kms_key. A customer-managed key is a flat $1/month per key
+# (Encryption Key family). Deterministic — one key per resource, no usage guess.
+# Modeled as a count charge (price_type `o`) with a fixed usage of 1 key. Request
+# charges ($0.03/10k) are a separate usage concern and out of scope here.
+resource_type: aws_kms_key
+service: AWSKMS
+
+components:
+  - product_family: "^Encryption Key$"
+    service_class: keys
+    select: { usagetype: { regex: "KMS-Keys$" } }
+    price: { type: o, unit: Keys }
+    tier: usage

--- a/pricegen/providers/aws/recipes/aws_secretsmanager_secret.yaml
+++ b/pricegen/providers/aws/recipes/aws_secretsmanager_secret.yaml
@@ -1,0 +1,13 @@
+# Secrets Manager -> aws_secretsmanager_secret. A flat $0.40/month per secret
+# (Secret family). Deterministic — one secret per resource. Modeled as a count
+# charge (price_type `o`) with a fixed usage of 1 secret. API-request charges
+# ($0.05/10k) are a separate usage concern and out of scope here.
+resource_type: aws_secretsmanager_secret
+service: AWSSecretsManager
+
+components:
+  - product_family: "^Secret$"
+    service_class: secrets
+    select: { usagetype: { regex: "Secrets$" } }
+    price: { type: o, unit: Secrets }
+    tier: usage

--- a/pricegen/providers/aws/recipes/aws_sns_topic.yaml
+++ b/pricegen/providers/aws/recipes/aws_sns_topic.yaml
@@ -1,0 +1,20 @@
+# SNS -> aws_sns_topic. Per-publish request pricing ($0.50 per million,
+# usage-driven so it carries a band). The first 1M requests/month are an
+# account-wide free tier ($0 SKU dropped by the adapter); consistent with our
+# Lambda/DynamoDB treatment we do NOT apply that free tier per-topic
+# (tier_bounds start:0 bills from the first request). Message DELIVERY charges
+# (HTTP/email/SMS — SMS especially varies by destination) are a separate concern
+# and out of scope here. From the small AmazonSNS offer.
+resource_type: aws_sns_topic
+service: AmazonSNS
+
+components:
+  - product_family: "^API Request$"
+    service_class: requests
+    select: { group: SNS-Requests-Tier1 }
+    price: { type: o, unit: Requests }
+    tier: usage
+    tier_bounds:
+      - when: { group: SNS-Requests-Tier1 }
+        start: "0"
+        end: Inf

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -101,3 +101,15 @@ recipes:
     recipe: aws_rds_cluster_instance
     offer: .cache/rds-us-east-1.json
     fetch: { service_code: AmazonRDS, region: us-east-1 }
+  - provider: aws
+    recipe: aws_kms_key
+    offer: .cache/kms-us-east-1.json
+    fetch: { service_code: awskms, region: us-east-1 }
+  - provider: aws
+    recipe: aws_secretsmanager_secret
+    offer: .cache/secretsmanager-us-east-1.json
+    fetch: { service_code: AWSSecretsManager, region: us-east-1 }
+  - provider: aws
+    recipe: aws_sns_topic
+    offer: .cache/sns-us-east-1.json
+    fetch: { service_code: AmazonSNS, region: us-east-1 }

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -337,5 +337,34 @@
     "usage": {
       "time": 730
     }
+  },
+  {
+    "description": "KMS customer-managed key",
+    "match_query": "type = aws_kms_key and service_class = keys",
+    "usage": {
+      "operations": 1
+    }
+  },
+  {
+    "description": "Secrets Manager secret",
+    "match_query": "type = aws_secretsmanager_secret and service_class = secrets",
+    "usage": {
+      "operations": 1
+    }
+  },
+  {
+    "description": "SNS publishes",
+    "match_query": "type = aws_sns_topic and service_class = requests",
+    "usage": {
+      "operations": 5000000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "publishes",
+      "unit": "requests/month",
+      "low": 100000,
+      "typical": 5000000,
+      "high": 1000000000
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -273,8 +273,9 @@ def test_default_usage_catalogue_loads():
     # io1/io2 (#928) + Azure Linux VM hours (#931) + GCP Compute hours (#933) +
     # NAT gateway hours+data (#966) + Elastic IP hours (#973) + load balancer
     # hours+LCU (#977) + classic ELB hours+data (#979) + EBS snapshot storage
-    # (#981) + EFS storage (#983) + Aurora cluster instance hours (#985).
-    assert len(entries) == 31
+    # (#981) + EFS storage (#983) + Aurora cluster instance hours (#985) +
+    # KMS key + Secrets Manager secret + SNS publishes (#987).
+    assert len(entries) == 34
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -100,6 +100,11 @@ _ROWS = [
     # standard mode. r6g.large $0.26 (MySQL/PostgreSQL price identically -> one
     # deduped row keyed on instance_class only).
     "AmazonRDS,Database Instance,type=aws_rds_cluster_instance&values.instance_class=db.r6g.large,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=instance&start_usage_amount=0&end_usage_amount=Inf,0.2600000000,t,USD",
+    # Flat-fee count charges (usage=1, deterministic): KMS key $1/mo, Secrets
+    # Manager secret $0.40/mo. SNS publishes $0.50/M (usage-driven band).
+    "AWSKMS,Encryption Key,type=aws_kms_key,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=keys&start_usage_amount=0&end_usage_amount=Inf,1.0000000000,o,USD",
+    "AWSSecretsManager,Secret,type=aws_secretsmanager_secret,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=secrets&start_usage_amount=0&end_usage_amount=Inf,0.4000000000,o,USD",
+    "AmazonSNS,API Request,type=aws_sns_topic,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&start_usage_amount=0&end_usage_amount=Inf,0.0000005000,o,USD",
 ]
 
 
@@ -730,6 +735,48 @@ def test_aurora_cluster_instance_prices_deterministically():
     r = d["resources"][0]
     assert r["monthly"]["max"] == pytest.approx(730 * 0.26, abs=0.01)  # $189.80
     assert "usage_assumptions" not in r  # deterministic
+
+
+def test_flat_fee_resources_price_deterministically():
+    """Flat monthly per-resource fees (KMS key $1, Secrets Manager secret $0.40)
+    price at usage=1 with no engine change and no usage band. (#893/#987)"""
+    for rtype, expected in [("aws_kms_key", 1.0), ("aws_secretsmanager_secret", 0.40)]:
+        plan = _plan(
+            [
+                {
+                    "address": f"{rtype}.x",
+                    "type": rtype,
+                    "name": "x",
+                    "mode": "managed",
+                    "values": {"region": "us-east-1"},
+                }
+            ]
+        )
+        d = estimate(plan, _sheet()).to_dict()
+        r = d["resources"][0]
+        assert r["monthly"]["max"] == pytest.approx(expected, abs=0.001), rtype
+        assert "usage_assumptions" not in r  # deterministic
+
+
+def test_sns_topic_usage_driven_publishes_band():
+    """aws_sns_topic: per-publish requests ($0.50/M), usage-driven band; the
+    account-wide 1M free tier is not applied per-topic. (#987)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_sns_topic.t",
+                "type": "aws_sns_topic",
+                "name": "t",
+                "mode": "managed",
+                "values": {"region": "us-east-1"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    assert r["monthly"]["max"] == pytest.approx(5_000_000 * 0.0000005, abs=0.01)  # $2.50
+    pub = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["publishes"]
+    assert pub["cost_high"] == pytest.approx(1_000_000_000 * 0.0000005, abs=0.5)  # $500
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

A bundle of flat-fee + per-request AWS service resources (bundled to save CI cycles as part of the comprehensive single-region coverage push):

- **`aws_kms_key`** — flat **$1/month** per customer-managed key. Deterministic.
- **`aws_secretsmanager_secret`** — flat **$0.40/month** per secret. Deterministic.
- **`aws_sns_topic`** — per-publish requests (**$0.50/million**), usage-driven with a band. The account-wide 1M free tier is not applied per-topic (consistent with Lambda/DynamoDB). Message *delivery* (SMS/email/HTTP) is a separate concern, out of scope.

## Key finding

**Flat monthly per-resource fees need no engine change** — they price as `price_type: o` (count) with a fixed usage of **1 unit** → cost = 1 × rate, deterministic, no band. This unlocks the whole flat-fee category (and later Route53, etc.).

## Verification

- Each recipe generated + probed E2E: KMS **$1.00**, Secrets **$0.40** (deterministic), SNS **$2.50/mo** typical (band **$0.05–$500**).
- `./scripts/test.sh python -- -k "cost or usage or pricer or catalogue"` — 134 pass (catalogue 31→34 + 2 new tests). `pytest pricegen/tests/` — 42 pass.

Part of #893. Closes #987.
