### PR TITLE
fix(929): price EBS provisioned IOPS (io1 flat, gp3 baseline, io2 graduated)

### DIFF
--- a/pricegen/providers/aws/recipes/aws_ebs_volume.yaml
+++ b/pricegen/providers/aws/recipes/aws_ebs_volume.yaml
@@ -15,24 +15,31 @@ components:
     price: { type: "a=values.size" }
     tier: none
 
-  # Provisioned IOPS: priced per IOPS-month (`o`). io2's tier rates are separate
-  # AWS SKUs (io2/io2.tier2/io2.tier3, groups "EBS IOPS"/"…Tier 2"/"…Tier 3"), so
-  # the group filter is a REGEX to catch all three. The tier BOUNDARIES aren't in
-  # the API (every SKU says 0-Inf) — gp3's free 3000-IOPS baseline and io2's
-  # 32000/64000 breaks are domain knowledge, encoded here as `tier_bounds`.
+  # Provisioned IOPS: charged from the volume's own `iops` attribute
+  # (`a=values.iops` — deterministic, so no usage assumption is needed; the older
+  # `o`/usage-based form never priced because there was no per-second usage entry
+  # for provisioned volumes, silently dropping the whole IOPS charge). io1 is
+  # FLAT (a single 0-Inf rate → full `iops` × rate). gp3 and io2 are TIERED: gp3's
+  # first 3000 IOPS are free, and io2's rate steps at 32000/64000 across three
+  # separate AWS SKUs (io2/io2.tier2/io2.tier3, groups "EBS IOPS"/"…Tier 2"/
+  # "…Tier 3") — so the group filter is a REGEX to catch all three. The tier
+  # BOUNDARIES aren't in the API (every SKU says 0-Inf); they're domain knowledge,
+  # encoded as `tier_bounds` and applied *graduated* by the consumer pricer (each
+  # tier's slice of `iops` × that tier's rate). `unit: IOPS-Mo` selects the
+  # IOPS-month price dimension.
   - product_family: "^System Operation$"
     service_class: iops
     match: { type: volumeApiName }
     select: { group: { regex: "^EBS IOPS" } }
-    price: { type: o, unit: IOPS-Mo }
+    price: { type: "a=values.iops", unit: IOPS-Mo }
     tier: provision
     tier_bounds:
       - when: { volumeApiName: gp3, group: EBS IOPS }
         start: "3000" # gp3 includes 3000 free IOPS; you pay only above it
         end: Inf
-      # io2's three tiers. Base must be bounded 0-32000 (not 0-Inf) so the engine
-      # tiers correctly — oiq omits this base row + io2 storage entirely (a gap;
-      # we are deliberately more complete).
+      # io2's three graduated tiers. The base is bounded 0-32000 (not 0-Inf) so the
+      # graduated pricer charges each tier's slice at its own rate; we deliberately
+      # price the io2 base row + io2 storage that some generators omit.
       - when: { volumeApiName: io2, group: EBS IOPS }
         start: "0"
         end: "32000"

