### PR TITLE
fix(1099): release the VCS commit claim when run creation fails

### DIFF
--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -533,19 +533,25 @@ async def _poll_workspace_branch(
                 error=repr(e),
             )
 
-    run = await _create_vcs_run(
-        db,
-        ws,
-        conn,
-        owner,
-        repo,
-        sha,
-        branch,
-        message=f"Triggered by commit {sha[:8]} on {branch}",
-        cache=cache,
-        meta=meta,
-        fetch_paths=fetch_paths,
-    )
+    try:
+        run = await _create_vcs_run(
+            db,
+            ws,
+            conn,
+            owner,
+            repo,
+            sha,
+            branch,
+            message=f"Triggered by commit {sha[:8]} on {branch}",
+            cache=cache,
+            meta=meta,
+            fetch_paths=fetch_paths,
+        )
+    except Exception:
+        # The claim above is already committed, so a rollback cannot undo it.
+        # Release it explicitly or this commit is skipped forever (#1099).
+        await _release_commit_claim(ws.id, sha, old_sha)
+        raise
 
     if run:
         VCS_RUNS_CREATED.labels(provider=conn.provider, type="push").inc()
@@ -1051,6 +1057,69 @@ async def _poll_workspace_owned(
             # `vcs-last-error: null` (#1089). Re-record it in its own
             # transaction so the failure is never invisible.
             await _record_poll_failure(ws_id, describe_vcs_error(e))
+
+
+async def _release_commit_claim(ws_id: uuid.UUID, claimed_sha: str, previous_sha: str) -> None:
+    """Roll the poll cursor back after failing to create a commit's run (#1099).
+
+    `_poll_workspace_branch` advances `vcs_last_commit_sha` *before* fetching the
+    archive and creating the run, so that a concurrent poll cycle cannot produce a
+    duplicate run for the same commit (#217). That ordering is deliberate, but it
+    leaves a window: once the claim is committed, a failure before the run exists
+    would leave the cursor reading "handled" with nothing to show for it, and the
+    next cycle — seeing HEAD unchanged — would skip the commit *permanently*
+    rather than retrying it. The window contains a network archive download, which
+    is the first thing to fail when an installation exhausts its rate limit.
+
+    Releasing the claim re-arms the next cycle. Two guards make it incapable of
+    doing harm:
+
+    * a compare-and-set on the claimed sha, so a newer poll that has already moved
+      the cursor on is never rewound;
+    * a check that no run exists for this commit, so a failure *after* the run was
+      created cannot produce a duplicate on the next cycle.
+
+    Best-effort, and in a fresh session: the session that failed is unusable, and
+    if the database itself is the problem there is nothing to be done. A hard
+    process death between the claim and this handler remains uncovered — nothing
+    in-process can compensate for that; it needs a separate claim column with
+    timeout-based re-drive, which #1099 records as the follow-up.
+    """
+    try:
+        async with get_db_session() as db:
+            existing = await db.execute(
+                select(Run.id)
+                .where(
+                    Run.workspace_id == ws_id,
+                    Run.vcs_commit_sha == claimed_sha,
+                    # A speculative PR run can share the sha; only a branch run
+                    # means this commit was genuinely handled.
+                    Run.vcs_pull_request_number.is_(None),
+                )
+                .limit(1)
+            )
+            if existing.scalar_one_or_none() is not None:
+                return
+
+            await db.execute(
+                update(Workspace)
+                .where(Workspace.id == ws_id)
+                .where(Workspace.vcs_last_commit_sha == claimed_sha)
+                .values(vcs_last_commit_sha=previous_sha)
+            )
+            await db.commit()
+            logger.info(
+                "Released VCS commit claim after run creation failed",
+                workspace_id=str(ws_id),
+                sha=claimed_sha[:8],
+            )
+    except Exception:
+        logger.warning(
+            "Failed to release VCS commit claim; this commit may be skipped",
+            workspace_id=str(ws_id),
+            sha=claimed_sha[:8],
+            exc_info=True,
+        )
 
 
 async def _record_poll_failure(ws_id: uuid.UUID, message: str) -> None:

--- a/services/tests/integration/test_vcs_commit_claim_release.py
+++ b/services/tests/integration/test_vcs_commit_claim_release.py
@@ -1,0 +1,152 @@
+"""Integration test (real Postgres) for releasing a VCS commit claim (#1099).
+
+`_poll_workspace_branch` advances `vcs_last_commit_sha` before fetching the
+archive and creating the run, so a concurrent poll cannot duplicate the run
+(#217). If the run creation then fails, the claim has to be released or the
+commit is skipped permanently.
+
+The guards on that release — a compare-and-set on the claimed sha, and a check
+for an existing run — are SQL predicates, so a mocked-DB test would only assert
+that we built the statement we built. These run against a real engine.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from terrapod.db.models import Run, Workspace
+from terrapod.db.session import get_db_session
+from terrapod.services import run_service
+from terrapod.services.vcs_poller import _release_commit_claim
+from tests.integration.conftest import AUTH, admin_user, set_auth
+
+WS_ENDPOINT = "/api/v2/organizations/default/workspaces"
+
+pytestmark = pytest.mark.asyncio
+
+OLD_SHA = "a" * 40
+NEW_SHA = "b" * 40
+NEWER_SHA = "c" * 40
+
+
+async def _seed_workspace(client, name: str, *, claimed: str = NEW_SHA) -> uuid.UUID:
+    """Create a workspace already holding a claim on `claimed`."""
+    resp = await client.post(
+        WS_ENDPOINT,
+        json={"data": {"type": "workspaces", "attributes": {"name": name}}},
+        headers=AUTH,
+    )
+    assert resp.status_code == 201, resp.text
+    ws_id = uuid.UUID(resp.json()["data"]["id"].removeprefix("ws-"))
+
+    async with get_db_session() as db:
+        ws = await db.get(Workspace, ws_id)
+        ws.vcs_last_commit_sha = claimed
+        await db.commit()
+    return ws_id
+
+
+async def _cursor(ws_id: uuid.UUID) -> str | None:
+    async with get_db_session() as db:
+        ws = await db.get(Workspace, ws_id)
+        return ws.vcs_last_commit_sha
+
+
+async def _seed_run(ws_id: uuid.UUID, *, sha: str, pr_number: int | None) -> None:
+    async with get_db_session() as db:
+        ws = await db.get(Workspace, ws_id)
+        run = await run_service.create_run(db, ws, message="seeded", source="vcs")
+        run.vcs_commit_sha = sha
+        run.vcs_pull_request_number = pr_number
+        await db.commit()
+
+
+class TestReleasesTheClaim:
+    """The point of the fix: a failed run creation must not consume the commit."""
+
+    async def test_cursor_rolls_back_when_no_run_was_created(self, app, client):
+        set_auth(app, admin_user())
+        ws_id = await _seed_workspace(client, "claim-release-basic")
+
+        await _release_commit_claim(ws_id, NEW_SHA, OLD_SHA)
+
+        assert await _cursor(ws_id) == OLD_SHA, (
+            "the next poll must see the commit again, or it is skipped forever"
+        )
+
+    async def test_first_ever_poll_rolls_back_to_empty(self, app, client):
+        """The column is non-nullable: "never polled" is "", not NULL."""
+        set_auth(app, admin_user())
+        ws_id = await _seed_workspace(client, "claim-release-first-poll")
+
+        await _release_commit_claim(ws_id, NEW_SHA, "")
+
+        assert await _cursor(ws_id) == ""
+
+    async def test_a_speculative_pr_run_does_not_count_as_handled(self, app, client):
+        """A PR run can share the head sha; only a branch run means it was handled."""
+        set_auth(app, admin_user())
+        ws_id = await _seed_workspace(client, "claim-release-pr-run")
+        await _seed_run(ws_id, sha=NEW_SHA, pr_number=7)
+
+        await _release_commit_claim(ws_id, NEW_SHA, OLD_SHA)
+
+        assert await _cursor(ws_id) == OLD_SHA
+
+
+class TestGuards:
+    """Releasing must never be able to do harm — these are the two guards."""
+
+    async def test_does_not_release_when_the_run_already_exists(self, app, client):
+        """A failure *after* the run was created must not re-run the commit."""
+        set_auth(app, admin_user())
+        ws_id = await _seed_workspace(client, "claim-release-run-exists")
+        await _seed_run(ws_id, sha=NEW_SHA, pr_number=None)
+
+        await _release_commit_claim(ws_id, NEW_SHA, OLD_SHA)
+
+        assert await _cursor(ws_id) == NEW_SHA, "would have produced a duplicate run"
+
+    async def test_never_rewinds_past_a_newer_claim(self, app, client):
+        """A concurrent poll may have claimed a later commit while we were failing."""
+        set_auth(app, admin_user())
+        ws_id = await _seed_workspace(client, "claim-release-cas", claimed=NEWER_SHA)
+
+        await _release_commit_claim(ws_id, NEW_SHA, OLD_SHA)
+
+        assert await _cursor(ws_id) == NEWER_SHA, "rewound over a newer poll's claim"
+
+    async def test_another_workspaces_run_does_not_suppress_the_release(self, app, client):
+        """The existing-run check must be scoped to this workspace."""
+        set_auth(app, admin_user())
+        ws_id = await _seed_workspace(client, "claim-release-scoped")
+        other_id = await _seed_workspace(client, "claim-release-scoped-other")
+        await _seed_run(other_id, sha=NEW_SHA, pr_number=None)
+
+        await _release_commit_claim(ws_id, NEW_SHA, OLD_SHA)
+
+        assert await _cursor(ws_id) == OLD_SHA
+
+
+class TestBestEffort:
+    """It runs on the failure path, so it must never raise on top of the failure."""
+
+    async def test_unknown_workspace_is_swallowed(self, app):
+        set_auth(app, admin_user())
+
+        await _release_commit_claim(uuid.uuid4(), NEW_SHA, OLD_SHA)
+
+    async def test_does_not_touch_other_rows(self, app, client):
+        set_auth(app, admin_user())
+        ws_id = await _seed_workspace(client, "claim-release-isolated")
+        bystander = await _seed_workspace(client, "claim-release-bystander")
+
+        await _release_commit_claim(ws_id, NEW_SHA, OLD_SHA)
+
+        async with get_db_session() as db:
+            rows = (
+                (await db.execute(select(Run).where(Run.workspace_id == bystander))).scalars().all()
+            )
+        assert rows == []
+        assert await _cursor(bystander) == NEW_SHA

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -1284,3 +1284,72 @@ class TestPollCycleFailuresAreNotSilent:
             _log_cycle_failures([], [])
 
         assert not log.error.called
+
+
+class TestCommitClaimReleasedOnFailure:
+    """#1099 — the claim is committed before the run exists, so a failure that
+    does not release it makes the poller skip that commit permanently."""
+
+    @patch("terrapod.services.vcs_poller._release_commit_claim")
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_branch_sha")
+    async def test_release_on_run_creation_failure(self, mock_sha, mock_create, mock_release):
+        from terrapod.services.vcs_poller import _poll_workspace_branch
+
+        ws = _mock_workspace(vcs_last_commit_sha="aaa111")
+        mock_sha.return_value = "bbb222"
+        mock_create.side_effect = RuntimeError("archive download failed")
+
+        with pytest.raises(RuntimeError, match="archive download failed"):
+            await _poll_workspace_branch(AsyncMock(), ws, _mock_connection(), "org", "repo", "main")
+
+        # Rolled back to the sha we were on before the claim, not to the claim.
+        mock_release.assert_awaited_once_with(ws.id, "bbb222", "aaa111")
+
+    @patch("terrapod.services.vcs_poller._release_commit_claim")
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_branch_sha")
+    async def test_failure_still_propagates(self, mock_sha, mock_create, mock_release):
+        """The caller records the poll failure (#1089) — releasing must not swallow it."""
+        from terrapod.services.vcs_poller import _poll_workspace_branch
+
+        ws = _mock_workspace(vcs_last_commit_sha="aaa111")
+        mock_sha.return_value = "bbb222"
+        mock_create.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            await _poll_workspace_branch(AsyncMock(), ws, _mock_connection(), "org", "repo", "main")
+
+    @patch("terrapod.services.vcs_poller._release_commit_claim")
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_branch_sha")
+    async def test_no_release_on_success(self, mock_sha, mock_create, mock_release):
+        from terrapod.services.vcs_poller import _poll_workspace_branch
+
+        ws = _mock_workspace(vcs_last_commit_sha="aaa111")
+        mock_sha.return_value = "bbb222"
+        mock_create.return_value = MagicMock(id=uuid.uuid4())
+
+        await _poll_workspace_branch(AsyncMock(), ws, _mock_connection(), "org", "repo", "main")
+
+        mock_release.assert_not_awaited()
+
+    @patch("terrapod.services.vcs_poller._release_commit_claim")
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._get_branch_sha")
+    async def test_no_release_when_prefixes_deliberately_skip_the_run(
+        self, mock_sha, mock_changed, mock_create, mock_release
+    ):
+        """Skipping because nothing matched the trigger prefixes is a decision,
+        not a failure — the commit really has been handled."""
+        from terrapod.services.vcs_poller import _poll_workspace_branch
+
+        ws = _mock_workspace(working_directory="terraform/prod", vcs_last_commit_sha="aaa111")
+        mock_sha.return_value = "bbb222"
+        mock_changed.return_value = ["docs/README.md"]
+
+        await _poll_workspace_branch(AsyncMock(), ws, _mock_connection(), "org", "repo", "main")
+
+        mock_create.assert_not_called()
+        mock_release.assert_not_awaited()


### PR DESCRIPTION
Closes #1099.

## The bug

`_poll_workspace_branch` claims a commit — advances `vcs_last_commit_sha` via a compare-and-set and commits it — **before** fetching the archive and creating the run. That ordering is deliberate: it is the #217 dedup guard that stops the periodic poll and a webhook-triggered poll both creating a run for the same commit.

The cost is a window. Once the claim is committed, a failure before the run exists leaves the cursor reading "handled" with nothing to show for it. The next cycle compares HEAD (unchanged) against the cursor (already advanced), sees no change, and does nothing — so the commit is skipped **permanently**, not retried. A `rollback` cannot help; the claim was already committed.

Two things make this worse than it sounds:

- The window contains a **network archive download** — the slowest and most failure-prone step in the cycle, and the first thing to fail when an installation exhausts its VCS rate limit.
- The symptom is the quietest possible one: a push that simply never produces a run. It surfaces only later, when a subsequent commit lands and its plan silently carries the skipped commit’s changes too.

## The fix

Release the claim when the run could not be created, re-arming the next cycle. Two guards make it incapable of doing harm:

- a **compare-and-set on the claimed sha**, so a newer poll that has already moved the cursor on is never rewound;
- a **check for an existing branch run**, so a failure *after* the run was created cannot produce a duplicate. A speculative PR run sharing the head sha does not count as handled.

It runs in a fresh session (the failed one is unusable) and is best-effort — if the database is what is failing there is nothing to be done — and it re-raises so #1089’s poll-failure recording still fires.

Deliberately **not** covered: hard process death between the claim and the handler. Nothing in-process can compensate for that; it needs a separate claim column with timeout-based re-drive, which #1099 records as the follow-up if pod-death-mid-poll ever shows up in practice.

The PR path is unaffected — it dedups on run existence (`workspace + PR number + head sha`) rather than a stored cursor, so it has no claim to lose.

## Tests

**Integration (real Postgres)** — the guards are SQL predicates, so a mocked-DB test would only assert that we built the statement we built:

- cursor rolls back when no run was created;
- rolls back to `""` for a never-polled workspace (the column is non-nullable);
- a speculative PR run on the same sha does not suppress the release;
- does **not** release when a branch run already exists (would duplicate);
- does **not** rewind past a newer poll’s claim;
- the existing-run check is scoped to the workspace;
- unknown workspace is swallowed, and no other rows are touched.

**Services tier** — the wiring: released with the right shas on failure, the exception still propagates, not released on success, and not released when the trigger-prefix filter deliberately skips the run (a decision, not a failure).

`make test` — 3346 passed.