### PR TITLE
feat(pricegen): AKS + storage account + Azure tiered-meter fix (#997)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -129,7 +129,7 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] AWS adapter + `aws_instance` (parity) + `aws_ebs_volume` (composite, exceptions)
 - [x] AWS RDS (`aws_db_instance`): instance + storage + io1/io2 provisioned IOPS, all validated end-to-end; Aurora (`aws_rds_cluster_instance`) instance hours (standard mode, 90 classes)
 - [x] End-to-end pricing validation (real consumer engine, not just row-parity) + generator drift diagnostics
-- [x] Azure adapter + `azurerm_linux_virtual_machine`, `azurerm_windows_virtual_machine` (Windows-licensed meter), `azurerm_public_ip` (Standard Static hourly) — validated end-to-end
+- [x] Azure adapter + `azurerm_linux_virtual_machine`, `azurerm_windows_virtual_machine` (Windows meter), `azurerm_public_ip`, `azurerm_kubernetes_cluster` (AKS Standard tier), `azurerm_storage_account` (Standard Hot, replication-matched, volume-tiered) — validated end-to-end. Azure adapter now bounds tiered meters (each tier ends at the next tier's start, not Inf)
 - [x] GCP computed engine + `google_compute_instance` (Σ vCPU-core + GiB-RAM, formulaic catalog, zone→region); `google_compute_disk` (pd-standard/balanced/ssd, per-GiB), `google_compute_address` (static IP hourly) — validated end-to-end. GCP adapter skips leading $0 tiers (unlocks pd-standard + IPs; bills the marginal rate from 0)
 - [x] Publish pipeline: `fetch_offers` (official APIs) → `publish` (combined gzipped-YAML sheet + drift manifest) → `drift` guardrail → scheduled workflow to a rolling GitHub Release
 - [x] Consumer reads the Terrapod YAML sheet (flip of `cost_estimation.prices_url` default deferred until coverage parity)

--- a/pricegen/providers/azure/adapter.py
+++ b/pricegen/providers/azure/adapter.py
@@ -38,6 +38,17 @@ def iter_units(offer: dict, *, term: str = "Consumption"):
     it's filtered by the recipe's canonical dimension (``type: Consumption``),
     not here — every priced item is yielded and the engine selects.
     """
+    # A tiered meter (e.g. blob "Data Stored": 0 / 50 TB / 500 TB) arrives as
+    # several Items sharing a meterId, differing only in tierMinimumUnits. The
+    # feed gives each tier's START but not its END, so we group by meter and set
+    # each tier's end to the next tier's start (the last is open-ended). Without
+    # this every tier would end at Inf and overlap, double-counting large usage.
+    # Keyed by (meterId, type, reservationTerm) so Consumption tiers never mix
+    # with Reservation ones. Single-tier meters (VMs, IPs, AKS) → one item per
+    # group → end "Inf", exactly as before.
+    from collections import defaultdict
+
+    groups: dict[tuple, list[dict]] = defaultdict(list)
     for item in offer.get("Items", []):
         usd = item.get("unitPrice")
         # A $0 retail price is a feed placeholder (e.g. not-yet-GA meters), not a
@@ -45,13 +56,28 @@ def iter_units(offer: dict, *, term: str = "Consumption"):
         # size's price. Mirrors the AWS adapter skipping items with no USD price.
         if usd is None or usd == 0:
             continue
-        # tierMinimumUnits is a float (0.0, 51200.0, …); the consumer parses tier
-        # bounds with int(), so normalize to an int-string ("0.0" would crash it).
-        begin = str(int(float(item.get("tierMinimumUnits", 0) or 0)))
-        price = Price(
-            usd=str(usd),
-            begin=begin,
-            end="Inf",
-            unit=item.get("unitOfMeasure", ""),
+        key = (
+            item.get("meterId") or item.get("meterName"),
+            item.get("type", ""),
+            item.get("reservationTerm", ""),
         )
-        yield Unit(item.get("serviceName", ""), item, [price])
+        groups[key].append(item)
+
+    for items in groups.values():
+        # tierMinimumUnits is a float (0.0, 51200.0, …); sort ascending so the
+        # end boundary is the next tier's start.
+        items.sort(key=lambda i: float(i.get("tierMinimumUnits", 0) or 0))
+        for idx, item in enumerate(items):
+            begin = int(float(item.get("tierMinimumUnits", 0) or 0))
+            end = (
+                "Inf"
+                if idx + 1 >= len(items)
+                else str(int(float(items[idx + 1].get("tierMinimumUnits", 0) or 0)))
+            )
+            price = Price(
+                usd=str(item["unitPrice"]),
+                begin=str(begin),
+                end=end,
+                unit=item.get("unitOfMeasure", ""),
+            )
+            yield Unit(item.get("serviceName", ""), item, [price])

--- a/pricegen/providers/azure/recipes/azurerm_kubernetes_cluster.yaml
+++ b/pricegen/providers/azure/recipes/azurerm_kubernetes_cluster.yaml
@@ -1,0 +1,14 @@
+# Azure AKS -> azurerm_kubernetes_cluster. The Standard tier carries a $0.10/hr
+# cluster uptime-SLA (control-plane) fee; the Free tier (the Terraform default)
+# is $0 and correctly stays unpriced. We match sku_tier=Standard. Node pools are
+# separate azurerm VMs (priced by the VM recipes). From the AKS offer.
+resource_type: azurerm_kubernetes_cluster
+service: Azure Kubernetes Service
+
+components:
+  - product_family: "^Azure Kubernetes Service$"
+    service_class: hours
+    select: { meterName: "Standard Uptime SLA" }
+    match: { sku_tier: { const: Standard } }
+    price: { type: t, unit: "1 Hour" }
+    tier: usage

--- a/pricegen/providers/azure/recipes/azurerm_storage_account.yaml
+++ b/pricegen/providers/azure/recipes/azurerm_storage_account.yaml
@@ -1,0 +1,22 @@
+# Azure Storage account -> azurerm_storage_account. Standard Hot blob storage
+# (StorageV2 / "General Block Blob v2"), per GB-month, usage-driven (size unknown
+# -> band). The rate depends on the redundancy, so we match
+# account_replication_type by extracting it from the skuName ("Hot LRS" ->
+# LRS, "Hot RA-GRS" -> RAGRS). Cool/Cold/Archive access tiers and Premium are
+# follow-ups. The offer's 50TB/450TB volume tiers flow through.
+resource_type: azurerm_storage_account
+service: Storage
+
+components:
+  - product_family: "^Storage$"
+    service_class: storage
+    select:
+      productName: "General Block Blob v2"
+      meterName: { regex: "^Hot .* Data Stored$" }
+    match:
+      account_replication_type:
+        attr: skuName
+        regex: "^Hot (\\S+)"
+        map: { LRS: LRS, ZRS: ZRS, GRS: GRS, GZRS: GZRS, "RA-GRS": RAGRS, "RA-GZRS": RAGZRS }
+    price: { type: d, unit: "1 GB/Month" }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -24,6 +24,14 @@ recipes:
     recipe: azurerm_public_ip
     offer: .cache/azure-vnet-eastus.json
     fetch: { service_name: "Virtual Network", region: eastus }
+  - provider: azure
+    recipe: azurerm_kubernetes_cluster
+    offer: .cache/azure-aks-eastus.json
+    fetch: { service_name: "Azure Kubernetes Service", region: eastus }
+  - provider: azure
+    recipe: azurerm_storage_account
+    offer: .cache/azure-storage-eastus.json
+    fetch: { service_name: "Storage", region: eastus }
   - provider: gcp
     recipe: google_compute_instance
     offer: .cache/gcp-compute.json

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -432,5 +432,27 @@
       "attr": "values.num_cache_nodes",
       "default": 1
     }
+  },
+  {
+    "description": "Azure AKS Standard tier hours",
+    "match_query": "type = azurerm_kubernetes_cluster and service_class = hours",
+    "usage": {
+      "time": 730
+    }
+  },
+  {
+    "description": "Azure storage account data stored",
+    "match_query": "type = azurerm_storage_account and service_class = storage",
+    "usage": {
+      "data": 5000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "stored data",
+      "unit": "GB-month",
+      "low": 100,
+      "typical": 5000,
+      "high": 500000
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -276,8 +276,9 @@ def test_default_usage_catalogue_loads():
     # (#981) + EFS storage (#983) + Aurora cluster instance hours (#985) +
     # KMS key + Secrets Manager secret + SNS publishes (#987) + Azure Windows VM
     # + Azure public IP (#989) + GCP persistent disk + GCP static IP (#991) +
-    # API Gateway REST + HTTP requests (#993) + ElastiCache nodes (#995).
-    assert len(entries) == 41
+    # API Gateway REST + HTTP requests (#993) + ElastiCache nodes (#995) +
+    # Azure AKS hours + Azure storage account data (#997).
+    assert len(entries) == 43
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -121,6 +121,12 @@ _ROWS = [
     # with num_cache_nodes via the count-multiply feature. memcached t3.micro
     # $0.017/hr.
     "AmazonElastiCache,Cache Instance,type=aws_elasticache_cluster&values.node_type=cache.t3.micro&values.engine=memcached,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=nodes&start_usage_amount=0&end_usage_amount=Inf,0.0170000000,t,USD",
+    # Azure AKS (#997) — Standard tier $0.10/hr (Free tier stays unpriced).
+    # Azure storage account — Standard Hot LRS, VOLUME-TIERED (proper tier ends
+    # from the adapter fix): $0.0208 to 50 TB, then $0.019968, then $0.019136.
+    "Azure Kubernetes Service,Azure Kubernetes Service,type=azurerm_kubernetes_cluster&values.sku_tier=Standard,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.1,t,USD",
+    "Storage,Storage,type=azurerm_storage_account&values.account_replication_type=LRS,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=storage&start_usage_amount=0&end_usage_amount=51200,0.0208,d,USD",
+    "Storage,Storage,type=azurerm_storage_account&values.account_replication_type=LRS,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=storage&start_usage_amount=51200&end_usage_amount=512000,0.019968,d,USD",
 ]
 
 
@@ -947,6 +953,62 @@ def test_count_multiply_defaults_to_one_when_attr_absent():
     )
     d = estimate(plan, _sheet()).to_dict()
     assert d["resources"][0]["monthly"]["max"] == pytest.approx(730 * 0.017, abs=0.01)
+
+
+def test_azure_aks_standard_and_free():
+    """Azure AKS: Standard tier is a $0.10/hr control-plane fee ($73/mo); the
+    Free tier (the Terraform default) stays unpriced ($0). (#997)"""
+    std = _plan(
+        [
+            {
+                "address": "azurerm_kubernetes_cluster.std",
+                "type": "azurerm_kubernetes_cluster",
+                "name": "std",
+                "mode": "managed",
+                "values": {"location": "eastus", "sku_tier": "Standard"},
+            }
+        ]
+    )
+    d = estimate(std, _sheet()).to_dict()
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(730 * 0.1, abs=0.01)
+    free = _plan(
+        [
+            {
+                "address": "azurerm_kubernetes_cluster.free",
+                "type": "azurerm_kubernetes_cluster",
+                "name": "free",
+                "mode": "managed",
+                "values": {"location": "eastus", "sku_tier": "Free"},
+            }
+        ]
+    )
+    d = estimate(free, _sheet()).to_dict()
+    assert d["resources"] == []  # Free tier is $0 -> unpriced
+
+
+def test_azure_storage_account_volume_tiered():
+    """Azure storage account (Standard Hot LRS) is usage-driven and VOLUME-TIERED
+    — the adapter fix gives each tier a proper end, so a >50 TB account is priced
+    across tiers rather than double-counted. 5 TB = 5000 * 0.0208 = $104. (#997)"""
+    plan = _plan(
+        [
+            {
+                "address": "azurerm_storage_account.sa",
+                "type": "azurerm_storage_account",
+                "name": "sa",
+                "mode": "managed",
+                "values": {"location": "eastus", "account_replication_type": "LRS"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    r = d["resources"][0]
+    assert r["monthly"]["max"] == pytest.approx(5000 * 0.0208, abs=0.01)  # typical 5 TB
+    band = {ua["dimension"]: ua for ua in r["usage_assumptions"]}["stored data"]
+    # high 500 TB is tiered: 51200*.0208 + 460800*.019968 + 12800(*... clipped) —
+    # the point is it is well BELOW the flat-rate 500000*.0208 = $10400 (no
+    # double-count) and above the second tier. Assert it applied the discount.
+    assert band["cost_high"] < 500000 * 0.0208
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
Bulk out **Azure** breadth with two common resources (+ an adapter fix for tiered meters):

- **`azurerm_kubernetes_cluster`** — the Standard tier carries a **$0.10/hr** cluster uptime-SLA (control-plane) fee; the Free tier (the Terraform default) is $0 and correctly stays unpriced. Node pools are separate VMs (priced by the VM recipes).
- **`azurerm_storage_account`** — Standard Hot blob storage (StorageV2), per GB-month, usage-driven with a band. The rate is matched by **`account_replication_type`** (LRS/ZRS/GRS/GZRS/RAGRS/RAGZRS, extracted from the skuName). **Volume-tiered** (50 TB / 500 TB breaks).

**Azure adapter fix:** the adapter set every tier's `end` to `Inf`, so a multi-tier meter's tiers overlapped and **double-counted** large usage. It now groups Items by meter (keyed `meterId`+`type`+`reservationTerm` so Consumption never mixes with Reservation), sorts by `tierMinimumUnits`, and sets each tier's end to the next tier's start. Single-tier meters (VMs, IPs, AKS) are unchanged (verified: Linux VM D2s_v5 still $0.096).

Verified E2E: AKS Standard $73/mo (Free unpriced); storage LRS 5 TB $104/mo, band $2.08–$10,027 (correctly tiered, not the $10,400 a flat rate would give).

`azurerm_managed_disk` (size→P/E/S tier) and Azure DB (`azurerm_mssql_database` / `azurerm_postgresql_flexible_server`, sku_name parse) remain — they need per-resource tier/sku modeling. Part of #893.
