### PR TITLE
fix(1029): fleet cost must be reflected in the estimate total

### DIFF
--- a/services/terrapod/services/cost/engine.py
+++ b/services/terrapod/services/cost/engine.py
@@ -202,14 +202,25 @@ def estimate(
         for res, change in unpriced
         if res.address not in synth_meta and res.address not in priced_addrs
     ]
+
+    # Recompute the totals from the FINAL resource lines (#1029 fix): price()'s
+    # totals were summed over the synth fleet-units priced at ×1, so they miss
+    # the ×count fold and the fleet-line merge. The per-resource costs already
+    # carry the count-multiplied, correctly-signed value (removes are negative
+    # via price()), so summing them reproduces total/diff/prev under the same
+    # convention (prev = total − diff; diff counts add/remove only).
+    total_min = sum(rc.monthly_min for rc in resource_costs)
+    total_max = sum(rc.monthly_max for rc in resource_costs)
+    diff_min = sum(rc.monthly_min for rc in resource_costs if rc.change in ("add", "remove"))
+    diff_max = sum(rc.monthly_max for rc in resource_costs if rc.change in ("add", "remove"))
     return CostEstimate(
         currency=result.currency,
-        total_min=result.total.min,
-        total_max=result.total.max,
-        prev_min=result.prev.min,
-        prev_max=result.prev.max,
-        diff_min=result.diff.min,
-        diff_max=result.diff.max,
+        total_min=total_min,
+        total_max=total_max,
+        prev_min=total_min - diff_min,
+        prev_max=total_max - diff_max,
+        diff_min=diff_min,
+        diff_max=diff_max,
         resources=resource_costs,
         unpriced=unpriced_resources,
     )

--- a/services/tests/services/test_cost_fleet.py
+++ b/services/tests/services/test_cost_fleet.py
@@ -206,6 +206,34 @@ def test_deferred_fleet_is_unpriced_not_crash():
     assert "aws_msk_cluster.kafka" in unpriced
 
 
+def test_fleet_cost_is_reflected_in_the_total():
+    # Regression (#1029): the estimate TOTAL must reflect fleet × count — not the
+    # synth fleet-unit priced at ×1. Before the fix, price()'s total summed the
+    # synth units (×1), so the total was less than the fleet's own line.
+    est = estimate(
+        _state(
+            _r("aws_instance", "solo", instance_type="m5.large", region="us-east-1"),
+            _r("aws_launch_template", "web", id="lt-1", instance_type="m5.large"),
+            _r(
+                "aws_autoscaling_group",
+                "web",
+                region="us-east-1",
+                desired_capacity=3,
+                launch_template=[{"id": "lt-1"}],
+            ),
+        ),
+        io.StringIO(_SHEET),
+    )
+    by = {r.address: r for r in est.resources}
+    solo = by["aws_instance.solo"].monthly_max
+    asg = by["aws_autoscaling_group.web"].monthly_max
+    assert asg == solo * 3
+    # total = solo + asg (launch template is unpriced) = 4 units, NOT the buggy
+    # solo + (synth ×1) = 2 units.
+    assert est.total_max == solo + asg
+    assert est.total_max == solo * 4
+
+
 def test_unresolvable_asg_reference_is_unpriced():
     # launch template not in the plan → can't resolve unit → unpriced, no crash.
     by, unpriced = _run(


### PR DESCRIPTION
Surfaced by a **live Tilt demo** of the just-landed fleet resolver (#1030) — the class of bug single-fleet unit tests miss.

The fleet resolver priced each fleet's per-resource line correctly (`unit × count`), but the estimate **total** was wrong: `price()` computes `total`/`diff`/`prev` by summing the **synthetic fleet-units**, which are priced at **×1** and dont include the `×count` fold or the fleet-line merge. So a 4-node ASG showed `$280/mo` on its own line but the total counted it as **one** node.

**Fix:** recompute `total`/`diff`/`prev` from the **final per-resource lines** (which already carry the count-multiplied, correctly-signed values), under the same convention `price()` used (`prev = total − diff`; `diff` counts add/remove). Regression test asserts the total reflects `fleet × count`.

Contract-safe: engine-internal aggregation only.