### PR TITLE
feat(1063): JSON:API house style — links as relationships (slice 2)

### DIFF
--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -628,6 +628,8 @@ def create_application() -> FastAPI:
     # the generic case is 409, not 500. Registered before the Exception handler
     # so the more specific type wins.
     from fastapi.exceptions import RequestValidationError
+    from fastapi.responses import Response
+    from fastapi.utils import is_body_allowed_for_status_code
     from sqlalchemy.exc import IntegrityError
     from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -638,10 +640,16 @@ def create_application() -> FastAPI:
     # clients keep reading `detail`; go-terrapod / JSON:API clients read
     # `errors`. Covers the ~740 `raise HTTPException(detail=…)` sites uniformly.
     @app.exception_handler(StarletteHTTPException)
-    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
-        return jsonapi_error_response(
-            exc.detail, exc.status_code, headers=getattr(exc, "headers", None)
-        )
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> Response:
+        headers = getattr(exc, "headers", None)
+        # Match FastAPI's default handler exactly for statuses that forbid a
+        # body (1xx / 204 / 304): emit NO body. Without this the dual-key
+        # envelope would put JSON on a 204/304, which is invalid HTTP and
+        # differs from pre-#1063 behaviour. Nothing raises those today, but the
+        # guard keeps this handler a strict superset of FastAPI's.
+        if not is_body_allowed_for_status_code(exc.status_code):
+            return Response(status_code=exc.status_code, headers=headers)
+        return jsonapi_error_response(exc.detail, exc.status_code, headers=headers)
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(

--- a/services/terrapod/api/routers/autodiscovery_rules.py
+++ b/services/terrapod/api/routers/autodiscovery_rules.py
@@ -88,6 +88,22 @@ def _rule_json(rule: AutodiscoveryRule) -> dict:
             "created-at": _rfc3339(rule.created_at),
             "updated-at": _rfc3339(rule.updated_at),
         },
+        # JSON:API house style (#1063): links belong in `relationships`. The
+        # `*-id` attributes above stay indefinitely for back-compat — additive.
+        "relationships": {
+            "vcs-connection": {
+                "data": {"id": f"vcs-{rule.vcs_connection_id}", "type": "vcs-connections"},
+            },
+            **(
+                {
+                    "agent-pool": {
+                        "data": {"id": f"apool-{rule.agent_pool_id}", "type": "agent-pools"},
+                    },
+                }
+                if rule.agent_pool_id
+                else {}
+            ),
+        },
         "links": {"self": f"/api/terrapod/v1/autodiscovery-rules/{rule.id}"},
     }
 

--- a/services/terrapod/api/routers/catalog.py
+++ b/services/terrapod/api/routers/catalog.py
@@ -148,6 +148,30 @@ def _instance_json(ws: Workspace) -> dict:
             "owner-email": ws.owner_email or "",
             "labels": dict(ws.labels or {}),
         },
+        # JSON:API house style (#1063): links belong in `relationships`. The
+        # `*-id` attributes above stay indefinitely for back-compat — this is
+        # purely additive.
+        "relationships": {
+            **(
+                {
+                    "catalog-item": {
+                        "data": {"id": str(ws.catalog_item_id), "type": "catalog-items"},
+                    },
+                }
+                if ws.catalog_item_id
+                else {}
+            ),
+            **(
+                {
+                    "agent-pool": {
+                        "data": {"id": f"apool-{ws.agent_pool_id}", "type": "agent-pools"},
+                    },
+                }
+                if ws.agent_pool_id
+                else {}
+            ),
+            "workspace": {"data": {"id": f"ws-{ws.id}", "type": "workspaces"}},
+        },
         "links": {"self": f"/api/terrapod/v1/workspaces/ws-{ws.id}"},
     }
 

--- a/services/terrapod/api/routers/onboarding.py
+++ b/services/terrapod/api/routers/onboarding.py
@@ -141,6 +141,21 @@ def _session_json(
             "created-at": rfc3339(s.created_at),
             "updated-at": rfc3339(s.updated_at),
         },
+        # JSON:API house style (#1063): links belong in `relationships`. The
+        # `*-id` attributes above stay indefinitely for back-compat — additive.
+        "relationships": {
+            "workspace": {"data": {"id": f"ws-{s.workspace_id}", "type": "workspaces"}},
+            **(
+                {"discovery-run": {"data": {"id": f"run-{s.discovery_run_id}", "type": "runs"}}}
+                if s.discovery_run_id
+                else {}
+            ),
+            **(
+                {"result-run": {"data": {"id": f"run-{s.result_run_id}", "type": "runs"}}}
+                if s.result_run_id
+                else {}
+            ),
+        },
     }
 
 

