### PR TITLE
fix(1060): serialize CA init across replicas (Postgres advisory lock)

### DIFF
--- a/services/terrapod/auth/ca.py
+++ b/services/terrapod/auth/ca.py
@@ -13,7 +13,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.x509.oid import NameOID
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.logging_config import get_logger
@@ -259,6 +259,11 @@ def parse_san_uris(cert: x509.Certificate) -> dict[str, str]:
 
 # ── Lifecycle ────────────────────────────────────────────────────────────
 
+# Stable, arbitrary key for the Postgres advisory lock that serializes CA
+# initialization across API replicas (#1060). Any fixed bigint works; it only
+# needs to be unique among advisory-lock keys the app uses.
+_CA_INIT_ADVISORY_LOCK = 776699001122
+
 
 async def init_ca(db: AsyncSession) -> CertificateAuthority:
     """Initialize the CA singleton from database, falling back to generate + persist.
@@ -273,6 +278,17 @@ async def init_ca(db: AsyncSession) -> CertificateAuthority:
 
     global _ca  # noqa: PLW0603
 
+    # Serialize the check-then-create across replicas with a transaction-scoped
+    # Postgres advisory lock (multi-replica safe, no leader election — same
+    # mutual-exclusion philosophy as the scheduler's Redis mutex). Without this,
+    # two API replicas starting against a fresh (CA-less) database each see
+    # "no CA", each generate one, and each insert a row — leaving the replicas
+    # caching *different* CAs and permanently disagreeing, which breaks listener
+    # cert validation ("Certificate not signed by this CA"). The lock makes
+    # concurrent starters queue: the first creates the CA, the rest load it. The
+    # lock releases automatically when this transaction commits below (#1060).
+    await db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": _CA_INIT_ADVISORY_LOCK})
+
     result = await db.execute(
         select(CertificateAuthorityModel)
         .order_by(CertificateAuthorityModel.created_at.desc())
@@ -285,6 +301,9 @@ async def init_ca(db: AsyncSession) -> CertificateAuthority:
             ca_record.ca_cert.encode(),
             ca_record.ca_key_pem.encode(),
         )
+        # Release the advisory lock (held on this transaction) now that the
+        # read is done; nothing was written.
+        await db.commit()
         logger.info(
             "Loaded CA from database",
             fingerprint=get_certificate_fingerprint(ca.ca_cert)[:16],

--- a/services/tests/integration/test_ca_init_race.py
+++ b/services/tests/integration/test_ca_init_race.py
@@ -1,0 +1,75 @@
+"""Integration test for the multi-replica CA-init race (#1060).
+
+`init_ca` must be safe when multiple API replicas start against a fresh
+(CA-less) database at once: exactly one CA row may be created, and every caller
+must load the *same* CA. Before the advisory-lock fix, two concurrent callers
+each saw "no CA", each generated one, and each inserted a row — leaving replicas
+caching different CAs and permanently disagreeing (listener certs then fail with
+"Certificate not signed by this CA").
+
+Requires a real Postgres engine (advisory locks are a Postgres feature), so this
+lives in the integration tier.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import text
+
+from terrapod.auth import ca as ca_module
+from terrapod.auth.ca import get_certificate_fingerprint, init_ca
+from terrapod.db.session import get_db_session
+
+
+async def _run_init_ca() -> str:
+    """Run init_ca on its own session/connection and return the CA fingerprint."""
+    async with get_db_session() as session:
+        ca = await init_ca(session)
+    return get_certificate_fingerprint(ca.ca_cert)
+
+
+async def test_concurrent_init_ca_creates_single_ca(app):
+    """Two concurrent init_ca calls on a fresh DB must yield ONE CA row.
+
+    Reproduces the #1060 race: without the advisory lock, both callers insert a
+    row (2 rows, divergent CAs). With the fix, the second caller blocks on the
+    advisory lock, then loads the row the first created — one row, identical CA.
+    """
+    # Start from a clean slate: no CA row, no cached singleton.
+    async with get_db_session() as session:
+        await session.execute(text("DELETE FROM certificate_authority"))
+        await session.commit()
+    ca_module._ca = None
+
+    # Fire N concurrent initializers, each on its own connection — the scenario
+    # of N API replicas starting together.
+    fingerprints = await asyncio.gather(*[_run_init_ca() for _ in range(4)])
+
+    # Exactly one CA row exists...
+    async with get_db_session() as session:
+        count = (
+            await session.execute(text("SELECT count(*) FROM certificate_authority"))
+        ).scalar_one()
+    assert count == 1, f"expected exactly one CA row, found {count} (multi-replica race)"
+
+    # ...and every caller loaded the identical CA.
+    assert len(set(fingerprints)) == 1, f"replicas disagree on CA: {set(fingerprints)}"
+
+
+async def test_init_ca_is_idempotent_when_ca_exists(app):
+    """A second init_ca against an existing CA loads it — no new row, same CA."""
+    async with get_db_session() as session:
+        await session.execute(text("DELETE FROM certificate_authority"))
+        await session.commit()
+    ca_module._ca = None
+
+    first = await _run_init_ca()
+    second = await _run_init_ca()
+
+    async with get_db_session() as session:
+        count = (
+            await session.execute(text("SELECT count(*) FROM certificate_authority"))
+        ).scalar_one()
+    assert count == 1
+    assert first == second


### PR DESCRIPTION
Closes #1060.

## Problem

`auth/ca.py::init_ca()` did an unguarded **check-then-create**. When two+ API replicas start against a fresh (CA-less) database at once — the normal first-install case — each sees "no CA", each generates one, and each inserts a `certificate_authority` row. The replicas then cache **different** CAs in the `_ca` module global and never reconcile. A listener joins via replica A (cert signed by CA-A) but its SSE / `runs/next` / renew calls hit replica B (CA-B) → `401 "Certificate not signed by this CA"`, a permanent re-join loop, and **no runs ever dispatch**. This violates the "multi-replica safe, no leader election" hard requirement.

Observed live: 2 CA rows created 0.0003s apart on a fresh DB with 2 API replicas.

## Fix

Wrap the SELECT+INSERT in a **transaction-scoped `pg_advisory_xact_lock`** so concurrent starters serialize — the first creates the CA, the rest load it; all replicas end up with the same single row / same `_ca`. The lock releases when the transaction commits (added a commit on the load path so the lock is always released promptly). Advisory-lock mutual exclusion is not leader election — same philosophy as the scheduler's Redis mutex.

## Test

`services/tests/integration/test_ca_init_race.py` (integration tier — advisory locks need real Postgres):
- 4 concurrent `init_ca` on separate sessions → **exactly one** CA row, **identical** fingerprints.
- second `init_ca` against an existing CA loads it (no new row, same CA).

Both pass. Surfaced during a live Tilt security-scan smoke after a DB reset.