### PR TITLE
feat(pricegen): azurerm_windows_virtual_machine + azurerm_public_ip (#989)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -129,7 +129,7 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] AWS adapter + `aws_instance` (parity) + `aws_ebs_volume` (composite, exceptions)
 - [x] AWS RDS (`aws_db_instance`): instance + storage + io1/io2 provisioned IOPS, all validated end-to-end; Aurora (`aws_rds_cluster_instance`) instance hours (standard mode, 90 classes)
 - [x] End-to-end pricing validation (real consumer engine, not just row-parity) + generator drift diagnostics
-- [x] Azure adapter + `azurerm_linux_virtual_machine` (regex select, validated end-to-end) — second cloud proven
+- [x] Azure adapter + `azurerm_linux_virtual_machine`, `azurerm_windows_virtual_machine` (Windows-licensed meter), `azurerm_public_ip` (Standard Static hourly) — validated end-to-end
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)

--- a/pricegen/providers/azure/recipes/azurerm_public_ip.yaml
+++ b/pricegen/providers/azure/recipes/azurerm_public_ip.yaml
@@ -1,0 +1,15 @@
+# Azure Public IP -> azurerm_public_ip. Priced per hour. We price the modern
+# default — a Standard Static IPv4 public IP ($0.005/hr, deterministic) — which
+# is the default sku in azurerm 4.x. Basic (retiring) and Global are distinct
+# meters, follow-ups. From the Virtual Network offer.
+resource_type: azurerm_public_ip
+service: Virtual Network
+
+components:
+  - product_family: "^Virtual Network$"
+    service_class: hours
+    select:
+      productName: "IP Addresses"
+      meterName: "Standard IPv4 Static Public IP"
+    price: { type: t, unit: "1 Hour" }
+    tier: usage

--- a/pricegen/providers/azure/recipes/azurerm_windows_virtual_machine.yaml
+++ b/pricegen/providers/azure/recipes/azurerm_windows_virtual_machine.yaml
@@ -1,0 +1,22 @@
+# Azure Windows VM -> azurerm_windows_virtual_machine (on-demand / Consumption).
+#
+# Same base compute as the Linux recipe, but the Windows-licensed meter — Azure
+# tags the Windows image premium with "Windows" in productName (e.g. "Virtual
+# Machines Dsv5 Series Windows"), so here we SELECT it (the Linux recipe excludes
+# it). Spot / Low Priority variants (in skuName) are excluded. `size` is
+# armSkuName verbatim. From the same Virtual Machines offer as the Linux VM.
+resource_type: azurerm_windows_virtual_machine
+service: Virtual Machines
+
+components:
+  - product_family: "^Virtual Machines$"
+    service_class: instance
+    select:
+      productName: { regex: "Windows" }
+      skuName: { regex: "Spot|Low Priority", negate: true }
+    match:
+      size: { attr: armSkuName }
+    pricing:
+      os: windows
+    price: { type: t, unit: "1 Hour" }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -16,6 +16,14 @@ recipes:
     recipe: azurerm_linux_virtual_machine
     offer: .cache/azure-vm-eastus.json
     fetch: { service_name: "Virtual Machines", region: eastus }
+  - provider: azure
+    recipe: azurerm_windows_virtual_machine
+    offer: .cache/azure-vm-eastus.json
+    fetch: { service_name: "Virtual Machines", region: eastus }
+  - provider: azure
+    recipe: azurerm_public_ip
+    offer: .cache/azure-vnet-eastus.json
+    fetch: { service_name: "Virtual Network", region: eastus }
   - provider: gcp
     recipe: google_compute_instance
     offer: .cache/gcp-compute.json

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -366,5 +366,19 @@
       "typical": 5000000,
       "high": 1000000000
     }
