### PR TITLE
perf(1096): deduplicate VCS metadata calls across workspaces sharing a repo

### DIFF
--- a/services/terrapod/services/vcs_metadata_cache.py
+++ b/services/terrapod/services/vcs_metadata_cache.py
@@ -1,0 +1,74 @@
+"""Per-poll-cycle memoisation of VCS repo-metadata calls (#1096).
+
+The poller asks the provider two questions per workspace — the tracked branch's
+head SHA, and the open PRs targeting it — plus the repo's default branch for
+workspaces that don't pin one. All three are pure functions of
+``(connection, owner, repo, branch)``, so every workspace beyond the first on a
+given repo was issuing an identical request every cycle.
+
+That is enough to exhaust a GitHub App installation's hourly quota on a modest
+estate: 65 workspaces across 16 distinct ``(repo, branch)`` pairs was ~7,800
+calls/hour against a 5,000/hour limit, and GitHub reports primary-limit
+exhaustion as a 403, which reads like a permission error.
+
+The cache is deliberately **per cycle**. Holding results across cycles would
+stop the poller noticing new commits — the whole point of polling. A fresh
+instance is created for each poll cycle and discarded with it.
+
+It also **single-flights**: workspaces are polled concurrently under a
+semaphore, so without it the first N concurrent pollers for one repo would each
+fire before any of them populated the cache. Callers share one in-flight task
+rather than racing.
+
+Failures are shared too, which is intentional. When a repo's metadata call
+fails, every workspace on that repo would have failed the same way; sharing the
+failure turns N doomed calls into one. That matters most during a rate-limit
+event, when extra calls are exactly what you cannot afford. The next cycle
+retries with a fresh cache.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from terrapod.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+# (connection_id, owner, repo, branch-or-"") — `branch` is "" for the
+# default-branch lookup, which does not take one.
+MetaKey = tuple[str, str, str, str]
+
+
+class VCSMetadataCache:
+    """Single-flight memoisation of provider metadata calls for one poll cycle."""
+
+    def __init__(self) -> None:
+        self._tasks: dict[MetaKey, asyncio.Task] = {}
+        self.hits = 0
+        self.misses = 0
+
+    async def get_or_fetch(self, key: MetaKey, fetch: Callable[[], Awaitable[T]]) -> T:
+        """Return the cached result for ``key``, or run ``fetch`` to produce it.
+
+        Concurrent callers for the same key await one shared task. The result —
+        including an exception — is shared by all of them.
+        """
+        task = self._tasks.get(key)
+        if task is None:
+            self.misses += 1
+            # create_task (not a bare coroutine) so concurrent callers can all
+            # await the same handle; awaiting one coroutine twice is an error.
+            task = asyncio.create_task(fetch())
+            self._tasks[key] = task
+        else:
+            self.hits += 1
+        return await task
+
+    def stats(self) -> dict[str, int]:
+        """Hit/miss counters, for logging how much upstream traffic was saved."""
+        return {"hits": self.hits, "misses": self.misses}

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -49,6 +49,7 @@ from terrapod.services import (
 )
 from terrapod.services.scheduler import enqueue_trigger
 from terrapod.services.vcs_archive_cache import VCSArchiveCache, materialize_archive
+from terrapod.services.vcs_metadata_cache import VCSMetadataCache
 from terrapod.services.vcs_provider import (
     PullRequest,
 )
@@ -83,12 +84,36 @@ def _parse_repo_url(conn: VCSConnection, repo_url: str) -> tuple[str, str] | Non
     return _provider_parse_repo_url(conn, repo_url)
 
 
-async def _get_branch_sha(conn: VCSConnection, owner: str, repo: str, branch: str) -> str | None:
-    return await _provider_get_branch_sha(conn, owner, repo, branch)
+async def _get_branch_sha(
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    branch: str,
+    meta: VCSMetadataCache | None = None,
+) -> str | None:
+    """Head SHA of `branch`, deduplicated across workspaces in this cycle (#1096).
+
+    Many workspaces share a repo+branch, and the answer is identical for all of
+    them. `meta` is None for one-shot callers, which behave exactly as before.
+    """
+    if meta is None:
+        return await _provider_get_branch_sha(conn, owner, repo, branch)
+    return await meta.get_or_fetch(
+        (str(conn.id), owner, repo, branch),
+        lambda: _provider_get_branch_sha(conn, owner, repo, branch),
+    )
 
 
-async def _get_default_branch(conn: VCSConnection, owner: str, repo: str) -> str | None:
-    return await _provider_get_default_branch(conn, owner, repo)
+async def _get_default_branch(
+    conn: VCSConnection, owner: str, repo: str, meta: VCSMetadataCache | None = None
+) -> str | None:
+    if meta is None:
+        return await _provider_get_default_branch(conn, owner, repo)
+    # "" in the branch slot — this lookup has no branch of its own.
+    return await meta.get_or_fetch(
+        (str(conn.id), owner, repo, ""),
+        lambda: _provider_get_default_branch(conn, owner, repo),
+    )
 
 
 async def _download_archive(conn: VCSConnection, owner: str, repo: str, ref: str) -> bytes:
@@ -159,9 +184,20 @@ async def _list_tags(conn: VCSConnection, owner: str, repo: str) -> list[dict[st
 
 
 async def _list_open_prs(
-    conn: VCSConnection, owner: str, repo: str, base_branch: str
+    conn: VCSConnection,
+    owner: str,
+    repo: str,
+    base_branch: str,
+    meta: VCSMetadataCache | None = None,
 ) -> list[PullRequest]:
-    """List open PRs/MRs via the appropriate provider."""
+    """Open PRs/MRs targeting `base_branch`, deduplicated per cycle (#1096)."""
+    if meta is not None:
+        # Distinct key space from the branch-SHA lookup, which shares the same
+        # (conn, owner, repo, branch) tuple.
+        return await meta.get_or_fetch(
+            (str(conn.id), owner, repo, f"prs:{base_branch}"),
+            lambda: _list_open_prs(conn, owner, repo, base_branch),
+        )
     if conn.provider == "gitlab":
         return await gitlab_service.list_open_prs(conn, owner, repo, base_branch)
     prs = await github_service.list_open_pull_requests(conn, owner, repo, base_branch)
@@ -233,7 +269,13 @@ def describe_vcs_error(e: BaseException) -> str:
     return text or type(e).__name__
 
 
-async def _resolve_branch(conn: VCSConnection, ws: Workspace, owner: str, repo: str) -> str | None:
+async def _resolve_branch(
+    conn: VCSConnection,
+    ws: Workspace,
+    owner: str,
+    repo: str,
+    meta: VCSMetadataCache | None = None,
+) -> str | None:
     """Resolve the tracked branch for a workspace.
 
     Returns None ONLY when the provider answered successfully but no branch
@@ -245,7 +287,7 @@ async def _resolve_branch(conn: VCSConnection, ws: Workspace, owner: str, repo: 
     if ws.vcs_branch:
         return ws.vcs_branch
 
-    default_branch = await _get_default_branch(conn, owner, repo)
+    default_branch = await _get_default_branch(conn, owner, repo, meta)
     if default_branch:
         return default_branch
     logger.warning(
@@ -289,6 +331,7 @@ async def _create_vcs_run(
     pr_number: int | None = None,
     message: str = "",
     cache: VCSArchiveCache | None = None,
+    meta: VCSMetadataCache | None = None,
     fetch_paths: list[str] | None = None,
 ) -> Run | None:
     """Download archive (via cache + streaming), create ConfigurationVersion and Run.
@@ -389,10 +432,11 @@ async def _poll_workspace_branch(
     repo: str,
     branch: str,
     cache: VCSArchiveCache | None = None,
+    meta: VCSMetadataCache | None = None,
     fetch_paths: list[str] | None = None,
 ) -> None:
     """Check the tracked branch for new commits and create a run."""
-    sha = await _get_branch_sha(conn, owner, repo, branch)
+    sha = await _get_branch_sha(conn, owner, repo, branch, meta)
 
     if sha is None:
         logger.warning(
@@ -499,6 +543,7 @@ async def _poll_workspace_branch(
         branch,
         message=f"Triggered by commit {sha[:8]} on {branch}",
         cache=cache,
+        meta=meta,
         fetch_paths=fetch_paths,
     )
 
@@ -704,10 +749,11 @@ async def _poll_workspace_prs(
     repo: str,
     branch: str,
     cache: VCSArchiveCache | None = None,
+    meta: VCSMetadataCache | None = None,
     fetch_paths: list[str] | None = None,
 ) -> None:
     """Check open PRs/MRs targeting the tracked branch for speculative plans."""
-    prs = await _list_open_prs(conn, owner, repo, branch)
+    prs = await _list_open_prs(conn, owner, repo, branch, meta)
 
     # Hook-and-poll fallbacks (#282). Only run for apply-then-merge —
     # default-mode PR runs are plan-only and don't drive any of this.
@@ -825,6 +871,7 @@ async def _poll_workspace_prs(
             pr_number=pr.number,
             message=message,
             cache=cache,
+            meta=meta,
             fetch_paths=fetch_paths,
         )
 
@@ -856,6 +903,7 @@ async def _poll_workspace(
     db: AsyncSession,
     ws: Workspace,
     cache: VCSArchiveCache | None = None,
+    meta: VCSMetadataCache | None = None,
     paths_unions: "PathsUnionMap | None" = None,
 ) -> None:
     """Poll a single workspace: check branch for pushes and PRs for speculative plans.
@@ -905,7 +953,7 @@ async def _poll_workspace(
     owner, repo = parsed
 
     try:
-        branch = await _resolve_branch(conn, ws, owner, repo)
+        branch = await _resolve_branch(conn, ws, owner, repo, meta)
     except Exception as e:
         # The provider call itself failed — report THAT, not a derived symptom.
         ws.vcs_last_error = describe_vcs_error(e)[:500]
@@ -930,10 +978,10 @@ async def _poll_workspace(
 
     try:
         # 1. Check tracked branch for new commits → real runs
-        await _poll_workspace_branch(db, ws, conn, owner, repo, branch, cache, fetch_paths)
+        await _poll_workspace_branch(db, ws, conn, owner, repo, branch, cache, fetch_paths, meta)
 
         # 2. Check open PRs/MRs targeting the tracked branch → speculative plans
-        await _poll_workspace_prs(db, ws, conn, owner, repo, branch, cache, fetch_paths)
+        await _poll_workspace_prs(db, ws, conn, owner, repo, branch, cache, fetch_paths, meta)
 
         # Success: update last-polled timestamp and clear any previous error
         ws.vcs_last_polled_at = now_utc()
@@ -963,6 +1011,7 @@ async def _poll_workspace_owned(
     ws_id: uuid.UUID,
     semaphore: asyncio.Semaphore,
     cache: VCSArchiveCache | None = None,
+    meta: VCSMetadataCache | None = None,
     paths_unions: "PathsUnionMap | None" = None,
 ) -> None:
     """Poll a single workspace in its own DB session, bounded by a semaphore.
@@ -983,7 +1032,7 @@ async def _poll_workspace_owned(
         if ws is None:
             return
         try:
-            await _poll_workspace(db, ws, cache, paths_unions)
+            await _poll_workspace(db, ws, cache=cache, paths_unions=paths_unions, meta=meta)
             await db.commit()
         except Exception as e:
             logger.error(
@@ -1028,6 +1077,37 @@ async def _record_poll_failure(ws_id: uuid.UUID, message: str) -> None:
             await db.commit()
     except Exception:
         logger.warning("Could not persist VCS poll failure", workspace_id=str(ws_id))
+
+
+def _log_cycle_failures(results: list, workspace_ids: list) -> None:
+    """Surface anything `asyncio.gather(return_exceptions=True)` swallowed.
+
+    `_poll_workspace_owned` already records per-workspace VCS failures on the
+    workspace itself, so anything escaping it is a defect in the poller — a
+    wiring or signature error, not a provider problem. Dropping those means VCS
+    change detection can stop dead while the cycle still reports success and
+    nothing anywhere says so. That is the worst failure mode this component has:
+    silence indistinguishable from "no changes".
+
+    Caught for real while building #1096, where a stale call signature made
+    every poll raise TypeError and zero workspaces were polled, with no error
+    surfaced anywhere.
+    """
+    failures = [r for r in results if isinstance(r, BaseException)]
+    if not failures:
+        return
+    logger.error(
+        "VCS poll cycle had workspace polls fail outright",
+        failed=len(failures),
+        total=len(workspace_ids),
+        # One representative — they are usually all the same defect.
+        error=f"{type(failures[0]).__name__}: {failures[0]}",
+    )
+    if len(failures) == len(workspace_ids) and workspace_ids:
+        logger.error(
+            "VCS poll cycle polled NO workspaces successfully — change detection is down",
+            total=len(workspace_ids),
+        )
 
 
 async def _select_workspace_ids(
@@ -1485,11 +1565,21 @@ async def poll_cycle() -> None:
     # One cache instance per cycle — coalesces concurrent (conn, sha, paths)
     # fetches across all workspace polls in this cycle.
     cache = VCSArchiveCache()
+    # One metadata cache per cycle too (#1096). Branch-SHA and open-PR lookups
+    # are identical for every workspace on the same repo+branch; without this,
+    # each workspace re-asked and a modest estate exhausted the provider's
+    # hourly quota. Per-cycle by design — holding results across cycles would
+    # stop the poller noticing new commits.
+    meta = VCSMetadataCache()
     semaphore = asyncio.Semaphore(_MAX_PARALLEL_WORKSPACE_POLLS)
-    await asyncio.gather(
-        *[_poll_workspace_owned(wid, semaphore, cache, paths_unions) for wid in workspace_ids],
+    results = await asyncio.gather(
+        *[
+            _poll_workspace_owned(wid, semaphore, cache=cache, meta=meta, paths_unions=paths_unions)
+            for wid in workspace_ids
+        ],
         return_exceptions=True,
     )
+    _log_cycle_failures(results, workspace_ids)
 
     VCS_POLL_DURATION.labels(provider="all").observe(time_mod.monotonic() - start)
 
@@ -1549,10 +1639,20 @@ async def handle_immediate_poll(payload: dict) -> None:
     # Webhook-triggered polls also share one cache instance — same coalescing
     # benefit when multiple workspaces map to the same repo.
     cache = VCSArchiveCache()
+    # One metadata cache per cycle too (#1096). Branch-SHA and open-PR lookups
+    # are identical for every workspace on the same repo+branch; without this,
+    # each workspace re-asked and a modest estate exhausted the provider's
+    # hourly quota. Per-cycle by design — holding results across cycles would
+    # stop the poller noticing new commits.
+    meta = VCSMetadataCache()
     semaphore = asyncio.Semaphore(_MAX_PARALLEL_WORKSPACE_POLLS)
-    await asyncio.gather(
-        *[_poll_workspace_owned(wid, semaphore, cache, paths_unions) for wid in workspace_ids],
+    results = await asyncio.gather(
+        *[
+            _poll_workspace_owned(wid, semaphore, cache=cache, meta=meta, paths_unions=paths_unions)
+            for wid in workspace_ids
+        ],
         return_exceptions=True,
     )
+    _log_cycle_failures(results, workspace_ids)
 
     VCS_POLL_DURATION.labels(provider="all").observe(time_mod.monotonic() - start)

--- a/services/tests/services/test_vcs_metadata_cache.py
+++ b/services/tests/services/test_vcs_metadata_cache.py
@@ -1,0 +1,156 @@
+"""Tests for the per-poll-cycle VCS metadata cache (#1096)."""
+
+import asyncio
+
+import pytest
+
+from terrapod.services.vcs_metadata_cache import VCSMetadataCache
+
+
+class TestMemoisation:
+    """The point of the cache: one upstream call per distinct key per cycle."""
+
+    async def test_repeated_key_calls_upstream_once(self):
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            return "abc123"
+
+        cache = VCSMetadataCache()
+        key = ("conn-1", "org", "repo", "main")
+        results = [await cache.get_or_fetch(key, fetch) for _ in range(5)]
+
+        assert results == ["abc123"] * 5
+        assert calls == 1, "five workspaces on one repo must not make five API calls"
+        assert cache.stats() == {"hits": 4, "misses": 1}
+
+    async def test_distinct_keys_each_call_upstream(self):
+        calls = []
+
+        def make(name):
+            async def fetch():
+                calls.append(name)
+                return name
+
+            return fetch
+
+        cache = VCSMetadataCache()
+        await cache.get_or_fetch(("c", "org", "repo-a", "main"), make("a"))
+        await cache.get_or_fetch(("c", "org", "repo-b", "main"), make("b"))
+        # Same repo, different branch — genuinely different question.
+        await cache.get_or_fetch(("c", "org", "repo-a", "develop"), make("a-dev"))
+        # Different connection, same repo — different credentials, so not shared.
+        await cache.get_or_fetch(("c2", "org", "repo-a", "main"), make("a-conn2"))
+
+        assert calls == ["a", "b", "a-dev", "a-conn2"]
+
+    async def test_branch_sha_and_pr_lookups_do_not_collide(self):
+        """Both lookups key on (conn, owner, repo, branch); they must stay distinct.
+
+        The PR listing prefixes its branch slot, so a workspace asking for the
+        head SHA of `main` must not receive the PR list for `main`.
+        """
+        cache = VCSMetadataCache()
+
+        async def sha():
+            return "sha-value"
+
+        async def prs():
+            return ["pr-value"]
+
+        got_sha = await cache.get_or_fetch(("c", "org", "repo", "main"), sha)
+        got_prs = await cache.get_or_fetch(("c", "org", "repo", "prs:main"), prs)
+
+        assert got_sha == "sha-value"
+        assert got_prs == ["pr-value"]
+
+
+class TestSingleFlight:
+    """Workspaces are polled concurrently, so caching alone is not enough."""
+
+    async def test_concurrent_callers_share_one_call(self):
+        calls = 0
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            started.set()
+            await release.wait()  # hold the call open while the others arrive
+            return "shared"
+
+        cache = VCSMetadataCache()
+        key = ("c", "org", "repo", "main")
+        tasks = [asyncio.create_task(cache.get_or_fetch(key, fetch)) for _ in range(10)]
+        await started.wait()
+        release.set()
+        results = await asyncio.gather(*tasks)
+
+        assert results == ["shared"] * 10
+        assert calls == 1, "ten concurrent pollers must not each fire a request"
+
+
+class TestFailureSharing:
+    """A failing repo should cost one call, not one per workspace."""
+
+    async def test_failure_is_shared_not_retried_per_caller(self):
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("rate limited")
+
+        cache = VCSMetadataCache()
+        key = ("c", "org", "repo", "main")
+
+        for _ in range(4):
+            with pytest.raises(RuntimeError, match="rate limited"):
+                await cache.get_or_fetch(key, fetch)
+
+        # This is the behaviour that matters during a rate-limit event: four
+        # workspaces on a failing repo spend one call, not four.
+        assert calls == 1
+
+    async def test_concurrent_callers_share_the_failure(self):
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            await asyncio.sleep(0)
+            raise RuntimeError("boom")
+
+        cache = VCSMetadataCache()
+        key = ("c", "org", "repo", "main")
+        results = await asyncio.gather(
+            *[cache.get_or_fetch(key, fetch) for _ in range(5)],
+            return_exceptions=True,
+        )
+
+        assert all(isinstance(r, RuntimeError) for r in results)
+        assert calls == 1
+
+
+class TestIsolation:
+    """A fresh cache per cycle is what keeps polling correct."""
+
+    async def test_a_new_cache_does_not_inherit_results(self):
+        """Holding results across cycles would stop the poller seeing new commits."""
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            return f"sha-{calls}"
+
+        key = ("c", "org", "repo", "main")
+        first = VCSMetadataCache()
+        assert await first.get_or_fetch(key, fetch) == "sha-1"
+
+        second = VCSMetadataCache()
+        assert await second.get_or_fetch(key, fetch) == "sha-2"
+        assert calls == 2

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -598,7 +598,7 @@ class TestPollCycleParallel:
         max_in_flight: list[int] = [0]
         entered = 0
 
-        async def fake_owned_poll(ws_id, semaphore, cache=None, paths_unions=None):
+        async def fake_owned_poll(ws_id, semaphore, cache=None, meta=None, paths_unions=None):
             import asyncio as _a
 
             nonlocal entered
@@ -675,7 +675,7 @@ class TestPollCycleParallel:
 
         polled: list[uuid.UUID] = []
 
-        async def fake_owned_poll(ws_id, semaphore, cache=None, paths_unions=None):
+        async def fake_owned_poll(ws_id, semaphore, cache=None, meta=None, paths_unions=None):
             polled.append(ws_id)
 
         with (
@@ -725,7 +725,7 @@ class TestPollCycleParallel:
 
         polled: list[uuid.UUID] = []
 
-        async def fake_owned_poll(ws_id, semaphore, cache=None, paths_unions=None):
+        async def fake_owned_poll(ws_id, semaphore, cache=None, meta=None, paths_unions=None):
             polled.append(ws_id)
 
         with (
@@ -774,7 +774,7 @@ class TestPollCycleParallel:
 
         polled: list[uuid.UUID] = []
 
-        async def fake_owned_poll(ws_id, semaphore, cache=None, paths_unions=None):
+        async def fake_owned_poll(ws_id, semaphore, cache=None, meta=None, paths_unions=None):
             polled.append(ws_id)
 
         with (
@@ -1130,3 +1130,157 @@ class TestPollFailureSurvivesRollback:
         mock_session.side_effect = Exception("database is down")
 
         await _record_poll_failure(uuid.uuid4(), "whatever")
+
+
+class TestMetadataDeduplication:
+    """#1096 — workspaces sharing a repo must not each re-ask the provider.
+
+    The cache lives in `vcs_metadata_cache` and is unit-tested there. These
+    assert the poller's thin provider wrappers are actually wired to it — a
+    cache nothing routes through would save nothing.
+    """
+
+    async def test_branch_sha_deduped_across_workspaces(self):
+        from terrapod.services.vcs_metadata_cache import VCSMetadataCache
+        from terrapod.services.vcs_poller import _get_branch_sha
+
+        conn = _mock_connection()
+        conn.id = uuid.uuid4()
+        meta = VCSMetadataCache()
+
+        with patch(
+            "terrapod.services.vcs_poller._provider_get_branch_sha",
+            new_callable=AsyncMock,
+            return_value="deadbeef",
+        ) as prov:
+            # Eleven workspaces on one repo+branch, as in a real monorepo estate.
+            for _ in range(11):
+                assert await _get_branch_sha(conn, "org", "repo", "main", meta) == "deadbeef"
+
+        assert prov.await_count == 1
+
+    async def test_open_prs_deduped_across_workspaces(self):
+        from terrapod.services.vcs_metadata_cache import VCSMetadataCache
+        from terrapod.services.vcs_poller import _list_open_prs
+
+        conn = _mock_connection()
+        conn.id = uuid.uuid4()
+        meta = VCSMetadataCache()
+
+        with patch(
+            "terrapod.services.github_service.list_open_pull_requests",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as prov:
+            for _ in range(11):
+                assert await _list_open_prs(conn, "org", "repo", "main", meta) == []
+
+        assert prov.await_count == 1
+
+    async def test_default_branch_deduped_across_workspaces(self):
+        from terrapod.services.vcs_metadata_cache import VCSMetadataCache
+        from terrapod.services.vcs_poller import _get_default_branch
+
+        conn = _mock_connection()
+        conn.id = uuid.uuid4()
+        meta = VCSMetadataCache()
+
+        with patch(
+            "terrapod.services.vcs_poller._provider_get_default_branch",
+            new_callable=AsyncMock,
+            return_value="main",
+        ) as prov:
+            for _ in range(5):
+                assert await _get_default_branch(conn, "org", "repo", meta) == "main"
+
+        assert prov.await_count == 1
+
+    async def test_without_a_cache_behaviour_is_unchanged(self):
+        """One-shot callers (UI-queued runs, module-impact) pass no cache."""
+        from terrapod.services.vcs_poller import _get_branch_sha
+
+        conn = _mock_connection()
+        conn.id = uuid.uuid4()
+
+        with patch(
+            "terrapod.services.vcs_poller._provider_get_branch_sha",
+            new_callable=AsyncMock,
+            return_value="deadbeef",
+        ) as prov:
+            for _ in range(3):
+                await _get_branch_sha(conn, "org", "repo", "main")
+
+        assert prov.await_count == 3, "no cache passed -> no caching, exactly as before"
+
+    async def test_different_branches_are_not_conflated(self):
+        from terrapod.services.vcs_metadata_cache import VCSMetadataCache
+        from terrapod.services.vcs_poller import _get_branch_sha
+
+        conn = _mock_connection()
+        conn.id = uuid.uuid4()
+        meta = VCSMetadataCache()
+
+        async def by_branch(_c, _o, _r, branch):
+            return f"sha-of-{branch}"
+
+        with patch(
+            "terrapod.services.vcs_poller._provider_get_branch_sha",
+            new=AsyncMock(side_effect=by_branch),
+        ) as prov:
+            assert await _get_branch_sha(conn, "org", "repo", "main", meta) == "sha-of-main"
+            assert await _get_branch_sha(conn, "org", "repo", "develop", meta) == "sha-of-develop"
+
+        assert prov.await_count == 2
+
+
+class TestPollCycleFailuresAreNotSilent:
+    """#1096 — a poll cycle must never fail silently.
+
+    `asyncio.gather(return_exceptions=True)` keeps one bad workspace from
+    killing the cycle, which is right. But it also swallowed defects in the
+    poller itself: while building the metadata cache, a stale call signature
+    made every poll raise TypeError, ZERO workspaces were polled, and the cycle
+    still reported success. For VCS change detection that is the worst possible
+    failure — silence is indistinguishable from "nothing changed".
+    """
+
+    def test_partial_failure_is_logged(self):
+        from terrapod.services.vcs_poller import _log_cycle_failures
+
+        ids = [uuid.uuid4() for _ in range(3)]
+        with patch("terrapod.services.vcs_poller.logger") as log:
+            _log_cycle_failures([None, RuntimeError("boom"), None], ids)
+
+        assert log.error.called, "a failed workspace poll must be logged, not dropped"
+        # Partial failure is not the total-outage alarm.
+        msgs = [c.args[0] for c in log.error.call_args_list]
+        assert not any("change detection is down" in m for m in msgs)
+
+    def test_total_failure_raises_the_louder_alarm(self):
+        from terrapod.services.vcs_poller import _log_cycle_failures
+
+        ids = [uuid.uuid4() for _ in range(3)]
+        with patch("terrapod.services.vcs_poller.logger") as log:
+            _log_cycle_failures([TypeError("bad signature")] * 3, ids)
+
+        msgs = [c.args[0] for c in log.error.call_args_list]
+        assert any("change detection is down" in m for m in msgs), (
+            "every workspace failing is an outage and must say so explicitly"
+        )
+
+    def test_clean_cycle_logs_nothing(self):
+        from terrapod.services.vcs_poller import _log_cycle_failures
+
+        with patch("terrapod.services.vcs_poller.logger") as log:
+            _log_cycle_failures([None, None], [uuid.uuid4(), uuid.uuid4()])
+
+        assert not log.error.called
+
+    def test_no_workspaces_is_not_an_outage(self):
+        """An empty estate polls nothing; that is not a failure."""
+        from terrapod.services.vcs_poller import _log_cycle_failures
+
+        with patch("terrapod.services.vcs_poller.logger") as log:
+            _log_cycle_failures([], [])
+
+        assert not log.error.called


### PR DESCRIPTION
The poller asked the provider two questions per workspace per cycle — the tracked branch's head SHA, and the open PRs targeting it — plus the repo's default branch for workspaces that don't pin one. All three are pure functions of `(connection, owner, repo, branch)`, so every workspace beyond the first on a given repo issued an identical request, every cycle.

On a real estate that is enough to exhaust a GitHub App installation's hourly quota:

| | calls/cycle | calls/hour |
|---|---|---|
| before | ~130 | **~7,800** |
| after | ~32 | **~1,920** |

(65 VCS workspaces collapsing to 16 distinct `(repo, branch)` pairs, 60s cycles, against a 5,000/hour installation limit.) The quota went about 38 minutes into each hour, after which polling failed until reset — surfacing as **403**, because that is how GitHub reports primary rate-limit exhaustion, which reads like a permission error.

## Retry was not the missing piece

`github_service` already honours `Retry-After`, falls back to `X-RateLimit-Reset`, and treats rate-limit 403s as retryable. That is right for riding out a burst and wrong for this: when call volume structurally exceeds the quota, retrying spends more of it, and a primary-limit reset can be an hour out — far past any sane in-cycle wait. The volume is the problem.

## The cache

`VCSMetadataCache` memoises the three lookups for one poll cycle and single-flights concurrent callers.

- **Per-cycle by design.** Holding results across cycles would stop the poller noticing new commits — the entire point of polling. A test asserts a fresh cache does not inherit results.
- **Single-flight matters as much as caching.** Workspaces are polled concurrently under a semaphore, so without it the first N concurrent pollers for one repo would each fire before any populated the cache.
- **Failures are shared too**, deliberately. The workspaces on a failing repo would all have failed identically; sharing turns N doomed calls into one. That matters most during exactly the rate-limit event that motivated this.
- One-shot callers (UI-queued runs, module-impact) pass no cache and behave **exactly** as before.

Tarball fetches were already coalesced by `VCSArchiveCache`; this closes the metadata half using the same seam.

## Also: the poll cycle no longer fails silently

This is the more important half, and I found it by accident.

`asyncio.gather(return_exceptions=True)` correctly stops one bad workspace killing the cycle. It was also swallowing defects in the poller itself. While wiring the cache I left a stale call signature: **every** poll raised `TypeError`, **zero** workspaces were polled, and the cycle still reported success. Nothing logged, no metric moved.

For VCS change detection that is the worst failure mode available — silence is indistinguishable from "nothing changed", so an estate can stop detecting commits indefinitely and look healthy. Escaped exceptions are now logged, with a distinct louder alarm when *no* workspace polled successfully.

The existing `TestPollCycleParallel` tests caught the regression, which is why they show in the diff: their test doubles needed the new signature.

## Verification

- `make test` — 3334 passed
- New: cache unit tests (memoisation, distinct keys, key-space collision between the SHA and PR lookups, single-flight under 10 concurrent callers, shared failure, cross-cycle isolation); poller-level tests asserting the three wrappers actually route through the cache — a cache nothing routes through would save nothing; and tests pinning the failure-logging.

Not covered: a live run against a real provider under rate-limiting, which can't be provoked on demand. The call-count assertions stand in for it.

Closes #1096
