### PR TITLE
fix(1091): make removing an Optional+Computed list attribute visible, not silent

### DIFF
--- a/docs/terraform-provider.md
+++ b/docs/terraform-provider.md
@@ -133,6 +133,36 @@ either `terraform` or `tofu`.
 - **Six platforms.** `linux/{amd64,arm64}`, `darwin/{amd64,arm64}`,
   `windows/{amd64,arm64}`, built and signed by GoReleaser on release.
 
+## Removing a list attribute does not clear it
+
+A handful of `terrapod_workspace` list attributes are `Optional + Computed`:
+
+`agent_pool_ids`, `var_files`, `trigger_prefixes`, `drift_ignore_rules`,
+`security_scan_skip_rules`.
+
+For these, **omitting the attribute means "leave alone", not "clear"**. Deleting
+the line from your configuration plans as *no changes* and the workspace keeps
+its existing value. To clear one, set it to the empty list:
+
+```hcl
+resource "terrapod_workspace" "example" {
+  # ...
+  var_files = []   # clears it; deleting this line would not
+}
+```
+
+This is deliberate. Terrapod lets these be set outside Terraform — through the
+UI, or the bulk-update endpoint — and the provider cannot tell "removed from the
+configuration" from "never in the configuration": both reach it as an absent
+value over a state value read back from the server. Treating absence as "clear"
+would wipe values that are legitimately managed elsewhere.
+
+Because a silent no-op is still a poor experience, the provider **warns at plan
+time** whenever a workspace holds a non-empty value for one of these attributes
+that your configuration does not declare. If you meant to clear it, set `= []`;
+if the value is managed outside Terraform, declare the attribute explicitly to
+silence the warning.
+
 ## Reserved-name note
 
 Terraform schema attribute names can't be `provider`, so the VCS-connection

