### PR TITLE
test(1112): fail the build when a replicated class lacks its test matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,18 @@ Routing rules of thumb:
   pattern, so the invariant fails CI loudly if a future change violates it.
 - A **behaviour-changing fix for a reported bug** → a regression test named
   after the failure mode that fails on the pre-fix code and passes after.
+- A **new replicated entity class** (registered in
+  `services/replication_registry.py`) → the **full per-class test matrix**,
+  claimed with `@pytest.mark.replication_matrix("<class>", "<row>")`. Registering
+  a class is one line and the outbox picks it up automatically, so it is easy to
+  ship one that never converges — and the symptom appears at a failover, not in
+  CI. The required rows are **derived** from the class spec and its model (a
+  class declaring `monotonic_fields`, `one_way_true_fields`, or holding an
+  encrypted column gains the matching row automatically), and
+  `tests/services/test_replication_matrix_gate.py` fails the build until they
+  exist. Backfill ships **with** each class, never behind it: adding a second
+  node to a running install has no deltas at all, so a class that only handles
+  deltas produces an empty peer on day one.
 
 E2E isolation invariants (higher worker/shard counts make violations flaky,
 not deterministic): every test creates its own uniquely-named resources and

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -149,6 +149,13 @@ key. Neither node holds the other's key.
 
 Runs and state versions are a separate phase.
 
+Each class carries a full test matrix — backfill from empty, delta apply,
+idempotent re-apply, delete, role-change conflict, plus a monotonic-merge or
+encrypted-column row where the class has one. The required rows are derived from
+the class definition rather than declared, and CI fails until they exist. A class
+that is registered but not tested does not converge, and the symptom appears at a
+failover rather than in a build.
+
 ## Join tokens and the two listener topologies
 
 Both listener topologies work, and neither needs anything beyond a shared CA —

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -139,6 +139,7 @@ testpaths = ["tests"]
 addopts = "-v --tb=short"
 markers = [
     "integration: Integration tests using real Postgres, Redis, and filesystem storage",
+    "replication_matrix(entity_class, row): Claims coverage of one per-class replication test-matrix row (#1112)",
 ]
 
 [tool.mypy]

--- a/services/tests/services/test_replication.py
+++ b/services/tests/services/test_replication.py
@@ -18,6 +18,8 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from terrapod.db.models import AgentPool, AgentPoolToken, ReplicationEvent
 from terrapod.services import replication, replication_registry
 
@@ -85,6 +87,7 @@ class TestSerialisation:
 class TestMergeRules:
     """The field-level exceptions that blanket last-write-wins gets wrong."""
 
+    @pytest.mark.replication_matrix("agent_pool_tokens", "monotonic-never-regresses")
     def test_counter_never_decreases(self):
         existing = SimpleNamespace(use_count=7, is_revoked=False)
 
@@ -99,6 +102,7 @@ class TestMergeRules:
 
         assert merged["use_count"] == 9
 
+    @pytest.mark.replication_matrix("agent_pool_tokens", "one-way-never-reverts")
     def test_revocation_is_one_way(self):
         existing = SimpleNamespace(use_count=0, is_revoked=True)
 
@@ -228,6 +232,7 @@ class TestApply:
         added = db.add.call_args[0][0]
         assert added.id == pool_id
 
+    @pytest.mark.replication_matrix("agent_pools", "delta-apply")
     async def test_update_applies_onto_the_existing_row(self):
         db = AsyncMock()
         existing = AgentPool(id=uuid.uuid4(), name="old")
@@ -238,6 +243,7 @@ class TestApply:
         assert existing.name == "new"
         db.add.assert_not_called()
 
+    @pytest.mark.replication_matrix("agent_pools", "idempotent-reapply")
     async def test_reapplying_the_same_row_changes_nothing(self):
         db = AsyncMock()
         existing = AgentPool(id=uuid.uuid4(), name="p", labels={"env": "prod"})
@@ -268,6 +274,7 @@ class TestApply:
 
         db.add.assert_not_called()
 
+    @pytest.mark.replication_matrix("agent_pools", "delete")
     async def test_delete_removes_the_row(self):
         db = AsyncMock()
 
@@ -348,6 +355,7 @@ class TestBackfillPaging:
     """Ordered by primary key, not by time, so an interrupted backfill resumes
     instead of restarting a large class."""
 
+    @pytest.mark.replication_matrix("agent_pools", "backfill-from-empty")
     async def test_returns_serialized_rows(self):
         db = AsyncMock()
         rows = [AgentPool(id=uuid.uuid4(), name="a"), AgentPool(id=uuid.uuid4(), name="b")]
