### PR TITLE
feat(1036): runner Checkov/Trivy security-scan phase (Slice 2)

### DIFF
--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -43,7 +43,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
 # Trivy (Go binary) — IaC config scanner for the security-scan phase (#1036).
 # Downloaded + checksum-verified here; COPY'd into the runtime so it stays free
 # of curl, exactly like OPA.
-ARG TRIVY_VERSION=0.58.1
+ARG TRIVY_VERSION=0.72.0
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && case "$ARCH" in \
         amd64) TARCH="Linux-64bit" ;; \

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -40,6 +40,35 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && rm /tmp/opa.sha256 \
     && chmod 0755 /tmp/opa
 
+# Trivy (Go binary) — IaC config scanner for the security-scan phase (#1036).
+# Downloaded + checksum-verified here; COPY'd into the runtime so it stays free
+# of curl, exactly like OPA.
+ARG TRIVY_VERSION=0.58.1
+RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
+    && case "$ARCH" in \
+        amd64) TARCH="Linux-64bit" ;; \
+        arm64) TARCH="Linux-ARM64" ;; \
+        *) echo "unsupported arch: $ARCH" && exit 1 ;; \
+    esac \
+    && BASE="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}" \
+    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/trivy.tar.gz "${BASE}/trivy_${TRIVY_VERSION}_${TARCH}.tar.gz" \
+    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/trivy.sums "${BASE}/trivy_${TRIVY_VERSION}_checksums.txt" \
+    && EXPECTED="$(grep "trivy_${TRIVY_VERSION}_${TARCH}.tar.gz" /tmp/trivy.sums | cut -d' ' -f1)" \
+    && echo "${EXPECTED}  /tmp/trivy.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/trivy.tar.gz -C /tmp trivy \
+    && chmod 0755 /tmp/trivy \
+    && rm /tmp/trivy.tar.gz /tmp/trivy.sums
+
+# Checkov (plan-fed IaC misconfig scanner, #1036) — the default/recommended
+# engine. Installed into an ISOLATED venv so its large, tightly-pinned
+# dependency tree can never collide with the runner's own deps. The scan phase
+# invokes the `checkov` CLI (subprocess), not the library, so a self-contained
+# venv is all it needs. Multi-arch: pip builds for the target arch (checkov's
+# standalone binary is x86_64-only, hence the venv).
+RUN python -m venv /opt/checkov \
+    && /opt/checkov/bin/pip install --no-cache-dir checkov \
+    && /opt/checkov/bin/checkov --version
+
 WORKDIR /build
 COPY services/pyproject-runner.toml pyproject.toml
 RUN pip install --no-cache-dir .
@@ -61,6 +90,14 @@ RUN echo "apt-refresh=${APT_REFRESH}" \
 # OPA from the builder stage. Verified there; just copy it.
 COPY --from=builder /tmp/opa /usr/local/bin/opa
 RUN /usr/local/bin/opa version
+
+# Security-scan engines (#1036). Trivy is a single verified Go binary; Checkov
+# is the isolated venv from the builder, exposed via a CLI symlink (the venv's
+# absolute /opt/checkov path is preserved so its python shebang resolves).
+COPY --from=builder /tmp/trivy /usr/local/bin/trivy
+RUN /usr/local/bin/trivy --version
+COPY --from=builder /opt/checkov /opt/checkov
+RUN ln -s /opt/checkov/bin/checkov /usr/local/bin/checkov && /usr/local/bin/checkov --version
 
 # terrapod-query — tofu-native discovery engine (#823), pre-built for this arch
 # by the build-query CI job (or the local go build) and staged in the build

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -60,3 +60,14 @@ CVE-2026-39822
 # mode, so the vulnerable server paths are unreachable. Same class as the
 # OPA-bundled CVEs above. Drop when OPA upstream bumps grpc to >=1.82.1.
 GHSA-hrxh-6v49-42gf
+
+# CVE-2026-50151 — oras-go credential forwarding via unvalidated redirect (fixed
+# in oras-go 2.6.1). Pulled into the runner image as a transitive Go dependency
+# of the *bundled `trivy` binary* (#1036) — Trivy 0.72.0 (the latest release)
+# still vendors oras-go v2.6.0, and Trivy reads its own embedded buildinfo and
+# flags it. Terrapod invokes only `trivy config <local plan.json>` for IaC
+# misconfig scanning; it never pulls OCI artifacts / images (the only path that
+# exercises oras-go's registry client + credential forwarding), so the
+# vulnerable code is unreachable in our usage. Same class as the OPA-bundled
+# transitive CVEs above. Drop when Trivy upstream bumps oras-go to >=2.6.1.
+CVE-2026-50151

