### PR TITLE
feat(1063): JSON:API house style — error envelope + pagination helper (slice 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,6 +443,38 @@ multi-language implementation ships in the same PR**:
     `ListAll*` loop helpers; the web UI, which deliberately shows whole lists and
     filters client-side (**no page-through UX**), fetches via `fetchAllPages()`
     in `web/src/lib/api.ts`.
+- **The API house style is JSON:API (convention)** — the API has **one** house
+  style, and both surfaces (`/api/v2` + `/api/terrapod/v1`) follow it. A new or
+  changed endpoint conforms to all of it:
+  - **`data` envelope** — a resource is `{"data": {"type", "id", "attributes",
+    "relationships"?}}`; a collection is `{"data": [...], "meta": {...}}`.
+  - **kebab-case attribute names** (`created-at`, `agent-pool-id`), never
+    snake_case, in both request and response bodies.
+  - **typed-prefixed ids** (`ws-…`, `run-…`, `cv-…`, `apool-…`); accept the id
+    both prefixed and raw on input where practical.
+  - **links as `relationships`** — a link to another resource is a JSON:API
+    relationship (`"relationships": {"workspace": {"data": {"id": "ws-…",
+    "type": "workspaces"}}}`). A redundant `*-id` **attribute** may also be
+    emitted for back-compat, but the relationship is the canonical form; new
+    links add the relationship.
+  - **dual-key error envelope** — errors carry **both** the JSON:API
+    `{"errors": [{"detail": …, "status": "404"}]}` array **and** the legacy
+    top-level `{"detail": …}`. This is automatic: `raise HTTPException(detail=…)`
+    goes through the shared handler in `api/app.py` (helper: `api/errors.py`).
+    Don't hand-build a bare `{"detail": …}` JSONResponse.
+  - **shared pagination** — list endpoints emit `meta.pagination` via
+    `api/pagination.py` (`paginate()` / `build_meta()`), never a hand-rolled
+    block (see the pagination convention above).
+  - **Deliberate flat-body exceptions (do NOT `data`-wrap):** the
+    **runner/listener protocol** endpoints (their own wire contract) and the
+    **OAuth token** endpoints (`grant_types`, `expires_in`, … — RFC 6749 shapes)
+    return flat, non-`data` bodies on purpose. These are the only sanctioned
+    deviations; everything else on the native surface is JSON:API.
+
+  This is enforced additively: the route/attribute/wire contract snapshots keep
+  every existing shape, so conforming an endpoint means *adding* the canonical
+  form (a `relationships` block, an `errors` array) alongside what's already
+  there — never removing a byte a lagging consumer reads.
 - **The config-channel contract (hard requirement)** — a three-way contract
   binding the **config code**, the **Helm chart**, and the **chart tests**:
   the in-code config models (the API's Pydantic `Settings`, the listener's

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -627,7 +627,33 @@ def create_application() -> FastAPI:
     # specific message (e.g. catalog "name already exists"); this is the net so
     # the generic case is 409, not 500. Registered before the Exception handler
     # so the more specific type wins.
+    from fastapi.exceptions import RequestValidationError
     from sqlalchemy.exc import IntegrityError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    from terrapod.api.errors import jsonapi_error_response
+
+    # JSON:API house style (#1063): every error body carries a JSON:API
+    # `errors` array AND the legacy top-level `detail`. Purely additive — old
+    # clients keep reading `detail`; go-terrapod / JSON:API clients read
+    # `errors`. Covers the ~740 `raise HTTPException(detail=…)` sites uniformly.
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+        return jsonapi_error_response(
+            exc.detail, exc.status_code, headers=getattr(exc, "headers", None)
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        # Keep FastAPI's 422 `detail` list verbatim; add the `errors` array.
+        # `exc.errors()` can carry non-JSON-serialisable `ctx` values (Pydantic
+        # v2), so run it through jsonable_encoder exactly as FastAPI's default
+        # handler does before it reaches the response.
+        from fastapi.encoders import jsonable_encoder
+
+        return jsonapi_error_response(jsonable_encoder(exc.errors()), 422)
 
     @app.exception_handler(IntegrityError)
     async def integrity_error_handler(request: Request, exc: IntegrityError) -> JSONResponse:
@@ -636,20 +662,14 @@ def create_application() -> FastAPI:
             path=str(request.url.path),
             error=str(getattr(exc, "orig", exc)),
         )
-        return JSONResponse(
-            status_code=409,
-            content={"detail": "Resource already exists or violates a constraint"},
-        )
+        return jsonapi_error_response("Resource already exists or violates a constraint", 409)
 
     # Global exception handler
     @app.exception_handler(Exception)
     async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
         """Global exception handler for unhandled errors."""
         logger.error("Unhandled exception", exc_info=exc, path=str(request.url.path))
-        return JSONResponse(
-            status_code=500,
-            content={"detail": "Internal server error"},
-        )
+        return jsonapi_error_response("Internal server error", 500)
 
     # ── API prefix conventions ──────────────────────────────────────
     #

--- a/services/terrapod/api/errors.py
+++ b/services/terrapod/api/errors.py
@@ -1,0 +1,67 @@
+"""JSON:API error-envelope helpers (#1063).
+
+Terrapod's house style is JSON:API: an error body is
+``{"errors": [{"detail": …, "status": "404"}]}``. Historically the native
+surface leaned on FastAPI's default ``HTTPException`` handler, which emits a
+bare ``{"detail": …}`` — the shape go-terrapod's error extractor does NOT
+understand, so it fell through and returned the raw body verbatim.
+
+The fix is **purely additive**: a shared handler emits BOTH keys —
+
+    {"errors": [{"detail": "...", "status": "404"}], "detail": "..."}
+
+Old clients keep reading the top-level ``detail``; JSON:API clients (and
+go-terrapod) read ``errors``. No existing response byte is removed, so the
+route/attribute/wire contract snapshots are untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+
+def jsonapi_error_content(detail: Any, status_code: int) -> dict[str, Any]:
+    """Build the dual-key error body: a JSON:API ``errors`` array plus the
+    legacy top-level ``detail`` (verbatim, for back-compat).
+
+    ``detail`` is usually a string, but FastAPI's request-validation errors pass
+    a list of per-field dicts. In that case each entry becomes its own
+    ``errors[]`` member (with a JSON-Pointer ``source``), and the original list
+    is still echoed at the top level unchanged.
+    """
+    status = str(status_code)
+    if isinstance(detail, list):
+        errors = []
+        for item in detail:
+            if isinstance(item, dict):
+                loc = item.get("loc") or []
+                pointer = "/" + "/".join(str(p) for p in loc)
+                errors.append(
+                    {
+                        "detail": item.get("msg", ""),
+                        "status": status,
+                        "source": {"pointer": pointer},
+                    }
+                )
+            else:
+                errors.append({"detail": str(item), "status": status})
+        if not errors:
+            errors = [{"detail": "Validation error", "status": status}]
+    else:
+        errors = [{"detail": detail if isinstance(detail, str) else str(detail), "status": status}]
+    # Keep the original `detail` verbatim alongside the new `errors` array.
+    return {"errors": errors, "detail": detail}
+
+
+def jsonapi_error_response(
+    detail: Any, status_code: int, headers: dict[str, str] | None = None
+) -> JSONResponse:
+    """A ``JSONResponse`` carrying the dual-key error envelope, preserving any
+    headers the original error set (e.g. ``WWW-Authenticate`` on a 401)."""
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonapi_error_content(detail, status_code),
+        headers=headers,
+    )

--- a/services/terrapod/api/routers/audit.py
+++ b/services/terrapod/api/routers/audit.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, require_admin_or_audit
+from terrapod.api.pagination import build_meta
 from terrapod.db.session import get_db
 from terrapod.services.audit_service import query_audit_log
 
@@ -67,12 +68,5 @@ async def list_audit_log(
             }
             for entry in entries
         ],
-        "meta": {
-            "pagination": {
-                "current-page": page_number,
-                "page-size": page_size,
-                "total-count": total,
-                "total-pages": (total + page_size - 1) // page_size if total > 0 else 0,
-            }
-        },
+        "meta": build_meta(total, page_number, page_size),
     }

--- a/services/terrapod/api/routers/config_versions.py
+++ b/services/terrapod/api/routers/config_versions.py
@@ -29,6 +29,7 @@ from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
+from terrapod.api.pagination import build_meta
 from terrapod.auth import capabilities as cap
 from terrapod.auth import download_tickets
 from terrapod.auth.capabilities import has_capability
@@ -215,12 +216,7 @@ async def list_configuration_versions(
         content={
             "data": [_cv_json(cv)["data"] for cv in cvs],
             "meta": {
-                "pagination": {
-                    "current-page": page_number,
-                    "page-size": page_size,
-                    "total-count": total,
-                    "total-pages": (total + page_size - 1) // page_size if total else 0,
-                },
+                **build_meta(total, page_number, page_size),
                 "current-id": f"cv-{current_cv_uuid}" if current_cv_uuid else None,
             },
         }

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -44,6 +44,7 @@ from terrapod.api.dependencies import (
     get_current_user,
     get_listener_identity,
 )
+from terrapod.api.pagination import build_meta
 from terrapod.auth import capabilities as cap
 from terrapod.auth.capabilities import has_capability
 from terrapod.config import settings
@@ -637,14 +638,7 @@ async def list_workspace_runs(
                 _run_json(r, workspace_name=ws.name, workspace_has_vcs=has_vcs)["data"]
                 for r in runs
             ],
-            "meta": {
-                "pagination": {
-                    "current-page": page_number,
-                    "page-size": page_size,
-                    "total-count": total,
-                    "total-pages": (total + page_size - 1) // page_size if total > 0 else 0,
-                }
-            },
+            "meta": build_meta(total, page_number, page_size),
         }
     )
 

--- a/services/terrapod/api/routers/users.py
+++ b/services/terrapod/api/routers/users.py
@@ -12,6 +12,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.api.dependencies import AuthenticatedUser, require_admin, require_admin_or_audit
+from terrapod.api.pagination import build_meta
 from terrapod.auth.passwords import hash_password, validate_password_strength
 from terrapod.db.models import (
     PlatformRoleAssignment,
@@ -145,14 +146,7 @@ async def list_users(
 
     return {
         "data": [_user_to_jsonapi(u) for u in users],
-        "meta": {
-            "pagination": {
-                "current-page": page_number,
-                "page-size": page_size,
-                "total-count": total,
-                "total-pages": (total + page_size - 1) // page_size if total > 0 else 0,
-            }
-        },
+        "meta": build_meta(total, page_number, page_size),
     }
 
 

--- a/services/tests/api/test_error_envelope.py
+++ b/services/tests/api/test_error_envelope.py
@@ -1,0 +1,116 @@
+"""JSON:API dual-key error envelope (#1063).
+
+Every error body must carry BOTH the JSON:API ``errors`` array (what
+go-terrapod's extractor understands) AND the legacy top-level ``detail`` (what
+older clients read). The change is additive — ``detail`` is never removed.
+"""
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel
+
+from terrapod.api.errors import jsonapi_error_content
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _app() -> FastAPI:
+    """A tiny app that registers the same exception handlers as the real one.
+
+    (The full app's real registration is exercised implicitly by the ~890
+    router tests, which now hit these handlers on every error path.)
+    """
+    application = FastAPI()
+
+    from fastapi.encoders import jsonable_encoder
+    from fastapi.exceptions import RequestValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    from terrapod.api.errors import jsonapi_error_response
+
+    @application.exception_handler(StarletteHTTPException)
+    async def _http(request, exc):
+        return jsonapi_error_response(
+            exc.detail, exc.status_code, headers=getattr(exc, "headers", None)
+        )
+
+    @application.exception_handler(RequestValidationError)
+    async def _val(request, exc):
+        return jsonapi_error_response(jsonable_encoder(exc.errors()), 422)
+
+    class Body(BaseModel):
+        n: int
+
+    @application.get("/boom")
+    async def boom():
+        raise HTTPException(status_code=404, detail="workspace not found")
+
+    @application.get("/teapot")
+    async def teapot():
+        raise HTTPException(status_code=401, detail="nope", headers={"WWW-Authenticate": "Bearer"})
+
+    @application.post("/validate")
+    async def validate(body: Body):
+        return {"ok": body.n}
+
+    return application
+
+
+async def test_http_exception_has_both_keys():
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        resp = await c.get("/boom")
+    assert resp.status_code == 404
+    body = resp.json()
+    # legacy key preserved verbatim
+    assert body["detail"] == "workspace not found"
+    # JSON:API errors array present
+    assert body["errors"] == [{"detail": "workspace not found", "status": "404"}]
+
+
+async def test_http_exception_preserves_headers():
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        resp = await c.get("/teapot")
+    assert resp.status_code == 401
+    assert resp.headers.get("www-authenticate") == "Bearer"
+    body = resp.json()
+    assert body["detail"] == "nope"
+    assert body["errors"][0]["detail"] == "nope"
+
+
+async def test_validation_error_has_both_keys():
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        resp = await c.post("/validate", json={"n": "not-an-int"})
+    assert resp.status_code == 422
+    body = resp.json()
+    # `detail` still the FastAPI validation list (back-compat)
+    assert isinstance(body["detail"], list)
+    # plus an errors array with a JSON-Pointer source
+    assert body["errors"]
+    assert body["errors"][0]["status"] == "422"
+    assert body["errors"][0]["source"]["pointer"].startswith("/")
+
+
+class TestEnvelopeHelper:
+    def test_string_detail(self):
+        c = jsonapi_error_content("boom", 500)
+        assert c == {"errors": [{"detail": "boom", "status": "500"}], "detail": "boom"}
+
+    def test_list_detail_maps_each_with_pointer(self):
+        detail = [{"loc": ["body", "n"], "msg": "field required", "type": "missing"}]
+        c = jsonapi_error_content(detail, 422)
+        assert c["detail"] == detail  # verbatim
+        assert c["errors"][0] == {
+            "detail": "field required",
+            "status": "422",
+            "source": {"pointer": "/body/n"},
+        }
+
+    def test_empty_list_detail_gets_placeholder(self):
+        c = jsonapi_error_content([], 422)
+        assert c["errors"] == [{"detail": "Validation error", "status": "422"}]


### PR DESCRIPTION
Additive standardisation of the native API on the one JSON:API house style — **Slice 1 of #1063** (the low-risk mechanical trio; the "relationships alongside `*-id` attributes" sweep is Slice 2).

## What's here

**Dual-key error envelope.** A shared `HTTPException` / `RequestValidationError` handler (`api/app.py`; helper `api/errors.py`) emits **both** the JSON:API `{"errors":[{"detail":…,"status":"404"}]}` array **and** the legacy top-level `{"detail":…}`. Covers all ~740 `raise HTTPException(detail=…)` sites uniformly and fixes go-terrapod's error extractor (which only understood `errors[]` and previously fell through to the raw body for the native/majority case). `IntegrityError` (409) + catch-all (500) emit the same shape; error headers (e.g. `WWW-Authenticate`) preserved; Pydantic-v2 `ctx` is `jsonable_encoder`-ed. **Purely additive** — `detail` is never removed.

**Pagination helper.** The 4 hand-rolled `meta.pagination` blocks (`audit`, `config_versions`, `runs`, `users`) now route through `api/pagination.py::build_meta`. **Byte-identical** (all four already clamp `page[size]` ≤100, matching the helper) — a pure internal refactor, and `config_versions` keeps its extra `current-id` meta key.

**Convention.** `AGENTS.md` gains an "API house style is JSON:API" section (data envelope, kebab attrs, prefixed ids, relationships-for-links, dual-key errors, shared pagination, and the two sanctioned flat-body exceptions: runner/listener protocol + OAuth token endpoints).

## Back-compat (the hard constraint)
- **Route + attribute contract snapshots pass WITHOUT regeneration** — the mechanical proof nothing broke: no success serializer, route signature, or existing byte changed.
- New `errors` array + the pagination refactor are supersets / byte-identical to the current payloads; every existing `detail` key and attribute remains.

## Verification
- New `services/tests/api/test_error_envelope.py` (dual-key shape, header preservation, validation-error mapping, helper units).
- Full `services/api/config/db` sweep: **2362 passed**, 0 failures.

Part of #1063