### PR TITLE
feat(1085): route a workspace's runs to more than one agent pool

### DIFF
--- a/alembic/versions/9b7161d25c9e_multi_pool_routing.py
+++ b/alembic/versions/9b7161d25c9e_multi_pool_routing.py
@@ -1,0 +1,62 @@
+"""multi-pool workspace routing (#1085 / #960 phase 0)
+
+A workspace can route runs to more than one agent pool. The pool set is
+`[agent_pool_id] + agent_pool_extra_ids` and is FLAT — every pool in it is
+equally eligible to claim a run.
+
+Expand-only. `workspaces.agent_pool_id` and `runs.pool_id` keep their existing
+meaning (element 0 / the currently-associated pool), so an API replica still
+running the previous release writes coherent rows throughout a rolling upgrade.
+
+Revision ID: 9b7161d25c9e
+Revises: af5d2a3c7bda
+Create Date: 2026-07-28
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "9b7161d25c9e"
+down_revision: str | None = "af5d2a3c7bda"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "agent_pool_extra_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "runs",
+        sa.Column(
+            "pool_extra_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+    )
+    # The claim predicate is `pool_id = :p OR pool_extra_ids @> '["<p>"]'`, and
+    # the containment half needs a GIN index to stay a lookup rather than a
+    # sequential scan of every queued run.
+    op.create_index(
+        "ix_runs_pool_extra_ids",
+        "runs",
+        ["pool_extra_ids"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_runs_pool_extra_ids", table_name="runs")
+    op.drop_column("runs", "pool_extra_ids")
+    op.drop_column("workspaces", "agent_pool_extra_ids")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -306,6 +306,57 @@ POST /api/v2/organizations/default/workspaces
 
 **Required permission:** Any authenticated user can create workspaces (creator becomes owner).
 
+### Agent pool set
+
+A workspace routes its runs to a **set** of agent pools. The set is **flat**:
+a queued run is offered to every pool at once and whichever pool has a live
+listener claims it first. There is no primary, no ordering preference and no
+rotation — losing one pool simply means another claims the work.
+
+Exactly-once execution is unaffected. A run is a single row claimed under
+`SELECT … FOR UPDATE SKIP LOCKED`, so offering it to N pools cannot produce N
+claims. On claim the run records the pool that took it, so cancellation,
+job-status queries and log streaming address the cluster actually running it.
+
+Two attributes carry this, and they are **mutually exclusive on write**:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `agent-pool-ids` | list of `apool-…` | The whole set. |
+| `agent-pool-id` | `apool-…` \| `null` | On read, element 0 of the set. On write, "this workspace has exactly this one pool" — it **replaces** the set. `null` clears it. |
+
+Sending both in one request returns **422**. `agent-pool-name` and the
+`agent-pool` relationship also resolve to element 0; an `agent-pools` to-many
+relationship carries the full set.
+
+```json
+{
+  "data": {
+    "type": "workspaces",
+    "attributes": {
+      "agent-pool-ids": ["apool-019e01db-...", "apool-019e02ac-..."]
+    }
+  }
+}
+```
+
+**Required permission:** workspace `admin`, plus `pool:assign` on **every**
+pool in the set — a caller may not attach a workspace to a pool they could not
+have attached it to on its own.
+
+> **Upgrading from a single pool:** `agent-pool-id` keeps working exactly as it
+> did, so no client has to change. Be aware that because it replaces the set, a
+> tool that manages `agent_pool_id` (an un-upgraded Terraform provider, say)
+> will drop pools added elsewhere the next time it applies. Manage the set with
+> `agent-pool-ids` if more than one tool touches it. The removal is
+> audit-logged either way.
+
+A workspace whose pools have **all** gone dark surfaces a
+`no_live_agent_pool` health condition (distinct from `no_agent_pool`, which
+means none is assigned at all) and is counted by the
+`terrapod_workspaces_without_live_pool` metric — the signal to alert on, since
+losing a single pool is now survivable.
+
 ### Update Workspace
 
 ```
@@ -2155,7 +2206,8 @@ Apply `update` to every workspace matching `filter`, in a **single all-or-nothin
 
 Semantics:
 
-- **Validated once up front** — field enums, `labels` reserved-key check, run-task/notification specs, and `agent-pool-id` existence + caller pool-`write` RBAC. Any error ⇒ `422`, **zero mutation**.
+- **Validated once up front** — field enums, `labels` reserved-key check, run-task/notification specs, and agent-pool existence + caller pool-`write` RBAC on **every** pool named. Any error ⇒ `422`, **zero mutation**.
+- **Agent pools** accept either `agent-pool-id` (one pool, replacing the set) or `agent-pool-ids` (the set) — the same mutually-exclusive pair as the workspace endpoints; both in one `update` ⇒ `422`.
 - `run-tasks` / `notification-configurations` **upsert by `(workspace, name)`**: created if absent, updated in place if present (so re-running with a changed `url` rotates it across the fleet).
 - **All-or-nothing**: the whole batch commits or nothing does. `dry_run` (default `true`, not enforced) runs the identical code path and rolls back — the preview is exactly what apply would do, with provably zero side effects.
 - **Triggers no runs** — pure config write; the change lands on each workspace's next normal run. Reversible (it only writes settings rows).

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -276,6 +276,7 @@ field CreateVarsetVariableRequest.Value string
 field CreateWorkspaceRequest.AISummaryContext string `json:"ai-summary-context,omitempty"`
 field CreateWorkspaceRequest.AISummaryMode string `json:"ai-summary-mode,omitempty"`
 field CreateWorkspaceRequest.AgentPoolID string `json:"agent-pool-id,omitempty"`
+field CreateWorkspaceRequest.AgentPoolIDs []string `json:"agent-pool-ids,omitempty"`
 field CreateWorkspaceRequest.AutoApply *bool `json:"auto-apply,omitempty"`
 field CreateWorkspaceRequest.AutoMerge *bool `json:"auto-merge,omitempty"`
 field CreateWorkspaceRequest.AutoMergeStrategy string `json:"auto-merge-strategy,omitempty"`
@@ -753,6 +754,7 @@ field UpdateVarsetVariableRequest.Value *string
 field UpdateWorkspaceRequest.AISummaryContext *string `json:"ai-summary-context,omitempty"`
 field UpdateWorkspaceRequest.AISummaryMode string `json:"ai-summary-mode,omitempty"`
 field UpdateWorkspaceRequest.AgentPoolID string `json:"agent-pool-id,omitempty"`
+field UpdateWorkspaceRequest.AgentPoolIDs []string `json:"agent-pool-ids,omitempty"`
 field UpdateWorkspaceRequest.AutoApply *bool `json:"auto-apply,omitempty"`
 field UpdateWorkspaceRequest.AutoMerge *bool `json:"auto-merge,omitempty"`
 field UpdateWorkspaceRequest.AutoMergeStrategy string `json:"auto-merge-strategy,omitempty"`
@@ -855,6 +857,7 @@ field WarmResult.Ref string `json:"ref"`
 field Workspace.AISummaryContext string `json:"ai-summary-context,omitempty"`
 field Workspace.AISummaryMode string `json:"ai-summary-mode,omitempty"`
 field Workspace.AgentPoolID string `json:"agent-pool-id,omitempty"`
+field Workspace.AgentPoolIDs []string `json:"agent-pool-ids,omitempty"`
 field Workspace.AgentPoolName string `json:"agent-pool-name,omitempty"`
 field Workspace.AutoApply bool `json:"auto-apply"`
 field Workspace.AutoMerge bool `json:"auto-merge"`

--- a/go-terrapod/workspaces.go
+++ b/go-terrapod/workspaces.go
@@ -40,6 +40,7 @@ type Workspace struct {
 	VCSWorkflow       string            `json:"vcs-workflow,omitempty"`
 	VCSConnectionID   string            `json:"vcs-connection-id,omitempty"` // resolved from `vcs-connection` relationship
 	AgentPoolID       string            `json:"agent-pool-id,omitempty"`
+	AgentPoolIDs      []string          `json:"agent-pool-ids,omitempty"` // flat pool set (#1085); AgentPoolID is element 0
 	AutoMerge         bool              `json:"auto-merge"`
 	AutoMergeStrategy string            `json:"auto-merge-strategy,omitempty"`
 	OwnerEmail        string            `json:"owner-email,omitempty"`
@@ -134,6 +135,7 @@ type CreateWorkspaceRequest struct {
 	VCSWorkflow                   string            `json:"vcs-workflow,omitempty"`
 	VCSConnectionID               string            `json:"-"` // → relationship, not attribute
 	AgentPoolID                   string            `json:"agent-pool-id,omitempty"`
+	AgentPoolIDs                  []string          `json:"agent-pool-ids,omitempty"` // whole pool set; mutually exclusive with AgentPoolID (422)
 	AutoMerge                     *bool             `json:"auto-merge,omitempty"`
 	AutoMergeStrategy             string            `json:"auto-merge-strategy,omitempty"`
 	OwnerEmail                    string            `json:"owner-email,omitempty"`
@@ -185,6 +187,7 @@ type UpdateWorkspaceRequest struct {
 	VCSWorkflow                   string            `json:"vcs-workflow,omitempty"`
 	VCSConnectionID               string            `json:"-"`
 	AgentPoolID                   string            `json:"agent-pool-id,omitempty"`
+	AgentPoolIDs                  []string          `json:"agent-pool-ids,omitempty"` // whole pool set; mutually exclusive with AgentPoolID (422)
 	AutoMerge                     *bool             `json:"auto-merge,omitempty"`
 	AutoMergeStrategy             string            `json:"auto-merge-strategy,omitempty"`
 	Labels                        map[string]string `json:"labels,omitempty"`
@@ -439,6 +442,9 @@ func workspaceCreateAttrs(req CreateWorkspaceRequest) map[string]any {
 	if req.AgentPoolID != "" {
 		attrs["agent-pool-id"] = req.AgentPoolID
 	}
+	if req.AgentPoolIDs != nil {
+		attrs["agent-pool-ids"] = req.AgentPoolIDs
+	}
 	if req.AutoMerge != nil {
 		attrs["auto-merge"] = *req.AutoMerge
 	}
@@ -542,6 +548,9 @@ func workspaceUpdateAttrs(req UpdateWorkspaceRequest) map[string]any {
 	if req.AgentPoolID != "" {
 		attrs["agent-pool-id"] = req.AgentPoolID
 	}
+	if req.AgentPoolIDs != nil {
+		attrs["agent-pool-ids"] = req.AgentPoolIDs
+	}
 	if req.AutoMerge != nil {
 		attrs["auto-merge"] = *req.AutoMerge
 	}
@@ -642,6 +651,7 @@ func workspaceFromResource(res *Resource) *Workspace {
 		VCSWorkflow:                   GetStringAttr(res, "vcs-workflow"),
 		VCSConnectionID:               GetRelationshipID(res, "vcs-connection"),
 		AgentPoolID:                   GetStringAttr(res, "agent-pool-id"),
+		AgentPoolIDs:                  GetListAttr(res, "agent-pool-ids"),
 		AutoMerge:                     GetBoolAttr(res, "auto-merge"),
 		AutoMergeStrategy:             GetStringAttr(res, "auto-merge-strategy"),
 		OwnerEmail:                    GetStringAttr(res, "owner-email"),

--- a/go-terrapod/workspaces_test.go
+++ b/go-terrapod/workspaces_test.go
@@ -668,3 +668,85 @@ func TestWorkspaceCreate_DoesNotRetryOn5xx(t *testing.T) {
 		t.Errorf("POST must not retry on 5xx: expected 1 call, got %d", calls)
 	}
 }
+
+// Multi-pool routing (#1085). The set is flat — AgentPoolID is simply element
+// 0, kept so callers written before multi-pool routing keep working.
+func TestWorkspace_AgentPoolSet_RoundTrip(t *testing.T) {
+	f := newWorkspaceFixtureServer(t)
+	f.readHandler = func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(minimalWorkspaceBody("ws-pools", "multi", map[string]any{
+			"agent-pool-id":  "apool-a",
+			"agent-pool-ids": []any{"apool-a", "apool-b"},
+		})))
+	}
+	c := f.client()
+	ws, err := c.GetWorkspace(t.Context(), "ws-pools")
+	if err != nil {
+		t.Fatalf("GetWorkspace: %v", err)
+	}
+	if len(ws.AgentPoolIDs) != 2 || ws.AgentPoolIDs[1] != "apool-b" {
+		t.Errorf("pool set not decoded: %+v", ws.AgentPoolIDs)
+	}
+	if ws.AgentPoolID != "apool-a" {
+		t.Errorf("singular pool should be element 0, got %q", ws.AgentPoolID)
+	}
+
+	f.createHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(minimalWorkspaceBody("ws-pools", "multi", nil)))
+	}
+	if _, err := c.CreateWorkspace(t.Context(), CreateWorkspaceRequest{
+		Name:         "multi",
+		AgentPoolIDs: []string{"apool-a", "apool-b"},
+	}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	var req struct {
+		Data struct {
+			Attributes map[string]any `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(f.lastBody, &req); err != nil {
+		t.Fatalf("request body: %v", err)
+	}
+	ids, ok := req.Data.Attributes["agent-pool-ids"].([]any)
+	if !ok || len(ids) != 2 || ids[0] != "apool-a" {
+		t.Errorf("agent-pool-ids missing from request: %+v", req.Data.Attributes)
+	}
+	// The singular attribute must NOT be sent alongside the set — the server
+	// rejects a body carrying both (422).
+	if _, present := req.Data.Attributes["agent-pool-id"]; present {
+		t.Errorf("agent-pool-id must not be sent with agent-pool-ids: %+v", req.Data.Attributes)
+	}
+}
+
+// An un-upgraded caller that only knows the singular attribute must still
+// produce exactly the request it produced before multi-pool routing existed.
+func TestWorkspace_SingularAgentPoolID_UnchangedWire(t *testing.T) {
+	f := newWorkspaceFixtureServer(t)
+	f.createHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(minimalWorkspaceBody("ws-one", "single", nil)))
+	}
+	c := f.client()
+	if _, err := c.CreateWorkspace(t.Context(), CreateWorkspaceRequest{
+		Name:        "single",
+		AgentPoolID: "apool-a",
+	}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	var req struct {
+		Data struct {
+			Attributes map[string]any `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(f.lastBody, &req); err != nil {
+		t.Fatalf("request body: %v", err)
+	}
+	if req.Data.Attributes["agent-pool-id"] != "apool-a" {
+		t.Errorf("agent-pool-id missing: %+v", req.Data.Attributes)
+	}
+	if _, present := req.Data.Attributes["agent-pool-ids"]; present {
+		t.Errorf("agent-pool-ids must be absent when unset: %+v", req.Data.Attributes)
+	}
+}

--- a/provider/internal/datasources/workspace/data_source.go
+++ b/provider/internal/datasources/workspace/data_source.go
@@ -41,6 +41,7 @@ type workspaceDataSourceModel struct {
 	VCSBranch                     types.String `tfsdk:"vcs_branch"`
 	VCSConnectionID               types.String `tfsdk:"vcs_connection_id"`
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
+	AgentPoolIDs                  types.List   `tfsdk:"agent_pool_ids"`
 	VarFiles                      types.List   `tfsdk:"var_files"`
 	TriggerPrefixes               types.List   `tfsdk:"trigger_prefixes"`
 	DriftIgnoreRules              types.List   `tfsdk:"drift_ignore_rules"`
@@ -99,7 +100,8 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"vcs_repo_url":                     computedString("VCS repo URL."),
 			"vcs_branch":                       computedString("VCS branch."),
 			"vcs_connection_id":                computedString("VCS connection ID."),
-			"agent_pool_id":                    computedString("Agent pool ID."),
+			"agent_pool_id":                    computedString("Agent pool ID — element 0 of `agent_pool_ids`, kept for callers written before multi-pool routing."),
+			"agent_pool_ids":                   computedList("Agent pools this workspace's runs may execute on (#1085). Flat set: a queued run is offered to every pool at once and whichever has a live listener claims it, so losing one pool does not stop the workspace."),
 			"var_files":                        computedList("Var files for -var-file arguments."),
 			"trigger_prefixes":                 computedList("Repo-root-relative paths the VCS sparse-checkout must include in addition to working_directory (e.g. sibling modules referenced via `source = \"../foo\"`)."),
 			"drift_ignore_rules":               computedList("Glob-aware patterns suppressed by the drift-result classifier (#482). See the resource attribute docs for syntax."),
@@ -207,6 +209,14 @@ func readDataSourceModel(ctx context.Context, res *terrapod.Resource, m *workspa
 	setOptionalString(&m.VCSRepoURL, terrapod.GetStringAttr(res, "vcs-repo-url"))
 	setOptionalString(&m.VCSBranch, terrapod.GetStringAttr(res, "vcs-branch"))
 	setOptionalString(&m.AgentPoolID, terrapod.GetStringAttr(res, "agent-pool-id"))
+
+	if poolIDs := terrapod.GetListAttr(res, "agent-pool-ids"); len(poolIDs) > 0 {
+		val, d := types.ListValueFrom(ctx, types.StringType, poolIDs)
+		diags.Append(d...)
+		m.AgentPoolIDs = val
+	} else {
+		m.AgentPoolIDs = types.ListNull(types.StringType)
+	}
 	setOptionalString(&m.DriftStatus, terrapod.GetStringAttr(res, "drift-status"))
 	setOptionalString(&m.DriftLastCheckedAt, terrapod.GetStringAttr(res, "drift-last-checked-at"))
 	setOptionalString(&m.DriftLatestRunID, terrapod.GetStringAttr(res, "drift-latest-run-id"))

--- a/provider/internal/provider/schema.golden
+++ b/provider/internal/provider/schema.golden
@@ -56,6 +56,7 @@ data terrapod_vcs_connection.status required=false optional=false computed=true 
 data terrapod_vcs_connection.updated_at required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_vcs_connection.vcs_provider required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.agent_pool_id required=false optional=false computed=true sensitive=false type=basetypes.StringType
+data terrapod_workspace.agent_pool_ids required=false optional=false computed=true sensitive=false type=types.ListType[basetypes.StringType]
 data terrapod_workspace.agent_pool_name required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.ai_summary_context required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.ai_summary_mode required=false optional=false computed=true sensitive=false type=basetypes.StringType
@@ -350,6 +351,7 @@ resource terrapod_vcs_connection.updated_at required=false optional=false comput
 resource terrapod_vcs_connection.vcs_provider required=true optional=false computed=false sensitive=false type=basetypes.StringType
 resource terrapod_vcs_connection.webhook_secret required=false optional=true computed=false sensitive=true type=basetypes.StringType
 resource terrapod_workspace.agent_pool_id required=false optional=true computed=false sensitive=false type=basetypes.StringType
+resource terrapod_workspace.agent_pool_ids required=false optional=true computed=true sensitive=false type=types.ListType[basetypes.StringType]
 resource terrapod_workspace.agent_pool_name required=false optional=false computed=true sensitive=false type=basetypes.StringType
 resource terrapod_workspace.ai_summary_context required=false optional=true computed=true sensitive=false type=basetypes.StringType
 resource terrapod_workspace.ai_summary_mode required=false optional=true computed=true sensitive=false type=basetypes.StringType

--- a/provider/internal/resources/workspace/model.go
+++ b/provider/internal/resources/workspace/model.go
@@ -25,6 +25,7 @@
 //	"vcs-repo-url"                      → vcs_repo_url        (string, optional)
 //	"vcs-branch"                        → vcs_branch          (string, optional)
 //	"agent-pool-id"                     → agent_pool_id       (string, optional)
+//	"agent-pool-ids"                    → agent_pool_ids      (list, optional+computed)
 //	"var-files"                         → var_files           (list,   optional)
 //	"trigger-prefixes"                  → trigger_prefixes    (list,   optional)
 //	"drift-detection-enabled"           → drift_detection_enabled (bool, optional)
@@ -73,6 +74,7 @@ type workspaceModel struct {
 	AutoMerge                     types.Bool   `tfsdk:"auto_merge"`
 	AutoMergeStrategy             types.String `tfsdk:"auto_merge_strategy"`
 	AgentPoolID                   types.String `tfsdk:"agent_pool_id"`
+	AgentPoolIDs                  types.List   `tfsdk:"agent_pool_ids"`
 	VarFiles                      types.List   `tfsdk:"var_files"`
 	TriggerPrefixes               types.List   `tfsdk:"trigger_prefixes"`
 	DriftIgnoreRules              types.List   `tfsdk:"drift_ignore_rules"`

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	_ resource.Resource                = &workspaceResource{}
-	_ resource.ResourceWithImportState = &workspaceResource{}
+	_ resource.Resource                   = &workspaceResource{}
+	_ resource.ResourceWithImportState    = &workspaceResource{}
+	_ resource.ResourceWithValidateConfig = &workspaceResource{}
 )
 
 // workspaceResource holds two clients during the provider's migration to
@@ -48,6 +49,26 @@ func NewResource() resource.Resource {
 
 func (r *workspaceResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_workspace"
+}
+
+// ValidateConfig rejects a config that sets both agent-pool attributes.
+//
+// The server returns 422 for the same combination (#1085); catching it at plan
+// time turns an apply-time failure into an error the operator sees before
+// anything is sent.
+func (r *workspaceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var m workspaceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &m)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !m.AgentPoolID.IsNull() && !m.AgentPoolIDs.IsNull() {
+		resp.Diagnostics.AddError(
+			"Conflicting agent pool attributes",
+			"Set either agent_pool_id or agent_pool_ids, not both. agent_pool_id assigns a "+
+				"single pool (replacing any set); agent_pool_ids assigns the whole set.",
+		)
+	}
 }
 
 func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -169,8 +190,21 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"agent_pool_id": schema.StringAttribute{
-				Description: "Agent pool ID for agent execution mode.",
+				Description: "Agent pool ID for agent execution mode. Assigns exactly one pool, replacing any existing set — use `agent_pool_ids` to assign several. Conflicts with `agent_pool_ids`.",
 				Optional:    true,
+			},
+			"agent_pool_ids": schema.ListAttribute{
+				Description: "Agent pools this workspace's runs may execute on (#1085). The set is flat: a queued run is offered to every pool at once and whichever pool has a live listener claims it first, so losing one pool does not stop the workspace. There is no primary and no ordering preference. `agent_pool_id` reads back as element 0. Conflicts with `agent_pool_id`.",
+				// Optional + Computed with UseStateForUnknown — same rationale as
+				// drift_ignore_rules (#684): the server may hold a set this config
+				// doesn't manage (assigned via the UI or bulk-update), so omitting
+				// it means "leave alone", not "clear".
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"var_files": schema.ListAttribute{
 				Description: "List of .tfvars file paths passed as -var-file arguments to plan/apply.",
@@ -631,6 +665,13 @@ func buildCreateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 	if !m.AgentPoolID.IsNull() {
 		req.AgentPoolID = m.AgentPoolID.ValueString()
 	}
+	if !m.AgentPoolIDs.IsNull() && !m.AgentPoolIDs.IsUnknown() {
+		poolIDs := make([]string, 0, len(m.AgentPoolIDs.Elements()))
+		for _, v := range m.AgentPoolIDs.Elements() {
+			poolIDs = append(poolIDs, v.(types.String).ValueString())
+		}
+		req.AgentPoolIDs = poolIDs
+	}
 	if !m.Labels.IsNull() && !m.Labels.IsUnknown() {
 		labels := map[string]string{}
 		for k, v := range m.Labels.Elements() {
@@ -762,6 +803,13 @@ func buildUpdateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 	if !m.AgentPoolID.IsNull() {
 		req.AgentPoolID = m.AgentPoolID.ValueString()
 	}
+	if !m.AgentPoolIDs.IsNull() && !m.AgentPoolIDs.IsUnknown() {
+		poolIDs := make([]string, 0, len(m.AgentPoolIDs.Elements()))
+		for _, v := range m.AgentPoolIDs.Elements() {
+			poolIDs = append(poolIDs, v.(types.String).ValueString())
+		}
+		req.AgentPoolIDs = poolIDs
+	}
 	if !m.Labels.IsNull() && !m.Labels.IsUnknown() {
 		labels := map[string]string{}
 		for k, v := range m.Labels.Elements() {
@@ -881,6 +929,16 @@ func readWorkspaceIntoModel(ctx context.Context, ws *terrapod.Workspace, m *work
 		m.AgentPoolID = types.StringValue(ws.AgentPoolID)
 	} else {
 		m.AgentPoolID = types.StringNull()
+	}
+	// Agent pool set (#1085) — same null-vs-empty rule as var_files above: a
+	// config that never declared the attribute must not flip to `[]`, and a
+	// config that declared `[]` must not flip to null.
+	if m.AgentPoolIDs.IsNull() && len(ws.AgentPoolIDs) == 0 {
+		m.AgentPoolIDs = types.ListNull(types.StringType)
+	} else {
+		apVal, apDiag := types.ListValueFrom(ctx, types.StringType, ws.AgentPoolIDs)
+		diags.Append(apDiag...)
+		m.AgentPoolIDs = apVal
 	}
 	if ws.VCSConnectionID != "" {
 		m.VCSConnectionID = types.StringValue(ws.VCSConnectionID)

--- a/services/terrapod/api/metrics.py
+++ b/services/terrapod/api/metrics.py
@@ -262,12 +262,36 @@ POOL_QUEUED_RUNS = Gauge(
     "terrapod_pool_queued_runs",
     (
         "Runs currently in `queued` state per agent pool — the backlog waiting "
-        "for a listener slot. Refreshed each reconciler cycle (2s) with a "
-        "single grouped COUNT. An operator watches this to see 'N runs waiting "
-        "on pool X' and decide whether the pool needs more listener capacity "
-        "(#750)."
+        "for a listener slot. Refreshed each reconciler cycle (2s). An operator "
+        "watches this to see 'N runs waiting on pool X' and decide whether the "
+        "pool needs more listener capacity (#750). A run whose workspace names "
+        "several pools (#1085) is claimable by each of them and counts toward "
+        "every one, so the sum across pools can exceed the number of queued "
+        "runs."
     ),
     ["pool_id"],
+)
+
+POOL_LIVE = Gauge(
+    "terrapod_pool_live",
+    (
+        "1 when an agent pool has at least one listener sending heartbeats, 0 "
+        "otherwise. Refreshed each reconciler cycle (2s) from the same Redis "
+        "heartbeat data the UI reads, so the dashboard and the alert can never "
+        "disagree (#1085)."
+    ),
+    ["pool_id"],
+)
+
+WORKSPACES_WITHOUT_LIVE_POOL = Gauge(
+    "terrapod_workspaces_without_live_pool",
+    (
+        "Agent-mode workspaces where NO pool in the workspace's pool set has a "
+        "live listener — runs queued against them cannot execute. The SLO to "
+        "alert on for execution-layer HA (#1085): multi-pool routing means "
+        "losing one pool is survivable, so a non-zero value here means a "
+        "workspace has lost all of its execution capacity."
+    ),
 )
 
 

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -67,6 +67,7 @@ from terrapod.db.models import (
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services import agent_pool_service as _agent_pool_service
+from terrapod.services import pool_set
 from terrapod.services.pool_rbac_service import resolve_pool_capabilities_for
 from terrapod.services.workspace_rbac_service import (
     resolve_workspace_capabilities_for,
@@ -599,8 +600,17 @@ async def create_project_unsupported(
 # ── Workspaces ───────────────────────────────────────────────────────────────
 
 
-def _compute_health_conditions(ws: Workspace) -> list[dict]:
-    """Compute all active health conditions from workspace DB fields."""
+def _compute_health_conditions(
+    ws: Workspace, live_pool_ids: frozenset[uuid.UUID] | None = None
+) -> list[dict]:
+    """Compute all active health conditions from workspace DB fields.
+
+    ``live_pool_ids`` is the set of agent pools that currently have a live
+    listener, resolved **once per request** by the caller (see
+    ``_resolve_live_pools``). When it is None the caller had no liveness
+    information available, and the liveness condition is skipped rather than
+    guessed — a false "no runner" banner is worse than a missing one.
+    """
     conditions: list[dict] = []
 
     if ws.state_diverged:
@@ -614,7 +624,9 @@ def _compute_health_conditions(ws: Workspace) -> list[dict]:
             }
         )
 
-    if ws.execution_mode == "agent" and not ws.agent_pool_id:
+    ws_pools = pool_set.workspace_pool_ids(ws)
+
+    if ws.execution_mode == "agent" and not ws_pools:
         conditions.append(
             {
                 "code": "no_agent_pool",
@@ -622,6 +634,29 @@ def _compute_health_conditions(ws: Workspace) -> list[dict]:
                 "title": "No agent pool assigned",
                 "detail": "This workspace is in agent execution mode but has no agent pool. "
                 "Runs will be queued indefinitely because no runner can claim them.",
+            }
+        )
+    elif (
+        ws.execution_mode == "agent"
+        and live_pool_ids is not None
+        and not any(p in live_pool_ids for p in ws_pools)
+    ):
+        # Multi-pool routing (#1085) means a workspace survives losing one of
+        # its pools — but not all of them. This is the "cut over now and
+        # nothing runs" condition, so it is worth its own banner rather than
+        # being inferred from a silent queue.
+        plural = len(ws_pools) > 1
+        conditions.append(
+            {
+                "code": "no_live_agent_pool",
+                "severity": "error",
+                "title": "No agent pool has a live runner",
+                "detail": (
+                    f"{'None of the ' if plural else 'The '}"
+                    f"{'agent pools' if plural else 'agent pool'} assigned to this "
+                    "workspace currently has a listener sending heartbeats. Runs will "
+                    "queue until one comes back or another pool is assigned."
+                ),
             }
         )
 
@@ -659,18 +694,42 @@ def _compute_health_conditions(ws: Workspace) -> list[dict]:
     return conditions
 
 
+async def _resolve_live_pools(workspaces: list[Workspace]) -> frozenset[uuid.UUID] | None:
+    """Resolve, in one Redis round-trip, which of these workspaces' pools are live.
+
+    Called **once per request** and threaded into every ``_workspace_json`` on
+    the page. Doing it per workspace would put a Redis round-trip on every row
+    of the workspace list and undo the paged fast path (#1056).
+
+    Returns None when liveness is unknown (Redis unreachable) so the caller
+    stays quiet rather than claiming every pool is dead.
+    """
+    distinct: list[uuid.UUID] = []
+    for ws in workspaces:
+        for pid in pool_set.workspace_pool_ids(ws):
+            if pid not in distinct:
+                distinct.append(pid)
+    live = await _agent_pool_service.live_pool_ids(distinct)
+    return None if live is None else frozenset(live)
+
+
 def _workspace_json(
     ws: Workspace,
     caps: frozenset[str] | None = None,
     latest_run: Run | None = None,
+    live_pool_ids: frozenset[uuid.UUID] | None = None,
 ) -> dict:
     """Serialize a Workspace to TFE V2 JSON:API format.
 
     When ``caps`` (the caller's resolved capability set on this workspace)
     is provided, the permissions block reflects the user's actual
     capabilities. Otherwise defaults to no access (empty set).
+
+    ``live_pool_ids`` feeds the pool-liveness health condition — see
+    ``_resolve_live_pools``.
     """
     caps = caps or frozenset()
+    ws_pools = pool_set.workspace_pool_ids(ws)
 
     latest_run_attr = None
     if latest_run is not None:
@@ -727,7 +786,7 @@ def _workspace_json(
                 "state-diverged": ws.state_diverged,
                 "lifecycle-state": ws.lifecycle_state,
                 "lifecycle-reason": ws.lifecycle_reason,
-                "health-conditions": _compute_health_conditions(ws),
+                "health-conditions": _compute_health_conditions(ws, live_pool_ids),
                 "vcs-last-polled-at": _rfc3339(ws.vcs_last_polled_at),
                 "vcs-last-error": ws.vcs_last_error,
                 "vcs-last-error-at": _rfc3339(ws.vcs_last_error_at),
@@ -735,7 +794,13 @@ def _workspace_json(
                 "auto-merge": ws.auto_merge,
                 "auto-merge-strategy": ws.auto_merge_strategy,
                 "latest-run": latest_run_attr,
-                "agent-pool-id": f"apool-{ws.agent_pool_id}" if ws.agent_pool_id else None,
+                # Multi-pool routing (#1085). `agent-pool-ids` is the full set;
+                # every pool in it is equally eligible to claim a run. The
+                # singular `agent-pool-id`/`agent-pool-name` are kept
+                # indefinitely for un-upgraded clients and resolve to element 0
+                # — a projection, NOT a preference.
+                "agent-pool-id": f"apool-{ws_pools[0]}" if ws_pools else None,
+                "agent-pool-ids": [f"apool-{p}" for p in ws_pools],
                 "agent-pool-name": ws.agent_pool.name if ws.agent_pool else None,
                 "vcs-connection-name": ws.vcs_connection.name if ws.vcs_connection else None,
                 "labels": ws.labels or {},
@@ -789,14 +854,19 @@ def _workspace_json(
                 ),
                 **(
                     {
+                        # Singular: element 0, for clients that predate the set.
                         "agent-pool": {
                             "data": {
-                                "id": f"apool-{ws.agent_pool_id}",
+                                "id": f"apool-{ws_pools[0]}",
                                 "type": "agent-pools",
                             },
                         },
+                        # Plural: the canonical form of the link (#1085).
+                        "agent-pools": {
+                            "data": [{"id": f"apool-{p}", "type": "agent-pools"} for p in ws_pools],
+                        },
                     }
-                    if ws.agent_pool_id
+                    if ws_pools
                     else {}
                 ),
             },
@@ -933,10 +1003,15 @@ async def list_workspaces(
             .all()
         )
         latest_runs = await _latest_runs_for([ws.id for ws in page_ws], db)
+        live_pools = await _resolve_live_pools(list(page_ws))
         data = []
         for ws in page_ws:
             caps = await resolve_workspace_capabilities_for(db, user, ws)
-            data.append(_workspace_json(ws, caps, latest_run=latest_runs.get(ws.id))["data"])
+            data.append(
+                _workspace_json(
+                    ws, caps, latest_run=latest_runs.get(ws.id), live_pool_ids=live_pools
+                )["data"]
+            )
         return JSONResponse(
             content={"data": data, "meta": build_meta(total, page_number, page_size)},
             headers=_tfe_headers(),
@@ -949,11 +1024,16 @@ async def list_workspaces(
     latest_runs = await _latest_runs_for([ws.id for ws in workspaces], db)
 
     # Filter to workspaces user has at least read access to
+    live_pools = await _resolve_live_pools(list(workspaces))
     visible = []
     for ws in workspaces:
         caps = await resolve_workspace_capabilities_for(db, user, ws)
         if caps:
-            visible.append(_workspace_json(ws, caps, latest_run=latest_runs.get(ws.id))["data"])
+            visible.append(
+                _workspace_json(
+                    ws, caps, latest_run=latest_runs.get(ws.id), live_pool_ids=live_pools
+                )["data"]
+            )
 
     # Optional JSON:API pagination (TFE wire shape). page[size]>=1 returns that
     # page; page[size]=0 or absent params return the full RBAC-filtered list as a
@@ -1003,9 +1083,89 @@ async def show_workspace(
     latest_run = run_result.scalar_one_or_none()
 
     return JSONResponse(
-        content=_workspace_json(ws, caps, latest_run=latest_run),
+        content=_workspace_json(
+            ws, caps, latest_run=latest_run, live_pool_ids=await _resolve_live_pools([ws])
+        ),
         headers=_tfe_headers(),
     )
+
+
+_POOL_SET_UNSET = object()
+
+
+async def _resolve_pool_set_attrs(
+    attrs: dict,
+    db: AsyncSession,
+    user: AuthenticatedUser,
+) -> object | tuple[uuid.UUID | None, list[str]]:
+    """Resolve the requested agent-pool set from workspace write attributes.
+
+    Accepts either form (#1085):
+
+    * ``agent-pool-ids`` — the full set. Every pool in it is equally eligible
+      to claim a run.
+    * ``agent-pool-id`` — the pre-multi-pool singular attribute, still sent by
+      un-upgraded clients. It means "this workspace has exactly this one pool",
+      so it *replaces* the whole set.
+
+    Sending both is rejected rather than silently picking one: the two would
+    disagree the moment a client set them inconsistently, and guessing which
+    the caller meant is exactly the kind of ambiguity that loses a pool.
+
+    Returns ``_POOL_SET_UNSET`` when neither attribute is present (so a PATCH
+    that doesn't mention pools leaves the set alone), otherwise the
+    ``(element 0, remainder)`` storage split. ``pool:assign`` is required on
+    **every** pool in the set — a caller may not attach a workspace to a pool
+    they could not attach it to individually.
+    """
+    has_singular = "agent-pool-id" in attrs
+    has_plural = "agent-pool-ids" in attrs
+    if has_singular and has_plural:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Set either agent-pool-id or agent-pool-ids, not both. "
+                "agent-pool-id assigns a single pool; agent-pool-ids assigns the full set."
+            ),
+        )
+    if not has_singular and not has_plural:
+        return _POOL_SET_UNSET
+
+    if has_plural:
+        raw = attrs.get("agent-pool-ids") or []
+        if not isinstance(raw, list):
+            raise HTTPException(status_code=422, detail="agent-pool-ids must be a list")
+    else:
+        singular = attrs.get("agent-pool-id")
+        raw = [singular] if singular else []
+
+    try:
+        requested = pool_set.normalise(raw)
+    except Exception:  # pragma: no cover - normalise is total, belt and braces
+        requested = []
+    if len(requested) != len([r for r in raw if r]):
+        raise HTTPException(status_code=422, detail="agent pool ids must be unique and valid")
+
+    for pool_id in requested:
+        target_pool = await _agent_pool_service.get_pool(db, pool_id)
+        if target_pool is None:
+            raise HTTPException(status_code=404, detail="Agent pool not found")
+        pool_caps = await resolve_pool_capabilities_for(
+            db,
+            user,
+            pool_name=target_pool.name,
+            pool_labels=target_pool.labels or {},
+            owner_email=target_pool.owner_email or "",
+        )
+        if not has_capability(pool_caps, cap.POOL_READ):
+            raise HTTPException(status_code=404, detail="Agent pool not found")
+        if not has_capability(pool_caps, cap.POOL_ASSIGN):
+            raise HTTPException(
+                status_code=403,
+                detail="Requires write permission on agent pool",
+            )
+
+    return pool_set.split(requested)
 
 
 @router.post("/organizations/default/workspaces")
@@ -1037,31 +1197,10 @@ async def create_workspace(
 
     from terrapod.config import settings
 
-    # Resolve agent pool ID from attributes (requires write permission on pool)
-    agent_pool_id = None
-    pool_val = attrs.get("agent-pool-id")
-    if pool_val:
-        import uuid as _uuid
-
-        agent_pool_id = _uuid.UUID(str(pool_val).removeprefix("apool-"))
-
-        target_pool = await _agent_pool_service.get_pool(db, agent_pool_id)
-        if target_pool is None:
-            raise HTTPException(status_code=404, detail="Agent pool not found")
-        pool_caps = await resolve_pool_capabilities_for(
-            db,
-            user,
-            pool_name=target_pool.name,
-            pool_labels=target_pool.labels or {},
-            owner_email=target_pool.owner_email or "",
-        )
-        if not has_capability(pool_caps, cap.POOL_READ):
-            raise HTTPException(status_code=404, detail="Agent pool not found")
-        if not has_capability(pool_caps, cap.POOL_ASSIGN):
-            raise HTTPException(
-                status_code=403,
-                detail="Requires write permission on agent pool",
-            )
+    resolved_pools = await _resolve_pool_set_attrs(attrs, db, user)
+    agent_pool_id, agent_pool_extra_ids = (
+        (None, []) if resolved_pools is _POOL_SET_UNSET else resolved_pools
+    )
 
     execution_mode = attrs.get("execution-mode", "local")
     if execution_mode not in ("local", "agent"):
@@ -1084,6 +1223,7 @@ async def create_workspace(
         labels=validate_labels(attrs.get("labels", {})),
         owner_email=user.email,
         agent_pool_id=agent_pool_id,
+        agent_pool_extra_ids=agent_pool_extra_ids,
         vcs_connection_id=vcs_connection_id,
         vcs_repo_url=attrs.get("vcs-repo-url", ""),
         vcs_branch=attrs.get("vcs-branch", ""),
@@ -1284,7 +1424,9 @@ async def show_workspace_by_id(
     latest_run = run_result.scalar_one_or_none()
 
     return JSONResponse(
-        content=_workspace_json(ws, caps, latest_run=latest_run),
+        content=_workspace_json(
+            ws, caps, latest_run=latest_run, live_pool_ids=await _resolve_live_pools([ws])
+        ),
         headers=_tfe_headers(),
     )
 
@@ -1595,33 +1737,24 @@ async def update_workspace(
         ws.trigger_prefixes = _validate_trigger_prefixes(attrs["trigger-prefixes"])
     if "drift-ignore-rules" in attrs:
         ws.drift_ignore_rules = _validate_drift_ignore_rules(attrs["drift-ignore-rules"])
-    if "agent-pool-id" in attrs:
-        import uuid as _uuid
-
-        pool_val = attrs["agent-pool-id"]
-        if pool_val is None:
-            ws.agent_pool_id = None
-        else:
-            new_pool_id = _uuid.UUID(str(pool_val).removeprefix("apool-"))
-            # Check write permission on target pool
-            target_pool = await _agent_pool_service.get_pool(db, new_pool_id)
-            if target_pool is None:
-                raise HTTPException(status_code=404, detail="Agent pool not found")
-            pool_caps = await resolve_pool_capabilities_for(
-                db,
-                user,
-                pool_name=target_pool.name,
-                pool_labels=target_pool.labels or {},
-                owner_email=target_pool.owner_email or "",
+    # Agent pool set (#1085). Either attribute replaces the whole set; a PATCH
+    # that mentions neither leaves it untouched. `pool:assign` is enforced on
+    # every pool by the shared resolver.
+    resolved_pools = await _resolve_pool_set_attrs(attrs, db, user)
+    if resolved_pools is not _POOL_SET_UNSET:
+        previous = pool_set.workspace_pool_ids(ws)
+        ws.agent_pool_id, ws.agent_pool_extra_ids = resolved_pools  # type: ignore[misc]
+        dropped = [p for p in previous if p not in pool_set.workspace_pool_ids(ws)]
+        if dropped and "agent-pool-ids" not in attrs:
+            # A singular write replaced a multi-pool set. That is the documented
+            # semantic, but it is also how an un-upgraded client silently drops
+            # a pool it cannot see — so leave a trail.
+            logger.info(
+                "Workspace pool set replaced by a singular agent-pool-id write",
+                workspace_id=str(ws.id),
+                dropped_pool_ids=[str(p) for p in dropped],
+                actor=user.email,
             )
-            if not has_capability(pool_caps, cap.POOL_READ):
-                raise HTTPException(status_code=404, detail="Agent pool not found")
-            if not has_capability(pool_caps, cap.POOL_ASSIGN):
-                raise HTTPException(
-                    status_code=403,
-                    detail="Requires write permission on agent pool",
-                )
-            ws.agent_pool_id = new_pool_id
     if "drift-detection-enabled" in attrs:
         ws.drift_detection_enabled = attrs["drift-detection-enabled"]
         # Reset drift status when disabling drift detection
@@ -1725,7 +1858,10 @@ async def update_workspace(
             )
         logger.info("Workspace renamed", old_name=old_name, new_name=ws.name)
 
-    return JSONResponse(content=_workspace_json(ws, old_caps), headers=_tfe_headers())
+    return JSONResponse(
+        content=_workspace_json(ws, old_caps, live_pool_ids=await _resolve_live_pools([ws])),
+        headers=_tfe_headers(),
+    )
 
 
 @extensions_router.delete("/workspaces/{workspace_id}")

--- a/services/terrapod/api/routers/workspace_bulk.py
+++ b/services/terrapod/api/routers/workspace_bulk.py
@@ -43,6 +43,7 @@ from terrapod.db.models import (
 )
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
+from terrapod.services import pool_set
 from terrapod.services.capability_resolver import resolve_capabilities
 from terrapod.services.notification_service import VALID_TRIGGERS
 from terrapod.services.run_task_service import VALID_ENFORCEMENT_LEVELS, VALID_STAGES
@@ -65,7 +66,8 @@ _FIELD_MAP: dict[str, str] = {
     "execution-backend": "execution_backend",
     "execution-mode": "execution_mode",
     "auto-apply": "auto_apply",
-    "agent-pool-id": "agent_pool_id",
+    # NOTE: the agent-pool attributes are deliberately NOT here — one input key
+    # writes two columns, so they are validated by _validate_pool_set below.
     "resource-cpu": "resource_cpu",
     "resource-memory": "resource_memory",
     "var-files": "var_files",
@@ -81,6 +83,7 @@ def _ws_summary(ws: Workspace) -> dict[str, Any]:
         "execution-backend": ws.execution_backend,
         "terraform-version": ws.terraform_version,
         "agent-pool-id": f"apool-{ws.agent_pool_id}" if ws.agent_pool_id else None,
+        "agent-pool-ids": [f"apool-{p}" for p in pool_set.workspace_pool_ids(ws)],
         "labels": ws.labels or {},
     }
 
@@ -177,6 +180,63 @@ def validate_notification_specs(items: Any) -> list[dict]:
     return out
 
 
+async def _validate_pool_set(
+    update: dict, db: AsyncSession, user: AuthenticatedUser
+) -> dict[str, Any]:
+    """Validate the requested agent-pool set, returning the columns to write.
+
+    Mirrors the single-workspace rules (#1085): either `agent-pool-id` (one
+    pool, replacing the whole set) or `agent-pool-ids` (the set), never both,
+    and `pool:assign` on *every* pool named.
+    """
+    has_singular = "agent-pool-id" in update
+    has_plural = "agent-pool-ids" in update
+    if has_singular and has_plural:
+        raise HTTPException(
+            status_code=422,
+            detail="Set either agent-pool-id or agent-pool-ids, not both",
+        )
+    if not has_singular and not has_plural:
+        return {}
+
+    if has_plural:
+        raw = update.get("agent-pool-ids") or []
+        if not isinstance(raw, list):
+            raise HTTPException(status_code=422, detail="agent-pool-ids must be a list")
+    else:
+        singular = update.get("agent-pool-id")
+        raw = [] if singular in (None, "") else [singular]
+
+    requested = pool_set.normalise(raw)
+    if len(requested) != len([r for r in raw if r]):
+        raise HTTPException(status_code=422, detail="agent pool ids must be unique and valid")
+
+    for pid in requested:
+        pool = await db.get(AgentPool, pid)
+        if pool is None:
+            raise HTTPException(status_code=422, detail="agent-pool-id not found")
+        # Assigning a pool requires the pool:assign capability (platform
+        # admin bypass) — mirrors the single-workspace rule (#585).
+        if "admin" not in effective_platform_roles(user):
+            pool_caps = await resolve_capabilities(
+                db,
+                user.email,
+                user.roles,
+                pool.name,
+                pool.labels or {},
+                pool.owner_email,
+                axis="pool",
+            )
+            if not has_capability(pool_caps, cap.POOL_ASSIGN):
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"write permission on agent pool '{pool.name}' is required",
+                )
+
+    head, extras = pool_set.split(requested)
+    return {"agent_pool_id": head, "agent_pool_extra_ids": extras}
+
+
 async def _validate_update(
     update: dict, db: AsyncSession, user: AuthenticatedUser
 ) -> dict[str, Any]:
@@ -207,38 +267,9 @@ async def _validate_update(
         if key == "var-files":
             if not isinstance(val, list):
                 raise HTTPException(status_code=422, detail="var-files must be a list")
-        if key == "agent-pool-id":
-            if val in (None, ""):
-                val = None
-            else:
-                try:
-                    pid = uuid.UUID(str(val).removeprefix("apool-"))
-                except ValueError as e:
-                    raise HTTPException(
-                        status_code=422, detail="agent-pool-id is not a UUID"
-                    ) from e
-                pool = await db.get(AgentPool, pid)
-                if pool is None:
-                    raise HTTPException(status_code=422, detail="agent-pool-id not found")
-                # Assigning a pool requires the pool:assign capability (platform
-                # admin bypass) — mirrors the single-workspace rule (#585).
-                if "admin" not in effective_platform_roles(user):
-                    pool_caps = await resolve_capabilities(
-                        db,
-                        user.email,
-                        user.roles,
-                        pool.name,
-                        pool.labels or {},
-                        pool.owner_email,
-                        axis="pool",
-                    )
-                    if not has_capability(pool_caps, cap.POOL_ASSIGN):
-                        raise HTTPException(
-                            status_code=403,
-                            detail=f"write permission on agent pool '{pool.name}' is required",
-                        )
-                val = pid
         fields[attr] = val
+
+    fields.update(await _validate_pool_set(update, db, user))
 
     run_tasks = validate_run_task_specs(update["run-tasks"]) if "run-tasks" in update else None
     notifications = (

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -302,6 +302,17 @@ class Workspace(Base):
     agent_pool: Mapped["AgentPool | None"] = relationship(
         "AgentPool", foreign_keys=[agent_pool_id], lazy="joined"
     )
+    # Multi-pool routing (#1085). The workspace's pool set is
+    # `[agent_pool_id] + agent_pool_extra_ids` — a FLAT set: every pool in it is
+    # equally eligible to claim a run, there is no primary and no preference.
+    # The split across two columns is a backward-compatibility device, not a
+    # hierarchy: `agent_pool_id` predates multi-pool and is still read by
+    # un-upgraded clients (provider, SDK, MCP, tfci), so it keeps holding
+    # element 0. Storing the whole set in one new column instead would let an
+    # old API replica's write of `agent_pool_id` during a rolling upgrade be
+    # silently ignored — dispatching to pools the operator had just removed.
+    # Always resolve via `pool_set.workspace_pool_ids()`, never read raw.
+    agent_pool_extra_ids: Mapped[list[Any]] = mapped_column(JSONB, default=list, nullable=False)
     resource_cpu: Mapped[str] = mapped_column(String(20), nullable=False, default="1")
     resource_memory: Mapped[str] = mapped_column(String(20), nullable=False, default="2Gi")
 
@@ -1538,11 +1549,19 @@ class Run(Base):
     terragrunt_version: Mapped[str] = mapped_column(String(20), nullable=False, default="")
     resource_cpu: Mapped[str] = mapped_column(String(20), nullable=False, default="1")
     resource_memory: Mapped[str] = mapped_column(String(20), nullable=False, default="2Gi")
+    # `pool_id` is the pool this run is currently associated with: at creation
+    # it is element 0 of the workspace's pool set, and on claim it is rewritten
+    # to the pool that actually took the run — so cancellation, job-status
+    # queries and log streaming all address the cluster that is running it.
     pool_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("agent_pools.id", ondelete="SET NULL"),
         nullable=True,
     )
+    # The rest of the candidate pool set, snapshotted at run creation (#1085).
+    # A listener in ANY candidate may claim this run; first claim wins. No FK —
+    # this is a snapshot, and a pool deleted mid-flight must not rewrite it.
+    pool_extra_ids: Mapped[list[Any]] = mapped_column(JSONB, default=list, nullable=False)
     listener_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         nullable=True,

--- a/services/terrapod/services/agent_pool_service.py
+++ b/services/terrapod/services/agent_pool_service.py
@@ -3,6 +3,7 @@
 import hashlib
 import secrets
 import uuid
+from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select
@@ -434,6 +435,54 @@ async def list_listeners(pool_id: uuid.UUID) -> list[dict]:
     # Sort by name for consistent ordering
     listeners.sort(key=lambda d: d.get("name", ""))
     return listeners
+
+
+async def live_pool_ids(pool_ids: Iterable[uuid.UUID]) -> set[uuid.UUID] | None:
+    """Return the subset of ``pool_ids`` that currently has a live listener.
+
+    "Live" means at least one listener hash still exists for the pool — the
+    hashes carry a TTL refreshed by heartbeat, so a pool whose listeners have
+    stopped heartbeating drops out within ~5 missed beats.
+
+    Resolved for a batch of pools in **one** Redis round-trip, because the
+    workspace list asks this question for every workspace on the page and a
+    per-workspace call would reintroduce the O(N) cost the paged fast path
+    (#1056) exists to avoid.
+
+    Returns **None** when liveness could not be determined (Redis unreachable).
+    That is deliberately distinct from an empty set: "nothing is live" is an
+    alarm, "I couldn't tell" is not, and conflating them would light up a false
+    "no runner for this workspace" banner across the whole estate the moment
+    Redis blipped. Callers must treat None as "no information" and stay quiet.
+    """
+    unique = list(dict.fromkeys(pool_ids))
+    if not unique:
+        return set()
+
+    try:
+        redis = get_redis_client()
+        pipe = redis.pipeline(transaction=False)
+        for pid in unique:
+            pipe.smembers(f"{_POOL_LISTENERS_PREFIX}{pid}")
+        member_sets = await pipe.execute()
+
+        # A pool-listener set can hold ids whose listener hash has already
+        # expired (the set itself is only lazily cleaned), so membership alone
+        # does not prove liveness — check that at least one hash still exists.
+        candidates: list[tuple[uuid.UUID, str]] = []
+        for pid, members in zip(unique, member_sets, strict=True):
+            candidates.extend((pid, lid) for lid in members or [])
+        if not candidates:
+            return set()
+
+        pipe = redis.pipeline(transaction=False)
+        for _, lid in candidates:
+            pipe.exists(f"{_LISTENER_PREFIX}{lid}")
+        exists = await pipe.execute()
+        return {pid for (pid, _), alive in zip(candidates, exists, strict=True) if alive}
+    except Exception as e:  # never fail a request on a liveness lookup
+        logger.debug("Pool liveness lookup failed", error=str(e))
+        return None
 
 
 async def delete_listener(listener_id: str, name: str, pool_id: str) -> None:

--- a/services/terrapod/services/pool_set.py
+++ b/services/terrapod/services/pool_set.py
@@ -1,0 +1,90 @@
+"""The workspace agent-pool set (#1085 / #960 phase 0).
+
+A workspace routes its runs to a **set** of agent pools rather than a single
+one. The set is **flat**: every pool in it is equally eligible to claim a run.
+There is no primary, no rank, no preference and no rotation — a queued run is
+offered to all of them at once and whichever pool has a listener that claims it
+first runs it.
+
+The set is stored across two columns, and that split is a *backward-compatibility
+device rather than a hierarchy*:
+
+* ``agent_pool_id`` predates multi-pool and is still read by clients that have
+  not been upgraded (the Terraform provider, go-terrapod, MCP, ``tfci``), so it
+  keeps holding element 0 and is what the legacy ``agent-pool-id`` attribute
+  resolves to.
+* ``agent_pool_extra_ids`` holds the remainder.
+
+Keeping the pre-existing column authoritative for element 0 is what makes a
+rolling upgrade safe: an API replica still running the previous release writes
+only ``agent_pool_id``, and that write stays meaningful. Had the whole set moved
+into one new column, the old replica's write would be silently ignored and runs
+would dispatch to pools the operator had just removed.
+
+Every caller resolves the set through this module rather than reading either
+column directly, so the storage split never leaks out as a preference order.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Protocol
+
+
+class _HasPoolSet(Protocol):
+    """Structural type for the two row shapes that carry a pool set."""
+
+    agent_pool_id: uuid.UUID | None
+    agent_pool_extra_ids: list[Any]
+
+
+def _coerce(value: Any) -> uuid.UUID | None:
+    """Best-effort UUID coercion, tolerating the ``apool-`` id prefix."""
+    if value is None or isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value).removeprefix("apool-"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def normalise(pool_ids: list[Any] | None) -> list[uuid.UUID]:
+    """Coerce a raw list to UUIDs, dropping blanks and de-duplicating.
+
+    Order is preserved because it is what the operator typed and what the UI
+    displays back — it carries no dispatch meaning.
+    """
+    seen: list[uuid.UUID] = []
+    for raw in pool_ids or []:
+        parsed = _coerce(raw)
+        if parsed is not None and parsed not in seen:
+            seen.append(parsed)
+    return seen
+
+
+def workspace_pool_ids(workspace: _HasPoolSet) -> list[uuid.UUID]:
+    """The workspace's full pool set, element 0 first.
+
+    Empty when the workspace has no pool assigned at all.
+    """
+    return normalise([workspace.agent_pool_id, *(workspace.agent_pool_extra_ids or [])])
+
+
+def run_pool_ids(run: Any) -> list[uuid.UUID]:
+    """The candidate pools a run may be claimed by, snapshotted at creation.
+
+    ``run.pool_id`` is included because a claim rewrites it to the pool that
+    actually took the run — so after a claim this returns the executing pool
+    first, and before one it returns element 0 first.
+    """
+    return normalise([run.pool_id, *(getattr(run, "pool_extra_ids", None) or [])])
+
+
+def split(pool_ids: list[uuid.UUID]) -> tuple[uuid.UUID | None, list[str]]:
+    """Split a resolved set into the ``(element 0, remainder)`` storage form.
+
+    The remainder is returned as strings because it lands in a JSONB column.
+    """
+    if not pool_ids:
+        return None, []
+    return pool_ids[0], [str(p) for p in pool_ids[1:]]

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -14,7 +14,7 @@ Registered as a periodic task (2s interval) in app.py.
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.config import load_runner_config
@@ -70,22 +70,31 @@ async def _persist_live_log_if_missing(run: Run, phase: str) -> None:
 async def _refresh_pool_queue_depth(db: AsyncSession) -> None:
     """Publish the per-pool `queued` backlog as a Prometheus gauge (#750).
 
-    One grouped COUNT per reconciler cycle (2s). Every existing pool is given
-    an explicit value (0 when idle) so the series is stable — a pool that drains
-    to empty reads as 0, not absent. Queued runs on a since-deleted pool are
-    still surfaced (they are a real backlog). Best-effort: never raises into the
-    reconcile cycle.
+    Every existing pool is given an explicit value (0 when idle) so the series
+    is stable — a pool that drains to empty reads as 0, not absent. Queued runs
+    on a since-deleted pool are still surfaced (they are a real backlog).
+    Best-effort: never raises into the reconcile cycle.
+
+    A run on a multi-pool workspace (#1085) is claimable by every pool in its
+    candidate set, so it counts toward each of them. The gauge answers "what
+    could this pool be asked to run", which is what capacity alerting needs;
+    the sum across pools therefore exceeds the number of queued runs when
+    workspaces name several pools.
     """
     from terrapod.api.metrics import POOL_QUEUED_RUNS
     from terrapod.db.models import AgentPool
+    from terrapod.services import pool_set
 
     try:
-        counts_result = await db.execute(
-            select(Run.pool_id, func.count())
-            .where(Run.status == "queued", Run.pool_id.isnot(None))
-            .group_by(Run.pool_id)
+        queued_result = await db.execute(
+            select(Run.pool_id, Run.pool_extra_ids).where(
+                Run.status == "queued", Run.pool_id.isnot(None)
+            )
         )
-        counts = {row[0]: row[1] for row in counts_result.all()}
+        counts: dict[uuid.UUID, int] = {}
+        for row in queued_result.all():
+            for pid in pool_set.normalise([row[0], *(row[1] or [])]):
+                counts[pid] = counts.get(pid, 0) + 1
 
         pool_ids_result = await db.execute(select(AgentPool.id))
         pool_ids = {row[0] for row in pool_ids_result.all()}
@@ -97,6 +106,50 @@ async def _refresh_pool_queue_depth(db: AsyncSession) -> None:
             POOL_QUEUED_RUNS.labels(pool_id=str(pid)).set(counts.get(pid, 0))
     except Exception as e:
         logger.debug("Failed to refresh pool queue-depth gauge", error=str(e))
+
+
+async def _refresh_pool_liveness(db: AsyncSession) -> None:
+    """Publish pool liveness and the "no live pool" workspace count (#1085).
+
+    Multi-pool routing means losing one pool is survivable, so the signal that
+    actually matters is "a workspace has no live pool left at all" — that is
+    the alertable SLO, and it is fed from the same Redis heartbeats the UI
+    health banner reads so the two can never disagree.
+
+    Best-effort: never raises into the reconcile cycle.
+    """
+    from terrapod.api.metrics import POOL_LIVE, WORKSPACES_WITHOUT_LIVE_POOL
+    from terrapod.db.models import AgentPool
+    from terrapod.services import agent_pool_service, pool_set
+
+    try:
+        pool_ids = [row[0] for row in (await db.execute(select(AgentPool.id))).all()]
+        live = await agent_pool_service.live_pool_ids(pool_ids)
+        if live is None:
+            # Liveness unknown (Redis unreachable) — leave the previous cycle's
+            # values in place rather than reporting the whole fleet as dead.
+            return
+
+        POOL_LIVE.clear()
+        for pid in pool_ids:
+            POOL_LIVE.labels(pool_id=str(pid)).set(1 if pid in live else 0)
+
+        agent_ws = (
+            await db.execute(
+                select(Workspace.agent_pool_id, Workspace.agent_pool_extra_ids).where(
+                    Workspace.execution_mode == "agent",
+                    Workspace.agent_pool_id.isnot(None),
+                )
+            )
+        ).all()
+        stranded = sum(
+            1
+            for row in agent_ws
+            if not any(p in live for p in pool_set.normalise([row[0], *(row[1] or [])]))
+        )
+        WORKSPACES_WITHOUT_LIVE_POOL.set(stranded)
+    except Exception as e:
+        logger.debug("Failed to refresh pool liveness gauges", error=str(e))
 
 
 async def reconcile_runs() -> None:
@@ -117,6 +170,7 @@ async def reconcile_runs() -> None:
         # independently of in-flight ones, so this must run before the early
         # return below (#750).
         await _refresh_pool_queue_depth(db)
+        await _refresh_pool_liveness(db)
 
         # `canceling` joins planning/applying here: it's the intermediate
         # state entered when a user cancels an in-flight apply. The

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -24,7 +24,7 @@ from terrapod.db.models import (
     now_utc,
 )
 from terrapod.logging_config import get_logger
-from terrapod.services import github_service, gitlab_service
+from terrapod.services import github_service, gitlab_service, pool_set
 from terrapod.services.notification_service import STATUS_TO_TRIGGER
 
 logger = get_logger(__name__)
@@ -226,18 +226,24 @@ async def _enqueue_drift_completed(run: Run) -> None:
 
 
 async def _publish_run_available(run: Run) -> None:
-    """Publish a run_available event to the pool's listener SSE channel.
+    """Publish a run_available event to every candidate pool's SSE channel.
 
     Called when a run transitions to queued or confirmed, notifying listeners
     that there is claimable work.
+
+    A run may name several pools (#1085) and they are all equally eligible, so
+    every one is notified — whichever listener claims first runs it. The event
+    carries the pool it was addressed to, because a listener uses it to decide
+    whether the notification is for a pool it serves.
     """
     try:
         from terrapod.redis.client import publish_listener_event
 
-        await publish_listener_event(
-            str(run.pool_id),
-            {"event": "run_available", "pool_id": str(run.pool_id)},
-        )
+        for pool_id in pool_set.run_pool_ids(run):
+            await publish_listener_event(
+                str(pool_id),
+                {"event": "run_available", "pool_id": str(pool_id)},
+            )
     except Exception as e:
         # Never let SSE publishing break the state machine
         logger.debug("Failed to publish run_available", error=str(e))
@@ -555,7 +561,10 @@ async def create_run(
     if auto_apply is None:
         auto_apply = workspace.auto_apply
 
-    pool_id = workspace.agent_pool_id
+    # Snapshot the workspace's pool set (#1085). Element 0 lands in `pool_id`
+    # and the rest in `pool_extra_ids`; they are equally eligible — the claim
+    # rewrites `pool_id` to whichever pool actually takes the run.
+    pool_id, pool_extra_ids = pool_set.split(pool_set.workspace_pool_ids(workspace))
 
     # Pin the execution version to an exact x.y.z at run creation, the
     # same way CPU/memory are snapshotted. The workspace stores the
@@ -596,6 +605,7 @@ async def create_run(
         resource_cpu=workspace.resource_cpu,
         resource_memory=workspace.resource_memory,
         pool_id=pool_id,
+        pool_extra_ids=pool_extra_ids,
         created_by=created_by,
         is_drift_detection=is_drift_detection,
         target_addrs=target_addrs or None,
@@ -1510,13 +1520,25 @@ async def claim_next_run(
     that ran the plan is no longer available — listeners are stateless.
 
     Uses SELECT ... FOR UPDATE SKIP LOCKED for Postgres job queue pattern.
+
+    A run may name several pools (#1085) and every one of them is equally
+    eligible, so the match is "this pool is anywhere in the run's candidate
+    set". Exactly-once execution is unaffected: the run is still a single row
+    claimed under SKIP LOCKED, so offering it to N pools cannot produce N
+    claims. The winning pool is written back to `run.pool_id` below.
     """
     # Try queued runs first (plan phase), then confirmed runs (apply phase)
     for target_status, phase, next_status in [
         ("queued", "plan", "planning"),
         ("confirmed", "apply", "applying"),
     ]:
-        conditions = [Run.status == target_status, Run.pool_id == pool_id]
+        conditions = [
+            Run.status == target_status,
+            or_(
+                Run.pool_id == pool_id,
+                Run.pool_extra_ids.contains([str(pool_id)]),
+            ),
+        ]
 
         # Per-workspace serialization + manual-lock gate, applied only when
         # STARTING a plan (queued → planning). An apply-capable (plan+apply)
@@ -1564,6 +1586,20 @@ async def claim_next_run(
 
         if run is not None:
             run.listener_id = listener_id
+            # Record where the run is actually executing (#1085). Everything
+            # downstream — cancel_job, check_job_status, log streaming, the
+            # terminal queue re-drive — addresses `run.pool_id`, so on a
+            # multi-pool workspace it must name the pool that won the claim,
+            # not whichever pool happened to be element 0.
+            # The candidate set is preserved, only re-ordered around the
+            # winner: the apply phase is claimed separately and must still be
+            # able to fall through if this pool goes dark between plan and
+            # apply. (Artifacts come from the API, so the apply need not run in
+            # the same cluster as the plan.)
+            claimed_elsewhere = run.pool_id != pool_id
+            candidates = pool_set.run_pool_ids(run)
+            run.pool_id = pool_id
+            run.pool_extra_ids = [str(p) for p in candidates if p != pool_id]
             run = await transition_run(db, run, next_status)
             await db.flush()
 
@@ -1572,6 +1608,8 @@ async def claim_next_run(
                 run_id=str(run.id),
                 listener=listener_name,
                 phase=phase,
+                pool_id=str(pool_id),
+                fell_through=claimed_elsewhere,
             )
 
             return run, phase

--- a/services/terrapod/services/workspace_search_service.py
+++ b/services/terrapod/services/workspace_search_service.py
@@ -20,7 +20,7 @@ import uuid
 from typing import Any
 
 from pydantic import BaseModel, Field
-from sqlalchemy import Select, select
+from sqlalchemy import Select, or_, select
 
 from terrapod.db.models import Workspace
 
@@ -134,7 +134,17 @@ def build_workspace_query(f: WorkspaceFilter) -> Select[tuple[Workspace]]:
     if f.terraform_version is not None:
         q = q.where(Workspace.terraform_version == f.terraform_version)
     if f.agent_pool_id is not None:
-        q = q.where(Workspace.agent_pool_id == _strip_uuid(f.agent_pool_id, "apool-"))
+        # Matches a workspace that names this pool ANYWHERE in its pool set
+        # (#1085) — "which workspaces would this pool have to run?" is the
+        # question an operator is asking, and a workspace that lists the pool
+        # as a fallback is just as much its responsibility.
+        pool_uuid = _strip_uuid(f.agent_pool_id, "apool-")
+        q = q.where(
+            or_(
+                Workspace.agent_pool_id == pool_uuid,
+                Workspace.agent_pool_extra_ids.contains([str(pool_uuid)]),
+            )
+        )
     if f.vcs_connection_id is not None:
         q = q.where(Workspace.vcs_connection_id == _strip_uuid(f.vcs_connection_id, "vcs-"))
     if f.owner_email is not None:

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -555,6 +555,7 @@
   "tfe_v2._workspace_json": [
     "actions",
     "agent-pool-id",
+    "agent-pool-ids",
     "agent-pool-name",
     "ai-summary-context",
     "ai-summary-mode",

--- a/services/tests/api/test_workspace_bulk.py
+++ b/services/tests/api/test_workspace_bulk.py
@@ -60,6 +60,7 @@ def _mock_ws(
     execution_backend="tofu",
     terraform_version="1.12",
     agent_pool_id=None,
+    agent_pool_extra_ids=None,
     labels=None,
     auto_apply=False,
     var_files=None,
@@ -71,6 +72,9 @@ def _mock_ws(
     w.execution_backend = execution_backend
     w.terraform_version = terraform_version
     w.agent_pool_id = agent_pool_id
+    # Real column, real default — a MagicMock here would never compare equal to
+    # the incoming `[]` and would show up as a spurious diff entry (#1085).
+    w.agent_pool_extra_ids = agent_pool_extra_ids if agent_pool_extra_ids is not None else []
     w.labels = labels if labels is not None else {}
     w.auto_apply = auto_apply
     w.var_files = var_files if var_files is not None else []

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -25,7 +25,7 @@ def _user(email="test@example.com", roles=None):
     )
 
 
-def _mock_workspace(ws_id=None, pool_id=None):
+def _mock_workspace(ws_id=None, pool_id=None, extra_pool_ids=None):
     ws = MagicMock()
     ws.id = ws_id or uuid.uuid4()
     ws.name = "test-ws"
@@ -39,6 +39,9 @@ def _mock_workspace(ws_id=None, pool_id=None):
     ws.locked = False
     ws.lock_id = None
     ws.agent_pool_id = pool_id
+    # Real column, real default (#1085) — a MagicMock here would leak into the
+    # serialized pool set.
+    ws.agent_pool_extra_ids = extra_pool_ids if extra_pool_ids is not None else []
     ws.agent_pool = None
     ws.resource_cpu = "1"
     ws.resource_memory = "2Gi"
@@ -275,3 +278,343 @@ class TestWorkspacePoolAssignment:
             )
 
         assert res.status_code == 200
+
+
+class TestWorkspacePoolSet:
+    """Multi-pool routing (#1085) — the API carries both attributes."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_pool_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    async def test_assign_several_pools(self, mock_ws_perm, mock_get_pool, mock_pool_perm, *mocks):
+        user = _user(roles=["everyone", "pool-writer"])
+        pool_a, pool_b = _mock_pool(name="eu"), _mock_pool(name="us")
+        ws = _mock_workspace()
+
+        mock_ws_perm.return_value = caps_for_level("admin")
+        mock_get_pool.side_effect = lambda _db, pid: {pool_a.id: pool_a, pool_b.id: pool_b}[pid]
+        mock_pool_perm.return_value = caps_for_level("write")
+
+        app, mock_db = _make_app(user)
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "agent-pool-ids": [f"apool-{pool_a.id}", f"apool-{pool_b.id}"],
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200, res.text
+        # Element 0 lands in the pre-existing column, the rest in the new one —
+        # a storage split, not a preference.
+        assert ws.agent_pool_id == pool_a.id
+        assert ws.agent_pool_extra_ids == [str(pool_b.id)]
+        attrs = res.json()["data"]["attributes"]
+        assert attrs["agent-pool-ids"] == [f"apool-{pool_a.id}", f"apool-{pool_b.id}"]
+        # The singular attribute stays, resolving to element 0.
+        assert attrs["agent-pool-id"] == f"apool-{pool_a.id}"
+        rels = res.json()["data"]["relationships"]
+        assert [d["id"] for d in rels["agent-pools"]["data"]] == [
+            f"apool-{pool_a.id}",
+            f"apool-{pool_b.id}",
+        ]
+        assert rels["agent-pool"]["data"]["id"] == f"apool-{pool_a.id}"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_pool_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    async def test_pool_assign_required_on_every_pool(
+        self, mock_ws_perm, mock_get_pool, mock_pool_perm, *mocks
+    ):
+        """403 when the caller lacks pool:assign on ANY pool in the set.
+
+        A caller must not be able to attach a workspace to a pool they could
+        not have attached it to on its own.
+        """
+        user = _user(roles=["everyone"])
+        allowed, denied = _mock_pool(name="mine"), _mock_pool(name="theirs")
+        ws = _mock_workspace()
+
+        mock_ws_perm.return_value = caps_for_level("admin")
+        mock_get_pool.side_effect = lambda _db, pid: {allowed.id: allowed, denied.id: denied}[pid]
+        mock_pool_perm.side_effect = lambda *a, **kw: (
+            caps_for_level("write") if kw.get("pool_name") == "mine" else caps_for_level("read")
+        )
+
+        app, mock_db = _make_app(user)
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "agent-pool-ids": [f"apool-{allowed.id}", f"apool-{denied.id}"],
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 403
+        # Nothing was written — the check runs before any mutation.
+        assert ws.agent_pool_extra_ids == []
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    async def test_setting_both_attributes_is_422(self, mock_ws_perm, *mocks):
+        user = _user(roles=["admin"])
+        ws = _mock_workspace()
+        mock_ws_perm.return_value = caps_for_level("admin")
+
+        app, mock_db = _make_app(user)
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={
+                    "data": {
+                        "attributes": {
+                            "agent-pool-id": f"apool-{uuid.uuid4()}",
+                            "agent-pool-ids": [f"apool-{uuid.uuid4()}"],
+                        }
+                    }
+                },
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 422
+        assert "not both" in res.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_pool_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    @patch("terrapod.api.routers.tfe_v2._agent_pool_service.get_pool", new_callable=AsyncMock)
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    async def test_singular_write_replaces_the_whole_set(
+        self, mock_ws_perm, mock_get_pool, mock_pool_perm, *mocks
+    ):
+        """The documented semantic: `agent-pool-id` means "exactly this one".
+
+        This is also how an un-upgraded client drops a pool it cannot see, so
+        the behaviour is pinned deliberately rather than left to chance.
+        """
+        user = _user(roles=["admin"])
+        old_a, old_b, new = uuid.uuid4(), uuid.uuid4(), _mock_pool(name="replacement")
+        ws = _mock_workspace(pool_id=old_a, extra_pool_ids=[str(old_b)])
+
+        mock_ws_perm.return_value = caps_for_level("admin")
+        mock_get_pool.return_value = new
+        mock_pool_perm.return_value = caps_for_level("write")
+
+        app, mock_db = _make_app(user)
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"agent-pool-id": f"apool-{new.id}"}}},
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200, res.text
+        assert ws.agent_pool_id == new.id
+        assert ws.agent_pool_extra_ids == []
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    async def test_patch_without_pool_attributes_leaves_the_set_alone(self, mock_ws_perm, *mocks):
+        """Back-compat: a PATCH that says nothing about pools changes nothing."""
+        user = _user(roles=["admin"])
+        a, b = uuid.uuid4(), uuid.uuid4()
+        ws = _mock_workspace(pool_id=a, extra_pool_ids=[str(b)])
+        mock_ws_perm.return_value = caps_for_level("admin")
+
+        app, mock_db = _make_app(user)
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = ws_result
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"auto-apply": True}}},
+                headers=_AUTH,
+            )
+
+        assert res.status_code == 200, res.text
+        assert ws.agent_pool_id == a
+        assert ws.agent_pool_extra_ids == [str(b)]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    async def test_single_pool_workspace_serializes_as_before(self, mock_ws_perm, *mocks):
+        """A workspace with one pool must serialize exactly as it did pre-#1085."""
+        user = _user(roles=["admin"])
+        pool_id = uuid.uuid4()
+        ws = _mock_workspace(pool_id=pool_id)
+        mock_ws_perm.return_value = caps_for_level("admin")
+
+        app, mock_db = _make_app(user)
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        # The GET also looks up the workspace's latest run.
+        no_run = MagicMock()
+        no_run.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+            res = await client.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+
+        assert res.status_code == 200, res.text
+        attrs = res.json()["data"]["attributes"]
+        assert attrs["agent-pool-id"] == f"apool-{pool_id}"
+        assert attrs["agent-pool-ids"] == [f"apool-{pool_id}"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    async def test_unknown_liveness_raises_no_alarm(self, mock_ws_perm, *mocks):
+        """Redis unreachable must NOT look like "every pool is dead" (#1085).
+
+        `live_pool_ids` returns None when it couldn't tell, and the health
+        condition is skipped — a false "no runner for this workspace" banner
+        across the whole estate on a Redis blip would be worse than no banner.
+        """
+        user = _user(roles=["admin"])
+        ws = _mock_workspace(pool_id=uuid.uuid4())
+        mock_ws_perm.return_value = caps_for_level("admin")
+
+        app, mock_db = _make_app(user)
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run = MagicMock()
+        no_run.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [ws_result, no_run]
+
+        with patch(
+            "terrapod.api.routers.tfe_v2._agent_pool_service.live_pool_ids",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+                res = await client.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+
+        assert res.status_code == 200, res.text
+        codes = [c["code"] for c in res.json()["data"]["attributes"]["health-conditions"]]
+        assert "no_live_agent_pool" not in codes
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch(
+        "terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for",
+        new_callable=AsyncMock,
+    )
+    async def test_all_pools_dark_raises_the_alarm(self, mock_ws_perm, *mocks):
+        """Losing ONE pool is survivable; losing them all is the alertable state."""
+        user = _user(roles=["admin"])
+        a, b = uuid.uuid4(), uuid.uuid4()
+        ws = _mock_workspace(pool_id=a, extra_pool_ids=[str(b)])
+        mock_ws_perm.return_value = caps_for_level("admin")
+
+        app, mock_db = _make_app(user)
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = ws
+        no_run = MagicMock()
+        no_run.scalar_one_or_none.return_value = None
+
+        # One pool still live → no alarm.
+        mock_db.execute.side_effect = [ws_result, no_run]
+        with patch(
+            "terrapod.api.routers.tfe_v2._agent_pool_service.live_pool_ids",
+            new_callable=AsyncMock,
+            return_value={b},
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+                res = await client.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+        assert res.status_code == 200, res.text
+        codes = [c["code"] for c in res.json()["data"]["attributes"]["health-conditions"]]
+        assert "no_live_agent_pool" not in codes
+
+        # Both dark → alarm.
+        mock_db.execute.side_effect = [ws_result, no_run]
+        with patch(
+            "terrapod.api.routers.tfe_v2._agent_pool_service.live_pool_ids",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as client:
+                res = await client.get(f"/api/v2/workspaces/ws-{ws.id}", headers=_AUTH)
+        assert res.status_code == 200, res.text
+        conditions = res.json()["data"]["attributes"]["health-conditions"]
+        stranded = [c for c in conditions if c["code"] == "no_live_agent_pool"]
+        assert len(stranded) == 1
+        assert stranded[0]["severity"] == "error"

--- a/services/tests/integration/test_multi_pool_dispatch.py
+++ b/services/tests/integration/test_multi_pool_dispatch.py
@@ -1,0 +1,160 @@
+"""Integration: multi-pool run dispatch against real Postgres (#1085).
+
+The property that matters is **exactly-once execution**. A workspace can name
+several agent pools and every one of them is offered the run, so the obvious
+worry is "does offering it to N pools produce N claims?" It cannot — the run is
+a single row claimed under ``SELECT … FOR UPDATE SKIP LOCKED`` — but that is a
+Postgres-row-level guarantee, which mocked tests cannot demonstrate. Hence a
+real engine.
+"""
+
+import asyncio
+
+import pytest
+from sqlalchemy import select
+
+from terrapod.db.models import AgentPool, ConfigurationVersion, Run, Workspace
+from terrapod.db.session import get_db_session
+from terrapod.services import run_service
+
+pytestmark = pytest.mark.integration
+
+
+async def _seed(pool_names: list[str]) -> tuple[Workspace, list[AgentPool]]:
+    """Create a workspace whose pool set is `pool_names`, plus an uploaded CV."""
+    async with get_db_session() as db:
+        pools = [AgentPool(name=n) for n in pool_names]
+        for p in pools:
+            db.add(p)
+        await db.flush()
+
+        head = pools[0].id
+        extras = [str(p.id) for p in pools[1:]]
+        ws = Workspace(
+            name=f"multi-pool-{pool_names[0]}",
+            execution_mode="agent",
+            agent_pool_id=head,
+            agent_pool_extra_ids=extras,
+        )
+        db.add(ws)
+        await db.flush()
+
+        cv = ConfigurationVersion(workspace_id=ws.id, status="uploaded", source="tfe-api")
+        db.add(cv)
+        await db.flush()
+        await db.commit()
+        return ws, pools
+
+
+async def _queue_run(ws_id, cv_id, **kwargs) -> Run:
+    async with get_db_session() as db:
+        ws = (await db.execute(select(Workspace).where(Workspace.id == ws_id))).scalar_one()
+        run = await run_service.create_run(db, ws, configuration_version_id=cv_id, **kwargs)
+        run = await run_service.transition_run(db, run, "queued")
+        await db.commit()
+        return run
+
+
+async def _latest_cv(ws_id):
+    async with get_db_session() as db:
+        return (
+            await db.execute(
+                select(ConfigurationVersion).where(ConfigurationVersion.workspace_id == ws_id)
+            )
+        ).scalar_one()
+
+
+class TestMultiPoolClaim:
+    async def test_run_snapshots_the_whole_pool_set(self, app):
+        ws, pools = await _seed(["snap-a", "snap-b", "snap-c"])
+        cv = await _latest_cv(ws.id)
+        run = await _queue_run(ws.id, cv.id)
+
+        async with get_db_session() as db:
+            stored = (await db.execute(select(Run).where(Run.id == run.id))).scalar_one()
+            assert stored.pool_id == pools[0].id
+            assert stored.pool_extra_ids == [str(pools[1].id), str(pools[2].id)]
+
+    async def test_a_pool_that_is_not_element_zero_can_claim(self, app):
+        ws, pools = await _seed(["claim-a", "claim-b"])
+        cv = await _latest_cv(ws.id)
+        run = await _queue_run(ws.id, cv.id)
+
+        async with get_db_session() as db:
+            import uuid as _uuid
+
+            claim = await run_service.claim_next_run(db, _uuid.uuid4(), pools[1].id, "listener-b")
+            await db.commit()
+
+        assert claim is not None
+        claimed, phase = claim
+        assert phase == "plan"
+        assert claimed.id == run.id
+        # The run now names the pool executing it.
+        assert claimed.pool_id == pools[1].id
+
+    async def test_concurrent_claims_from_both_pools_yield_exactly_one(self, app):
+        """The whole point: offering a run to N pools must not run it N times.
+
+        Two listeners in different pools race for the same run. SKIP LOCKED
+        means exactly one transaction sees a claimable row; the other gets
+        nothing rather than blocking or double-claiming.
+        """
+        import uuid as _uuid
+
+        ws, pools = await _seed(["race-a", "race-b"])
+        cv = await _latest_cv(ws.id)
+        await _queue_run(ws.id, cv.id)
+
+        async def _try_claim(pool_id):
+            async with get_db_session() as db:
+                claim = await run_service.claim_next_run(db, _uuid.uuid4(), pool_id, "racer")
+                await db.commit()
+                return claim
+
+        results = await asyncio.gather(
+            _try_claim(pools[0].id),
+            _try_claim(pools[1].id),
+            return_exceptions=True,
+        )
+        claims = [r for r in results if isinstance(r, tuple)]
+        assert len(claims) == 1, f"expected exactly one claim, got {results}"
+
+        # And the run is in-flight exactly once.
+        async with get_db_session() as db:
+            runs = list((await db.execute(select(Run).where(Run.workspace_id == ws.id))).scalars())
+            assert len(runs) == 1
+            assert runs[0].status == "planning"
+
+    async def test_single_pool_workspace_is_unchanged(self, app):
+        """Back-compat: one pool behaves exactly as it did before #1085."""
+        import uuid as _uuid
+
+        ws, pools = await _seed(["solo"])
+        cv = await _latest_cv(ws.id)
+        run = await _queue_run(ws.id, cv.id)
+
+        async with get_db_session() as db:
+            stored = (await db.execute(select(Run).where(Run.id == run.id))).scalar_one()
+            assert stored.pool_id == pools[0].id
+            assert stored.pool_extra_ids == []
+
+            claim = await run_service.claim_next_run(db, _uuid.uuid4(), pools[0].id, "listener-1")
+            await db.commit()
+        assert claim is not None
+        assert claim[0].pool_id == pools[0].id
+
+    async def test_a_pool_outside_the_set_claims_nothing(self, app):
+        import uuid as _uuid
+
+        ws, _pools = await _seed(["scoped-a", "scoped-b"])
+        cv = await _latest_cv(ws.id)
+        await _queue_run(ws.id, cv.id)
+
+        async with get_db_session() as db:
+            stranger = AgentPool(name="unrelated")
+            db.add(stranger)
+            await db.flush()
+            claim = await run_service.claim_next_run(db, _uuid.uuid4(), stranger.id, "outsider")
+            await db.commit()
+        assert claim is None

--- a/services/tests/services/test_pool_set.py
+++ b/services/tests/services/test_pool_set.py
@@ -1,0 +1,92 @@
+"""The workspace agent-pool set (#1085 / #960 phase 0).
+
+The set is FLAT — element 0 carries no dispatch preference, it is only where
+the pre-multi-pool `agent_pool_id` column keeps a value so un-upgraded clients
+keep working. These tests pin that split, and the normalisation that stops a
+malformed or duplicated id reaching the dispatcher.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+from terrapod.services import pool_set
+
+
+def _ws(pool_id=None, extras=None):
+    return SimpleNamespace(agent_pool_id=pool_id, agent_pool_extra_ids=extras or [])
+
+
+class TestWorkspacePoolIDs:
+    def test_no_pool_is_empty_set(self):
+        assert pool_set.workspace_pool_ids(_ws()) == []
+
+    def test_single_pool_matches_pre_multi_pool_behaviour(self):
+        p = uuid.uuid4()
+        assert pool_set.workspace_pool_ids(_ws(p)) == [p]
+
+    def test_element_zero_first_then_the_rest(self):
+        a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        assert pool_set.workspace_pool_ids(_ws(a, [str(b), str(c)])) == [a, b, c]
+
+    def test_null_extras_column_tolerated(self):
+        # A row written before the column existed reads back as NULL, not [].
+        p = uuid.uuid4()
+        assert pool_set.workspace_pool_ids(_ws(p, None)) == [p]
+
+    def test_duplicate_of_element_zero_is_dropped(self):
+        p = uuid.uuid4()
+        assert pool_set.workspace_pool_ids(_ws(p, [str(p)])) == [p]
+
+
+class TestNormalise:
+    def test_accepts_prefixed_and_raw_ids(self):
+        p = uuid.uuid4()
+        assert pool_set.normalise([f"apool-{p}"]) == [p]
+        assert pool_set.normalise([str(p)]) == [p]
+        assert pool_set.normalise([p]) == [p]
+
+    def test_drops_blanks_and_garbage(self):
+        p = uuid.uuid4()
+        assert pool_set.normalise([None, "", "not-a-uuid", p]) == [p]
+
+    def test_preserves_declared_order(self):
+        a, b = uuid.uuid4(), uuid.uuid4()
+        assert pool_set.normalise([b, a]) == [b, a]
+        assert pool_set.normalise([a, b]) == [a, b]
+
+    def test_deduplicates(self):
+        p = uuid.uuid4()
+        assert pool_set.normalise([p, f"apool-{p}", str(p)]) == [p]
+
+
+class TestSplit:
+    def test_empty_set_clears_both_columns(self):
+        assert pool_set.split([]) == (None, [])
+
+    def test_head_and_string_tail(self):
+        a, b = uuid.uuid4(), uuid.uuid4()
+        head, extras = pool_set.split([a, b])
+        assert head == a
+        # The tail lands in a JSONB column, so it must be JSON-native strings.
+        assert extras == [str(b)]
+        assert all(isinstance(e, str) for e in extras)
+
+    def test_round_trips_through_the_workspace_reader(self):
+        a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        head, extras = pool_set.split([a, b, c])
+        assert pool_set.workspace_pool_ids(_ws(head, extras)) == [a, b, c]
+
+
+class TestRunPoolIDs:
+    def test_candidate_set_from_snapshot(self):
+        a, b = uuid.uuid4(), uuid.uuid4()
+        run = SimpleNamespace(pool_id=a, pool_extra_ids=[str(b)])
+        assert pool_set.run_pool_ids(run) == [a, b]
+
+    def test_run_without_the_column_still_resolves(self):
+        # A Run object built before the column existed (or a lightweight stub).
+        a = uuid.uuid4()
+        assert pool_set.run_pool_ids(SimpleNamespace(pool_id=a)) == [a]
+
+    def test_unassigned_run_has_no_candidates(self):
+        assert pool_set.run_pool_ids(SimpleNamespace(pool_id=None, pool_extra_ids=[])) == []

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -822,13 +822,14 @@ class TestPoolQueueDepth:
         p1 = uuid.uuid4()  # 3 queued
         p2 = uuid.uuid4()  # idle → explicit 0, not absent
 
-        counts_result = MagicMock()
-        counts_result.all.return_value = [(p1, 3)]
+        # Rows are (pool_id, pool_extra_ids) — one row per queued run.
+        queued_result = MagicMock()
+        queued_result.all.return_value = [(p1, []), (p1, []), (p1, [])]
         pools_result = MagicMock()
         pools_result.all.return_value = [(p1,), (p2,)]
 
         db = AsyncMock()
-        db.execute.side_effect = [counts_result, pools_result]
+        db.execute.side_effect = [queued_result, pools_result]
 
         await _refresh_pool_queue_depth(db)
 
@@ -839,17 +840,40 @@ class TestPoolQueueDepth:
         from terrapod.api.metrics import POOL_QUEUED_RUNS
 
         p3 = uuid.uuid4()  # has queued runs but the pool row is gone
-        counts_result = MagicMock()
-        counts_result.all.return_value = [(p3, 2)]
+        queued_result = MagicMock()
+        queued_result.all.return_value = [(p3, []), (p3, [])]
         pools_result = MagicMock()
         pools_result.all.return_value = []
 
         db = AsyncMock()
-        db.execute.side_effect = [counts_result, pools_result]
+        db.execute.side_effect = [queued_result, pools_result]
 
         await _refresh_pool_queue_depth(db)
 
         assert POOL_QUEUED_RUNS.labels(pool_id=str(p3))._value.get() == 2
+
+    async def test_multi_pool_run_counts_toward_every_candidate(self):
+        """A run claimable by two pools is backlog for both (#1085).
+
+        The gauge answers "what could this pool be asked to run", so the same
+        run appears under each pool that could claim it.
+        """
+        from terrapod.api.metrics import POOL_QUEUED_RUNS
+
+        primary = uuid.uuid4()
+        fallback = uuid.uuid4()
+        queued_result = MagicMock()
+        queued_result.all.return_value = [(primary, [str(fallback)])]
+        pools_result = MagicMock()
+        pools_result.all.return_value = [(primary,), (fallback,)]
+
+        db = AsyncMock()
+        db.execute.side_effect = [queued_result, pools_result]
+
+        await _refresh_pool_queue_depth(db)
+
+        assert POOL_QUEUED_RUNS.labels(pool_id=str(primary))._value.get() == 1
+        assert POOL_QUEUED_RUNS.labels(pool_id=str(fallback))._value.get() == 1
 
     async def test_db_error_fails_open(self):
         db = AsyncMock()

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -121,6 +121,10 @@ def _mock_run(**kwargs):
     run.listener_id = kwargs.get("listener_id", None)
     run.locked = kwargs.get("locked", False)
     run.source = kwargs.get("source", "tfe-api")
+    # Multi-pool candidate set (#1085) — real columns with real defaults; a
+    # MagicMock here silently defeats the pool-set resolution.
+    run.pool_id = kwargs.get("pool_id", None)
+    run.pool_extra_ids = kwargs.get("pool_extra_ids", [])
     return run
 
 
@@ -669,6 +673,46 @@ class TestClaimNextRun:
         result = await claim_next_run(db, uuid.uuid4(), pool_id)
         assert result is None
 
+    async def test_claiming_pool_is_recorded_on_the_run(self):
+        """A fallback pool that claims the run becomes the run's pool (#1085).
+
+        Everything downstream — cancel_job, check_job_status, log streaming,
+        the terminal queue re-drive — addresses `run.pool_id`, so it has to
+        name the pool actually executing the run, not whichever pool happened
+        to be element 0 of the workspace's set.
+        """
+        primary = uuid.uuid4()
+        fallback = uuid.uuid4()
+        db = AsyncMock(spec=AsyncSession)
+        run = _mock_run(status="queued", pool_id=primary, pool_extra_ids=[str(fallback)])
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = run
+        db.execute.return_value = mock_result
+
+        result = await claim_next_run(db, uuid.uuid4(), fallback, "listener-b")
+        assert result is not None
+        claimed_run, _ = result
+        assert claimed_run.pool_id == fallback
+        # The candidate set survives the claim, only re-ordered around the
+        # winner: the apply phase is claimed separately and must still be able
+        # to fall through if this pool goes dark between plan and apply.
+        assert claimed_run.pool_extra_ids == [str(primary)]
+
+    async def test_single_pool_claim_leaves_the_set_untouched(self):
+        """Back-compat: a single-pool workspace behaves exactly as before."""
+        pool_id = uuid.uuid4()
+        db = AsyncMock(spec=AsyncSession)
+        run = _mock_run(status="queued", pool_id=pool_id)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = run
+        db.execute.return_value = mock_result
+
+        result = await claim_next_run(db, uuid.uuid4(), pool_id, "listener-1")
+        assert result is not None
+        claimed_run, _ = result
+        assert claimed_run.pool_id == pool_id
+        assert claimed_run.pool_extra_ids == []
+
 
 # ── _publish_run_event ────────────────────────────────────────────────
 
@@ -716,6 +760,34 @@ class TestPublishRunAvailable:
 
         # Should not raise
         await _publish_run_available(run)
+
+    @patch("terrapod.redis.client.publish_listener_event", new_callable=AsyncMock)
+    async def test_fans_out_to_every_candidate_pool(self, mock_publish):
+        """Every pool in the run's set is notified (#1085).
+
+        The pools are equally eligible, so all of them are told there is
+        claimable work — the first listener to claim wins, and SKIP LOCKED
+        guarantees only one does.
+        """
+        primary = uuid.uuid4()
+        fallback = uuid.uuid4()
+        run = _mock_run(status="queued", pool_id=primary, pool_extra_ids=[str(fallback)])
+
+        await _publish_run_available(run)
+
+        channels = [c.args[0] for c in mock_publish.call_args_list]
+        assert channels == [str(primary), str(fallback)]
+        # Each event names the pool it was addressed to — a listener uses it to
+        # decide whether the notification is for a pool it serves.
+        for call in mock_publish.call_args_list:
+            assert call.args[1]["event"] == "run_available"
+            assert call.args[1]["pool_id"] == call.args[0]
+
+    @patch("terrapod.redis.client.publish_listener_event", new_callable=AsyncMock)
+    async def test_unassigned_run_publishes_nothing(self, mock_publish):
+        run = _mock_run(status="queued", pool_id=None)
+        await _publish_run_available(run)
+        mock_publish.assert_not_called()
 
 
 # ── complete_plan / complete_apply ────────────────────────────────────


### PR DESCRIPTION
Server + Go consumers for multi-pool workspace routing. Web, MCP, autodiscovery templating and the remaining docs follow in a second PR.

A workspace could target exactly one agent pool, so a pool with no healthy listener — a dead cluster, a lost region, a pool scaled to zero — meant every run for that workspace waited indefinitely. Within a pool we already had HA; across pools we had none.

## What it does

A workspace can now name several pools. The set is **flat**: a queued run is offered to every pool at once and whichever pool has a live listener claims it first. No primary, no ordering preference, no rotation.

**Exactly-once is unaffected.** The run is still one row claimed under `SELECT … FOR UPDATE SKIP LOCKED`, so offering it to N pools cannot produce N claims. That is a row-level guarantee mocked tests can't demonstrate, so it's exercised against real Postgres: two listeners in different pools race the same run, exactly one claim survives.

On claim the run records the pool that took it, so cancellation, job-status queries and log streaming address the cluster actually running it. The candidate set is preserved (only re-ordered around the winner) so the apply phase can still fall through if that pool goes dark between plan and apply.

`pool:assign` is required on **every** pool in the set, at every write path — a caller may not attach a workspace to a pool they could not have attached it to on its own.

## Backward compatibility

This governs the shape of the whole change.

| Surface | How it stays intact |
|---|---|
| **Attributes** | `agent-pool-id`, `agent-pool-name` and the `agent-pool` relationship all stay, resolving to element 0. `agent-pool-ids` and an `agent-pools` to-many relationship are *added* alongside. |
| **Write path** | A client sending only `agent-pool-id` behaves exactly as before. Both in one request ⇒ 422. |
| **DB** | The existing `agent_pool_id` column keeps holding element 0; a new nullable JSONB column holds the remainder. The split is a compat device, not a hierarchy — it is what makes a rolling upgrade safe, because an API replica still on the previous release writes only the scalar and that write stays meaningful. One new full-list column would let it be silently ignored and dispatch to pools the operator had just removed. |
| **Runner/listener wire** | **Unchanged.** Fan-out is entirely server-side, so a lagging listener works unmodified and needs no redeploy. |
| **Helm/config** | No new key. |

Contract snapshots moved **additively only** — one attribute, three SDK fields, two provider schema entries; nothing removed.

The one behaviour worth knowing: `agent-pool-id` means "exactly this one pool", so it replaces the set. A tool that manages `agent_pool_id` (an un-upgraded provider, say) will drop pools added elsewhere on its next apply. That's deliberate and documented; the removal is logged.

## Visibility

Per the monitoring requirement on the epic:

- a workspace health condition when **no** pool in its set has a live listener — distinct from `no_agent_pool` (none assigned at all);
- `terrapod_pool_live` per pool, and `terrapod_workspaces_without_live_pool` — the SLO to alert on, since losing one pool is now survivable;
- the per-pool queued gauge counts a run against every pool that could claim it.

Liveness returns "unknown" rather than an empty set when Redis is unreachable, so a blip can't light up a false "no runner" banner across the estate. The workspace list resolves it once per request in a single Redis round-trip rather than per row, which would have undone the paged fast path from #1056.

## Verification

- `make test` — 3298 passed, including 5 new integration tests against real Postgres and back-compat regression tests pinning the single-pool serialization and write path.
- `go build ./... && go test ./...` green in `go-terrapod/` and `provider/`; both goldens regenerated additively.
- Live Tilt F-gate (two pools, kill one listener, confirm fall-through) still to run before this is called done.

Closes #1085
Part of #960