--- a/provider/internal/resources/workspace/modify_plan_test.go
+++ b/provider/internal/resources/workspace/modify_plan_test.go
@@ -1,0 +1,88 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// The #1091 warning turns on two predicates: the config value being null, and
+// the state value holding at least one element. `hasElements` is the second, and
+// it has to be right about every shape a list attribute can be in — a null or
+// unknown list is not "a value the config isn't managing", and neither is an
+// empty one (the server default), so none of them should raise a warning.
+func TestHasElements(t *testing.T) {
+	strList := func(vals ...string) types.List {
+		elems := make([]attr.Value, 0, len(vals))
+		for _, v := range vals {
+			elems = append(elems, types.StringValue(v))
+		}
+		return types.ListValueMust(types.StringType, elems)
+	}
+
+	cases := []struct {
+		name string
+		val  attr.Value
+		want bool
+	}{
+		{"null list is not a value to warn about", types.ListNull(types.StringType), false},
+		{"unknown list is not a value to warn about", types.ListUnknown(types.StringType), false},
+		{"empty list is the server default, not an unmanaged value", strList(), false},
+		{"one element is an unmanaged value", strList("envs/prod.tfvars"), true},
+		{"several elements likewise", strList("a.tfvars", "b.tfvars"), true},
+		{"a non-list value never warns", types.StringValue("nope"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasElements(tc.val); got != tc.want {
+				t.Errorf("hasElements(%v) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// Every entry in unmanagedCollections must actually read a distinct field off
+// the model. A copy-paste that left two entries pointing at the same field would
+// silence the warning for one attribute and double it for another, and nothing
+// else would catch it.
+func TestUnmanagedCollectionAccessorsAreDistinct(t *testing.T) {
+	strList := func(s string) types.List {
+		return types.ListValueMust(types.StringType, []attr.Value{types.StringValue(s)})
+	}
+
+	for _, target := range unmanagedCollections {
+		// Populate exactly one field, then assert only that entry's accessor sees it.
+		var m workspaceModel
+		m.AgentPoolIDs = types.ListNull(types.StringType)
+		m.VarFiles = types.ListNull(types.StringType)
+		m.TriggerPrefixes = types.ListNull(types.StringType)
+		m.DriftIgnoreRules = types.ListNull(types.StringType)
+		m.SecurityScanSkipRules = types.ListNull(types.StringType)
+
+		switch target.name {
+		case "agent_pool_ids":
+			m.AgentPoolIDs = strList("apool-x")
+		case "var_files":
+			m.VarFiles = strList("envs/prod.tfvars")
+		case "trigger_prefixes":
+			m.TriggerPrefixes = strList("modules/shared")
+		case "drift_ignore_rules":
+			m.DriftIgnoreRules = strList("aws_iam_role.foo")
+		case "security_scan_skip_rules":
+			m.SecurityScanSkipRules = strList("CKV_AWS_24")
+		default:
+			t.Fatalf("unmanagedCollections gained %q with no case here — extend this test", target.name)
+		}
+
+		for _, a := range unmanagedCollections {
+			got := hasElements(a.value(&m))
+			want := a.name == target.name
+			if got != want {
+				t.Errorf("with only %s populated, accessor for %s returned %v (want %v) — "+
+					"the accessors are crossed", target.name, a.name, got, want)
+			}
+		}
+	}
+}

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -71,6 +71,85 @@ func (r *workspaceResource) ValidateConfig(ctx context.Context, req resource.Val
 	}
 }
 
+// unmanagedCollections are the Optional+Computed collection attributes whose
+// plan value falls back to prior state when the config omits them
+// (`UseStateForUnknown`). That fallback is deliberate — the server may hold a
+// value this config does not manage, set through the UI or the bulk-update
+// endpoint, and clobbering it on every apply would be worse. The cost is that
+// *removing* the attribute from a config is indistinguishable from never having
+// declared it, so it plans as no-change and the server-side value survives
+// (#1091). ModifyPlan below makes that visible rather than silent.
+var unmanagedCollections = []struct {
+	name  string
+	value func(*workspaceModel) attr.Value
+}{
+	{"agent_pool_ids", func(m *workspaceModel) attr.Value { return m.AgentPoolIDs }},
+	{"var_files", func(m *workspaceModel) attr.Value { return m.VarFiles }},
+	{"trigger_prefixes", func(m *workspaceModel) attr.Value { return m.TriggerPrefixes }},
+	{"drift_ignore_rules", func(m *workspaceModel) attr.Value { return m.DriftIgnoreRules }},
+	{"security_scan_skip_rules", func(m *workspaceModel) attr.Value { return m.SecurityScanSkipRules }},
+}
+
+// hasElements reports whether a list attribute holds at least one element.
+func hasElements(v attr.Value) bool {
+	l, ok := v.(types.List)
+	if !ok || l.IsNull() || l.IsUnknown() {
+		return false
+	}
+	return len(l.Elements()) > 0
+}
+
+// ModifyPlan warns when the workspace holds a value for an Optional+Computed
+// collection that the configuration does not declare (#1091).
+//
+// Terraform would otherwise report "no changes" while the config and the remote
+// object genuinely disagree — the shape that bites is deleting a `var_files`
+// line to retire a tfvars file, reading the empty plan as confirmation, and
+// deleting the file while the workspace still passes `-var-file` for it.
+//
+// This is a warning rather than a real diff on purpose. The framework cannot
+// tell "removed from config" from "never in config": both arrive here as a null
+// config value over a state value the read-back populated from the server.
+// Planning a clear would therefore also clear values legitimately managed
+// out-of-band — and, worse, would do it on the first plan after upgrading the
+// provider, silently. A warning costs nothing and cannot destroy anything.
+func (r *workspaceResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Nothing to compare on create (no prior state) or destroy (no plan).
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+	var cfg, state workspaceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	for _, a := range unmanagedCollections {
+		// `agent_pool_ids` reads back the set that `agent_pool_id` assigns, so a
+		// config using the singular attribute IS managing it — warning there
+		// would fire on every plan and be wrong.
+		if a.name == "agent_pool_ids" && !cfg.AgentPoolID.IsNull() {
+			continue
+		}
+		if !a.value(&cfg).IsNull() || !hasElements(a.value(&state)) {
+			continue
+		}
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root(a.name),
+			"Workspace has "+a.name+" that this configuration does not manage",
+			"The workspace has a non-empty `"+a.name+"` but the configuration does not "+
+				"declare it, so Terraform will report no changes and the existing value "+
+				"will be left in place.\n\n"+
+				"If you removed `"+a.name+"` from the configuration intending to clear it, "+
+				"set `"+a.name+" = []` instead — omitting the attribute means \"leave "+
+				"alone\", not \"clear\".\n\n"+
+				"If the value is managed outside Terraform (the UI or the bulk-update "+
+				"endpoint), this warning is expected; declare the attribute explicitly to "+
+				"silence it.",
+		)
+	}
+}
+
 func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Manages a Terrapod workspace.",
@@ -194,7 +273,7 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 			},
 			"agent_pool_ids": schema.ListAttribute{
-				Description: "Agent pools this workspace's runs may execute on (#1085). The set is flat: a queued run is offered to every pool at once and whichever pool has a live listener claims it first, so losing one pool does not stop the workspace. There is no primary and no ordering preference. `agent_pool_id` reads back as element 0. Conflicts with `agent_pool_id`.",
+				Description: "Agent pools this workspace's runs may execute on (#1085). The set is flat: a queued run is offered to every pool at once and whichever pool has a live listener claims it first, so losing one pool does not stop the workspace. There is no primary and no ordering preference. `agent_pool_id` reads back as element 0. Conflicts with `agent_pool_id`. Omitting this attribute leaves any existing server-side value untouched — it does not clear it; set `agent_pool_ids = []` to clear.",
 				// Optional + Computed with UseStateForUnknown — same rationale as
 				// drift_ignore_rules (#684): the server may hold a set this config
 				// doesn't manage (assigned via the UI or bulk-update), so omitting
@@ -207,7 +286,7 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"var_files": schema.ListAttribute{
-				Description: "List of .tfvars file paths passed as -var-file arguments to plan/apply.",
+				Description: "List of .tfvars file paths passed as -var-file arguments to plan/apply. Omitting this attribute leaves any existing server-side value untouched — it does not clear it; set `var_files = []` to clear.",
 				// Optional + Computed with UseStateForUnknown — same rationale as
 				// drift_ignore_rules (#684): tolerate a server-held value the
 				// config doesn't set. Set `= []` to clear.
@@ -219,7 +298,7 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"trigger_prefixes": schema.ListAttribute{
-				Description: "Repo-root-relative directories to include in the sparse VCS fetch in addition to `working_directory`. Required when the workspace's terraform crosses directory boundaries via relative module sources (`module \"foo\" { source = \"../foo\" }`) — sparse-checkout cone mode includes parents of the listed directories but NOT siblings, so the referenced sibling must be declared here or the runner will error with `Unable to evaluate directory symlink`.",
+				Description: "Repo-root-relative directories to include in the sparse VCS fetch in addition to `working_directory`. Required when the workspace's terraform crosses directory boundaries via relative module sources (`module \"foo\" { source = \"../foo\" }`) — sparse-checkout cone mode includes parents of the listed directories but NOT siblings, so the referenced sibling must be declared here or the runner will error with `Unable to evaluate directory symlink`. Omitting this attribute leaves any existing server-side value untouched — it does not clear it; set `trigger_prefixes = []` to clear.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
@@ -228,7 +307,7 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"drift_ignore_rules": schema.ListAttribute{
-				Description: "Glob-aware patterns suppressed by the drift-result classifier (#482). Each entry is a Terraform resource address optionally suffixed with a dotted attribute path; `*` matches zero or more non-`.` characters (so it can span `[N]` indices but not segment boundaries), and `[*]` matches any bracketed index. A bare address with no attribute suffix silences any change to that resource — including destroys — so use carefully. Examples: `aws_iam_role.foo.tags.Environment`, `aws_autoscaling_group.workers[*].desired_capacity`, `module.eks*.argocd_cluster.*.config.tls_client_config.ca_data`, `aws_iam_role.foo`. Empty list (the default) means classic drift behaviour: every plan diff counts. Affects drift-detection runs only — regular plan/apply is untouched.",
+				Description: "Glob-aware patterns suppressed by the drift-result classifier (#482). Each entry is a Terraform resource address optionally suffixed with a dotted attribute path; `*` matches zero or more non-`.` characters (so it can span `[N]` indices but not segment boundaries), and `[*]` matches any bracketed index. A bare address with no attribute suffix silences any change to that resource — including destroys — so use carefully. Examples: `aws_iam_role.foo.tags.Environment`, `aws_autoscaling_group.workers[*].desired_capacity`, `module.eks*.argocd_cluster.*.config.tls_client_config.ca_data`, `aws_iam_role.foo`. Empty list (the default) means classic drift behaviour: every plan diff counts. Affects drift-detection runs only — regular plan/apply is untouched. Omitting this attribute leaves any existing server-side value untouched — it does not clear it; set `drift_ignore_rules = []` to clear.",
 				// Optional + Computed: the server may hold a value this config
 				// doesn't set (e.g. set out-of-band via the bulk-update endpoint),
 				// so omitting it must mean "leave alone" (plan = unknown), not
@@ -287,7 +366,7 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"security_scan_skip_rules": schema.ListAttribute{
-				Description: "Scanner rule-ids to suppress (Checkov `CKV_*` / Trivy `AVD-*`). Empty list (default) skips nothing.",
+				Description: "Scanner rule-ids to suppress (Checkov `CKV_*` / Trivy `AVD-*`). Empty list (default) skips nothing. Omitting this attribute leaves any existing server-side value untouched — it does not clear it; set `security_scan_skip_rules = []` to clear.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,

--- a/provider/internal/resources/workspace/resource_schema_test.go
+++ b/provider/internal/resources/workspace/resource_schema_test.go
@@ -2,9 +2,11 @@ package workspace
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 // TestListAttributesAreComputed is the regression guard for #684.
@@ -33,6 +35,69 @@ func TestListAttributesAreComputed(t *testing.T) {
 		}
 		if !attr.IsOptional() {
 			t.Errorf("attribute %q must stay Optional", name)
+		}
+	}
+}
+
+// TestUnmanagedCollectionDescriptionsDocumentClearing is the regression guard
+// for #1091.
+//
+// Because these attributes are Optional+Computed (#684 above), *removing* one
+// from a config is a silent no-op: the plan reports no changes and the workspace
+// keeps its value. That convention only ever existed in a source comment, so the
+// natural way to remove a var-file — deleting the line — failed silently. The
+// rendered Description is what a practitioner actually reads, so it has to say
+// so.
+func TestUnmanagedCollectionDescriptionsDocumentClearing(t *testing.T) {
+	var resp resource.SchemaResponse
+	NewResource().Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema build error: %v", resp.Diagnostics)
+	}
+
+	for _, a := range unmanagedCollections {
+		attr, ok := resp.Schema.Attributes[a.name]
+		if !ok {
+			t.Fatalf("attribute %q missing from schema", a.name)
+		}
+		desc := attr.GetDescription()
+		if !strings.Contains(desc, a.name+" = []") {
+			t.Errorf("attribute %q description must tell the reader to set `%s = []` to clear (#1091); got: %s",
+				a.name, a.name, desc)
+		}
+		if !strings.Contains(desc, "does not clear it") {
+			t.Errorf("attribute %q description must state that omitting it does NOT clear the value (#1091); got: %s",
+				a.name, desc)
+		}
+	}
+}
+
+// TestUnmanagedCollectionsCoversEveryOptionalComputedCollection stops a future
+// Optional+Computed list attribute from being added with the same silent-no-op
+// removal behaviour and no warning or documentation (#1091).
+func TestUnmanagedCollectionsCoversEveryOptionalComputedCollection(t *testing.T) {
+	var resp resource.SchemaResponse
+	NewResource().Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema build error: %v", resp.Diagnostics)
+	}
+
+	covered := map[string]bool{}
+	for _, a := range unmanagedCollections {
+		covered[a.name] = true
+	}
+
+	for name, attr := range resp.Schema.Attributes {
+		if _, isList := attr.(schema.ListAttribute); !isList {
+			continue
+		}
+		if !attr.IsOptional() || !attr.IsComputed() {
+			continue
+		}
+		if !covered[name] {
+			t.Errorf("list attribute %q is Optional+Computed but is not in unmanagedCollections — "+
+				"removing it from a config would be a silent no-op with no warning and no "+
+				"documentation (#1091). Add it, or make it Optional-only.", name)
 		}
 	}
 }


### PR DESCRIPTION
Deleting `var_files` from a `terrapod_workspace` config planned as **no changes** and left the workspace's var-files in place. "No changes" reasonably reads as "already gone" — and in the case that prompted this, the next step was deleting the tfvars file, which would have left the workspace passing `-var-file` for a path that no longer existed. The breakage would have surfaced one step later, in a different repo, with nothing pointing back at the cause.

## What is not changing

The attributes stay `Optional + Computed` with `UseStateForUnknown`. That is the #684 fix and it is right: Terrapod lets these be set outside Terraform (the UI, the bulk-update endpoint), so an absent config value has to mean "leave alone". Nothing here alters what an apply does.

## What is changing

**The descriptions tell the truth.** The "set `= []` to clear" convention existed only in a source comment. Every affected attribute's `Description` — the thing that renders in the provider docs and that a practitioner actually reads — now states that omitting it does *not* clear the value, and that `= []` does.

**`ModifyPlan` warns instead of staying quiet.** When the workspace holds a non-empty value for one of these attributes that the configuration does not declare, the plan now says so. It no longer claims agreement while config and remote genuinely disagree — which was the issue's stated minimum bar.

## Why a warning and not a real diff

The issue floats the better fix: distinguish "not managed" from "removed" so deleting the attribute plans a diff. I looked at it and it is not safely reachable.

The framework cannot tell the two apart. Both arrive at `ModifyPlan` as a null config value over a state value that `readWorkspaceIntoModel` populated from the server (`resource.go` — `if m.VarFiles.IsNull() && len(ws.VarFiles) == 0 { null } else { server value }`). Making absence mean "clear" would therefore also clear values legitimately managed out-of-band — and it would do it on the **first plan after upgrading the provider**, to anyone whose state holds a server-populated value under a config that never declared it. Trading a silent no-op for a silent destructive diff is a bad trade.

A warning costs nothing, cannot destroy anything, and is dismissible by declaring the attribute explicitly.

`agent_pool_ids` is exempt from the warning when `agent_pool_id` is set — the singular attribute manages the same set, so warning there would fire on every plan and be wrong.

## The fifth attribute

The completeness guard (`TestUnmanagedCollectionsCoversEveryOptionalComputedCollection`) fails CI if any Optional+Computed list attribute is missing from the covered set. It failed on first run and named `security_scan_skip_rules`, which the issue had not listed. Now covered. That guard is the durable part of this change — the next attribute added with this shape cannot ship undocumented and unwarned.

## Verification

- `go build ./...`, `go vet`, `go test ./...` in `provider/` — all green
- `make test` — 3318 passed (the API↔SDK contract test reads provider source, so it exercises the schema change)
- Provider schema golden unchanged: it tracks names and types, not descriptions, so no regen was needed
- New tests: description content for all five attributes, the completeness guard, `hasElements` across every list shape (null / unknown / empty / populated / non-list), and an accessor-crossing guard so a copy-paste in `unmanagedCollections` cannot silently mis-wire two attributes

Not covered: an acceptance test driving a real `terraform plan` to observe the warning text — the provider has no acceptance-test harness, and the predicates it turns on are unit-tested directly instead.

Closes #1091
