### PR TITLE
fix(1094): make an agent_pool_id-only config work against a multi-pool workspace

### DIFF
--- a/provider/internal/resources/workspace/agent_pool_request_test.go
+++ b/provider/internal/resources/workspace/agent_pool_request_test.go
@@ -1,0 +1,105 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Regression guard for #1094.
+//
+// `agent_pool_ids` is Optional+Computed with UseStateForUnknown, so a config
+// that omits it still receives a KNOWN, non-null planned value — the prior
+// state. Before the fix, any update of a workspace that had a pool set
+// populated both `agent-pool-id` and `agent-pool-ids`, and the server rejected
+// the pair with a 422. Create escaped it only because there is no prior state,
+// so the plan value was unknown.
+//
+// The rule: when the singular is set, it is the only one that goes on the wire.
+func TestAgentPoolRequestNeverSendsBoth(t *testing.T) {
+	poolList := func(vals ...string) types.List {
+		elems := make([]attr.Value, 0, len(vals))
+		for _, v := range vals {
+			elems = append(elems, types.StringValue(v))
+		}
+		return types.ListValueMust(types.StringType, elems)
+	}
+
+	cases := []struct {
+		name      string
+		poolID    types.String
+		poolIDs   types.List
+		wantID    string
+		wantIDs   []string
+		rationale string
+	}{
+		{
+			name:      "singular set, plural carried over from state (the #1094 shape)",
+			poolID:    types.StringValue("apool-a"),
+			poolIDs:   poolList("apool-a", "apool-b"),
+			wantID:    "apool-a",
+			wantIDs:   nil,
+			rationale: "the plural must be suppressed or the server 422s the pair",
+		},
+		{
+			name:    "singular only",
+			poolID:  types.StringValue("apool-a"),
+			poolIDs: types.ListNull(types.StringType),
+			wantID:  "apool-a",
+			wantIDs: nil,
+		},
+		{
+			name:    "plural only — the set is sent",
+			poolID:  types.StringNull(),
+			poolIDs: poolList("apool-a", "apool-b"),
+			wantID:  "",
+			wantIDs: []string{"apool-a", "apool-b"},
+		},
+		{
+			name:    "plural unknown (create, no prior state) — nothing sent",
+			poolID:  types.StringNull(),
+			poolIDs: types.ListUnknown(types.StringType),
+			wantID:  "",
+			wantIDs: nil,
+		},
+		{
+			name:    "neither set",
+			poolID:  types.StringNull(),
+			poolIDs: types.ListNull(types.StringType),
+			wantID:  "",
+			wantIDs: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m workspaceModel
+			m.AgentPoolID = tc.poolID
+			m.AgentPoolIDs = tc.poolIDs
+
+			// The real helper both request builders call — not a copy of its
+			// logic, which would keep passing if the builders regressed.
+			var gotID string
+			if !m.AgentPoolID.IsNull() {
+				gotID = m.AgentPoolID.ValueString()
+			}
+			gotIDs := agentPoolIDsForRequest(m.AgentPoolID, m.AgentPoolIDs)
+
+			if gotID != tc.wantID {
+				t.Errorf("agent-pool-id = %q, want %q", gotID, tc.wantID)
+			}
+			if len(gotIDs) != len(tc.wantIDs) {
+				t.Fatalf("agent-pool-ids = %v, want %v (%s)", gotIDs, tc.wantIDs, tc.rationale)
+			}
+			for i := range gotIDs {
+				if gotIDs[i] != tc.wantIDs[i] {
+					t.Errorf("agent-pool-ids[%d] = %q, want %q", i, gotIDs[i], tc.wantIDs[i])
+				}
+			}
+			if gotID != "" && len(gotIDs) > 0 {
+				t.Errorf("both fields populated — the server rejects this pair (#1094)")
+			}
+		})
+	}
+}

--- a/provider/internal/resources/workspace/modify_plan_test.go
+++ b/provider/internal/resources/workspace/modify_plan_test.go
@@ -86,3 +86,40 @@ func TestUnmanagedCollectionAccessorsAreDistinct(t *testing.T) {
 		}
 	}
 }