--- a/services/terrapod/services/cost/pricer.py
+++ b/services/terrapod/services/cost/pricer.py
@@ -114,6 +114,63 @@ def _apply_provision_amount(entry: Entry, products: list[Product]) -> tuple[Entr
     return (entry, kept)
 
 
+def _price_graduated_attr_provision(
+    entry: Entry, products: list[Product]
+) -> list[PricedProduct] | None:
+    """Graduated per-tier pricing for **attribute-priced provision tiers**.
+
+    When a component is priced from a resource attribute (``a=values.iops``) AND
+    its products carry provision-tier bounds, the charge is not ``rate × attr`` at
+    one tier but the **sum over tiers** of ``rate_i × (attr's slice of tier i)`` —
+    so a free baseline (gp3's first 3000 IOPS) and graduated breaks (io2's
+    32000/64000 tiers, each a distinct AWS SKU with its own rate) are honoured.
+    Each tier's slice is ``min(attr, tier_end) − tier_lower``, where ``tier_lower``
+    is the tier's own start for the first tier and the previous tier's end after
+    that (contiguous tiers).
+
+    Returns priced products, or ``None`` when the group isn't
+    attribute-priced-with-provision-tiers, so the caller falls through to the
+    standard chain unchanged: **io1** (attribute-priced but with no tier bounds →
+    full ``iops`` at one rate) and usage-priced provision tiers both take that
+    path. Returns ``[]`` (a priced $0) when the attribute sits entirely within a
+    free baseline (e.g. gp3 at exactly 3000 IOPS).
+    """
+    if not products or not all(p.price.kind is PriceKind.ATTR for p in products):
+        return None
+    tiers: list[tuple[int, int, Product]] = []
+    for product in products:
+        ms = product.pricing_match_set
+        spa = ms.find_by_key("start_provision_amount")
+        epa = ms.find_by_key("end_provision_amount")
+        if spa is None or epa is None:
+            return None  # untiered attr product (io1) — standard chain charges full attr
+        tiers.append((_int_of_usage(spa[1]), _int_of_usage(epa[1]), product))
+
+    assert entry.usage is not None
+    attr = entry.usage.data.max  # ATTR usage was synthesized as a point Range(v, v)
+    divisor = float(entry.divisor if entry.divisor is not None else 1)
+    tiers.sort(key=lambda t: t[0])
+    out: list[PricedProduct] = []
+    prev_end = 0
+    for i, (start, end, product) in enumerate(tiers):
+        lower = start if i == 0 else prev_end
+        prev_end = end
+        qty = min(attr, end) - lower
+        if qty <= 0:
+            continue
+        cost = qty / divisor * product.price.value
+        out.append(
+            PricedProduct(
+                service=product.service,
+                product_family=product.product_family,
+                price=Range(cost, cost),
+                usage_description=entry.description,
+                ccy=product.ccy,
+            )
+        )
+    return out
+
+
 def _priced_by_range(product: Product, usage: Usage) -> Range[int]:
     kind = product.price.kind
     if kind is PriceKind.PER_TIME:
@@ -232,6 +289,13 @@ def _quote_group(
     syn_entry, syn_products = _synthesize_usage_from_attr(resource_ms, entry, group_products)
     # Fixed-per-size-tier (Azure disk): pick the tier the size rounds into first.
     syn_products = _apply_size_tier(syn_entry, syn_products, resource_ms)
+    # Graduated attribute-priced provision tiers (gp3 free baseline, io2 tiers):
+    # charge each tier's slice of the attribute, not the full attribute at one
+    # rate. Non-None ⇒ this branch owns the quote; None ⇒ fall through (io1 flat,
+    # usage-priced provision) to the standard chain below.
+    graduated = _price_graduated_attr_provision(syn_entry, syn_products)
+    if graduated is not None:
+        return graduated
     prov_entry, prov_products = _apply_provision_amount(syn_entry, syn_products)
     for bounded_entry, bounded_products in _apply_usage_amount(prov_entry, prov_products):
         if not bounded_products:

--- a/services/terrapod/services/cost/usage_defaults.json
+++ b/services/terrapod/services/cost/usage_defaults.json
@@ -144,6 +144,10 @@
     }
   },
   {
+    "description": "AWS EBS provisioned IOPS (io1/io2/gp3)",
+    "match_query": "type = aws_ebs_volume and service_class = iops"
+  },
+  {
     "description": "AWS EBS Storage",
     "match_query": "type = aws_ebs_volume and service_class = storage"
   },

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -280,8 +280,8 @@ def test_default_usage_catalogue_loads():
     # Azure AKS hours + Azure storage account data (#997) + GCS bucket storage
     # (#999) + GKE cluster management (#1001) + Kinesis shards (#1003) + VPC
     # interface endpoint hours+data (#1005) + Azure managed disk per-size tier
