### PR TITLE
feat(1031): default prices_url to the self-generated pricesheet (retire dead oiq default)

### DIFF
--- a/docs/cost-estimation.md
+++ b/docs/cost-estimation.md
@@ -2,7 +2,7 @@
 
 Terrapod estimates the **monthly cost** of the infrastructure a workspace manages, both as a per-plan *delta* on every run and as the *current* total on a workspace. The numbers are data — no AI, no guesswork — so you can read the price of a change before you apply it and see what a workspace is costing you today.
 
-Cost estimation is powered by a **native, pure-Python reader engine that is compatible with — and consumes the published pricesheet of — [OpenInfraQuote](https://github.com/terrateamio/openinfraquote)** (oiq, by Terrateam, MPL-2.0). Terrapod ships **no binary and shells out to nothing**: it downloads oiq's `prices.csv` and matches plan/state resources against it in-process. The pricing data and the matcher/pricer design are OpenInfraQuote's, and Terrapod credits them wherever a cost is shown.
+Cost estimation is powered by a **native, pure-Python reader engine** whose matcher/pricer design is compatible with [OpenInfraQuote](https://github.com/terrateamio/openinfraquote) (oiq, by Terrateam, MPL-2.0) — Terrapod credits them for the format and the algorithm, and the engine still reads an oiq-compatible CSV. By default, though, it consumes **Terrapod's own self-generated, multi-region pricesheet** (#893/#1025), published weekly to a rolling GitHub Release — so Terrapod depends on no third-party hosted feed. Terrapod ships **no binary and shells out to nothing**: it fetches the gzipped sheet, decompresses it, and matches plan/state resources against it in-process (the reader auto-detects the sheet format).
 
 ---
 
@@ -30,7 +30,7 @@ api:
 
 - **Region is resolved per resource** — from the resource's own attributes (`region`/`location`), then its provider config, and only then the `default_region` fallback.
 - The pricesheet is a **pull-through cache**: it is mirrored into object storage on first use (no schedule, no extra Helm wiring), and a stale copy is served if a refresh fails so a transient upstream outage never breaks a run.
-- **Air-gapped / restricted-network** deployments pre-seed the cached object or point `cost_estimation.prices_url` at an internal mirror of oiq's `prices.csv`.
+- **Air-gapped / restricted-network** deployments pre-seed the cached object or point `cost_estimation.prices_url` at an internal mirror of the pricesheet (the self-generated `prices.yaml.gz`, or an oiq-compatible `prices.csv.gz` — the reader accepts either).
 
 ## How it works
 
@@ -84,7 +84,7 @@ expected values. No third-party cost binary is ever shipped in a Terrapod image.
 
 ## AI enhancement (separate, optional)
 
-The figures above are always **authoritative oiq-derived data**. An optional AI layer rides the existing [plan-analysis AI switch](ai-plan-summary.md) (`api.config.ai_summary.enabled` + the per-workspace mode) and renders **beside** the data on the run Cost tab — never blended into it. With AI disabled, only the data view shows. Every AI dollar figure is tagged `source: "ai-estimate"`, shown separately, and is **never** summed into the authoritative oiq total and never a gate.
+The figures above are always **authoritative deterministic data** (from the pricesheet). An optional AI layer rides the existing [plan-analysis AI switch](ai-plan-summary.md) (`api.config.ai_summary.enabled` + the per-workspace mode) and renders **beside** the data on the run Cost tab — never blended into it. With AI disabled, only the data view shows. Every AI dollar figure is tagged `source: "ai-estimate"`, shown separately, and is **never** summed into the authoritative deterministic total and never a gate.
 
 Its layers, in order of importance:
 
@@ -93,7 +93,7 @@ Its layers, in order of importance:
 - **Narrative (tertiary).** A short plain-language summary of the estimate.
 - **Chat.** A follow-up Q&A thread grounded in the estimate — ask why a resource is expensive, or what a cheaper instance class would cost. One shared thread per run (anyone with workspace read), gated by the same per-run message cap and daily token budget as the plan-summary chat. The model answers from the estimate only and keeps computed-vs-estimated figures distinct.
 
-**Languages.** Like the plan analysis, the AI cost prose (narrative, each estimate's basis, advisory text, and chat replies) is generated in the deployment's `ai_summary.summary_language` and **translated on view** into the reader's UI locale (best-effort, cached); the authoritative oiq figures are locale-agnostic numbers.
+**Languages.** Like the plan analysis, the AI cost prose (narrative, each estimate's basis, advisory text, and chat replies) is generated in the deployment's `ai_summary.summary_language` and **translated on view** into the reader's UI locale (best-effort, cached); the authoritative deterministic figures are locale-agnostic numbers.
 
 The authoritative figures always live on the data-only cost-estimate endpoint and are never restated by the AI layer.
 

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -359,16 +359,18 @@ api:
       enabled: true
 
     # Cost estimation (#871). Estimates monthly cost by matching plan/state
-    # resources against OpenInfraQuote's published prices.csv, mirrored into
-    # object storage on demand (pull-through — fetched when missing or stale, no
-    # schedule; no per-run egress). On by default (first-class feature); because
-    # the cache is pull-through, nothing is fetched until a cost surface is used.
-    # This is an API-side setting — the API instructs runners per-run whether to
-    # estimate (falling back to yes). Air-gapped: pre-seed the cached object or
-    # point prices_url at an internal mirror. Powered by OpenInfraQuote (MPL-2.0).
+    # resources against a pricesheet, mirrored into object storage on demand
+    # (pull-through — fetched when missing or stale, no schedule; no per-run
+    # egress). On by default (first-class feature); because the cache is
+    # pull-through, nothing is fetched until a cost surface is used. This is an
+    # API-side setting — the API instructs runners per-run whether to estimate
+    # (falling back to yes). Defaults to Terrapod's self-generated, multi-region
+    # pricesheet (#893/#1025); the reader also accepts an OpenInfraQuote-compatible
+    # CSV (MPL-2.0). Air-gapped: pre-seed the cached object or point prices_url at
+    # an internal mirror.
     cost_estimation:
       enabled: true
-      prices_url: "https://oiq.terrateam.io/prices.csv.gz"
+      prices_url: "https://github.com/mattrobinsonsre/terrapod/releases/download/pricesheet/prices.yaml.gz"
       # Fallback only: region is resolved per resource (AWS v6 `region`, Azure
       # `location`, GCP `region`/`location`, then provider config). A plan can
       # span regions, so this default is used only when a resource has no region.

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -768,11 +768,14 @@ class CostEstimationConfig(BaseModel):
 
     enabled: bool = Field(default=True)
     prices_url: str = Field(
-        default="https://oiq.terrateam.io/prices.csv.gz",
+        default="https://github.com/mattrobinsonsre/terrapod/releases/download/pricesheet/prices.yaml.gz",
         description=(
-            "Upstream OpenInfraQuote pricesheet (gzipped CSV). Fetched on demand "
-            "(pull-through) when the cached copy is missing or stale — no schedule. "
-            "Point at an internal mirror for air-gapped deployments."
+            "Pricesheet source (gzipped). Defaults to Terrapod's self-generated, "
+            "multi-region pricesheet published weekly to a rolling GitHub Release "
+            "(#893). Fetched on demand (pull-through) when the cached copy is "
+            "missing or stale — no schedule. The reader auto-detects the format "
+            "(Terrapod YAML or an OpenInfraQuote-compatible CSV), so an internal "
+            "mirror of either shape works for air-gapped deployments."
         ),
     )
     default_region: str = Field(

--- a/services/terrapod/services/cost_pricesheet_service.py
+++ b/services/terrapod/services/cost_pricesheet_service.py
@@ -1,12 +1,15 @@
 """Pricesheet cache service for cost estimation (#871).
 
-Mirrors OpenInfraQuote's published ``prices.csv.gz`` into object storage so the
-runner (plan path) and the API (state/workspace path) read a cached copy — no
-per-run egress to ``oiq.terrateam.io``. This is a **pull-through** cache, exactly
-like Terrapod's binary/provider caches: the sheet is fetched **on demand** when
-it's missing or stale, not on a schedule. No operator scheduling, no interval to
-tune. Air-gapped deployments pre-seed the cached object or point
-``cost_estimation.prices_url`` at an internal mirror.
+Mirrors the configured pricesheet (``cost_estimation.prices_url``, a gzipped
+sheet) into object storage so the runner (plan path) and the API (state/workspace
+path) read a cached copy — no per-run egress. It defaults to Terrapod's own
+self-generated, multi-region pricesheet (#893/#1025), and also accepts an
+OpenInfraQuote-compatible CSV; the reader auto-detects the format by content, so
+this cache is format-agnostic (it stores the decompressed bytes verbatim). This
+is a **pull-through** cache, exactly like Terrapod's binary/provider caches: the
+sheet is fetched **on demand** when it's missing or stale, not on a schedule. No
+operator scheduling, no interval to tune. Air-gapped deployments pre-seed the
+cached object or point ``cost_estimation.prices_url`` at an internal mirror.
 
 Staleness comes straight from object storage (the cached object's
 ``last_modified``), so there's no separate timestamp store. Refresh is


### PR DESCRIPTION
Closes #1031.

`cost_estimation.prices_url` still **defaulted** to `https://oiq.terrateam.io/prices.csv.gz` — now **NXDOMAIN** (the domain is gone), so every deployment on the default was pointed at a dead host. Terrapod now publishes its **own multi-region pricesheet** (#893/#1025) to a rolling GitHub Release. This flips the default (code + Helm) onto it.

## Changes
- **`config.py` + `helm/values.yaml`** — default → the rolling-release `prices.yaml.gz`. The chart hardcoded the old oiq URL; it renders via `configmap-api.yaml` (verified across `values.yaml` / `values-local.yaml` / `values-eval.yaml`).
- **`cost_pricesheet_service.py`** — the fetch decompresses gzip generically and the reader auto-detects CSV-vs-YAML by content, so a `.yaml.gz` works unchanged; docstring made format/source-neutral (drops the dead `oiq.terrateam.io` reference).
- **`docs/cost-estimation.md`** — framing updated to the self-generated sheet as the default; **OpenInfraQuote kept credited** for the compatible format/algorithm, and an oiq-compatible CSV is still accepted (internal mirror / air-gapped).

## Safety
- **Verified** the published rolling-release asset is a valid `terrapod-pricesheet/v1` YAML (5024 products) before flipping — the URL already serves a good sheet, and the in-flight multi-region publish clobbers it with the fuller one.
- `prices_url` stays overridable.
- Additive / contract-safe: only a default value + docs (no route/attribute/wire/schema change).