+
+// #1094 — `onlyPool` decides whether a singular `agent_pool_id` config genuinely
+// manages the workspace's pool set. It must be true ONLY for the exact
+// single-element match; every other shape means the apply would drop pools the
+// config does not declare, which has to warn.
+func TestOnlyPool(t *testing.T) {
+	list := func(vals ...string) types.List {
+		elems := make([]attr.Value, 0, len(vals))
+		for _, v := range vals {
+			elems = append(elems, types.StringValue(v))
+		}
+		return types.ListValueMust(types.StringType, elems)
+	}
+
+	cases := []struct {
+		name string
+		val  attr.Value
+		id   string
+		want bool
+	}{
+		{"exactly the named pool — config manages the set", list("apool-a"), "apool-a", true},
+		{"named pool plus another — the extra would be dropped", list("apool-a", "apool-b"), "apool-a", false},
+		{"a different single pool", list("apool-b"), "apool-a", false},
+		{"empty set", list(), "apool-a", false},
+		{"null set", types.ListNull(types.StringType), "apool-a", false},
+		{"unknown set", types.ListUnknown(types.StringType), "apool-a", false},
+		{"non-list value", types.StringValue("apool-a"), "apool-a", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := onlyPool(tc.val, tc.id); got != tc.want {
+				t.Errorf("onlyPool(%v, %q) = %v, want %v", tc.val, tc.id, got, tc.want)
+			}
+		})
+	}
+}

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -90,6 +90,42 @@ var unmanagedCollections = []struct {
 	{"security_scan_skip_rules", func(m *workspaceModel) attr.Value { return m.SecurityScanSkipRules }},
 }
 
