### PR TITLE
feat(pricegen): azurerm_postgresql_flexible_server + resource-side match derivation (#1023)

### DIFF
--- a/pricegen/README.md
+++ b/pricegen/README.md
@@ -137,4 +137,5 @@ operators mirror it as today. Weekly regeneration is the target cadence.
 - [x] Count-multiply engine feature (a component's cost × a resource attribute) + `aws_elasticache_cluster` (per-node × num_cache_nodes, by node_type + engine)
 - [ ] More AWS breadth (Route53 + CloudFront [global offers], Kinesis [count-multiply], CloudWatch) + all-regions + a row-parity CI gate
 - [x] Cloud SQL (`google_sql_database_instance`): db-custom-N-M COMPUTED (vCPU + RAM parsed from the tier) + storage (Zonal PostgreSQL/MySQL)
-- [ ] Azure DB (mssql/postgresql sku_name parse); Regional-HA + predefined Cloud SQL tiers
+- [x] Azure `azurerm_postgresql_flexible_server` (COMPUTED per vCore, tier derived from sku_name via resource_derivations)
+- [ ] Azure `azurerm_mssql_database` (same pattern); Regional-HA + predefined Cloud SQL tiers

--- a/pricegen/providers/azure/adapter.py
+++ b/pricegen/providers/azure/adapter.py
@@ -56,22 +56,35 @@ def iter_units(offer: dict, *, term: str = "Consumption"):
         # size's price. Mirrors the AWS adapter skipping items with no USD price.
         if usd is None or usd == 0:
             continue
-        # Include armRegionName: Azure reuses a meterId ACROSS regions, so
-        # grouping by meterId alone would merge every region's copy of a single-
-        # tier meter and set their ends to each other (a bogus [0,0] tier). Each
-        # (meter, type, term, region) is its own independent tier ladder.
+        # A tiered meter's tiers share every descriptor and differ only in
+        # tierMinimumUnits. `meterId` is NOT a reliable tier-ladder key: Azure
+        # reuses one meterId across regions AND across skuNames (e.g. blob "Data
+        # Stored" shares a meterId over Hot LRS / GRS / ZRS). So key on the full
+        # meter identity — grouping by meterId would merge unrelated meters and
+        # then either fabricate a [0,0] tier or drop rows in the dedup below.
         key = (
-            item.get("meterId") or item.get("meterName"),
+            item.get("meterName", ""),
+            item.get("skuName", ""),
+            item.get("productName", ""),
             item.get("type", ""),
             item.get("reservationTerm", ""),
             item.get("armRegionName", ""),
         )
         groups[key].append(item)
 
-    for items in groups.values():
+    for group in groups.values():
         # tierMinimumUnits is a float (0.0, 51200.0, …); sort ascending so the
         # end boundary is the next tier's start.
-        items.sort(key=lambda i: float(i.get("tierMinimumUnits", 0) or 0))
+        group.sort(key=lambda i: float(i.get("tierMinimumUnits", 0) or 0))
+        # Dedup consecutive same-tier entries: the retail feed sometimes lists a
+        # meter twice at the same tierMinimumUnits, which would otherwise make a
+        # zero-width [start, start] tier that prices to $0.
+        items: list[dict] = []
+        for it in group:
+            t = float(it.get("tierMinimumUnits", 0) or 0)
+            if items and float(items[-1].get("tierMinimumUnits", 0) or 0) == t:
+                continue
+            items.append(it)
         for idx, item in enumerate(items):
             begin = int(float(item.get("tierMinimumUnits", 0) or 0))
             end = (

--- a/pricegen/providers/azure/recipes/azurerm_postgresql_flexible_server.yaml
+++ b/pricegen/providers/azure/recipes/azurerm_postgresql_flexible_server.yaml
@@ -1,0 +1,25 @@
+# Azure PostgreSQL Flexible Server -> azurerm_postgresql_flexible_server.
+# COMPUTED per vCore-hour, and the rate depends on the TIER (General Purpose
+# $0.089, Memory Optimized $0.125) — both of which are encoded in the compound
+# `sku_name` ("GP_Standard_D4s_v3"). The vCore count is parsed from sku_name by
+# the count feature; the tier is DERIVED into values.sku_tier
+# (resource_derivations.json) so the per-tier rate rows match. We pin the
+# current-gen v5 series as the representative rate per tier. Burstable, storage
+# (storage_mb -> GB needs an a= divisor), IOPS, and HA/read-replicas are
+# follow-ups. From the Azure Database for PostgreSQL offer.
+resource_type: azurerm_postgresql_flexible_server
+service: Azure Database for PostgreSQL
+
+components:
+  - product_family: "^Azure Database for PostgreSQL$"
+    service_class: vcore
+    select:
+      productName: { regex: "(General Purpose Ddsv5|Memory Optimized Edsv5) Series Compute$" }
+      skuName: vCore
+    match:
+      sku_tier:
+        attr: productName
+        regex: "(General Purpose|Memory Optimized)"
+        map: { "General Purpose": general_purpose, "Memory Optimized": memory_optimized }
+    price: { type: t, unit: "1 Hour" }
+    tier: usage

--- a/pricegen/recipes.yaml
+++ b/pricegen/recipes.yaml
@@ -40,6 +40,10 @@ recipes:
     recipe: azurerm_container_registry
     offer: .cache/azure-acr.json
     fetch: { service_name: "Container Registry", region: eastus }
+  - provider: azure
+    recipe: azurerm_postgresql_flexible_server
+    offer: .cache/azure-pg.json
+    fetch: { service_name: "Azure Database for PostgreSQL", region: eastus }
   - provider: gcp
     recipe: google_compute_instance
     offer: .cache/gcp-compute.json

--- a/services/terrapod/services/cost/resource_derivations.json
+++ b/services/terrapod/services/cost/resource_derivations.json
@@ -1,0 +1,10 @@
+{
+  "azurerm_postgresql_flexible_server": [
+    {
+      "from": "values.sku_name",
+      "to": "values.sku_tier",
+      "regex": "^(GP|MO|B)_",
+      "map": {"GP": "general_purpose", "MO": "memory_optimized", "B": "burstable"}
+    }
+  ]
+}

--- a/services/terrapod/services/cost/tf.py
+++ b/services/terrapod/services/cost/tf.py
@@ -20,11 +20,55 @@ same ``{type, values.*}`` shape falls out either way.
 
 from __future__ import annotations
 
+import json as _json
 import re
 from dataclasses import dataclass
+from importlib import resources
 from typing import Any, Literal
 
 from terrapod.services.cost.match_set import MatchSet
+
+# Resource-side match-attribute derivations. Some resources encode a
+# match-relevant dimension inside a compound string that the pricing rows key on
+# separately — e.g. an azurerm_postgresql_flexible_server's `sku_name`
+# ("GP_Standard_D4s_v3") carries the tier (GP/MO/B, which sets the vCore rate)
+# that the SKUs price as distinct products. Subset matching needs an exact
+# resource attribute, so we DERIVE one (values.sku_tier) from the string before
+# matching. Each rule: {from, to, regex (capture group 1), map?}. Loaded lazily.
+_DERIVATIONS: dict[str, list[dict[str, Any]]] | None = None
+
+
+def _derivations() -> dict[str, list[dict[str, Any]]]:
+    global _DERIVATIONS
+    if _DERIVATIONS is None:
+        text = (
+            resources.files("terrapod.services.cost")
+            .joinpath("resource_derivations.json")
+            .read_text()
+        )
+        _DERIVATIONS = _json.loads(text)
+    return _DERIVATIONS
+
+
+def _derive(rtype: str, pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    rules = _derivations().get(rtype)
+    if not rules:
+        return []
+    lookup: dict[str, str] = {}
+    for k, v in pairs:
+        lookup.setdefault(k, v)
+    out: list[tuple[str, str]] = []
+    for r in rules:
+        val = lookup.get(r["from"])
+        if val is None:
+            continue
+        m = re.search(r["regex"], val)
+        if m is None:
+            continue
+        cap = m.group(1)
+        out.append((r["to"], r.get("map", {}).get(cap, cap)))
+    return out
+
 
 Change = Literal["noop", "add", "remove"]
 
@@ -80,7 +124,8 @@ class Resource:
     data: dict[str, Any]
 
     def to_match_set(self) -> MatchSet:
-        return MatchSet.of_list(flatten(self.data))
+        pairs = flatten(self.data)
+        return MatchSet.of_list(pairs + _derive(self.type, pairs))
 
 
 def _resource_of_obj(obj: dict[str, Any]) -> Resource:

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -614,5 +614,17 @@
   {
     "description": "Cloud SQL storage",
     "match_query": "type = google_sql_database_instance and service_class = storage"
+  },
+  {
+    "description": "Azure PostgreSQL Flexible Server vCore (from sku_name)",
+    "match_query": "type = azurerm_postgresql_flexible_server and service_class = vcore",
+    "usage": {
+      "time": 730
+    },
+    "count": {
+      "attr": "values.sku_name",
+      "regex": "Standard_[A-Za-z](\\d+)",
+      "default": 2
+    }
   }
 ]

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -280,8 +280,8 @@ def test_default_usage_catalogue_loads():
     # Azure AKS hours + Azure storage account data (#997) + GCS bucket storage
     # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003) + VPC
     # interface endpoint hours+data (#1005) + Azure managed disk per-size tier
-    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013) + Cloud DNS zone (#1015) + Azure ACR tier (#1017) + Pub/Sub throughput (#1019) + Cloud SQL vCPU/RAM/storage (#1021).
-    assert len(entries) == 58
+    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013) + Cloud DNS zone (#1015) + Azure ACR tier (#1017) + Pub/Sub throughput (#1019) + Cloud SQL vCPU/RAM/storage (#1021) + Azure PG vCore (#1023).
+    assert len(entries) == 59
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -159,6 +159,11 @@ _ROWS = [
     "Cloud SQL,vCPU,type=google_sql_database_instance,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=vcpu&start_usage_amount=0&end_usage_amount=Inf,0.0413000000,t,USD",
     "Cloud SQL,RAM,type=google_sql_database_instance,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=ram&start_usage_amount=0&end_usage_amount=Inf,0.0070000000,t,USD",
     "Cloud SQL,Storage,type=google_sql_database_instance,service_provider=gcp&purchase_option=on_demand&region=us-central1&service_class=storage,0.1700000000,a=values.settings.disk_size,USD",
+    # Azure PostgreSQL Flexible Server (#1023) — COMPUTED per vCore, rate by TIER
+    # (GP $0.089 / MO $0.125). The tier is DERIVED into values.sku_tier from the
+    # sku_name (resource_derivations.json); the vCore count is parsed from it too.
+    "Azure Database for PostgreSQL,Azure Database for PostgreSQL,type=azurerm_postgresql_flexible_server&values.sku_tier=general_purpose,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=vcore&start_usage_amount=0&end_usage_amount=Inf,0.089,t,USD",
+    "Azure Database for PostgreSQL,Azure Database for PostgreSQL,type=azurerm_postgresql_flexible_server&values.sku_tier=memory_optimized,service_provider=azure&purchase_option=on_demand&region=eastus&service_class=vcore&start_usage_amount=0&end_usage_amount=Inf,0.125,t,USD",
 ]
 
 
@@ -1297,6 +1302,37 @@ def test_cloud_sql_computed_from_db_custom_tier():
     d = estimate(plan, _sheet()).to_dict()
     expected = 2 * 0.0413 * 730 + 7.5 * 0.007 * 730 + 100 * 0.17
     assert d["resources"][0]["monthly"]["max"] == pytest.approx(expected, abs=0.05)
+
+
+def test_azure_postgres_flexible_computed_by_tier_and_vcore():
+    """azurerm_postgresql_flexible_server is COMPUTED per vCore, and the rate
+    depends on the TIER — both encoded in the sku_name. resource_derivations
+    turns sku_name into values.sku_tier so the GP ($0.089) vs MO ($0.125) rate
+    matches; the vCore count is parsed from sku_name too. (#1023)"""
+
+    def plan(sku):
+        return {
+            "format_version": "1.2",
+            "terraform_version": "1.9.0",
+            "planned_values": {
+                "root_module": {
+                    "resources": [
+                        {
+                            "address": "azurerm_postgresql_flexible_server.db",
+                            "type": "azurerm_postgresql_flexible_server",
+                            "name": "db",
+                            "mode": "managed",
+                            "values": {"location": "eastus", "sku_name": sku},
+                        }
+                    ]
+                }
+            },
+        }
+
+    d = estimate(plan("GP_Standard_D4s_v3"), _sheet()).to_dict()
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(4 * 0.089 * 730, abs=0.05)
+    d = estimate(plan("MO_Standard_E8s_v3"), _sheet()).to_dict()
+    assert d["resources"][0]["monthly"]["max"] == pytest.approx(8 * 0.125 * 730, abs=0.05)
 
 
 def test_ec2_instance_prices():


### PR DESCRIPTION
feat(pricegen): azurerm_postgresql_flexible_server + resource-side match derivation (#1023)

Azure PostgreSQL Flexible Server is COMPUTED per vCore, and the rate depends
on the TIER (General Purpose $0.089 vs Memory Optimized $0.125) — both encoded
in the compound sku_name ("GP_Standard_D4s_v3"). count-multiply parses the
vCore; but selecting the RATE needs matching on the tier, which subset-matching
can't derive from sku_name.

New engine feature — resource-side match-attribute derivation: a per-type
config (resource_derivations.json) derives extra match keys from a resource's
string attributes before matching. Here it turns sku_name -> values.sku_tier
(GP/MO/B), so the per-tier rate rows match. General and reusable.

Also fixes the Azure adapter tier-grouping key: meterId is NOT unique per tier
ladder (Azure reuses it across regions AND skuNames — blob "Data Stored"
shares one meterId over Hot LRS/GRS/ZRS), so grouping keyed on the full meter
identity (meterName+skuName+productName+type+term+region) + a same-tier dedup.
This fixes bogus [0,0] tiers (ACR/PG) and dropped replications (storage) that
an all-tier/all-region offer surfaced. Verified storage/VM/ACR unchanged.

Scope: GP/MO tiers, v5-gen representative rate. Burstable, storage
(storage_mb->GB needs an a= divisor), IOPS, HA/replicas are follow-ups.
azurerm_mssql_database follows the same pattern next.

Verified E2E: GP_Standard_D4s_v3 $259.88, MO_Standard_E8s_v3 $730.

Closes #1023. Part of #893.