--- a/services/terrapod/api/routers/policy_sets.py
+++ b/services/terrapod/api/routers/policy_sets.py
@@ -135,12 +135,19 @@ def _policy_set_json(ps: PolicySet, *, embed_policies: bool = False) -> dict:
         "updated-at": _rfc3339(ps.updated_at),
     }
     doc: dict = {"id": f"polset-{ps.id}", "type": "policy-sets", "attributes": attrs}
-    if embed_policies:
-        doc["relationships"] = {
-            "policies": {
-                "data": [_policy_json(p) for p in sorted(ps.policies, key=lambda x: x.name)]
-            }
+    # JSON:API house style (#1063): links belong in `relationships`. The
+    # `vcs-connection-id` attribute above stays indefinitely for back-compat.
+    relationships: dict = {}
+    if ps.vcs_connection_id:
+        relationships["vcs-connection"] = {
+            "data": {"id": f"vcs-{ps.vcs_connection_id}", "type": "vcs-connections"},
         }
+    if embed_policies:
+        relationships["policies"] = {
+            "data": [_policy_json(p) for p in sorted(ps.policies, key=lambda x: x.name)]
+        }
+    if relationships:
+        doc["relationships"] = relationships
     return doc
 
 

--- a/services/terrapod/api/routers/registry_modules.py
+++ b/services/terrapod/api/routers/registry_modules.py
@@ -173,6 +173,22 @@ def _module_to_jsonapi(module, caps: frozenset[str] | None = None) -> dict:  # t
                 "can-create-version": has_capability(caps, cap.REGISTRY_WRITE),
             },
         },
+        # JSON:API house style (#1063): links belong in `relationships`. The
+        # `vcs-connection-id` attribute above stays indefinitely for back-compat.
+        "relationships": {
+            **(
+                {
+                    "vcs-connection": {
+                        "data": {
+                            "id": f"vcs-{module.vcs_connection_id}",
+                            "type": "vcs-connections",
+                        },
+                    },
+                }
+                if module.vcs_connection_id
+                else {}
+            ),
+        },
     }
 
 
@@ -859,6 +875,11 @@ def _link_to_jsonapi(link: ModuleWorkspaceLink) -> dict:
             "workspace-name": ws.name if ws else "",
             "created-at": rfc3339(link.created_at),
             "created-by": link.created_by,
+        },
+        # JSON:API house style (#1063): links belong in `relationships`. The
+        # `workspace-id` attribute above stays indefinitely for back-compat.
+        "relationships": {
+            "workspace": {"data": {"id": f"ws-{link.workspace_id}", "type": "workspaces"}},
         },
     }
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -768,6 +768,9 @@ def _workspace_json(
                     "is-destroyable": has_capability(caps, cap.WORKSPACE_DELETE),
                 },
             },
+            # JSON:API house style (#1063): links live in `relationships`. The
+            # matching `*-id` attributes above are kept indefinitely for
+            # back-compat — the relationship is the canonical form, additive.
             "relationships": {
                 "organization": {
                     "data": {"id": DEFAULT_ORG, "type": "organizations"},
@@ -782,6 +785,18 @@ def _workspace_json(
                         },
                     }
                     if ws.vcs_connection_id
+                    else {}
+                ),
+                **(
+                    {
+                        "agent-pool": {
+                            "data": {
+                                "id": f"apool-{ws.agent_pool_id}",
+                                "type": "agent-pools",
+                            },
+                        },
+                    }
+                    if ws.agent_pool_id
                     else {}
                 ),
             },

--- a/services/tests/api/test_error_envelope.py
+++ b/services/tests/api/test_error_envelope.py
@@ -114,3 +114,97 @@ class TestEnvelopeHelper:
     def test_empty_list_detail_gets_placeholder(self):
         c = jsonapi_error_content([], 422)
         assert c["errors"] == [{"detail": "Validation error", "status": "422"}]
