### PR TITLE
feat(pricegen): google_sql_database_instance — computed db-custom tier (#1021)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -136,4 +136,5 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] AWS breadth: `aws_sqs_queue`, `aws_lambda_function`, `aws_s3_bucket`, `aws_dynamodb_table`, `aws_nat_gateway`, `aws_eip`, `aws_lb` (ALB+NLB), `aws_elb`, `aws_ebs_snapshot`, `aws_efs_file_system`, `aws_kms_key` ($1 flat), `aws_secretsmanager_secret` ($0.40 flat), `aws_sns_topic` (publishes band), `aws_kinesis_stream` (shards × count), `aws_elasticache_cluster` (nodes × count), `aws_api_gateway_rest_api` + `aws_apigatewayv2_api` (tiered request bands) (deterministic + usage-driven, with low/typical/high cost bands)
 - [x] Count-multiply engine feature (a component's cost × a resource attribute) + `aws_elasticache_cluster` (per-node × num_cache_nodes, by node_type + engine)
 - [ ] More AWS breadth (Route53 + CloudFront [global offers], Kinesis [count-multiply], CloudWatch) + all-regions + a row-parity CI gate
-- [ ] Broaden GCP families/regions; Azure managed disks / Windows
+- [x] Cloud SQL (`google_sql_database_instance`): db-custom-N-M COMPUTED (vCPU + RAM parsed from the tier) + storage (Zonal PostgreSQL/MySQL)
+- [ ] Azure DB (mssql/postgresql sku_name parse); Regional-HA + predefined Cloud SQL tiers

--- a/pricegen/providers/gcp/recipes/google_sql_database_instance.yaml
+++ b/pricegen/providers/gcp/recipes/google_sql_database_instance.yaml
@@ -1,0 +1,30 @@
+# Cloud SQL -> google_sql_database_instance. A COMPUTED, custom-tier model:
+# db-custom-N-M prices as N vCPUs + M/1024 GiB RAM (+ storage). We price the
+# common case — Zonal, Enterprise edition, PostgreSQL/MySQL (which share the
+# same per-vCPU $0.0413/hr and per-GiB-RAM $0.007/hr rates), so the recipe
+# matches on type only (the two engines' identical SKUs dedup). The vCPU and RAM
+# counts are parsed out of the `settings.tier` string (db-custom-N-M) by the
+# count feature. Storage is priced from settings.disk_size at $0.17/GiB-month.
+#
+# Follow-ups: Regional/HA (doubles the rates), SQL Server (pricier), the legacy
+# predefined tiers (db-n1-standard-N) and shared-core (db-f1-micro/db-g1-small),
+# and the newer HyperDisk storage variants. From the Cloud SQL offer.
+resource_type: google_sql_database_instance
+service: Cloud SQL
+
+components:
+  - product_family: '^Cloud SQL for PostgreSQL: Zonal - vCPU in Americas$'
+    service_class: vcpu
+    pricing: { region: { attr: region } }
+    price: { type: t, unit: h }
+    tier: usage
+  - product_family: '^Cloud SQL for PostgreSQL: Zonal - RAM in Americas$'
+    service_class: ram
+    pricing: { region: { attr: region } }
+    price: { type: t, unit: GiBy.h }
+    tier: usage
+  - product_family: '^Cloud SQL for PostgreSQL: Zonal - Standard storage in Americas$'
+    service_class: storage
+    pricing: { region: { attr: region } }
+    price: { type: "a=values.settings.disk_size", unit: GiBy.mo }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -68,6 +68,10 @@ recipes:
     recipe: google_pubsub_topic
     offer: .cache/gcp-pubsub.json
     fetch: { service_id: "A1E8-BE35-7EBC" } # Cloud Pub/Sub
+  - provider: gcp
+    recipe: google_sql_database_instance
+    offer: .cache/gcp-sql.json
+    fetch: { service_id: "9662-B51E-5089" } # Cloud SQL
   - provider: aws
     recipe: aws_sqs_queue
     offer: .cache/sqs-us-east-1.json

--- a/services/terrapod/services/cost/pricer.py
+++ b/services/terrapod/services/cost/pricer.py
@@ -14,6 +14,7 @@ filter of the upstream CLI is not needed by Terrapod and is omitted.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field, replace
 
 from terrapod.services.cost import usage as usage_mod
@@ -293,9 +294,14 @@ def _cost_band(
 
 def _count_factor(entry: Entry, resource_ms: MatchSet) -> float:
     """Multiplier for a per-unit component whose quantity scales with a resource
-    attribute — ElastiCache node cost × ``num_cache_nodes``, Kinesis × ``shard_count``.
-    Reads the attribute named by the entry's ``count`` spec; defaults to 1 (the
-    single-unit case) when unset, absent, or unparseable, so nothing regresses."""
+    attribute — ElastiCache node cost × ``num_cache_nodes``, Kinesis ×
+    ``shard_count``, or a value parsed out of a string attribute (Cloud SQL's
+    ``db-custom-N-M`` tier → N vCPUs, M/1024 GiB RAM).
+
+    Spec shape: {attr, default?, regex?, divisor?}. ``regex`` extracts capture
+    group 1 from the attribute string; ``divisor`` scales the result (e.g. RAM
+    MB → GiB). Defaults to 1 (or ``default``) when unset, absent, or
+    unparseable, so nothing regresses."""
     spec = entry.count
     if not spec:
         return 1.0
@@ -306,8 +312,19 @@ def _count_factor(entry: Entry, resource_ms: MatchSet) -> float:
     found = resource_ms.find_by_key(attr)
     if found is None:
         return default
+    raw = found[1]
+    rx = spec.get("regex")
+    if rx:
+        m = re.search(rx, raw)
+        if m is None:
+            return default
+        raw = m.group(1)
+    divisor = float(spec.get("divisor", 1) or 1)
     try:
-        return max(1.0, float(found[1]))
+        # No floor of 1 here: a parsed RAM count can be fractional GiB, and a
+        # count of 0 means the component contributes nothing. Absent/unparseable
+        # still fall back to ``default`` above.
+        return max(0.0, float(raw) / divisor)
     except (ValueError, TypeError):
         return default
 

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -585,5 +585,34 @@
       "typical": 1,
       "high": 100
     }
+  },
+  {
+    "description": "Cloud SQL vCPU (from db-custom tier)",
+    "match_query": "type = google_sql_database_instance and service_class = vcpu",
+    "usage": {
+      "time": 730
+    },
+    "count": {
+      "attr": "values.settings.tier",
+      "regex": "db-custom-(\\d+)-",
+      "default": 1
+    }
+  },
+  {
+    "description": "Cloud SQL RAM (from db-custom tier)",
+    "match_query": "type = google_sql_database_instance and service_class = ram",
+    "usage": {
+      "time": 730
+    },
+    "count": {
+      "attr": "values.settings.tier",
+      "regex": "db-custom-\\d+-(\\d+)",
+      "divisor": 1024,
+      "default": 0
+    }
+  },
+  {
+    "description": "Cloud SQL storage",
+    "match_query": "type = google_sql_database_instance and service_class = storage"
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -280,8 +280,8 @@ def test_default_usage_catalogue_loads():
     # Azure AKS hours + Azure storage account data (#997) + GCS bucket storage
     # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003) + VPC
     # interface endpoint hours+data (#1005) + Azure managed disk per-size tier
-    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013) + Cloud DNS zone (#1015) + Azure ACR tier (#1017) + Pub/Sub throughput (#1019).
-    assert len(entries) == 55
+    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013) + Cloud DNS zone (#1015) + Azure ACR tier (#1017) + Pub/Sub throughput (#1019) + Cloud SQL vCPU/RAM/storage (#1021).
+    assert len(entries) == 58
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -154,6 +154,11 @@ _ROWS = [
     "Container Registry,Container Registry,type=azurerm_container_registry&values.sku=Premium,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=registry&start_usage_amount=0&end_usage_amount=Inf,1.6666,t,USD",
     # Cloud Pub/Sub (#1019) — message throughput $40/TiB (band), global.
     "Cloud Pub/Sub,Message Delivery Basic,type=google_pubsub_topic,service_provider=gcp&purchase_option=on_demand&service_class=throughput&start_usage_amount=0&end_usage_amount=Inf,40.0000000000,d,USD",
+    # Cloud SQL (#1021) — COMPUTED: db-custom-N-M -> N vCPU ($0.0413/hr) +
+    # M/1024 GiB RAM ($0.007/GiB-hr) + storage ($0.17/GiB-mo). Zonal PostgreSQL.
+    "Cloud SQL,vCPU,type=google_sql_database_instance,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=vcpu&start_usage_amount=0&end_usage_amount=Inf,0.0413000000,t,USD",
+    "Cloud SQL,RAM,type=google_sql_database_instance,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=ram&start_usage_amount=0&end_usage_amount=Inf,0.0070000000,t,USD",
+    "Cloud SQL,Storage,type=google_sql_database_instance,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=storage,0.1700000000,a=values.settings.disk_size,USD",
 ]
 
 
@@ -1256,6 +1261,42 @@ def test_gcp_pubsub_topic_throughput_band():
     )
     d = estimate(plan, _sheet()).to_dict()
     assert d["resources"][0]["monthly"]["max"] == pytest.approx(40.0, abs=0.01)
+
+
+def test_cloud_sql_computed_from_db_custom_tier():
+    """google_sql_database_instance is COMPUTED: the db-custom-N-M tier string is
+    parsed to N vCPUs + M/1024 GiB RAM (each priced per-hour), plus storage.
+    db-custom-2-7680 + 100 GB = 2*0.0413*730 + 7.5*0.007*730 + 100*0.17. (#1021)"""
+    plan = {
+        "format_version": "1.2",
+        "terraform_version": "1.9.0",
+        "planned_values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "google_sql_database_instance.db",
+                        "type": "google_sql_database_instance",
+                        "name": "db",
+                        "mode": "managed",
+                        "values": {
+                            "region": "us-central1",
+                            "database_version": "POSTGRES_15",
+                            "settings": [
+                                {
+                                    "tier": "db-custom-2-7680",
+                                    "disk_size": 100,
+                                    "availability_type": "ZONAL",
+                                }
+                            ],
+                        },
+                    }
+                ]
+            }
+        },
+    }
+    d = estimate(plan, _sheet()).to_dict()
+    expected = 2 * 0.0413 * 730 + 7.5 * 0.007 * 730 + 100 * 0.17
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(expected, abs=0.05)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
feat(pricegen): google_sql_database_instance — computed db-custom tier (#1021)

Cloud SQL is a COMPUTED, custom-tier model: db-custom-N-M prices as N vCPUs
($0.0413/hr) + M/1024 GiB RAM ($0.007/GiB-hr) + storage ($0.17/GiB-mo). To
handle it, the count-multiply feature now supports parsing the count out of a
STRING attribute via `regex` (capture group 1) + `divisor` — so the vCPU and
RAM components read N and M straight from the `settings.tier` string. Existing
count-multiply (ElastiCache/Kinesis) is unchanged.

Scope: the common case — Zonal, Enterprise edition, PostgreSQL/MySQL (which
share the same per-vCPU/per-RAM rates, so their identical SKUs dedup). Storage
from settings.disk_size. Regional/HA (2x), SQL Server, the legacy predefined
(db-n1-*) and shared-core (db-f1-micro) tiers, and HyperDisk storage are
follow-ups.

Verified E2E: db-custom-2-7680 + 100 GB = $115.62; db-custom-4-15360 + 250 GB
= $239.75.

Closes #1021. Part of #893.