@@ -381,3 +389,142 @@ class TestEventPayloadPolicy:
         columns = {c.name for c in event.__table__.columns}
         assert "payload" not in columns
         assert "attributes" not in columns
+
+
+class TestAgentPoolTokensMatrix:
+    """The per-class matrix for join tokens (#1112).
+
+    Tokens get their own block rather than riding the generic tests because
+    they are the class with merge rules — and a class whose counter is only
+    exercised through a shared helper is one whose real apply path was never
+    tried.
+    """
+
+    def _token(self, **kw):
+        base = {
+            "id": uuid.uuid4(),
+            "pool_id": uuid.uuid4(),
+            "token_hash": "h" * 64,
+            "description": "",
+            "max_uses": 10,
+            "use_count": 0,
+            "is_revoked": False,
+            "created_at": datetime.now(UTC),
+            "created_by": "admin",
+        }
+        base.update(kw)
+        return AgentPoolToken(**base)
+
+    @pytest.mark.replication_matrix("agent_pool_tokens", "backfill-from-empty")
+    async def test_backfill_serializes_tokens(self):
+        db = AsyncMock()
+        rows = [self._token(use_count=3)]
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = rows
+        db.execute.return_value = result
+
+        page = await replication.read_backfill(db, TOKENS)
+
+        assert page[0]["use_count"] == 3
+        assert page[0]["token_hash"] == "h" * 64
+
+    @pytest.mark.replication_matrix("agent_pool_tokens", "delta-apply")
+    async def test_delta_applies_onto_an_existing_token(self):
+        db = AsyncMock()
+        existing = self._token(description="old")
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(
+            db, TOKENS, {"id": str(existing.id), "description": "rotated", "use_count": 0}
+        )
+
+        assert existing.description == "rotated"
+
+    @pytest.mark.replication_matrix("agent_pool_tokens", "idempotent-reapply")
+    async def test_reapplying_a_token_changes_nothing(self):
+        db = AsyncMock()
+        existing = self._token(use_count=4)
+        db.scalar.return_value = existing
+        payload = replication.serialize_row(TOKENS, existing)
+
+        await replication.apply_upsert(db, TOKENS, payload)
+        await replication.apply_upsert(db, TOKENS, payload)
+
+        assert existing.use_count == 4
+        assert existing.is_revoked is False
+
+    @pytest.mark.replication_matrix("agent_pool_tokens", "delete")
+    async def test_a_deleted_token_is_removed(self):
+        db = AsyncMock()
+
+        await replication.apply_delete(db, TOKENS, str(uuid.uuid4()))
+
+        db.execute.assert_awaited()
+
+
+class TestRoleChangeConflict:
+    """What happens when both sides touched the same row (#1112).
+
+    This is the case a failover actually produces: A was written to before the
+    cutover, B after it. There is no clever resolution here, and there should
+    not be — the rules just have to be the intended ones, and stated.
+    """
+
+    @pytest.mark.replication_matrix("agent_pools", "role-change-conflict")
+    async def test_settings_take_the_peers_value(self):
+        """Plain settings are last-writer-wins by arrival, and that is correct:
+        only the leader originates change, so the value arriving from the peer
+        is the one the leader has."""
+        db = AsyncMock()
+        existing = AgentPool(id=uuid.uuid4(), name="edited-locally", description="local")
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(db, POOLS, {"id": str(existing.id), "name": "from-peer"})
+
+        assert existing.name == "from-peer"
+
+    @pytest.mark.replication_matrix("agent_pool_tokens", "role-change-conflict")
+    async def test_both_sides_spending_the_budget_converges_upward(self):
+        """The real shape of a shared listener fleet across a failover: joins
+        landed on A before the cutover and on B after it. Neither count is
+        'right' — but the token must never end up with MORE budget than the two
+        of them have already spent between them."""
+        db = AsyncMock()
+        local = AgentPoolToken(
+            id=uuid.uuid4(),
+            pool_id=uuid.uuid4(),
+            token_hash="h" * 64,
+            max_uses=10,
+            use_count=6,  # spent here after the cutover
+            is_revoked=False,
+            created_by="admin",
+        )
+        db.scalar.return_value = local
+
+        # The peer reports its own, older count.
+        await replication.apply_upsert(
+            db, TOKENS, {"id": str(local.id), "use_count": 4, "is_revoked": False}
+        )
+
+        assert local.use_count == 6, "converging downward would refund spent uses"
+
+    @pytest.mark.replication_matrix("agent_pool_tokens", "one-way-never-reverts")
+    async def test_a_revocation_on_either_side_sticks(self):
+        """Revoking during an incident, on whichever node answered, must survive
+        replication from a peer that had not seen it yet."""
+        db = AsyncMock()
+        local = AgentPoolToken(
+            id=uuid.uuid4(),
+            pool_id=uuid.uuid4(),
+            token_hash="h" * 64,
+            use_count=1,
+            is_revoked=True,
+            created_by="admin",
+        )
+        db.scalar.return_value = local
+
+        await replication.apply_upsert(
+            db, TOKENS, {"id": str(local.id), "use_count": 1, "is_revoked": False}
+        )
+
+        assert local.is_revoked is True

