### PR TITLE
feat(pricegen): aws_cloudfront_distribution — US data transfer band (#1011)

### DIFF
--- a/pricegen/providers/aws/recipes/aws_cloudfront_distribution.yaml
+++ b/pricegen/providers/aws/recipes/aws_cloudfront_distribution.yaml
@@ -1,0 +1,20 @@
+# CloudFront -> aws_cloudfront_distribution. The dominant cost is data transfer
+# out to viewers, priced by viewer GEOGRAPHY (US/EU/AP/AU/…) and tiered by
+# volume. Viewer geography is unknowable from the plan, so we price the US/NA
+# tier (the common default) as a usage-driven band; the volume tiers (first
+# 10 TB $0.085/GB, then cheaper) flow through. Per-region egress + request
+# charges are follow-ups. Global pricing (empty region=). From the global
+# CloudFront offer.
+resource_type: aws_cloudfront_distribution
+service: AmazonCloudFront
+
+components:
+  - product_family: "^Data Transfer$"
+    service_class: data
+    select: { usagetype: { regex: "US-DataTransfer-Out-Bytes$" } }
+    # CloudFront has no `regionCode` attr (it's global; the default
+    # region={attr: regionCode} resolves to absent and drops the row). Override
+    # to an empty region so it prices globally (the empty-region match).
+    pricing: { region: { const: "" } }
+    price: { type: d, unit: GB }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -173,3 +173,7 @@ recipes:
     recipe: aws_route53_zone
     offer: .cache/route53.json
     fetch: { service_code: AmazonRoute53, global: true }
+  - provider: aws
+    recipe: aws_cloudfront_distribution
+    offer: .cache/cloudfront.json
+    fetch: { service_code: AmazonCloudFront, global: true }

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -526,5 +526,20 @@
     "usage": {
       "operations": 1
     }
+  },
+  {
+    "description": "CloudFront data transfer out (US tier)",
+    "match_query": "type = aws_cloudfront_distribution and service_class = data",
+    "usage": {
+      "data": 5000
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "data transfer out",
+      "unit": "GB/month",
+      "low": 100,
+      "typical": 5000,
+      "high": 1000000
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -280,8 +280,8 @@ def test_default_usage_catalogue_loads():
     # Azure AKS hours + Azure storage account data (#997) + GCS bucket storage
     # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003) + VPC
     # interface endpoint hours+data (#1005) + Azure managed disk per-size tier
-    # (#1007) + Route53 hosted zone (#1009).
-    assert len(entries) == 50
+    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011).
+    assert len(entries) == 51
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -142,6 +142,10 @@ _ROWS = [
     "Storage,Storage,type=azurerm_managed_disk&values.storage_account_type=Premium_LRS,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=disk&tier_max_gb=256,38.012142,o,USD",
     # Route53 hosted zone (#1009) — flat $0.50/zone, GLOBAL (empty region= dim).
     "AmazonRoute53,DNS Zone,type=aws_route53_zone,service_provider=aws&purchase_option=on_demand&region=&service_class=zones&start_usage_amount=0&end_usage_amount=25,0.5000000000,o,USD",
+    # CloudFront (#1011) — US-tier data transfer out, tiered ($0.085/GB first
+    # 10 TB), global (empty region), usage-driven band.
+    "AmazonCloudFront,Data Transfer,type=aws_cloudfront_distribution,service_provider=aws&purchase_option=on_demand&region=&service_class=data&start_usage_amount=0&end_usage_amount=10240,0.0850000000,d,USD",
+    "AmazonCloudFront,Data Transfer,type=aws_cloudfront_distribution,service_provider=aws&purchase_option=on_demand&region=&service_class=data&start_usage_amount=10240&end_usage_amount=51200,0.0800000000,d,USD",
 ]
 
 
@@ -1156,6 +1160,25 @@ def test_route53_zone_flat_global():
     )
     d = estimate(plan, _sheet()).to_dict()
     assert d["resources"][0]["monthly"]["max"] == pytest.approx(0.50, abs=0.001)
+
+
+def test_cloudfront_us_data_transfer_band():
+    """aws_cloudfront_distribution prices US-tier data transfer out (tiered) as a
+    usage band; it's global (empty region). 5 TB in the first tier = 5000 *
+    0.085 = $425. (#1011)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_cloudfront_distribution.d",
+                "type": "aws_cloudfront_distribution",
+                "name": "d",
+                "mode": "managed",
+                "values": {},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(5000 * 0.085, abs=0.01)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
CloudFront US-tier data transfer out band (global). Closes #1011. Part of #893.