### PR TITLE
fix(1089): report the real VCS poll failure, and make a stall detectable

### DIFF
--- a/alembic/versions/3d76eac29cf2_vcs_last_attempted_at.py
+++ b/alembic/versions/3d76eac29cf2_vcs_last_attempted_at.py
@@ -1,0 +1,36 @@
+"""Add workspaces.vcs_last_attempted_at
+
+`vcs_last_polled_at` only advances on a successful poll, so a workspace whose
+polls fail every cycle has a frozen timestamp that is indistinguishable from one
+that simply is not due yet. This column is stamped at the top of every poll
+attempt, before anything can fail, so a monitor can detect a stalled workspace
+from the API alone — even in the cases where the error field was never written
+(#1089).
+
+Purely additive: nullable, no backfill (NULL honestly means "not attempted since
+this upgrade"), no contraction.
+
+Revision ID: 3d76eac29cf2
+Revises: 598eb2329821
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "3d76eac29cf2"
+down_revision: str | None = "598eb2329821"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column("vcs_last_attempted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "vcs_last_attempted_at")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -473,6 +473,24 @@ The following read-only attributes are included in workspace responses when drif
 | `drift-status` | string | Current drift status: `""` (never checked), `"no_drift"`, `"drifted"`, or `"errored"` |
 | `drift-latest-run-id` | string (run-…) or null | ID of the drift run that produced the current `drift-status`. Lets the workspace-list UI link the badge straight to the run that explains the status. Cleared on a successful (non-drift) apply because the previous drift run is no longer the canonical link. Null when drift detection has never run or when the column predates v0.35.3 |
 
+### VCS Polling Health Attributes
+
+Read-only, present on every workspace. The pair is what makes a stalled VCS
+connection detectable from the API alone — `vcs-last-polled-at` advances only on
+a **successful** poll, so on its own a frozen value cannot be told apart from a
+workspace that is simply not due yet.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `vcs-last-polled-at` | string (RFC3339) or null | Timestamp of the last **successful** poll. Null if no poll has ever succeeded |
+| `vcs-last-attempted-at` | string (RFC3339) or null | Timestamp of the last poll **attempt**, successful or not. Stamped before anything in the poll can fail. Null on workspaces not polled since the upgrade that added it |
+| `vcs-last-error` | string or null | The most recent poll failure, named as specifically as the provider allows — a rate limit reports the HTTP status and, when the response carries the headers, how long until the window resets. Cleared on the next successful poll |
+| `vcs-last-error-at` | string (RFC3339) or null | Timestamp of `vcs-last-error` |
+
+To alert on a stalled connection, compare the two timestamps rather than relying
+on `vcs-last-error` being populated: `vcs-last-attempted-at` newer than
+`vcs-last-polled-at` means the most recent attempt did not succeed.
+
 ### Lifecycle Attributes (Autodiscovery)
 
 Workspaces created by autodiscovery carry read-only lifecycle attributes that track rename/delete/orphan reconciliation. They are included in workspace responses and surfaced by the UI as a banner on the workspace detail page and a badge on the workspace list.

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -895,6 +895,7 @@ field Workspace.UpdatedAt string `json:"updated-at,omitempty"`
 field Workspace.VCSBranch string `json:"vcs-branch,omitempty"`
 field Workspace.VCSConnectionID string `json:"vcs-connection-id,omitempty"`
 field Workspace.VCSConnectionName string `json:"vcs-connection-name,omitempty"`
+field Workspace.VCSLastAttemptedAt string `json:"vcs-last-attempted-at,omitempty"`
 field Workspace.VCSLastError string `json:"vcs-last-error,omitempty"`
 field Workspace.VCSLastErrorAt string `json:"vcs-last-error-at,omitempty"`
 field Workspace.VCSLastPolledAt string `json:"vcs-last-polled-at,omitempty"`

--- a/go-terrapod/workspaces.go
+++ b/go-terrapod/workspaces.go
@@ -86,6 +86,11 @@ type Workspace struct {
 	// VCSLastPolledAt is the timestamp of the most recent successful VCS
 	// poll cycle for this workspace.
 	VCSLastPolledAt string `json:"vcs-last-polled-at,omitempty"`
+	// VCSLastAttemptedAt is the timestamp of the most recent poll ATTEMPT,
+	// successful or not. VCSLastPolledAt only advances on success, so the gap
+	// between the two is what identifies a workspace whose polls are failing
+	// rather than one that is simply not due yet.
+	VCSLastAttemptedAt string `json:"vcs-last-attempted-at,omitempty"`
 	// VCSLastError is the last error from a VCS poll attempt (auth
 	// failure, repo gone, etc.). Empty when the last poll succeeded.
 	VCSLastError string `json:"vcs-last-error,omitempty"`
@@ -672,6 +677,7 @@ func workspaceFromResource(res *Resource) *Workspace {
 		LifecycleState:                GetStringAttr(res, "lifecycle-state"),
 		LifecycleReason:               GetStringAttr(res, "lifecycle-reason"),
 		VCSLastPolledAt:               GetStringAttr(res, "vcs-last-polled-at"),
+		VCSLastAttemptedAt:            GetStringAttr(res, "vcs-last-attempted-at"),
 		VCSLastError:                  GetStringAttr(res, "vcs-last-error"),
 		VCSLastErrorAt:                GetStringAttr(res, "vcs-last-error-at"),
 		AgentPoolName:                 GetStringAttr(res, "agent-pool-name"),

--- a/provider/internal/datasources/workspace/data_source.go
+++ b/provider/internal/datasources/workspace/data_source.go
@@ -63,6 +63,7 @@ type workspaceDataSourceModel struct {
 	LifecycleState                types.String `tfsdk:"lifecycle_state"`
 	LifecycleReason               types.String `tfsdk:"lifecycle_reason"`
 	VCSLastPolledAt               types.String `tfsdk:"vcs_last_polled_at"`
+	VCSLastAttemptedAt            types.String `tfsdk:"vcs_last_attempted_at"`
 	VCSLastError                  types.String `tfsdk:"vcs_last_error"`
 	VCSLastErrorAt                types.String `tfsdk:"vcs_last_error_at"`
 	AgentPoolName                 types.String `tfsdk:"agent_pool_name"`
@@ -123,6 +124,7 @@ func (d *workspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			"lifecycle_state":                  computedString("Workspace lifecycle state (e.g. active, or flagged/destroying when its autodiscovery source directory was deleted)."),
 			"lifecycle_reason":                 computedString("Human-readable reason for the current lifecycle state."),
 			"vcs_last_polled_at":               computedString("Timestamp of the most recent successful VCS poll cycle."),
+			"vcs_last_attempted_at":            computedString("Timestamp of the most recent VCS poll attempt, successful or not."),
 			"vcs_last_error":                   computedString("Most recent VCS poll error message. Empty when the last poll succeeded."),
 			"vcs_last_error_at":                computedString("Timestamp of `vcs_last_error`."),
 			"agent_pool_name":                  computedString("Human-readable name of the assigned agent pool, server-derived from `agent_pool_id`."),
@@ -223,6 +225,7 @@ func readDataSourceModel(ctx context.Context, res *terrapod.Resource, m *workspa
 	setOptionalString(&m.LifecycleState, terrapod.GetStringAttr(res, "lifecycle-state"))
 	setOptionalString(&m.LifecycleReason, terrapod.GetStringAttr(res, "lifecycle-reason"))
 	setOptionalString(&m.VCSLastPolledAt, terrapod.GetStringAttr(res, "vcs-last-polled-at"))
+	setOptionalString(&m.VCSLastAttemptedAt, terrapod.GetStringAttr(res, "vcs-last-attempted-at"))
 	setOptionalString(&m.VCSLastError, terrapod.GetStringAttr(res, "vcs-last-error"))
 	setOptionalString(&m.VCSLastErrorAt, terrapod.GetStringAttr(res, "vcs-last-error-at"))
 	setOptionalString(&m.AgentPoolName, terrapod.GetStringAttr(res, "agent-pool-name"))

--- a/provider/internal/provider/schema.golden
+++ b/provider/internal/provider/schema.golden
@@ -95,6 +95,7 @@ data terrapod_workspace.var_files required=false optional=false computed=true se
 data terrapod_workspace.vcs_branch required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.vcs_connection_id required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.vcs_connection_name required=false optional=false computed=true sensitive=false type=basetypes.StringType
+data terrapod_workspace.vcs_last_attempted_at required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.vcs_last_error required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.vcs_last_error_at required=false optional=false computed=true sensitive=false type=basetypes.StringType
 data terrapod_workspace.vcs_last_polled_at required=false optional=false computed=true sensitive=false type=basetypes.StringType
@@ -393,6 +394,7 @@ resource terrapod_workspace.var_files required=false optional=true computed=true
 resource terrapod_workspace.vcs_branch required=false optional=true computed=false sensitive=false type=basetypes.StringType
 resource terrapod_workspace.vcs_connection_id required=false optional=true computed=false sensitive=false type=basetypes.StringType
 resource terrapod_workspace.vcs_connection_name required=false optional=false computed=true sensitive=false type=basetypes.StringType
+resource terrapod_workspace.vcs_last_attempted_at required=false optional=false computed=true sensitive=false type=basetypes.StringType
 resource terrapod_workspace.vcs_last_error required=false optional=false computed=true sensitive=false type=basetypes.StringType
 resource terrapod_workspace.vcs_last_error_at required=false optional=false computed=true sensitive=false type=basetypes.StringType
 resource terrapod_workspace.vcs_last_polled_at required=false optional=false computed=true sensitive=false type=basetypes.StringType

--- a/provider/internal/resources/workspace/model.go
+++ b/provider/internal/resources/workspace/model.go
@@ -106,6 +106,7 @@ type workspaceModel struct {
 	LifecycleState     types.String `tfsdk:"lifecycle_state"`
 	LifecycleReason    types.String `tfsdk:"lifecycle_reason"`
 	VCSLastPolledAt    types.String `tfsdk:"vcs_last_polled_at"`
+	VCSLastAttemptedAt types.String `tfsdk:"vcs_last_attempted_at"`
 	VCSLastError       types.String `tfsdk:"vcs_last_error"`
 	VCSLastErrorAt     types.String `tfsdk:"vcs_last_error_at"`
 	AgentPoolName      types.String `tfsdk:"agent_pool_name"`

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -399,6 +399,10 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "Timestamp of the most recent successful VCS poll cycle. Server-volatile — VCS poller writes this every `vcs.poll_interval_seconds` (default 60s).",
 				Computed:    true,
 			},
+			"vcs_last_attempted_at": schema.StringAttribute{
+				Description: "Timestamp of the most recent VCS poll attempt, successful or not. `vcs_last_polled_at` only advances on success, so a gap between the two identifies a workspace whose polls are failing. Server-volatile.",
+				Computed:    true,
+			},
 			"vcs_last_error": schema.StringAttribute{
 				Description: "Most recent VCS poll error message. Empty when the last poll succeeded. Server-volatile.",
 				Computed:    true,
@@ -998,6 +1002,11 @@ func readWorkspaceIntoModel(ctx context.Context, ws *terrapod.Workspace, m *work
 		m.VCSLastPolledAt = types.StringValue(ws.VCSLastPolledAt)
 	} else {
 		m.VCSLastPolledAt = types.StringNull()
+	}
+	if ws.VCSLastAttemptedAt != "" {
+		m.VCSLastAttemptedAt = types.StringValue(ws.VCSLastAttemptedAt)
+	} else {
+		m.VCSLastAttemptedAt = types.StringNull()
 	}
 	if ws.VCSLastError != "" {
 		m.VCSLastError = types.StringValue(ws.VCSLastError)

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -789,6 +789,11 @@ def _workspace_json(
                 "lifecycle-reason": ws.lifecycle_reason,
                 "health-conditions": _compute_health_conditions(ws, live_pool_ids),
                 "vcs-last-polled-at": _rfc3339(ws.vcs_last_polled_at),
+                # Advances on every poll ATTEMPT, where `vcs-last-polled-at`
+                # advances only on success. The gap between the two is what
+                # makes a stalled workspace detectable from the API without
+                # having to trust that an error was recorded (#1089).
+                "vcs-last-attempted-at": _rfc3339(ws.vcs_last_attempted_at),
                 "vcs-last-error": ws.vcs_last_error,
                 "vcs-last-error-at": _rfc3339(ws.vcs_last_error_at),
                 "vcs-workflow": ws.vcs_workflow,

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -327,8 +327,18 @@ class Workspace(Base):
     vcs_branch: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     vcs_last_commit_sha: Mapped[str] = mapped_column(String(40), nullable=False, default="")
 
-    # VCS polling health
+    # VCS polling health.
+    #
+    # `vcs_last_polled_at` advances only on a SUCCESSFUL poll, so on its own it
+    # cannot tell "not due yet" from "failing every cycle" — both look like a
+    # timestamp that stopped moving. `vcs_last_attempted_at` is stamped at the
+    # top of every poll before anything can fail, so a monitor can alert on
+    # `attempted_at - polled_at > threshold` and catch a stall even when the
+    # error field was never written (#1089).
     vcs_last_polled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    vcs_last_attempted_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
     vcs_last_error: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -20,6 +20,7 @@ the scheduler's trigger queue with deduplication.
 import asyncio
 import time as time_mod
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -178,27 +179,80 @@ async def _list_open_prs(
 # --- Shared logic ---
 
 
+def describe_vcs_error(e: BaseException) -> str:
+    """Render a provider failure into a message an operator can act on (#1089).
+
+    A VCS-wide stall — provider rate limiting, an outage, an expired
+    credential — hits every workspace at once. Reporting it as a generic
+    per-workspace failure sends triage in exactly the wrong direction, so the
+    message names the HTTP status and, for a rate-limit response, how long
+    until the window resets.
+
+    Both providers call `raise_for_status()`, so the status and headers are
+    already on the exception — they were simply being discarded.
+    """
+    import httpx
+
+    if isinstance(e, httpx.HTTPStatusError):
+        resp = e.response
+        status = resp.status_code
+        # GitHub uses x-ratelimit-*; GitLab uses RateLimit-*. httpx headers are
+        # case-insensitive, so one lookup covers both spellings.
+        remaining = resp.headers.get("x-ratelimit-remaining") or resp.headers.get(
+            "ratelimit-remaining"
+        )
+        reset = resp.headers.get("x-ratelimit-reset") or resp.headers.get("ratelimit-reset")
+        retry_after = resp.headers.get("retry-after")
+
+        if status in (403, 429) and (remaining == "0" or retry_after or status == 429):
+            detail = f"VCS provider rate limit hit (HTTP {status})"
+            if remaining is not None:
+                detail += f", {remaining} requests remaining"
+            if retry_after:
+                detail += f", retry after {retry_after}s"
+            elif reset:
+                try:
+                    secs = int(reset) - int(datetime.now(UTC).timestamp())
+                    if secs > 0:
+                        detail += f", resets in {secs}s"
+                except ValueError:
+                    detail += f", resets at {reset}"
+            return detail
+
+        reason = (resp.reason_phrase or "").strip()
+        return f"VCS provider returned HTTP {status}{f' {reason}' if reason else ''}"
+
+    if isinstance(e, httpx.TimeoutException):
+        return f"VCS provider request timed out: {type(e).__name__}"
+    if isinstance(e, httpx.TransportError):
+        return f"Cannot reach VCS provider: {type(e).__name__}: {e}"
+    # Anything else keeps its own message — it is usually already the clearest
+    # thing available. The type name is only worth adding when the exception
+    # carries no message at all (a bare `KeyError()` would otherwise read as "").
+    text = str(e).strip()
+    return text or type(e).__name__
+
+
 async def _resolve_branch(conn: VCSConnection, ws: Workspace, owner: str, repo: str) -> str | None:
-    """Resolve the tracked branch for a workspace."""
+    """Resolve the tracked branch for a workspace.
+
+    Returns None ONLY when the provider answered successfully but no branch
+    could be determined. A transport or HTTP failure **propagates** (#1089):
+    swallowing it here is what turned a provider 403/429 into the misleading
+    "Cannot determine tracked branch", which reads like per-workspace
+    misconfiguration rather than a shared upstream condition.
+    """
     if ws.vcs_branch:
         return ws.vcs_branch
 
-    try:
-        default_branch = await _get_default_branch(conn, owner, repo)
-        if default_branch:
-            return default_branch
-        logger.warning(
-            "Cannot determine default branch",
-            workspace=ws.name,
-            repo=f"{owner}/{repo}",
-        )
-    except Exception as e:
-        logger.error(
-            "Failed to get default branch",
-            workspace=ws.name,
-            repo=f"{owner}/{repo}",
-            error=str(e),
-        )
+    default_branch = await _get_default_branch(conn, owner, repo)
+    if default_branch:
+        return default_branch
+    logger.warning(
+        "Cannot determine default branch",
+        workspace=ws.name,
+        repo=f"{owner}/{repo}",
+    )
     return None
 
 
@@ -818,6 +872,13 @@ async def _poll_workspace(
     if not ws.vcs_repo_url or not ws.vcs_connection_id:
         return
 
+    # Stamp the attempt BEFORE anything that can fail (#1089). `vcs_last_polled_at`
+    # only advances on success, so a workspace failing every cycle has a frozen
+    # timestamp indistinguishable from "not due yet". This one always moves, which
+    # is what lets a monitor alert on `attempted_at - polled_at > threshold`
+    # regardless of whether an error was recorded.
+    ws.vcs_last_attempted_at = now_utc()
+
     conn = await db.get(VCSConnection, ws.vcs_connection_id)
     if not conn or conn.status != "active":
         ws.vcs_last_error = "VCS connection is not active"
@@ -843,8 +904,22 @@ async def _poll_workspace(
 
     owner, repo = parsed
 
-    branch = await _resolve_branch(conn, ws, owner, repo)
+    try:
+        branch = await _resolve_branch(conn, ws, owner, repo)
+    except Exception as e:
+        # The provider call itself failed — report THAT, not a derived symptom.
+        ws.vcs_last_error = describe_vcs_error(e)[:500]
+        ws.vcs_last_error_at = now_utc()
+        logger.error(
+            "Failed to resolve tracked branch",
+            workspace=ws.name,
+            repo=f"{owner}/{repo}",
+            error=str(e),
+        )
+        return
     if not branch:
+        # Genuinely unresolvable from a SUCCESSFUL response — the only case this
+        # message is now used for.
         ws.vcs_last_error = "Cannot determine tracked branch"
         ws.vcs_last_error_at = now_utc()
         return
@@ -871,7 +946,7 @@ async def _poll_workspace(
             error=str(e),
             exc_info=e,
         )
-        ws.vcs_last_error = str(e)[:500]
+        ws.vcs_last_error = describe_vcs_error(e)[:500]
         ws.vcs_last_error_at = now_utc()
 
 
@@ -921,6 +996,38 @@ async def _poll_workspace_owned(
                 await db.rollback()
             except Exception:
                 pass
+            # The rollback just discarded whatever `_poll_workspace` recorded
+            # about this failure — including the error it may already have set
+            # on the workspace. That is why a stalled workspace could report
+            # `vcs-last-error: null` (#1089). Re-record it in its own
+            # transaction so the failure is never invisible.
+            await _record_poll_failure(ws_id, describe_vcs_error(e))
+
+
+async def _record_poll_failure(ws_id: uuid.UUID, message: str) -> None:
+    """Persist a poll failure in a fresh transaction (#1089).
+
+    Deliberately a targeted UPDATE rather than a re-read + ORM write: the
+    session that failed is unusable, and this must not depend on any of the
+    state that was just rolled back. Best-effort by necessity — if the database
+    itself is what is failing there is nowhere to record anything — but it
+    closes the common case where the poll failed for a VCS reason and the
+    commit or a later statement took the error record down with it.
+    """
+    try:
+        async with get_db_session() as db:
+            await db.execute(
+                update(Workspace)
+                .where(Workspace.id == ws_id)
+                .values(
+                    vcs_last_error=message[:500],
+                    vcs_last_error_at=now_utc(),
+                    vcs_last_attempted_at=now_utc(),
+                )
+            )
+            await db.commit()
+    except Exception:
+        logger.warning("Could not persist VCS poll failure", workspace_id=str(ws_id))
 
 
 async def _select_workspace_ids(

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -600,6 +600,7 @@
     "vcs-branch",
     "vcs-connection-id",
     "vcs-connection-name",
+    "vcs-last-attempted-at",
     "vcs-last-error",
     "vcs-last-error-at",
     "vcs-last-polled-at",

--- a/services/tests/api/test_ai_summary.py
+++ b/services/tests/api/test_ai_summary.py
@@ -60,6 +60,7 @@ def _mock_workspace(ws_id=None, **overrides):
     ws.trigger_prefixes = []
     ws.drift_ignore_rules = []
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     ws.vcs_workflow = "merge_then_apply"

--- a/services/tests/api/test_drift_detection.py
+++ b/services/tests/api/test_drift_detection.py
@@ -75,6 +75,7 @@ def _mock_workspace(ws_id=None, name="test-ws", **overrides):
     ws.trigger_prefixes = []
     ws.drift_ignore_rules = []
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     ws.created_at = datetime(2026, 1, 1, tzinfo=UTC)

--- a/services/tests/api/test_health_conditions.py
+++ b/services/tests/api/test_health_conditions.py
@@ -37,6 +37,7 @@ def _mock_workspace(**overrides):
     ws.drift_status = overrides.get("drift_status", "")
     ws.state_diverged = overrides.get("state_diverged", False)
     ws.vcs_last_polled_at = overrides.get("vcs_last_polled_at", None)
+    ws.vcs_last_attempted_at = overrides.get("vcs_last_attempted_at", None)
     ws.vcs_last_error = overrides.get("vcs_last_error", None)
     ws.vcs_last_error_at = overrides.get("vcs_last_error_at", None)
     ws.labels = {}

--- a/services/tests/api/test_module_impact.py
+++ b/services/tests/api/test_module_impact.py
@@ -65,6 +65,7 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.id = ws_id or uuid.uuid4()
     ws.name = name
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     return ws

--- a/services/tests/api/test_notification_configurations.py
+++ b/services/tests/api/test_notification_configurations.py
@@ -34,6 +34,7 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.labels = {}
     ws.owner_email = "test@example.com"
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     return ws

--- a/services/tests/api/test_run_tasks.py
+++ b/services/tests/api/test_run_tasks.py
@@ -34,6 +34,7 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.labels = {}
     ws.owner_email = "test@example.com"
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     return ws

--- a/services/tests/api/test_run_triggers.py
+++ b/services/tests/api/test_run_triggers.py
@@ -32,6 +32,7 @@ def _mock_workspace(ws_id=None, name="test-ws"):
     ws.auto_apply = False
     ws.execution_backend = "tofu"
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     return ws

--- a/services/tests/api/test_state_management.py
+++ b/services/tests/api/test_state_management.py
@@ -37,6 +37,7 @@ def _mock_workspace(ws_id=None, name="test-ws", owner_email=""):
     ws.vcs_connection = None
     ws.vcs_repo_url = ""
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     return ws

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -57,6 +57,7 @@ def _mock_workspace(ws_id=None, pool_id=None, extra_pool_ids=None):
     ws.vcs_branch = ""
     ws.vcs_last_commit_sha = ""
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     ws.var_files = []

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -61,6 +61,7 @@ def _mock_workspace(
     ws.vcs_repo_url = ""
     ws.vcs_branch = ""
     ws.vcs_last_polled_at = None
+    ws.vcs_last_attempted_at = None
     ws.vcs_last_error = None
     ws.vcs_last_error_at = None
     ws.var_files = []

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -1,5 +1,6 @@
 """Tests for VCS poller — subdirectory filtering and VCS error tracking."""
 
+import asyncio
 import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -18,6 +19,7 @@ def _mock_workspace(**overrides):
     ws.trigger_prefixes = overrides.get("trigger_prefixes", [])
     ws.vcs_last_commit_sha = overrides.get("vcs_last_commit_sha", "aaa111")
     ws.vcs_last_polled_at = overrides.get("vcs_last_polled_at", None)
+    ws.vcs_last_attempted_at = overrides.get("vcs_last_attempted_at", None)
     ws.vcs_last_error = overrides.get("vcs_last_error", None)
     ws.vcs_last_error_at = overrides.get("vcs_last_error_at", None)
     ws.locked = False
@@ -903,3 +905,228 @@ class TestPollCycleParallel:
             await handle_immediate_poll({"repo": "nobody/has-this"})
 
         mock_poll.assert_not_called()
+
+
+class TestDescribeVCSError:
+    """#1089 — the error a workspace reports must name the actual cause.
+
+    Both providers call `raise_for_status()`, so the status and rate-limit
+    headers are already on the exception. They were being discarded, which is
+    how a provider-wide rate limit came out as a flat per-workspace message.
+    """
+
+    def _status_error(self, status: int, headers: dict[str, str] | None = None):
+        import httpx
+
+        request = httpx.Request("GET", "https://api.github.com/repos/org/repo")
+        response = httpx.Response(status, headers=headers or {}, request=request)
+        return httpx.HTTPStatusError("err", request=request, response=response)
+
+    def test_github_rate_limit_names_the_rate_limit(self):
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        msg = describe_vcs_error(
+            self._status_error(403, {"x-ratelimit-remaining": "0"}),
+        )
+        assert "rate limit" in msg.lower()
+        assert "403" in msg
+
+    def test_gitlab_spelling_of_the_rate_limit_headers(self):
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        # GitLab spells them RateLimit-*; httpx headers are case-insensitive so
+        # one lookup must cover both providers.
+        msg = describe_vcs_error(self._status_error(429, {"ratelimit-remaining": "0"}))
+        assert "rate limit" in msg.lower()
+
+    def test_retry_after_is_surfaced(self):
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        msg = describe_vcs_error(self._status_error(429, {"retry-after": "60"}))
+        assert "60" in msg
+
+    def test_reset_epoch_rendered_as_a_duration(self):
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        # An absolute epoch is useless in a UI banner; the operator wants "how long".
+        future = int(datetime.now(UTC).timestamp()) + 300
+        msg = describe_vcs_error(
+            self._status_error(
+                403, {"x-ratelimit-remaining": "0", "x-ratelimit-reset": str(future)}
+            )
+        )
+        assert "resets in" in msg
+
+    def test_auth_failure_is_not_reported_as_a_rate_limit(self):
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        # A 401 has no rate-limit headers — it must not be swept into that branch,
+        # which would send triage in exactly the wrong direction.
+        msg = describe_vcs_error(self._status_error(401))
+        assert "rate limit" not in msg.lower()
+        assert "401" in msg
+
+    def test_403_without_rate_limit_headers_stays_a_403(self):
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        # A plain permission denial also returns 403. Only the headers distinguish it.
+        msg = describe_vcs_error(self._status_error(403))
+        assert "rate limit" not in msg.lower()
+        assert "403" in msg
+
+    def test_timeout_says_so(self):
+        import httpx
+
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        msg = describe_vcs_error(httpx.ConnectTimeout("timed out"))
+        assert "timed out" in msg.lower()
+
+    def test_transport_error_says_unreachable(self):
+        import httpx
+
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        msg = describe_vcs_error(httpx.ConnectError("no route to host"))
+        assert "cannot reach" in msg.lower()
+
+    def test_plain_exception_keeps_its_own_message(self):
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        assert describe_vcs_error(Exception("403 Forbidden")) == "403 Forbidden"
+
+    def test_message_less_exception_falls_back_to_its_type(self):
+        from terrapod.services.vcs_poller import describe_vcs_error
+
+        assert describe_vcs_error(KeyError()) == "KeyError"
+
+
+class TestPollAttemptedAt:
+    """#1089 — a stalled workspace must be detectable from the API alone.
+
+    `vcs_last_polled_at` only advances on success, so on its own it cannot
+    distinguish "not due yet" from "failing every cycle".
+    """
+
+    @patch("terrapod.services.vcs_poller._poll_workspace_prs")
+    @patch("terrapod.services.vcs_poller._poll_workspace_branch")
+    @patch("terrapod.services.vcs_poller._resolve_branch")
+    @patch("terrapod.services.vcs_poller._parse_repo_url")
+    async def test_stamped_on_success(self, mock_parse, mock_resolve, mock_branch, mock_prs):
+        from terrapod.services.vcs_poller import _poll_workspace
+
+        ws = _mock_workspace()
+        mock_parse.return_value = ("org", "repo")
+        mock_resolve.return_value = "main"
+        mock_branch.return_value = None
+        mock_prs.return_value = None
+        mock_db = AsyncMock()
+        mock_db.get.return_value = _mock_connection()
+
+        await _poll_workspace(mock_db, ws)
+
+        assert ws.vcs_last_attempted_at is not None
+
+    @patch("terrapod.services.vcs_poller._poll_workspace_prs")
+    @patch("terrapod.services.vcs_poller._poll_workspace_branch")
+    @patch("terrapod.services.vcs_poller._resolve_branch")
+    @patch("terrapod.services.vcs_poller._parse_repo_url")
+    async def test_stamped_on_failure_too(self, mock_parse, mock_resolve, mock_branch, mock_prs):
+        from terrapod.services.vcs_poller import _poll_workspace
+
+        ws = _mock_workspace()
+        mock_parse.return_value = ("org", "repo")
+        mock_resolve.return_value = "main"
+        mock_branch.side_effect = Exception("boom")
+        mock_db = AsyncMock()
+        mock_db.get.return_value = _mock_connection()
+
+        await _poll_workspace(mock_db, ws)
+
+        # This is the point: the attempt is recorded even though the poll failed
+        # and `vcs_last_polled_at` never moved.
+        assert ws.vcs_last_attempted_at is not None
+        assert ws.vcs_last_polled_at is None
+
+    async def test_stamped_before_the_connection_lookup_can_fail(self):
+        from terrapod.services.vcs_poller import _poll_workspace
+
+        # An inactive connection returns early. The attempt must still be on record
+        # — otherwise the earliest failures are exactly the invisible ones.
+        ws = _mock_workspace()
+        conn = _mock_connection()
+        conn.status = "inactive"
+        mock_db = AsyncMock()
+        mock_db.get.return_value = conn
+
+        await _poll_workspace(mock_db, ws)
+
+        assert ws.vcs_last_attempted_at is not None
+
+
+class TestPollFailureSurvivesRollback:
+    """#1089 — the rollback used to discard the very error it had just recorded.
+
+    That is why a stalled workspace could report `vcs-last-error: null`: the
+    poll set the error, something later in the transaction failed, and the
+    rollback took the error record down with it.
+    """
+
+    @patch("terrapod.services.vcs_poller._record_poll_failure")
+    @patch("terrapod.services.vcs_poller._poll_workspace")
+    @patch("terrapod.services.vcs_poller.get_db_session")
+    async def test_failure_is_re_recorded_after_rollback(
+        self, mock_session, mock_poll, mock_record
+    ):
+        import contextlib
+
+        from terrapod.services.vcs_poller import _poll_workspace_owned
+
+        ws = _mock_workspace()
+        db = AsyncMock()
+        db.get.return_value = ws
+
+        @contextlib.asynccontextmanager
+        async def _session():
+            yield db
+
+        mock_session.side_effect = lambda: _session()
+        mock_poll.side_effect = Exception("commit blew up")
+
+        await _poll_workspace_owned(ws.id, asyncio.Semaphore(1), None, {})
+
+        db.rollback.assert_awaited()
+        mock_record.assert_awaited_once()
+        # And it re-records the real cause, not a placeholder.
+        assert "commit blew up" in mock_record.await_args.args[1]
+
+    @patch("terrapod.services.vcs_poller.get_db_session")
+    async def test_record_poll_failure_writes_in_its_own_transaction(self, mock_session):
+        import contextlib
+
+        from terrapod.services.vcs_poller import _record_poll_failure
+
+        db = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def _session():
+            yield db
+
+        mock_session.side_effect = lambda: _session()
+
+        await _record_poll_failure(uuid.uuid4(), "rate limited")
+
+        # A targeted UPDATE, committed — it must not depend on the session that
+        # just failed, nor on any state that was rolled back.
+        db.execute.assert_awaited_once()
+        db.commit.assert_awaited_once()
+
+    @patch("terrapod.services.vcs_poller.get_db_session")
+    async def test_record_poll_failure_never_raises(self, mock_session):
+        from terrapod.services.vcs_poller import _record_poll_failure
+
+        # If the database is what is failing there is nowhere to record anything,
+        # but that must not take the poll cycle down with it.
+        mock_session.side_effect = Exception("database is down")
+
+        await _record_poll_failure(uuid.uuid4(), "whatever")

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "خطأ",
       "ok": "موافق ({time})",
+      "stalled": "متوقف — آخر محاولة {attempted}، آخر نجاح {succeeded}",
+      "never": "أبدًا",
       "notPolled": "لم يُستقصَ بعد"
     },
     "lockout": {

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Chyba",
       "ok": "OK ({time})",
+      "stalled": "Zastaveno — poslední pokus {attempted}, poslední úspěch {succeeded}",
+      "never": "nikdy",
       "notPolled": "Zatím nepolováno"
     },
     "lockout": {

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Gwall",
       "ok": "IAWN ({time})",
+      "stalled": "Wedi stopio — ymgais olaf {attempted}, llwyddiant olaf {succeeded}",
+      "never": "byth",
       "notPolled": "Heb ei bolio eto"
     },
     "lockout": {

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Fejl",
       "ok": "OK ({time})",
+      "stalled": "Gået i stå — sidste forsøg {attempted}, sidste succes {succeeded}",
+      "never": "aldrig",
       "notPolled": "Ikke pollet endnu"
     },
     "lockout": {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Fehler",
       "ok": "OK ({time})",
+      "stalled": "Stockt — letzter Versuch {attempted}, letzter Erfolg {succeeded}",
+      "never": "nie",
       "notPolled": "Noch nicht abgefragt"
     },
     "lockout": {

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "3rr0r",
       "ok": "0K ({time})",
+      "stalled": "574ll3d — l457 4773mp7 {attempted}, l457 5ucc355 {succeeded}",
+      "never": "n3v3r",
       "notPolled": "N07 p0ll3d y37"
     },
     "lockout": {

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Errur",
       "ok": "OK ({time})",
+      "stalled": "Stukd — last tri wuz {attempted}, last win wuz {succeeded}",
+      "never": "nevar",
       "notPolled": "Not polld yet"
     },
     "lockout": {

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Marklar",
       "ok": "OK ({time})",
+      "stalled": "Stalled — last marklar {attempted}, last marklar {succeeded}",
+      "never": "never",
       "notPolled": "Not polled yet"
     },
     "lockout": {

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Squall",
       "ok": "OK ({time})",
+      "stalled": "Becalmed — last try {attempted}, last fair wind {succeeded}",
+      "never": "ne''er",
       "notPolled": "Not polled yet, matey"
     },
     "lockout": {

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Error",
       "ok": "OK ({time})",
+      "stalled": "Stalled, it is — {attempted} the last attempt, {succeeded} the last success",
+      "never": "never",
       "notPolled": "Polled yet, not"
     },
     "lockout": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2247,6 +2247,8 @@
     "vcsPolling": {
       "error": "Error",
       "ok": "OK ({time})",
+      "stalled": "Stalled — last attempt {attempted}, last success {succeeded}",
+      "never": "never",
       "notPolled": "Not polled yet"
     },
     "lockout": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Error",
       "ok": "OK ({time})",
+      "stalled": "Estancado — último intento {attempted}, último éxito {succeeded}",
+      "never": "nunca",
       "notPolled": "Aún no se ha sondeado"
     },
     "lockout": {

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "خطا",
       "ok": "درست ({time})",
+      "stalled": "متوقف — آخرین تلاش {attempted}، آخرین موفقیت {succeeded}",
+      "never": "هرگز",
       "notPolled": "هنوز نظرسنجی نشده"
     },
     "lockout": {

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Virhe",
       "ok": "OK ({time})",
+      "stalled": "Jumissa — viimeisin yritys {attempted}, viimeisin onnistuminen {succeeded}",
+      "never": "ei koskaan",
       "notPolled": "Ei vielä kyselty"
     },
     "lockout": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Erreur",
       "ok": "OK ({time})",
+      "stalled": "Bloqué — dernière tentative {attempted}, dernier succès {succeeded}",
+      "never": "jamais",
       "notPolled": "Pas encore interrogé"
     },
     "lockout": {

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "שגיאה",
       "ok": "תקין ({time})",
+      "stalled": "תקוע — ניסיון אחרון {attempted}, הצלחה אחרונה {succeeded}",
+      "never": "מעולם לא",
       "notPolled": "טרם נסקר"
     },
     "lockout": {

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Errore",
       "ok": "OK ({time})",
+      "stalled": "Bloccato — ultimo tentativo {attempted}, ultimo successo {succeeded}",
+      "never": "mai",
       "notPolled": "Non ancora interrogato"
     },
     "lockout": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "エラー",
       "ok": "OK（{time}）",
+      "stalled": "停止 — 最終試行 {attempted}、最終成功 {succeeded}",
+      "never": "なし",
       "notPolled": "まだポーリングされていません"
     },
     "lockout": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "오류",
       "ok": "정상 ({time})",
+      "stalled": "중단됨 — 마지막 시도 {attempted}, 마지막 성공 {succeeded}",
+      "never": "없음",
       "notPolled": "아직 폴링되지 않음"
     },
     "lockout": {

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Error",
       "ok": "OK ({time})",
+      "stalled": "Stagnans — conatus ultimus {attempted}, successus ultimus {succeeded}",
+      "never": "numquam",
       "notPolled": "Nondum interrogatum"
     },
     "lockout": {

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Feil",
       "ok": "OK ({time})",
+      "stalled": "Stanset — siste forsøk {attempted}, siste vellykkede {succeeded}",
+      "never": "aldri",
       "notPolled": "Ikke avspurt ennå"
     },
     "lockout": {

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Fout",
       "ok": "OK ({time})",
+      "stalled": "Vastgelopen — laatste poging {attempted}, laatste succes {succeeded}",
+      "never": "nooit",
       "notPolled": "Nog niet gepolld"
     },
     "lockout": {

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Błąd",
       "ok": "OK ({time})",
+      "stalled": "Zatrzymane — ostatnia próba {attempted}, ostatni sukces {succeeded}",
+      "never": "nigdy",
       "notPolled": "Jeszcze nie odpytano"
     },
     "lockout": {

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Erro",
       "ok": "OK ({time})",
+      "stalled": "Travado — última tentativa {attempted}, último sucesso {succeeded}",
+      "never": "nunca",
       "notPolled": "Ainda não consultado"
     },
     "lockout": {

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Erro",
       "ok": "OK ({time})",
+      "stalled": "Bloqueado — última tentativa {attempted}, último sucesso {succeeded}",
+      "never": "nunca",
       "notPolled": "Ainda sem polling"
     },
     "lockout": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Ошибка",
       "ok": "OK ({time})",
+      "stalled": "Остановлено — последняя попытка {attempted}, последний успех {succeeded}",
+      "never": "никогда",
       "notPolled": "Ещё не опрашивалось"
     },
     "lockout": {

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Fel",
       "ok": "OK ({time})",
+      "stalled": "Stannat — senaste försök {attempted}, senaste lyckade {succeeded}",
+      "never": "aldrig",
       "notPolled": "Inte pollad ännu"
     },
     "lockout": {

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Qagh",
       "ok": "lugh ({time})",
+      "stalled": "mevpu'' — nID Qav {attempted}, Qapla'' Qav {succeeded}",
+      "never": "not",
       "notPolled": "ghelqa'be' DaH"
     },
     "lockout": {

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Hata",
       "ok": "TAMAM ({time})",
+      "stalled": "Takıldı — son deneme {attempted}, son başarı {succeeded}",
+      "never": "hiç",
       "notPolled": "Henüz yoklanmadı"
     },
     "lockout": {

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "Помилка",
       "ok": "OK ({time})",
+      "stalled": "Зупинено — остання спроба {attempted}, останній успіх {succeeded}",
+      "never": "ніколи",
       "notPolled": "Ще не опитано"
     },
     "lockout": {

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "错误",
       "ok": "正常（{time}）",
+      "stalled": "已停滞 — 最后尝试 {attempted}，最后成功 {succeeded}",
+      "never": "从未",
       "notPolled": "尚未轮询"
     },
     "lockout": {

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -2239,6 +2239,8 @@
     "vcsPolling": {
       "error": "錯誤",
       "ok": "正常（{time}）",
+      "stalled": "已停滯 — 最後嘗試 {attempted}，最後成功 {succeeded}",
+      "never": "從未",
       "notPolled": "尚未輪詢"
     },
     "lockout": {

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -81,6 +81,7 @@ interface WorkspaceAttrs {
   'lifecycle-state': 'active' | 'pending_deletion' | 'archived'
   'lifecycle-reason': string
   'vcs-last-polled-at': string | null
+  'vcs-last-attempted-at': string | null
   'vcs-last-error': string | null
   'vcs-last-error-at': string | null
   'created-at': string
@@ -1750,6 +1751,15 @@ function WorkspaceDetailContent() {
   const attrs = workspace.attributes
   const perms = attrs.permissions || {} as WorkspacePermissions
 
+  // VCS polling is stalled when the most recent ATTEMPT is newer than the most
+  // recent SUCCESS. Comparing the two needs no knowledge of the poll interval,
+  // and it catches the case an error message alone misses (#1089).
+  const vcsPollStalled =
+    !attrs['vcs-last-error'] &&
+    !!attrs['vcs-last-attempted-at'] &&
+    (!attrs['vcs-last-polled-at'] ||
+      new Date(attrs['vcs-last-attempted-at']) > new Date(attrs['vcs-last-polled-at']))
+
   // Rows for the pool-set editor: everything the caller may assign, PLUS any
   // pool already on the workspace that they may not. Without the second half a
   // caller lacking pool:assign on one of the pools would silently drop it just
@@ -2211,6 +2221,19 @@ function WorkspaceDetailContent() {
                     <dd className="mt-1 text-sm">
                       {attrs['vcs-last-error'] ? (
                         <span className="text-red-400" title={attrs['vcs-last-error']}>{t('vcsPolling.error')}{attrs['vcs-last-error-at'] ? ` (${new Date(attrs['vcs-last-error-at']).toLocaleString()})` : ''}</span>
+                      ) : vcsPollStalled ? (
+                        // No error recorded, but the newest ATTEMPT is newer than the
+                        // newest SUCCESS — the polls are failing without leaving a
+                        // message. Reporting that as green was the misleading half
+                        // of #1089.
+                        <span className="text-amber-400">
+                          {t('vcsPolling.stalled', {
+                            attempted: new Date(attrs['vcs-last-attempted-at']!).toLocaleString(),
+                            succeeded: attrs['vcs-last-polled-at']
+                              ? new Date(attrs['vcs-last-polled-at']).toLocaleString()
+                              : t('vcsPolling.never'),
+                          })}
+                        </span>
                       ) : attrs['vcs-last-polled-at'] ? (
                         <span className="text-green-400">{t('vcsPolling.ok', { time: new Date(attrs['vcs-last-polled-at']).toLocaleString() })}</span>
                       ) : (


### PR DESCRIPTION
A workspace whose VCS polling had stopped reported `Cannot determine tracked branch` — a *symptom* of the failure rather than the failure — and in some cases reported no error at all while the UI still showed a green "polled OK".

There turned out to be three separate causes, so this fixes each rather than improving the one message.

## The misleading error

`_resolve_branch` caught every provider exception and returned `None`, so an expired credential, a provider outage and a rate limit all arrived at the same branch-shaped message. Transport and HTTP failures now propagate; `None` means only "the provider answered successfully but no branch could be determined", which is the one case that message is still used for.

## The discarded detail

Both providers call `raise_for_status()`, so the status and rate-limit headers were already on the exception — they were simply thrown away. `describe_vcs_error` now names the HTTP status, and for a rate-limited response the remaining quota and how long until the window resets (GitHub's `x-ratelimit-*`, GitLab's `ratelimit-*`, and `retry-after`; httpx headers are case-insensitive so one lookup covers both).

This matters beyond wording: a provider-wide rate limit hits every workspace at once, and reporting it as a generic per-workspace failure sends triage in exactly the wrong direction.

A 401, and a 403 *without* rate-limit headers, are deliberately kept out of the rate-limit branch — both have tests.

## The vanishing error record

`_poll_workspace_owned` rolls the transaction back when a poll raises, which discarded the error the poll had just written to the workspace. That is the mechanism behind `vcs-last-error: null` on a workspace that was plainly failing.

The failure is now re-recorded in its own transaction (`_record_poll_failure`), as a targeted `UPDATE` that deliberately depends on none of the rolled-back state — the session that failed is unusable. It is best-effort by necessity (if the database is what is failing there is nowhere to record anything) but it must never take the poll cycle down with it, which is tested.

## Making a stall detectable without trusting the error field

`vcs_last_polled_at` advances only on **success**, so on its own a frozen timestamp cannot be distinguished from a workspace that simply is not due yet.

`vcs-last-attempted-at` is stamped at the very top of every poll, before the connection lookup or anything else can fail. When it is newer than `vcs-last-polled-at`, the most recent attempt did not succeed — a check that needs no knowledge of the poll interval and holds even in the cases where no error was recorded. The workspace page now renders that as an amber *stalled* state instead of the green "OK" it used to show.

## Compatibility

Additive throughout — one nullable column, one new read-only attribute, no removals or renames. The attribute snapshot delta is a single added line; the migration is reversible and adds no contraction.

Carried through every consumer the contract gate forces: go-terrapod, the provider resource *and* data source, the web UI (with all 32 locales filled, joke locales genuinely transformed rather than copied), and `docs/api-reference.md`.

## Verification

- `make test` — 3318 passed
- `web`: `tsc --noEmit`, `i18n:check` (all locales complete + ICU-valid), `i18n:lint` (0 new), `npm run build`
- `go build ./...` in `go-terrapod/` and `provider/`; both goldens regenerated additively
- New tests cover the rate-limit rendering (both provider header spellings, `retry-after`, reset-as-duration), the 401/403 negatives, the attempted-at stamping on success/failure/early-return, and the rollback-survival path

Not covered: a live provider rate limit, which can't be provoked on demand — the header rendering is tested against constructed `httpx` responses instead.

Closes #1089