--- a/services/tests/services/test_replication_matrix_gate.py
+++ b/services/tests/services/test_replication_matrix_gate.py
@@ -1,0 +1,159 @@
+"""Every replicated class must carry its full test matrix (#1112).
+
+Registering a class is deliberately one line — the flush hook picks it up
+automatically, so no write path can forget to emit an event. The flip side is
+that registering one is *too easy*: nothing otherwise stops a class shipping
+with no delete test, no idempotency test, and no merge-rule test. That gap would
+not surface in CI, in review, or in normal operation. It would surface at a
+failover, as a row that quietly did not converge.
+
+So this fails the build rather than reminding anyone.
+
+**The requirement is derived, not declared.** A per-class manifest of "which
+rows apply here" is something a contributor can quietly weaken; instead the
+required rows are computed from the class spec and its model. A class that gains
+a counter therefore *starts* failing until its monotonic test exists — which is
+exactly the case where losing an update issues extra credentials rather than
+merely losing information.
+
+**Coverage is claimed at the test**, with `@pytest.mark.replication_matrix`, not
+in a list of node ids. A manifest rots the moment a test is renamed; a mark
+moves with the test it describes.
+"""
+
+import ast
+from pathlib import Path
+
+from terrapod.crypto.types import EncryptedText
+from terrapod.services import replication
+
+#: Rows every replicated class must cover, whatever it holds.
+ALWAYS_REQUIRED = frozenset(
+    {
+        "backfill-from-empty",
+        "delta-apply",
+        "idempotent-reapply",
+        "delete",
+        "role-change-conflict",
+    }
+)
+
+#: Rows required only when the class actually has the thing they protect.
+CONDITIONAL = {
+    "monotonic-never-regresses": lambda spec: bool(spec.monotonic_fields),
+    "one-way-never-reverts": lambda spec: bool(spec.one_way_true_fields),
+    "encrypted-columns": lambda spec: _has_encrypted_column(spec),
+}
+
+ALL_ROWS = ALWAYS_REQUIRED | set(CONDITIONAL)
+
+_TESTS_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _has_encrypted_column(spec) -> bool:
+    from sqlalchemy import inspect as sa_inspect
+
+    return any(
+        isinstance(col.expression.type, EncryptedText)
+        for col in sa_inspect(spec.model).column_attrs
+    )
+
+
+def required_rows(spec) -> set[str]:
+    rows = set(ALWAYS_REQUIRED)
+    rows.update(row for row, applies in CONDITIONAL.items() if applies(spec))
+    return rows
+
+
+def _collect_marks() -> dict[str, set[str]]:
+    """Parse the test tree for `replication_matrix` marks.
+
+    Parsing rather than importing keeps this independent of collection order and
+    of whether the marked module imports cleanly in isolation.
+    """
+    covered: dict[str, set[str]] = {}
+    for path in _TESTS_ROOT.rglob("test_*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                func = dec.func
+                if not (isinstance(func, ast.Attribute) and func.attr == "replication_matrix"):
+                    continue
+                args = [a.value for a in dec.args if isinstance(a, ast.Constant)]
+                if len(args) >= 2:
+                    covered.setdefault(str(args[0]), set()).add(str(args[1]))
+    return covered
+
+
+class TestMatrixIsComplete:
+    def test_every_registered_class_covers_its_required_rows(self):
+        covered = _collect_marks()
+        gaps = []
+        for name, spec in replication.registered().items():
+            missing = required_rows(spec) - covered.get(name, set())
+            if missing:
+                gaps.append(f"{name}: missing {sorted(missing)}")
+
+        assert not gaps, (
+            "Replicated classes are missing test-matrix rows. A class that is not "
+            "tested for these does not converge, and you find out at a failover:\n  "
+            + "\n  ".join(gaps)
+        )
+
+    def test_no_class_is_registered_without_any_coverage(self):
+        """The blunt case the derived rules would otherwise report row by row."""
+        covered = _collect_marks()
+        unmarked = [name for name in replication.registered() if name not in covered]
+
+        assert not unmarked, f"registered but entirely untested: {unmarked}"
+
+
+class TestTheGateItself:
+    """A gate that cannot fail is not a gate."""
+
+    def test_a_counter_class_requires_the_monotonic_row(self):
+        spec = replication.get("agent_pool_tokens")
+
+        assert "monotonic-never-regresses" in required_rows(spec)
+
+    def test_a_plain_class_does_not(self):
+        """Requiring a monotonic test of a class with no counter would train
+        people to write empty tests to satisfy the gate."""
+        spec = replication.get("agent_pools")
+
+        assert "monotonic-never-regresses" not in required_rows(spec)
+        assert "one-way-never-reverts" not in required_rows(spec)
+
+    def test_every_class_always_needs_the_base_rows(self):
+        for spec in replication.registered().values():
+            assert ALWAYS_REQUIRED <= required_rows(spec)
+
+    def test_marks_are_actually_found(self):
+        """Guards the parser: if this silently returned nothing, the gate above
+        would pass for every class forever."""
+        covered = _collect_marks()
+
+        assert covered, "the mark parser found nothing — the gate is inert"
+        assert "agent_pools" in covered
+
+    def test_only_known_rows_are_claimed(self):
+        """A typo'd row name would otherwise look like coverage while satisfying
+        nothing."""
+        unknown = {
+            (name, row)
+            for name, rows in _collect_marks().items()
+            for row in rows
+            if row not in ALL_ROWS
+        }
+
+        assert not unknown, f"unrecognised matrix rows claimed: {sorted(unknown)}"
+
+    def test_marks_name_registered_classes(self):
+        registered = set(replication.registered())
+        stray = set(_collect_marks()) - registered
+
+        assert not stray, f"coverage claimed for classes that are not registered: {sorted(stray)}"


### PR DESCRIPTION
Slice 2 of #1110 (phase 3 of #960). The framework landed with the requirement stated — *every replicated class must backfill, and every replicated class must be tested* — and enforced by nothing. This makes it mechanical.

## Why a gate rather than a checklist

Registering a class is deliberately one line: the flush hook picks it up automatically, so no write path can forget to emit an event. The flip side is that registering one is **too easy**. Nothing otherwise stops a class shipping with no delete test, no idempotency test, and no merge-rule test — and that gap does not surface in CI, in review, or in normal operation. It surfaces at a failover, as a row that quietly did not converge.

## The requirement is derived, not declared

A per-class manifest of "which rows apply here" is something a contributor can quietly weaken. Instead the required rows are computed from the class spec and its model:

| Row | Required when |
|---|---|
| Backfill from empty, delta apply, idempotent re-apply, delete, role-change conflict | always |
| Monotonic field never regresses | the spec declares `monotonic_fields` |
| One-way boolean never reverts | the spec declares `one_way_true_fields` |
| Encrypted columns round-trip | the model has an `EncryptedText` column |

A class that gains a counter therefore **starts failing** until its monotonic test exists — precisely the case where losing an update issues extra credentials rather than merely losing information.

## Coverage is claimed at the test

`@pytest.mark.replication_matrix("<class>", "<row>")`, collected by parsing the test tree. A list of node ids rots the moment a test is renamed; a mark moves with the test it describes. The gate additionally rejects unrecognised row names and marks naming unregistered classes, so neither a typo nor a stale mark can masquerade as coverage — and asserts the parser found *something*, since a silently-empty parse would make the whole gate inert.

## Verified by watching it fail

Temporarily registered `vcs_connections` with no coverage:

```
vcs_connections: missing ['backfill-from-empty', 'delete', 'delta-apply',
                          'encrypted-columns', 'idempotent-reapply',
                          'role-change-conflict']
```

Note `encrypted-columns` — derived on its own from the model's `EncryptedText` token column, with nothing declared. Registry restored afterwards; the probe is not in the diff.

## Gaps this exposed, now filled

- **`agent_pool_tokens` had no matrix of its own** — its behaviour was only exercised through shared helpers, so its real apply path was never tried.
- **Neither class covered role-change conflict** — both sides having touched the same row, which is the case a failover actually produces. Settings take the peer's value (correct: only the leader originates change). A join token's spent budget converges *upward*, because joins landed on A before the cutover and on B after it, and converging downward would refund uses that were really spent.

## Verification

- `make test` — **3497 passed**
- `make lint` — green
- The gate demonstrated failing, then passing

## Docs

The routing rule goes in `AGENTS.md` beside the other Code↔Tests rules, since it is a public contributor convention: *a new replicated class ships its full matrix.* `docs/high-availability.md` gains the same statement in operator terms.

Closes #1112
Part of #960