-    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013) + Cloud DNS zone (#1015) + Azure ACR tier (#1017) + Pub/Sub throughput (#1019) + Cloud SQL vCPU/RAM/storage (#1021) + Azure PG vCore (#1023).
-    assert len(entries) == 59
+    # (#1007) + Route53 hosted zone (#1009) + CloudFront data transfer (#1011) + ECR image storage (#1013) + Cloud DNS zone (#1015) + Azure ACR tier (#1017) + Pub/Sub throughput (#1019) + Cloud SQL vCPU/RAM/storage (#1021) + Azure PG vCore (#1023) + EBS provisioned IOPS io1/io2/gp3 (#929).
+    assert len(entries) == 60
     ec2 = match_entry(
         _ms(
             ("type", "aws_instance"),

--- a/services/tests/services/test_cost_pricegen_contract.py
+++ b/services/tests/services/test_cost_pricegen_contract.py
@@ -84,9 +84,21 @@ _ROWS = [
     "AmazonDynamoDB,Amazon DynamoDB PayPerRequest Throughput,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&request_type=read&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.0000001250,o,USD",
     "AmazonDynamoDB,Amazon DynamoDB PayPerRequest Throughput,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=requests&request_type=write&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.0000006250,o,USD",
     "AmazonDynamoDB,Database Storage,type=aws_dynamodb_table,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage&table_class=standard&start_usage_amount=0&end_usage_amount=Inf,0.2500000000,d,USD",
-    # EBS gp3 storage — priced a=values.size. From the ~450 MB EC2 offer, now in
-    # the published sheet via the ijson stream-filter (#893).
+    # EBS storage — priced a=values.size. From the ~450 MB EC2 offer, now in the
+    # published sheet via the ijson stream-filter (#893). gp3 $0.08, io1/io2 $0.125.
     "AmazonEC2,Storage,type=aws_ebs_volume&values.type=gp3,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage,0.0800000000,a=values.size,USD",
+    "AmazonEC2,Storage,type=aws_ebs_volume&values.type=io1,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage,0.1250000000,a=values.size,USD",
+    "AmazonEC2,Storage,type=aws_ebs_volume&values.type=io2,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=storage,0.1250000000,a=values.size,USD",
+    # EBS provisioned IOPS — priced a=values.iops (#929). io1 is FLAT (no
+    # provision bounds → the whole `iops` at one $0.065 rate). gp3 has a free
+    # 3000-IOPS baseline ([3000,Inf] @ $0.005). io2 is GRADUATED across three
+    # SKUs: [0,32000] @ $0.065, (32000,64000] @ $0.046, (64000,Inf] @ $0.032 —
+    # the consumer pricer charges each tier's slice of `iops` at its own rate.
+    "AmazonEC2,System Operation,type=aws_ebs_volume&values.type=io1,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=iops,0.0650000000,a=values.iops,USD",
+    "AmazonEC2,System Operation,type=aws_ebs_volume&values.type=gp3,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=iops&start_provision_amount=3000&end_provision_amount=Inf,0.0050000000,a=values.iops,USD",
+    "AmazonEC2,System Operation,type=aws_ebs_volume&values.type=io2,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=iops&start_provision_amount=0&end_provision_amount=32000,0.0650000000,a=values.iops,USD",
+    "AmazonEC2,System Operation,type=aws_ebs_volume&values.type=io2,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=iops&start_provision_amount=32001&end_provision_amount=64000,0.0460000000,a=values.iops,USD",
+    "AmazonEC2,System Operation,type=aws_ebs_volume&values.type=io2,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=iops&start_provision_amount=64001&end_provision_amount=Inf,0.0320000000,a=values.iops,USD",
     # NAT gateway — deterministic always-on hours + usage-driven data processed.
     "AmazonEC2,NAT Gateway,type=aws_nat_gateway,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=hours&start_usage_amount=0&end_usage_amount=Inf,0.0450000000,t,USD",
     "AmazonEC2,NAT Gateway,type=aws_nat_gateway,service_provider=aws&purchase_option=on_demand&region=us-east-1&service_class=data&start_usage_amount=0&end_usage_amount=Inf,0.0450000000,d,USD",
@@ -559,6 +571,66 @@ def test_ebs_gp3_volume_prices_by_size():
     )
     est = estimate(plan, _sheet())
     assert est.resources[0].monthly_min == pytest.approx(100 * 0.08, abs=0.01)  # $8.00
+
+
+# --- EBS provisioned IOPS: flat (io1), free-baseline (gp3), graduated (io2) --
+# (#929) Before this, io1/io2/gp3 provisioned IOPS were silently dropped — the
+# recipe priced them `o` with no usage entry, so a 10k-IOPS io1 lost ~$650/mo.
+
+
+def _ebs(addr, values):
+    return {
+        "address": addr,
+        "type": "aws_ebs_volume",
+        "name": addr.split(".")[-1],
+        "mode": "managed",
+        "values": {"region": "us-east-1", **values},
+    }
+
+
+def test_ebs_io1_provisioned_iops_prices_flat_from_attr():
+    """io1 has no free baseline and no graduated tiers: the whole `iops` attribute
+    is billed at one rate. This is the case the #929 probe caught dropping ~$650."""
+    plan = _plan([_ebs("aws_ebs_volume.io1", {"type": "io1", "size": 100, "iops": 10000})])
+    est = estimate(plan, _sheet())
+    # storage 100*0.125=12.50 + iops 10000*0.065=650.00 = 662.50
+    assert est.resources[0].monthly_min == pytest.approx(12.50 + 650.0, abs=0.01)
+
+
+def test_ebs_gp3_iops_charges_only_above_the_free_baseline():
+    """gp3's first 3000 IOPS are free; only the excess is billed. The [3000,Inf]
+    provision tier must SUBTRACT the baseline, not charge the full attribute."""
+    plan = _plan([_ebs("aws_ebs_volume.gp3", {"type": "gp3", "size": 100, "iops": 5000})])
+    est = estimate(plan, _sheet())
+    # storage 100*0.08=8.00 + iops (5000-3000)*0.005=10.00 = 18.00
+    assert est.resources[0].monthly_min == pytest.approx(8.0 + 10.0, abs=0.01)
+
+
+def test_ebs_gp3_iops_at_baseline_is_free():
+    """A gp3 volume provisioned at exactly its 3000 free IOPS incurs no IOPS
+    charge — the tier slice is zero, so only storage is billed."""
+    plan = _plan([_ebs("aws_ebs_volume.gp3b", {"type": "gp3", "size": 50, "iops": 3000})])
+    est = estimate(plan, _sheet())
+    assert est.resources[0].monthly_min == pytest.approx(50 * 0.08, abs=0.01)  # storage only
+
+
+def test_ebs_io2_provisioned_iops_prices_graduated_across_tiers():
+    """io2 steps down in price at 32000 and 64000 IOPS across three separate SKUs.
+    The charge is the SUM of each tier's slice at its own rate — not the whole
+    attribute at the single tier that happens to contain it."""
+    plan = _plan([_ebs("aws_ebs_volume.io2", {"type": "io2", "size": 100, "iops": 50000})])
+    est = estimate(plan, _sheet())
+    # storage 100*0.125=12.50 + iops [32000*0.065 + 18000*0.046] = 2080 + 828 = 2908
+    assert est.resources[0].monthly_min == pytest.approx(12.50 + 2080.0 + 828.0, abs=0.01)
+
+
+def test_ebs_io2_iops_spanning_all_three_tiers():
+    """A 100k-IOPS io2 volume exercises all three graduated tiers."""
+    plan = _plan([_ebs("aws_ebs_volume.io2big", {"type": "io2", "size": 10, "iops": 100000})])
+    est = estimate(plan, _sheet())
+    # storage 10*0.125=1.25 + iops [32000*0.065 + 32000*0.046 + 36000*0.032]
+    #                              = 2080 + 1472 + 1152 = 4704
+    assert est.resources[0].monthly_min == pytest.approx(1.25 + 4704.0, abs=0.01)
 
 
 def test_usage_assumptions_flagged_with_bands_for_usage_driven_resources():


### PR DESCRIPTION
Closes #929.

`aws_ebs_volume` provisioned IOPS was silently dropped — the recipe priced the IOPS component as `o` (usage-based) but no usage entry matched io1/io2/gp3, so a 10k-IOPS io1 volume lost **~$650/mo** of IOPS charge and priced storage only.

## Change

**Recipe** (`pricegen`): the IOPS component switches `type: o` → `type: "a=values.iops"` — deterministic, read from the volume’s own attribute, no usage assumption. `unit: IOPS-Mo` is kept (it selects the IOPS-month price dimension). Tier bounds are unchanged.

**Consumer pricer**: a new graduated per-tier path (`_price_graduated_attr_provision`) charges each provision tier’s *slice* of the attribute at its own rate, so the tiered volume types are correct:

| type | shape | charge |
|---|---|---|
| **io1** | no provision bounds | whole `iops` at one flat rate |
| **gp3** | first 3000 IOPS free (`[3000,Inf]`) | only the excess; `$0` at exactly 3000 |
| **io2** | graduated at 32000/64000 across three SKUs | sum of each tier’s slice at its own rate |

It triggers **only** when every product in a group is attribute-priced *and* carries provision bounds, so RDS provisioned IOPS (`a=values.iops`, `tier: none`), EBS storage (`a=values.size`), and usage-priced provision tiers all fall through the existing chain unchanged.

**Catalogue**: a usage-less `type = aws_ebs_volume and service_class = iops` entry lets the attribute-priced rows match — ordered *after* the specific `values.type = standard` magnetic entry so first-match precedence is preserved.

## Tests

Crafted-sheet contract tests (no EC2 offer needed): io1 exact (`$662.50` = 100 GB + 10k IOPS), gp3 above baseline, gp3 at baseline (IOPS free), io2 across two tiers, io2 across all three. Full cost + runner-cost suite green (130 tests).

## Note on scope

The graduated pricer lives in the current `oiq`-port `pricer.py`; #1038 (the original-cost-engine rewrite, next) will carry this logic forward behaviour-preserving. After #1038, all pricing work is complete.