### PR TITLE
fix(1034): SQLite pricesheet index — stop OOM-ing on the multi-region sheet

### DIFF
--- a/services/terrapod/runner/phases/cost.py
+++ b/services/terrapod/runner/phases/cost.py
@@ -36,10 +36,11 @@ from terrapod.runner.runner_config import RunnerConfig
 
 logger = structlog.get_logger("runner.cost")
 
-# Where the fetched pricesheet CSV and the produced estimate land. On the runner
-# Job pod (unlike the API pod) /tmp is ordinary ephemeral disk, so the ~200k-row
-# CSV is safe here — this is not the RAM-tmpfs API pod the PVC rule guards.
-_PRICESHEET_CSV = Path("/tmp/prices.csv")
+# Where the fetched pricesheet index and the produced estimate land. On the
+# runner Job pod (unlike the API pod) /tmp is ordinary ephemeral disk. The
+# pre-built SQLite index (#1034) is fetched here and queried off disk — the
+# runner never parses the whole 260k-product sheet.
+_PRICESHEET_DB = Path("/tmp/prices.sqlite")
 _COST_ESTIMATE_JSON = Path("/tmp/cost_estimate.json")
 
 _PRICESHEET_PATH = "/api/terrapod/v1/cost-estimation/pricesheet"
@@ -71,11 +72,15 @@ def estimate_cost(cfg: RunnerConfig, plan_json: Path) -> Path | None:
         # Imported lazily so a failure to fetch the pricesheet never even
         # touches the engine, and the engine's import cost is off the hot path.
         from terrapod.services.cost import estimate
+        from terrapod.services.cost.pricesheet_db import PricesheetIndex
 
         with plan_json.open() as fh:
             tf_json = json.load(fh)
-        with _PRICESHEET_CSV.open() as sheet:
-            result = estimate(tf_json, sheet, default_region=cfg.cost_default_region)
+        index = PricesheetIndex.open(str(_PRICESHEET_DB))
+        try:
+            result = estimate(tf_json, index=index, default_region=cfg.cost_default_region)
+        finally:
+            index.close()
     except Exception as exc:  # noqa: BLE001 — advisory; any failure → skip
         logger.warning("cost engine raised — skipping cost estimate", err=str(exc))
         return None
@@ -98,17 +103,17 @@ def estimate_cost(cfg: RunnerConfig, plan_json: Path) -> Path | None:
 
 
 def _fetch_pricesheet(cfg: RunnerConfig) -> bool:
-    """Download the cached pricesheet CSV to ``_PRICESHEET_CSV``.
+    """Download the cached pricesheet **SQLite index** to ``_PRICESHEET_DB``.
 
-    Hits the API's pull-through cache endpoint (which fetches upstream on a
-    cold/stale cache), authenticated with the runner token; the endpoint 302s
+    Hits the API's pull-through cache endpoint (which builds the index upstream on
+    a cold/stale cache), authenticated with the runner token; the endpoint 302s
     to a presigned storage URL that ``download_to_file`` follows.
     """
     url = f"{cfg.api_url}{_PRICESHEET_PATH}"
     headers = {"Authorization": f"Bearer {cfg.auth_token}"} if cfg.auth_token else {}
     result = download_to_file(
         url,
-        _PRICESHEET_CSV,
+        _PRICESHEET_DB,
         headers=headers,
         api_url=cfg.api_url,
         retries=cfg.download_retries,
@@ -117,4 +122,4 @@ def _fetch_pricesheet(cfg: RunnerConfig) -> bool:
     if not result.ok:
         logger.warning("pricesheet download failed", url=url, status=result.status)
         return False
-    return _PRICESHEET_CSV.exists() and _PRICESHEET_CSV.stat().st_size > 0
+    return _PRICESHEET_DB.exists() and _PRICESHEET_DB.stat().st_size > 0

--- a/services/terrapod/services/cost/engine.py
+++ b/services/terrapod/services/cost/engine.py
@@ -21,10 +21,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import IO, Any
 
-from terrapod.services.cost import fleet_resolver
+from terrapod.services.cost import fleet_resolver, pricesheet_db
 from terrapod.services.cost import usage as usage_mod
 from terrapod.services.cost.pricer import price
-from terrapod.services.cost.prices import load_pricesheet
 from terrapod.services.cost.tf import (
     Change,
     provider_regions,
@@ -95,16 +94,22 @@ class CostEstimate:
 
 def estimate(
     tf_json: dict[str, Any],
-    pricesheet: IO[str],
+    pricesheet: IO[str] | None = None,
     usage_json: list[dict[str, Any]] | None = None,
     default_region: str = "us-east-1",
+    *,
+    index: pricesheet_db.PricesheetIndex | None = None,
 ) -> CostEstimate:
     """Estimate monthly cost for a plan or state against a pricesheet.
 
     ``tf_json``   — parsed ``terraform show -json`` (plan or state) or a raw
                     state v4 file.
