### PR TITLE
fix(1036): resolve CodeQL py/side-effect-in-assert in security-scan runner test (#360)

### DIFF
--- a/services/tests/runner/test_phase_security_scan.py
+++ b/services/tests/runner/test_phase_security_scan.py
@@ -208,7 +208,11 @@ class TestFetchScanConfig:
             return httpx.Response(503)
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
-        assert scan.fetch_scan_config(cfg, client=client, sleep=lambda s: sleeps.append(s)) is None
+        # Call outside the assert: the sleep callback mutates `sleeps`, and an
+        # assert expression with a side effect is stripped under `python -O`
+        # (py/side-effect-in-assert).
+        result = scan.fetch_scan_config(cfg, client=client, sleep=lambda s: sleeps.append(s))
+        assert result is None
         assert len(sleeps) == 2  # 3 attempts, 2 sleeps
 
     def test_no_api_returns_none(self) -> None:


### PR DESCRIPTION
Resolves code-scanning alert #360 (`py/side-effect-in-assert`, severity: error), which arose from the #1036 security-scan runner test.

`test_non_200_retries_then_none` asserted directly on `scan.fetch_scan_config(cfg, client=client, sleep=lambda s: sleeps.append(s))`. The `sleep` callback mutates `sleeps`, so the assert **expression has a side effect** — under `python -O` (asserts stripped) the call would never run, and the subsequent `assert len(sleeps) == 2` check would break too. Bind the result to a variable first, then assert on it.

Test-only change; the 29 runner-phase tests still pass.

Part of #1036.