--- a/services/terrapod/runner/job_entrypoint.py
+++ b/services/terrapod/runner/job_entrypoint.py
@@ -51,6 +51,7 @@ from terrapod.runner.phases import (
     opa,
     plan_apply,
     resource_profile,
+    security_scan,
     terragrunt,
     tf_args,
     tfvars,
@@ -312,11 +313,42 @@ def _run_plan_phase(
         log.error("policy evaluation failed", err=str(exc))
         return 1
 
+    # Security scan (#1036). Non-fatal throughout — the server's post-plan gate
+    # enforces (a missing enforced result is failed-closed there). Ordering:
+    # an ENFORCED scan on a non-plan-only run must post its result BEFORE the
+    # plan-result POST, because plan-result drives complete_plan → the gate,
+    # which must see the recorded result. Everything else (advisory, plan-only,
+    # off) scans as add-on work AFTER plan-result so apply isn't made to wait —
+    # "advisory = no wait, enforced = wait".
+    scan_cfg = None
+    try:
+        scan_cfg = security_scan.fetch_scan_config(cfg)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("scan config fetch raised (non-fatal)", err=str(exc))
+    scan_before = bool(
+        scan_cfg
+        and scan_cfg.get("enabled")
+        and scan_cfg.get("enforcement_level") == "enforced"
+        and not cfg.plan_only
+    )
+    if scan_before:
+        try:
+            security_scan.run_and_post(cfg, scan_cfg, plan_json=_PLAN_JSON)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("security scan raised (non-fatal, pre-result)", err=str(exc))
+
     # plan-result POST.
     try:
         uploads.post_plan_result(cfg, has_changes=plan_result.has_changes)
     except Exception as exc:  # noqa: BLE001
         log.warning("plan-result raised (non-fatal)", err=str(exc))
+
+    # Advisory / plan-only scan runs AFTER plan-result (no-wait add-on work).
+    if scan_cfg and scan_cfg.get("enabled") and not scan_before:
+        try:
+            security_scan.run_and_post(cfg, scan_cfg, plan_json=_PLAN_JSON)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("security scan raised (non-fatal, post-result)", err=str(exc))
 
     # Plan binary upload (skip for plan-only).
     if plan_file.exists() and not cfg.plan_only:

--- a/services/terrapod/runner/phases/security_scan.py
+++ b/services/terrapod/runner/phases/security_scan.py
@@ -1,0 +1,408 @@
+"""Deterministic IaC security-scan phase — Checkov / Trivy (#1036).
+
+The runner-side twin of the OPA policy phase (:mod:`terrapod.runner.phases.opa`),
+but with one deliberate difference: **this phase is non-fatal throughout.** OPA
+must fail the run closed when its bundle can't be fetched; the security scan does
+not, because the *server* fails closed — ``security_scan_service.evaluate_post_plan``
+synthesises an ``errored`` result and blocks the run if an ``enforced`` workspace
+records no scan result. So a scanner crash, a config-fetch failure, or a
+results-POST failure here just means "no result recorded", which the server
+turns into a block for enforced workspaces and a no-op for advisory/off ones.
+
+Flow:
+  1. GET /api/terrapod/v1/runs/{run_id}/security-scan-config →
+     {enabled, enforcement_level, engine, severity_threshold, skip_rules}.
+     On failure or ``enabled=false`` → return None (skip).
+  2. Run the configured engine(s) against the resolved plan JSON:
+       - Checkov: ``--framework terraform_plan -f plan.json`` (plan-fed — scans
+         *resolved* values, the recommended/verified engine).
+       - Trivy: ``config`` on the plan JSON (best-effort; Trivy's plan-JSON
+         support is engine-version-dependent, so an empty/errored Trivy run is
+         tolerated).
+  3. Normalise findings to a common shape and compute the outcome against the
+     severity threshold.
+  4. POST results to /api/terrapod/v1/runs/{run_id}/security-scan-results
+     (idempotent — the API does ON CONFLICT DO NOTHING on run_id).
+
+Severity model: scanners that don't rate a finding (Checkov OSS omits severity
+for most checks — it's a Prisma-paid signal) default to **high**, so the default
+``high`` threshold still counts them while an operator who raises the threshold
+to ``critical`` can narrow to critical-rated findings. Suppress noise via
+``skip_rules`` (Checkov ``CKV_*`` / Trivy ``AVD-*`` ids).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import structlog
+
+from terrapod.runner.runner_config import RunnerConfig
+
+logger = structlog.get_logger("runner.security_scan")
+
+# Severity ranking. Unknown / unrated → treated as "high" (see module docstring).
+_SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1}
+_DEFAULT_SEVERITY = "high"
+
+_SCAN_TIMEOUT = 300  # per-engine wall-clock cap (seconds)
+
+
+def _severity_rank(sev: str | None) -> int:
+    if not sev:
+        return _SEVERITY_RANK[_DEFAULT_SEVERITY]
+    return _SEVERITY_RANK.get(sev.strip().lower(), _SEVERITY_RANK[_DEFAULT_SEVERITY])
+
+
+def _norm_severity(sev: str | None) -> str:
+    if not sev:
+        return _DEFAULT_SEVERITY
+    s = sev.strip().lower()
+    return s if s in _SEVERITY_RANK else _DEFAULT_SEVERITY
+
+
+# ── config fetch ──────────────────────────────────────────────────────────
+
+
+def fetch_scan_config(
+    cfg: RunnerConfig,
+    *,
+    client: httpx.Client | None = None,
+    sleep: Any = time.sleep,
+) -> dict | None:
+    """GET the per-workspace scan config. Bounded retries (3, 3s apart). Returns
+    the config dict, or None on failure / no-API / disabled — the phase then
+    skips (the server fails closed for enforced workspaces)."""
+    if not cfg.has_api:
+        return None
+
+    url = f"{cfg.api_url}/api/terrapod/v1/runs/{cfg.run_id}/security-scan-config"
+    headers = {"Authorization": f"Bearer {cfg.auth_token}"} if cfg.auth_token else {}
+
+    own_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=httpx.Timeout(cfg.upload_timeout_seconds, connect=10.0))
+    try:
+        for attempt in (1, 2, 3):
+            try:
+                resp = client.get(url, headers=headers)
+                if resp.status_code == 200:
+                    try:
+                        data = resp.json()
+                    except json.JSONDecodeError:
+                        return None
+                    return data if data.get("enabled") else None
+                logger.info(
+                    "scan config non-200 — will retry", attempt=attempt, status=resp.status_code
+                )
+            except httpx.RequestError as exc:
+                logger.info(
+                    "scan config request failed — will retry", attempt=attempt, err=str(exc)
+                )
+            if attempt < 3:
+                sleep(3)
+        logger.warning(
+            "scan config fetch failed after retries — skipping scan (server fails closed)"
+        )
+        return None
+    finally:
+        if own_client:
+            client.close()
+
+
+# ── engine runners ──────────────────────────────────────────────────────────
+
+
+def _run_checkov(
+    plan_json: Path, skip_rules: list[str], *, binary: str = "checkov"
+) -> tuple[bool, list[dict], str | None]:
+    """Run Checkov against the resolved plan JSON. Returns (ok, findings, error)."""
+    cmd = [
+        binary,
+        "-f",
+        str(plan_json),
+        "--framework",
+        "terraform_plan",
+        "--output",
+        "json",
+        "--compact",
+        "--soft-fail",  # never let the exit code fail the run; the gate is server-side
+        "--quiet",
+    ]
+    for rule in skip_rules:
+        cmd += ["--skip-check", rule]
+    try:
+        result = subprocess.run(  # noqa: S603 — checkov is operator-controlled
+            cmd, check=False, capture_output=True, text=True, timeout=_SCAN_TIMEOUT
+        )
+    except FileNotFoundError as exc:
+        return False, [], f"checkov binary not found: {exc}"
+    except subprocess.TimeoutExpired:
+        return False, [], "checkov timed out"
+    except OSError as exc:
+        return False, [], f"checkov failed: {exc}"
+
+    if not result.stdout.strip():
+        # No stdout at all — treat as errored unless checkov cleanly found nothing.
+        if result.returncode == 0:
+            return True, [], None
+        return False, [], (result.stderr.strip()[:1000] or "checkov produced no output")
+    try:
+        return True, _normalize_checkov(result.stdout), None
+    except (json.JSONDecodeError, TypeError, KeyError, AttributeError) as exc:
+        return False, [], f"failed to parse checkov output: {exc}"
+
+
+def _normalize_checkov(output: str) -> list[dict]:
+    """Normalise Checkov JSON (object for a single framework, or a list) into the
+    common finding shape."""
+    parsed = json.loads(output)
+    frameworks = parsed if isinstance(parsed, list) else [parsed]
+    findings: list[dict] = []
+    for fw in frameworks:
+        if not isinstance(fw, dict):
+            continue
+        failed = ((fw.get("results") or {}).get("failed_checks")) or []
+        for chk in failed:
+            line_range = chk.get("file_line_range") or []
+            line = line_range[0] if line_range else None
+            findings.append(
+                {
+                    "engine": "checkov",
+                    "rule_id": chk.get("check_id") or "",
+                    "severity": _norm_severity(chk.get("severity")),
+                    "title": chk.get("check_name") or "",
+                    "resource": chk.get("resource") or "",
+                    "file": chk.get("file_path") or "",
+                    "line": line,
+                    "guideline": chk.get("guideline") or "",
+                }
+            )
+    return findings
+
+
+def _run_trivy(
+    plan_json: Path, skip_rules: list[str], *, binary: str = "trivy"
+) -> tuple[bool, list[dict], str | None]:
+    """Run Trivy config-scan against the plan JSON. Best-effort — Trivy's
+    plan-JSON support is version-dependent, so failures are tolerated."""
+    cmd = [binary, "config", "--format", "json", "--quiet", str(plan_json)]
+    try:
+        result = subprocess.run(  # noqa: S603 — trivy is operator-controlled
+            cmd, check=False, capture_output=True, text=True, timeout=_SCAN_TIMEOUT
+        )
+    except FileNotFoundError as exc:
+        return False, [], f"trivy binary not found: {exc}"
+    except subprocess.TimeoutExpired:
+        return False, [], "trivy timed out"
+    except OSError as exc:
+        return False, [], f"trivy failed: {exc}"
+
+    if not result.stdout.strip():
+        if result.returncode == 0:
+            return True, [], None
+        return False, [], (result.stderr.strip()[:1000] or "trivy produced no output")
+    try:
+        return True, _normalize_trivy(result.stdout, skip_rules), None
+    except (json.JSONDecodeError, TypeError, KeyError, AttributeError) as exc:
+        return False, [], f"failed to parse trivy output: {exc}"
+
+
+def _normalize_trivy(output: str, skip_rules: list[str]) -> list[dict]:
+    """Normalise Trivy config-scan JSON into the common finding shape. Trivy
+    doesn't take a --skip-check flag for config ids the way Checkov does, so we
+    filter its findings by id here."""
+    parsed = json.loads(output)
+    skip = set(skip_rules)
+    findings: list[dict] = []
+    for res in parsed.get("Results") or []:
+        target = res.get("Target") or ""
+        for mis in res.get("Misconfigurations") or []:
+            rule_id = mis.get("ID") or ""
+            if rule_id in skip:
+                continue
+            cause = mis.get("CauseMetadata") or {}
+            findings.append(
+                {
+                    "engine": "trivy",
+                    "rule_id": rule_id,
+                    "severity": _norm_severity(mis.get("Severity")),
+                    "title": mis.get("Title") or "",
+                    "resource": cause.get("Resource") or "",
+                    "file": target,
+                    "line": cause.get("StartLine"),
+                    "guideline": mis.get("PrimaryURL") or "",
+                }
+            )
+    return findings
+
+
+# ── outcome ──────────────────────────────────────────────────────────────────
+
+
+def compute_outcome(findings: list[dict], threshold: str, *, errored: bool) -> tuple[str, dict]:
+    """Compute (outcome, summary) from findings and the severity threshold.
+
+    outcome: ``errored`` if an engine crashed; else ``failed`` if any finding is
+    at or above the threshold; else ``passed``. ``summary`` carries the counts
+    the UI shows.
+    """
+    trank = _severity_rank(threshold)
+    by_sev: dict[str, int] = {}
+    blocking = 0
+    for f in findings:
+        sev = _norm_severity(f.get("severity"))
+        by_sev[sev] = by_sev.get(sev, 0) + 1
+        if _severity_rank(sev) >= trank:
+            blocking += 1
+    if errored:
+        outcome = "errored"
+    elif blocking:
+        outcome = "failed"
+    else:
+        outcome = "passed"
+    summary = {
+        "total": len(findings),
+        "blocking": blocking,
+        "by_severity": by_sev,
+        "threshold": threshold,
+    }
+    return outcome, summary
+
+
+# ── results POST ──────────────────────────────────────────────────────────────
+
+
+def post_scan_result(
+    cfg: RunnerConfig,
+    *,
+    engine: str,
+    outcome: str,
+    findings: list[dict],
+    summary: dict,
+    error: str | None,
+    client: httpx.Client | None = None,
+    sleep: Any = time.sleep,
+) -> bool:
+    """POST the scan result. Bounded retries (3, 3s apart); idempotent server-side
+    (ON CONFLICT DO NOTHING on run_id). Returns True on 201, False otherwise —
+    non-fatal (the server fails closed on a missing enforced result)."""
+    if not cfg.has_api:
+        return False
+
+    url = f"{cfg.api_url}/api/terrapod/v1/runs/{cfg.run_id}/security-scan-results"
+    headers = {"Authorization": f"Bearer {cfg.auth_token}"} if cfg.auth_token else {}
+    body = {
+        "engine": engine,
+        "outcome": outcome,
+        "findings": findings,
+        "summary": summary,
+        "error": error,
+    }
+
+    own_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=httpx.Timeout(cfg.upload_timeout_seconds, connect=10.0))
+    try:
+        for attempt in (1, 2, 3):
+            try:
+                resp = client.post(url, json=body, headers=headers)
+                if resp.status_code == 201:
+                    return True
+                # A definitive 4xx is final — don't retry a bad request.
+                if 400 <= resp.status_code < 500:
+                    logger.warning("scan results POST rejected", status=resp.status_code)
+                    return False
+                logger.info(
+                    "scan results POST non-201 — will retry",
+                    attempt=attempt,
+                    status=resp.status_code,
+                )
+            except httpx.RequestError as exc:
+                logger.info("scan results POST failed — will retry", attempt=attempt, err=str(exc))
+            if attempt < 3:
+                sleep(3)
+        logger.warning("scan results POST failed after retries — server fails closed for enforced")
+        return False
+    finally:
+        if own_client:
+            client.close()
+
+
+# ── orchestrator ──────────────────────────────────────────────────────────────
+
+
+def run_and_post(
+    cfg: RunnerConfig,
+    scan_config: dict,
+    *,
+    plan_json: Path,
+    client: httpx.Client | None = None,
+) -> str | None:
+    """Run the configured engine(s) against the plan JSON, compute the outcome,
+    and POST results. Returns the outcome, or None if nothing ran. Fully
+    non-fatal — the server gate enforces."""
+    engine = (scan_config.get("engine") or "checkov").lower()
+    threshold = (scan_config.get("severity_threshold") or "high").lower()
+    skip_rules = list(scan_config.get("skip_rules") or [])
+
+    if plan_json is None or not plan_json.exists() or plan_json.stat().st_size == 0:
+        # No plan JSON to scan — record an errored result so an enforced
+        # workspace surfaces it (rather than the generic missing-result net).
+        outcome, summary = "errored", {"total": 0, "blocking": 0}
+        post_scan_result(
+            cfg,
+            engine=engine,
+            outcome=outcome,
+            findings=[],
+            summary=summary,
+            error="plan JSON was not available for security scanning",
+            client=client,
+        )
+        return outcome
+
+    findings: list[dict] = []
+    errors: list[str] = []
+    any_errored = False
+
+    if engine in ("checkov", "both"):
+        ok, ck_findings, err = _run_checkov(plan_json, skip_rules)
+        if ok:
+            findings += ck_findings
+        else:
+            any_errored = True
+            if err:
+                errors.append(f"checkov: {err}")
+
+    if engine in ("trivy", "both"):
+        ok, tv_findings, err = _run_trivy(plan_json, skip_rules)
+        if ok:
+            findings += tv_findings
+        else:
+            any_errored = True
+            if err:
+                errors.append(f"trivy: {err}")
+
+    outcome, summary = compute_outcome(findings, threshold, errored=any_errored)
+    logger.info(
+        "security scan complete",
+        engine=engine,
+        outcome=outcome,
+        total=summary.get("total"),
+        blocking=summary.get("blocking"),
+    )
+    post_scan_result(
+        cfg,
+        engine=engine,
+        outcome=outcome,
+        findings=findings,
+        summary=summary,
+        error=("; ".join(errors)[:2000] or None),
+        client=client,
+    )
+    return outcome

--- a/services/tests/runner/test_phase_security_scan.py
+++ b/services/tests/runner/test_phase_security_scan.py
@@ -1,0 +1,422 @@
+"""Tests for terrapod.runner.phases.security_scan (#1036)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+
+from terrapod.runner.phases import security_scan as scan
+from terrapod.runner.runner_config import RunnerConfig
+
+
+def _cfg(**overrides) -> RunnerConfig:
+    base = {
+        "TP_API_URL": "https://api.example.com",
+        "TP_AUTH_TOKEN": "tok",
+        "TP_RUN_ID": "run-1",
+        "TP_BACKEND": "tofu",
+        "TP_VERSION": "1.12.1",
+    }
+    base.update(overrides)
+    return RunnerConfig.from_env(env=base)
+
+
+# ── severity helpers ──────────────────────────────────────────────────────
+
+
+class TestSeverity:
+    def test_unrated_defaults_to_high(self) -> None:
+        assert scan._norm_severity(None) == "high"
+        assert scan._norm_severity("") == "high"
+        assert scan._norm_severity("nonsense") == "high"
+
+    def test_known_normalised(self) -> None:
+        assert scan._norm_severity("CRITICAL") == "critical"
+        assert scan._norm_severity(" Low ") == "low"
+
+    def test_rank_order(self) -> None:
+        assert scan._severity_rank("critical") > scan._severity_rank("high")
+        assert scan._severity_rank("high") > scan._severity_rank("medium")
+        assert scan._severity_rank("medium") > scan._severity_rank("low")
+        # unrated ranks as high
+        assert scan._severity_rank(None) == scan._severity_rank("high")
+
+
+# ── checkov normalisation ──────────────────────────────────────────────────
+
+
+class TestNormalizeCheckov:
+    def test_single_framework_object(self) -> None:
+        out = json.dumps(
+            {
+                "check_type": "terraform_plan",
+                "results": {
+                    "failed_checks": [
+                        {
+                            "check_id": "CKV_AWS_18",
+                            "check_name": "Ensure S3 has access logging",
+                            "severity": None,
+                            "resource": "aws_s3_bucket.b",
+                            "file_path": "/plan.json",
+                            "file_line_range": [10, 20],
+                            "guideline": "https://x",
+                        }
+                    ]
+                },
+            }
+        )
+        findings = scan._normalize_checkov(out)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["engine"] == "checkov"
+        assert f["rule_id"] == "CKV_AWS_18"
+        assert f["severity"] == "high"  # None → high
+        assert f["resource"] == "aws_s3_bucket.b"
+        assert f["line"] == 10
+
+    def test_list_of_frameworks(self) -> None:
+        out = json.dumps(
+            [
+                {"results": {"failed_checks": [{"check_id": "CKV_1", "severity": "HIGH"}]}},
+                {"results": {"failed_checks": [{"check_id": "CKV_2", "severity": "LOW"}]}},
+            ]
+        )
+        findings = scan._normalize_checkov(out)
+        assert {f["rule_id"] for f in findings} == {"CKV_1", "CKV_2"}
+        assert {f["severity"] for f in findings} == {"high", "low"}
+
+    def test_empty_results(self) -> None:
+        out = json.dumps({"results": {"failed_checks": []}})
+        assert scan._normalize_checkov(out) == []
+
+
+# ── trivy normalisation ────────────────────────────────────────────────────
+
+
+class TestNormalizeTrivy:
+    def test_misconfigurations_mapped(self) -> None:
+        out = json.dumps(
+            {
+                "Results": [
+                    {
+                        "Target": "plan.json",
+                        "Misconfigurations": [
+                            {
+                                "ID": "AVD-AWS-0107",
+                                "Title": "No public ingress",
+                                "Severity": "CRITICAL",
+                                "CauseMetadata": {"StartLine": 5, "Resource": "aws_sg.x"},
+                                "PrimaryURL": "https://avd",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        findings = scan._normalize_trivy(out, [])
+        assert len(findings) == 1
+        assert findings[0]["engine"] == "trivy"
+        assert findings[0]["rule_id"] == "AVD-AWS-0107"
+        assert findings[0]["severity"] == "critical"
+        assert findings[0]["line"] == 5
+
+    def test_skip_rules_filter(self) -> None:
+        out = json.dumps(
+            {
+                "Results": [
+                    {
+                        "Misconfigurations": [
+                            {"ID": "AVD-1", "Severity": "HIGH"},
+                            {"ID": "AVD-2", "Severity": "HIGH"},
+                        ]
+                    }
+                ]
+            }
+        )
+        findings = scan._normalize_trivy(out, ["AVD-1"])
+        assert [f["rule_id"] for f in findings] == ["AVD-2"]
+
+
+# ── outcome computation ────────────────────────────────────────────────────
+
+
+class TestComputeOutcome:
+    def test_errored_wins(self) -> None:
+        outcome, summary = scan.compute_outcome([], "high", errored=True)
+        assert outcome == "errored"
+
+    def test_no_findings_passes(self) -> None:
+        outcome, summary = scan.compute_outcome([], "high", errored=False)
+        assert outcome == "passed"
+        assert summary["total"] == 0
+        assert summary["blocking"] == 0
+
+    def test_below_threshold_passes(self) -> None:
+        findings = [{"severity": "low"}, {"severity": "medium"}]
+        outcome, summary = scan.compute_outcome(findings, "high", errored=False)
+        assert outcome == "passed"
+        assert summary["total"] == 2
+        assert summary["blocking"] == 0
+
+    def test_at_or_above_threshold_fails(self) -> None:
+        findings = [{"severity": "low"}, {"severity": "high"}, {"severity": "critical"}]
+        outcome, summary = scan.compute_outcome(findings, "high", errored=False)
+        assert outcome == "failed"
+        assert summary["blocking"] == 2  # high + critical
+        assert summary["by_severity"]["critical"] == 1
+
+    def test_threshold_critical_narrows(self) -> None:
+        findings = [{"severity": "high"}, {"severity": "critical"}]
+        outcome, summary = scan.compute_outcome(findings, "critical", errored=False)
+        assert outcome == "failed"
+        assert summary["blocking"] == 1  # only critical
+
+
+# ── config fetch ───────────────────────────────────────────────────────────
+
+
+class TestFetchScanConfig:
+    def test_enabled_returned(self) -> None:
+        cfg = _cfg()
+        payload = {"enabled": True, "enforcement_level": "enforced", "engine": "checkov"}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path.endswith("/security-scan-config")
+            return httpx.Response(200, json=payload)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        assert scan.fetch_scan_config(cfg, client=client) == payload
+
+    def test_disabled_returns_none(self) -> None:
+        cfg = _cfg()
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"enabled": False, "enforcement_level": "off"})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        assert scan.fetch_scan_config(cfg, client=client) is None
+
+    def test_non_200_retries_then_none(self) -> None:
+        cfg = _cfg()
+        sleeps: list = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(503)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        assert scan.fetch_scan_config(cfg, client=client, sleep=lambda s: sleeps.append(s)) is None
+        assert len(sleeps) == 2  # 3 attempts, 2 sleeps
+
+    def test_no_api_returns_none(self) -> None:
+        cfg = _cfg(TP_API_URL="")
+        assert scan.fetch_scan_config(cfg) is None
+
+
+# ── results POST ───────────────────────────────────────────────────────────
+
+
+class TestPostScanResult:
+    def test_201_returns_true(self) -> None:
+        cfg = _cfg()
+        seen = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(req.content)
+            return httpx.Response(201, json={"recorded": 1})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        ok = scan.post_scan_result(
+            cfg,
+            engine="checkov",
+            outcome="failed",
+            findings=[{"rule_id": "CKV_1"}],
+            summary={"total": 1},
+            error=None,
+            client=client,
+        )
+        assert ok is True
+        assert seen["body"]["engine"] == "checkov"
+        assert seen["body"]["outcome"] == "failed"
+
+    def test_4xx_is_final_no_retry(self) -> None:
+        cfg = _cfg()
+        calls = {"n": 0}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(422, json={"detail": "bad"})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        ok = scan.post_scan_result(
+            cfg,
+            engine="checkov",
+            outcome="passed",
+            findings=[],
+            summary={},
+            error=None,
+            client=client,
+            sleep=lambda s: None,
+        )
+        assert ok is False
+        assert calls["n"] == 1  # 4xx not retried
+
+    def test_5xx_retries_then_false(self) -> None:
+        cfg = _cfg()
+        calls = {"n": 0}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(500)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        ok = scan.post_scan_result(
+            cfg,
+            engine="checkov",
+            outcome="passed",
+            findings=[],
+            summary={},
+            error=None,
+            client=client,
+            sleep=lambda s: None,
+        )
+        assert ok is False
+        assert calls["n"] == 3
+
+
+# ── engine subprocess wrappers ─────────────────────────────────────────────
+
+
+class TestRunCheckov:
+    def test_findings_parsed(self, tmp_path: Path) -> None:
+        plan = tmp_path / "plan.json"
+        plan.write_text("{}")
+        out = json.dumps(
+            {"results": {"failed_checks": [{"check_id": "CKV_1", "severity": "HIGH"}]}}
+        )
+        with patch.object(
+            scan.subprocess, "run", return_value=subprocess.CompletedProcess([], 1, out, "")
+        ):
+            ok, findings, err = scan._run_checkov(plan, [])
+        assert ok is True
+        assert findings[0]["rule_id"] == "CKV_1"
+        assert err is None
+
+    def test_skip_rules_passed_as_flags(self, tmp_path: Path) -> None:
+        plan = tmp_path / "plan.json"
+        plan.write_text("{}")
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+        with patch.object(scan.subprocess, "run", side_effect=fake_run):
+            scan._run_checkov(plan, ["CKV_AWS_18", "CKV_AWS_21"])
+        assert "--skip-check" in seen["cmd"]
+        assert "CKV_AWS_18" in seen["cmd"] and "CKV_AWS_21" in seen["cmd"]
+
+    def test_binary_missing_errors(self, tmp_path: Path) -> None:
+        plan = tmp_path / "plan.json"
+        plan.write_text("{}")
+        with patch.object(scan.subprocess, "run", side_effect=FileNotFoundError("no checkov")):
+            ok, findings, err = scan._run_checkov(plan, [])
+        assert ok is False
+        assert "not found" in err
+
+    def test_timeout_errors(self, tmp_path: Path) -> None:
+        plan = tmp_path / "plan.json"
+        plan.write_text("{}")
+        with patch.object(
+            scan.subprocess, "run", side_effect=subprocess.TimeoutExpired("checkov", 300)
+        ):
+            ok, findings, err = scan._run_checkov(plan, [])
+        assert ok is False
+        assert "timed out" in err
+
+    def test_clean_empty_stdout_rc0_ok(self, tmp_path: Path) -> None:
+        plan = tmp_path / "plan.json"
+        plan.write_text("{}")
+        with patch.object(
+            scan.subprocess, "run", return_value=subprocess.CompletedProcess([], 0, "", "")
+        ):
+            ok, findings, err = scan._run_checkov(plan, [])
+        assert ok is True
+        assert findings == []
+
+
+# ── orchestrator ───────────────────────────────────────────────────────────
+
+
+class TestRunAndPost:
+    def test_missing_plan_json_posts_errored(self, tmp_path: Path) -> None:
+        cfg = _cfg()
+        missing = tmp_path / "nope.json"
+        posted = {}
+        with patch.object(
+            scan, "post_scan_result", side_effect=lambda cfg, **kw: posted.update(kw)
+        ):
+            outcome = scan.run_and_post(cfg, {"engine": "checkov"}, plan_json=missing)
+        assert outcome == "errored"
+        assert posted["outcome"] == "errored"
+        assert "not available" in posted["error"]
+
+    def test_checkov_happy_path_posts(self, tmp_path: Path) -> None:
+        cfg = _cfg()
+        plan = tmp_path / "plan.json"
+        plan.write_text('{"x":1}')
+        posted = {}
+        with (
+            patch.object(
+                scan,
+                "_run_checkov",
+                return_value=(True, [{"severity": "critical", "rule_id": "CKV_1"}], None),
+            ),
+            patch.object(scan, "post_scan_result", side_effect=lambda cfg, **kw: posted.update(kw)),
+        ):
+            outcome = scan.run_and_post(
+                cfg, {"engine": "checkov", "severity_threshold": "high"}, plan_json=plan
+            )
+        assert outcome == "failed"
+        assert posted["engine"] == "checkov"
+        assert posted["summary"]["blocking"] == 1
+
+    def test_both_engines_merge(self, tmp_path: Path) -> None:
+        cfg = _cfg()
+        plan = tmp_path / "plan.json"
+        plan.write_text('{"x":1}')
+        posted = {}
+        with (
+            patch.object(
+                scan,
+                "_run_checkov",
+                return_value=(True, [{"severity": "low", "rule_id": "CKV_1"}], None),
+            ),
+            patch.object(
+                scan,
+                "_run_trivy",
+                return_value=(True, [{"severity": "low", "rule_id": "AVD-1"}], None),
+            ),
+            patch.object(scan, "post_scan_result", side_effect=lambda cfg, **kw: posted.update(kw)),
+        ):
+            outcome = scan.run_and_post(
+                cfg, {"engine": "both", "severity_threshold": "high"}, plan_json=plan
+            )
+        assert outcome == "passed"  # both low, below high
+        assert posted["summary"]["total"] == 2
+
+    def test_engine_error_marks_errored(self, tmp_path: Path) -> None:
+        cfg = _cfg()
+        plan = tmp_path / "plan.json"
+        plan.write_text('{"x":1}')
+        posted = {}
+        with (
+            patch.object(scan, "_run_checkov", return_value=(False, [], "checkov exploded")),
+            patch.object(scan, "post_scan_result", side_effect=lambda cfg, **kw: posted.update(kw)),
+        ):
+            outcome = scan.run_and_post(cfg, {"engine": "checkov"}, plan_json=plan)
+        assert outcome == "errored"
+        assert "checkov exploded" in posted["error"]


### PR DESCRIPTION
Slice 2 of #1036 — the runner-side execution for the deterministic IaC security scan (Slice 1 backend landed in #1051).

**The structural twin of the OPA policy phase, but non-fatal throughout.** OPA fails the run closed when its bundle can't be fetched; the security scan does not, because the **server** fails closed — a scanner crash, config-fetch failure, or results-POST failure here is just "no result recorded", which the post-plan gate turns into a block for enforced workspaces and a no-op for advisory/off.

### What's in this slice
- **`phases/security_scan.py`** — fetch per-workspace config from the dedicated GET endpoint; run **Checkov** (`--framework terraform_plan`, plan-fed, the recommended engine) and/or **Trivy** (config scan, best-effort — Trivy's plan-JSON support is version-dependent); normalise findings to a common shape; compute outcome vs the severity threshold; POST results (idempotent, bounded retry, 4xx final). Unrated findings (Checkov OSS omits severity — it's a Prisma signal) default to **high** so the default `high` threshold still counts them, while raising the threshold to `critical` narrows to critical-rated findings.
- **`job_entrypoint` ordering** — `enforced` + non-plan-only → scan + POST **before** `plan-result` (so `complete_plan`'s gate sees the recorded result — this is the *wait*); advisory / plan-only / off → scan **after** `plan-result` as no-wait add-on work. This is "advisory = no wait, enforced = wait", with **no listener/wire change** — the runner just does add-on work after posting the interim result (the same pattern it already uses for the plan-JSON upload).
- **`Dockerfile.runner`** — Trivy as a checksum-verified Go binary (like OPA); Checkov in an **isolated venv** so its large pinned dep tree can't collide with the runner's own deps (the phase calls the CLI, not the library; venv also sidesteps Checkov's x86_64-only standalone binary for multi-arch).
- **29 runner unit tests** — normalisation, outcome/threshold, config-fetch skip, POST retry/4xx-final, engine subprocess wrappers, orchestration.

### Verification
Runner tier green (386 passed incl. the entrypoint import). The CI **runner image build** (amd64+arm64) validates the Dockerfile — the Trivy download + Checkov venv install.

**Live-smoke (F-gate) is pending** — the definitive check is a real agent run against a workspace with a misconfigured resource on the Tilt stack, confirming Checkov scans the plan JSON and an enforced failure holds the run at the gate. That needs the local stack and is flagged for a follow-up smoke.

Part of #1036.