### PR TITLE
chore: v1.2.0 prep — surface cost estimation + OPA 1.18.2 + drop cleared CVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ And a few standout, first-class features you may really like:
 
 - **Runs anywhere your network is awkward.** Runners dial *out* and create Kubernetes Jobs locally, so the control plane never needs inbound reach into an execution cluster — isolated VPCs, other regions, on-prem, or behind egress-only firewalls. VCS is polled outbound, and a pull-through provider mirror + binary cache (with an air-gap sealed mode) lets runs resolve providers and binaries with no upstream internet.
 - **Zero static cloud credentials.** Runs and the platform reach cloud APIs through Kubernetes workload identity (AWS IRSA, GCP WIF, Azure WI) — nothing long-lived to store, leak, or rotate.
+- **Cost visibility built in** — no third-party service. See the monthly cost of your managed infrastructure right in the run and workspace: a per-plan cost *delta* on every run and the current *total* on each workspace, priced by a native engine over Terrapod's own self-generated pricesheet (AWS, Azure, GCP; air-gap-friendly). On by default; an optional AI layer estimates what the engine can't price and answers a grounded [cost chat](docs/cost-estimation.md).
 - **An AI-augmented review layer** — optional and off by default — plan change-summaries, risk assessment, failure analysis, and a chat to interrogate a run.
 - **A reversible, dry-run-first migration** off TFE / HCP Terraform / Atlantis with [`terrapod-migrate`](docs/migration.md) — preview everything, apply, verify parity, and roll back cleanly.
 

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -73,7 +73,7 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 # OPA version via the image tag — see docs/policies.md). TARGETARCH is set
 # by buildx; fall back to dpkg for a plain `docker build`.
 ARG TARGETARCH
-ARG OPA_VERSION=1.18.0
+ARG OPA_VERSION=1.18.2
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-ARG OPA_VERSION=1.18.0
+ARG OPA_VERSION=1.18.2
 # GitHub Releases intermittently 5xx; --retry-all-errors covers 5xx as
 # well as transport errors. 6 attempts × 4s base = ~25s ceiling.
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pin and verify the same OPA_VERSION + SHA256 so a bump in one without
 # the other can't silently land an unverified binary in either image.
 ARG TARGETARCH
-ARG OPA_VERSION=1.18.0
+ARG OPA_VERSION=1.18.2
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
     && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -51,7 +51,7 @@ The main self-hosted, open-source options in this space, described neutrally:
 
 | Tool | What it is | Execution model | Notes |
 |---|---|---|---|