+
+
+class TestNoBodyStatusCodes:
+    """Statuses that forbid a body (1xx/204/304) must emit NO body — matching
+    FastAPI's default handler exactly. Regression guard: the dual-key envelope
+    must not put JSON on a 204/304 (invalid HTTP, and a behaviour change vs
+    pre-#1063). Nothing raises these today; the guard keeps the handler a strict
+    superset of FastAPI's."""
+
+    def _app_with_status(self, status: int) -> FastAPI:
+        from fastapi.responses import Response
+        from fastapi.utils import is_body_allowed_for_status_code
+        from starlette.exceptions import HTTPException as StarletteHTTPException
+
+        from terrapod.api.errors import jsonapi_error_response
+
+        application = FastAPI()
+
+        @application.exception_handler(StarletteHTTPException)
+        async def _http(request, exc):
+            headers = getattr(exc, "headers", None)
+            if not is_body_allowed_for_status_code(exc.status_code):
+                return Response(status_code=exc.status_code, headers=headers)
+            return jsonapi_error_response(exc.detail, exc.status_code, headers=headers)
+
+        @application.get("/x")
+        async def x():
+            raise HTTPException(status_code=status, detail="ignored")
+
+        return application
+
+    async def test_204_has_empty_body(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=self._app_with_status(204)), base_url="http://t"
+        ) as c:
+            resp = await c.get("/x")
+        assert resp.status_code == 204
+        assert resp.content == b""
+
+    async def test_304_has_empty_body(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=self._app_with_status(304)), base_url="http://t"
+        ) as c:
+            resp = await c.get("/x")
+        assert resp.status_code == 304
+        assert resp.content == b""
+
+    async def test_404_still_has_the_dual_key_body(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=self._app_with_status(404)), base_url="http://t"
+        ) as c:
+            resp = await c.get("/x")
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "ignored"
+        assert resp.json()["errors"][0]["detail"] == "ignored"
+
+
+class TestPaginationRefactorIsByteIdentical:
+    """`build_meta` must reproduce the hand-rolled `meta.pagination` blocks the
+    audit/config_versions/runs/users routers used before #1063, byte for byte.
+    All four clamp `page[size]` to 1..100, so the helper's cap never engages.
+    """
+
+    @staticmethod
+    def _old(total: int, number: int, size: int, *, falsy_guard: bool) -> dict:
+        # `falsy_guard` reproduces config_versions' `if total else 0`; the other
+        # three used `if total > 0 else 0`. Equivalent for non-negative ints.
+        pages = (total + size - 1) // size if (total if falsy_guard else total > 0) else 0
+        return {
+            "pagination": {
+                "current-page": number,
+                "page-size": size,
+                "total-count": total,
+                "total-pages": pages,
+            }
+        }
+
+    def test_matches_across_the_clamped_input_space(self):
+        from terrapod.api.pagination import build_meta
+
+        for total in (0, 1, 2, 19, 20, 21, 99, 100, 101, 1000, 12345):
+            for size in (1, 5, 20, 50, 99, 100):
+                for number in (1, 2, 3, 7, 100):
+                    new = build_meta(total, number, size)
+                    assert new == self._old(total, number, size, falsy_guard=False), (
+                        total,
+                        number,
+                        size,
+                    )
+                    assert new == self._old(total, number, size, falsy_guard=True), (
+                        total,
+                        number,
+                        size,
+                    )

