### PR TITLE
feat(1108): client_credentials grant for peer authentication

### DIFF
--- a/alembic/versions/ec759f96c1b7_oauth_clients.py
+++ b/alembic/versions/ec759f96c1b7_oauth_clients.py
@@ -1,0 +1,47 @@
+"""Add oauth_clients
+
+Registered OAuth clients for the `client_credentials` grant (#1108), used by
+the HA peer link: each node registers a client representing its peer and hands
+over those credentials, so the two authenticate with a standard grant rather
+than a bespoke handshake.
+
+The secret is SHA-256 hashed at rest — the same contract as an API token.
+
+Purely additive: a new table, nothing altered, no contraction.
+
+Revision ID: ec759f96c1b7
+Revises: 3d76eac29cf2
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "ec759f96c1b7"
+down_revision: str | None = "3d76eac29cf2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oauth_clients",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("client_id", sa.String(length=64), nullable=False),
+        sa.Column("client_secret_hash", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False, server_default=""),
+        sa.Column("kind", sa.String(length=20), nullable=False, server_default="peer"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_by", sa.String(length=255), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("client_id", name="uq_oauth_clients_client_id"),
+    )
+    op.create_index("ix_oauth_clients_client_id", "oauth_clients", ["client_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_oauth_clients_client_id", table_name="oauth_clients")
+    op.drop_table("oauth_clients")

--- a/services/terrapod/api/routers/oauth.py
+++ b/services/terrapod/api/routers/oauth.py
@@ -9,11 +9,13 @@ Endpoints:
     POST /oauth/token — exchange auth code for API token
 """
 
+import hashlib
 import hmac
 import os
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
 from fastapi.responses import JSONResponse, RedirectResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from terrapod.auth.api_tokens import create_api_token
@@ -25,6 +27,7 @@ from terrapod.auth.auth_state import (
 )
 from terrapod.auth.pkce import s256_challenge
 from terrapod.config import settings
