### PR TITLE
docs+chore: v1.2.0 release-prep — docs, consumer drift, cost nits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,6 +683,7 @@ jobs:
           # Cost estimation (#871): non-secret config renders into config.yaml.
           echo "$out" | grep -q "cost_estimation:" || { echo "FAIL: cost_estimation config not rendered into config.yaml (#871)"; exit 1; }
           echo "$out" | grep -q "prices_url:" || { echo "FAIL: cost_estimation.prices_url not rendered (#871)"; exit 1; }
+          echo "$out" | grep -q "default_region:" || { echo "FAIL: cost_estimation.default_region not rendered (#871)"; exit 1; }
           echo "values-local renders OK (incl. Slack config + secretKeyRef)"
       - name: Eval values render (embedded Postgres/Redis)
         run: |

--- a/README.md
+++ b/README.md
@@ -158,13 +158,14 @@ Everything below is implemented and shipped today.
 | Workspace autodiscovery | Atlantis-style monorepo autodiscovery — pattern-matched rules auto-create workspaces on PRs to new directories |
 | Terragrunt | Per-workspace Terragrunt for agent-mode runs (a flag + pinned version, pull-through binary cache, local-backend reconciliation so Terrapod still owns state); CLI-driven runs need no extra config |
 | Variables & secrets | Per-workspace env and Terraform variables; sensitive values protected by database encryption-at-rest; variable sets |
+| Private module source auth | First-class auth for private `git::https://` / `git::ssh://` module sources — a scoped `git_http_auth` / `git_ssh_auth` variable (static token or minted from a VCS connection), with ssh↔https protocol rewriting; credentials are log-safe and delivered only via the per-run Secret ([module-auth.md](docs/module-auth.md)) |
 | Drift detection | Scheduled plan-only runs to detect out-of-band changes, with a per-workspace ignore allowlist |
 | Notifications | Webhook (HMAC-SHA512), Slack (Block Kit), and email alerts on run events |
 | Interactive Slack app | Outbound Socket Mode app — `/terrapod` account linking + opt-in per-workspace run notifications with RBAC-checked Approve/Discard buttons; multiple deployments can share one Slack workspace |
 | Run tasks | Pre/post-plan webhook hooks for external validation |
 | Execution hooks | **Custom execution steps** — admin-managed shell run in the runner Job at pre_init / pre_plan / post_plan / pre_apply / post_apply, associated with workspaces (`pre_init` is the setup/tooling/auth slot; custom runner images cover heavier needs) |
 | Service catalog | No-code self-service provisioning over the module registry |
-| Cost estimation | Monthly cost of managed infrastructure — a per-plan delta on every run and the current total on a workspace; data via a native cost engine (credited), on by default; optional AI layer estimates the resources the engine can't price + savings advisories + a grounded cost chat |
+| Cost estimation | Monthly cost of managed infrastructure — a per-plan delta on every run and the current total on a workspace; data via a native cost engine, on by default; optional AI layer estimates the resources the engine can't price + savings advisories + a grounded cost chat |
 | Impact graph | Interactive dependency + blast-radius view of a plan on the run page — module-clustered, click a resource to light up its transitive downstream impact |
 | Estate topology | Whole-estate dependency graph — workspaces + modules wired by run-triggers, remote-state, and module links; group by any label / pool / name prefix; RBAC-filtered; accessible table fallback |
 | State resource graph | Per-workspace resource dependency graph from Terraform state — resources wired by `depends-on`; current state version by default with an older-version picker; group by type / module / provider / mode; accessible table fallback |
@@ -380,6 +381,7 @@ See [docs/authentication.md](docs/authentication.md) for setup guides.
 | [Deployment](docs/deployment.md) | Production Helm deployment, storage backends, scaling |
 | [Registry](docs/registry.md) | Private module/provider registry, caching layers |
 | [Registry Publishing](docs/registry-publishing.md) | Publishing providers/modules with `terrapod-publish` and the client-signed publish protocol |
