### PR TITLE
fix(1117): a single-node install now does no replication work at all

### DIFF
--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -1,5 +1,10 @@
 # High availability
 
+> **A single-node install does none of this.** With the shipped defaults —
+> `ha.role: leader`, no `ha.peer.url` — Terrapod records no replication events,
+> runs no replication tasks, and never probes. The tables exist and stay empty.
+> This is asserted in the test suite, not just intended.
+>
 > **Status: in development.** Role resolution and the peer link are complete;
 > settings replication is being built out class by class. The replication scope
 > today covers **agent pools and join tokens** — see [Replication

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -53,12 +53,22 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     logger.info("Storage initialized")
 
     # Replication outbox hooks (#960 phase 3, #1110). Installed before any DB
-    # write so no change can slip past unrecorded, and unconditional: a node
-    # that is a leader today may be replicated FROM tomorrow, and an outbox with
-    # a hole in it is worse than one nobody reads.
-    from terrapod.services import replication
+    # write so no change can slip past unrecorded — but ONLY when this node is
+    # actually part of a pair (#1117).
+    #
+    # `ha.peer.url` is the signal because BOTH nodes set it: the leader needs it
+    # for when the roles swap and it becomes the puller. A single-node install
+    # leaves it empty and does no replication work at all.
+    #
+    # An earlier version recorded unconditionally, on the reasoning that a node
+    # which gains a peer later should not have a hole in its outbox. That does
+    # not hold since #1115: the new peer backfills each class from scratch, and
+    # backfill reconciles — so the hole is irrelevant, and the cost was being
+    # paid by the overwhelming majority of installs for nothing.
+    if settings.ha.peer.url:
+        from terrapod.services import replication
 
-    replication.install_outbox_hooks()
+        replication.install_outbox_hooks()
 
     # Initialize app-layer encryption at rest (#553) BEFORE the CA — the CA
     # private key column is EncryptedText, so the service must be ready first.
@@ -417,20 +427,20 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # Settings replication (#960 phase 3, #1110). Both tasks are in the
     # scheduler's follower-safe set: the pull loop is the follower's entire
     # purpose, and the purge keeps the outbox bounded.
-    from terrapod.services.replication_sync import purge_cycle, sync_cycle
+    from terrapod.services.replication_sync import purge_cycle, sync_cycle  # noqa: F401
 
-    # The purge is registered UNCONDITIONALLY, unlike the pull loop, because
-    # the outbox is recorded unconditionally. A single-node install with
-    # replication off still produces events (so its outbox has no hole the day
-    # it gains a peer) and would otherwise accumulate them forever. The task is
-    # a no-op query against an empty table for the overwhelming majority of
-    # installs, which is a far better trade than an unbounded table.
-    register_periodic_task(
-        "replication_purge",
-        interval_seconds=3600,
-        handler=purge_cycle,
-        description="Trim replication outbox events beyond the retained window",
-    )
+    # Paired only (#1117) — a single-node install records no events, so there is
+    # nothing to trim and no reason to run an hourly task. The purge is still
+    # registered more broadly than the pull loop: BOTH nodes of a pair record
+    # events (a follower tags its own with its origin so the two cannot echo),
+    # so both need their outbox bounded, whereas only the follower pulls.
+    if settings.ha.peer.url:
+        register_periodic_task(
+            "replication_purge",
+            interval_seconds=3600,
+            handler=purge_cycle,
+            description="Trim replication outbox events beyond the retained window",
+        )
 
     if settings.ha.replication.enabled:
         register_periodic_task(

--- a/services/tests/services/test_replication_singleton.py
+++ b/services/tests/services/test_replication_singleton.py
@@ -1,0 +1,88 @@
+"""A single-node install does no replication work at all (#1117).
+
+The overwhelming majority of installs are one node, and they must not pay for
+machinery built for pairs. This is asserted rather than claimed because it is a
+property an operator should be able to rely on — and because every future
+addition to the HA surface is a chance to quietly break it.
+
+The signal is `ha.peer.url`: **both** nodes of a pair set it, since the leader
+needs it for when the roles swap and it becomes the puller. A singleton leaves
+it empty.
+"""
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from terrapod.api import app as app_module
+from terrapod.config import HAConfig
+from terrapod.services import replication
+
+
+class TestDefaultsAreInert:
+    def test_no_peer_is_configured_by_default(self):
+        cfg = HAConfig()
+
+        assert cfg.peer.url == ""
+        assert cfg.replication.enabled is False
+
+    def test_the_role_is_leader_and_needs_no_redis(self):
+        """A singleton must never probe, never transition, and never spend a
+        threshold's worth of time passive after a pod restart."""
+        assert HAConfig().role == "leader"
+
+    def test_the_write_gate_is_answered_from_config(self):
+        """The gate must add no dependency and no failure mode to the 99% case."""
+        source = inspect.getsource(replication)
+        assert "get_redis_client" not in source, (
+            "the replication path must not reach Redis; the role does, and only under `auto`"
+        )
+
+
+class TestStartupSkipsReplication:
+    """Both the outbox hooks and the purge task are gated on `ha.peer.url`."""
+
+    def test_outbox_hooks_are_gated(self):
+        source = inspect.getsource(app_module)
+        hook = source.index("replication.install_outbox_hooks()")
+        gate = source.rindex("if settings.ha.peer.url:", 0, hook)
+        between = source[gate:hook]
+
+        assert "register_periodic_task" not in between, (
+            "install_outbox_hooks must sit directly under the peer-url gate"
+        )
+
+    def test_the_purge_task_is_gated(self):
+        source = inspect.getsource(app_module)
+        purge = source.index('"replication_purge"')
+        gate = source.rindex("if settings.ha.peer.url:", 0, purge)
+
+        assert gate > 0, "replication_purge must be registered under the peer-url gate"
+
+    def test_the_pull_loop_stays_gated_on_replication_enabled(self):
+        """Narrower than the purge on purpose: both nodes record events, only
+        the follower pulls."""
+        source = inspect.getsource(app_module)
+        sync = source.index('"replication_sync"')
+        gate = source.rindex("if settings.ha.replication.enabled:", 0, sync)
+
+        assert gate > 0
+
+
+class TestNothingIsRecordedWithoutAPeer:
+    @patch("terrapod.services.replication._BY_MODEL", {})
+    def test_a_flush_with_no_registered_models_records_nothing(self):
+        """With hooks never installed the registry is never consulted, but this
+        pins the inner guard too — the hook returns immediately rather than
+        walking the session."""
+        session = MagicMock()
+        session.new = [object()]
+        session.dirty = []
+        session.deleted = []
+
+        with patch("terrapod.config.settings") as mock_settings:
+            mock_settings.ha = SimpleNamespace(node_name="")
+            # The hook's first action is the empty-registry check.
+            assert not replication._BY_MODEL
+
+        session.add.assert_not_called()


### PR DESCRIPTION
Confirming the property directly: **with the shipped defaults, Terrapod does nothing replication-related.**

Most of it was already true. The write gate answers `leader` from config without touching Redis; the role probe, the pull loop and the peer endpoints are unregistered or closed to everything. Two things were not:

- **The outbox hooks were installed unconditionally**, so every write to a replicated class emitted a `replication_events` row that nothing would ever read.
- **`replication_purge` ran hourly** to clean those rows up.

## Why that justification stopped holding

I made recording unconditional on the grounds that a node which gains a peer later shouldn't have a hole in its outbox.

That was true when I wrote it. It stopped being true at #1115: a node that gains a peer has that peer **backfill each class from scratch**, and backfill now reconciles. The hole is irrelevant, because backfill *is* the mechanism for "I have no usable event history". So the cost was being paid by the overwhelming majority of installs for no benefit at all.

## The gate

`ha.peer.url`, because **both** nodes of a pair set it — the leader needs it for when the roles swap and it becomes the puller — while a singleton leaves it empty.

The purge stays gated more broadly than the pull loop deliberately: both nodes of a pair record events (a follower tags its own with its origin so the two can't echo), so both need their outbox bounded, whereas only the follower pulls.

## Asserted, not described

New `test_replication_singleton.py` pins it as a property rather than a claim in a PR description — defaults are inert, the hooks and the purge sit under the peer gate, the pull loop stays on the narrower gate, and the replication path reaches no Redis. Every future addition to the HA surface is a chance to quietly break this, so it should fail a build rather than be noticed in production.

## Net effect on a single-node install

| | Before | After |
|---|---|---|
| Rows written per agent-pool/token change | 1 extra | 0 |
| Hourly background task | yes | no |
| `replication_*` tables | grow then get purged | stay empty |
| Everything else | already inert | unchanged |

## Verification

- `make test` — **3513 passed**
- `make lint` — green

Closes #1117
Part of #960