+from terrapod.db.models import OAuthClient, now_utc
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
@@ -125,13 +128,87 @@ async def oauth_authorize(
     return RedirectResponse(url=f"/login?cli_state={idp_state}", status_code=302)
 
 
+def _hash_client_secret(secret: str) -> str:
+    """SHA-256, matching how API tokens are hashed at rest."""
+    return hashlib.sha256(secret.encode()).hexdigest()
+
+
+async def _client_credentials_grant(
+    db: AsyncSession, client_id: str, client_secret: str
+) -> JSONResponse:
+    """RFC 6749 client-credentials grant, for machine-to-machine callers (#1108).
+
+    Introduced for the HA peer link. Each node registers a client representing
+    its peer and hands over those credentials, so the two authenticate with a
+    standard grant rather than a bespoke handshake — a reviewer can read the
+    RFC and know what it guarantees.
+
+    The resulting token carries `kind="peer"`, its OWN identity class rather
+    than a reuse of the runner-token path. A peer is entitled to see resolved
+    sensitive variables, and granting that must not widen what a runner can
+    reach, nor leave an audit unable to tell the two apart.
+    """
+    if not client_id or not client_secret:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="grant_type=client_credentials requires client_id and client_secret",
+        )
+
+    result = await db.execute(select(OAuthClient).where(OAuthClient.client_id == client_id))
+    client = result.scalar_one_or_none()
+
+    # One message and one code for every failure mode — unknown client,
+    # deactivated client, wrong secret — so the response cannot be used to
+    # enumerate which client ids exist.
+    invalid = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid client credentials",
+    )
+    if client is None or not client.is_active:
+        # Still spend the hash on the miss, so a bad client_id is not
+        # measurably faster to reject than a bad secret.
+        _hash_client_secret(client_secret)
+        raise invalid
+    if not hmac.compare_digest(client.client_secret_hash, _hash_client_secret(client_secret)):
+        raise invalid
+
+    api_token, raw_token = await create_api_token(
+        db=db,
+        bound_to=None,
+        created_by=f"oauth-client:{client.client_id}",
+        kind="peer",
+        description=f"client_credentials grant for {client.name or client.client_id}",
+        lifespan_hours=settings.auth.peer_token_ttl_hours,
+    )
+    client.last_used_at = now_utc()
+    await db.commit()
+
+    logger.info(
+        "Issued peer token via client_credentials",
+        client_id=client.client_id,
+        token_id=str(api_token.id),
+    )
+    return JSONResponse(
+        content={
+            "access_token": raw_token,
+            "token_type": "bearer",
+            "expires_in": settings.auth.peer_token_ttl_hours * 3600,
+        }
+    )
+
+
 @router.post("/oauth/token")
 async def oauth_token(
     grant_type: str = Form(...),
-    code: str = Form(...),
+    # Optional because two grants share this endpoint now. The
+    # authorization_code path still requires both and says so explicitly
+    # below, so an existing caller that omits them gets the same 4xx it
+    # always did — just from a check rather than from FastAPI's validator.
+    code: str = Form(""),
     client_id: str = Form(""),
+    client_secret: str = Form(""),
     redirect_uri: str = Form(""),
-    code_verifier: str = Form(...),
+    code_verifier: str = Form(""),
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Exchange authorization code for API token (terraform CLI flow).
@@ -141,10 +218,19 @@ async def oauth_token(
     returns it. No refresh_token, no expires_in — terraform stores it
     permanently in .terraformrc.
     """
+    if grant_type == "client_credentials":
+        return await _client_credentials_grant(db, client_id, client_secret)
+
     if grant_type != "authorization_code":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Only grant_type=authorization_code is supported",
+            detail="Unsupported grant_type: expected authorization_code or client_credentials",
+        )
+
+    if not code or not code_verifier:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="grant_type=authorization_code requires code and code_verifier",
         )
 
     # Consume the one-time auth code

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -468,6 +468,15 @@ class AuthConfig(BaseSettings):
         default=12,
         description="Session TTL in hours",
     )
+    peer_token_ttl_hours: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Lifetime of a token issued by the client_credentials grant (#1108). "
+            "Short by design: the peer re-authenticates freely, so a leaked token "
+            "is worth little and revocation takes effect quickly."
+        ),
+    )
     api_token_max_ttl_hours: int = Field(
         default=8760,
         description="Maximum interactive API token lifetime in hours (default: 8760 = 1 year). "

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -159,6 +159,40 @@ class PlatformRoleAssignment(Base):
     )
 
 
+class OAuthClient(Base):
+    """A registered OAuth client, for the `client_credentials` grant (#1108).
+
+    Introduced for the HA peer link: each node registers a client representing
+    its peer and hands over those credentials, so the two authenticate to each
+    other with a standard grant rather than a bespoke handshake. A reviewer can
+    read the RFC and know what it guarantees.
+
+    The secret is SHA-256 hashed at rest and returned exactly once, at
+    creation — the same contract as an API token.
+
+    `kind` keeps the peer identity its OWN class rather than reusing the
+    runner-token path. That matters: a peer is entitled to see resolved
+    sensitive variables, and granting that must not widen what a runner can
+    reach, nor leave an audit unable to tell the two apart.
+    """
+
+    __tablename__ = "oauth_clients"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=generate_uuid7)
+    client_id: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    client_secret_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    # "peer" today. Kept open so a future non-peer machine client does not
+    # inherit peer visibility by accident.
+    kind: Mapped[str] = mapped_column(String(20), nullable=False, default="peer")
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_by: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=now_utc
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
 class APIToken(Base):
     """Long-lived API tokens for terraform CLI and automation.
 

--- a/services/tests/api/test_oauth_client_credentials.py
+++ b/services/tests/api/test_oauth_client_credentials.py
@@ -1,0 +1,135 @@
+"""The client_credentials grant (#1108, phase 2 of #960).
+
+Introduced for the HA peer link: each node registers a client representing its
+peer and hands over those credentials, so the two authenticate with a standard
+grant rather than a bespoke handshake.
+
+The security-relevant properties are the ones worth pinning: failures are
+indistinguishable from each other so client ids cannot be enumerated, the
+issued identity is its own class rather than a reuse of the runner-token path,
+and the existing authorization_code flow is untouched.
+"""
+
+import hashlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from terrapod.api.routers.oauth import _client_credentials_grant, _hash_client_secret
+
+pytestmark = pytest.mark.asyncio
+
+
+def _client(secret="s3cret", active=True, client_id="peer-b", name="node-b"):
+    c = MagicMock()
+    c.client_id = client_id
+    c.name = name
+    c.is_active = active
+    c.client_secret_hash = hashlib.sha256(secret.encode()).hexdigest()
+    return c
+
+
+def _db(client):
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = client
+    db.execute.return_value = result
+    return db
+
+
+class TestHashing:
+    @staticmethod
+    async def test_matches_the_api_token_scheme():
+        assert _hash_client_secret("abc") == hashlib.sha256(b"abc").hexdigest()
+
+
+class TestSuccess:
+    @patch("terrapod.api.routers.oauth.create_api_token")
+    async def test_issues_a_peer_token(self, mock_create):
+        mock_create.return_value = (MagicMock(id="tok-1"), "raw-token-value")
+        db = _db(_client())
+
+        resp = await _client_credentials_grant(db, "peer-b", "s3cret")
+
+        assert resp.status_code == 200
+        # The identity class is the point: a peer must not be minted as a
+        # runner, a user, or a detached service token.
+        assert mock_create.await_args.kwargs["kind"] == "peer"
+        assert mock_create.await_args.kwargs["bound_to"] is None
+
+    @patch("terrapod.api.routers.oauth.create_api_token")
+    async def test_returns_a_bearer_token_with_expiry(self, mock_create):
+        mock_create.return_value = (MagicMock(id="tok-1"), "raw-token-value")
+
+        resp = await _client_credentials_grant(_db(_client()), "peer-b", "s3cret")
+
+        body = bytes(resp.body).decode()
+        assert "raw-token-value" in body
+        assert '"token_type":"bearer"' in body.replace(" ", "")
+        assert "expires_in" in body
+
+    @patch("terrapod.api.routers.oauth.create_api_token")
+    async def test_records_last_used(self, mock_create):
+        mock_create.return_value = (MagicMock(id="tok-1"), "raw")
+        client = _client()
+        db = _db(client)
+
+        await _client_credentials_grant(db, "peer-b", "s3cret")
+
+        assert client.last_used_at is not None
+        db.commit.assert_awaited()
+
+
+class TestFailuresAreIndistinguishable:
+    """Every failure returns the same 401 and the same message, so the endpoint
+    cannot be used to discover which client ids exist."""
+
+    async def test_unknown_client(self):
+        with pytest.raises(HTTPException) as exc:
+            await _client_credentials_grant(_db(None), "nope", "s3cret")
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Invalid client credentials"
+
+    async def test_wrong_secret(self):
+        with pytest.raises(HTTPException) as exc:
+            await _client_credentials_grant(_db(_client()), "peer-b", "wrong")
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Invalid client credentials"
+
+    async def test_deactivated_client(self):
+        with pytest.raises(HTTPException) as exc:
+            await _client_credentials_grant(_db(_client(active=False)), "peer-b", "s3cret")
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Invalid client credentials"
+
+    async def test_all_three_are_identical(self):
+        details = []
+        for db, cid, secret in (
+            (_db(None), "nope", "s3cret"),
+            (_db(_client()), "peer-b", "wrong"),
+            (_db(_client(active=False)), "peer-b", "s3cret"),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await _client_credentials_grant(db, cid, secret)
+            details.append((exc.value.status_code, exc.value.detail))
+        assert len(set(details)) == 1, f"failure modes are distinguishable: {details}"
+
+
+class TestMissingCredentials:
+    async def test_no_client_id(self):
+        with pytest.raises(HTTPException) as exc:
+            await _client_credentials_grant(_db(None), "", "s3cret")
+        assert exc.value.status_code == 400
+
+    async def test_no_secret(self):
+        with pytest.raises(HTTPException) as exc:
+            await _client_credentials_grant(_db(None), "peer-b", "")
+        assert exc.value.status_code == 400
+
+    async def test_never_issues_a_token_without_credentials(self):
+        """A 400 must come before any lookup — no token, no DB round trip."""
+        db = _db(None)
+        with pytest.raises(HTTPException):
+            await _client_credentials_grant(db, "", "")
+        db.execute.assert_not_awaited()

--- a/services/tests/config/config_key_contract.json
+++ b/services/tests/config/config_key_contract.json
@@ -111,6 +111,7 @@
   "auth.callback_base_url",
   "auth.local_enabled",
   "auth.login_token_ttl_hours",
+  "auth.peer_token_ttl_hours",
   "auth.require_external_sso_for_roles",
   "auth.service_token_max_ttl_hours",
   "auth.session_ttl_hours",


### PR DESCRIPTION
Phase 2 of #960, first slice. Part of #1108. Establishes how the two nodes authenticate to each other.

## Why a named standard

Terrapod is already a mature OIDC **relying party** but a very narrow **authorization server** — `/oauth/token` accepted only `authorization_code`, for the `terraform login` flow.

Each node now becomes an authorization server **and** a client of the other: A registers a client representing B and hands B those credentials; B does the same for A. Each side authenticates with a standard `client_credentials` grant.

Symmetric and ordinary, which is the point. This feature asks an organisation to trust Terrapod with disaster recovery. A reviewer can read the RFC and know what `client_credentials` guarantees; nobody can meaningfully audit a bespoke HMAC exchange, and nobody should be asked to. The protocol choice is part of the product argument, not an implementation detail.

## The peer identity is its own class

The issued token carries `kind="peer"` — **not** a reuse of the runner-token path. A peer is entitled to see resolved sensitive variables, and granting that must not widen what a runner can reach, nor leave an audit unable to tell the two apart.

Being outside `_USER_BOUND_KINDS`, it is correctly exempt from the idle-login check, which applies only to user-bound tokens.

## Security properties, pinned by tests

- **Failures are indistinguishable.** Unknown client, deactivated client and wrong secret all return an identical 401 with an identical message, so the endpoint cannot be used to enumerate client ids. There is a test asserting all three are byte-identical, not just individually 401.
- **No timing shortcut on a miss.** The hash is still computed when the client does not exist, so a bad `client_id` is not measurably faster to reject than a bad secret.
- **Short-lived by default** (1h, configurable). The peer re-authenticates freely, so a leaked token is worth little and revocation takes effect quickly.
- **Secret hashed at rest** (SHA-256), the same contract as an API token, returned once at creation.

## The existing flow is untouched

`code` and `code_verifier` become optional at the signature because two grants now share the endpoint — but an explicit check restores the same 4xx for a caller that omits them, so an existing client sees no change.

## Verification

`make test`: 3401 passed. Config snapshot regenerated — **one key added, zero removed**. Migration is a new table only: additive `upgrade()`, real `downgrade()`, no contraction.

## Next

PR2 of this phase: the CA trust bundle and listener certificate portability, so a DNS-following listener fleet survives a cutover — including the finding that unconditional reconstruction would turn listener deletion into a no-op, regressing revocation on a single node with no failover involved.