+| [Module Source Auth](docs/module-auth.md) | Authenticating private `git::https://` / `git::ssh://` module sources (scoped credentials, ssh↔https rewrite, log-safe delivery) |
 | [VCS Integration](docs/vcs-integration.md) | GitHub and GitLab setup, polling, webhooks |
 | [VCS Workflows](docs/vcs-workflows.md) | PR/MR comment commands, speculative plans, apply-on-merge |
 | [Policies (OPA)](docs/policies.md) | Rego policy authoring, advisory vs mandatory enforcement, label-based scoping, admin override |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1472,7 +1472,7 @@ POST /api/v2/workspaces/{id}/vars
 }
 ```
 
-`category` is either `terraform` or `env`. In agent mode both are delivered to the runner Job via a per-run Kubernetes Secret (never plaintext in the Job spec): `terraform` vars are rendered into a generated `terrapod.auto.tfvars` from a Secret-mounted blob (honouring `hcl`), and `env` vars are injected via `secretKeyRef`. (In local execution mode the CLI handles variables itself.)
+`category` is one of `terraform`, `env`, `git_http_auth`, or `git_ssh_auth`. In agent mode all are delivered to the runner Job via a per-run Kubernetes Secret (never plaintext in the Job spec): `terraform` vars are rendered into a generated `terrapod.auto.tfvars` from a Secret-mounted blob (honouring `hcl`), and `env` vars are injected via `secretKeyRef`. (In local execution mode the CLI handles variables itself.) The two `git_*_auth` categories carry credentials for private git module sources — the `key` is a host/URL pattern and the `value` a JSON credential; they are always forced `sensitive` and consumed by the runner's git-auth phase before `init` (see [Module Source Auth](module-auth.md)), not by terraform/tofu directly.
 
 **Required permission:** `write` on the workspace.
 
@@ -3409,7 +3409,7 @@ The attributes match the run estimate, plus `state-version` naming the priced ve
 ### Pricesheet (runner + admin)
 
 ```
-GET  /api/terrapod/v1/cost-estimation/pricesheet             # 302 → presigned cached CSV (any authenticated caller; consumed by runner Jobs)
+GET  /api/terrapod/v1/cost-estimation/pricesheet             # 302 → presigned cached pricesheet (gzipped YAML) (any authenticated caller; consumed by runner Jobs)
 GET  /api/terrapod/v1/cost-estimation/pricesheet/status      # admin: enabled + cached?
 POST /api/terrapod/v1/cost-estimation/pricesheet/refresh     # admin: force re-fetch from upstream
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,10 +30,11 @@ Beyond broad TFE compatibility, Terrapod is built with three deliberate design f
 | **VCS Integration** | GitHub (App) and GitLab (access token); inbound webhooks supported (GitHub HMAC + GitLab token) for instant triggers, plus outbound polling so webhooks are optional, never required |
 | **VCS Workflows** | Default merge-then-apply (TFE standard) plus opt-in apply-then-merge mode (Atlantis-style: PR comments drive applies, `terrapod apply` from a PR comment, auto-merge after apply) |
 | **Variables & Secrets** | Per-workspace env and Terraform variables; sensitive values protected by database encryption-at-rest; variable sets |
+| **Private Module Source Auth** | First-class auth for private `git::https://` / `git::ssh://` module sources — a scoped `git_http_auth` / `git_ssh_auth` variable (static token or minted from a VCS connection), ssh↔https protocol rewrite, log-safe per-run-Secret delivery ([module-auth.md](module-auth.md)) |
 | **RBAC** | Label-based role system with hierarchical workspace permissions (read/plan/write/admin) |
 | **Private Registry** | Publish, version, and share modules and providers internally with pull-through caching |
 | **Service Catalog** | No-code self-service provisioning over the private registry; blessed modules become one-click agent-mode workspaces with provider templates and a dedicated RBAC axis |
-| **Cost Estimation** | Monthly cost of managed infrastructure — a per-plan delta on every run and the current total on a workspace; data via a native cost engine (credited), on by default; optional AI layer estimates the resources the engine can't price + savings advisories + a grounded cost chat |
+| **Cost Estimation** | Monthly cost of managed infrastructure — a per-plan delta on every run and the current total on a workspace; data via a native cost engine, on by default; optional AI layer estimates the resources the engine can't price + savings advisories + a grounded cost chat |
 | **Agent Pools** | Named groups of runner listeners; join token → certificate exchange for auth |
 | **SSO (OIDC / SAML)** | Pluggable identity providers (Auth0, Okta, Azure AD, etc.) |
 | **Run Triggers** | Cross-workspace dependency chains -- source apply triggers downstream runs |

