### PR TITLE
feat(pricegen): aws_vpc_endpoint — interface hours + data band (#1005)

### DIFF
--- a/pricegen/providers/aws/recipes/aws_vpc_endpoint.yaml
+++ b/pricegen/providers/aws/recipes/aws_vpc_endpoint.yaml
@@ -1,0 +1,23 @@
+# VPC Interface endpoint -> aws_vpc_endpoint (vpc_endpoint_type=Interface /
+# PrivateLink). Two charges: the endpoint HOUR ($0.01/hr) and per-GB data
+# processed ($0.01/GB, tiered). Gateway endpoints (S3/DynamoDB) are free and
+# correctly stay unpriced (they don't match Interface). NOTE: the hourly charge
+# is per-AZ (per ENI); we price a single ENI as the baseline — a multi-subnet
+# endpoint costs proportionally more (per-AZ count is a follow-up). From the
+# AmazonVPC offer.
+resource_type: aws_vpc_endpoint
+service: AmazonVPC
+
+components:
+  - product_family: "^VpcEndpoint$"
+    service_class: hours
+    select: { usagetype: { regex: "VpcEndpoint-Hours$" }, endpointType: PrivateLink }
+    match: { vpc_endpoint_type: { const: Interface } }
+    price: { type: t, unit: Hrs }
+    tier: usage
+  - product_family: "^VpcEndpoint$"
+    service_class: data
+    select: { usagetype: { regex: "VpcEndpoint-Bytes$" }, endpointType: PrivateLink }
+    match: { vpc_endpoint_type: { const: Interface } }
+    price: { type: d, unit: GB }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -161,3 +161,7 @@ recipes:
     recipe: aws_kinesis_stream
     offer: .cache/kinesis-us-east-1.json
     fetch: { service_code: AmazonKinesis, region: us-east-1 }
+  - provider: aws
+    recipe: aws_vpc_endpoint
+    offer: .cache/vpc-us-east-1.json
+    fetch: { service_code: AmazonVPC, region: us-east-1 }

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -487,5 +487,27 @@
       "attr": "values.shard_count",
       "default": 1
     }
+  },
+  {
+    "description": "VPC interface endpoint hours (per ENI)",
+    "match_query": "type = aws_vpc_endpoint and service_class = hours",
+    "usage": {
+      "time": 730
+    }
+  },
+  {
+    "description": "VPC interface endpoint data",
+    "match_query": "type = aws_vpc_endpoint and service_class = data",
+    "usage": {
+      "data": 100
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "data processed",
+      "unit": "GB/month",
+      "low": 10,
+      "typical": 100,
+      "high": 100000
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -278,8 +278,9 @@ def test_default_usage_catalogue_loads():
     # + Azure public IP (#989) + GCP persistent disk + GCP static IP (#991) +
     # API Gateway REST + HTTP requests (#993) + ElastiCache nodes (#995) +
     # Azure AKS hours + Azure storage account data (#997) + GCS bucket storage
-    # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003).
-    assert len(entries) == 46
+    # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003) + VPC
+    # interface endpoint hours+data (#1005).
+    assert len(entries) == 48
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -133,6 +133,9 @@ _ROWS = [
     "Kubernetes Engine,Zonal Kubernetes Clusters,type=google_container_cluster,service_provider=gcp&purchase_option=on_demand&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.1000000000,t,USD",
     # Kinesis (#1003) — per shard-hour $0.015, scaled by shard_count (count-multiply).
     "AmazonKinesis,Kinesis Streams,type=aws_kinesis_stream,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=shards&start_usage_amount=0&end_usage_amount=Inf,0.0150000000,t,USD",
+    # VPC interface endpoint (#1005) — $0.01/hr per ENI + data processed band.
+    "AmazonVPC,VpcEndpoint,type=aws_vpc_endpoint&values.vpc_endpoint_type=Interface,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0100000000,t,USD",
+    "AmazonVPC,VpcEndpoint,type=aws_vpc_endpoint&values.vpc_endpoint_type=Interface,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=data&start_usage_amount=0&end_usage_amount=Inf,0.0100000000,d,USD",
 ]
 
 
@@ -1072,6 +1075,38 @@ def test_kinesis_stream_scales_with_shard_count():
     )
     d = estimate(plan, _sheet()).to_dict()
     assert d["resources"][0]["monthly"]["max"] == pytest.approx(4 * 730 * 0.015, abs=0.01)
+
+
+def test_vpc_interface_endpoint_hours_plus_data():
+    """aws_vpc_endpoint Interface: $0.01/hr per ENI + data band. A Gateway
+    endpoint (S3/DynamoDB) is free and stays unpriced. (#1005)"""
+    iface = _plan(
+        [
+            {
+                "address": "aws_vpc_endpoint.i",
+                "type": "aws_vpc_endpoint",
+                "name": "i",
+                "mode": "managed",
+                "values": {"region": "us-east-1", "vpc_endpoint_type": "Interface"},
+            }
+        ]
+    )
+    d = estimate(iface, _sheet()).to_dict()
+    # hours 730*0.01 + data typical 100*0.01 = 7.30 + 1.00 = 8.30
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(730 * 0.01 + 100 * 0.01, abs=0.01)
+    gw = _plan(
+        [
+            {
+                "address": "aws_vpc_endpoint.g",
+                "type": "aws_vpc_endpoint",
+                "name": "g",
+                "mode": "managed",
+                "values": {"region": "us-east-1", "vpc_endpoint_type": "Gateway"},
+            }
+        ]
+    )
+    d = estimate(gw, _sheet()).to_dict()
+    assert d["resources"] == []  # Gateway endpoints are free
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
VPC Interface endpoint $0.01/hr per ENI + data band; Gateway free/unpriced. Closes #1005. Part of #893.