### PR TITLE
test(1028): harden git-auth coverage — real-git rewrite proof, Go SDK, E2E

### DIFF
--- a/e2e/tests/variables.spec.ts
+++ b/e2e/tests/variables.spec.ts
@@ -85,6 +85,42 @@ test.describe('Variables', () => {
     await expect(valField).toHaveClass(/text-masked/);
   });
 
+  test('git-auth category swaps the form to a credential builder and round-trips', async ({
+    page,
+  }) => {
+    // #1028 / #1042: selecting a git category must ADAPT the form (the user's
+    // complaint was that the generic value field stayed put), expose a
+    // credential-source picker, and store a masked, URL-pattern-scoped var.
+    const pattern = `github.com/e2e-${Date.now()}`;
+    await page.goto(`/workspaces/${workspaceId}?tab=variables`);
+    await page.click('button:has-text("Add Variable")');
+
+    // Baseline: the generic value field is present for a normal category.
+    await expect(page.locator('#var-val')).toBeVisible();
+
+    // Switch to the git HTTPS credential category.
+    await page.selectOption('#var-cat', 'git_http_auth');
+
+    // The form ADAPTED: the generic value field is gone; the git builder is shown.
+    await expect(page.locator('#var-val')).toHaveCount(0);
+    await expect(page.locator('#git-source')).toBeVisible();
+
+    // The key field is now the URL pattern; use a static token source so the
+    // test needs no configured VCS connection.
+    await page.fill('#var-key', pattern);
+    await page.selectOption('#git-source', 'static');
+    await page.fill('#git-token', 'ghp_e2e_fake_token');
+
+    await page.click('form button:has-text("Add Variable")');
+
+    // Row renders with the VISIBLE URL pattern (not secret) and a MASKED value
+    // (the token is forced sensitive; it must never render in the table).
+    const row = page.locator(`tr:has-text("${pattern}")`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row.locator('text=***')).toBeVisible();
+    await expect(page.locator(`text=ghp_e2e_fake_token`)).toHaveCount(0);
+  });
+
   test('delete variable removes it from list', async ({ page }) => {
     const varKey = `DELETE_e2e_${Date.now()}`;
 

--- a/go-terrapod/variables_test.go
+++ b/go-terrapod/variables_test.go
@@ -103,6 +103,48 @@ func TestCreateVariable_SensitiveDefaultsOff(t *testing.T) {
 	}
 }
 
+func TestCreateVariable_GitAuthCategories(t *testing.T) {
+	// The git-auth categories (#1028) are plain string pass-through on the SDK
+	// side — no enum, no special marshalling — but the contract is that the SDK
+	// transmits them verbatim (category + the JSON credential value + sensitive)
+	// so the server receives what the runner will later materialize.
+	for _, cat := range []string{"git_http_auth", "git_ssh_auth"} {
+		t.Run(cat, func(t *testing.T) {
+			c, _, lastBody := newVarFixture(t)
+			jsonVal := `{"source":"static","username":"x-access-token","token":"ghp_x","rewrite":"to_https"}`
+			_, err := c.CreateVariable(t.Context(), "ws-aaa", CreateVariableRequest{
+				Key:       "github.com/myorg",
+				Value:     jsonVal,
+				Category:  cat,
+				Sensitive: true,
+			})
+			if err != nil {
+				t.Fatalf("CreateVariable: %v", err)
+			}
+			var req struct {
+				Data struct {
+					Attributes map[string]any `json:"attributes"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(*lastBody, &req); err != nil {
+				t.Fatal(err)
+			}
+			if req.Data.Attributes["category"] != cat {
+				t.Errorf("category = %v, want %q", req.Data.Attributes["category"], cat)
+			}
+			if req.Data.Attributes["key"] != "github.com/myorg" {
+				t.Errorf("key (URL pattern) not transmitted: %+v", req.Data.Attributes)
+			}
+			if req.Data.Attributes["value"] != jsonVal {
+				t.Errorf("JSON credential value not transmitted verbatim: %+v", req.Data.Attributes["value"])
+			}
+			if v, _ := req.Data.Attributes["sensitive"].(bool); !v {
+				t.Errorf("sensitive should be true for a git-auth credential: %+v", req.Data.Attributes)
+			}
+		})
+	}
+}
+
 func TestListVariables(t *testing.T) {
 	c, _, _ := newVarFixture(t)
 	vars, err := c.ListVariables(t.Context(), "ws-aaa")

--- a/services/tests/runner/test_phase_git_auth.py
+++ b/services/tests/runner/test_phase_git_auth.py
@@ -11,10 +11,20 @@ could reach an argv/stdout.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
 import stat
+import subprocess
+
+import pytest
 
 from terrapod.runner.phases import git_auth
+
+# Some assertions below drive git's OWN `insteadOf` engine to prove the rewrite
+# semantics (not just that we wrote the right config strings). Skip cleanly where
+# the git binary is unavailable (it is present in the runner + test images).
+_HAS_GIT = shutil.which("git") is not None
 
 
 def _http(pattern, token="ghp_SECRETTOKEN", username=None, rewrite="to_https"):
@@ -103,6 +113,64 @@ def test_ssh_writes_key_known_hosts_and_config(tmp_path):
     # https→ssh rewrite.
     assert "insteadOf = https://gitlab.example.com/" in cfg
     assert env["GIT_CONFIG_GLOBAL"] == str(tmp_path / "gitconfig")
+
+
+# --- real-git rewrite semantics (git's own insteadOf engine) -----------------
+# The string-level tests above prove we EMIT the right `insteadOf` lines; these
+# prove git actually REWRITES with them. `git ls-remote --get-url` applies
+# insteadOf and prints the resolved URL with no network I/O — deterministic.
+
+
+def _get_url(env, source):
+    r = subprocess.run(
+        ["git", "ls-remote", "--get-url", source],
+        env={**os.environ, **env},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return r.stdout.strip()
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git binary required")
+@pytest.mark.parametrize(
+    "source",
+    ["ssh://git@github.com/org/repo.git", "git@github.com:org/repo.git"],
+)
+def test_to_https_rewrite_resolves_ssh_and_scp_sources(tmp_path, source):
+    """`rewrite=to_https`: both the ssh:// and scp-style git@host: forms of a
+    source resolve to the tokenless https URL (git supplies the token via the
+    store helper out-of-band, so the resolved URL itself carries no secret)."""
+    env = git_auth.configure([_http("github.com", rewrite="to_https")], base_dir=tmp_path)
+    assert _get_url(env, source) == "https://github.com/org/repo.git"
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git binary required")
+def test_to_ssh_rewrite_resolves_https_source(tmp_path):
+    """`rewrite=to_ssh`: an https:// source resolves to the ssh:// deploy-key URL
+    (the direction the live smoke did not exercise)."""
+    env = git_auth.configure([_ssh("gitlab.example.com", rewrite="to_ssh")], base_dir=tmp_path)
+    assert (
+        _get_url(env, "https://gitlab.example.com/grp/proj.git")
+        == "ssh://git@gitlab.example.com/grp/proj.git"
+    )
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git binary required")
+def test_rewrite_is_scoped_to_its_host(tmp_path):
+    """A rewrite for host A must NEVER touch a source on host B — over-broad
+    insteadOf would silently reroute unrelated module fetches."""
+    env = git_auth.configure([_http("github.com", rewrite="to_https")], base_dir=tmp_path)
+    assert _get_url(env, "https://example.com/x.git") == "https://example.com/x.git"
+    assert _get_url(env, "ssh://git@example.com/x.git") == "ssh://git@example.com/x.git"
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git binary required")
+def test_rewrite_none_does_not_touch_urls(tmp_path):
+    """`rewrite=none`: sources pass through unchanged (auth still applies via the
+    store helper for matching https URLs, but no protocol rewrite happens)."""
+    env = git_auth.configure([_http("github.com", rewrite="none")], base_dir=tmp_path)
+    assert _get_url(env, "ssh://git@github.com/org/repo.git") == "ssh://git@github.com/org/repo.git"
 
 
 # --- HARD log-safety invariant ----------------------------------------------

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -2638,7 +2638,7 @@ function WorkspaceDetailContent() {
                     <p className="text-xs text-slate-400">{t('variables.gitHttpHint')}</p>
                     <div>
                       <label className="block text-sm font-medium text-slate-300 mb-1">{t('variables.gitCredSource')}</label>
-                      <select value={gitSource} onChange={(e) => setGitSource(e.target.value as 'vcs_connection' | 'static')} className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent">
+                      <select id="git-source" value={gitSource} onChange={(e) => setGitSource(e.target.value as 'vcs_connection' | 'static')} className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent">
                         <option value="vcs_connection">{t('variables.gitSourceVcs')}</option>
                         <option value="static">{t('variables.gitSourceStatic')}</option>
                       </select>
@@ -2658,7 +2658,7 @@ function WorkspaceDetailContent() {
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                         <div>
                           <label className="block text-sm font-medium text-slate-300 mb-1">{t('variables.gitUsername')}</label>
-                          <input type="text" value={gitUsername} onChange={(e) => setGitUsername(e.target.value)} placeholder="x-access-token" className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
+                          <input id="git-username" type="text" value={gitUsername} onChange={(e) => setGitUsername(e.target.value)} placeholder="x-access-token" className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent" />
                         </div>
                         <div>
                           <label className="block text-sm font-medium text-slate-300 mb-1">{t('variables.gitToken')}</label>


### PR DESCRIPTION
Follow-up to #1041/#1042. The git-auth + protocol-rewrite feature had strong unit coverage of materialization, the log-safety invariant, and server-side minting — but three honest gaps that this closes (rewriting is easy to get subtly wrong):

1. **Rewrite tests asserted config *strings*, not git behavior.** Added 5 tests that drive gits OWN `insteadOf` engine (`git ls-remote --get-url`, no network) to prove:
   - `to_https`: `ssh://git@host/…` **and** scp `git@host:…` → `https://host/…`
   - `to_ssh`: `https://host/…` → `ssh://git@host/…` (**the direction the live smoke did not run**)
   - **host-scoping**: a rewrite for host A never touches host B (over-broad `insteadOf` would silently reroute unrelated fetches)
   - `rewrite=none`: URLs untouched
2. **Go SDK** had no git-category test → `TestCreateVariable_GitAuthCategories` (both categories transmit category + JSON value + forced sensitive verbatim).
3. **No E2E** for the #1042 adaptive form → a spec asserting the form **adapts** (generic value field disappears, credential builder appears) and a static-token `git_http_auth` var round-trips with a **visible URL pattern + masked value** (token never renders). Two stable form ids added.

Test-only + two `id=` additions. `make test` (phase file: 15 passed), `go test` green, web build + i18n gates pass.