--- a/services/tests/api/test_relationship_links.py
+++ b/services/tests/api/test_relationship_links.py
@@ -1,0 +1,160 @@
+"""JSON:API links live in `relationships` (#1063 slice 2).
+
+The house style says a link to another resource is a JSON:API *relationship*.
+Historically several serializers only emitted a `*-id` **attribute**. Slice 2
+adds the relationship alongside, additively — the attribute stays indefinitely
+for back-compat.
+
+These tests call the serializers directly (no DB) and assert BOTH forms are
+present and agree, so a future edit can't drop either half silently.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+from terrapod.api.routers.autodiscovery_rules import _rule_json
+from terrapod.api.routers.catalog import _instance_json
+from terrapod.api.routers.policy_sets import _policy_set_json
+from terrapod.api.routers.registry_modules import _link_to_jsonapi
+
+
+def _rel_id(doc: dict, name: str) -> str | None:
+    return doc.get("relationships", {}).get(name, {}).get("data", {}).get("id")
+
+
+class TestCatalogInstance:
+    def _ws(self, *, pool: uuid.UUID | None, item: uuid.UUID | None):
+        return SimpleNamespace(
+            id=uuid.uuid4(),
+            name="inst",
+            catalog_item_id=item,
+            catalog_version_pin="1.0.0",
+            agent_pool_id=pool,
+            owner_email="a@b.c",
+            labels={},
+        )
+
+    def test_agent_pool_in_both_attribute_and_relationship(self):
+        pool = uuid.uuid4()
+        doc = _instance_json(self._ws(pool=pool, item=uuid.uuid4()))
+        assert doc["attributes"]["agent-pool-id"] == f"apool-{pool}"
+        assert _rel_id(doc, "agent-pool") == f"apool-{pool}"
+        assert doc["relationships"]["agent-pool"]["data"]["type"] == "agent-pools"
+
+    def test_workspace_relationship_always_present(self):
+        ws = self._ws(pool=None, item=None)
+        doc = _instance_json(ws)
+        assert _rel_id(doc, "workspace") == f"ws-{ws.id}"
+
+    def test_absent_links_omit_relationship_entirely(self):
+        doc = _instance_json(self._ws(pool=None, item=None))
+        assert doc["attributes"]["agent-pool-id"] is None
+        assert "agent-pool" not in doc["relationships"]
+        assert "catalog-item" not in doc["relationships"]
+
+
+class TestAutodiscoveryRule:
+    def _rule(self, *, pool: uuid.UUID | None):
+        return SimpleNamespace(
+            id=uuid.uuid4(),
+            name="r",
+            name_template="",
+            vcs_connection_id=uuid.uuid4(),
+            repo_url="https://example.com/org/repo",
+            branch="main",
+            pattern="**",
+            ignore_patterns=[],
+            enabled=True,
+            execution_mode="agent",
+            execution_backend="tofu",
+            agent_pool_id=pool,
+            terraform_version="1.12",
+            resource_cpu="1",
+            resource_memory="2Gi",
+            auto_apply=False,
+            on_directory_delete="flag",
+            labels={},
+            owner_email="",
+            var_files=[],
+            run_task_templates=[],
+            notification_templates=[],
+            execution_hook_templates=[],
+            created_at=None,
+            updated_at=None,
+        )
+
+    def test_vcs_connection_and_agent_pool_relationships(self):
+        rule = self._rule(pool=uuid.uuid4())
+        doc = _rule_json(rule)
+        assert _rel_id(doc, "vcs-connection") == f"vcs-{rule.vcs_connection_id}"
+        assert _rel_id(doc, "agent-pool") == f"apool-{rule.agent_pool_id}"
+        # attributes retained (back-compat)
+        assert doc["attributes"]["vcs-connection-id"] == str(rule.vcs_connection_id)
+        assert doc["attributes"]["agent-pool-id"] == str(rule.agent_pool_id)
+
+    def test_no_pool_omits_agent_pool_relationship(self):
+        doc = _rule_json(self._rule(pool=None))
+        assert "agent-pool" not in doc["relationships"]
+        assert _rel_id(doc, "vcs-connection") is not None
+
+
+class TestPolicySet:
+    def _ps(self, *, vcs: uuid.UUID | None):
+        return SimpleNamespace(
+            id=uuid.uuid4(),
+            name="ps",
+            description="",
+            enforcement_level="advisory",
+            enabled=True,
+            global_scope=True,
+            allow_labels={},
+            allow_names=[],
+            deny_labels={},
+            deny_names=[],
+            source="api",
+            vcs_connection_id=vcs,
+            vcs_repo_url=None,
+            vcs_branch=None,
+            policy_path=None,
+            vcs_last_commit_sha=None,
+            vcs_last_synced_at=None,
+            vcs_last_error=None,
+            policies=[],
+            created_by="",
+            created_at=None,
+            updated_at=None,
+        )
+
+    def test_vcs_relationship_added_when_connected(self):
+        ps = self._ps(vcs=uuid.uuid4())
+        doc = _policy_set_json(ps)
+        assert doc["attributes"]["vcs-connection-id"] == f"vcs-{ps.vcs_connection_id}"
+        assert _rel_id(doc, "vcs-connection") == f"vcs-{ps.vcs_connection_id}"
+
+    def test_api_sourced_set_has_no_relationships_key(self):
+        # No VCS link and no embedded policies → nothing to relate; the key is
+        # omitted rather than emitted empty.
+        doc = _policy_set_json(self._ps(vcs=None))
+        assert "relationships" not in doc
+
+    def test_embedded_policies_still_work_alongside_vcs(self):
+        ps = self._ps(vcs=uuid.uuid4())
+        doc = _policy_set_json(ps, embed_policies=True)
+        assert "policies" in doc["relationships"]
+        assert "vcs-connection" in doc["relationships"]
+
+
+class TestModuleWorkspaceLink:
+    def test_workspace_relationship_and_attribute(self):
+        ws_id = uuid.uuid4()
+        link = SimpleNamespace(
+            id=uuid.uuid4(),
+            workspace_id=ws_id,
+            workspace=SimpleNamespace(name="ws"),
+            created_at=None,
+            created_by="a@b.c",
+        )
+        doc = _link_to_jsonapi(link)
+        assert doc["attributes"]["workspace-id"] == f"ws-{ws_id}"
+        assert _rel_id(doc, "workspace") == f"ws-{ws_id}"
+        assert doc["relationships"]["workspace"]["data"]["type"] == "workspaces"

--- a/services/tests/test_api_sdk_contract.py
+++ b/services/tests/test_api_sdk_contract.py
@@ -116,8 +116,12 @@ def _extract_workspace_api_attrs() -> set[str]:
     body = m.group(0)
     # Pull the `"attributes": { ... }` block out so we don't pick up
     # `relationships` keys or unrelated dict literals defined later in
-    # the function.
-    attrs_match = re.search(r'"attributes":\s*\{(.*?)\n\s+\}\s*,\s*"relationships"', body, re.S)
+    # the function. Comment lines are allowed to sit between the closing
+    # `},` and `"relationships"` (a comment is not API surface, so it must
+    # not fail this gate — see #1063, which documents the house style there).
+    attrs_match = re.search(
+        r'"attributes":\s*\{(.*?)\n\s+\}\s*,\s*(?:#[^\n]*\n\s*)*"relationships"', body, re.S
+    )
     if attrs_match is None:
         raise AssertionError("Could not locate attributes block inside _workspace_json")
     attrs_block = attrs_match.group(1)


### PR DESCRIPTION
Completes the additive JSON:API standardisation begun in #1083 (slice 1) and **closes #1063**. Slice 1 landed the dual-key error envelope, the shared pagination helper, and the written convention; this slice fixes the deviation the issue called "the main one" — links modelled as `*-id` **attributes** instead of JSON:API **relationships** — plus one back-compat finding from auditing slice 1.

## 1. Links as relationships (the slice-2 sweep)

Every serializer that emitted a link only as an attribute now **also** emits the canonical `relationships` block:

| Serializer | Relationships added |
|---|---|
| `tfe_v2._workspace_json` | `agent-pool` (flagship: it already had `organization` + `vcs-connection`, but read the pool from an attribute only) |
| `catalog._instance_json` | `catalog-item`, `agent-pool`, `workspace` |
| `autodiscovery_rules._rule_json` | `vcs-connection`, `agent-pool` |
| `onboarding._session_json` | `workspace`, `discovery-run`, `result-run` |
| `policy_sets._policy_set_json` | `vcs-connection` (merged with the existing conditional `policies` block, which is no longer overwritten) |
| `registry_modules` | `vcs-connection` (module) + `workspace` (workspace-link) |

**The `*-id` attributes are kept indefinitely** — option A per the issue's agreed decision. Optional links omit the relationship rather than emitting a null one.

**Deliberately unchanged:** `workspace_bulk._ws_summary` is a flat summary dict (no `type`/`attributes`), not a JSON:API resource — a `relationships` block would be meaningless there; and `workspace_bulk`'s `agent-pool-id` entries at the input-mapping layer are request parsing, not serialization.

## 2. Back-compat fix: no error body on 204/304/1xx

Auditing slice 1 surfaced a **latent divergence**: the shared `HTTPException` handler emitted the dual-key JSON envelope for *every* status, but FastAPI's default handler — the behaviour it replaced — skips the body entirely when `is_body_allowed_for_status_code()` is false (1xx/204/304). JSON on a 204/304 is invalid HTTP and a change vs pre-#1063.

Nothing in Terrapod raises `HTTPException` with those statuses today (verified by grep), so it was latent, not live — but the handler now **matches FastAPI exactly**: no body where a body is forbidden, dual-key envelope everywhere else. That makes it a strict superset of the old behaviour rather than a divergence.

## Back-compat evidence

- **All 6 contract gates pass with NO regeneration** — route, attribute, wire, config, migration, helm-values (16 tests). **Zero snapshot/golden files changed in either slice** (slice 1's merged commit touched 0; this branch touches 0).
- **Pagination proven byte-identical**, not asserted: a differential sweep of **330 `(total, page, size)` combinations** against *both* pre-#1063 formulas (including `config_versions`' `if total else 0` variant) — 0 mismatches, now a CI test.
- **Error envelope is a strict superset**: `detail` preserved verbatim (validation errors keep FastAPI's exact `jsonable_encoder(exc.errors())` list); `errors[]` added; headers (e.g. `WWW-Authenticate`) preserved.
- **Consumers verified, no changes needed:** go-terrapod's `Resource` already decodes `Relationships`; its `extractErrorDetail` previously fell through to dumping the raw body for native `{"detail":…}` and now parses cleanly (an improvement, safe in both skew directions). Web `apiFetch` already checks `errors[0].detail` *then* `detail` → renders the identical message. Runner + listener contain **zero** error-body key reads (status-code driven only). `provider`, `migrate`, `mcp`, `publish` all build + test clean.
- Full `services/api/config/db/helm` sweep: **2377 passed**, 0 failures.

Closes #1063