### PR TITLE
fix: contain cost-engine crashes + harden git-auth (v1.2.0 release-audit findings)

### DIFF
--- a/services/terrapod/runner/phases/git_auth.py
+++ b/services/terrapod/runner/phases/git_auth.py
@@ -110,6 +110,10 @@ def configure(entries: list[dict], *, base_dir: Path) -> dict[str, str]:
     ssh_hosts: list[tuple[str, Path, Path]] = []  # (host, key_path, known_hosts_path)
 
     for entry in entries:
+        if not isinstance(entry, dict):
+            # Honour the "never raises" contract: a non-dict item in the mounted
+            # list must be skipped, not `.get()`-ed into an AttributeError.
+            continue
         category = entry.get("category")
         pattern = (entry.get("key") or "").strip()
         if not pattern:
@@ -136,11 +140,25 @@ def configure(entries: list[dict], *, base_dir: Path) -> dict[str, str]:
                 use_http_path = True
             creds_lines.append(f"https://{username}:{token}@{scope}")
             if rewrite == "to_https":
-                # Tokenless rewrite — the store helper supplies the token per host.
+                # Tokenless rewrite (the store helper supplies the token per matched
+                # URL). SCOPE it to the org path when the pattern names one, so a
+                # host-wide insteadOf can't silently hijack a *different* org's ssh
+                # source on the same host — e.g. an org-b deploy-key fetch getting
+                # rewritten to https and losing its auth. Host-wide only when the
+                # pattern is a bare host.
+                if "/" in scope:
+                    org_path = scope.split("/", 1)[1].rstrip("/")
+                    https_target = f"https://{host}/{org_path}/"
+                    ssh_src = f"ssh://git@{host}/{org_path}/"
+                    scp_src = f"git@{host}:{org_path}/"
+                else:
+                    https_target = f"https://{host}/"
+                    ssh_src = f"ssh://git@{host}/"
+                    scp_src = f"git@{host}:"
                 config += [
-                    f'[url "https://{host}/"]\n',
-                    f"\tinsteadOf = ssh://git@{host}/\n",
-                    f"\tinsteadOf = git@{host}:\n",
+                    f'[url "{https_target}"]\n',
+                    f"\tinsteadOf = {ssh_src}\n",
+                    f"\tinsteadOf = {scp_src}\n",
                 ]
         elif category == _SSH:
             key = cred.get("private_key")
@@ -195,6 +213,15 @@ def configure(entries: list[dict], *, base_dir: Path) -> dict[str, str]:
     git_config.write_text("".join(config), encoding="utf-8")
     # GIT_CONFIG_GLOBAL isolates our config so nothing user-owned is clobbered.
     env["GIT_CONFIG_GLOBAL"] = str(git_config)
+    # Log-safety backstop: force git tracing OFF so an operator-set GIT_TRACE_CURL /
+    # GIT_CURL_VERBOSE (which log the Authorization header — base64 `user:token`) to
+    # the stderr the runner streams verbatim can't defeat the tokenless-mechanism
+    # guarantee. We only reach here when a credential is being materialised, and
+    # these override any inherited env value for the git subprocess.
+    env["GIT_TRACE"] = "0"
+    env["GIT_TRACE_CURL"] = "0"
+    env["GIT_CURL_VERBOSE"] = "0"
+    env["GIT_TRACE_PACKET"] = "0"
     return env
 
 

