### PR TITLE
fix(1077): MCP — don't send the bearer token to presigned object URLs

### DIFF
--- a/mcp/internal/mcpserver/transport.go
+++ b/mcp/internal/mcpserver/transport.go
@@ -3,6 +3,8 @@ package mcpserver
 import (
 	"crypto/tls"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -27,6 +29,16 @@ type refreshTransport struct {
 	// host). nil when the token is fixed (flag/env) and must not be re-read.
 	refresh func() string
 
+	// apiHost is the Terrapod API's host[:port]. The bearer token is ONLY sent
+	// to this host. A go-terrapod call that 302-redirects to a presigned object
+	// URL (S3/GCS/Azure/filesystem on a different host) must NOT carry the
+	// Authorization header: the presigned query string IS the auth, and S3
+	// rejects a request bearing two auth mechanisms (400 InvalidArgument —
+	// issue #1077). Go's stdlib strips Authorization on a cross-domain redirect,
+	// but this RoundTripper runs for the redirected request too, so it must not
+	// re-add the header for a non-API host.
+	apiHost string
+
 	mu    sync.RWMutex
 	token string // best-known current token (starts at the startup token)
 }
@@ -38,6 +50,22 @@ func (t *refreshTransport) current() string {
 }
 
 func (t *refreshTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// A request to any host OTHER than the Terrapod API is a redirect to a
+	// self-authenticating presigned object URL (plan JSON / state / artifacts in
+	// S3 etc.). It must go out with NO bearer token — sending one makes S3 reject
+	// it (two auth mechanisms, issue #1077) — and there is nothing to refresh.
+	// Actively STRIP any Authorization the caller or Go's redirect copier left on
+	// (belt-and-suspenders), then pass it through. Clone first — a RoundTripper
+	// must not mutate the caller's request.
+	if t.apiHost != "" && req.URL.Host != t.apiHost {
+		if req.Header.Get("Authorization") != "" {
+			clean := req.Clone(req.Context())
+			clean.Header.Del("Authorization")
+			return t.base.RoundTrip(clean)
+		}
+		return t.base.RoundTrip(req)
+	}
+
 	// Send our best-known token. After a refresh this is fresher than the value
 	// the go-terrapod client re-sets from its startup token on every request, so
 	// subsequent calls succeed on the first attempt instead of 401→refresh→retry.
@@ -91,9 +119,28 @@ func newHTTPClient(host, token string, refreshable, skipTLSVerify bool) *http.Cl
 	if skipTLSVerify {
 		base.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec
 	}
-	rt := &refreshTransport{base: base, token: token}
+	rt := &refreshTransport{base: base, token: token, apiHost: hostOf(host)}
 	if refreshable {
 		rt.refresh = func() string { return tokenFromCredentialsFile(host) }
 	}
 	return &http.Client{Transport: rt, Timeout: 30 * time.Second}
+}
+
+// hostOf extracts the host[:port] from a Terrapod base URL or bare hostname so
+// the bearer token can be scoped to exactly that host (issue #1077). Returns ""
+// when it can't be parsed, in which case the transport falls back to its prior
+// behaviour (inject on every request) rather than silently dropping auth.
+func hostOf(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if !strings.Contains(s, "://") {
+		s = "https://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+	return u.Host
 }

--- a/mcp/internal/mcpserver/transport_test.go
+++ b/mcp/internal/mcpserver/transport_test.go
@@ -143,3 +143,55 @@ func TestRefreshTransportNoRetryWhenTokenUnchanged(t *testing.T) {
 		t.Fatalf("calls=%d, want 1 (no retry when re-resolved token is unchanged)", got)
 	}
 }
+
+// The Terrapod API 302-redirects a plan-JSON / state / artifact fetch to a
+// presigned object URL (S3/GCS/Azure) whose query string IS the auth. The
+// bearer token must NOT ride along to that host — S3 rejects a request bearing
+// two auth mechanisms with 400 InvalidArgument (issue #1077). This proves the
+// API host gets the bearer while the (different) presigned host does not.
+func TestRefreshTransportStripsAuthOnPresignedRedirect(t *testing.T) {
+	var presignedAuth, apiAuth string
+	presigned := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		presignedAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"format_version":"1.0","planned_values":{}}`))
+	}))
+	defer presigned.Close()
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiAuth = r.Header.Get("Authorization")
+		http.Redirect(w, r, presigned.URL+"/blob?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc", http.StatusFound)
+	}))
+	defer api.Close()
+
+	hc := newHTTPClient(api.URL, "tok", false, false)
+	resp, err := hc.Get(api.URL + "/api/v2/plans/plan-x/json-output")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	if apiAuth != "Bearer tok" {
+		t.Errorf("API host should receive the bearer, got %q", apiAuth)
+	}
+	if presignedAuth != "" {
+		t.Errorf("presigned host must NOT receive Authorization, got %q", presignedAuth)
+	}
+	if !strings.Contains(string(body), "format_version") {
+		t.Errorf("presigned body not returned: %s", body)
+	}
+}
+
+func TestHostOf(t *testing.T) {
+	cases := map[string]string{
+		"https://terrapod.local":           "terrapod.local",
+		"https://terrapod.markupai.ts.net": "terrapod.markupai.ts.net",
+		"terrapod.local":                   "terrapod.local", // bare host, no scheme
+		"http://127.0.0.1:8080":            "127.0.0.1:8080",
+		"":                                 "",
+	}
+	for in, want := range cases {
+		if got := hostOf(in); got != want {
+			t.Errorf("hostOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes **#1077** — `terrapod_run_plan_json` (and any presigned-object fetch) failed against an S3-backed instance with an S3 `400 InvalidArgument` ("Only one auth mechanism allowed").

## Root cause

The MCP's `refreshTransport` (issue #880) re-set `Authorization: Bearer …` on **every** `RoundTrip`. When a go-terrapod call 302-redirects to a **presigned** object URL (plan JSON / state / artifacts live in S3/GCS/Azure), the `X-Amz-*` query signature IS the auth — S3 rejects a request that *also* carries an `Authorization` header. Go's stdlib strips `Authorization` on a cross-domain redirect, but this RoundTripper runs for the redirected request too and put the header right back on the S3 request.

## Fix

Scope the bearer to the **API host**. The transport now records the API host (`hostOf(cfg.Host)`) and:
- injects the bearer + does the 401-refresh **only** for that host;
- for any other host, passes the request through with `Authorization` **actively stripped** (belt-and-suspenders — covers a same-hostname/different-port presigned URL where Go's redirect copier would leave the header on).

Presigned fetches are self-authenticating, so this is correct for all storage backends (the filesystem backend's presigned URLs stay on the API host and are unaffected).

## Tests
- `TestRefreshTransportStripsAuthOnPresignedRedirect`: an httptest API server 302-redirecting to a presigned server on a different port — asserts the **API** host receives `Bearer tok` and the **presigned** host receives no `Authorization`, and the body is returned.
- `TestHostOf`: URL / bare-host / empty parsing.
- The existing token-refresh tests still pass. `go build ./... && go vet ./... && go test ./...` green in `mcp/`.

Closes #1077