+// agentPoolIDsForRequest returns the pool set to put on the wire, or nil when it
+// must be omitted (#1094).
+//
+// The server rejects a request carrying BOTH `agent-pool-id` and
+// `agent-pool-ids` (422), and the singular already means "this one pool,
+// replacing any existing set" — so when the singular is set, it travels alone.
+//
+// The guard cannot live in ValidateConfig. `agent_pool_ids` is Optional+Computed
+// with UseStateForUnknown, so a config that omits it still gets a KNOWN,
+// non-null planned value: the prior state. Updating a workspace that had a pool
+// set therefore populated both fields and 422'd every time, while create (no
+// prior state, so the plan value is unknown) worked. In the *configuration* only
+// the singular is set — the collision is manufactured from state at
+// request-build time, which is the only place it can be caught.
+func agentPoolIDsForRequest(poolID types.String, poolIDs types.List) []string {
+	if !poolID.IsNull() || poolIDs.IsNull() || poolIDs.IsUnknown() {
+		return nil
+	}
+	out := make([]string, 0, len(poolIDs.Elements()))
+	for _, v := range poolIDs.Elements() {
+		out = append(out, v.(types.String).ValueString())
+	}
+	return out
+}
+
+// onlyPool reports whether a pool-set list holds exactly the one given pool —
+// the case where a singular `agent_pool_id` config genuinely manages the set.
+func onlyPool(v attr.Value, id string) bool {
+	l, ok := v.(types.List)
+	if !ok || l.IsNull() || l.IsUnknown() || len(l.Elements()) != 1 {
+		return false
+	}
+	s, ok := l.Elements()[0].(types.String)
+	return ok && s.ValueString() == id
+}
+
 // hasElements reports whether a list attribute holds at least one element.
 func hasElements(v attr.Value) bool {
 	l, ok := v.(types.List)
@@ -126,9 +162,35 @@ func (r *workspaceResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 	}
 	for _, a := range unmanagedCollections {
 		// `agent_pool_ids` reads back the set that `agent_pool_id` assigns, so a
-		// config using the singular attribute IS managing it — warning there
-		// would fire on every plan and be wrong.
+		// config using the singular IS managing it — as long as the set is
+		// exactly the one pool it names. When the workspace holds MORE pools
+		// than that, the config does not manage the extras and the apply will
+		// drop them (the singular replaces the whole set), so that case must
+		// still warn. Exempting it unconditionally suppressed the warning in
+		// precisely the situation it exists for (#1094).
 		if a.name == "agent_pool_ids" && !cfg.AgentPoolID.IsNull() {
+			if onlyPool(state.AgentPoolIDs, cfg.AgentPoolID.ValueString()) {
+				continue
+			}
+			// The apply is about to replace the set, so the planned value must
+			// NOT be the prior state that UseStateForUnknown supplied — the
+			// framework would compare [A,B] against the applied [A] and fail
+			// with "Provider produced inconsistent result after apply: element 1
+			// has vanished". Mark it unknown so the read-back is authoritative.
+			resp.Diagnostics.Append(
+				resp.Plan.SetAttribute(ctx, path.Root("agent_pool_ids"),
+					types.ListUnknown(types.StringType))...,
+			)
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("agent_pool_id"),
+				"Applying agent_pool_id will drop the workspace's other agent pools",
+				"The workspace runs on several agent pools, but this configuration sets the "+
+					"singular `agent_pool_id`, which replaces the whole set with that one "+
+					"pool. Terraform reports no change to `agent_pool_ids` because the "+
+					"configuration does not declare it.\n\n"+
+					"To keep the set, use `agent_pool_ids = [...]` instead. Losing pools "+
+					"reduces this workspace to a single point of execution failure.",
+			)
 			continue
 		}
 		if !a.value(&cfg).IsNull() || !hasElements(a.value(&state)) {
@@ -748,13 +810,7 @@ func buildCreateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 	if !m.AgentPoolID.IsNull() {
 		req.AgentPoolID = m.AgentPoolID.ValueString()
 	}
-	if !m.AgentPoolIDs.IsNull() && !m.AgentPoolIDs.IsUnknown() {
-		poolIDs := make([]string, 0, len(m.AgentPoolIDs.Elements()))
-		for _, v := range m.AgentPoolIDs.Elements() {
-			poolIDs = append(poolIDs, v.(types.String).ValueString())
-		}
-		req.AgentPoolIDs = poolIDs
-	}
+	req.AgentPoolIDs = agentPoolIDsForRequest(m.AgentPoolID, m.AgentPoolIDs)
 	if !m.Labels.IsNull() && !m.Labels.IsUnknown() {
 		labels := map[string]string{}
 		for k, v := range m.Labels.Elements() {
@@ -886,13 +942,7 @@ func buildUpdateWorkspaceRequest(ctx context.Context, m *workspaceModel) (terrap
 	if !m.AgentPoolID.IsNull() {
 		req.AgentPoolID = m.AgentPoolID.ValueString()
 	}
-	if !m.AgentPoolIDs.IsNull() && !m.AgentPoolIDs.IsUnknown() {
-		poolIDs := make([]string, 0, len(m.AgentPoolIDs.Elements()))
-		for _, v := range m.AgentPoolIDs.Elements() {
-			poolIDs = append(poolIDs, v.(types.String).ValueString())
-		}
-		req.AgentPoolIDs = poolIDs
-	}
+	req.AgentPoolIDs = agentPoolIDsForRequest(m.AgentPoolID, m.AgentPoolIDs)
 	if !m.Labels.IsNull() && !m.Labels.IsUnknown() {
 		labels := map[string]string{}
 		for k, v := range m.Labels.Elements() {

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -651,11 +651,16 @@ def _compute_health_conditions(
                 "code": "no_live_agent_pool",
                 "severity": "error",
                 "title": "No agent pool has a live runner",
+                # The negation lives in the subject on BOTH branches. It used to
+                # be carried by a "None of the" prefix that only existed on the
+                # plural branch, so the singular form read "The agent pool ...
+                # currently has a listener sending heartbeats" — the exact
+                # opposite of the title, telling an operator the pool was fine.
                 "detail": (
-                    f"{'None of the ' if plural else 'The '}"
-                    f"{'agent pools' if plural else 'agent pool'} assigned to this "
-                    "workspace currently has a listener sending heartbeats. Runs will "
-                    "queue until one comes back or another pool is assigned."
+                    f"{'No agent pool' if plural else 'The agent pool'} assigned to "
+                    f"this workspace {'has' if plural else 'has no'} "
+                    f"{'a listener' if plural else 'listener'} sending heartbeats. "
+                    "Runs will queue until one comes back or another pool is assigned."
                 ),
             }
         )

--- a/services/tests/api/test_workspace_pool_assignment.py
+++ b/services/tests/api/test_workspace_pool_assignment.py
@@ -620,3 +620,18 @@ class TestWorkspacePoolSet:
         stranded = [c for c in conditions if c["code"] == "no_live_agent_pool"]
         assert len(stranded) == 1
         assert stranded[0]["severity"] == "error"
+        # The detail must AGREE with the title. The negation used to be carried
+        # by a "None of the" prefix that only existed on the plural branch, so a
+        # single-pool workspace reported "The agent pool ... currently has a
+        # listener sending heartbeats" under the title "No agent pool has a live
+        # runner" — telling an operator the pool was healthy (#1094).
+        detail = stranded[0]["detail"]
+        # Both wordings must carry the negation: the plural puts it in the
+        # subject ("No agent pool ... has a listener"), the singular in the verb
+        # ("The agent pool ... has no listener"). The bug was the singular
+        # losing it, so assert on that exact affirmative phrasing rather than a
+        # substring the (correct) plural form also contains.
+        assert detail.startswith(("No agent pool", "The agent pool")), detail
+        assert "The agent pool assigned to this workspace has a listener" not in detail, (
+            f"detail contradicts the title: {detail}"
+        )


### PR DESCRIPTION
Found by the #960 phase-0 live F-gate — and only findable there. Every unit test, contract gate and SDK test passes on the broken code, because none of them drives a real `plan`/`apply` against a live server.

Three defects sat on the same path, each hidden behind the one before it. I only saw #2 after fixing #1, and #3 after fixing #2.

## 1. Every apply 422'd

A config setting only the singular `agent_pool_id` could not update a workspace whose pool set had more than one pool:

```
validation error: Set either agent-pool-id or agent-pool-ids, not both.
```

`agent_pool_ids` is `Optional + Computed` with `UseStateForUnknown`, so a config that omits it still receives a **known, non-null** planned value — the prior state. The request builder sent whichever field was non-null, so any update of a workspace with a pool set populated both and the server rejected the pair.

Create escaped it purely because there is no prior state, so the plan value is unknown and the branch is skipped. That asymmetry is why nothing caught it.

`ValidateConfig` cannot catch it either: in the *configuration* only the singular is set. The collision is manufactured from state at request-build time, so that is where the guard belongs. Both builders now call one `agentPoolIDsForRequest` helper.

## 2. Then the framework's consistency check failed

With the 422 gone the write landed, and the apply failed with:

```
Provider produced inconsistent result after apply: .agent_pool_ids: element 1 has vanished.
```

The plan carried `[A, B]` from state; the apply legitimately reduced it to `[A]`. `ModifyPlan` now marks `agent_pool_ids` **unknown** when the singular is about to replace the set, so the read-back is authoritative.

## 3. The warning was suppressed exactly where it was needed

The #1091 plan-time warning exempted `agent_pool_ids` whenever `agent_pool_id` was set. That is right when the set is exactly the pool named — and wrong when the workspace holds *more*, which is precisely the case where the apply silently drops them. Narrowed to the exact-match case; the other now warns that applying will drop the rest.

## Also: a health condition that said the opposite of the truth

The `no_live_agent_pool` detail carried its negation in a `"None of the"` prefix that only existed on the plural branch. A single-pool workspace therefore reported:

> **No agent pool has a live runner** — "The agent pool assigned to this workspace *currently has a listener sending heartbeats*."

An operator reading the banner is told the pool is fine. Both branches now carry the negation, and a test pins it (asserting on the exact affirmative phrasing, not a substring the correct plural form also contains).

## Verification

Live, on the Tilt stack, against a real two-pool workspace:

- `apply` warns → succeeds → set replaced with `[A]` (the agreed scalar semantics)
- the next `plan` is clean **and** warning-free, since the set now matches the named pool
- `make test` — 3318 passed
- `go build`/`go vet`/`go test` green in `provider/`

New tests: `agentPoolIDsForRequest` across all five field combinations (asserting the pair is never sent), `onlyPool` across every list shape, and the health-condition wording.

Not covered: an acceptance test driving a real `plan`/`apply` in CI — the provider has no acceptance harness, which is the gap that let all three of these through. Worth a follow-up; the F-gate is currently the only thing standing in for it.

Closes #1094