--- a/services/terrapod/services/cost/pricer.py
+++ b/services/terrapod/services/cost/pricer.py
@@ -147,7 +147,7 @@ def _price_graduated_attr_provision(
 
     assert entry.usage is not None
     attr = entry.usage.data.max  # ATTR usage was synthesized as a point Range(v, v)
-    divisor = float(entry.divisor if entry.divisor is not None else 1)
+    divisor = float(entry.divisor or 1)  # None OR 0 → 1 (guard ZeroDivisionError)
     tiers.sort(key=lambda t: t[0])
     out: list[PricedProduct] = []
     prev_end = 0
@@ -189,10 +189,21 @@ def _apply_usage_amount(entry: Entry, products: list[Product]) -> list[tuple[Ent
         return [(entry, products)]
 
     groups: dict[tuple[Range[int], str], list[Product]] = {}
+    untiered: list[Product] = []
     for product in products:
         ms = product.pricing_match_set
-        sua = _int_of_usage(ms.find_by_key("start_usage_amount")[1])  # type: ignore[index]
-        eua = _int_of_usage(ms.find_by_key("end_usage_amount")[1])  # type: ignore[index]
+        start = ms.find_by_key("start_usage_amount")
+        end = ms.find_by_key("end_usage_amount")
+        if start is None or end is None:
+            # Mixed group: `has_usage_amount` (any-product) is true, but THIS product
+            # carries no usage-amount tier bounds — e.g. a flat PER_TIME hour charge
+            # sharing one entry with tiered PER_DATA bands (aws_lb/aws_elb shape).
+            # Price it as the untiered remainder rather than indexing a missing key
+            # (find_by_key → None → None[1] → TypeError, which price() doesn't catch).
+            untiered.append(product)
+            continue
+        sua = _int_of_usage(start[1])
+        eua = _int_of_usage(end[1])
         rng = Range(sua, eua)
         kind = product.price.kind
         priced_by = (
@@ -214,6 +225,8 @@ def _apply_usage_amount(entry: Entry, products: list[Product]) -> list[tuple[Ent
         bounded = usage_mod.bound_to_usage_amount(accessor, usage_range, entry)
         if bounded is not None:
             out.append((bounded, group))
+    if untiered:
+        out.append((entry, untiered))
     return out
 
 
@@ -221,7 +234,7 @@ def _price_products(
     entry: Entry, products: list[Product]
 ) -> tuple[PricedProduct, float, float] | None:
     assert entry.usage is not None
-    divisor = float(entry.divisor if entry.divisor is not None else 1)
+    divisor = float(entry.divisor or 1)  # None OR 0 → 1 (guard ZeroDivisionError)
     priced: list[tuple[Product, float]] = []
     for product in products:
         unit_price = product.price.value

--- a/services/terrapod/services/workspace_cost_service.py
+++ b/services/terrapod/services/workspace_cost_service.py
@@ -148,6 +148,19 @@ async def estimate_workspace_cost(db: AsyncSession, user, workspace_id: str) -> 
     try:
         default_region = settings.cost_estimation.default_region
         attrs = await asyncio.to_thread(_run_engine, state_bytes, pricesheet_path, default_region)
+    except Exception as exc:  # noqa: BLE001 — contain ANY engine error to a clean 503
+        # The runner plan path treats a pricing failure as advisory (skips the
+        # estimate); this endpoint must likewise never 500 on an engine bug. Fail
+        # closed to a 503 (mapped from PricesheetUnavailable) rather than surfacing a
+        # raw traceback or the misleading $0 the fail-closed philosophy avoids.
+        logger.warning(
+            "workspace_cost_engine_failed",
+            workspace_id=str(ws.id),
+            state_version_id=str(sv.id),
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        raise PricesheetUnavailable(f"cost estimation failed ({type(exc).__name__})") from exc
     finally:
         await asyncio.to_thread(cost_pricesheet_service._safe_unlink, pricesheet_path)
 

--- a/services/tests/runner/test_phase_git_auth.py
+++ b/services/tests/runner/test_phase_git_auth.py
@@ -64,10 +64,11 @@ def test_http_writes_credential_store_and_tokenless_rewrite(tmp_path):
     # store helper wired to the creds file; path-scoped (host/org).
     assert "helper = store --file=" in cfg
     assert "useHttpPath = true" in cfg
-    # ssh→https rewrite is present and TOKENLESS.
-    assert "insteadOf = ssh://git@github.com/" in cfg
-    assert "insteadOf = git@github.com:" in cfg
-    assert 'url "https://github.com/"' in cfg
+    # ssh→https rewrite is present, TOKENLESS, and PATH-SCOPED to the org (the
+    # pattern names one) so it can't hijack another org's ssh source on the host.
+    assert 'url "https://github.com/myorg/"' in cfg
+    assert "insteadOf = ssh://git@github.com/myorg/" in cfg
+    assert "insteadOf = git@github.com:myorg/" in cfg
 
 
 def test_http_default_username_is_x_access_token(tmp_path):
@@ -171,6 +172,54 @@ def test_rewrite_none_does_not_touch_urls(tmp_path):
     store helper for matching https URLs, but no protocol rewrite happens)."""
     env = git_auth.configure([_http("github.com", rewrite="none")], base_dir=tmp_path)
     assert _get_url(env, "ssh://git@github.com/org/repo.git") == "ssh://git@github.com/org/repo.git"
+
+
+@pytest.mark.skipif(not _HAS_GIT, reason="git binary required")
+def test_to_https_rewrite_is_path_scoped_and_spares_other_orgs(tmp_path):
+    """Regression (#1028 audit finding 7): an http `to_https` rewrite scoped to
+    org-a must NOT rewrite a DIFFERENT org's ssh source on the same host — a
+    host-wide insteadOf would silently strip org-b's ssh (deploy-key) auth."""
+    env = git_auth.configure(
+        [
+            _http("github.com/org-a", rewrite="to_https"),
+            _ssh("github.com/org-b", rewrite="none"),
+        ],
+        base_dir=tmp_path,
+    )
+    # org-a's ssh source IS rewritten to https (token path).
+    assert (
+        _get_url(env, "ssh://git@github.com/org-a/repo.git") == "https://github.com/org-a/repo.git"
+    )
+    # org-b's ssh source is UNTOUCHED — still ssh, so its deploy key applies.
+    assert (
+        _get_url(env, "ssh://git@github.com/org-b/repo.git")
+        == "ssh://git@github.com/org-b/repo.git"
+    )
+
+
+def test_env_neutralises_git_tracing(tmp_path):
+    """Regression (#1028 audit finding 8): the returned env forces git tracing OFF
+    so an operator-set GIT_TRACE_CURL/GIT_CURL_VERBOSE (which log the Authorization
+    header) can't leak the token into the streamed run log."""
+    env = git_auth.configure([_http("github.com")], base_dir=tmp_path)
+    assert env["GIT_TRACE_CURL"] == "0"
+    assert env["GIT_CURL_VERBOSE"] == "0"
+    assert env["GIT_TRACE"] == "0"
+    assert env["GIT_TRACE_PACKET"] == "0"
+
+
+def test_non_dict_entry_is_skipped_not_raised(tmp_path):
+    """Regression (#1028 audit finding 9): a non-dict item in the mounted list is
+    skipped, honouring the phase's 'never raises' contract (was: AttributeError)."""
+    entries = [
+        "not-a-dict",
+        42,
+        None,
+        {"category": "git_http_auth", "key": "github.com", "value": '{"token":"ghp_X"}'},
+    ]
+    git_auth.configure(entries, base_dir=tmp_path)  # must not raise
+    creds = (tmp_path / "git-credentials").read_text().splitlines()
+    assert creds == ["https://x-access-token:ghp_X@github.com"]  # only the good entry
 
 
 # --- HARD log-safety invariant ----------------------------------------------

--- a/services/tests/services/test_cost_engine.py
+++ b/services/tests/services/test_cost_engine.py
@@ -319,6 +319,77 @@ def test_bound_to_usage_amount_clamps_to_tier():
     assert bound_to_usage_amount(DATA, Range(2000, 3000), entry) is None
 
 
+def test_apply_usage_amount_mixed_group_does_not_crash():
+    """Regression (#1028 cost audit finding 1): a group where SOME products carry
+    usage-amount tier bounds and some don't (the aws_lb/aws_elb shape — a flat
+    PER_TIME hour sharing one entry with tiered PER_DATA bands) must NOT index a
+    missing key (find_by_key → None → None[1] → TypeError, uncaught by price()).
+    The untiered product is priced as the remainder instead."""
+    from terrapod.services.cost.pricer import _apply_usage_amount
+    from terrapod.services.cost.prices import product_from_yaml
+    from terrapod.services.cost.usage import Entry, Usage
+
+    tiered = product_from_yaml(
+        {
+            "service": "s",
+            "family": "f",
+            "match": "type=aws_lb",
+            "price_type": "d",
+            "price": "0.008",
+            "pricing": "region=us-east-1&start_usage_amount=0&end_usage_amount=10000",
+        },
+        "USD",
+    )
+    flat = product_from_yaml(  # no usage-amount bounds → the missing-key crash source
+        {
+            "service": "s",
+            "family": "f",
+            "match": "type=aws_lb",
+            "price_type": "t",
+            "price": "0.0225",
+            "pricing": "region=us-east-1",
+        },
+        "USD",
+    )
+    entry = Entry(
+        description="d",
+        divisor=None,
+        match_query=MatchQuery.parse(""),
+        usage=Usage.from_data_range(Range(0, 5000)),
+    )
+    out = _apply_usage_amount(entry, [tiered, flat])  # must not raise TypeError
+    priced = [p for _, group in out for p in group]
+    assert flat in priced and tiered in priced  # both accounted for
+
+
+def test_price_products_zero_divisor_does_not_crash():
+    """Regression (#1028 cost audit finding 2): a usage entry with divisor=0 must be
+    treated as divisor 1 (parity with _count_factor's `or 1`), not ZeroDivisionError."""
+    from terrapod.services.cost.pricer import _price_products
+    from terrapod.services.cost.prices import product_from_yaml
+    from terrapod.services.cost.usage import Entry, Usage
+
+    product = product_from_yaml(
+        {
+            "service": "s",
+            "family": "f",
+            "match": "type=aws_x",
+            "price_type": "d",
+            "price": "0.10",
+            "pricing": "region=us-east-1",
+        },
+        "USD",
+    )
+    entry = Entry(
+        description="d",
+        divisor=0,
+        match_query=MatchQuery.parse(""),
+        usage=Usage.from_data_range(Range(100, 100)),
+    )
+    result = _price_products(entry, [product])  # must not raise ZeroDivisionError
+    assert result is not None
+
+
 def test_range_intersect():
     assert intersect(Range(0, 5), Range(3, 10)) == Range(3, 5)
     assert intersect(Range(0, 5), Range(6, 10)) is None

--- a/services/tests/services/test_workspace_cost_service.py
+++ b/services/tests/services/test_workspace_cost_service.py
@@ -161,14 +161,17 @@ async def test_happy_path_prices_and_attaches_sv_meta():
     }
 
 
-async def test_pricesheet_tempfile_is_always_unlinked():
-    """The PVC pricesheet tempfile is cleaned up even when the engine raises."""
+async def test_engine_exception_is_contained_and_tempfile_unlinked():
+    """The PVC pricesheet tempfile is cleaned up even when the engine raises, AND
+    (#1028 cost audit finding 3) an engine crash — e.g. the TypeError/ZeroDivisionError
+    a pricing edge could throw — is CONTAINED to PricesheetUnavailable (→ 503), never
+    propagated as a raw 500 the way the runner plan path avoids by skipping."""
     sv = _sv()
     patches = _patches(frozenset({cap.STATE_READ}), sv)
     unlink = MagicMock()
     patches[6] = patch.object(svc.cost_pricesheet_service, "_safe_unlink", unlink)
-    patches[7] = patch.object(svc, "_run_engine", MagicMock(side_effect=ValueError("bad state")))
+    patches[7] = patch.object(svc, "_run_engine", MagicMock(side_effect=TypeError("mixed group")))
     with _Ctx(patches):
-        with pytest.raises(ValueError):
+        with pytest.raises(svc.PricesheetUnavailable):  # was a raw TypeError → HTTP 500
             await svc.estimate_workspace_cost(_db_returning(sv), _user(), str(WS))
     unlink.assert_called_once_with("/tmp/prices.sqlite")


### PR DESCRIPTION
Fixes from the v1.2.0 pre-release third-party adversarial review — two real crash paths in the cost engine + three git-auth hardening gaps, all verified against the code.

## Cost engine — was a raw HTTP 500 on `GET /workspaces/{id}/cost-estimate`
The runner plan path skips on a pricing failure, but the workspace endpoint only caught `PricesheetUnavailable`, so an engine exception surfaced as a 500.
- **`_apply_usage_amount` mixed-group `TypeError`** — the `any()` guard proves *some* product has usage-amount bounds, but the loop then indexed `find_by_key(...)[1]` on **every** product → `None[1]` → crash on the `aws_lb`/`aws_elb` shape (flat PER_TIME hour + tiered PER_DATA bands). Untiered products are now priced as the remainder.
- **Unguarded `divisor`** at both sites → `divisor:0` → `ZeroDivisionError`. Added the `or 1` guard `_count_factor` already has.
- **`workspace_cost_service`** now contains *any* engine exception to a clean **503** (mapped from `PricesheetUnavailable`), never a raw 500 or a misleading $0.

## git-auth (#1028) hardening
- **Path-scoped `insteadOf`** — the ssh→https rewrite is scoped to the org path when the pattern names one, so a host-wide rewrite can no longer silently hijack a *different* org's ssh (deploy-key) source on the same host and strip its auth.
- **Git tracing forced off** in the returned env (`GIT_TRACE_CURL`/`GIT_CURL_VERBOSE`/`GIT_TRACE`/`GIT_TRACE_PACKET`) — an operator-set trace var can no longer log the Authorization header (base64 `user:token`) into the streamed run log.
- **Non-dict entries skipped** in `configure()` (was `AttributeError`) — honours the phase's "never raises" contract.

Each fix ships a regression test (incl. a real-git same-host-cross-org rewrite test); the two behaviour-changing existing tests are updated. `make test` on the affected suites: 118 passed.

Part of the v1.2.0 release-prep audit.