### PR TITLE
feat(pricegen): google_compute_disk + google_compute_address (+ GCP $0-tier skip) (#991)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -130,7 +130,7 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] AWS RDS (`aws_db_instance`): instance + storage + io1/io2 provisioned IOPS, all validated end-to-end; Aurora (`aws_rds_cluster_instance`) instance hours (standard mode, 90 classes)
 - [x] End-to-end pricing validation (real consumer engine, not just row-parity) + generator drift diagnostics
 - [x] Azure adapter + `azurerm_linux_virtual_machine`, `azurerm_windows_virtual_machine` (Windows-licensed meter), `azurerm_public_ip` (Standard Static hourly) — validated end-to-end
-- [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region, validated end-to-end) — **all three clouds proven**
+- [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region); `google_compute_disk` (pd-standard/balanced/ssd, per-GiB), `google_compute_address` (static IP hourly) — validated end-to-end. GCP adapter skips leading $0 tiers (unlocks pd-standard + IPs; bills the marginal rate from 0)
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)
 - [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB), `aws_elb`, `aws_ebs_snapshot`, `aws_efs_file_system`, `aws_kms_key` ($1 flat), `aws_secretsmanager_secret` ($0.40 flat), `aws_sns_topic` (publishes band) (deterministic + usage-driven, with low/typical/high cost bands)

--- a/pricegen/providers/gcp/adapter.py
+++ b/pricegen/providers/gcp/adapter.py
@@ -37,12 +37,19 @@ def _rate(sku: dict) -> str | None:
     if not infos:
         return None
     tiers = infos[0].get("pricingExpression", {}).get("tieredRates") or []
-    if not tiers:
-        return None
-    up = tiers[0].get("unitPrice", {})
-    units = int(up.get("units", "0") or 0)
-    nanos = up.get("nanos", 0)
-    return f"{units + nanos / 1e9:.10f}"
+    # Take the first tier with a NON-ZERO unit price. Many GCP SKUs lead with a
+    # $0 tier that encodes an always-free allotment (e.g. pd-standard's first
+    # 30 GiB, a static IP's first hour) before the real marginal rate kicks in.
+    # We bill the marginal rate from unit 0 — i.e. we do NOT apply the
+    # account-wide free tier per-resource, exactly as we drop AWS/Azure free
+    # tiers. An all-zero SKU returns None (skipped, like the AWS $0-skip). This
+    # leaves single-tier SKUs (compute Core/Ram, SSD/Balanced PD) unchanged.
+    for t in tiers:
+        up = t.get("unitPrice", {})
+        val = int(up.get("units", "0") or 0) + up.get("nanos", 0) / 1e9
+        if val > 0:
+            return f"{val:.10f}"
+    return None
 
 
 def iter_units(offer: dict, *, term: str = "OnDemand"):

--- a/pricegen/providers/gcp/recipes/google_compute_address.yaml
+++ b/pricegen/providers/gcp/recipes/google_compute_address.yaml
@@ -1,0 +1,13 @@
+# GCP static IP -> google_compute_address. A reserved static external IPv4 is
+# $0.01/hr (Static Ip Charge). Deterministic. (An in-use external IP on a
+# running VM is billed under a different, near-free meter; we price the reserved
+# static-IP rate, the clearest google_compute_address cost.)
+resource_type: google_compute_address
+service: Compute Engine
+
+components:
+  - product_family: "^Static Ip Charge$"
+    service_class: hours
+    pricing: { region: { attr: region } }
+    price: { type: t, unit: h }
+    tier: usage

--- a/pricegen/providers/gcp/recipes/google_compute_disk.yaml
+++ b/pricegen/providers/gcp/recipes/google_compute_disk.yaml
@@ -1,0 +1,29 @@
+# GCP persistent disk -> google_compute_disk. Priced per GiB-month by disk type,
+# deterministic (size is a plan attribute). Three common types, each a distinct
+# Cloud Billing SKU description: pd-standard ($0.04), pd-balanced ($0.10),
+# pd-ssd ($0.17). We stamp the Terraform `type` (via const) to keep the rows
+# distinct and price with `a=values.size` (size GiB × per-GiB rate). Region is
+# emitted from the SKU's region attr; the consumer resolves google_compute_disk
+# region from its `zone`. pd-extreme / regional / hyperdisk are follow-ups.
+resource_type: google_compute_disk
+service: Compute Engine
+
+components:
+  - product_family: "^Storage PD Capacity$"
+    service_class: storage
+    match: { type: { const: pd-standard } }
+    pricing: { region: { attr: region } }
+    price: { type: "a=values.size", unit: GiBy.mo }
+    tier: usage
+  - product_family: "^Balanced PD Capacity$"
+    service_class: storage
+    match: { type: { const: pd-balanced } }
+    pricing: { region: { attr: region } }
+    price: { type: "a=values.size", unit: GiBy.mo }
+    tier: usage
+  - product_family: "^SSD backed PD Capacity$"
+    service_class: storage
+    match: { type: { const: pd-ssd } }
+    pricing: { region: { attr: region } }
+    price: { type: "a=values.size", unit: GiBy.mo }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -28,6 +28,14 @@ recipes:
     recipe: google_compute_instance
     offer: .cache/gcp-compute.json
     fetch: { service_id: "6F81-5844-456A" } # Compute Engine
