### PR TITLE
fix(1075): stop rate limiter freezing streamed run logs behind the BFF

### DIFF
--- a/services/terrapod/api/rate_limit.py
+++ b/services/terrapod/api/rate_limit.py
@@ -4,6 +4,8 @@ Multi-replica safe — uses Redis INCR + EXPIRE for distributed counting.
 Disabled by default; enable via config.rate_limit.enabled = true.
 """
 
+import hashlib
+import re
 import time
 from collections.abc import Callable
 
@@ -41,20 +43,72 @@ def _get_client_ip(request: Request) -> str:
     return "unknown"
 
 
+# Capability-scoped read endpoints: the run/plan/apply UUID in the PATH is the
+# capability (go-tfe's LogReader and the web log viewer poll these anonymously —
+# no bearer — matching the state-upload capability pattern). They are polled at
+# high frequency while a run streams (~every 2.5s), so keying them on the source
+# IP collapses every browser's stream into ONE anonymous bucket behind the BFF
+# (the API sees a single web-pod IP) — which live log-tailing then exhausts,
+# 429-ing the poll so the log freezes and never recovers (#1075). Bucketing on
+# the path UUID instead gives each run's stream its own budget, isolating runs
+# from each other and from the shared source IP.
+_CAPABILITY_PATH_RE = re.compile(r"^/api/v2/(?:plans|applies)/([^/]+)/(?:log|json-output)$")
+
+
+def _capability_bucket(path: str) -> str | None:
+    """Per-capability bucket id for UUID-scoped anonymous polling endpoints.
+
+    Returns ``cap:{id}`` for the plan/apply log + plan json-output readers (the
+    id in the path IS the capability, not a secret — no hashing needed), or None
+    for any other path so the caller falls back to credential/IP keying.
+    """
+    m = _CAPABILITY_PATH_RE.match(path)
+    if m is None:
+        return None
+    return "cap:" + m.group(1)
+
+
+def _credential_bucket(auth_header: str, listener_cert: str) -> str | None:
+    """A stable, non-reversible per-principal bucket id from the credential.
+
+    For AUTHENTICATED traffic the rate-limit bucket must key on WHO is calling,
+    not on the source IP: behind the BFF/ingress the API sees a single internal
+    pod IP for every browser, so an IP-keyed authenticated tier collapses the
+    per-user limit into one shared global bucket — which a single live run's
+    log-polling (every 2.5s) then exhausts, 429-ing everyone's log streams
+    (#1075). Keying on a hash of the bearer token / client cert gives each
+    principal its own budget regardless of the shared source IP. Returns None
+    when there is no credential (fall back to IP for the unauthenticated tier).
+    """
+    cred = auth_header or listener_cert
+    if not cred:
+        return None
+    return "cred:" + hashlib.sha256(cred.encode("utf-8")).hexdigest()[:20]
+
+
 class RateLimitMiddleware:
     """Sliding window rate limiter using Redis.
 
     Pure ASGI middleware for correct async behavior.
 
     Tiers:
+    - Capability reads (`/api/v2/{plans,applies}/{id}/log`, `.../json-output`):
+      `authenticated_requests_per_minute`, bucketed per-run on the path UUID
+      (the capability). These authenticate by the UUID in the path — not a
+      header — and are polled continuously while a run streams, so they must
+      NOT share the unauthenticated IP bucket (which behind the BFF is one
+      global bucket that live log-tailing exhausts, freezing the log — #1075).
     - Runner tokens (HMAC-verified inline): `runner_requests_per_minute`
       (default 0 = unlimited). Runners are service-to-service callers and
       burst through the network-mirror and artifact endpoints during
       `tofu init`/`apply`; a low limit starves them.
-    - Authenticated (any `Authorization` header): `authenticated_requests_per_minute`.
+    - Authenticated (any `Authorization` header): `authenticated_requests_per_minute`,
+      bucketed per-principal on a hash of the credential (NOT the source IP —
+      behind the BFF every browser shares one pod IP, so IP-keying collapses
+      the whole tier into one bucket, #1075).
       Interactive users and API-token automation rarely approach this, but
       it stops one noisy client taking the pool.
-    - Unauthenticated: base limit (`requests_per_minute`).
+    - Unauthenticated: base limit (`requests_per_minute`), IP-keyed.
     - Auth endpoints (`/api/terrapod/v1/auth/*`, `/oauth/*`): always `auth_requests_per_minute`
       regardless of who's calling — brute-force defence on login.
     """
@@ -115,7 +169,17 @@ class RateLimitMiddleware:
         listener_cert = request.headers.get("x-terrapod-client-cert", "")
         is_authenticated = bool(auth_header) or bool(listener_cert)
 
-        if is_auth_endpoint:
+        # A UUID-scoped log/json-output reader authenticates by the path
+        # capability and is polled continuously while a run streams. It gets its
+        # own per-run bucket (not the shared anonymous IP bucket) at the
+        # authenticated limit — the capability is a real principal, just carried
+        # in the path rather than a header (#1075).
+        capability = _capability_bucket(path)
+
+        if capability is not None:
+            limit = self.authenticated_requests_per_minute
+            prefix = "api_capability"
+        elif is_auth_endpoint:
             limit = self.auth_requests_per_minute
             prefix = "auth"
         elif is_runner:
@@ -140,11 +204,17 @@ class RateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        client_ip = _get_client_ip(request)
+        # Bucket by WHO, not WHERE, for authenticated traffic — the source IP is
+        # the shared BFF/ingress pod IP behind the proxy, so an IP-keyed
+        # authenticated tier is one global bucket (#1075). Unauthenticated
+        # traffic (login, anon) has no credential and stays IP-keyed.
+        identity = (
+            capability or _credential_bucket(auth_header, listener_cert) or _get_client_ip(request)
+        )
 
         # Sliding window: 60-second buckets
         window_id = int(time.time()) // 60
-        key = f"tp:ratelimit:{prefix}:{client_ip}:{window_id}"
+        key = f"tp:ratelimit:{prefix}:{identity}:{window_id}"
 
         try:
             pipe = redis.pipeline(transaction=False)

--- a/services/tests/api/test_rate_limit.py
+++ b/services/tests/api/test_rate_limit.py
@@ -267,3 +267,107 @@ class TestRateLimitMiddleware:
             "/api/terrapod/v1/auth/login", headers={"Authorization": f"Bearer {token}"}
         )
         assert response.status_code == 429
+
+
+class TestCredentialBucketing:
+    """Authenticated traffic buckets by credential, not IP (#1075).
+
+    Behind the BFF/ingress every browser shares one internal source IP, so an
+    IP-keyed authenticated tier is a single global bucket that a live run's
+    log-polling exhausts, 429-ing everyone's log streams. Keying on the bearer
+    token / client cert gives each principal its own budget.
+    """
+
+    def test_credential_bucket_pure(self):
+        from terrapod.api.rate_limit import _credential_bucket
+
+        a = _credential_bucket("Bearer tokenA", "")
+        b = _credential_bucket("Bearer tokenB", "")
+        again = _credential_bucket("Bearer tokenA", "")
+        assert a and b and a != b  # different tokens → different buckets
+        assert a == again  # stable per token
+        assert a.startswith("cred:") and "tokenA" not in a  # hashed, not reversible
+        assert _credential_bucket("", "cert-pem") is not None  # listener cert counts
+        assert _credential_bucket("", "") is None  # no credential → fall back to IP
+
+    def test_two_tokens_same_ip_get_separate_buckets(self):
+        # Two distinct principals from the SAME source IP (the shared BFF pod IP)
+        # must land in DIFFERENT rate-limit buckets.
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, authenticated_rpm=1000)
+        client = TestClient(app)
+
+        client.get("/api/terrapod/v1/workspaces", headers={"Authorization": "Bearer AAA"})
+        client.get("/api/terrapod/v1/workspaces", headers={"Authorization": "Bearer BBB"})
+
+        keys = [c.args[0] for c in mock_redis.pipeline.return_value.incr.call_args_list]
+        assert len(keys) == 2
+        # Same tier prefix + same source IP, but the credential discriminator differs.
+        assert keys[0] != keys[1]
+        assert all(k.startswith("tp:ratelimit:api_authn:cred:") for k in keys)
+
+    def test_same_token_shares_bucket(self):
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, authenticated_rpm=1000)
+        client = TestClient(app)
+        client.get("/api/terrapod/v1/workspaces", headers={"Authorization": "Bearer SAME"})
+        client.get("/api/terrapod/v1/workspaces", headers={"Authorization": "Bearer SAME"})
+        keys = [c.args[0] for c in mock_redis.pipeline.return_value.incr.call_args_list]
+        # Same token → same bucket (minus the time-window suffix, which is equal here).
+        assert keys[0] == keys[1]
+
+
+class TestCapabilityBucketing:
+    """Log/json-output readers authenticate by the run UUID in the path and are
+    polled while a run streams. They must bucket per-run — NOT on the shared BFF
+    source IP, which would collapse every browser's log stream into one
+    anonymous bucket that live tailing exhausts, freezing the log (#1075).
+    """
+
+    def test_capability_bucket_pure(self):
+        from terrapod.api.rate_limit import _capability_bucket
+
+        assert _capability_bucket("/api/v2/applies/run-abc/log") == "cap:run-abc"
+        assert _capability_bucket("/api/v2/plans/run-abc/log") == "cap:run-abc"
+        assert _capability_bucket("/api/v2/plans/run-abc/json-output") == "cap:run-abc"
+        # Distinct runs → distinct buckets.
+        assert _capability_bucket("/api/v2/applies/run-A/log") != _capability_bucket(
+            "/api/v2/applies/run-B/log"
+        )
+        # Non-capability paths fall through to credential/IP keying.
+        assert _capability_bucket("/api/terrapod/v1/workspaces") is None
+        assert _capability_bucket("/api/v2/workspaces/ws-1") is None
+
+    def test_log_reader_buckets_per_run_not_shared_ip(self):
+        # Two DIFFERENT runs polled anonymously from the SAME source IP (the
+        # shared BFF pod IP) must land in DIFFERENT buckets under the capability
+        # tier — so one streaming run cannot 429 another's log.
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, authenticated_rpm=1000)
+        client = TestClient(app)
+
+        client.get("/api/v2/applies/run-AAA/log")
+        client.get("/api/v2/applies/run-BBB/log")
+
+        keys = [c.args[0] for c in mock_redis.pipeline.return_value.incr.call_args_list]
+        assert len(keys) == 2
+        assert keys[0] != keys[1]
+        assert all(k.startswith("tp:ratelimit:api_capability:cap:") for k in keys)
+
+    def test_same_run_log_shares_bucket(self):
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, authenticated_rpm=1000)
+        client = TestClient(app)
+        client.get("/api/v2/applies/run-SAME/log")
+        client.get("/api/v2/applies/run-SAME/log")
+        keys = [c.args[0] for c in mock_redis.pipeline.return_value.incr.call_args_list]
+        assert keys[0] == keys[1]
+
+    def test_capability_tier_uses_authenticated_limit(self):
+        # The capability reader gets the generous authenticated limit, not the
+        # low unauthenticated base — live tailing polls it continuously.
+        mock_redis = _make_redis_mock(count=1)
+        app = _make_app(get_redis=lambda: mock_redis, rpm=100, authenticated_rpm=1000)
+        client = TestClient(app)
+        resp = client.get("/api/v2/applies/run-XYZ/log")
+        assert resp.headers.get("x-ratelimit-limit") == "1000"


### PR DESCRIPTION
## Problem

Live run-log streaming in the web UI **freezes when the surface is briefly hidden** (switch to another in-app tab, or another browser tab) and never recovers on return — the log stays stuck at the byte offset it was at, even though the run keeps producing output and finishes normally server-side.

## Root cause (live-reproduced, not theorised)

Reproduced on the Tilt stack: a streaming apply, watched on the Apply Log, then Overview for ~10s, then back — the log froze, and the console showed **HTTP 429** on every `GET /api/v2/applies/{id}/log?offset=…`.

The log readers (`/api/v2/{plans,applies}/{id}/log`) authenticate by the **run UUID in the path**, not a bearer header (matching go-tfe's `LogReader`), and the web viewer polls them with a plain (unauthenticated) `fetch` every 2.5s while a run streams. The rate limiter therefore classified those polls as the **unauthenticated tier** and keyed the bucket on the **source IP** — but behind the BFF the API sees a **single web-pod IP** for every browser, so the whole tier collapsed into one shared 100/min bucket. Live log-tailing (2.5s poll + SSE-triggered reloads + tab-switch remounts) exhausted it; the client silently swallowed the 429s, so the log froze.

The same IP-collapse also affected the **authenticated** tier (SSE, `apiFetch`) — every browser shared the one BFF-pod-IP bucket instead of getting a per-user budget.

## Fix

Two changes to the rate-limiter bucket key (`api/rate_limit.py`):

1. **Authenticated traffic buckets on a hash of the credential** (bearer token / client cert), not the source IP — so the per-user limit applies per user instead of collapsing into one shared BFF-pod-IP bucket.
2. **UUID-scoped capability readers** (`log` + `json-output`) get their own **per-run bucket keyed on the path UUID**, at the authenticated limit — each run's stream is isolated and can't 429 another's, and it's never lumped into the anonymous IP tier.

No new routes, attributes, config keys, or DB changes — contract snapshots untouched.

## Verification

- **Live on Tilt (the gate):** a streaming apply now tails the full log (`streaming-line-0` → `-29`, "Apply complete!") through a mid-stream tab switch with **zero 429s** (previously froze at the switch point). Confirmed the Redis bucket is now `tp:ratelimit:api_capability:cap:{run-uuid}` (per-run), not the shared IP.
- **Tests:** `services/tests/api/test_rate_limit.py` — added `TestCapabilityBucketing` (per-run isolation, same-run sharing, capability-tier limit) alongside the credential-bucketing tests. Full `make test` green.

Closes #1075
