### PR TITLE
fix(1115): backfill could not converge a deletion — a revoked token survived

### DIFF
--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -135,6 +135,19 @@ unbounded growth and blocking on a dead peer.
 Backfill is also the *ordinary* path, not an error path: adding a second node to
 a running install has no deltas at all.
 
+A complete backfill also **removes rows the peer no longer has**. That is not
+tidiness — without it a deletion can never converge through the recovery path,
+and the concrete failure is a revoked API token surviving on the follower and
+working again after a failover. It is safe because everything replicated
+originates on the leader and a follower originates nothing, so a row the
+follower holds and the leader does not is a row the leader deleted.
+
+It only happens on a complete, error-free pass, and every removal is logged. A
+node that has just stopped being the leader may hold writes from the moments
+before cutover that never replicated; those are lost either way under
+asynchronous replication, but the log is what lets an operator see exactly what
+was discarded to reach convergence.
+
 **Encryption is per-node.** Values are decrypted by the sender, cross the
 authenticated peer link, and are re-encrypted under the receiving node's own
 key. Neither node holds the other's key.

--- a/services/terrapod/services/replication.py
+++ b/services/terrapod/services/replication.py
@@ -47,6 +47,9 @@ DELETE = "delete"
 #: Cursor row that tracks the shared event stream rather than a class backfill.
 EVENT_STREAM = "*"
 
+#: Rows removed per statement during backfill reconciliation.
+_DELETE_CHUNK = 500
+
 
 @dataclass(frozen=True)
 class ReplicatedClass:
@@ -353,6 +356,55 @@ async def apply_upsert(db: AsyncSession, spec: ReplicatedClass, payload: dict) -
     for key, value in _merge(spec, existing, values).items():
         if key != spec.pk_attr:
             setattr(existing, key, value)
+
+
+async def reconcile_deletions(
+    db: AsyncSession, spec: ReplicatedClass, seen_ids: set[str]
+) -> list[str]:
+    """Remove local rows of this class that the peer no longer has (#1115).
+
+    Backfill upserts what the peer holds; without this it can never converge a
+    **deletion**. That matters because a delete may have happened while this
+    node was beyond the retained event window — the case backfill exists to
+    recover from. The concrete failure is a revoked API token surviving on the
+    follower and working again after a failover.
+
+    Tombstones would be the obvious alternative and are worse: they need their
+    own retention (so the window problem simply recurs), and they must be
+    written on every delete path including bulk statements that bypass the ORM.
+    The cheaper property is already true — everything replicated originates on
+    the leader and a follower originates nothing, so **a row the follower holds
+    and the peer does not is a row the peer deleted.**
+
+    Returns the ids removed. The caller MUST only invoke this after a complete,
+    error-free pass: a truncated `seen_ids` would read as mass deletion.
+    """
+    pk = getattr(spec.model, spec.pk_attr)
+    local = [str(row) for row in (await db.execute(select(pk))).scalars().all()]
+    extra = [row_id for row_id in local if row_id not in seen_ids]
+    if not extra:
+        return []
+
+    # Delete by explicit id rather than a NOT IN over the whole set, so the
+    # statement size tracks what is being removed, not the size of the class.
+    for chunk_start in range(0, len(extra), _DELETE_CHUNK):
+        chunk = extra[chunk_start : chunk_start + _DELETE_CHUNK]
+        values: list[Any] = chunk
+        if pk.expression.type.python_type is uuid.UUID:
+            values = [uuid.UUID(v) for v in chunk]
+        await db.execute(delete(spec.model).where(pk.in_(values)))
+
+    # This is the one place replication removes data that was never deleted
+    # locally. It must never be silent — an operator failing back needs to see
+    # exactly what was discarded to reach convergence.
+    logger.warning(
+        "Backfill removed rows the peer no longer has",
+        entity_class=spec.name,
+        removed=len(extra),
+        ids=extra[:20],
+        truncated=len(extra) > 20,
+    )
+    return extra
 
 
 async def apply_delete(db: AsyncSession, spec: ReplicatedClass, entity_id: str) -> None:

