### PR TITLE
refactor(1087): model the workspace pool set as a mapping table with real FKs

### DIFF
--- a/alembic/versions/598eb2329821_workspace_agent_pools.py
+++ b/alembic/versions/598eb2329821_workspace_agent_pools.py
@@ -1,0 +1,131 @@
+"""workspace→agent-pool mapping table (#1087 / #960 phase 0)
+
+Replaces the two-column pool set on `workspaces` (`agent_pool_id` holding
+element 0, `agent_pool_extra_ids` JSONB holding the rest) with a mapping table
+carrying a real foreign key on each side.
+
+The columns did not earn their keep and the split left an integrity hole:
+`delete_pool` is a bare DELETE that relies on `agent_pool_id`'s
+`ON DELETE SET NULL` to detach workspaces, so the JSONB half — which can carry
+no foreign key — left a dangling id in every set that named a deleted pool.
+Both sides of the mapping table CASCADE, so a pool deletion now detaches
+cleanly everywhere with no application-side sweeping.
+
+**This drops two columns (a contraction).** Migrations run as a Helm
+`pre-upgrade` hook, so during a rolling upgrade the new schema lands before the
+new pods: an API replica still on the previous release will error on workspace
+queries until the rollout completes. That is a rollout-window cost, minutes
+long and self-healing. It is not a compatibility break — the database is not a
+public surface, and the API's `agent-pool-id` / `agent-pool-ids` attributes are
+unchanged.
+
+Revision ID: 598eb2329821
+Revises: 9b7161d25c9e
+Create Date: 2026-07-28
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "598eb2329821"
+down_revision: str | None = "9b7161d25c9e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_agent_pools",
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_pool_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("ordinal", sa.Integer(), server_default="0", nullable=False),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["agent_pool_id"], ["agent_pools.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("workspace_id", "agent_pool_id"),
+    )
+    # Claim-side lookups go workspace → pools; the pool → workspaces direction
+    # is what "which workspaces would this pool have to run?" needs.
+    op.create_index(
+        "ix_workspace_agent_pools_pool",
+        "workspace_agent_pools",
+        ["agent_pool_id"],
+    )
+
+    # Backfill: element 0 from the scalar column, the remainder from the JSONB
+    # list, preserving order. `WITH ORDINALITY` numbers the JSONB entries from
+    # 1, which is exactly the ordinal they need given element 0 takes 0.
+    op.execute(
+        """
+        INSERT INTO workspace_agent_pools (workspace_id, agent_pool_id, ordinal)
+        SELECT id, agent_pool_id, 0
+        FROM workspaces
+        WHERE agent_pool_id IS NOT NULL
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO workspace_agent_pools (workspace_id, agent_pool_id, ordinal)
+        SELECT w.id, extra.value::uuid, extra.ordinality
+        FROM workspaces w
+        CROSS JOIN LATERAL jsonb_array_elements_text(w.agent_pool_extra_ids)
+             WITH ORDINALITY AS extra(value, ordinality)
+        WHERE jsonb_typeof(w.agent_pool_extra_ids) = 'array'
+          AND EXISTS (SELECT 1 FROM agent_pools p WHERE p.id = extra.value::uuid)
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    op.drop_column("workspaces", "agent_pool_extra_ids")
+    op.drop_column("workspaces", "agent_pool_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column("agent_pool_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "agent_pool_extra_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+    )
+    op.create_foreign_key(
+        "workspaces_agent_pool_id_fkey",
+        "workspaces",
+        "agent_pools",
+        ["agent_pool_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.execute(
+        """
+        UPDATE workspaces w
+        SET agent_pool_id = link.agent_pool_id
+        FROM workspace_agent_pools link
+        WHERE link.workspace_id = w.id AND link.ordinal = 0
+        """
+    )
+    op.execute(
+        """
+        UPDATE workspaces w
+        SET agent_pool_extra_ids = COALESCE(rest.ids, '[]'::jsonb)
+        FROM (
+            SELECT workspace_id,
+                   jsonb_agg(agent_pool_id::text ORDER BY ordinal) AS ids
+            FROM workspace_agent_pools
+            WHERE ordinal > 0
+            GROUP BY workspace_id
+        ) AS rest
+        WHERE rest.workspace_id = w.id
+        """
+    )
+    op.drop_index("ix_workspace_agent_pools_pool", table_name="workspace_agent_pools")
+    op.drop_table("workspace_agent_pools")

--- a/services/terrapod/api/routers/catalog.py
+++ b/services/terrapod/api/routers/catalog.py
@@ -56,7 +56,7 @@ from terrapod.db.models import (
 )
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services import catalog_service, run_service
+from terrapod.services import catalog_service, pool_set, run_service
 from terrapod.services.catalog_rbac_service import (
     resolve_catalog_capabilities_for,
 )
@@ -144,7 +144,9 @@ def _instance_json(ws: Workspace) -> dict:
             "name": ws.name,
             "catalog-item-id": str(ws.catalog_item_id) if ws.catalog_item_id else None,
             "catalog-version-pin": ws.catalog_version_pin,
-            "agent-pool-id": f"apool-{ws.agent_pool_id}" if ws.agent_pool_id else None,
+            "agent-pool-id": (
+                f"apool-{_ws_pools[0]}" if (_ws_pools := pool_set.workspace_pool_ids(ws)) else None
+            ),
             "owner-email": ws.owner_email or "",
             "labels": dict(ws.labels or {}),
         },
@@ -164,10 +166,13 @@ def _instance_json(ws: Workspace) -> dict:
             **(
                 {
                     "agent-pool": {
-                        "data": {"id": f"apool-{ws.agent_pool_id}", "type": "agent-pools"},
+                        "data": {
+                            "id": f"apool-{pool_set.workspace_pool_ids(ws)[0]}",
+                            "type": "agent-pools",
+                        },
                     },
                 }
-                if ws.agent_pool_id
+                if pool_set.workspace_pool_ids(ws)
                 else {}
             ),
             "workspace": {"data": {"id": f"ws-{ws.id}", "type": "workspaces"}},

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -730,6 +730,7 @@ def _workspace_json(
     """
     caps = caps or frozenset()
     ws_pools = pool_set.workspace_pool_ids(ws)
+    ws_pool_names = pool_set.workspace_pool_names(ws)
 
     latest_run_attr = None
     if latest_run is not None:
@@ -801,7 +802,7 @@ def _workspace_json(
                 # — a projection, NOT a preference.
                 "agent-pool-id": f"apool-{ws_pools[0]}" if ws_pools else None,
                 "agent-pool-ids": [f"apool-{p}" for p in ws_pools],
-                "agent-pool-name": ws.agent_pool.name if ws.agent_pool else None,
+                "agent-pool-name": (ws_pool_names[0] if ws_pool_names else None),
                 "vcs-connection-name": ws.vcs_connection.name if ws.vcs_connection else None,
                 "labels": ws.labels or {},
                 # `tag-names` is what OpenTofu/Terraform's cloud backend
@@ -1097,7 +1098,7 @@ async def _resolve_pool_set_attrs(
     attrs: dict,
     db: AsyncSession,
     user: AuthenticatedUser,
-) -> object | tuple[uuid.UUID | None, list[str]]:
+) -> object | list[uuid.UUID]:
     """Resolve the requested agent-pool set from workspace write attributes.
 
     Accepts either form (#1085):
@@ -1113,10 +1114,10 @@ async def _resolve_pool_set_attrs(
     the caller meant is exactly the kind of ambiguity that loses a pool.
 
     Returns ``_POOL_SET_UNSET`` when neither attribute is present (so a PATCH
-    that doesn't mention pools leaves the set alone), otherwise the
-    ``(element 0, remainder)`` storage split. ``pool:assign`` is required on
-    **every** pool in the set — a caller may not attach a workspace to a pool
-    they could not attach it to individually.
+    that doesn't mention pools leaves the set alone), otherwise the resolved
+    pool ids in declared order. ``pool:assign`` is required on **every** pool
+    in the set — a caller may not attach a workspace to a pool they could not
+    attach it to individually.
     """
     has_singular = "agent-pool-id" in attrs
     has_plural = "agent-pool-ids" in attrs
@@ -1165,7 +1166,7 @@ async def _resolve_pool_set_attrs(
                 detail="Requires write permission on agent pool",
             )
 
-    return pool_set.split(requested)
+    return requested
 
 
 @router.post("/organizations/default/workspaces")
@@ -1198,9 +1199,7 @@ async def create_workspace(
     from terrapod.config import settings
 
     resolved_pools = await _resolve_pool_set_attrs(attrs, db, user)
-    agent_pool_id, agent_pool_extra_ids = (
-        (None, []) if resolved_pools is _POOL_SET_UNSET else resolved_pools
-    )
+    requested_pool_ids: list = [] if resolved_pools is _POOL_SET_UNSET else resolved_pools
 
     execution_mode = attrs.get("execution-mode", "local")
     if execution_mode not in ("local", "agent"):
@@ -1222,8 +1221,6 @@ async def create_workspace(
         resource_memory=attrs.get("resource-memory", "2Gi"),
         labels=validate_labels(attrs.get("labels", {})),
         owner_email=user.email,
-        agent_pool_id=agent_pool_id,
-        agent_pool_extra_ids=agent_pool_extra_ids,
         vcs_connection_id=vcs_connection_id,
         vcs_repo_url=attrs.get("vcs-repo-url", ""),
         vcs_branch=attrs.get("vcs-branch", ""),
@@ -1262,6 +1259,7 @@ async def create_workspace(
         # Slack opt-in channel (#556): empty = silent for this workspace.
         slack_channel=(attrs.get("slack-channel") or "").strip()[:128],
     )
+    pool_set.set_workspace_pools(ws, requested_pool_ids)
     db.add(ws)
     await db.commit()
     await db.refresh(ws)
@@ -1743,7 +1741,7 @@ async def update_workspace(
     resolved_pools = await _resolve_pool_set_attrs(attrs, db, user)
     if resolved_pools is not _POOL_SET_UNSET:
         previous = pool_set.workspace_pool_ids(ws)
-        ws.agent_pool_id, ws.agent_pool_extra_ids = resolved_pools  # type: ignore[misc]
+        pool_set.set_workspace_pools(ws, resolved_pools)  # type: ignore[arg-type]
         dropped = [p for p in previous if p not in pool_set.workspace_pool_ids(ws)]
         if dropped and "agent-pool-ids" not in attrs:
             # A singular write replaced a multi-pool set. That is the documented

--- a/services/terrapod/api/routers/workspace_bulk.py
+++ b/services/terrapod/api/routers/workspace_bulk.py
@@ -82,7 +82,9 @@ def _ws_summary(ws: Workspace) -> dict[str, Any]:
         "execution-mode": ws.execution_mode,
         "execution-backend": ws.execution_backend,
         "terraform-version": ws.terraform_version,
-        "agent-pool-id": f"apool-{ws.agent_pool_id}" if ws.agent_pool_id else None,
+        "agent-pool-id": (
+            f"apool-{_pools[0]}" if (_pools := pool_set.workspace_pool_ids(ws)) else None
+        ),
         "agent-pool-ids": [f"apool-{p}" for p in pool_set.workspace_pool_ids(ws)],
         "labels": ws.labels or {},
     }
@@ -180,6 +182,12 @@ def validate_notification_specs(items: Any) -> list[dict]:
     return out
 
 
+# Sentinel key in the validated plan's `fields` map. The pool set is a
+# relationship, not a column, so `_apply` routes it through
+# `pool_set.set_workspace_pools` instead of setattr.
+_POOL_SET_FIELD = "__agent_pool_set__"
+
+
 async def _validate_pool_set(
     update: dict, db: AsyncSession, user: AuthenticatedUser
 ) -> dict[str, Any]:
@@ -233,8 +241,8 @@ async def _validate_pool_set(
                     detail=f"write permission on agent pool '{pool.name}' is required",
                 )
 
-    head, extras = pool_set.split(requested)
-    return {"agent_pool_id": head, "agent_pool_extra_ids": extras}
+    # Not an ORM column — the caller applies it via pool_set.set_workspace_pools.
+    return {_POOL_SET_FIELD: requested}
 
 
 async def _validate_update(
@@ -310,6 +318,16 @@ def _diff_for(ws: Workspace, plan: dict[str, Any]) -> dict[str, Any]:
     """Compute the per-workspace change set without mutating."""
     diff: dict[str, Any] = {}
     for attr, new in plan["fields"].items():
+        if attr == _POOL_SET_FIELD:
+            # The pool set is a relationship, so the "before" is read through
+            # the same helper every other caller uses, not off a column.
+            old = pool_set.workspace_pool_ids(ws)
+            if old != new:
+                diff["agent-pool-ids"] = {
+                    "from": [f"apool-{p}" for p in old],
+                    "to": [f"apool-{p}" for p in new],
+                }
+            continue
         old = getattr(ws, attr)
         if old != new:
             diff[attr] = {"from": _jsonable(old), "to": _jsonable(new)}
@@ -340,7 +358,10 @@ async def _apply(
         diff = _diff_for(ws, plan)
 
         for attr, new in plan["fields"].items():
-            setattr(ws, attr, new)
+            if attr == _POOL_SET_FIELD:
+                pool_set.set_workspace_pools(ws, new)
+            else:
+                setattr(ws, attr, new)
 
         for spec in plan["run_tasks"] or []:
             existing = (

--- a/services/terrapod/cli/bootstrap.py
+++ b/services/terrapod/cli/bootstrap.py
@@ -38,6 +38,7 @@ from terrapod.db.models import (
     Workspace,
     now_utc,
 )
+from terrapod.services import pool_set
 
 # Use stdlib logging — structlog isn't configured yet during bootstrap
 logger = logging.getLogger("terrapod.bootstrap")
@@ -213,10 +214,11 @@ async def _bootstrap_sample_workspace(
         execution_mode="agent",
         execution_backend="tofu",
         terraform_version="1.12",
-        agent_pool_id=pool_id,
         owner_email=owner_email,
         labels={"env": "demo", "team": "platform"},
     )
+    if pool_id:
+        pool_set.set_workspace_pools(workspace, [pool_id])
     session.add(workspace)
     await session.flush()
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -294,25 +294,19 @@ class Workspace(Base):
     working_directory: Mapped[str] = mapped_column(String(500), nullable=False, default="")
     locked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     lock_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    agent_pool_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True),
-        ForeignKey("agent_pools.id", ondelete="SET NULL"),
-        nullable=True,
+    # The agent pools this workspace's runs may execute on (#1085, #1087).
+    # A FLAT set: every pool in it is equally eligible to claim a run — there is
+    # no primary and no dispatch preference. `ordinal` is display order only.
+    #
+    # A mapping table rather than columns, because both sides are real foreign
+    # keys: deleting a pool detaches it from every workspace by CASCADE, with no
+    # application-side sweeping to forget. Resolve via
+    # `pool_set.workspace_pool_ids()` rather than walking the links by hand.
+    agent_pool_links: Mapped[list["WorkspaceAgentPool"]] = relationship(
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="WorkspaceAgentPool.ordinal",
     )
-    agent_pool: Mapped["AgentPool | None"] = relationship(
-        "AgentPool", foreign_keys=[agent_pool_id], lazy="joined"
-    )
-    # Multi-pool routing (#1085). The workspace's pool set is
-    # `[agent_pool_id] + agent_pool_extra_ids` — a FLAT set: every pool in it is
-    # equally eligible to claim a run, there is no primary and no preference.
-    # The split across two columns is a backward-compatibility device, not a
-    # hierarchy: `agent_pool_id` predates multi-pool and is still read by
-    # un-upgraded clients (provider, SDK, MCP, tfci), so it keeps holding
-    # element 0. Storing the whole set in one new column instead would let an
-    # old API replica's write of `agent_pool_id` during a rolling upgrade be
-    # silently ignored — dispatching to pools the operator had just removed.
-    # Always resolve via `pool_set.workspace_pool_ids()`, never read raw.
-    agent_pool_extra_ids: Mapped[list[Any]] = mapped_column(JSONB, default=list, nullable=False)
     resource_cpu: Mapped[str] = mapped_column(String(20), nullable=False, default="1")
     resource_memory: Mapped[str] = mapped_column(String(20), nullable=False, default="2Gi")
 
@@ -1350,6 +1344,37 @@ class VariableSetVariable(Base):
         sa.UniqueConstraint("variable_set_id", "key", name="uq_variable_set_variables"),
         Index("ix_variable_set_variables_set_id", "variable_set_id"),
     )
+
+
+class WorkspaceAgentPool(Base):
+    """Junction table linking workspaces to the agent pools they may run on.
+
+    Multi-pool routing (#1085, #1087): a workspace's runs are offered to every
+    pool in this set at once and whichever pool has a live listener claims
+    first. The set is **flat** — ``ordinal`` fixes display order so the UI and
+    API echo back what the operator typed, and carries no dispatch meaning.
+
+    Both columns are real foreign keys with ``ON DELETE CASCADE``, which is the
+    point: deleting an agent pool detaches it from every workspace that named
+    it, with no application-side cleanup to forget. The composite primary key
+    also makes a pool physically unable to appear twice in one set.
+    """
+
+    __tablename__ = "workspace_agent_pools"
+
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    agent_pool_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_pools.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    agent_pool: Mapped["AgentPool"] = relationship(lazy="joined")
 
 
 class VariableSetWorkspace(Base):

--- a/services/terrapod/services/catalog_service.py
+++ b/services/terrapod/services/catalog_service.py
@@ -43,7 +43,7 @@ from terrapod.db.models import (
     Workspace,
 )
 from terrapod.logging_config import get_logger
-from terrapod.services import run_service, variable_service
+from terrapod.services import pool_set, run_service, variable_service
 
 logger = get_logger(__name__)
 
@@ -547,7 +547,6 @@ async def provision_instance(
         auto_apply=auto_apply,
         execution_backend=settings.default_execution_backend,
         terraform_version=settings.default_terraform_version,
-        agent_pool_id=agent_pool_id,
         labels=labels or {},
         owner_email=user_email,
         catalog_item_id=item.id,
@@ -555,6 +554,7 @@ async def provision_instance(
         # catalog_input_values is set by _materialise to the non-sensitive
         # resolved subset (secrets are write-only and never snapshotted here).
     )
+    pool_set.set_workspace_pools(ws, [agent_pool_id])
     db.add(ws)
     await db.flush()  # assign ws.id
 

--- a/services/terrapod/services/estate_graph_service.py
+++ b/services/terrapod/services/estate_graph_service.py
@@ -37,6 +37,7 @@ from terrapod.db.models import (
     Workspace,
     WorkspaceRemoteStateConsumer,
 )
+from terrapod.services import pool_set
 from terrapod.services.workspace_rbac_service import resolve_workspace_capabilities_for
 
 
@@ -56,8 +57,9 @@ async def derive_estate_graph(db: AsyncSession, user: AuthenticatedUser) -> dict
 
     nodes: list[dict] = []
     for ws in visible.values():
-        if ws.agent_pool_id:
-            pool = pool_name.get(ws.agent_pool_id, "(pool)")
+        _ws_pools = pool_set.workspace_pool_ids(ws)
+        if _ws_pools:
+            pool = pool_name.get(_ws_pools[0], "(pool)")
         else:
             pool = "(local)" if ws.execution_mode == "local" else "(no pool)"
         nodes.append(

--- a/services/terrapod/services/onboarding_service.py
+++ b/services/terrapod/services/onboarding_service.py
@@ -46,6 +46,7 @@ from terrapod.config import settings
 from terrapod.db.models import OnboardingSession, Workspace
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
+from terrapod.services import pool_set
 
 logger = get_logger(__name__)
 
@@ -217,7 +218,7 @@ async def start_discovery(
     if workspace is None:
         raise OnboardingError("workspace no longer exists")
     # D2/D3 need a runner (cloud creds) — agent execution with an assigned pool.
-    if workspace.execution_mode != "agent" or workspace.agent_pool_id is None:
+    if workspace.execution_mode != "agent" or not pool_set.workspace_pool_ids(workspace):
         raise OnboardingError(
             "discovery requires an agent-mode workspace with an assigned agent pool"
         )

--- a/services/terrapod/services/pool_set.py
+++ b/services/terrapod/services/pool_set.py
@@ -1,4 +1,4 @@
-"""The workspace agent-pool set (#1085 / #960 phase 0).
+"""The workspace agent-pool set (#1085 / #1087, #960 phase 0).
 
 A workspace routes its runs to a **set** of agent pools rather than a single
 one. The set is **flat**: every pool in it is equally eligible to claim a run.
@@ -6,36 +6,28 @@ There is no primary, no rank, no preference and no rotation — a queued run is
 offered to all of them at once and whichever pool has a listener that claims it
 first runs it.
 
-The set is stored across two columns, and that split is a *backward-compatibility
-device rather than a hierarchy*:
+It is stored as a mapping table (``workspace_agent_pools``) with a real foreign
+key on each side, so deleting an agent pool detaches it from every workspace by
+``ON DELETE CASCADE`` — no application-side sweeping that a future code path
+could forget. Order is display-only: it is what the operator typed and what the
+UI and API echo back, and carries no dispatch meaning.
 
-* ``agent_pool_id`` predates multi-pool and is still read by clients that have
-  not been upgraded (the Terraform provider, go-terrapod, MCP, ``tfci``), so it
-  keeps holding element 0 and is what the legacy ``agent-pool-id`` attribute
-  resolves to.
-* ``agent_pool_extra_ids`` holds the remainder.
+Runs are deliberately different. A run's candidate pools are a **snapshot**
+frozen at creation (``pool_id`` plus a ``pool_extra_ids`` JSONB list, the same
+shape as the run's other snapshots), because history must not be rewritten by a
+pool being deleted mid-flight. After a claim ``run.pool_id`` holds one true
+value: the pool actually executing the run.
 
-Keeping the pre-existing column authoritative for element 0 is what makes a
-rolling upgrade safe: an API replica still running the previous release writes
-only ``agent_pool_id``, and that write stays meaningful. Had the whole set moved
-into one new column, the old replica's write would be silently ignored and runs
-would dispatch to pools the operator had just removed.
-
-Every caller resolves the set through this module rather than reading either
-column directly, so the storage split never leaks out as a preference order.
+Every caller resolves the set through this module rather than walking the links
+by hand.
 """
 
 from __future__ import annotations
 
 import uuid
-from typing import Any, Protocol
+from typing import Any
 
-
-class _HasPoolSet(Protocol):
-    """Structural type for the two row shapes that carry a pool set."""
-
-    agent_pool_id: uuid.UUID | None
-    agent_pool_extra_ids: list[Any]
+from terrapod.db.models import Workspace, WorkspaceAgentPool
 
 
 def _coerce(value: Any) -> uuid.UUID | None:
@@ -51,8 +43,8 @@ def _coerce(value: Any) -> uuid.UUID | None:
 def normalise(pool_ids: list[Any] | None) -> list[uuid.UUID]:
     """Coerce a raw list to UUIDs, dropping blanks and de-duplicating.
 
-    Order is preserved because it is what the operator typed and what the UI
-    displays back — it carries no dispatch meaning.
+    Order is preserved because it is what the operator typed — it carries no
+    dispatch meaning.
     """
     seen: list[uuid.UUID] = []
     for raw in pool_ids or []:
@@ -62,12 +54,29 @@ def normalise(pool_ids: list[Any] | None) -> list[uuid.UUID]:
     return seen
 
 
-def workspace_pool_ids(workspace: _HasPoolSet) -> list[uuid.UUID]:
-    """The workspace's full pool set, element 0 first.
+def workspace_pool_ids(workspace: Any) -> list[uuid.UUID]:
+    """The workspace's pool set, in display order. Empty when none is assigned."""
+    links = getattr(workspace, "agent_pool_links", None) or []
+    return normalise([link.agent_pool_id for link in links])
 
-    Empty when the workspace has no pool assigned at all.
+
+def workspace_pool_names(workspace: Any) -> list[str]:
+    """Pool names in the same order, for display. Skips any link with no row."""
+    links = getattr(workspace, "agent_pool_links", None) or []
+    return [link.agent_pool.name for link in links if link.agent_pool is not None]
+
+
+def set_workspace_pools(workspace: Workspace, pool_ids: list[Any]) -> list[uuid.UUID]:
+    """Replace the workspace's pool set, returning the resolved ids.
+
+    Assigning the collection (rather than mutating it) lets SQLAlchemy's
+    ``delete-orphan`` cascade remove the rows that are no longer in the set.
     """
-    return normalise([workspace.agent_pool_id, *(workspace.agent_pool_extra_ids or [])])
+    resolved = normalise(pool_ids)
+    workspace.agent_pool_links = [
+        WorkspaceAgentPool(agent_pool_id=pid, ordinal=i) for i, pid in enumerate(resolved)
+    ]
+    return resolved
 
 
 def run_pool_ids(run: Any) -> list[uuid.UUID]:
@@ -75,15 +84,15 @@ def run_pool_ids(run: Any) -> list[uuid.UUID]:
 
     ``run.pool_id`` is included because a claim rewrites it to the pool that
     actually took the run — so after a claim this returns the executing pool
-    first, and before one it returns element 0 first.
+    first, and before one it returns the pool the run was created against.
     """
     return normalise([run.pool_id, *(getattr(run, "pool_extra_ids", None) or [])])
 
 
 def split(pool_ids: list[uuid.UUID]) -> tuple[uuid.UUID | None, list[str]]:
-    """Split a resolved set into the ``(element 0, remainder)`` storage form.
+    """Split a resolved set into the run snapshot's ``(pool_id, extras)`` form.
 
-    The remainder is returned as strings because it lands in a JSONB column.
+    The extras are strings because they land in a JSONB column.
     """
     if not pool_ids:
         return None, []

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -119,8 +119,8 @@ async def _refresh_pool_liveness(db: AsyncSession) -> None:
     Best-effort: never raises into the reconcile cycle.
     """
     from terrapod.api.metrics import POOL_LIVE, WORKSPACES_WITHOUT_LIVE_POOL
-    from terrapod.db.models import AgentPool
-    from terrapod.services import agent_pool_service, pool_set
+    from terrapod.db.models import AgentPool, WorkspaceAgentPool
+    from terrapod.services import agent_pool_service
 
     try:
         pool_ids = [row[0] for row in (await db.execute(select(AgentPool.id))).all()]
@@ -134,19 +134,20 @@ async def _refresh_pool_liveness(db: AsyncSession) -> None:
         for pid in pool_ids:
             POOL_LIVE.labels(pool_id=str(pid)).set(1 if pid in live else 0)
 
-        agent_ws = (
+        assignments = (
             await db.execute(
-                select(Workspace.agent_pool_id, Workspace.agent_pool_extra_ids).where(
-                    Workspace.execution_mode == "agent",
-                    Workspace.agent_pool_id.isnot(None),
-                )
+                select(WorkspaceAgentPool.workspace_id, WorkspaceAgentPool.agent_pool_id)
+                .join(Workspace, Workspace.id == WorkspaceAgentPool.workspace_id)
+                .where(Workspace.execution_mode == "agent")
             )
         ).all()
-        stranded = sum(
-            1
-            for row in agent_ws
-            if not any(p in live for p in pool_set.normalise([row[0], *(row[1] or [])]))
-        )
+        by_workspace: dict[uuid.UUID, list[uuid.UUID]] = {}
+        for ws_id, agent_pool_id in assignments:
+            by_workspace.setdefault(ws_id, []).append(agent_pool_id)
+        # A workspace with no assignment at all is "no pool assigned", which is
+        # its own health condition — this gauge counts the ones that HAVE pools
+        # and have lost every one of them.
+        stranded = sum(1 for pools in by_workspace.values() if not any(p in live for p in pools))
         WORKSPACES_WITHOUT_LIVE_POOL.set(stranded)
     except Exception as e:
         logger.debug("Failed to refresh pool liveness gauges", error=str(e))

--- a/services/terrapod/services/workspace_autodiscovery_service.py
+++ b/services/terrapod/services/workspace_autodiscovery_service.py
@@ -45,6 +45,7 @@ from terrapod.db.models import (
     Workspace,
 )
 from terrapod.logging_config import get_logger
+from terrapod.services import pool_set
 from terrapod.services.label_validation import sanitize_labels
 
 logger = get_logger(__name__)
@@ -276,7 +277,6 @@ async def find_or_autocreate_workspace(
         resource_memory=rule.resource_memory,
         auto_apply=rule.auto_apply,
         working_directory=root_directory,
-        agent_pool_id=rule.agent_pool_id,
         labels=safe_labels,
         owner_email=rule.owner_email or "",
         var_files=list(rule.var_files or []),
@@ -295,6 +295,9 @@ async def find_or_autocreate_workspace(
         # working_directory-targeted one from now on.
         trigger_prefixes=[root_directory] if root_directory else [],
     )
+    # The rule's pool template seeds the workspace's pool set (#1087).
+    if rule.agent_pool_id:
+        pool_set.set_workspace_pools(ws, [rule.agent_pool_id])
     db.add(ws)
     try:
         await db.flush()

--- a/services/terrapod/services/workspace_search_service.py
+++ b/services/terrapod/services/workspace_search_service.py
@@ -20,9 +20,9 @@ import uuid
 from typing import Any
 
 from pydantic import BaseModel, Field
-from sqlalchemy import Select, or_, select
+from sqlalchemy import Select, select
 
-from terrapod.db.models import Workspace
+from terrapod.db.models import Workspace, WorkspaceAgentPool
 
 
 class WorkspaceFilterError(ValueError):
@@ -140,10 +140,12 @@ def build_workspace_query(f: WorkspaceFilter) -> Select[tuple[Workspace]]:
         # as a fallback is just as much its responsibility.
         pool_uuid = _strip_uuid(f.agent_pool_id, "apool-")
         q = q.where(
-            or_(
-                Workspace.agent_pool_id == pool_uuid,
-                Workspace.agent_pool_extra_ids.contains([str(pool_uuid)]),
+            select(WorkspaceAgentPool.workspace_id)
+            .where(
+                WorkspaceAgentPool.workspace_id == Workspace.id,
+                WorkspaceAgentPool.agent_pool_id == pool_uuid,
             )
+            .exists()
         )
     if f.vcs_connection_id is not None:
         q = q.where(Workspace.vcs_connection_id == _strip_uuid(f.vcs_connection_id, "vcs-"))

--- a/services/tests/api/test_ai_summary.py
+++ b/services/tests/api/test_ai_summary.py
@@ -53,7 +53,6 @@ def _mock_workspace(ws_id=None, **overrides):
     ws.vcs_branch = ""
     ws.vcs_connection_id = None
     ws.vcs_connection = None
-    ws.agent_pool_id = None
     ws.agent_pool = None
     ws.labels = {}
     ws.owner_email = "test@example.com"

--- a/services/tests/api/test_catalog.py
+++ b/services/tests/api/test_catalog.py
@@ -2,6 +2,7 @@
 on management endpoints, catalog-RBAC on read/use, and provision validation."""
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -203,7 +204,7 @@ class TestProvision:
         ws.name = "smoke"
         ws.catalog_item_id = uuid.uuid4()
         ws.catalog_version_pin = None
-        ws.agent_pool_id = pool_uuid
+        ws.agent_pool_links = [SimpleNamespace(agent_pool_id=pool_uuid, ordinal=0, agent_pool=None)]
         ws.owner_email = "u@test.com"
         ws.labels = {}
         mock_prov.return_value = ws

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import ASGITransport, AsyncClient
@@ -66,7 +67,10 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.slack_channel = overrides.get("slack_channel", "")
     ws.execution_backend = overrides.get("execution_backend", "tofu")
     ws.agent_pool = None
-    ws.agent_pool_id = overrides.get("agent_pool_id", None)
+    _pool = overrides.get("agent_pool_id", None)
+    ws.agent_pool_links = (
+        [SimpleNamespace(agent_pool_id=_pool, ordinal=0, agent_pool=None)] if _pool else []
+    )
     ws.var_files = []
     ws.trigger_prefixes = []
     ws.drift_ignore_rules = []

--- a/services/tests/api/test_health_conditions.py
+++ b/services/tests/api/test_health_conditions.py
@@ -1,6 +1,7 @@
 """Tests for _compute_health_conditions and workspace JSON serialization."""
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 
@@ -17,7 +18,10 @@ def _mock_workspace(**overrides):
     ws.lock_id = None
     ws.resource_cpu = "1"
     ws.resource_memory = "2Gi"
-    ws.agent_pool_id = overrides.get("agent_pool_id", None)
+    _pool = overrides.get("agent_pool_id", None)
+    ws.agent_pool_links = (
+        [SimpleNamespace(agent_pool_id=_pool, ordinal=0, agent_pool=None)] if _pool else []
+    )
     ws.agent_pool = None
     ws.vcs_connection_id = overrides.get("vcs_connection_id", None)
     ws.vcs_connection = None
@@ -67,6 +71,17 @@ class TestComputeHealthConditions:
         assert len(conditions) == 1
         assert conditions[0]["code"] == "no_agent_pool"
         assert conditions[0]["severity"] == "warning"
+
+    def test_agent_mode_with_a_pool_has_no_condition(self):
+        """The positive case — the one that catches a fixture going stale.
+
+        Without it, a fixture that silently stopped assigning a pool would
+        leave every `no_agent_pool` assertion passing for the wrong reason.
+        """
+        from terrapod.api.routers.tfe_v2 import _compute_health_conditions
+
+        ws = _mock_workspace(execution_mode="agent", agent_pool_id=uuid.uuid4())
+        assert _compute_health_conditions(ws) == []
 
     def test_no_agent_pool_local_mode_no_condition(self):
         from terrapod.api.routers.tfe_v2 import _compute_health_conditions

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -64,7 +64,6 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws = MagicMock()
     ws.id = ws_id or uuid.uuid4()
     ws.name = name
-    ws.agent_pool_id = None
     ws.vcs_last_polled_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None

--- a/services/tests/api/test_notification_configurations.py
+++ b/services/tests/api/test_notification_configurations.py
@@ -31,7 +31,6 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.name = name
     ws.auto_apply = False
     ws.execution_backend = "tofu"
-    ws.agent_pool_id = None
     ws.labels = {}
     ws.owner_email = "test@example.com"
     ws.vcs_last_polled_at = None

--- a/services/tests/api/test_relationship_links.py
+++ b/services/tests/api/test_relationship_links.py
@@ -29,7 +29,10 @@ class TestCatalogInstance:
             name="inst",
             catalog_item_id=item,
             catalog_version_pin="1.0.0",
-            agent_pool_id=pool,
+            # The pool set is a relationship (#1087), not a column.
+            agent_pool_links=(
+                [SimpleNamespace(agent_pool_id=pool, ordinal=0, agent_pool=None)] if pool else []
+            ),
             owner_email="a@b.c",
             labels={},
         )

--- a/services/tests/api/test_run_tasks.py
+++ b/services/tests/api/test_run_tasks.py
@@ -31,7 +31,6 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.name = name
     ws.auto_apply = False
     ws.execution_backend = "tofu"
-    ws.agent_pool_id = None
     ws.labels = {}
     ws.owner_email = "test@example.com"
     ws.vcs_last_polled_at = None

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -31,7 +31,6 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.name = name
     ws.auto_apply = False
     ws.execution_backend = "tofu"
-    ws.agent_pool_id = None
     ws.vcs_last_polled_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -104,7 +104,6 @@ def _mock_workspace(ws_id=None, name="test-ws", catalog_item_id=None):
     ws = MagicMock()
     ws.id = ws_id or uuid.uuid4()
     ws.name = name
-    ws.agent_pool_id = None
     ws.vcs_connection_id = None
     ws.vcs_connection = None
     ws.vcs_repo_url = ""

--- a/services/tests/api/test_state_management.py
+++ b/services/tests/api/test_state_management.py
@@ -33,7 +33,6 @@ def _mock_workspace(ws_id=None, name="test-ws", owner_email=""):
     ws.name = name
     ws.owner_email = owner_email
     ws.labels = {}
-    ws.agent_pool_id = None
     ws.vcs_connection_id = None
     ws.vcs_connection = None
     ws.vcs_repo_url = ""

--- a/services/tests/api/test_variables.py
+++ b/services/tests/api/test_variables.py
@@ -30,7 +30,6 @@ def _mock_workspace(ws_id=None):
     ws.id = ws_id or uuid.uuid4()
     ws.name = "test-ws"
     ws.execution_backend = "tofu"
-    ws.agent_pool_id = None
     ws.vcs_last_polled_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None

--- a/services/tests/api/test_workspace_bulk.py
+++ b/services/tests/api/test_workspace_bulk.py
@@ -9,6 +9,7 @@ Harness mirrors `test_vcs_connections.py` / `test_autodiscovery_rules.py`.
 """
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import ASGITransport, AsyncClient
@@ -60,7 +61,6 @@ def _mock_ws(
     execution_backend="tofu",
     terraform_version="1.12",
     agent_pool_id=None,
-    agent_pool_extra_ids=None,
     labels=None,
     auto_apply=False,
     var_files=None,
@@ -71,10 +71,12 @@ def _mock_ws(
     w.execution_mode = execution_mode
     w.execution_backend = execution_backend
     w.terraform_version = terraform_version
-    w.agent_pool_id = agent_pool_id
-    # Real column, real default — a MagicMock here would never compare equal to
-    # the incoming `[]` and would show up as a spurious diff entry (#1085).
-    w.agent_pool_extra_ids = agent_pool_extra_ids if agent_pool_extra_ids is not None else []
+    # The pool set is a relationship (#1087) — a MagicMock here would never
+    # read back as a list of links.
+    w.agent_pool_links = [
+        SimpleNamespace(agent_pool_id=p, ordinal=i, agent_pool=None)
+        for i, p in enumerate([agent_pool_id] if agent_pool_id else [])
+    ]
     w.labels = labels if labels is not None else {}
     w.auto_apply = auto_apply
     w.var_files = var_files if var_files is not None else []
@@ -642,5 +644,5 @@ class TestBulkUpdatePoolRbac:
                 headers=_AUTH,
             )
         assert resp.status_code == 200, resp.text
-        assert ws.agent_pool_id == pool.id
+        assert [link.agent_pool_id for link in ws.agent_pool_links] == [pool.id]
         db.commit.assert_awaited_once()

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import ASGITransport, AsyncClient
@@ -38,11 +39,14 @@ def _mock_workspace(ws_id=None, pool_id=None, extra_pool_ids=None):
     ws.working_directory = ""
     ws.locked = False
     ws.lock_id = None
-    ws.agent_pool_id = pool_id
-    # Real column, real default (#1085) — a MagicMock here would leak into the
-    # serialized pool set.
-    ws.agent_pool_extra_ids = extra_pool_ids if extra_pool_ids is not None else []
-    ws.agent_pool = None
+    # The pool set is a relationship (#1087). A MagicMock here would leak into
+    # the serialized set, so the links are always a real list.
+    ws.agent_pool_links = [
+        SimpleNamespace(agent_pool_id=p, ordinal=i, agent_pool=SimpleNamespace(name=f"pool-{i}"))
+        for i, p in enumerate(
+            [pool_id, *[uuid.UUID(str(e)) for e in (extra_pool_ids or [])]] if pool_id else []
+        )
+    ]
     ws.resource_cpu = "1"
     ws.resource_memory = "2Gi"
     ws.labels = {}
@@ -327,8 +331,7 @@ class TestWorkspacePoolSet:
         assert res.status_code == 200, res.text
         # Element 0 lands in the pre-existing column, the rest in the new one —
         # a storage split, not a preference.
-        assert ws.agent_pool_id == pool_a.id
-        assert ws.agent_pool_extra_ids == [str(pool_b.id)]
+        assert [link.agent_pool_id for link in ws.agent_pool_links] == [pool_a.id, pool_b.id]
         attrs = res.json()["data"]["attributes"]
         assert attrs["agent-pool-ids"] == [f"apool-{pool_a.id}", f"apool-{pool_b.id}"]
         # The singular attribute stays, resolving to element 0.
@@ -390,7 +393,7 @@ class TestWorkspacePoolSet:
 
         assert res.status_code == 403
         # Nothing was written — the check runs before any mutation.
-        assert ws.agent_pool_extra_ids == []
+        assert ws.agent_pool_links == []
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -469,8 +472,7 @@ class TestWorkspacePoolSet:
             )
 
         assert res.status_code == 200, res.text
-        assert ws.agent_pool_id == new.id
-        assert ws.agent_pool_extra_ids == []
+        assert [link.agent_pool_id for link in ws.agent_pool_links] == [new.id]
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")
@@ -501,8 +503,7 @@ class TestWorkspacePoolSet:
             )
 
         assert res.status_code == 200, res.text
-        assert ws.agent_pool_id == a
-        assert ws.agent_pool_extra_ids == [str(b)]
+        assert [link.agent_pool_id for link in ws.agent_pool_links] == [a, b]
 
     @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
     @patch("terrapod.api.app.init_redis")

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -52,7 +52,6 @@ def _mock_workspace(
     ws.resource_cpu = resource_cpu
     ws.execution_backend = "tofu"
     ws.resource_memory = resource_memory
-    ws.agent_pool_id = None
     ws.agent_pool = None
     ws.catalog_item_id = None
     ws.labels = labels or {}

--- a/services/tests/db/migration_contractions.json
+++ b/services/tests/db/migration_contractions.json
@@ -16,6 +16,10 @@
     "alter_column(api_tokens, created_by)",
     "alter_column(api_tokens, user_email)"
   ],
+  "598eb2329821_workspace_agent_pools": [
+    "drop_column(workspaces, agent_pool_extra_ids)",
+    "drop_column(workspaces, agent_pool_id)"
+  ],
   "7dac5695bc0e_default_tofu_1_12": [
     "alter_column(autodiscovery_rules, terraform_version)",
     "alter_column(workspaces, terraform_version)"

--- a/services/tests/integration/test_multi_pool_dispatch.py
+++ b/services/tests/integration/test_multi_pool_dispatch.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 
 from terrapod.db.models import AgentPool, ConfigurationVersion, Run, Workspace
 from terrapod.db.session import get_db_session
-from terrapod.services import run_service
+from terrapod.services import pool_set, run_service
 
 pytestmark = pytest.mark.integration
 
@@ -28,14 +28,11 @@ async def _seed(pool_names: list[str]) -> tuple[Workspace, list[AgentPool]]:
             db.add(p)
         await db.flush()
 
-        head = pools[0].id
-        extras = [str(p.id) for p in pools[1:]]
         ws = Workspace(
             name=f"multi-pool-{pool_names[0]}",
             execution_mode="agent",
-            agent_pool_id=head,
-            agent_pool_extra_ids=extras,
         )
+        pool_set.set_workspace_pools(ws, [p.id for p in pools])
         db.add(ws)
         await db.flush()
 
@@ -158,3 +155,59 @@ class TestMultiPoolClaim:
             claim = await run_service.claim_next_run(db, _uuid.uuid4(), stranger.id, "outsider")
             await db.commit()
         assert claim is None
+
+
+class TestPoolDeletionCascade:
+    """Deleting a pool detaches it from every workspace (#1087).
+
+    This is the integrity the mapping table exists for: `delete_pool` is a bare
+    DELETE that relies on the foreign key, so a set stored without one would
+    leave the workspace advertising a pool that no longer exists.
+    """
+
+    async def test_deleting_a_pool_removes_it_from_every_set(self, app):
+        ws, pools = await _seed(["cascade-a", "cascade-b"])
+
+        async with get_db_session() as db:
+            doomed = (
+                await db.execute(select(AgentPool).where(AgentPool.id == pools[0].id))
+            ).scalar_one()
+            await db.delete(doomed)
+            await db.commit()
+
+        async with get_db_session() as db:
+            refreshed = (
+                await db.execute(select(Workspace).where(Workspace.id == ws.id))
+            ).scalar_one()
+            assert pool_set.workspace_pool_ids(refreshed) == [pools[1].id]
+
+    async def test_deleting_the_last_pool_empties_the_set(self, app):
+        ws, pools = await _seed(["solo-cascade"])
+
+        async with get_db_session() as db:
+            doomed = (
+                await db.execute(select(AgentPool).where(AgentPool.id == pools[0].id))
+            ).scalar_one()
+            await db.delete(doomed)
+            await db.commit()
+
+        async with get_db_session() as db:
+            refreshed = (
+                await db.execute(select(Workspace).where(Workspace.id == ws.id))
+            ).scalar_one()
+            assert pool_set.workspace_pool_ids(refreshed) == []
+
+    async def test_deleting_a_workspace_leaves_the_pool_alone(self, app):
+        """CASCADE runs the other way too, without taking the pool with it."""
+        ws, pools = await _seed(["ws-delete"])
+
+        async with get_db_session() as db:
+            doomed = (await db.execute(select(Workspace).where(Workspace.id == ws.id))).scalar_one()
+            await db.delete(doomed)
+            await db.commit()
+
+        async with get_db_session() as db:
+            survivors = list(
+                (await db.execute(select(AgentPool).where(AgentPool.id == pools[0].id))).scalars()
+            )
+            assert len(survivors) == 1

--- a/services/tests/services/test_drift_detection_service.py
+++ b/services/tests/services/test_drift_detection_service.py
@@ -23,7 +23,6 @@ def _mock_workspace(**overrides):
     ws.terraform_version = "1.11"
     ws.resource_cpu = "1"
     ws.resource_memory = "2Gi"
-    ws.agent_pool_id = None
     ws.owner_email = "test@example.com"
     return ws
 

--- a/services/tests/services/test_estate_graph_service.py
+++ b/services/tests/services/test_estate_graph_service.py
@@ -1,6 +1,7 @@
 """Tests for estate_graph_service — whole-estate topology derivation (#763)."""
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from terrapod.services import estate_graph_service
@@ -12,7 +13,11 @@ POOL = uuid.uuid4()
 
 def _ws(wid, name, labels=None, pool=None, mode="agent"):
     m = MagicMock()
-    m.id, m.name, m.labels, m.agent_pool_id, m.execution_mode = wid, name, labels or {}, pool, mode
+    m.id, m.name, m.labels, m.execution_mode = wid, name, labels or {}, mode
+    # Pool set is a relationship (#1087).
+    m.agent_pool_links = (
+        [SimpleNamespace(agent_pool_id=pool, ordinal=0, agent_pool=None)] if pool else []
+    )
     return m
 
 

--- a/services/tests/services/test_onboarding_service.py
+++ b/services/tests/services/test_onboarding_service.py
@@ -160,7 +160,7 @@ def _agent_ws():
         execution_backend="tofu",
         terraform_version="1.12",
         execution_mode="agent",
-        agent_pool_id=uuid.uuid4(),
+        agent_pool_links=[SimpleNamespace(agent_pool_id=uuid.uuid4(), ordinal=0, agent_pool=None)],
         auto_apply=False,
         terragrunt_enabled=False,
         terragrunt_version="",
@@ -180,7 +180,7 @@ async def test_start_discovery_requires_schema_ready():
 
 @pytest.mark.asyncio
 async def test_start_discovery_requires_agent_pool():
-    ws = SimpleNamespace(id=uuid.uuid4(), execution_mode="local", agent_pool_id=None)
+    ws = SimpleNamespace(id=uuid.uuid4(), execution_mode="local", agent_pool_links=[])
     session = OnboardingSession(workspace_id=ws.id, provider="aws", status="schema_ready")
     db = _fake_db(session, ws)
     with pytest.raises(svc.OnboardingError):

--- a/services/tests/services/test_pool_set.py
+++ b/services/tests/services/test_pool_set.py
@@ -12,30 +12,37 @@ from types import SimpleNamespace
 from terrapod.services import pool_set
 
 
-def _ws(pool_id=None, extras=None):
-    return SimpleNamespace(agent_pool_id=pool_id, agent_pool_extra_ids=extras or [])
+def _link(pool_id, ordinal=0, name="pool"):
+    return SimpleNamespace(
+        agent_pool_id=pool_id, ordinal=ordinal, agent_pool=SimpleNamespace(name=name)
+    )
+
+
+def _ws(*pool_ids):
+    return SimpleNamespace(
+        agent_pool_links=[_link(p, i, f"pool-{i}") for i, p in enumerate(pool_ids)]
+    )
 
 
 class TestWorkspacePoolIDs:
     def test_no_pool_is_empty_set(self):
         assert pool_set.workspace_pool_ids(_ws()) == []
 
-    def test_single_pool_matches_pre_multi_pool_behaviour(self):
+    def test_single_pool(self):
         p = uuid.uuid4()
         assert pool_set.workspace_pool_ids(_ws(p)) == [p]
 
-    def test_element_zero_first_then_the_rest(self):
+    def test_links_read_back_in_declared_order(self):
         a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
-        assert pool_set.workspace_pool_ids(_ws(a, [str(b), str(c)])) == [a, b, c]
+        assert pool_set.workspace_pool_ids(_ws(a, b, c)) == [a, b, c]
 
-    def test_null_extras_column_tolerated(self):
-        # A row written before the column existed reads back as NULL, not [].
-        p = uuid.uuid4()
-        assert pool_set.workspace_pool_ids(_ws(p, None)) == [p]
+    def test_workspace_without_the_relationship_loaded(self):
+        # A lightweight stub, or a row read before the relationship existed.
+        assert pool_set.workspace_pool_ids(SimpleNamespace()) == []
 
-    def test_duplicate_of_element_zero_is_dropped(self):
-        p = uuid.uuid4()
-        assert pool_set.workspace_pool_ids(_ws(p, [str(p)])) == [p]
+    def test_names_track_the_same_order(self):
+        a, b = uuid.uuid4(), uuid.uuid4()
+        assert pool_set.workspace_pool_names(_ws(a, b)) == ["pool-0", "pool-1"]
 
 
 class TestNormalise:
@@ -60,6 +67,8 @@ class TestNormalise:
 
 
 class TestSplit:
+    """`split` now serves only the run snapshot — workspaces use the links."""
+
     def test_empty_set_clears_both_columns(self):
         assert pool_set.split([]) == (None, [])
 
@@ -71,10 +80,11 @@ class TestSplit:
         assert extras == [str(b)]
         assert all(isinstance(e, str) for e in extras)
 
-    def test_round_trips_through_the_workspace_reader(self):
+    def test_feeds_the_run_snapshot_reader(self):
         a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
         head, extras = pool_set.split([a, b, c])
-        assert pool_set.workspace_pool_ids(_ws(head, extras)) == [a, b, c]
+        run = SimpleNamespace(pool_id=head, pool_extra_ids=extras)
+        assert pool_set.run_pool_ids(run) == [a, b, c]
 
 
 class TestRunPoolIDs:

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -401,7 +402,9 @@ def _mock_workspace(**kwargs):
     ws.terragrunt_version = kwargs.get("terragrunt_version", "1.0")
     ws.resource_cpu = kwargs.get("resource_cpu", "1")
     ws.resource_memory = kwargs.get("resource_memory", "2Gi")
-    ws.agent_pool_id = kwargs.get("agent_pool_id", None)
+    # Pool set is a relationship (#1087); a MagicMock here would not read back
+    # as links, so it is always a real list.
+    ws.agent_pool_links = kwargs.get("agent_pool_links", [])
     return ws
 
 
@@ -492,7 +495,9 @@ class TestCreateRun:
     async def test_pool_from_workspace(self, MockRun):
         db = AsyncMock(spec=AsyncSession)
         pool_id = uuid.uuid4()
-        ws = _mock_workspace(agent_pool_id=pool_id)
+        ws = _mock_workspace(
+            agent_pool_links=[SimpleNamespace(agent_pool_id=pool_id, ordinal=0, agent_pool=None)]
+        )
         instance = MockRun.return_value
         instance.id = uuid.uuid4()
         instance.status = "pending"

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -26,7 +26,6 @@ def _mock_workspace(**overrides):
     ws.terraform_version = "1.11"
     ws.resource_cpu = "1"
     ws.resource_memory = "2Gi"
-    ws.agent_pool_id = None
     ws.owner_email = "test@example.com"
     return ws
 

--- a/services/tests/services/test_workspace_search_service.py
+++ b/services/tests/services/test_workspace_search_service.py
@@ -151,7 +151,7 @@ class TestBuildQueryDimensions:
     def test_agent_pool_id_adds_where(self):
         pid = uuid.uuid4()
         q = build_workspace_query(WorkspaceFilter(agent_pool_id=f"apool-{pid}"))
-        assert "workspaces.agent_pool_id" in str(q)
+        assert "workspace_agent_pools.agent_pool_id" in str(q)
 
     def test_agent_pool_id_bad_uuid_raises(self):
         with pytest.raises(WorkspaceFilterError):


### PR DESCRIPTION
Follow-up to #1086. Internal storage change only — **the API does not move**.

Multi-pool routing landed with the workspace's pool set split across two columns: the pre-existing `agent_pool_id` holding element 0, and a new `agent_pool_extra_ids` JSONB holding the rest. The split was justified as protecting a rolling upgrade, but it doesn't earn its keep, and it left an integrity hole I introduced.

## The hole

`delete_pool` is a bare `db.delete(pool)` — detaching workspaces relies entirely on the FK's `ON DELETE SET NULL`. A JSONB column can carry no FK, so deleting a pool left a **dangling id in every set that named it**: the workspace kept advertising a pool that no longer existed, in `agent-pool-ids`, in the `agent-pools` relationship, and in the UI. Element 0 had referential integrity and the rest didn't — worse than either consistent option.

## The change

```
workspace_agent_pools (workspace_id  FK → workspaces.id   ON DELETE CASCADE,
                       agent_pool_id FK → agent_pools.id  ON DELETE CASCADE,
                       ordinal)
```

Two real foreign keys. Pool deletion detaches cleanly everywhere with no application-side sweeping to forget, and the composite primary key makes a pool physically unable to appear twice in one set. `ordinal` is display order only — the set stays flat, with no primary and no dispatch preference.

This is how Terrapod already models the same shape in `module_workspace_links` and `variable_set_workspaces`.

Proven against real Postgres, not asserted: deleting a pool removes it from a two-pool workspace leaving the other intact; deleting the last one empties the set; deleting a workspace doesn't take the pool with it.

**Runs are deliberately unchanged.** A run's candidate pools are a *snapshot* frozen at creation (JSONB, like its other snapshots) because a pool deleted mid-flight must not rewrite history, and `runs.pool_id` holds one true value after a claim — the pool actually executing it. Relationship vs snapshot, modelled differently on purpose.

## Surfaces

**The API is untouched.** `agent-pool-ids` is still the set; `agent-pool-id` is still a derived read (element 0) and an accepted write meaning "exactly this one pool". Those are the real consumer contracts. No contract snapshot moves, and neither go-terrapod nor the provider changes — the only snapshot in the diff is the migration-contraction ledger.

## On dropping the columns

The migration drops both, which is a contraction, and it's ledgered as one.

Worth being precise about why that's allowed, because I got the framing wrong earlier: this is **not** a backward-compatibility question. The database is not a public surface — nothing outside Terrapod sees a column name and we promise nothing about it. The real constraint is operational: migrations run as a Helm `pre-upgrade` hook, so the schema lands *before* the new pods roll, and an API replica still on the previous release will error on workspace queries until the rollout completes. Minutes, self-healing, invisible to consumers. That cost is the operator's to weigh, and it's cheaper than carrying a dead dual-write for a release.

## Verification

- `make test` — 3302 passed, including 3 new CASCADE integration tests against real Postgres.
- No code outside the migration references the dropped columns; dead fixture lines cleared across 11 test files.
- Added the missing positive assertion: agent mode **with** a pool raises no `no_agent_pool` condition — the test that catches a fixture silently going stale, which is exactly how this refactor could have hidden a regression.

Closes #1087
Part of #960
