### PR TITLE
feat(pricegen): google_dns_managed_zone — flat Cloud DNS zone fee (#1015)

### DIFF
--- a/pricegen/providers/gcp/recipes/google_dns_managed_zone.yaml
+++ b/pricegen/providers/gcp/recipes/google_dns_managed_zone.yaml
@@ -1,0 +1,12 @@
+# Cloud DNS -> google_dns_managed_zone. A flat $0.20/month per managed zone
+# (first 25; $0.10 beyond, not applied per-resource). Global. Query charges are
+# a separate usage concern. Modeled as a flat count charge (usage=1). From the
+# Cloud DNS offer.
+resource_type: google_dns_managed_zone
+service: Cloud DNS
+
+components:
+  - product_family: "^ManagedZone$"
+    service_class: zones
+    price: { type: o, unit: mo }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -56,6 +56,10 @@ recipes:
     recipe: google_container_cluster
     offer: .cache/gcp-gke.json
     fetch: { service_id: "CCD8-9BF1-090E" } # Kubernetes Engine
+  - provider: gcp
+    recipe: google_dns_managed_zone
+    offer: .cache/gcp-dns.json
+    fetch: { service_id: "FA26-5236-B8B5" } # Cloud DNS
   - provider: aws
     recipe: aws_sqs_queue
     offer: .cache/sqs-us-east-1.json

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -556,5 +556,12 @@
       "typical": 50,
       "high": 5000
     }
+  },
+  {
+    "description": "Cloud DNS managed zone",
+    "match_query": "type = google_dns_managed_zone and service_class = zones",
+    "usage": {
+      "operations": 1
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -280,8 +280,8 @@ def test_default_usage_catalogue_loads():
     # Azure AKS hours + Azure storage account data (#997) + GCS bucket storage
     # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003) + VPC
     # interface endpoint hours+data (#1005) + Azure managed disk per-size tier
-    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013).
-    assert len(entries) == 52
+    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013) + Cloud DNS zone (#1015).
+    assert len(entries) == 53
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -148,6 +148,8 @@ _ROWS = [
     "AmazonCloudFront,Data Transfer,type=aws_cloudfront_distribution,service_provider=aws&purchase_option=on_demand&region=&service_class=data&start_usage_amount=10240&end_usage_amount=51200,0.0800000000,d,USD",
     # ECR (#1013) — image storage $0.10/GB-mo (band).
     "AmazonECR,EC2 Container Registry,type=aws_ecr_repository,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&start_usage_amount=0&end_usage_amount=Inf,0.1000000000,d,USD",
+    # Cloud DNS zone (#1015) — flat $0.20/mo, global.
+    "Cloud DNS,ManagedZone,type=google_dns_managed_zone,service_provider=gcp&purchase_option=on_demand&service_class=zones&start_usage_amount=0&end_usage_amount=Inf,0.2000000000,o,USD",
 ]
 
 
@@ -1198,6 +1200,23 @@ def test_ecr_repository_storage_band():
     )
     d = estimate(plan, _sheet()).to_dict()
     assert d["resources"][0]["monthly"]["max"] == pytest.approx(50 * 0.10, abs=0.01)
+
+
+def test_gcp_dns_managed_zone_flat():
+    """google_dns_managed_zone is a flat $0.20/mo, global. (#1015)"""
+    plan = _plan(
+        [
+            {
+                "address": "google_dns_managed_zone.z",
+                "type": "google_dns_managed_zone",
+                "name": "z",
+                "mode": "managed",
+                "values": {"name": "ex"},
+            }
+        ]
+    )
+    d = estimate(plan, _sheet()).to_dict()
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(0.20, abs=0.001)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
Cloud DNS zone flat $0.20/mo. Closes #1015. Part of #893.