### PR TITLE
feat(pricegen): count-multiply engine feature + aws_elasticache_cluster (#995)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -134,5 +134,6 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)
 - [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB), `aws_elb`, `aws_ebs_snapshot`, `aws_efs_file_system`, `aws_kms_key` ($1 flat), `aws_secretsmanager_secret` ($0.40 flat), `aws_sns_topic` (publishes band), `aws_api_gateway_rest_api` + `aws_apigatewayv2_api` (tiered request bands) (deterministic + usage-driven, with low/typical/high cost bands)
-- [ ] More AWS breadth (Route53 + CloudFront [global offers], ElastiCache [needs node-count engine feature], CloudWatch) + all-regions + a row-parity CI gate
+- [x] Count-multiply engine feature (a component's cost × a resource attribute) + `aws_elasticache_cluster` (per-node × num_cache_nodes, by node_type + engine)
+- [ ] More AWS breadth (Route53 + CloudFront [global offers], Kinesis [count-multiply], CloudWatch) + all-regions + a row-parity CI gate
 - [ ] Broaden GCP families/regions; Azure managed disks / Windows

--- a/pricegen/health.yaml
+++ b/pricegen/health.yaml
@@ -13,6 +13,7 @@ min_rows:
   azurerm_linux_virtual_machine: 500
   google_compute_instance: 50
   aws_rds_cluster_instance: 50
+  aws_elasticache_cluster: 100
 
 # WARN if a recipe's row count moves more than this fraction vs the last publish.
 row_delta_fraction: 0.5

--- a/pricegen/providers/aws/recipes/aws_elasticache_cluster.yaml
+++ b/pricegen/providers/aws/recipes/aws_elasticache_cluster.yaml
@@ -1,0 +1,23 @@
+# ElastiCache -> aws_elasticache_cluster. Priced per cache-node-hour by
+# node_type. A cluster's cost scales with num_cache_nodes, so the paired usage
+# entry carries a `count` (× values.num_cache_nodes) — the count-multiply engine
+# feature. Redis/Memcached/Valkey price identically per node, so we match
+# node_type only and let the per-engine SKUs dedup. From the AmazonElastiCache
+# offer. Reserved nodes + data-tiering are follow-ups.
+resource_type: aws_elasticache_cluster
+service: AmazonElastiCache
+
+components:
+  - product_family: "^Cache Instance$"
+    service_class: nodes
+    # Exclude the "Extended Support" surcharge SKUs (for running EOL engine
+    # versions) — we price the base node rate.
+    select: { usagetype: { regex: "ExtendedSupport", negate: true } }
+    match:
+      node_type: { attr: instanceType }
+      # Engines price differently (Redis/Memcached $0.017 vs Valkey $0.0136 for
+      # t3.micro), so match the engine — map the product's cacheEngine to the
+      # Terraform `engine` value.
+      engine: { attr: cacheEngine, map: { Redis: redis, Memcached: memcached, Valkey: valkey } }
+    price: { type: t, unit: Hrs }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -137,3 +137,7 @@ recipes:
     recipe: aws_apigatewayv2_api
     offer: .cache/apigw-us-east-1.json
     fetch: { service_code: AmazonApiGateway, region: us-east-1 }
+  - provider: aws
+    recipe: aws_elasticache_cluster
+    offer: .cache/elasticache-us-east-1.json
+    fetch: { service_code: AmazonElastiCache, region: us-east-1 }

--- a/services/terrapod/services/cost/pricer.py
+++ b/services/terrapod/services/cost/pricer.py
@@ -14,7 +14,7 @@ filter of the upstream CLI is not needed by Terrapod and is omitted.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from terrapod.services.cost import usage as usage_mod
 from terrapod.services.cost.match_set import MatchSet
@@ -256,6 +256,27 @@ def _cost_band(
         return None
 
 
+def _count_factor(entry: Entry, resource_ms: MatchSet) -> float:
+    """Multiplier for a per-unit component whose quantity scales with a resource
+    attribute — ElastiCache node cost × ``num_cache_nodes``, Kinesis × ``shard_count``.
+    Reads the attribute named by the entry's ``count`` spec; defaults to 1 (the
+    single-unit case) when unset, absent, or unparseable, so nothing regresses."""
+    spec = entry.count
+    if not spec:
+        return 1.0
+    default = float(spec.get("default", 1) or 1)
+    attr = spec.get("attr")
+    if not attr:
+        return default
+    found = resource_ms.find_by_key(attr)
+    if found is None:
+        return default
+    try:
+        return max(1.0, float(found[1]))
+    except (ValueError, TypeError):
+        return default
+
+
 def _region_matches(product: Product, region: str | None) -> bool:
     """Keep region-agnostic products and region-specific products in ``region``.
 
@@ -317,11 +338,21 @@ def price(
                 # Pathological product/usage combo — treat this resource as
                 # unpriced rather than crashing the whole estimate.
                 continue
+            # Scale the whole component by its unit count (× num_cache_nodes,
+            # × shard_count, …). Factor 1 for the common single-unit case.
+            factor = _count_factor(entry, resource_ms)
+            if factor != 1.0:
+                group_pps = [
+                    replace(pp, price=Range(pp.price.min * factor, pp.price.max * factor))
+                    for pp in group_pps
+                ]
             for pp in group_pps:
                 priced_products.append(pp)
                 currency = pp.ccy
             if group_pps:
                 band = _cost_band(resource_ms, entry, group_products)
+                if band is not None and factor != 1.0:
+                    band = (band[0] * factor, band[1] * factor, band[2] * factor)
                 if band is not None and entry.bands:
                     dim = entry.bands.get("dimension")
                     if dim is not None:

--- a/services/terrapod/services/cost/usage.py
+++ b/services/terrapod/services/cost/usage.py
@@ -71,6 +71,13 @@ class Entry:
     # both unset. ``bands`` shape: {dimension, unit, low, typical, high}.
     assumption: bool = False
     bands: dict[str, Any] | None = None
+    # A per-unit component whose quantity scales with a resource attribute —
+    # e.g. an ElastiCache cluster's cost is per-NODE (× num_cache_nodes), a
+    # Kinesis stream's is per-SHARD (× shard_count). ``count`` names that
+    # attribute; the pricer multiplies this entry's component cost by it. Shape:
+    # {attr: "values.num_cache_nodes", default: 1}. Absent/unset ⇒ factor 1 (the
+    # common single-unit case), so existing entries are unchanged.
+    count: dict[str, Any] | None = None
 
     def with_usage(self, usage: Usage) -> Entry:
         return replace(self, usage=usage)
@@ -140,6 +147,7 @@ def _entry_from_obj(obj: dict[str, Any]) -> Entry:
         usage=_parse_usage(obj.get("usage")),
         assumption=bool(obj.get("assumption", False)),
         bands=obj.get("bands"),
+        count=obj.get("count"),
     )
 
 

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -421,5 +421,16 @@
       "typical": 10000000,
       "high": 1000000000
     }
+  },
+  {
+    "description": "ElastiCache cache nodes (always-on)",
+    "match_query": "type = aws_elasticache_cluster and service_class = nodes",
+    "usage": {
+      "time": 730
+    },
+    "count": {
+      "attr": "values.num_cache_nodes",
+      "default": 1
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -276,8 +276,8 @@ def test_default_usage_catalogue_loads():
     # (#981) + EFS storage (#983) + Aurora cluster instance hours (#985) +
     # KMS key + Secrets Manager secret + SNS publishes (#987) + Azure Windows VM
     # + Azure public IP (#989) + GCP persistent disk + GCP static IP (#991) +
-    # API Gateway REST + HTTP requests (#993).
-    assert len(entries) == 40
+    # API Gateway REST + HTTP requests (#993) + ElastiCache nodes (#995).
+    assert len(entries) == 41
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -117,6 +117,10 @@ _ROWS = [
     "AWSKMS,Encryption Key,type=aws_kms_key,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=keys&start_usage_amount=0&end_usage_amount=Inf,1.0000000000,o,USD",
     "AWSSecretsManager,Secret,type=aws_secretsmanager_secret,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=secrets&start_usage_amount=0&end_usage_amount=Inf,0.4000000000,o,USD",
     "AmazonSNS,API Request,type=aws_sns_topic,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&start_usage_amount=0&end_usage_amount=Inf,0.0000005000,o,USD",
+    # ElastiCache (#995) — per cache-node-hour by node_type + engine; cost scales
+    # with num_cache_nodes via the count-multiply feature. memcached t3.micro
+    # $0.017/hr.
+    "AmazonElastiCache,Cache Instance,type=aws_elasticache_cluster&values.node_type=cache.t3.micro&values.engine=memcached,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=nodes&start_usage_amount=0&end_usage_amount=Inf,0.0170000000,t,USD",
 ]
 
 
@@ -877,6 +881,72 @@ def test_api_gateway_rest_and_http_request_bands():
     # typical 10M requests: REST 10M*3.5e-6 = $35, HTTP 10M*1e-6 = $10.
     assert by["aws_api_gateway_rest_api.r"]["monthly"]["max"] == pytest.approx(35.0, abs=0.5)
     assert by["aws_apigatewayv2_api.h"]["monthly"]["max"] == pytest.approx(10.0, abs=0.5)
+
+
+def test_elasticache_cost_scales_with_num_cache_nodes():
+    """aws_elasticache_cluster prices per node-hour and the count-multiply
+    feature scales it by num_cache_nodes: 3 memcached t3.micro nodes =
+    3 * 730 * 0.017 = $37.23. A 1-node default matches the single-node cost. (#995)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_elasticache_cluster.multi",
+                "type": "aws_elasticache_cluster",
+                "name": "multi",
+                "mode": "managed",
+                "values": {
+                    "region": "us-east-1",
+                    "node_type": "cache.t3.micro",
+                    "engine": "memcached",
+                    "num_cache_nodes": 3,
+                },
+            },
+            {
+                "address": "aws_elasticache_cluster.one",
+                "type": "aws_elasticache_cluster",
+                "name": "one",
+                "mode": "managed",
+                "values": {
+                    "region": "us-east-1",
+                    "node_type": "cache.t3.micro",
+                    "engine": "memcached",
+                    "num_cache_nodes": 1,
+                },
+            },
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    by = {r["address"]: r for r in d["resources"]}
+    assert by["aws_elasticache_cluster.multi"]["monthly"]["max"] == pytest.approx(
+        3 * 730 * 0.017, abs=0.01
+    )
+    assert by["aws_elasticache_cluster.one"]["monthly"]["max"] == pytest.approx(
+        1 * 730 * 0.017, abs=0.01
+    )
+
+
+def test_count_multiply_defaults_to_one_when_attr_absent():
+    """The count-multiply falls back to 1 when the count attribute is absent from
+    the plan (a Redis cluster that omits num_cache_nodes) — no under/over-count,
+    no crash. (#995)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_elasticache_cluster.redis",
+                "type": "aws_elasticache_cluster",
+                "name": "redis",
+                "mode": "managed",
+                # no num_cache_nodes -> factor defaults to 1
+                "values": {
+                    "region": "us-east-1",
+                    "node_type": "cache.t3.micro",
+                    "engine": "memcached",
+                },
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(730 * 0.017, abs=0.01)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
Add a **count-multiply** engine feature — a component's cost scales by a resource attribute — and the first consumer, `aws_elasticache_cluster`.

## Engine feature

Some resources' cost is per-unit × a count attribute: an ElastiCache cluster is per **node** (× `num_cache_nodes`), a Kinesis stream is per **shard** (× `shard_count`), a VPC interface endpoint is per **AZ**. The pricer previously priced one unit only.

A usage entry may now carry `count: {attr: "values.num_cache_nodes", default: 1}`; the pricer multiplies that entry's component cost (and its cost band, if any) by the resolved attribute. Absent/unset/unparseable → factor 1, so nothing existing regresses (verified: all prior tests pass unchanged).

## First consumer

`aws_elasticache_cluster` — priced per cache-node-hour by `node_type` + `engine` (Redis/Memcached $0.017 vs Valkey $0.0136 for t3.micro differ, so engine is matched; Extended-Support surcharge SKUs excluded), scaled by `num_cache_nodes`. 333 rows; `min_rows: 100` drift floor added.

Verified E2E: memcached ×3 = $37.23, redis ×1 = $12.41, valkey ×2 = $19.86, and absent-num_cache_nodes → ×1.

Unlocks `aws_kinesis_stream` (× shard_count) and `aws_vpc_endpoint` (× AZ) next. Part of #893.