+  },
+  {
+    "description": "Azure Windows VM hours (always-on)",
+    "match_query": "type = azurerm_windows_virtual_machine and service_class = instance",
+    "usage": {
+      "time": 730
+    }
+  },
+  {
+    "description": "Azure public IP hours (always-on)",
+    "match_query": "type = azurerm_public_ip and service_class = hours",
+    "usage": {
+      "time": 730
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -274,8 +274,9 @@ def test_default_usage_catalogue_loads():
     # NAT gateway hours+data (#966) + Elastic IP hours (#973) + load balancer
     # hours+LCU (#977) + classic ELB hours+data (#979) + EBS snapshot storage
     # (#981) + EFS storage (#983) + Aurora cluster instance hours (#985) +
-    # KMS key + Secrets Manager secret + SNS publishes (#987).
-    assert len(entries) == 34
+    # KMS key + Secrets Manager secret + SNS publishes (#987) + Azure Windows VM
+    # + Azure public IP (#989).
+    assert len(entries) == 36
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -46,6 +46,10 @@ _ROWS = [
     # Azure Linux VM (#931) — proves the second cloud prices through the same
     # engine. size = armSkuName; region resolved from the resource's `location`.
     "Virtual Machines,Virtual Machines,type=azurerm_linux_virtual_machine&values.size=Standard_D2s_v5,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=instance&os=linux&start_usage_amount=0&end_usage_amount=Inf,0.096,t,USD",
+    # Azure Windows VM (#989) — the Windows-licensed meter ($0.188 vs Linux
+    # $0.096). Azure public IP — Standard Static $0.005/hr.
+    "Virtual Machines,Virtual Machines,type=azurerm_windows_virtual_machine&values.size=Standard_D2s_v5,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=instance&os=windows&start_usage_amount=0&end_usage_amount=Inf,0.188,t,USD",
+    "Virtual Network,Virtual Network,type=azurerm_public_ip,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.005,t,USD",
     # GCP compute (#933) — the computed kind: this row is pre-assembled from the
     # per-vCPU-core + per-GiB-RAM rates (n2-standard-4 = 4*core + 16*ram). Region
     # is derived from the resource's `zone`.
@@ -777,6 +781,35 @@ def test_sns_topic_usage_driven_publishes_band():
     assert r["monthly"]["max"] == pytest.approx(5_000_000 * 0.0000005, abs=0.01)  # $2.50
     pub = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["publishes"]
     assert pub["cost_high"] == pytest.approx(1_000_000_000 * 0.0000005, abs=0.5)  # $500
+
+
+def test_azure_windows_vm_and_public_ip():
+    """Azure Windows VM prices at the Windows-licensed meter (region from
+    `location`); a Standard public IP is a deterministic hourly charge. (#989)"""
+    plan = _plan(
+        [
+            {
+                "address": "azurerm_windows_virtual_machine.win",
+                "type": "azurerm_windows_virtual_machine",
+                "name": "win",
+                "mode": "managed",
+                "values": {"location": "eastus", "size": "Standard_D2s_v5"},
+            },
+            {
+                "address": "azurerm_public_ip.ip",
+                "type": "azurerm_public_ip",
+                "name": "ip",
+                "mode": "managed",
+                "values": {"location": "eastus"},
+            },
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    by = {r["address"]: r for r in d["resources"]}
+    assert by["azurerm_windows_virtual_machine.win"]["monthly"]["max"] == pytest.approx(
+        730 * 0.188, abs=0.01
+    )
+    assert by["azurerm_public_ip.ip"]["monthly"]["max"] == pytest.approx(730 * 0.005, abs=0.01)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

Extends **Azure** coverage beyond Linux VM (part of the comprehensive single-region coverage push):

- **`azurerm_windows_virtual_machine`** — same base compute as the Linux recipe but the **Windows-licensed meter** (Azure tags the license premium with "Windows" in productName — $0.188/hr vs Linux $0.096 for D2s_v5). 1561 sizes.
- **`azurerm_public_ip`** — the modern default, a **Standard Static IPv4** public IP ($0.005/hr, deterministic). Basic (retiring) and Global are follow-ups.

## Verification

- Windows D2s_v5 is a unique row (no ambiguity); E2E: **$137.24/mo**. Public IP **$3.65/mo**.
- `./scripts/test.sh python -- -k "cost or usage or pricer or catalogue"` — 135 pass (catalogue 34→36 + new test). `pytest pricegen/tests/` — 42 pass.

`azurerm_managed_disk` / `azurerm_storage_account` are deferred — they need proper size→tier / replication-type handling (a distinct effort, not a clean drop-in).

Part of #893. Closes #989.
