### PR TITLE
feat(pricegen): aws_ecr_repository — image storage band (#1013)

### DIFF
--- a/pricegen/providers/aws/recipes/aws_ecr_repository.yaml
+++ b/pricegen/providers/aws/recipes/aws_ecr_repository.yaml
@@ -1,0 +1,12 @@
+# ECR -> aws_ecr_repository. Container image storage at $0.10/GB-month, usage-
+# driven (repo size unknown -> band). We match the standard TimedStorage SKU
+# (not the Archive tier). From the AmazonECR offer.
+resource_type: aws_ecr_repository
+service: AmazonECR
+
+components:
+  - product_family: "^EC2 Container Registry$"
+    service_class: storage
+    select: { usagetype: { regex: "TimedStorage-ByteHrs$" } }
+    price: { type: d, unit: GB-Mo }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -177,3 +177,7 @@ recipes:
     recipe: aws_cloudfront_distribution
     offer: .cache/cloudfront.json
     fetch: { service_code: AmazonCloudFront, global: true }
+  - provider: aws
+    recipe: aws_ecr_repository
+    offer: .cache/ecr-us-east-1.json
+    fetch: { service_code: AmazonECR, region: us-east-1 }

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -541,5 +541,20 @@
       "typical": 5000,
       "high": 1000000
     }
+  },
+  {
+    "description": "ECR image storage",
+    "match_query": "type = aws_ecr_repository and service_class = storage",
+    "usage": {
+      "data": 50
+    },
+    "assumption": true,
+    "bands": {
+      "dimension": "stored images",
+      "unit": "GB-month",
+      "low": 1,
+      "typical": 50,
+      "high": 5000
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -280,8 +280,8 @@ def test_default_usage_catalogue_loads():
     # Azure AKS hours + Azure storage account data (#997) + GCS bucket storage
     # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003) + VPC
     # interface endpoint hours+data (#1005) + Azure managed disk per-size tier
-    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011).
-    assert len(entries) == 51
+    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013).
+    assert len(entries) == 52
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -146,6 +146,8 @@ _ROWS = [
     # 10 TB), global (empty region), usage-driven band.
     "AmazonCloudFront,Data Transfer,type=aws_cloudfront_distribution,service_provider=aws&purchase_option=on_demand&region=&service_class=data&start_usage_amount=0&end_usage_amount=10240,0.0850000000,d,USD",
     "AmazonCloudFront,Data Transfer,type=aws_cloudfront_distribution,service_provider=aws&purchase_option=on_demand&region=&service_class=data&start_usage_amount=10240&end_usage_amount=51200,0.0800000000,d,USD",
+    # ECR (#1013) — image storage $0.10/GB-mo (band).
+    "AmazonECR,EC2 Container Registry,type=aws_ecr_repository,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&start_usage_amount=0&end_usage_amount=Inf,0.1000000000,d,USD",
 ]
 
 
@@ -1179,6 +1181,23 @@ def test_cloudfront_us_data_transfer_band():
     )
     d = estimate(plan, _sheet()).to_dict()
     assert d["resources"][0]["monthly"]["max"] == pytest.approx(5000 * 0.085, abs=0.01)
+
+
+def test_ecr_repository_storage_band():
+    """aws_ecr_repository: container image storage $0.10/GB-month (band). (#1013)"""
+    plan = _plan(
+        [
+            {
+                "address": "aws_ecr_repository.r",
+                "type": "aws_ecr_repository",
+                "name": "r",
+                "mode": "managed",
+                "values": {"region": "us-east-1"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(50 * 0.10, abs=0.01)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
ECR image storage $0.10/GB-mo band. Closes #1013. Part of #893.