-| **Terrapod** | Full self-hosted TFE/TFC replacement (control plane + UI + registry) | Its own **outbound-only** runners on Kubernetes (ARC pattern) | TFE-V2 API parity; air-gap/firewall-friendly; native Terragrunt; AI review; OPA policy sets. MPL-2.0. |
+| **Terrapod** | Full self-hosted TFE/TFC replacement (control plane + UI + registry) | Its own **outbound-only** runners on Kubernetes (ARC pattern) | TFE-V2 API parity; air-gap/firewall-friendly; native Terragrunt; built-in cost estimation; AI review; OPA policy sets. MPL-2.0. |
 | **Terrakube** | Full self-hosted TFE/TFC replacement | Its own Kubernetes-Job executors | The most mature open-source peer; multi-org tenancy; established community. Apache-2.0. |
 | **Digger** | Orchestration layer that reuses your CI | Runs inside your existing GitHub Actions / GitLab CI | Very lightweight — no separate execution engine to operate; you keep your CI as the runner. |
 | **Atlantis** | Focused PR-based plan/apply automation | Webhook-driven, runs in its own server | Battle-tested and widely deployed; lightweight to run. Works alongside your existing state/registry/RBAC tooling. |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -149,6 +149,20 @@ If a run is OOM-killed, Terrapod surfaces the peak memory it reached and names
 the exact value to raise before retrying. See
 [Per-workspace resources](architecture.md#per-workspace-resources).
 
+## Does Terrapod estimate infrastructure costs?
+
+Yes — cost estimation is built in and on by default, with no third-party
+service. Every run shows the monthly cost **delta** its plan would introduce, and
+each workspace shows its current monthly **total**, priced by a native engine
+over Terrapod's own self-generated pricesheet (AWS, Azure, and GCP). It works
+air-gapped — the pricesheet is a pull-through cache you can pre-seed or point at
+an internal mirror (`cost_estimation.prices_url`). The deterministic numbers
+stand on their own; an optional AI layer (off unless you enable the plan-analysis
+AI) additionally estimates the resources the engine can't price, offers savings
+advisories, and answers a grounded cost chat — always clearly marked as an AI
+estimate and never blended into the deterministic total. See
+[Cost estimation](cost-estimation.md).
+
 ## How is Terrapod different from Terrakube?
 
 Both are full self-hosted TFE/TFC replacements at rough feature parity. Terrapod's

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -22,16 +22,10 @@ CVE-2025-69720
 # backports the fix or when the python:3.13-slim base drops systemd.
 CVE-2026-29111
 
-# CVE-2026-46680 — containerd user ID handling bypass that allows a
-# crafted image to evade `runAsNonRoot`. Pulled into the API image as
-# a *transitive Go dependency of the bundled `opa` binary* (Trivy reads
-# OPA's embedded buildinfo and flags every Go module it sees, including
-# ones whose code path never runs at OPA's runtime). Terrapod uses
-# `opa eval` and `opa check` only — pure Rego evaluation against
-# in-memory inputs; no OPA bundle/server/Kubernetes-controller mode is
-# invoked, so OPA never reaches its containerd integration. Re-evaluate
-# when OPA upstream bumps containerd in a patch release.
-CVE-2026-46680
+# (CVE-2026-46680 — containerd runAsNonRoot bypass, was OPA-bundled — removed:
+# the OPA 1.18.2 bump no longer vendors containerd at all (its buildinfo carries
+# no containerd module), so Trivy can't flag it and the ignore would only shadow
+# a regression. Dropped in the same PR as the bump per the release-audit rule.)
 
 # CVE-2026-40217 — was litellm proxy-mode arbitrary code execution.
 # Dropped: v0.32.0 (PR #442) bumped litellm to >=1.87 on Python 3.13,
@@ -52,7 +46,8 @@ CVE-2026-46680
 # release binary; we can't recompile it, and Terrapod invokes only `opa eval`
 # / `opa check` (pure in-memory Rego over trusted inputs) — no path handling
 # reaches the vulnerable `os.Root` symlink code. Same class as the OPA-Go
-# CVEs above. Drop when OPA ships a release built with a patched Go toolchain.
+# CVEs above. Verified against OPA 1.18.2: still built with go1.26.4 (< the
+# 1.26.5 fix), so it stays. Drop when OPA ships a release built with go >= 1.26.5.
 CVE-2026-39822
 
 # GHSA-hrxh-6v49-42gf — gRPC-Go xDS RBAC + HTTP/2 vulnerabilities (fixed in


### PR DESCRIPTION
Final v1.2.0 release-prep polish: make the cost-estimation headline discoverable, bump OPA, and retire the one CVE ignore the bump genuinely clears.

**Cost discoverability** (it was under-surfaced for LLMs + search engines despite being the release headline):
- **README** — cost visibility added to the "standout, first-class features" bullets (was only in the collapsed feature table).
- **docs/faq.md** — a new *"Does Terrapod estimate infrastructure costs?"* Q&A (answer-engine-optimal — the heading is the query; the FAQ previously only covered what the *software* costs to run).
- **docs/alternatives.md** — "built-in cost estimation" added to Terrapod's TACOS-comparison row (the feature was absent from the comparison entirely).

**OPA 1.18.0 → 1.18.2** (api/runner/test images) — the static-binary SHA is fetched + verified at build time, so this is just the `ARG` bump.

**CVE ignores — reduced by one, honestly:**
- ✅ **Drop `CVE-2026-46680`** (containerd runAsNonRoot bypass): OPA 1.18.2 **no longer vendors containerd** — its Go buildinfo carries no containerd module — so Trivy can't flag it. Verified by reading the 1.18.2 buildinfo (the exact data Trivy parses); CI's image scan re-confirms.
- ❌ **Keep** `CVE-2026-39822` (OPA still built with **go1.26.4** < the 1.26.5 fix) and `GHSA-hrxh-6v49-42gf` (OPA still vendors **grpc v1.81.1** < the 1.82.1 fix) — comments refreshed to record the 1.18.2 check. Both remain unreachable (opa eval/check only); they drop when OPA ships a build with go ≥ 1.26.5 / grpc ≥ 1.82.1.

Part of the v1.2.0 release-prep audit.