### PR TITLE
ci(1058): allowlist the dev-only brace-expansion advisory in npm audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,7 +550,36 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run npm audit
-        run: npm audit --audit-level=high
+        # Fail on any high/critical advisory EXCEPT explicitly-allowlisted ones
+        # (mirrors pip-audit's --ignore-vuln and trivy's .trivyignore). Each
+        # allowlisted advisory is build/lint-only, non-reachable, and awaiting a
+        # fix that only lands via a major toolchain upgrade — keep each with a
+        # reason + tracking issue, and drop it the moment the upgrade is taken:
+        #   GHSA-mh99-v99m-4gvg  brace-expansion ReDoS — a devDependency only
+        #     (eslint -> minimatch -> brace-expansion; never sees runtime/user
+        #     input). Patched only in brace-expansion 5.0.8, whose new export
+        #     shape breaks the eslint chain's minimatch, so the real fix is a
+        #     major `eslint` 10 upgrade. Tracked in #1058.
+        run: |
+          npm audit --audit-level=high --json > audit.json || true
+          node -e '
+            const a = require("./audit.json");
+            const allow = new Set(["GHSA-mh99-v99m-4gvg"]);
+            const bad = [];
+            for (const [name, v] of Object.entries(a.vulnerabilities || {})) {
+              if (!["high", "critical"].includes(v.severity)) continue;
+              const ids = (v.via || [])
+                .filter((x) => x && typeof x === "object" && x.url)
+                .map((x) => x.url.split("/").pop());
+              const unhandled = ids.filter((id) => !allow.has(id));
+              if (unhandled.length) bad.push(`${name} [${v.severity}]: ${unhandled.join(", ")}`);
+            }
+            if (bad.length) {
+              console.error("Non-allowlisted high/critical npm advisories:\n" + bad.join("\n"));
+              process.exit(1);
+            }
+            console.log("npm audit: clean (only allowlisted advisories remain — see step comment).");
+          '
 
   # ── Secret Scanning (gitleaks) ────────────────────────
   secret-scan:


### PR DESCRIPTION
## Why

The repo-wide `npm Audit` CI gate is red on **every** branch after a new high advisory for `brace-expansion` — **GHSA-mh99-v99m-4gvg** (ReDoS/DoS). It's a **devDependency only** (`eslint` → `minimatch` → `brace-expansion`), so it never sees runtime or user input; the real-world risk to Terrapod is nil. But `npm audit --audit-level=high` fails on any high advisory regardless of reachability.

## Why not just bump it

The advisory is patched **only in brace-expansion 5.0.8**, and 5.x changed its export shape so it breaks the eslint chain's `minimatch` — I confirmed this by forcing `overrides: brace-expansion: ^5.0.8`, which makes `npm run lint` throw `TypeError: expand is not a function`. npm's own remediation is a **major `eslint` 10 upgrade** (it even mis-suggests an `eslint-config-next` *downgrade* to 0.2.4) — too large and risky for a CI unblock.

## What this does

Matching the repo's existing per-advisory ignore pattern (pip-audit `--ignore-vuln`, trivy `.trivyignore`), the `npm audit` step now fails on any high/critical advisory **except an explicit, documented allowlist** — currently just this one GHSA, with a rationale and a tracking reference. No dependency or lockfile change; the gate still bites on everything else.

Verified locally: the gate **passes** with the allowlist (only the allowlisted GHSA remains) and **still fails** with an empty allowlist (re-fails on the same advisory) — so it hasn't been neutered. `ci.yml` YAML validates.

The proper fix — the major `eslint` 10 upgrade — is the tracked follow-up; drop the allowlist entry when it lands.

Closes #1058