### PR TITLE
feat(pricegen): aws_route53_zone + global-offer fetch (#1009)

### DIFF
--- a/pricegen/fetch_offers.py
+++ b/pricegen/fetch_offers.py
@@ -111,7 +111,13 @@ def fetch_aws(fetch: dict) -> dict:
     Small offers load whole. Large ones (a ``families`` filter in the fetch
     block, e.g. AmazonEC2) are stream-filtered with ijson to just the needed
     families + ``keep_attrs``, so RAM stays flat regardless of offer size."""
-    svc, region = fetch["service_code"], fetch["region"]
+    svc = fetch["service_code"]
+    # A few services (Route53, CloudFront) price globally — their products aren't
+    # region-split, so there is no region_index; the whole offer lives at
+    # current/index.json. `global: true` fetches that instead of a region.
+    if fetch.get("global"):
+        return _get_json(f"{_AWS_BULK}/offers/v1.0/aws/{svc}/current/index.json")
+    region = fetch["region"]
     idx = _get_json(f"{_AWS_BULK}/offers/v1.0/aws/{svc}/current/region_index.json")
     region_url = _AWS_BULK + idx["regions"][region]["currentVersionUrl"]
     families = fetch.get("families")

--- a/pricegen/providers/aws/recipes/aws_route53_zone.yaml
+++ b/pricegen/providers/aws/recipes/aws_route53_zone.yaml
@@ -1,0 +1,14 @@
+# Route53 hosted zone -> aws_route53_zone. A flat $0.50/month per hosted zone
+# (first 25 zones; $0.10 beyond, which per our convention we don't apply
+# per-resource). Global pricing (no region). Query charges are a separate usage
+# concern. Modeled as a flat count charge (usage=1). From the global Route53
+# offer (current/index.json).
+resource_type: aws_route53_zone
+service: AmazonRoute53
+
+components:
+  - product_family: "^DNS Zone$"
+    service_class: zones
+    select: { usagetype: { regex: "HostedZone$" } }
+    price: { type: o, unit: HostedZone }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -169,3 +169,7 @@ recipes:
     recipe: aws_vpc_endpoint
     offer: .cache/vpc-us-east-1.json
     fetch: { service_code: AmazonVPC, region: us-east-1 }
+  - provider: aws
+    recipe: aws_route53_zone
+    offer: .cache/route53.json
+    fetch: { service_code: AmazonRoute53, global: true }

--- a/services/terrapod/services/cost/pricer.py
+++ b/services/terrapod/services/cost/pricer.py
@@ -322,7 +322,9 @@ def _region_matches(product: Product, region: str | None) -> bool:
     their pricing match set are global (e.g. Route53) and always kept.
     """
     pr = product.pricing_match_set.find_by_key("region")
-    if pr is None:
+    # No region dim, or an EMPTY one, means the product prices globally (Route53,
+    # CloudFront — their AWS `regionCode` attribute is empty) — always keep it.
+    if pr is None or pr[1] == "":
         return True
     return region is None or pr[1] == region
 

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -519,5 +519,12 @@
     "size_tier": {
       "attr": "values.disk_size_gb"
     }
+  },
+  {
+    "description": "Route53 hosted zone",
+    "match_query": "type = aws_route53_zone and service_class = zones",
+    "usage": {
+      "operations": 1
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -280,8 +280,8 @@ def test_default_usage_catalogue_loads():
     # Azure AKS hours + Azure storage account data (#997) + GCS bucket storage
     # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003) + VPC
     # interface endpoint hours+data (#1005) + Azure managed disk per-size tier
-    # (#1007).
-    assert len(entries) == 49
+    # (#1007) + Route53 hosted zone (#1009).
+    assert len(entries) == 50
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -140,6 +140,8 @@ _ROWS = [
     # feature). Premium P10 (<=128 GiB) $19.71/mo; P15 (<=256) $38.01.
     "Storage,Storage,type=azurerm_managed_disk&values.storage_account_type=Premium_LRS,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=disk&tier_max_gb=128,19.71,o,USD",
     "Storage,Storage,type=azurerm_managed_disk&values.storage_account_type=Premium_LRS,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=disk&tier_max_gb=256,38.012142,o,USD",
+    # Route53 hosted zone (#1009) — flat $0.50/zone, GLOBAL (empty region= dim).
+    "AmazonRoute53,DNS Zone,type=aws_route53_zone,service_provider=aws&purchase_option=on_demand&region=&service_class=zones&start_usage_amount=0&end_usage_amount=25,0.5000000000,o,USD",
 ]
 
 
@@ -1135,6 +1137,25 @@ def test_azure_managed_disk_rounds_up_to_size_tier():
         )
         d = estimate(plan, _sheet()).to_dict()
         assert d["resources"][0]["monthly"]["max"] == pytest.approx(expected, abs=0.01), size
+
+
+def test_route53_zone_flat_global():
+    """aws_route53_zone is a flat $0.50/mo hosted-zone fee, priced GLOBALLY — the
+    row carries an empty region= dim, and a resource with any resolved region
+    still matches it. (#1009)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_route53_zone.z",
+                "type": "aws_route53_zone",
+                "name": "z",
+                "mode": "managed",
+                "values": {"name": "example.com"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(0.50, abs=0.001)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
feat(pricegen): aws_route53_zone + global-offer fetch + empty-region match (#1009)

Route53 hosted zone is a flat $0.50/mo, priced GLOBALLY (not region-split).
Three pieces:
- fetch_offers: a `global: true` AWS fetch pulls current/index.json (the
  whole non-region-split offer) instead of a region_index — for Route53 and
  (next) CloudFront.
- consumer: _region_matches now treats an EMPTY region= dim as global
  (Route53/CloudFront products carry an empty regionCode), so a resource with
  any resolved region still matches.
- recipe aws_route53_zone: flat count charge (usage=1) on the DNS Zone /
  HostedZone SKU. The $0.10 beyond-25-zones tier is not applied per-resource.

Verified E2E: $0.50/mo. Closes #1009. Part of #893.