+  - provider: gcp
+    recipe: google_compute_disk
+    offer: .cache/gcp-compute.json
+    fetch: { service_id: "6F81-5844-456A" } # Compute Engine
+  - provider: gcp
+    recipe: google_compute_address
+    offer: .cache/gcp-compute.json
+    fetch: { service_id: "6F81-5844-456A" } # Compute Engine
   - provider: aws
     recipe: aws_sqs_queue
     offer: .cache/sqs-us-east-1.json

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -380,5 +380,16 @@
     "usage": {
       "time": 730
     }
+  },
+  {
+    "description": "GCP persistent disk",
+    "match_query": "type = google_compute_disk and service_class = storage"
+  },
+  {
+    "description": "GCP static IP hours (reserved)",
+    "match_query": "type = google_compute_address and service_class = hours",
+    "usage": {
+      "time": 730
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -275,8 +275,8 @@ def test_default_usage_catalogue_loads():
     # hours+LCU (#977) + classic ELB hours+data (#979) + EBS snapshot storage
     # (#981) + EFS storage (#983) + Aurora cluster instance hours (#985) +
     # KMS key + Secrets Manager secret + SNS publishes (#987) + Azure Windows VM
-    # + Azure public IP (#989).
-    assert len(entries) == 36
+    # + Azure public IP (#989) + GCP persistent disk + GCP static IP (#991).
+    assert len(entries) == 38
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -54,6 +54,11 @@ _ROWS = [
     # per-vCPU-core + per-GiB-RAM rates (n2-standard-4 = 4*core + 16*ram). Region
     # is derived from the resource's `zone`.
     "Compute Engine,Compute Instance,type=google_compute_instance&values.machine_type=n2-standard-4,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=instance&start_usage_amount=0&end_usage_amount=Inf,0.1942360000,t,USD",
+    # GCP persistent disk (#991) — per GiB-month by type, priced a=values.size.
+    # pd-ssd $0.17, pd-standard $0.04. Static IP $0.01/hr.
+    "Compute Engine,SSD backed PD Capacity,type=google_compute_disk&values.type=pd-ssd,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=storage,0.1700000000,a=values.size,USD",
+    "Compute Engine,Storage PD Capacity,type=google_compute_disk&values.type=pd-standard,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=storage,0.0400000000,a=values.size,USD",
+    "Compute Engine,Static Ip Charge,type=google_compute_address,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0100000000,t,USD",
     # SQS — first request tier for a standard (fifo=false) and a FIFO queue. The
     # CORRECT mapping: FIFO is pricier ($0.50/M) than Standard ($0.40/M); oiq has
     # these inverted, so this row set deliberately does NOT match oiq.
@@ -810,6 +815,37 @@ def test_azure_windows_vm_and_public_ip():
         730 * 0.188, abs=0.01
     )
     assert by["azurerm_public_ip.ip"]["monthly"]["max"] == pytest.approx(730 * 0.005, abs=0.01)
+
+
+def test_gcp_disk_and_static_ip():
+    """GCP persistent disk prices by type at a=values.size (region from `zone`);
+    a static IP is a deterministic hourly reserved charge. (#991)"""
+    plan = _plan(
+        [
+            {
+                "address": "google_compute_disk.d",
+                "type": "google_compute_disk",
+                "name": "d",
+                "mode": "managed",
+                "values": {"zone": "us-central1-a", "type": "pd-ssd", "size": 100},
+            },
+            {
+                "address": "google_compute_address.ip",
+                "type": "google_compute_address",
+                "name": "ip",
+                "mode": "managed",
+                "values": {"region": "us-central1"},
+            },
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    by = {r["address"]: r for r in d["resources"]}
+    assert by["google_compute_disk.d"]["monthly"]["max"] == pytest.approx(
+        100 * 0.17, abs=0.01
+    )  # $17
+    assert by["google_compute_address.ip"]["monthly"]["max"] == pytest.approx(
+        730 * 0.01, abs=0.01
+    )  # $7.30
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
## What

Extends **GCP** coverage beyond compute instance (part of the comprehensive single-region coverage push):

- **`google_compute_disk`** — persistent disk per GiB-month by type: pd-standard $0.04, pd-balanced $0.10, pd-ssd $0.17. Deterministic (`a=values.size`). The SKU carries ~40 serviceRegions at uniform rates, so this is partially **multi-region for free**.
- **`google_compute_address`** — reserved static external IPv4 at $0.01/hr, deterministic.

## GCP adapter fix (unblocks these + future SKUs)

The adapter read only `tieredRates[0]`, which is **$0** for SKUs that lead with an always-free allotment (pd-standard's first 30 GiB, a static IP's first hour) — so pd-standard and IPs priced as free. It now **skips leading $0 tiers and takes the first real rate**, billing the marginal rate from unit 0 (does NOT apply the account-wide free tier per-resource — exactly as we drop AWS/Azure free tiers). An all-zero SKU is skipped, like the AWS $0-skip.

**Verified the computed compute recipe is unchanged** — n2-standard-4 still $0.194236/hr, all 42 pricegen tests pass.

## Verification

- E2E: pd-ssd 100 GB **$17/mo**, pd-standard 500 GB **$20/mo**, static IP **$7.30/mo**.
- `./scripts/test.sh python -- -k "cost or usage or pricer or catalogue"` — 136 pass (catalogue 36→38 + new test). `pytest pricegen/tests/` — 42 pass.

Part of #893. Closes #991.