-    ``pricesheet`` — an open text file object over OpenInfraQuote's
-                    ``prices.csv`` (streamed once, never fully materialised).
+    ``pricesheet`` — an open text pricesheet stream (CSV or Terrapod YAML). Built
+                    into an in-memory SQLite index (small sheets / mirrors / tests).
+    ``index``     — a pre-built :class:`~pricesheet_db.PricesheetIndex` (the API /
+                    runner pass the cached ``.sqlite`` so the 260k-product sheet is
+                    parsed once per refresh, not per request, #1034). Exactly one
+                    of ``pricesheet`` / ``index`` is used.
     ``usage_json`` — optional user usage overrides; prepended to the vendored
                     OpenInfraQuote defaults.
     ``default_region`` — fallback region for a resource whose region can't be
@@ -137,15 +142,28 @@ def estimate(
 
     priceable = list(resources) + synth_pairs
 
-    # Accumulate matching products per resource in a single pass over the sheet.
-    acc = [(res, change, res.to_match_set(), []) for res, change in priceable]
-    for product in load_pricesheet(pricesheet):
-        prod_ms = product.match_set
-        for _res, _change, res_ms, products in acc:
-            if prod_ms.is_subset_of(res_ms):
-                products.append(product)
-
-    matches = [(res, change, products) for res, change, _ms, products in acc]
+    # Match via the SQLite index (#1034): for each resource, query only the
+    # products sharing its type + resolved region (plus region-agnostic rows),
+    # then subset-match those — never scanning the full 260k-product sheet. A raw
+    # stream (tests, small CSV/YAML mirrors) is built into an in-memory index so
+    # there is one matching path.
+    own_index = index is None
+    if own_index:
+        if pricesheet is None:
+            raise ValueError("estimate() needs either `pricesheet` or `index`")
+        index = pricesheet_db.PricesheetIndex.build_memory(pricesheet)
+    try:
+        matches = []
+        for res, change in priceable:
+            res_ms = res.to_match_set()
+            region = region_by_address.get(res.address)
+            products = [
+                p for p in index.candidates(res.type, region) if p.match_set.is_subset_of(res_ms)
+            ]
+            matches.append((res, change, products))
+    finally:
+        if own_index:
+            index.close()
     usage_entries = usage_mod.load_usage(usage_json)
     result, unpriced = price(matches, usage_entries, region_by_address)
 

--- a/services/terrapod/services/cost/engine.py
+++ b/services/terrapod/services/cost/engine.py
@@ -151,7 +151,10 @@ def estimate(
     if own_index:
         if pricesheet is None:
             raise ValueError("estimate() needs either `pricesheet` or `index`")
-        index = pricesheet_db.PricesheetIndex.build_memory(pricesheet)
+        # File-backed temp build (streamed, bounded) — never an in-memory DB. The
+        # API/runner pass a pre-built `index=` (the cached .sqlite); this path is
+        # for tests + small raw CSV/YAML mirrors.
+        index = pricesheet_db.PricesheetIndex.build_temp(pricesheet)
     try:
         matches = []
         for res, change in priceable:

--- a/services/terrapod/services/cost/pricesheet_db.py
+++ b/services/terrapod/services/cost/pricesheet_db.py
@@ -20,14 +20,17 @@ Neither ever holds the whole sheet:
   agnostic rows) *before* the existing subset-match runs — bounded memory, and
   a few milliseconds per plan.
 
-A raw ``prices_url`` (CSV mirror, small YAML) still works: :func:`build_memory`
-builds an in-memory index from any stream, so the engine has one code path.
+A raw ``prices_url`` (CSV mirror, small YAML) still works: :meth:`build_temp`
+builds a **file-backed** index from any stream into a temp file (auto-cleaned),
+so the engine has one code path and never holds the DB in memory.
 """
 
 from __future__ import annotations
 
+import os
 import re
 import sqlite3
+import tempfile
 from collections.abc import Iterator
 from typing import IO
 
@@ -197,27 +200,43 @@ def build_index(fp: IO[str], db_path: str) -> int:
 
 
 class PricesheetIndex:
-    """Query wrapper over a built SQLite pricesheet index (file or in-memory).
+    """Query wrapper over a built SQLite pricesheet index — **always file-backed**.
 
-    :meth:`candidates` returns the products whose ``type`` matches a resource and
-    whose ``region`` is the resource's region or region-agnostic — the *only*
-    products that can subset-match it — so the engine never scans the full sheet.
+    The DB is a real file so SQLite pages it off disk (bounded ~18 MB query
+    memory), never materialised in RAM. :meth:`candidates` returns the products
+    whose ``type`` matches a resource and whose ``region`` is the resource's
+    region or region-agnostic — the *only* products that can subset-match it — so
+    the engine never scans the full sheet.
     """
 
-    def __init__(self, con: sqlite3.Connection):
+    def __init__(self, con: sqlite3.Connection, tmp_path: str | None = None):
         self._con = con
+        self._tmp_path = tmp_path  # a build_temp() file to unlink on close()
 
     @classmethod
     def open(cls, db_path: str) -> PricesheetIndex:
+        """Open a pre-built index file (the cached ``.sqlite`` — API/runner)."""
         return cls(sqlite3.connect(db_path, check_same_thread=False))
 
     @classmethod
-    def build_memory(cls, fp: IO[str]) -> PricesheetIndex:
-        """Build an in-memory index from a raw stream (tests, small CSV/YAML
-        mirrors) so the engine has a single index-based code path."""
-        con = sqlite3.connect(":memory:")
-        _create(con, stream_records(fp))
-        return cls(con)
+    def build_temp(cls, fp: IO[str], dir: str | None = None) -> PricesheetIndex:
+        """Build a **file-backed** index from a raw stream into a temp file, for
+        tests and small CSV/YAML mirrors (the API/runner use a pre-built cached
+        file via :meth:`open`). Streamed build (bounded memory); the temp file is
+        deleted on :meth:`close`. Never an in-memory DB — the index is always a
+        real file so the query stays paged off disk.
+        """
+        fd, path = tempfile.mkstemp(suffix=".sqlite", dir=dir)
+        os.close(fd)
+        try:
+            build_index(fp, path)
+        except BaseException:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            raise
+        return cls(sqlite3.connect(path, check_same_thread=False), tmp_path=path)
 
     def candidates(self, rtype: str, region: str | None) -> Iterator[Product]:
         """Yield candidate products for a resource of ``rtype`` in ``region``
@@ -242,3 +261,9 @@ class PricesheetIndex:
 
     def close(self) -> None:
         self._con.close()
+        if self._tmp_path is not None:
+            try:
+                os.unlink(self._tmp_path)
+            except OSError:
+                pass
+            self._tmp_path = None

--- a/services/terrapod/services/cost/pricesheet_db.py
+++ b/services/terrapod/services/cost/pricesheet_db.py
@@ -1,0 +1,244 @@
+"""SQLite pricesheet index for cost estimation (#1034).
+
+At multi-region scale (#1025) the published sheet grew to ~260k products /
+~84 MB decompressed. The old consumer parsed the **whole** YAML document with
+``yaml.safe_load`` (~1.7 GB peak) on **every** cost request, which OOM-kills the
+1 Gi API pod and re-does the work each time.
+
+Instead, the sheet is streamed **once** into a SQLite index keyed by
+``(type, region)`` — stored in object storage — and both consumers (the
+long-lived API *and* the ephemeral runner Job) **query** the pre-built index.
+Neither ever holds the whole sheet:
+
+* **Build** (once per cache refresh): :func:`build_index` streams the sheet with
+  ``yaml.parse`` — the low-level **event** parser, which emits scalars/mapping
+  markers incrementally and never materialises the document — and inserts rows.
+  Peak memory is one product + the parser buffer (~23 MB for the full sheet),
+  regardless of sheet size. The CSV path streams row-by-row as before.
+* **Query** (per estimate): :class:`PricesheetIndex` narrows 260k products to the
+  handful sharing a resource's ``type`` + resolved ``region`` (plus region-
+  agnostic rows) *before* the existing subset-match runs — bounded memory, and
+  a few milliseconds per plan.
+
+A raw ``prices_url`` (CSV mirror, small YAML) still works: :func:`build_memory`
+builds an in-memory index from any stream, so the engine has one code path.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections.abc import Iterator
+from typing import IO
+
+from terrapod.services.cost.match_set import MatchSet
+from terrapod.services.cost.prices import (
+    _YAML_SCHEMA_PREFIX,
+    EmptyMatchSet,
+    Product,
+    _parse_price_type,
+)
+
+# type=X is always the first token of a product's match set; region=X lives in
+# the pricing set (absent ⇒ region-agnostic, stored as '' and matched everywhere).
+_TYPE_RE = re.compile(r"(?:^|&)type=([^&]+)")
+_REGION_RE = re.compile(r"(?:^|&)region=([^&]+)")
+
+# record = (type, region, service, family, match, pricing, price, price_type, ccy)
+_Record = tuple[str, str, str, str, str, str, str, str, str]
+
+
+def _record(
+    service: str, family: str, match: str, pricing: str, price: str, price_type: str, ccy: str
+) -> _Record:
+    tm = _TYPE_RE.search(match)
+    rm = _REGION_RE.search(pricing)
+    return (
+        tm.group(1) if tm else "",
+        rm.group(1) if rm else "",
+        service,
+        family,
+        match,
+        pricing,
+        price,
+        price_type,
+        ccy,
+    )
+
+
+def _stream_csv_records(fp: IO[str]) -> Iterator[_Record]:
+    """Yield records from an oiq-style CSV (the header line already consumed)."""
+    import csv
+
+    for row in csv.reader(fp):
+        if len(row) != 7 or row[2] == "":  # skip blanks + empty-match rows
+            continue
+        service, family, match, pricing, price, price_type, ccy = row
+        yield _record(service, family, match, pricing, price, price_type, ccy)
+
+
+def _stream_yaml_records(first: str, fp: IO[str]) -> Iterator[_Record]:
+    """Yield records from a Terrapod YAML sheet via the ``yaml.parse`` **event**
+    stream — never materialising the document (the whole point, #1034).
+
+    The document is ``{schema, currency, products: [ {flat product}, ... ]}``.
+    We capture ``currency`` from the top-level mapping, then reconstruct each
+    product mapping inside the ``products`` sequence one at a time.
+    """
+    import yaml
+
+    # libyaml's C event parser when available (fast); pure-Python events still
+    # stream at bounded memory, just slower — fine for a once-per-refresh build.
+    loader = yaml.CSafeLoader if getattr(yaml, "__with_libyaml__", False) else yaml.SafeLoader
+
+    class _Chain:
+        """Feed the already-read first line back before the rest of the stream."""
+
+        def __init__(self, head: str, rest: IO[str]):
+            self._head: str | None = head
+            self._rest = rest
+
+        def read(self, n: int = -1) -> str:
+            if self._head is not None:
+                head, self._head = self._head, None
+                return head + (self._rest.read(n) if n != 0 else "")
+            return self._rest.read(n)
+
+    events = yaml.parse(_Chain(first, fp), Loader=loader)
+    currency = "USD"
+    in_products = False
+    top_key: str | None = None
+    prod: dict[str, str] | None = None
+    field_key: str | None = None
+
+    for ev in events:
+        if not in_products:
+            if isinstance(ev, yaml.ScalarEvent):
+                if top_key is None:
+                    top_key = ev.value  # a top-level key (schema/currency/products)
+                    if top_key == "products":
+                        # the next structural event is the sequence start
+                        nxt = next(events, None)
+                        if isinstance(nxt, yaml.SequenceStartEvent):
+                            in_products = True
+                        top_key = None
+                else:
+                    if top_key == "currency":
+                        currency = ev.value
+                    top_key = None
+            continue
+        # inside the products sequence
+        if isinstance(ev, yaml.SequenceEndEvent):
+            break
+        if isinstance(ev, yaml.MappingStartEvent):
+            prod, field_key = {}, None
+        elif isinstance(ev, yaml.MappingEndEvent):
+            if prod is not None and prod.get("match", ""):
+                yield _record(
+                    prod.get("service", ""),
+                    prod.get("family", ""),
+                    prod["match"],
+                    prod.get("pricing", ""),
+                    str(prod.get("price", "")),
+                    prod.get("price_type", ""),
+                    currency,
+                )
+            prod = None
+        elif isinstance(ev, yaml.ScalarEvent) and prod is not None:
+            if field_key is None:
+                field_key = ev.value
+            else:
+                prod[field_key] = ev.value
+                field_key = None
+
+
+def stream_records(fp: IO[str]) -> Iterator[_Record]:
+    """Stream ``(type, region, …)`` records from a sheet, bounded memory.
+
+    Auto-detects Terrapod YAML (``schema: terrapod-pricesheet/vN`` first line,
+    parsed as events) vs oiq CSV (streamed row-by-row).
+    """
+    first = fp.readline()
+    if first.lstrip().startswith("schema:") and _YAML_SCHEMA_PREFIX in first:
+        yield from _stream_yaml_records(first, fp)
+    else:
+        yield from _stream_csv_records(fp)
+
+
+_SCHEMA = (
+    "CREATE TABLE products("
+    "type TEXT, region TEXT, service TEXT, family TEXT, "
+    "match TEXT, pricing TEXT, price TEXT, price_type TEXT, ccy TEXT)"
+)
+
+
+def _create(con: sqlite3.Connection, records: Iterator[_Record]) -> int:
+    con.execute("PRAGMA journal_mode=OFF")
+    con.execute("PRAGMA synchronous=OFF")
+    con.execute(_SCHEMA)
+    con.executemany("INSERT INTO products VALUES (?,?,?,?,?,?,?,?,?)", records)
+    con.execute("CREATE INDEX idx_type_region ON products(type, region)")
+    con.commit()
+    return con.execute("SELECT count(*) FROM products").fetchone()[0]
+
+
+def build_index(fp: IO[str], db_path: str) -> int:
+    """Stream a sheet into a SQLite index file at ``db_path``. Returns row count.
+
+    Bounded memory (streams the sheet; never materialises it). Overwrites any
+    existing table content by creating a fresh DB — callers write to a temp path
+    then swap.
+    """
+    con = sqlite3.connect(db_path)
+    try:
+        return _create(con, stream_records(fp))
+    finally:
+        con.close()
+
+
+class PricesheetIndex:
+    """Query wrapper over a built SQLite pricesheet index (file or in-memory).
+
+    :meth:`candidates` returns the products whose ``type`` matches a resource and
+    whose ``region`` is the resource's region or region-agnostic — the *only*
+    products that can subset-match it — so the engine never scans the full sheet.
+    """
+
+    def __init__(self, con: sqlite3.Connection):
+        self._con = con
+
+    @classmethod
+    def open(cls, db_path: str) -> PricesheetIndex:
+        return cls(sqlite3.connect(db_path, check_same_thread=False))
+
+    @classmethod
+    def build_memory(cls, fp: IO[str]) -> PricesheetIndex:
+        """Build an in-memory index from a raw stream (tests, small CSV/YAML
+        mirrors) so the engine has a single index-based code path."""
+        con = sqlite3.connect(":memory:")
+        _create(con, stream_records(fp))
+        return cls(con)
+
+    def candidates(self, rtype: str, region: str | None) -> Iterator[Product]:
+        """Yield candidate products for a resource of ``rtype`` in ``region``
+        (plus region-agnostic products). The caller runs the subset-match."""
+        cur = self._con.execute(
+            "SELECT service, family, match, pricing, price, price_type, ccy "
+            "FROM products WHERE type = ? AND (region = ? OR region = '')",
+            (rtype, region or ""),
+        )
+        for service, family, match, pricing, price, price_type, ccy in cur:
+            try:
+                yield Product(
+                    service=service,
+                    product_family=family,
+                    match_set=MatchSet.of_string(match),
+                    pricing_match_set=MatchSet.of_string(pricing),
+                    price=_parse_price_type(price_type, float(price)),
+                    ccy=ccy,
+                )
+            except (EmptyMatchSet, ValueError):
+                continue
+
+    def close(self) -> None:
+        self._con.close()

--- a/services/terrapod/services/cost/pricesheet_db.py
+++ b/services/terrapod/services/cost/pricesheet_db.py
@@ -70,7 +70,7 @@ def _record(
 
 
 def _stream_csv_records(fp: IO[str]) -> Iterator[_Record]:
-    """Yield records from an oiq-style CSV (the header line already consumed)."""
+    """Yield records from a CSV sheet (the header line already consumed)."""
     import csv
 
     for row in csv.reader(fp):
@@ -159,7 +159,7 @@ def stream_records(fp: IO[str]) -> Iterator[_Record]:
     """Stream ``(type, region, …)`` records from a sheet, bounded memory.
 
     Auto-detects Terrapod YAML (``schema: terrapod-pricesheet/vN`` first line,
-    parsed as events) vs oiq CSV (streamed row-by-row).
+    parsed as events) vs CSV (streamed row-by-row).
     """
     first = fp.readline()
     if first.lstrip().startswith("schema:") and _YAML_SCHEMA_PREFIX in first:

--- a/services/terrapod/services/cost_pricesheet_service.py
+++ b/services/terrapod/services/cost_pricesheet_service.py
@@ -39,7 +39,8 @@ import httpx
 import structlog
 
 from terrapod.config import settings
-from terrapod.storage.keys import cost_pricesheet_key
+from terrapod.services.cost import pricesheet_db
+from terrapod.storage.keys import cost_pricesheet_db_key
 from terrapod.storage.protocol import ObjectStore
 
 logger = structlog.get_logger(__name__)
@@ -88,22 +89,33 @@ async def _file_chunks(path: str) -> AsyncIterator[bytes]:
         await asyncio.to_thread(fh.close)
 
 
-async def refresh_pricesheet(storage: ObjectStore) -> int:
-    """Fetch the configured pricesheet, decompress it, and cache it in storage.
+def _build_db(sheet_path: str, db_path: str) -> int:
+    """Stream a decompressed sheet file into a SQLite index (sync, off-loop)."""
+    with open(sheet_path) as fp:
+        return pricesheet_db.build_index(fp, db_path)
 
-    Streams ``cost_estimation.prices_url`` (gzipped CSV) to a PVC tempfile,
-    gunzips it off-loop, then streams the decompressed CSV into object storage
-    at :func:`cost_pricesheet_key`. Returns the stored CSV size in bytes. Raises
-    on any download/decompress failure (the store only happens on success, so a
+
+async def refresh_pricesheet(storage: ObjectStore) -> int:
+    """Fetch the configured pricesheet, build a SQLite index, and cache it (#1034).
+
+    Streams ``cost_estimation.prices_url`` (gzipped CSV / Terrapod YAML) to a PVC
+    tempfile, gunzips it off-loop, **streams it into a SQLite index**
+    (:mod:`pricesheet_db` — bounded memory even for the ~260k-product multi-region
+    sheet), then stores the ``.sqlite`` in object storage at
+    :func:`cost_pricesheet_db_key`. Both the API and runner query that file off
+    disk instead of parsing the whole sheet. Returns the stored DB size in bytes.
+    Raises on any download/build failure (the store only happens on success, so a
     previously cached copy is left intact).
     """
     url = settings.cost_estimation.prices_url
     tmpdir = _resolve_ephemeral_tmpdir()
 
-    gz_fd, gz_path = await asyncio.to_thread(tempfile.mkstemp, suffix=".csv.gz", dir=tmpdir)
+    gz_fd, gz_path = await asyncio.to_thread(tempfile.mkstemp, suffix=".gz", dir=tmpdir)
     await asyncio.to_thread(os.close, gz_fd)
-    csv_fd, csv_path = await asyncio.to_thread(tempfile.mkstemp, suffix=".csv", dir=tmpdir)
-    await asyncio.to_thread(os.close, csv_fd)
+    sheet_fd, sheet_path = await asyncio.to_thread(tempfile.mkstemp, suffix=".sheet", dir=tmpdir)
+    await asyncio.to_thread(os.close, sheet_fd)
+    db_fd, db_path = await asyncio.to_thread(tempfile.mkstemp, suffix=".sqlite", dir=tmpdir)
+    await asyncio.to_thread(os.close, db_fd)
     try:
         async with httpx.AsyncClient(follow_redirects=True) as client:
             # trust_env (httpx default) routes via the configured proxy/CA (#592).
@@ -112,18 +124,22 @@ async def refresh_pricesheet(storage: ObjectStore) -> int:
                 async for chunk in resp.aiter_bytes(_CHUNK):
                     await asyncio.to_thread(_append_chunk, gz_path, chunk)
 
-        await asyncio.to_thread(_gunzip_file, gz_path, csv_path)
-        size = await asyncio.to_thread(os.path.getsize, csv_path)
+        await asyncio.to_thread(_gunzip_file, gz_path, sheet_path)
+        # SQLite can't be built into via a stream, so build to the temp file then
+        # (over)write the cache atomically at the DB key.
+        await asyncio.to_thread(os.unlink, db_path)  # build_index creates fresh
+        rows = await asyncio.to_thread(_build_db, sheet_path, db_path)
+        size = await asyncio.to_thread(os.path.getsize, db_path)
 
         await storage.put_stream(
-            cost_pricesheet_key(),
-            _file_chunks(csv_path),
-            content_type="text/csv",
+            cost_pricesheet_db_key(),
+            _file_chunks(db_path),
+            content_type="application/x-sqlite3",
         )
-        logger.info("cost_pricesheet_refreshed", url=url, size_bytes=size)
+        logger.info("cost_pricesheet_refreshed", url=url, rows=rows, size_bytes=size)
         return size
     finally:
-        for path in (gz_path, csv_path):
+        for path in (gz_path, sheet_path, db_path):
             try:
                 await asyncio.to_thread(os.unlink, path)
             except OSError:
@@ -132,10 +148,10 @@ async def refresh_pricesheet(storage: ObjectStore) -> int:
 
 async def _is_fresh(storage: ObjectStore) -> bool:
     """True when a cached pricesheet exists and is younger than the TTL."""
-    if not await storage.exists(cost_pricesheet_key()):
+    if not await storage.exists(cost_pricesheet_db_key()):
         return False
     try:
-        meta = await storage.head(cost_pricesheet_key())
+        meta = await storage.head(cost_pricesheet_db_key())
     except Exception:  # noqa: BLE001 - any head failure => treat as stale
         return False
     modified = meta.last_modified
@@ -155,7 +171,7 @@ async def ensure_pricesheet(storage: ObjectStore) -> bool:
     """
     if await _is_fresh(storage):
         return True
-    had_copy = await storage.exists(cost_pricesheet_key())
+    had_copy = await storage.exists(cost_pricesheet_db_key())
     try:
         await refresh_pricesheet(storage)
         return True
@@ -166,18 +182,18 @@ async def ensure_pricesheet(storage: ObjectStore) -> bool:
 
 async def pricesheet_available(storage: ObjectStore) -> bool:
     """Whether a cached pricesheet currently exists (no refetch)."""
-    return await storage.exists(cost_pricesheet_key())
+    return await storage.exists(cost_pricesheet_db_key())
 
 
 async def pricesheet_download_url(storage: ObjectStore) -> str:
     """Presigned download URL for the cached pricesheet (302 target for runners)."""
-    presigned = await storage.presigned_get_url(cost_pricesheet_key())
+    presigned = await storage.presigned_get_url(cost_pricesheet_db_key())
     return presigned.url
 
 
 def pricesheet_stream(storage: ObjectStore) -> AsyncIterator[bytes]:
     """Stream the cached pricesheet's bytes (for the API state/workspace path)."""
-    return storage.get_stream(cost_pricesheet_key())
+    return storage.get_stream(cost_pricesheet_db_key())
 
 
 def _safe_unlink(path: str) -> None:
@@ -197,10 +213,10 @@ async def download_cached_to_file(storage: ObjectStore) -> str:
     no sheet is cached (call :func:`ensure_pricesheet` first).
     """
     tmpdir = _resolve_ephemeral_tmpdir()
-    fd, path = await asyncio.to_thread(tempfile.mkstemp, suffix=".csv", dir=tmpdir)
+    fd, path = await asyncio.to_thread(tempfile.mkstemp, suffix=".sqlite", dir=tmpdir)
     await asyncio.to_thread(os.close, fd)
     try:
-        async for chunk in storage.get_stream(cost_pricesheet_key()):
+        async for chunk in storage.get_stream(cost_pricesheet_db_key()):
             await asyncio.to_thread(_append_chunk, path, chunk)
     except BaseException:
         await asyncio.to_thread(_safe_unlink, path)

--- a/services/terrapod/services/workspace_cost_service.py
+++ b/services/terrapod/services/workspace_cost_service.py
@@ -64,12 +64,20 @@ def _empty_attrs(state_version: dict | None = None) -> dict[str, Any]:
 
 
 def _run_engine(state_bytes: bytes, pricesheet_path: str, default_region: str) -> dict[str, Any]:
-    """Parse state + run the cost engine (sync — called via ``to_thread``)."""
+    """Parse state + run the cost engine (sync — called via ``to_thread``).
+
+    ``pricesheet_path`` is the cached **SQLite index** (#1034); the engine queries
+    it off disk (bounded memory) instead of parsing the whole sheet.
+    """
     from terrapod.services.cost import estimate
+    from terrapod.services.cost.pricesheet_db import PricesheetIndex
 
     tf_json = json.loads(state_bytes)
-    with open(pricesheet_path) as sheet:
-        result = estimate(tf_json, sheet, default_region=default_region)
+    index = PricesheetIndex.open(pricesheet_path)
+    try:
+        result = estimate(tf_json, index=index, default_region=default_region)
+    finally:
+        index.close()
     return result.to_dict()
 
 

--- a/services/terrapod/storage/keys.py
+++ b/services/terrapod/storage/keys.py
@@ -159,6 +159,17 @@ def cost_pricesheet_key() -> str:
     return "cache/cost/prices.csv"
 
 
+def cost_pricesheet_db_key() -> str:
+    """Key for the cached pricesheet **SQLite index** (#1034).
+
+    The multi-region sheet (~260k products) is streamed once into a SQLite index
+    at cache refresh and stored here; both the API and runner download this file
+    and query it off disk (bounded memory) instead of parsing the whole sheet.
+    A distinct key from the raw-sheet key above so the two never get confused.
+    """
+    return "cache/cost/prices.sqlite"
+
+
 # --- Platform Provider Cache ---
 
 

--- a/services/tests/runner/test_phase_cost.py
+++ b/services/tests/runner/test_phase_cost.py
@@ -56,8 +56,18 @@ def _cfg(**overrides) -> RunnerConfig:
 
 def _redirect_paths(tmp_path, monkeypatch):
     """Point the phase's fixed /tmp paths at the test's tmp dir."""
-    monkeypatch.setattr(cost, "_PRICESHEET_CSV", tmp_path / "prices.csv")
+    monkeypatch.setattr(cost, "_PRICESHEET_DB", tmp_path / "prices.sqlite")
     monkeypatch.setattr(cost, "_COST_ESTIMATE_JSON", tmp_path / "cost_estimate.json")
+
+
+def _write_sheet_db(output_path) -> None:
+    """The endpoint serves a pre-built SQLite index (#1034); the fake download
+    builds one from the sample sheet at the runner's download target."""
+    import io
+
+    from terrapod.services.cost.pricesheet_db import build_index
+
+    build_index(io.StringIO(_SHEET), str(output_path))
 
 
 def test_happy_path_writes_estimate(tmp_path, monkeypatch):
@@ -66,7 +76,7 @@ def test_happy_path_writes_estimate(tmp_path, monkeypatch):
     plan.write_text(json.dumps(_PLAN))
 
     def fake_download(url, output_path, **_kw):
-        output_path.write_text(_SHEET)
+        _write_sheet_db(output_path)
         return DownloadResult(ok=True, status=200)
 
     with patch.object(cost, "download_to_file", side_effect=fake_download):
@@ -138,7 +148,7 @@ def test_pricesheet_request_sends_well_formed_bearer_header(tmp_path, monkeypatc
 
     def capture_download(url, output_path, headers=None, **_kw):
         seen.update(headers or {})
-        output_path.write_text(_SHEET)
+        _write_sheet_db(output_path)
         return DownloadResult(ok=True, status=200)
 
     with patch.object(cost, "download_to_file", side_effect=capture_download):

--- a/services/tests/services/test_cost_pricesheet_db.py
+++ b/services/tests/services/test_cost_pricesheet_db.py
@@ -1,0 +1,142 @@
+"""SQLite pricesheet index — build + query (#1034).
+
+Covers the `yaml.parse` event-streaming build (the core of #1034 — the whole
+sheet is never materialised), the CSV build, the `(type, region)` candidate
+narrowing, and an end-to-end `estimate()` through the YAML path.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+
+from terrapod.services.cost.engine import estimate
+from terrapod.services.cost.pricesheet_db import PricesheetIndex, build_index
+
+# A Terrapod YAML sheet exactly as pricegen emits it: schema, currency, then a
+# `products:` list of flat mappings. Diverse types + regions.
+_YAML = """\
+schema: terrapod-pricesheet/v1
+currency: USD
+products:
+- service: AmazonEC2
+  family: Compute Instance
+  match: type=aws_instance&values.instance_type=m5.large
+  pricing: service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=instance&os=linux&start_usage_amount=0&end_usage_amount=Inf
+  price: '0.0960000000'
+  price_type: t
+- service: AmazonEC2
+  family: Compute Instance
+  match: type=aws_instance&values.instance_type=m5.large
+  pricing: service_provider=aws&purchase_option=on_demand&region=eu-west-1&service_class=instance&os=linux&start_usage_amount=0&end_usage_amount=Inf
+  price: '0.1070000000'
+  price_type: t
+- service: AmazonS3
+  family: Storage
+  match: type=aws_s3_bucket
+  pricing: service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&start_usage_amount=0&end_usage_amount=51200
+  price: '0.0230000000'
+  price_type: d
+"""
+
+_CSV = (
+    "service,product_family,match_set,pricing_match_set,price,price_type,ccy\n"
+    "AmazonEC2,Compute Instance,type=aws_instance&values.instance_type=m5.large,"
+    "region=us-east-1&service_class=instance&os=linux&start_usage_amount=0&end_usage_amount=Inf,"
+    "0.0960000000,t,USD\n"
+)
+
+
+def test_yaml_event_build_extracts_type_region_currency():
+    idx = PricesheetIndex.build_temp(io.StringIO(_YAML))
+    # us-east-1 aws_instance → the us-east row (0.096); eu-west row excluded
+    c = list(idx.candidates("aws_instance", "us-east-1"))
+    assert len(c) == 1
+    assert c[0].price.value == 0.096
+    assert c[0].ccy == "USD"  # captured from the doc-level `currency`
+    # eu-west-1 → the eu row (0.107)
+    e = list(idx.candidates("aws_instance", "eu-west-1"))
+    assert len(e) == 1 and e[0].price.value == 0.107
+
+
+def test_candidates_narrow_by_type_and_region():
+    idx = PricesheetIndex.build_temp(io.StringIO(_YAML))
+    # a type with no products → nothing
+    assert list(idx.candidates("aws_db_instance", "us-east-1")) == []
+    # s3 is only in us-east-1 → empty in another region
+    assert list(idx.candidates("aws_s3_bucket", "eu-west-1")) == []
+    assert len(list(idx.candidates("aws_s3_bucket", "us-east-1"))) == 1
+
+
+def test_csv_build_matches_yaml():
+    y = PricesheetIndex.build_temp(io.StringIO(_YAML))
+    c = PricesheetIndex.build_temp(io.StringIO(_CSV))
+    yp = list(y.candidates("aws_instance", "us-east-1"))
+    cp = list(c.candidates("aws_instance", "us-east-1"))
+    assert yp[0].price.value == cp[0].price.value == 0.096
+
+
+def test_estimate_end_to_end_through_yaml_event_path():
+    # A multi-region plan priced through the yaml.parse build → correct per-region.
+    state = {
+        "values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "aws_instance.east",
+                        "type": "aws_instance",
+                        "name": "east",
+                        "values": {"instance_type": "m5.large", "region": "us-east-1"},
+                    },
+                    {
+                        "address": "aws_instance.euw",
+                        "type": "aws_instance",
+                        "name": "euw",
+                        "values": {"instance_type": "m5.large", "region": "eu-west-1"},
+                    },
+                ]
+            }
+        }
+    }
+    est = estimate(state, io.StringIO(_YAML))
+    by = {r.address: r.monthly_max for r in est.resources}
+    # each instance priced at its region's rate (0.107 > 0.096 confirms multi-region)
+    assert by["aws_instance.euw"] > by["aws_instance.east"] > 0
+    # 730h/mo × 0.096 for the us-east instance
+    assert abs(by["aws_instance.east"] - 730 * 0.096) < 0.5
+
+
+def test_build_index_file_and_open():
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        n = build_index(io.StringIO(_YAML), path)
+        assert n == 3  # all three products indexed
+        idx = PricesheetIndex.open(path)
+        assert len(list(idx.candidates("aws_instance", "us-east-1"))) == 1
+        idx.close()
+    finally:
+        os.unlink(path)
+
+
+def test_index_estimate_matches_stream_estimate():
+    # Passing a pre-built index yields the same result as passing the stream.
+    state = {
+        "values": {
+            "root_module": {
+                "resources": [
+                    {
+                        "address": "aws_instance.a",
+                        "type": "aws_instance",
+                        "name": "a",
+                        "values": {"instance_type": "m5.large", "region": "us-east-1"},
+                    }
+                ]
+            }
+        }
+    }
+    via_stream = estimate(state, io.StringIO(_YAML))
+    idx = PricesheetIndex.build_temp(io.StringIO(_YAML))
+    via_index = estimate(state, index=idx)
+    assert via_stream.total_max == via_index.total_max

--- a/services/tests/services/test_cost_pricesheet_service.py
+++ b/services/tests/services/test_cost_pricesheet_service.py
@@ -81,7 +81,8 @@ def _meta(age: timedelta) -> MagicMock:
 # --- refresh (real gunzip + streamed store) --------------------------------
 
 
-async def test_refresh_downloads_decompresses_and_stores():
+async def test_refresh_downloads_builds_sqlite_index_and_stores():
+    # refresh now gunzips → builds a SQLite index → stores the .sqlite (#1034).
     gz = gzip.compress(_CSV)
     captured: dict = {}
     storage = _storage_capturing(captured)
@@ -89,10 +90,28 @@ async def test_refresh_downloads_decompresses_and_stores():
     with patch.object(svc.httpx, "AsyncClient", lambda **kw: _FakeClient(gz)):
         size = await svc.refresh_pricesheet(storage)
 
-    assert captured["key"] == "cache/cost/prices.csv"
-    assert captured["content_type"] == "text/csv"
-    assert captured["data"] == _CSV  # decompressed round-trip
-    assert size == len(_CSV)
+    assert captured["key"] == "cache/cost/prices.sqlite"
+    assert captured["content_type"] == "application/x-sqlite3"
+    assert size == len(captured["data"]) > 0
+    assert captured["data"][:16].startswith(b"SQLite format 3")  # real sqlite file
+
+    # the stored index is queryable and has the CSV's product
+    import os
+    import tempfile
+
+    from terrapod.services.cost.pricesheet_db import PricesheetIndex
+
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        with open(path, "wb") as f:
+            f.write(captured["data"])
+        idx = PricesheetIndex.open(path)
+        cands = list(idx.candidates("aws_instance", "us-east-1"))
+        assert len(cands) == 1 and cands[0].price.value == 0.10
+        idx.close()
+    finally:
+        os.unlink(path)
 
 
 async def test_pricesheet_available_and_download_url():
@@ -104,7 +123,7 @@ async def test_pricesheet_available_and_download_url():
 
     assert await svc.pricesheet_available(storage) is True
     assert await svc.pricesheet_download_url(storage) == "https://example/presigned/prices.csv"
-    storage.exists.assert_awaited_with("cache/cost/prices.csv")
+    storage.exists.assert_awaited_with("cache/cost/prices.sqlite")
 
 
 # --- pull-through ensure_pricesheet ----------------------------------------

--- a/services/tests/services/test_workspace_cost_service.py
+++ b/services/tests/services/test_workspace_cost_service.py
@@ -78,7 +78,7 @@ def _patches(caps, sv, *, state_bytes=b"{}", engine=_ENGINE_RESULT):
         patch.object(
             svc.cost_pricesheet_service,
             "download_cached_to_file",
-            AsyncMock(return_value="/tmp/prices.csv"),
+            AsyncMock(return_value="/tmp/prices.sqlite"),
         ),
         patch.object(svc.cost_pricesheet_service, "_safe_unlink", MagicMock()),
         patch.object(svc, "_run_engine", MagicMock(return_value=dict(engine))),
@@ -171,4 +171,4 @@ async def test_pricesheet_tempfile_is_always_unlinked():
     with _Ctx(patches):
         with pytest.raises(ValueError):
             await svc.estimate_workspace_cost(_db_returning(sv), _user(), str(WS))
-    unlink.assert_called_once_with("/tmp/prices.csv")
+    unlink.assert_called_once_with("/tmp/prices.sqlite")


### PR DESCRIPTION
Closes #1034.

The multi-region sheet (#1025) is **~84 MB decompressed / ~260k products**. The consumer parsed the **whole** YAML document with `yaml.safe_load` (~1.7 GB peak, confirmed) on **every** cost request → OOM-kills the 1 Gi API pod (`exit 137`), and re-does the work each time. #1026 + #1032 were not production-safe as-is.

## Fix — build a SQLite index once, query it off disk

- **Cache refresh** (`cost_pricesheet_service`): the fetched sheet is streamed into a **SQLite index** keyed by `(type, region)` — via `yaml.parse` (the low-level *event* parser: emits scalars/mapping markers incrementally, never materialising the document; the CSV path streams too) — and the `.sqlite` is stored in object storage. **Bounded build (~23 MB)** regardless of sheet size.
- **Query** (`engine.estimate`, API + runner): for each resource, query only the products sharing its `type` + resolved `region` (plus region-agnostic rows), then run the existing subset-match on that handful — **never scanning the full sheet**. SQLite pages off disk → **~18 MB query**, a few ms per plan.
- **Both consumers** — the long-lived API *and* the ephemeral runner Job — fetch the **pre-built** `.sqlite` and query it, so the 260k-product parse happens **once per refresh**, not per request. **No in-memory SQLite anywhere** — the index is always a real file (a temp-file build with auto-cleanup covers tests + raw CSV/YAML mirrors; the API/runner open the cached file).

## Measured (real sheet)

| | old (`safe_load`) | new (SQLite) |
|---|---|---|
| build/parse | 67 s / **2.08 GB** | 4 s / **23 MB** (stream→file) |
| per-request | full re-parse | query **~18 MB / ~6 ms** |

## Notes
- No published-format change — `pricegen` keeps emitting single-doc YAML; the fix is entirely consumer-side.
- No route/attribute/wire/config/migration change (a new storage key + a widened `estimate()` signature only).
- Builds on #1033 (the fleet-total fix). Full cost + service + runner suite green in Docker (171 passed).