--- a/go-terrapod/runs.go
+++ b/go-terrapod/runs.go
@@ -77,6 +77,13 @@ type Run struct {
 	HasChanges       *bool `json:"has-changes,omitempty"`
 	HasJSONOutput    bool  `json:"has-json-output"`
 	StateDiverged    bool  `json:"state-diverged"`
+	// Cost estimation (#871): HasCostEstimate gates the run's Cost tab; the cached
+	// monthly range is echoed for cheap list display. Currency/min/max are nil
+	// until an estimate exists (a plan-only or errored run may have none).
+	HasCostEstimate bool     `json:"has-cost-estimate"`
+	CostCurrency    string   `json:"cost-currency,omitempty"`
+	CostMonthlyMin  *float64 `json:"cost-monthly-min,omitempty"`
+	CostMonthlyMax  *float64 `json:"cost-monthly-max,omitempty"`
 	// Workspace context.
 	WorkspaceID   string `json:"workspace-id,omitempty"` // from the `workspace` relationship
 	WorkspaceName string `json:"workspace-name,omitempty"`
@@ -321,6 +328,8 @@ func runFromResource(res *Resource) *Run {
 		IsDriftDetection:  GetBoolAttr(res, "is-drift-detection"),
 		HasJSONOutput:     GetBoolAttr(res, "has-json-output"),
 		StateDiverged:     GetBoolAttr(res, "state-diverged"),
+		HasCostEstimate:   GetBoolAttr(res, "has-cost-estimate"),
+		CostCurrency:      GetStringAttr(res, "cost-currency"),
 		WorkspaceName:     GetStringAttr(res, "workspace-name"),
 		VCSCommitSHA:      GetStringAttr(res, "vcs-commit-sha"),
 		VCSBranch:         GetStringAttr(res, "vcs-branch"),
@@ -336,6 +345,8 @@ func runFromResource(res *Resource) *Run {
 	r.RunnerExitCode = nullableInt(res, "runner-exit-code")
 	r.VCSPullRequestNumber = nullableInt(res, "vcs-pull-request-number")
 	r.HasChanges = nullableBool(res, "has-changes")
+	r.CostMonthlyMin = nullableFloat(res, "cost-monthly-min")
+	r.CostMonthlyMax = nullableFloat(res, "cost-monthly-max")
 	unmarshalAttr(res, "actions", &r.Actions)
 	unmarshalAttr(res, "status-timestamps", &r.StatusTimestamps)
 	return r
@@ -352,6 +363,20 @@ func nullableInt(res *Resource, key string) *int64 {
 		return nil
 	}
 	return &n
+}
+
+// nullableFloat returns a *float64 for an attribute that may be JSON null /
+// absent (distinguishing "no estimate" from an explicit 0.0).
+func nullableFloat(res *Resource, key string) *float64 {
+	raw, ok := res.Attributes[key]
+	if !ok || len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var f float64
+	if json.Unmarshal(raw, &f) != nil {
+		return nil
+	}
+	return &f
 }
 
 // nullableBool returns a *bool for an attribute that may be JSON null / absent

--- a/go-terrapod/runs_test.go
+++ b/go-terrapod/runs_test.go
@@ -19,6 +19,7 @@ const runAttrs = `{
   "refresh-only":false,"refresh":true,"allow-empty-apply":false,
   "is-drift-detection":false,"has-changes":true,"has-json-output":true,
   "state-diverged":false,
+  "has-cost-estimate":true,"cost-currency":"USD","cost-monthly-min":12.5,"cost-monthly-max":40.0,
   "peak-memory-bytes":536870912,"peak-cpu-usec":null,"runner-exit-code":0,
   "runner-exit-reason":"","workspace-name":"app",
   "vcs-commit-sha":"abc123","vcs-branch":"main","vcs-pull-request-number":null,
@@ -142,6 +143,13 @@ func TestGetRunParsesNativeFields(t *testing.T) {
 	}
 	if run.HasChanges == nil || !*run.HasChanges {
 		t.Errorf("has-changes: %+v", run.HasChanges)
+	}
+	// Cost estimation fields (#871) surfaced on the run object.
+	if !run.HasCostEstimate || run.CostCurrency != "USD" {
+		t.Errorf("cost flags: has=%v ccy=%q", run.HasCostEstimate, run.CostCurrency)
+	}
+	if run.CostMonthlyMax == nil || *run.CostMonthlyMax != 40.0 {
+		t.Errorf("cost-monthly-max: %+v", run.CostMonthlyMax)
 	}
 	if run.PeakMemoryBytes == nil || *run.PeakMemoryBytes != 536870912 {
 		t.Errorf("peak-memory-bytes: %+v", run.PeakMemoryBytes)

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -512,12 +512,16 @@ field RoleAssignment.RoleName string `json:"role-name"`
 field Run.Actions RunActions `json:"actions"`
 field Run.AllowEmptyApply bool `json:"allow-empty-apply"`
 field Run.AutoApply bool `json:"auto-apply"`
+field Run.CostCurrency string `json:"cost-currency,omitempty"`
+field Run.CostMonthlyMax *float64 `json:"cost-monthly-max,omitempty"`
+field Run.CostMonthlyMin *float64 `json:"cost-monthly-min,omitempty"`
 field Run.CreatedAt string `json:"created-at,omitempty"`
 field Run.CreatedBy string `json:"created-by,omitempty"`
 field Run.DiscardReason string `json:"discard-reason,omitempty"`
 field Run.ErrorMessage string `json:"error-message,omitempty"`
 field Run.ExecutionBackend string `json:"execution-backend,omitempty"`
 field Run.HasChanges *bool `json:"has-changes,omitempty"`
+field Run.HasCostEstimate bool `json:"has-cost-estimate"`
 field Run.HasJSONOutput bool `json:"has-json-output"`
 field Run.ID string `json:"id"`
 field Run.IsDestroy bool `json:"is-destroy"`

--- a/llms.txt
+++ b/llms.txt
@@ -91,6 +91,7 @@ How each capability is turned on. **Platform-level** features are Helm values un
 | AI plan summary | `api.config.ai_summary.enabled` + provider/model config | [ai-plan-summary.md](docs/ai-plan-summary.md) |
 | Service catalog | `api.config.catalog.enabled` (on by default; the `catalog_permission` RBAC axis is opt-in) | [service-catalog.md](docs/service-catalog.md) |
 | Cost estimation | `api.config.cost_estimation.enabled` (on by default; per-plan delta + per-workspace state cost; native cost engine, data only; air-gap via `cost_estimation.prices_url` mirror) | [cost-estimation.md](docs/cost-estimation.md) |
+| Private module source auth | On by default — no enable key; create a sensitive `git_http_auth`/`git_ssh_auth` workspace variable scoped by URL pattern (static token or minted from a VCS connection) | [module-auth.md](docs/module-auth.md) |
 | Prometheus metrics | `api.config.metrics.enabled` | [monitoring.md](docs/monitoring.md) |
 | Shipped Grafana dashboard | `api.config.metrics.grafanaDashboards.enabled` (sidecar auto-import; off by default) | [monitoring.md](docs/monitoring.md#grafana-dashboards) |
 | Shipped Prometheus alert rules | `api.config.metrics.prometheusRule.enabled` (off by default; each alert links a runbook) | [monitoring.md](docs/monitoring.md#alerting-shipped-prometheusrule) |

--- a/mcp/internal/mcpserver/crud.go
+++ b/mcp/internal/mcpserver/crud.go
@@ -145,7 +145,7 @@ func registerCRUD(s *mcp.Server, c *terrapod.Client) {
 		WorkspaceID string `json:"workspace_id" jsonschema:"the workspace id (ws-...)"`
 		Key         string `json:"key" jsonschema:"the variable key"`
 		Value       string `json:"value,omitempty" jsonschema:"the value (empty is legal, e.g. flag-shaped env vars)"`
-		Category    string `json:"category,omitempty" jsonschema:"terraform or env (default terraform)"`
+		Category    string `json:"category,omitempty" jsonschema:"terraform, env, git_http_auth, or git_ssh_auth (default terraform); the git_* categories carry private-git-module credentials as a JSON value and are always sensitive"`
 		HCL         *bool  `json:"hcl,omitempty" jsonschema:"the value is a raw HCL expression (lists/objects); default false"`
 		Sensitive   *bool  `json:"sensitive,omitempty" jsonschema:"mark sensitive — masked at rest and in responses; default false"`
 		Description string `json:"description,omitempty" jsonschema:"optional human description"`
@@ -153,7 +153,7 @@ func registerCRUD(s *mcp.Server, c *terrapod.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name: "terrapod_variable_set",
 		Description: "Set a workspace variable — creates it if the key is new, updates it in place if it exists (an upsert keyed on `key`). " +
-			"category defaults to terraform; set category=env for an environment variable. Set hcl=true for non-string values (lists/objects/numbers). Returns the variable.",
+			"category defaults to terraform; set category=env for an environment variable, or git_http_auth/git_ssh_auth for private-git-module credentials (JSON value, always sensitive — see the module-auth docs). Set hcl=true for non-string values (lists/objects/numbers). Returns the variable.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in variableSetIn) (*mcp.CallToolResult, *terrapod.Variable, error) {
 		if in.WorkspaceID == "" || in.Key == "" {
 			return errText("workspace_id and key are required"), nil, nil

--- a/mcp/internal/mcpserver/observe.go
+++ b/mcp/internal/mcpserver/observe.go
@@ -188,7 +188,7 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "terrapod_workspace_cost",
-		Description: "Estimate the CURRENT monthly cost of a workspace's managed infrastructure from its latest state (native native cost engine — data only, no AI). Returns currency, the total monthly range, per-resource costs, the unpriced resources, and which state version was priced. `state-version` is null when the workspace has no state yet.",
+		Description: "Estimate the CURRENT monthly cost of a workspace's managed infrastructure from its latest state (native cost engine — data only, no AI). Returns currency, the total monthly range, per-resource costs, the unpriced resources, and which state version was priced. `state-version` is null when the workspace has no state yet.",
 		Annotations: readOnly,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in wsCostIn) (*mcp.CallToolResult, *terrapod.WorkspaceCostEstimate, error) {
 		if in.WorkspaceID == "" {
@@ -207,7 +207,7 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "terrapod_run_cost",
-		Description: "Get a run's monthly cost estimate — the plan's cost DELTA: the projected monthly total, the delta this run introduces, the previous total, per-resource costs, and unpriced resources (native native cost engine — data only, no AI). Returns 'not available' when the run produced no cost estimate.",
+		Description: "Get a run's monthly cost estimate — the plan's cost DELTA: the projected monthly total, the delta this run introduces, the previous total, per-resource costs, and unpriced resources (native cost engine — data only, no AI). Returns 'not available' when the run produced no cost estimate.",
 		Annotations: readOnly,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runCostIn) (*mcp.CallToolResult, *terrapod.CostEstimate, error) {
 		if in.RunID == "" {

--- a/mcp/internal/mcpserver/tool_catalogue.json
+++ b/mcp/internal/mcpserver/tool_catalogue.json
@@ -387,7 +387,7 @@
       "additionalProperties": false,
       "properties": {
         "category": {
-          "description": "terraform or env (default terraform)",
+          "description": "terraform, env, git_http_auth, or git_ssh_auth (default terraform); the git_* categories carry private-git-module credentials as a JSON value and are always sensitive",
           "type": "string"
         },
         "description": {

--- a/services/terrapod/api/routers/cost_estimation.py
+++ b/services/terrapod/api/routers/cost_estimation.py
@@ -33,7 +33,7 @@ async def download_pricesheet(
     user: AuthenticatedUser = Depends(get_current_user),
     storage: ObjectStore = Depends(get_storage),
 ) -> RedirectResponse:
-    """Redirect (302) to a presigned URL for the cached pricesheet CSV.
+    """Redirect (302) to a presigned URL for the cached pricesheet (gzipped YAML).
 
     Consumed by runner Jobs (plan-path cost phase). Pull-through: the sheet is
     fetched on demand if the cached copy is missing or stale (no schedule), and

--- a/services/terrapod/services/cost/engine.py
+++ b/services/terrapod/services/cost/engine.py
@@ -13,7 +13,7 @@ ranges, per-resource costs, and the list of resources nothing priced (the
 "Unpriced" bucket surfaced in the UX).
 
 The engine is pure and synchronous. On the API event loop it must be called via
-``asyncio.to_thread`` (streaming a ~200k-row CSV is CPU-bound — rule 13).
+``asyncio.to_thread`` (streaming a large pricesheet is CPU-bound — rule 13).
 """
 
 from __future__ import annotations
@@ -104,7 +104,7 @@ def estimate(
 
     ``tf_json``   — parsed ``terraform show -json`` (plan or state) or a raw
                     state v4 file.
-    ``pricesheet`` — an open text pricesheet stream (CSV or Terrapod YAML). Built
+    ``pricesheet`` — an open text pricesheet stream (Terrapod YAML). Built
                     into an in-memory SQLite index (small sheets / mirrors / tests).
     ``index``     — a pre-built :class:`~pricesheet_db.PricesheetIndex` (the API /
                     runner pass the cached ``.sqlite`` so the 260k-product sheet is
@@ -145,7 +145,7 @@ def estimate(
     # Match via the SQLite index (#1034): for each resource, query only the
     # products sharing its type + resolved region (plus region-agnostic rows),
     # then subset-match those — never scanning the full 260k-product sheet. A raw
-    # stream (tests, small CSV/YAML mirrors) is built into an in-memory index so
+    # stream (tests, small YAML mirrors) is built into an in-memory index so
     # there is one matching path.
     own_index = index is None
     if own_index:
@@ -153,7 +153,7 @@ def estimate(
             raise ValueError("estimate() needs either `pricesheet` or `index`")
         # File-backed temp build (streamed, bounded) — never an in-memory DB. The
         # API/runner pass a pre-built `index=` (the cached .sqlite); this path is
-        # for tests + small raw CSV/YAML mirrors.
+        # for tests + small raw YAML mirrors.
         index = pricesheet_db.PricesheetIndex.build_temp(pricesheet)
     try:
         matches = []

--- a/services/terrapod/services/cost/fleet_resolver.py
+++ b/services/terrapod/services/cost/fleet_resolver.py
@@ -338,13 +338,6 @@ def resolve_fleets(resources: list[tuple[Resource, Change]]) -> list[Fleet]:
     return out
 
 
-def is_fleet(resource_type: str) -> bool:
-    """Whether a resource type is handled by the fleet resolver (priced or
-    deferred) — the engine excludes these from normal matching to avoid
-    double-handling and lets the resolver own their output."""
-    return resource_type in DESCRIPTORS or resource_type in DEFERRED_FLEETS
-
-
 def synth_resources(fleet: Fleet, region: str) -> list[tuple[str, Resource, float]]:
     """Build a minimal priceable resource per part, stamped with the fleet's
     resolved region. Returns ``(synth_address, resource, count)`` — the engine

--- a/services/terrapod/services/cost/tf.py
+++ b/services/terrapod/services/cost/tf.py
@@ -300,4 +300,4 @@ def resolve_region(resource: Resource, provider_region_map: dict[str, str], defa
     provider = resource.data.get("provider_name")
     if isinstance(provider, str) and provider in provider_region_map:
         return provider_region_map[provider].lower()
-    return default
+    return default.lower()  # sheet regions are lowercase; match exactly


### PR DESCRIPTION
The non-code half of the v1.2.0 pre-release audit + third-party review punch-list (the crash/hardening code fixes are #1045).

**Docs (audit A/H — discoverability + stale content)**
- README + `docs/index`: add a **Private Module Source Auth** feature row + `docs/module-auth.md` link — the #1028 flagship was invisible from the repo front door.
- Drop **"(credited)"** from the cost-engine row (README + index) — a stale leftover from the pre-#1040 OpenInfraQuote lineage; the engine is now original Terrapod code, so it both misled and re-introduced the scrubbed crediting.
- `api-reference`: `category` now lists `git_http_auth`/`git_ssh_auth`; the pricesheet endpoint says gzipped YAML, not the removed CSV.
- `llms.txt`: module-auth row added to the enable-table (was only in the prose).
- Scrub the last stale "CSV" docstrings + the `"native native cost engine"` typo in MCP tool copy.

**Consumer drift (review b)**
- `go-terrapod` `Run` gains the 4 run-object cost fields the server emits + the UI consumes (`has-cost-estimate`, `cost-currency`, `cost-monthly-min`/`max`), with a `nullableFloat` helper + decode test; surface golden regenerated (additive).
- MCP `terrapod_variable_set` advertises the git-auth categories (jsonschema + description) so an agent can discover private-module auth; catalogue golden regenerated from source.

**Cost nits (review a)**
- `resolve_region` lowercases the default too (an uppercase `default_region` silently matched zero region products).
- Remove dead `is_fleet()` (no callers; docstring falsely claimed the engine excludes fleets from matching — it keeps them).
- helm-smoke now asserts `default_region` renders.

Part of the v1.2.0 release-prep audit. `go test`/`make test` on affected suites + ruff green.