### PR TITLE
test+fix: close v1.2.0 audit coverage gaps + CodeQL unused-global (#357)

### DIFF
--- a/pricegen/tests/test_recipes_parse.py
+++ b/pricegen/tests/test_recipes_parse.py
@@ -1,0 +1,59 @@
+"""Every committed recipe parses and conforms to the shape the engine requires.
+
+The cost-contract tests (`services/tests/services/test_cost_pricegen_contract.py`)
+pin the *engine's* output against hand-curated rows, but nothing loaded the actual
+`pricegen/providers/*/recipes/*.yaml` files — so a typo'd field or a malformed
+recipe passed CI and only failed later in the scheduled live-cloud pricesheet
+build. This test globs every real recipe (and `recipes.yaml`) and asserts each is
+valid YAML with the keys `generate.py` / `engine.generate` read, so a broken
+recipe fails at PR time instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_PRICEGEN = Path(__file__).resolve().parents[1]
+_RECIPE_FILES = sorted(_PRICEGEN.glob("providers/*/recipes/*.yaml"))
+
+
+def test_there_are_recipes_to_check():
+    # Guard against a glob that silently matches nothing (e.g. a layout move) —
+    # a green "0 recipes checked" would be a false pass.
+    assert len(_RECIPE_FILES) >= 20, f"expected the recipe corpus, found {len(_RECIPE_FILES)}"
+
+
+@pytest.mark.parametrize("recipe_path", _RECIPE_FILES, ids=lambda p: f"{p.parent.parent.name}/{p.stem}")
+def test_recipe_parses_and_has_required_shape(recipe_path: Path):
+    doc = yaml.safe_load(recipe_path.read_text())
+    assert isinstance(doc, dict), f"{recipe_path.name}: top level is not a mapping"
+    # Keys generate.py reads unconditionally.
+    assert doc.get("resource_type"), f"{recipe_path.name}: missing resource_type"
+    assert doc.get("service"), f"{recipe_path.name}: missing service"
+    # A recipe is either component-based (AWS/Azure direct match) or computed
+    # (GCP arithmetic assembly) — engine.generate vs generate_computed.
+    has_components = isinstance(doc.get("components"), list) and doc["components"]
+    has_computed = "computed" in doc
+    assert has_components or has_computed, (
+        f"{recipe_path.name}: needs a non-empty `components:` list or a `computed:` block"
+    )
+    # The file stem should match its declared resource_type (how generate.py
+    # resolves `--recipe <name>` → the file), catching a mis-named file.
+    assert recipe_path.stem == doc["resource_type"], (
+        f"{recipe_path.name}: stem != resource_type ({doc['resource_type']})"
+    )
+
+
+def test_recipes_yaml_index_parses():
+    doc = yaml.safe_load((_PRICEGEN / "recipes.yaml").read_text())
+    assert isinstance(doc.get("recipes"), list) and doc["recipes"], "recipes.yaml: no recipes list"
+    # regions is a per-provider map: {aws: [...], azure: [...], gcp: [...]}.
+    regions = doc.get("regions")
+    assert isinstance(regions, dict) and regions, "recipes.yaml: no regions map"
+    assert all(isinstance(v, list) and v for v in regions.values()), "recipes.yaml: empty region list"
+    # Every recipes[] entry names a provider + recipe + offer.
+    for r in doc["recipes"]:
+        assert r.get("provider") and r.get("recipe"), f"recipes.yaml entry missing provider/recipe: {r}"

--- a/services/terrapod/services/cost/prices.py
+++ b/services/terrapod/services/cost/prices.py
@@ -65,9 +65,6 @@ class EmptyMatchSet(Exception):
     """A product carried a blank resource match set — skipped, not an error."""
 
 
-_YAML_SCHEMA_PREFIX = "terrapod-pricesheet/"
-
-
 def product_from_yaml(entry: dict, currency: str) -> Product:
     """Build a :class:`Product` from one product mapping of a YAML pricesheet.
 

--- a/services/tests/runner/test_job_template.py
+++ b/services/tests/runner/test_job_template.py
@@ -160,6 +160,37 @@ class TestExecutionHooksMount:
         keys = {i["key"] for i in vol["secret"]["items"]}
         assert keys == {"terraform.tfvars.json", "execution-hooks.json"}
 
+    def test_git_auth_added_as_secret_item(self):
+        """#1028 audit C-2: the git-auth credential is delivered as a `git-auth.json`
+        item projected from the per-run Secret onto the tfvars volume — never in the
+        Job spec/env. A regression in this mount wiring would pass every phase test
+        (they build their own inputs), so pin it at the job-builder layer."""
+        from terrapod.runner.job_template import build_job_spec
+
+        spec = build_job_spec(
+            run_id="abc123",
+            phase="plan",
+            runner_config=_runner_config(),
+            auth_secret_name="tprun-abc12345-auth",
+            env_vars=[],
+            terraform_vars=[],
+            execution_hooks=[],
+            vars_secret_name="tprun-abc12345-plan-vars",
+            git_auth=[{"category": "git_http_auth", "key": "github.com", "value": "{}"}],
+        )
+        vol = self._tfvars_volume(spec)
+        assert vol is not None
+        items = vol["secret"]["items"]
+        keys = {i["key"] for i in items}
+        assert "git-auth.json" in keys
+        # Delivered as a projected file, mounted read-only — never a container env var.
+        git_item = next(i for i in items if i["key"] == "git-auth.json")
+        assert git_item["path"] == "git-auth.json"
+        env = spec["spec"]["template"]["spec"]["containers"][0].get("env", [])
+        assert not any("git" in (e.get("name", "").lower()) for e in env), (
+            "git-auth must never be delivered via a container env var"
+        )
+
     def test_no_volume_when_no_hooks_no_vars(self):
         spec = self._spec(
             execution_hooks=[],

--- a/services/tests/services/test_variable_service.py
+++ b/services/tests/services/test_variable_service.py
@@ -184,6 +184,22 @@ class TestUpdateVariable:
         await update_variable(db, var, description="new desc")
         assert var.value == "keep-me"
 
+    async def test_git_auth_update_cannot_downgrade_sensitive_or_clear_value(self):
+        """#1028 audit C-3: a git-auth credential is force-sensitive — an update
+        with sensitive=False must keep it sensitive AND preserve its value (the
+        downgrade-clears-value path must NOT fire for git categories, else a valid
+        credential would be silently wiped)."""
+        db = AsyncMock(spec=AsyncSession)
+        var = MagicMock()
+        var.key = "github.com"
+        var.value = '{"token":"ghp_secret"}'
+        var.sensitive = True
+        var.category = "git_http_auth"
+
+        await update_variable(db, var, sensitive=False)  # attempt downgrade
+        assert var.sensitive is True  # forced back on
+        assert var.value == '{"token":"ghp_secret"}'  # value preserved, not cleared
+
 
 # ── resolve_variables ──────────────────────────────────────────────────
 


### PR DESCRIPTION
Test-coverage gaps from the v1.2.0 pre-release audit (step C), plus the CodeQL #357 fix.

- **pricegen recipe schema test** — globs every committed recipe + `recipes.yaml` and asserts each parses with the shape `generate.py` reads (`resource_type`/`service`/`components`|`computed`, `stem==resource_type`). ~30 recipes shipped this cycle with **no PR-time validation** — a typo'd recipe only failed in the scheduled live-cloud build. **43 recipes checked.**
- **git-auth Secret mount** — the `git-auth.json` delivery wiring (projected file on the tfvars volume, **never** a container env var) is now pinned at the job-builder layer; a regression there passed every phase test (they build their own inputs).
- **git-auth force-sensitive on UPDATE** — updating a git-auth var with `sensitive=false` keeps it sensitive **and** preserves its value (the downgrade-clears-value path must not fire for git categories, or a valid credential is silently wiped). Negative path on a security guard.

**CodeQL #357** (`py/unused-global-variable`): remove the dead `_YAML_SCHEMA_PREFIX` in `cost/prices.py` — orphaned by the CSV→YAML rework (#1038/#1040), zero references.

**Follow-up (noted, not blocking):** a `cost_summaries` ON CONFLICT idempotency integration test — the upsert is correct + guarded, but proving convergence needs an integration-tier Run/session fixture the suite does not yet expose.

Part of the v1.2.0 release-prep audit.