--- a/services/terrapod/services/replication_sync.py
+++ b/services/terrapod/services/replication_sync.py
@@ -146,7 +146,18 @@ async def _apply_event(
 async def backfill_class(
     db: AsyncSession, client: httpx.AsyncClient, token: str, entity_class: str
 ) -> int:
-    """Pull a whole class from the peer, resuming from the stored position."""
+    """Pull a whole class from the peer, resuming from the stored position.
+
+    On a **complete, error-free** pass this also reconciles deletions (#1115):
+    rows this node holds that the peer does not are removed, because backfill
+    otherwise cannot converge a delete that happened while this node was beyond
+    the retained event window — and a revoked API token surviving that gap
+    works again after a failover.
+
+    Reconciliation is deliberately gated on completion. A pass that raised
+    part-way has a truncated view of the peer's rows, and acting on it would
+    read as mass deletion.
+    """
     spec = replication.get(entity_class)
     if spec is None:
         return 0
@@ -155,6 +166,11 @@ async def backfill_class(
     cursor = await _get_cursor(db, entity_class)
     after = cursor.position
     applied = 0
+    # Only meaningful when the pass starts from the beginning; a resumed
+    # backfill has already-applied pages it never sees again, so it cannot
+    # judge what is missing.
+    from_scratch = not after
+    seen: set[str] = set()
 
     while True:
         resp = await arequest_with_retry(
@@ -169,6 +185,7 @@ async def backfill_class(
         body = resp.json()
         for row in body["data"]:
             await replication.apply_upsert(db, spec, row["attributes"])
+            seen.add(str(row["id"]))
             applied += 1
         after = body["meta"]["cursor"]
         # Persist per page so an interrupted backfill resumes rather than
@@ -178,7 +195,26 @@ async def backfill_class(
         if body["meta"]["complete"]:
             break
 
-    logger.info("Backfilled replication class", entity_class=entity_class, rows=applied)
+    removed = 0
+    if from_scratch:
+        removed = len(await replication.reconcile_deletions(db, spec, seen))
+
+    # Clear the resume point now the pass is done. The class cursor is a
+    # position WITHIN an in-progress backfill, not a high-water mark: leaving
+    # it set means the next backfill of this class resumes past every row it
+    # already saw and re-syncs almost nothing — so a node that ages out a
+    # second time would never recover. Clearing it also makes the next pass
+    # eligible to reconcile.
+    await _set_cursor(db, entity_class, "", backfilling=False)
+    await db.commit()
+
+    logger.info(
+        "Backfilled replication class",
+        entity_class=entity_class,
+        rows=applied,
+        removed=removed,
+        reconciled=from_scratch,
+    )
     return applied
 
 

--- a/services/tests/services/test_replication.py
+++ b/services/tests/services/test_replication.py
@@ -528,3 +528,62 @@ class TestRoleChangeConflict:
         )
 
         assert local.is_revoked is True
+
+
+class TestBackfillConvergesDeletion:
+    """Backfill must remove rows the peer no longer has (#1115).
+
+    Distinct from the `delete` row above, which only exercises the delta path.
+    The gap this covers is a delete that happened while the node was beyond the
+    retained event window — the exact case backfill exists to recover from, and
+    the one where a revoked API token would otherwise survive and work again
+    after a failover.
+    """
+
+    async def _db_with_local_ids(self, ids):
+        db = AsyncMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = ids
+        db.execute.return_value = result
+        return db
+
+    @pytest.mark.replication_matrix("agent_pools", "backfill-converges-deletion")
+    async def test_removes_a_row_the_peer_dropped(self):
+        kept, dropped = uuid.uuid4(), uuid.uuid4()
+        db = await self._db_with_local_ids([kept, dropped])
+
+        removed = await replication.reconcile_deletions(db, POOLS, {str(kept)})
+
+        assert removed == [str(dropped)]
+        db.execute.assert_awaited()
+
+    @pytest.mark.replication_matrix("agent_pool_tokens", "backfill-converges-deletion")
+    async def test_a_revoked_token_does_not_survive(self):
+        """The motivating case: revoked on the leader while this node was too
+        far behind to see the event."""
+        live, revoked = uuid.uuid4(), uuid.uuid4()
+        db = await self._db_with_local_ids([live, revoked])
+
+        removed = await replication.reconcile_deletions(db, TOKENS, {str(live)})
+
+        assert removed == [str(revoked)]
+
+    async def test_an_in_sync_class_removes_nothing(self):
+        """The overwhelmingly common case must not issue a DELETE at all."""
+        a, b = uuid.uuid4(), uuid.uuid4()
+        db = await self._db_with_local_ids([a, b])
+
+        removed = await replication.reconcile_deletions(db, POOLS, {str(a), str(b)})
+
+        assert removed == []
+        # One SELECT for the local ids, and no DELETE.
+        assert db.execute.await_count == 1
+
+    async def test_the_peer_having_nothing_clears_the_class(self):
+        """Legitimate — the leader really may have deleted every row — but it
+        is the highest-blast-radius case, so it is pinned deliberately."""
+        db = await self._db_with_local_ids([uuid.uuid4(), uuid.uuid4()])
+
+        removed = await replication.reconcile_deletions(db, POOLS, set())
+
+        assert len(removed) == 2

--- a/services/tests/services/test_replication_matrix_gate.py
+++ b/services/tests/services/test_replication_matrix_gate.py
@@ -28,12 +28,17 @@ from terrapod.crypto.types import EncryptedText
 from terrapod.services import replication
 
 #: Rows every replicated class must cover, whatever it holds.
+#:
+#: `delete` and `backfill-converges-deletion` are deliberately separate: the
+#: first exercises the delta path, the second the recovery path, and #1115 was
+#: exactly the case where one worked and the other silently did not.
 ALWAYS_REQUIRED = frozenset(
     {
         "backfill-from-empty",
         "delta-apply",
         "idempotent-reapply",
         "delete",
+        "backfill-converges-deletion",
         "role-change-conflict",
     }
 )

--- a/services/tests/services/test_replication_sync.py
+++ b/services/tests/services/test_replication_sync.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 
 from terrapod.db.models import ReplicationCursor
 from terrapod.services import replication_sync
@@ -273,21 +274,25 @@ class TestApplyEvent:
 
 
 class TestBackfillPaging:
+    @patch("terrapod.services.replication.reconcile_deletions", new_callable=AsyncMock)
     @patch("terrapod.services.replication.apply_upsert", new_callable=AsyncMock)
     @patch("terrapod.services.replication_sync.arequest_with_retry", new_callable=AsyncMock)
     @patch("terrapod.services.replication_sync.settings")
-    async def test_walks_pages_until_complete(self, mock_settings, mock_request, mock_upsert):
+    async def test_walks_pages_until_complete(
+        self, mock_settings, mock_request, mock_upsert, mock_reconcile
+    ):
         mock_settings.ha = _cfg()
+        mock_reconcile.return_value = []
         mock_request.side_effect = [
             _resp(
                 body={
-                    "data": [{"attributes": {"id": "1"}}],
+                    "data": [{"id": "1", "attributes": {"id": "1"}}],
                     "meta": {"cursor": "1", "complete": False},
                 }
             ),
             _resp(
                 body={
-                    "data": [{"attributes": {"id": "2"}}],
+                    "data": [{"id": "2", "attributes": {"id": "2"}}],
                     "meta": {"cursor": "2", "complete": True},
                 }
             ),
@@ -299,11 +304,13 @@ class TestBackfillPaging:
         assert count == 2
         assert mock_request.await_count == 2
 
+    @patch("terrapod.services.replication.reconcile_deletions", new_callable=AsyncMock)
     @patch("terrapod.services.replication_sync.arequest_with_retry", new_callable=AsyncMock)
     @patch("terrapod.services.replication_sync.settings")
-    async def test_persists_progress_per_page(self, mock_settings, mock_request):
+    async def test_persists_progress_per_page(self, mock_settings, mock_request, mock_reconcile):
         """An interrupted backfill must resume, not restart a large class."""
         mock_settings.ha = _cfg()
+        mock_reconcile.return_value = []
         mock_request.return_value = _resp(
             body={"data": [], "meta": {"cursor": "abc", "complete": True}}
         )
@@ -360,3 +367,132 @@ class TestOutboxIsBounded:
             "replication_purge must be registered before (and outside) the "
             "enabled gate, or an install with replication off never trims its outbox"
         )
+
+
+class TestBackfillReconciliation:
+    """Backfill removes rows the peer no longer has (#1115) — under guards.
+
+    This is the one place replication deletes data that was never deleted
+    locally, so the conditions under which it does NOT fire matter at least as
+    much as the ones under which it does.
+    """
+
+    @patch("terrapod.services.replication.reconcile_deletions", new_callable=AsyncMock)
+    @patch("terrapod.services.replication.apply_upsert", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.settings")
+    async def test_reconciles_after_a_complete_pass(
+        self, mock_settings, mock_request, _upsert, mock_reconcile
+    ):
+        mock_settings.ha = _cfg()
+        mock_reconcile.return_value = []
+        mock_request.return_value = _resp(
+            body={
+                "data": [{"id": "a", "attributes": {"id": "a"}}],
+                "meta": {"cursor": "a", "complete": True},
+            }
+        )
+
+        await replication_sync.backfill_class(
+            _db_with_cursor(""), MagicMock(), "tok", "agent_pools"
+        )
+
+        mock_reconcile.assert_awaited_once()
+        assert mock_reconcile.await_args[0][2] == {"a"}, "must pass the ids it actually saw"
+
+    @patch("terrapod.services.replication.reconcile_deletions", new_callable=AsyncMock)
+    @patch("terrapod.services.replication.apply_upsert", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.settings")
+    async def test_a_resumed_pass_does_not_reconcile(
+        self, mock_settings, mock_request, _upsert, mock_reconcile
+    ):
+        """A backfill resuming from a cursor never sees the pages it already
+        applied, so its view of the peer's rows is partial — acting on it would
+        delete everything before the resume point."""
+        mock_settings.ha = _cfg()
+        mock_request.return_value = _resp(
+            body={"data": [], "meta": {"cursor": "z", "complete": True}}
+        )
+
+        await replication_sync.backfill_class(
+            _db_with_cursor("m"), MagicMock(), "tok", "agent_pools"
+        )
+
+        mock_reconcile.assert_not_awaited()
+
+    @patch("terrapod.services.replication.reconcile_deletions", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.settings")
+    async def test_a_failed_pass_does_not_reconcile(
+        self, mock_settings, mock_request, mock_reconcile
+    ):
+        """A truncated set would read as mass deletion."""
+        mock_settings.ha = _cfg()
+        mock_request.side_effect = httpx.ConnectError("peer went away")
+
+        with pytest.raises(httpx.ConnectError):
+            await replication_sync.backfill_class(
+                _db_with_cursor(""), MagicMock(), "tok", "agent_pools"
+            )
+
+        mock_reconcile.assert_not_awaited()
+
+
+class TestBackfillIsRepeatable:
+    """The class cursor is a resume point, not a high-water mark.
+
+    Leaving it set after a completed pass means the next backfill resumes past
+    every row it already saw and re-syncs almost nothing — so a node that ages
+    out of the event window a second time would never recover.
+    """
+
+    @patch("terrapod.services.replication.reconcile_deletions", new_callable=AsyncMock)
+    @patch("terrapod.services.replication.apply_upsert", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.settings")
+    async def test_the_cursor_is_cleared_on_completion(
+        self, mock_settings, mock_request, _upsert, mock_reconcile
+    ):
+        mock_settings.ha = _cfg()
+        mock_reconcile.return_value = []
+        cursor = ReplicationCursor(entity_class="agent_pools", position="", backfilling=False)
+        db = AsyncMock()
+        db.scalar.return_value = cursor
+        mock_request.return_value = _resp(
+            body={
+                "data": [{"id": "a", "attributes": {"id": "a"}}],
+                "meta": {"cursor": "a", "complete": True},
+            }
+        )
+
+        await replication_sync.backfill_class(db, MagicMock(), "tok", "agent_pools")
+
+        assert cursor.position == "", "a completed backfill must not leave a resume point"
+        assert cursor.backfilling is False
+
+    @patch("terrapod.services.replication.apply_upsert", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.arequest_with_retry", new_callable=AsyncMock)
+    @patch("terrapod.services.replication_sync.settings")
+    async def test_an_incomplete_pass_keeps_its_resume_point(
+        self, mock_settings, mock_request, _upsert
+    ):
+        mock_settings.ha = _cfg()
+        cursor = ReplicationCursor(entity_class="agent_pools", position="", backfilling=False)
+        db = AsyncMock()
+        db.scalar.return_value = cursor
+        mock_request.side_effect = [
+            _resp(
+                body={
+                    "data": [{"id": "a", "attributes": {"id": "a"}}],
+                    "meta": {"cursor": "a", "complete": False},
+                }
+            ),
+            httpx.ConnectError("peer went away"),
+        ]
+
+        with pytest.raises(httpx.ConnectError):
+            await replication_sync.backfill_class(db, MagicMock(), "tok", "agent_pools")
+
+        assert cursor.position == "a", "an interrupted backfill must be resumable"
+        assert cursor.backfilling is True


### PR DESCRIPTION
Found while starting the identity classes (users, roles, assignments, API tokens) for phase 3 of #960 — which is where it bites hardest, so it blocks them.

## The bug

`backfill_class` only **upserted**. It never removed a local row the peer no longer has, so the *recovery* path could not converge a deletion — while the delta path could.

1. The follower falls behind past `ha.replication.retention_days`
2. Someone revokes an API token on the leader — a hard `DELETE`
3. The delete event is recorded, then purged along with the rest of the window
4. The follower returns, its cursor is stale, and it falls back to backfill
5. Backfill upserts everything the leader has. The deleted token isn't in that set, so **nothing touches it**
6. At failover, the revoked token works again

This is the exact failure #1110 warned about in its own text. I built the delta path to handle deletes (`before_flush` records `session.deleted`) and left the recovery path silently undoing it.

## Reconciliation, not tombstones

Tombstones are the obvious answer and are worse: they need their own retention — so the window problem recurs one level down — and must be written on every delete path, including bulk statements that bypass ORM events.

The cheaper property is already true. Everything replicated originates on the leader, and a follower originates nothing (the write gate). So **a row the follower holds and the peer does not is a row the peer deleted.** A complete backfill can reconcile against the peer's row set with no schema change and no second retention policy.

## Guards

This is the one place replication removes data that was never deleted locally, so the conditions it does *not* fire under matter as much as the ones it does:

- **Only on a complete, error-free pass.** A backfill that raised part-way has a truncated view; acting on it would read as mass deletion.
- **Only from scratch.** A resumed backfill never sees the pages it already applied, so it cannot judge what is missing.
- **Per class**, never global.
- **Every removal logged**, with counts and ids.

The last one matters for failback. A node that has just stopped being the leader may hold writes from the moments before cutover that never replicated. Those are lost either way under asynchronous replication — that is what the promotion staleness gate bounds — but reconciliation turns "still sitting there, recoverable by hand" into "gone", so it must be loud rather than quietly making the two nodes agree.

## A worse bug found while writing it

**The class cursor was never cleared on completion.** It is a resume point *within* a pass, not a high-water mark — so a second backfill of the same class resumed past every row it had already seen and re-synced almost nothing. A node that aged out of the event window twice would never recover.

Fixed in the same change, since reconciliation depends on it.

## Matrix

Adds `backfill-converges-deletion`, deliberately separate from the existing `delete` row: one exercises the delta path, the other the recovery path, and this issue is precisely the case where one worked and the other did not. Both existing classes now carry it.

Verified by removing a mark and watching the gate fail:

```
agent_pools: missing ['backfill-converges-deletion']
```

## Also

One slice-1 test fixture had drifted from the router's real response shape — it omitted the top-level `id` the endpoint actually emits. Corrected, and it's the reason the new code's first run failed rather than passing on a fiction.

## Verification

- `make test` — **3506 passed**
- `make lint` — green
- The new matrix row demonstrated failing, then passing

Closes #1115
Part of #960