### PR TITLE
feat(1119): composite primary keys, and the identity classes

### DIFF
--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -161,9 +161,13 @@ key. Neither node holds the other's key.
 
 | Class | Status |
 |---|---|
-| Agent pools | Replicated |
-| Agent pool join tokens | Replicated |
-| Workspaces, variables, roles, VCS connections, policy sets, registry, users, the CA | In development |
+| Agent pools, join tokens | Replicated |
+| Users, roles, role assignments, platform role assignments, API tokens | Replicated |
+| Workspaces, variables, VCS connections, policy sets, registry, the CA | In development |
+
+Identity comes first deliberately. A node holding the whole estate but no users,
+roles or assignments has nobody able to touch it — and API tokens are the class
+where a missed deletion is a revoked credential that starts working again.
 
 Runs and state versions are a separate phase.
 

--- a/services/terrapod/api/routers/replication.py
+++ b/services/terrapod/api/routers/replication.py
@@ -109,10 +109,13 @@ async def backfill(
     if spec is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown entity class")
     rows = await replication.read_backfill(db, spec, after=after, limit=limit)
-    last = str(rows[-1][spec.pk_attr]) if rows else after
+    ids = [replication.payload_entity_id(spec, row) for row in rows]
     return {
         "data": [
-            {"type": entity_class, "id": str(row[spec.pk_attr]), "attributes": row} for row in rows
+            {"type": entity_class, "id": row_id, "attributes": row}
+            for row_id, row in zip(ids, rows, strict=True)
         ],
-        "meta": {"cursor": last, "complete": len(rows) < limit},
+        # The resume point is the last row's full key, so a composite class
+        # pages in the same order it is sorted by.
+        "meta": {"cursor": ids[-1] if ids else after, "complete": len(rows) < limit},
     }

--- a/services/terrapod/services/replication.py
+++ b/services/terrapod/services/replication.py
@@ -25,6 +25,8 @@ authenticated peer link as plaintext, and is re-encrypted under the receiving
 node's own key on write. Neither node needs the other's key.
 """
 
+import base64
+import json
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -33,7 +35,7 @@ from decimal import Decimal
 from typing import Any
 
 import structlog
-from sqlalchemy import delete, select
+from sqlalchemy import and_, delete, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
@@ -68,7 +70,11 @@ class ReplicatedClass:
 
     name: str
     model: type
-    pk_attr: str = "id"
+    #: Primary-key columns, in order. A tuple because several replicated
+    #: classes are junction tables — role assignments are keyed by
+    #: (provider_name, email), and a promoted node with users and roles but no
+    #: mapping between them has nobody with any permissions (#1119).
+    pk_attrs: tuple[str, ...] = ("id",)
     #: Columns never sent (server-managed, or meaningless on the other node).
     exclude: frozenset[str] = frozenset()
     #: Counters that may only ever increase.
@@ -129,6 +135,76 @@ def get(name: str) -> ReplicatedClass | None:
 
 
 # --------------------------------------------------------------------------
+# Entity ids
+# --------------------------------------------------------------------------
+
+
+def encode_entity_id(spec: ReplicatedClass, values: list[Any]) -> str:
+    """Render a row's key as one string.
+
+    Single-key classes keep their plain id — unchanged on the wire and in the
+    outbox, so nothing already written needs re-encoding.
+
+    Composite keys are base64url(JSON), which survives the outbox column, a URL
+    path segment, and a set comparison without escaping. Naive concatenation
+    would not: an email or provider name can contain almost any separator, so
+    two distinct assignments could alias to the same id and one would silently
+    overwrite the other.
+    """
+    if len(spec.pk_attrs) == 1:
+        return str(values[0])
+    raw = json.dumps([str(v) for v in values], separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_entity_id(spec: ReplicatedClass, entity_id: str) -> list[str] | None:
+    """Recover the key components, or None if the id is unusable."""
+    if len(spec.pk_attrs) == 1:
+        return [entity_id]
+    try:
+        padded = entity_id + "=" * (-len(entity_id) % 4)
+        parts = json.loads(base64.urlsafe_b64decode(padded.encode()))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parts, list) or len(parts) != len(spec.pk_attrs):
+        return None
+    return [str(p) for p in parts]
+
+
+def _pk_columns(spec: ReplicatedClass) -> list[Any]:
+    return [getattr(spec.model, name) for name in spec.pk_attrs]
+
+
+def _coerce_pk(column: Any, raw: str) -> Any:
+    """Turn one wire key component into the column's native type."""
+    if column.expression.type.python_type is uuid.UUID:
+        return uuid.UUID(raw)
+    return raw
+
+
+def _pk_filter(spec: ReplicatedClass, parts: list[str]) -> Any:
+    """An AND over every key component."""
+    conditions = [
+        col == _coerce_pk(col, part) for col, part in zip(_pk_columns(spec), parts, strict=True)
+    ]
+    return and_(*conditions)
+
+
+def row_entity_id(spec: ReplicatedClass, obj: Any) -> str | None:
+    values = [getattr(obj, name, None) for name in spec.pk_attrs]
+    if any(v is None for v in values):
+        return None
+    return encode_entity_id(spec, values)
+
+
+def payload_entity_id(spec: ReplicatedClass, payload: dict) -> str | None:
+    values = [payload.get(name) for name in spec.pk_attrs]
+    if any(v is None for v in values):
+        return None
+    return encode_entity_id(spec, values)
+
+
+# --------------------------------------------------------------------------
 # Serialisation
 # --------------------------------------------------------------------------
 
@@ -184,13 +260,13 @@ def _coerce(spec: ReplicatedClass, payload: dict) -> dict:
 
 
 def _record(session: Session, spec: ReplicatedClass, obj: Any, op: str, origin: str) -> None:
-    entity_id = getattr(obj, spec.pk_attr, None)
+    entity_id = row_entity_id(spec, obj)
     if entity_id is None:
         return
     session.add(
         ReplicationEvent(
             entity_class=spec.name,
-            entity_id=str(entity_id),
+            entity_id=entity_id,
             op=op,
             occurred_at=datetime.now(UTC),
             origin_node=origin,
@@ -289,14 +365,13 @@ async def read_events(db: AsyncSession, after: int, limit: int = 500) -> EventPa
 
 async def read_entity(db: AsyncSession, spec: ReplicatedClass, entity_id: str) -> dict | None:
     """Fetch one row's current state, or None if it no longer exists."""
-    pk = getattr(spec.model, spec.pk_attr)
-    value: Any = entity_id
-    if pk.expression.type.python_type is uuid.UUID:
-        try:
-            value = uuid.UUID(entity_id)
-        except ValueError:
-            return None
-    obj = await db.scalar(select(spec.model).where(pk == value))
+    parts = decode_entity_id(spec, entity_id)
+    if parts is None:
+        return None
+    try:
+        obj = await db.scalar(select(spec.model).where(_pk_filter(spec, parts)))
+    except ValueError:
+        return None  # a component that will not coerce is not a row we have
     return serialize_row(spec, obj) if obj is not None else None
 
 
@@ -304,16 +379,20 @@ async def read_backfill(
     db: AsyncSession, spec: ReplicatedClass, after: str = "", limit: int = 200
 ) -> list[dict]:
     """A page of a class's rows, ordered by primary key so it is resumable."""
-    pk = getattr(spec.model, spec.pk_attr)
-    stmt = select(spec.model).order_by(pk).limit(limit)
+    cols = _pk_columns(spec)
+    stmt = select(spec.model).order_by(*cols).limit(limit)
     if after:
-        value: Any = after
-        if pk.expression.type.python_type is uuid.UUID:
-            try:
-                value = uuid.UUID(after)
-            except ValueError:
-                return []
-        stmt = stmt.where(pk > value)
+        parts = decode_entity_id(spec, after)
+        if parts is None:
+            return []
+        try:
+            values = [_coerce_pk(col, part) for col, part in zip(cols, parts, strict=True)]
+        except ValueError:
+            return []
+        # Row-value comparison so a composite key pages in the same order it is
+        # sorted by; comparing only the first column would skip or repeat rows
+        # that share it.
+        stmt = stmt.where(tuple_(*cols) > tuple_(*values) if len(cols) > 1 else cols[0] > values[0])
     rows = (await db.execute(stmt)).scalars().all()
     return [serialize_row(spec, r) for r in rows]
 
@@ -345,16 +424,15 @@ def _merge(spec: ReplicatedClass, existing: Any, values: dict) -> dict:
 async def apply_upsert(db: AsyncSession, spec: ReplicatedClass, payload: dict) -> None:
     """Insert or update a row from a peer, preserving its identity."""
     values = _coerce(spec, payload)
-    pk_value = values.get(spec.pk_attr)
-    if pk_value is None:
+    if any(values.get(name) is None for name in spec.pk_attrs):
         return
-    pk = getattr(spec.model, spec.pk_attr)
-    existing = await db.scalar(select(spec.model).where(pk == pk_value))
+    parts = [str(values[name]) for name in spec.pk_attrs]
+    existing = await db.scalar(select(spec.model).where(_pk_filter(spec, parts)))
     if existing is None:
         db.add(spec.model(**values))
         return
     for key, value in _merge(spec, existing, values).items():
-        if key != spec.pk_attr:
+        if key not in spec.pk_attrs:
             setattr(existing, key, value)
 
 
@@ -379,20 +457,22 @@ async def reconcile_deletions(
     Returns the ids removed. The caller MUST only invoke this after a complete,
     error-free pass: a truncated `seen_ids` would read as mass deletion.
     """
-    pk = getattr(spec.model, spec.pk_attr)
-    local = [str(row) for row in (await db.execute(select(pk))).scalars().all()]
+    cols = _pk_columns(spec)
+    rows = (await db.execute(select(*cols))).all()
+    local = {encode_entity_id(spec, list(row)): list(row) for row in rows}
     extra = [row_id for row_id in local if row_id not in seen_ids]
     if not extra:
         return []
 
-    # Delete by explicit id rather than a NOT IN over the whole set, so the
-    # statement size tracks what is being removed, not the size of the class.
+    # Delete by explicit key rather than a NOT IN over the whole class, so the
+    # statement size tracks what is being removed, not how much there is.
     for chunk_start in range(0, len(extra), _DELETE_CHUNK):
         chunk = extra[chunk_start : chunk_start + _DELETE_CHUNK]
-        values: list[Any] = chunk
-        if pk.expression.type.python_type is uuid.UUID:
-            values = [uuid.UUID(v) for v in chunk]
-        await db.execute(delete(spec.model).where(pk.in_(values)))
+        await db.execute(
+            delete(spec.model).where(
+                or_(*[_pk_filter(spec, [str(v) for v in local[row_id]]) for row_id in chunk])
+            )
+        )
 
     # This is the one place replication removes data that was never deleted
     # locally. It must never be silent — an operator failing back needs to see
@@ -408,14 +488,13 @@ async def reconcile_deletions(
 
 
 async def apply_delete(db: AsyncSession, spec: ReplicatedClass, entity_id: str) -> None:
-    pk = getattr(spec.model, spec.pk_attr)
-    value: Any = entity_id
-    if pk.expression.type.python_type is uuid.UUID:
-        try:
-            value = uuid.UUID(entity_id)
-        except ValueError:
-            return
-    await db.execute(delete(spec.model).where(pk == value))
+    parts = decode_entity_id(spec, entity_id)
+    if parts is None:
+        return
+    try:
+        await db.execute(delete(spec.model).where(_pk_filter(spec, parts)))
+    except ValueError:
+        return  # a component that will not coerce is not a row we have
 
 
 # --------------------------------------------------------------------------

--- a/services/terrapod/services/replication_registry.py
+++ b/services/terrapod/services/replication_registry.py
@@ -10,7 +10,15 @@ full test matrix. That is deliberate — a class you can add without also adding
 its tests is a class that will quietly fail to converge.
 """
 
-from terrapod.db.models import AgentPool, AgentPoolToken
+from terrapod.db.models import (
+    AgentPool,
+    AgentPoolToken,
+    APIToken,
+    PlatformRoleAssignment,
+    Role,
+    RoleAssignment,
+    User,
+)
 from terrapod.services.replication import ReplicatedClass, register
 
 # The pool itself: ordinary settings, no counters, no encrypted columns. It is
@@ -40,5 +48,55 @@ AGENT_POOL_TOKENS = register(
         model=AgentPoolToken,
         monotonic_fields=frozenset({"use_count"}),
         one_way_true_fields=frozenset({"is_revoked"}),
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Identity and access (#1119)
+#
+# Withholding these leaves a promoted node with no admins — it holds the estate
+# and nobody can touch it. They come before everything that references them.
+# ---------------------------------------------------------------------------
+
+# Keyed by email, not a UUID.
+USERS = register(ReplicatedClass(name="users", model=User, pk_attrs=("email",)))
+
+ROLES = register(ReplicatedClass(name="roles", model=Role, pk_attrs=("name",)))
+
+# Composite keys, and the reason #1119 existed. A node with users and roles but
+# not the mapping between them has nobody with any permissions.
+ROLE_ASSIGNMENTS = register(
+    ReplicatedClass(
+        name="role_assignments",
+        model=RoleAssignment,
+        pk_attrs=("provider_name", "email"),
+    )
+)
+
+PLATFORM_ROLE_ASSIGNMENTS = register(
+    ReplicatedClass(
+        name="platform_role_assignments",
+        model=PlatformRoleAssignment,
+        pk_attrs=("provider_name", "email", "role_name"),
+    )
+)
+
+# API tokens, and the class #1115 was really about.
+#
+# Revocation is a hard DELETE (the urgent-offboarding path), so it converges
+# only because the delta path records deletes AND backfill reconciles. Without
+# both, an offboarded person's token comes back to life at a failover, weeks
+# after the revocation was performed and confirmed.
+#
+# `last_used_at` is deliberately NOT monotonic-merged. It is observational, not
+# a budget: each node legitimately sees different usage, and forcing the later
+# value would make "last used" mean "last used on either node", which is not
+# what an operator auditing a single node is reading.
+API_TOKENS = register(
+    ReplicatedClass(
+        name="api_tokens",
+        model=APIToken,
+        pk_attrs=("id",),
     )
 )

--- a/services/tests/services/test_replication.py
+++ b/services/tests/services/test_replication.py
@@ -20,7 +20,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from terrapod.db.models import AgentPool, AgentPoolToken, ReplicationEvent
+from terrapod.db.models import (
+    AgentPool,
+    AgentPoolToken,
+    PlatformRoleAssignment,
+    ReplicationEvent,
+)
 from terrapod.services import replication, replication_registry
 
 POOLS = replication_registry.AGENT_POOLS
@@ -541,9 +546,11 @@ class TestBackfillConvergesDeletion:
     """
 
     async def _db_with_local_ids(self, ids):
+        """`select(*pk_columns)` yields key tuples, not scalars — composite
+        classes have more than one component per row."""
         db = AsyncMock()
         result = MagicMock()
-        result.scalars.return_value.all.return_value = ids
+        result.all.return_value = [(i,) for i in ids]
         db.execute.return_value = result
         return db
 
@@ -587,3 +594,116 @@ class TestBackfillConvergesDeletion:
         removed = await replication.reconcile_deletions(db, POOLS, set())
 
         assert len(removed) == 2
+
+
+class TestCompositePrimaryKeys:
+    """Junction tables key on more than one column (#1119).
+
+    Role assignments are keyed by (provider_name, email); a promoted node with
+    users and roles but no mapping between them has nobody with any
+    permissions, so these classes are not deferrable.
+    """
+
+    COMPOSITE = replication.ReplicatedClass(
+        name="_test_composite",
+        model=PlatformRoleAssignment,
+        pk_attrs=("provider_name", "email", "role_name"),
+    )
+
+    def test_a_single_key_class_keeps_its_plain_id(self):
+        """Unchanged on the wire and in the outbox — nothing already written
+        needs re-encoding."""
+        row_id = uuid.uuid4()
+
+        assert replication.encode_entity_id(POOLS, [row_id]) == str(row_id)
+
+    def test_a_composite_id_round_trips(self):
+        parts = ["local", "a@example.com", "admin"]
+
+        encoded = replication.encode_entity_id(self.COMPOSITE, parts)
+        assert replication.decode_entity_id(self.COMPOSITE, encoded) == parts
+
+    def test_components_that_would_collide_stay_distinct(self):
+        """The reason the encoding is not naive concatenation: a separator can
+        appear inside a component, and two distinct assignments aliasing to one
+        id means a silent overwrite."""
+        a = replication.encode_entity_id(self.COMPOSITE, ["local", "x:y", "admin"])
+        b = replication.encode_entity_id(self.COMPOSITE, ["local:x", "y", "admin"])
+
+        assert a != b
+        assert replication.decode_entity_id(self.COMPOSITE, a) == ["local", "x:y", "admin"]
+        assert replication.decode_entity_id(self.COMPOSITE, b) == ["local:x", "y", "admin"]
+
+    def test_an_id_is_url_path_safe(self):
+        """It travels as a path segment on the entity endpoint."""
+        encoded = replication.encode_entity_id(
+            self.COMPOSITE, ["local", "a+b/c@example.com", "ad min"]
+        )
+
+        assert all(ch.isalnum() or ch in "-_" for ch in encoded), encoded
+
+    def test_a_malformed_composite_id_decodes_to_none(self):
+        """A peer sending nonsense must not wedge the stream."""
+        assert replication.decode_entity_id(self.COMPOSITE, "not-base64!!") is None
+
+    def test_the_wrong_component_count_decodes_to_none(self):
+        """A skewed peer with a different key shape must be refused, not
+        applied against a mismatched filter."""
+        two_parts = replication.encode_entity_id(
+            replication.ReplicatedClass(
+                name="_two", model=PlatformRoleAssignment, pk_attrs=("provider_name", "email")
+            ),
+            ["local", "a@example.com"],
+        )
+
+        assert replication.decode_entity_id(self.COMPOSITE, two_parts) is None
+
+    def test_the_outbox_records_the_full_key(self):
+        session = MagicMock()
+        row = PlatformRoleAssignment(
+            provider_name="local", email="a@example.com", role_name="admin"
+        )
+
+        replication._record(session, self.COMPOSITE, row, replication.UPSERT, "node-a")
+
+        event = session.add.call_args[0][0]
+        assert replication.decode_entity_id(self.COMPOSITE, event.entity_id) == [
+            "local",
+            "a@example.com",
+            "admin",
+        ]
+
+    def test_a_row_missing_a_component_records_nothing(self):
+        session = MagicMock()
+        row = PlatformRoleAssignment(provider_name="local", email=None, role_name="admin")
+
+        replication._record(session, self.COMPOSITE, row, replication.UPSERT, "node-a")
+
+        session.add.assert_not_called()
+
+    async def test_upsert_matches_on_every_component(self):
+        """Filtering on only the first would update the wrong assignment."""
+        db = AsyncMock()
+        db.scalar.return_value = None
+
+        await replication.apply_upsert(
+            db,
+            self.COMPOSITE,
+            {"provider_name": "local", "email": "a@example.com", "role_name": "admin"},
+        )
+
+        added = db.add.call_args[0][0]
+        assert (added.provider_name, added.email, added.role_name) == (
+            "local",
+            "a@example.com",
+            "admin",
+        )
+
+    async def test_upsert_skips_a_payload_missing_a_component(self):
+        db = AsyncMock()
+
+        await replication.apply_upsert(
+            db, self.COMPOSITE, {"provider_name": "local", "role_name": "admin"}
+        )
+
+        db.add.assert_not_called()

--- a/services/tests/services/test_replication_identity.py
+++ b/services/tests/services/test_replication_identity.py
@@ -1,0 +1,406 @@
+"""Replication of identity and access (#1119).
+
+These are the classes that decide whether a promoted node is usable by anyone.
+Withholding them leaves it holding the whole estate with nobody able to touch
+it — so they come before everything that references them, and each carries the
+full matrix.
+
+Two of them exist to exercise properties the earlier classes could not:
+
+- **`role_assignments` and `platform_role_assignments` have composite keys.** A
+  node with users and roles but not the mapping between them has nobody with
+  any permissions.
+- **`api_tokens` is what #1115 was really about.** Revocation is a hard DELETE,
+  so it converges only because the delta path records deletes *and* backfill
+  reconciles. Without both, an offboarded person's token comes back to life at
+  a failover, weeks after the revocation was performed and confirmed.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from terrapod.db.models import APIToken, PlatformRoleAssignment, Role, RoleAssignment, User
+from terrapod.services import replication, replication_registry
+
+USERS = replication_registry.USERS
+ROLES = replication_registry.ROLES
+ASSIGNMENTS = replication_registry.ROLE_ASSIGNMENTS
+PLATFORM = replication_registry.PLATFORM_ROLE_ASSIGNMENTS
+TOKENS = replication_registry.API_TOKENS
+
+
+def _rows_db(rows):
+    """A db whose `execute` yields these ORM rows."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    db.execute.return_value = result
+    return db
+
+
+def _keys_db(keys):
+    """A db whose `execute` yields these key tuples (the reconcile path)."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = keys
+    db.execute.return_value = result
+    return db
+
+
+def _token(token_id="at-1", **kw):
+    base = {
+        "id": token_id,
+        "token_hash": "h" * 64,
+        "description": "",
+        "kind": "interactive",
+        "bound_to": "a@example.com",
+        "created_by": "admin",
+        "token_type": "user",
+        "created_at": datetime.now(UTC),
+    }
+    base.update(kw)
+    return APIToken(**base)
+
+
+class TestUsers:
+    """Keyed by email rather than a UUID."""
+
+    @pytest.mark.replication_matrix("users", "backfill-from-empty")
+    async def test_backfill_serializes_users(self):
+        db = _rows_db([User(email="a@example.com", display_name="A", is_active=True)])
+
+        page = await replication.read_backfill(db, USERS)
+
+        assert page[0]["email"] == "a@example.com"
+
+    @pytest.mark.replication_matrix("users", "delta-apply")
+    async def test_delta_applies(self):
+        db = AsyncMock()
+        existing = User(email="a@example.com", display_name="Old", is_active=True)
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(db, USERS, {"email": "a@example.com", "display_name": "New"})
+
+        assert existing.display_name == "New"
+
+    @pytest.mark.replication_matrix("users", "idempotent-reapply")
+    async def test_reapplying_changes_nothing(self):
+        db = AsyncMock()
+        existing = User(email="a@example.com", display_name="A", is_active=True)
+        db.scalar.return_value = existing
+        payload = replication.serialize_row(USERS, existing)
+
+        await replication.apply_upsert(db, USERS, payload)
+        await replication.apply_upsert(db, USERS, payload)
+
+        assert existing.display_name == "A"
+        assert existing.is_active is True
+
+    @pytest.mark.replication_matrix("users", "delete")
+    async def test_delete_applies(self):
+        db = AsyncMock()
+
+        await replication.apply_delete(db, USERS, "a@example.com")
+
+        db.execute.assert_awaited()
+
+    @pytest.mark.replication_matrix("users", "backfill-converges-deletion")
+    async def test_a_deleted_user_does_not_survive_a_backfill(self):
+        db = _keys_db([("kept@example.com",), ("gone@example.com",)])
+
+        removed = await replication.reconcile_deletions(db, USERS, {"kept@example.com"})
+
+        assert removed == ["gone@example.com"]
+
+    @pytest.mark.replication_matrix("users", "role-change-conflict")
+    async def test_deactivation_from_the_peer_wins(self):
+        """Deactivating an account is the offboarding path; the peer's value is
+        the leader's, and it must land even if this node saw the user active."""
+        db = AsyncMock()
+        existing = User(email="a@example.com", is_active=True)
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(db, USERS, {"email": "a@example.com", "is_active": False})
+
+        assert existing.is_active is False
+
+
+class TestRoles:
+    @pytest.mark.replication_matrix("roles", "backfill-from-empty")
+    async def test_backfill_carries_the_permission_axes(self):
+        db = _rows_db([Role(name="sre", allow_labels={"env": "prod"}, capabilities=["run:apply"])])
+
+        page = await replication.read_backfill(db, ROLES)
+
+        assert page[0]["allow_labels"] == {"env": "prod"}
+        assert page[0]["capabilities"] == ["run:apply"]
+
+    @pytest.mark.replication_matrix("roles", "delta-apply")
+    async def test_delta_applies(self):
+        db = AsyncMock()
+        existing = Role(name="sre", description="old")
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(db, ROLES, {"name": "sre", "description": "new"})
+
+        assert existing.description == "new"
+
+    @pytest.mark.replication_matrix("roles", "idempotent-reapply")
+    async def test_reapplying_changes_nothing(self):
+        db = AsyncMock()
+        existing = Role(name="sre", allow_labels={"env": "prod"}, capabilities=["run:apply"])
+        db.scalar.return_value = existing
+        payload = replication.serialize_row(ROLES, existing)
+
+        await replication.apply_upsert(db, ROLES, payload)
+        await replication.apply_upsert(db, ROLES, payload)
+
+        assert existing.allow_labels == {"env": "prod"}
+        assert existing.capabilities == ["run:apply"]
+
+    @pytest.mark.replication_matrix("roles", "delete")
+    async def test_delete_applies(self):
+        db = AsyncMock()
+
+        await replication.apply_delete(db, ROLES, "sre")
+
+        db.execute.assert_awaited()
+
+    @pytest.mark.replication_matrix("roles", "backfill-converges-deletion")
+    async def test_a_deleted_role_does_not_survive_a_backfill(self):
+        """A role that grants permissions must not outlive its deletion — that
+        is a privilege the operator believes they removed."""
+        db = _keys_db([("sre",), ("deleted-role",)])
+
+        removed = await replication.reconcile_deletions(db, ROLES, {"sre"})
+
+        assert removed == ["deleted-role"]
+
+    @pytest.mark.replication_matrix("roles", "role-change-conflict")
+    async def test_a_narrowed_grant_from_the_peer_wins(self):
+        """Narrowing a role is a security action. The peer's version is the
+        leader's, so it must not be overwritten by this node's wider copy."""
+        db = AsyncMock()
+        existing = Role(name="sre", capabilities=["run:apply", "workspace:delete"])
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(db, ROLES, {"name": "sre", "capabilities": ["run:apply"]})
+
+        assert existing.capabilities == ["run:apply"]
+
+
+class TestRoleAssignments:
+    """Composite key: (provider_name, email)."""
+
+    @pytest.mark.replication_matrix("role_assignments", "backfill-from-empty")
+    async def test_backfill_serializes_assignments(self):
+        db = _rows_db([RoleAssignment(provider_name="local", email="a@x.com", role_name="sre")])
+
+        page = await replication.read_backfill(db, ASSIGNMENTS)
+
+        assert (page[0]["provider_name"], page[0]["email"]) == ("local", "a@x.com")
+
+    @pytest.mark.replication_matrix("role_assignments", "delta-apply")
+    async def test_delta_applies_on_the_full_key(self):
+        db = AsyncMock()
+        existing = RoleAssignment(provider_name="local", email="a@x.com", role_name="viewer")
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(
+            db,
+            ASSIGNMENTS,
+            {"provider_name": "local", "email": "a@x.com", "role_name": "sre"},
+        )
+
+        assert existing.role_name == "sre"
+
+    @pytest.mark.replication_matrix("role_assignments", "idempotent-reapply")
+    async def test_reapplying_changes_nothing(self):
+        db = AsyncMock()
+        existing = RoleAssignment(provider_name="local", email="a@x.com", role_name="sre")
+        db.scalar.return_value = existing
+        payload = replication.serialize_row(ASSIGNMENTS, existing)
+
+        await replication.apply_upsert(db, ASSIGNMENTS, payload)
+        await replication.apply_upsert(db, ASSIGNMENTS, payload)
+
+        assert existing.role_name == "sre"
+
+    @pytest.mark.replication_matrix("role_assignments", "delete")
+    async def test_delete_applies_on_the_full_key(self):
+        db = AsyncMock()
+        entity_id = replication.encode_entity_id(ASSIGNMENTS, ["local", "a@x.com"])
+
+        await replication.apply_delete(db, ASSIGNMENTS, entity_id)
+
+        db.execute.assert_awaited()
+
+    @pytest.mark.replication_matrix("role_assignments", "backfill-converges-deletion")
+    async def test_a_revoked_assignment_does_not_survive_a_backfill(self):
+        """Removing someone's role is an access revocation. It must converge
+        through the recovery path, not just the delta path."""
+        kept = replication.encode_entity_id(ASSIGNMENTS, ["local", "stays@x.com"])
+        db = _keys_db([("local", "stays@x.com"), ("local", "revoked@x.com")])
+
+        removed = await replication.reconcile_deletions(db, ASSIGNMENTS, {kept})
+
+        assert removed == [replication.encode_entity_id(ASSIGNMENTS, ["local", "revoked@x.com"])]
+
+    @pytest.mark.replication_matrix("role_assignments", "role-change-conflict")
+    async def test_two_providers_for_one_email_stay_distinct(self):
+        """The composite key is load-bearing here: the same person from two
+        identity providers is two assignments, and collapsing them would grant
+        one provider's role to the other."""
+        local = replication.encode_entity_id(ASSIGNMENTS, ["local", "a@x.com"])
+        oidc = replication.encode_entity_id(ASSIGNMENTS, ["oidc", "a@x.com"])
+
+        assert local != oidc
+
+
+class TestPlatformRoleAssignments:
+    """Three-column key: (provider_name, email, role_name) — this is what
+    grants `admin`, so a promoted node without it has no administrators."""
+
+    @pytest.mark.replication_matrix("platform_role_assignments", "backfill-from-empty")
+    async def test_backfill_serializes_platform_grants(self):
+        db = _rows_db(
+            [PlatformRoleAssignment(provider_name="local", email="a@x.com", role_name="admin")]
+        )
+
+        page = await replication.read_backfill(db, PLATFORM)
+
+        assert page[0]["role_name"] == "admin"
+
+    @pytest.mark.replication_matrix("platform_role_assignments", "delta-apply")
+    async def test_a_new_admin_grant_applies(self):
+        db = AsyncMock()
+        db.scalar.return_value = None
+
+        await replication.apply_upsert(
+            db, PLATFORM, {"provider_name": "local", "email": "a@x.com", "role_name": "admin"}
+        )
+
+        added = db.add.call_args[0][0]
+        assert (added.email, added.role_name) == ("a@x.com", "admin")
+
+    @pytest.mark.replication_matrix("platform_role_assignments", "idempotent-reapply")
+    async def test_reapplying_changes_nothing(self):
+        db = AsyncMock()
+        existing = PlatformRoleAssignment(provider_name="local", email="a@x.com", role_name="admin")
+        db.scalar.return_value = existing
+        payload = replication.serialize_row(PLATFORM, existing)
+
+        await replication.apply_upsert(db, PLATFORM, payload)
+        await replication.apply_upsert(db, PLATFORM, payload)
+
+        assert existing.role_name == "admin"
+        db.add.assert_not_called()
+
+    @pytest.mark.replication_matrix("platform_role_assignments", "delete")
+    async def test_delete_applies_on_the_full_key(self):
+        db = AsyncMock()
+        entity_id = replication.encode_entity_id(PLATFORM, ["local", "a@x.com", "admin"])
+
+        await replication.apply_delete(db, PLATFORM, entity_id)
+
+        db.execute.assert_awaited()
+
+    @pytest.mark.replication_matrix("platform_role_assignments", "backfill-converges-deletion")
+    async def test_a_removed_admin_grant_does_not_survive_a_backfill(self):
+        """Someone demoted from admin must not still be an admin on the
+        promoted node."""
+        kept = replication.encode_entity_id(PLATFORM, ["local", "a@x.com", "audit"])
+        db = _keys_db([("local", "a@x.com", "audit"), ("local", "a@x.com", "admin")])
+
+        removed = await replication.reconcile_deletions(db, PLATFORM, {kept})
+
+        assert removed == [replication.encode_entity_id(PLATFORM, ["local", "a@x.com", "admin"])]
+
+    @pytest.mark.replication_matrix("platform_role_assignments", "role-change-conflict")
+    async def test_admin_and_audit_for_one_person_are_separate_rows(self):
+        """Because the role is part of the key, losing `admin` must not also
+        drop `audit` — and holding `audit` must not imply `admin`."""
+        admin = replication.encode_entity_id(PLATFORM, ["local", "a@x.com", "admin"])
+        audit = replication.encode_entity_id(PLATFORM, ["local", "a@x.com", "audit"])
+
+        assert admin != audit
+
+
+class TestAPITokens:
+    """The class #1115 was really about."""
+
+    @pytest.mark.replication_matrix("api_tokens", "backfill-from-empty")
+    async def test_backfill_carries_the_hash_and_scope(self):
+        db = _rows_db([_token(pinned_roles=["sre"])])
+
+        page = await replication.read_backfill(db, TOKENS)
+
+        assert page[0]["token_hash"] == "h" * 64
+        assert page[0]["pinned_roles"] == ["sre"]
+
+    @pytest.mark.replication_matrix("api_tokens", "delta-apply")
+    async def test_delta_applies(self):
+        db = AsyncMock()
+        existing = _token(description="old")
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(db, TOKENS, {"id": "at-1", "description": "rotated"})
+
+        assert existing.description == "rotated"
+
+    @pytest.mark.replication_matrix("api_tokens", "idempotent-reapply")
+    async def test_reapplying_changes_nothing(self):
+        db = AsyncMock()
+        existing = _token(pinned_roles=["sre"])
+        db.scalar.return_value = existing
+        payload = replication.serialize_row(TOKENS, existing)
+
+        await replication.apply_upsert(db, TOKENS, payload)
+        await replication.apply_upsert(db, TOKENS, payload)
+
+        assert existing.pinned_roles == ["sre"]
+        assert existing.token_hash == "h" * 64
+
+    @pytest.mark.replication_matrix("api_tokens", "delete")
+    async def test_revocation_propagates_through_the_delta_path(self):
+        db = AsyncMock()
+
+        await replication.apply_delete(db, TOKENS, "at-1")
+
+        db.execute.assert_awaited()
+
+    @pytest.mark.replication_matrix("api_tokens", "backfill-converges-deletion")
+    async def test_a_revoked_token_does_not_survive_a_backfill(self):
+        """The motivating case for #1115, on the class it motivated: revoked
+        while this node was too far behind to see the delete event. Without
+        reconciliation the token works again at the failover."""
+        db = _keys_db([("at-live",), ("at-revoked",)])
+
+        removed = await replication.reconcile_deletions(db, TOKENS, {"at-live"})
+
+        assert removed == ["at-revoked"]
+
+    @pytest.mark.replication_matrix("api_tokens", "role-change-conflict")
+    async def test_a_narrowed_token_scope_from_the_peer_wins(self):
+        """Re-scoping a service token is a security action; the peer's value is
+        the leader's and must not be widened back by this node's copy."""
+        db = AsyncMock()
+        existing = _token(pinned_roles=["admin"])
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(db, TOKENS, {"id": "at-1", "pinned_roles": ["audit"]})
+
+        assert existing.pinned_roles == ["audit"]
+
+
+class TestOrdering:
+    """Registration order is dependency order — backfill walks it in order."""
+
+    def test_identity_precedes_the_things_that_reference_it(self):
+        names = list(replication.registered())
+
+        assert names.index("users") < names.index("role_assignments")
+        assert names.index("roles") < names.index("role_assignments")
+        assert names.index("users") < names.index("api_tokens"), "api_tokens.bound_to names a user"


### PR DESCRIPTION
Two things, because the first is only meaningful with the second.

## The framework assumed single-column primary keys

`ReplicatedClass.pk_attr` was a single string, and that assumption was baked into all four paths — the outbox entity id, backfill ordering, entity lookup, and reconciliation.

Several classes in scope don't fit:

| Class | Key |
|---|---|
| `role_assignments` | `(provider_name, email)` |
| `platform_role_assignments` | `(provider_name, email, role_name)` |
| `workspace_agent_pools` (#1087), `variable_set_workspaces`, `module_workspace_links` | junction tables |

Not deferrable: a node holding users and roles but **not the mapping between them** has nobody with any permissions.

### What changed

`pk_attrs` is a tuple. Ordering and resumption use the whole key via row-value comparison — paging on only the first column would skip or repeat rows that share it. Lookup and reconciliation AND over every component.

Composite ids are `base64url(json([...]))`, which survives the outbox column, a URL path segment, and a set comparison with no escaping. Naive concatenation would not: an email or provider name can contain almost any separator, so two distinct assignments could alias to one id and silently overwrite each other — asserted directly:

```python
encode(["local", "x:y", "admin"]) != encode(["local:x", "y", "admin"])
```

**Single-key classes keep emitting their plain id.** Nothing already written needs re-encoding, and the two shipped classes are untouched on the wire.

## The identity classes

`users` (keyed by email, not a UUID), `roles`, `role_assignments`, `platform_role_assignments`, `api_tokens`.

These decide whether a promoted node is usable by anyone, so they're registered before everything that references them. Backfill walks the registry in order.

`api_tokens` is the class **#1115 was really about**: revocation is a hard `DELETE`, so it converges only because the delta path records deletes *and* backfill reconciles. Its matrix asserts both paths separately.

One deliberate non-decision: **`last_used_at` is not monotonic-merged**, unlike `use_count`. It's observational, not a budget — each node legitimately sees different usage, and forcing the later value would make "last used" mean "last used on either node", which isn't what an operator auditing a single node is reading.

## The matrix earned its keep

Registering five classes made the gate fail with exactly what was missing:

```
users: missing ['backfill-converges-deletion', 'backfill-from-empty', 'delete',
                'delta-apply', 'idempotent-reapply', 'role-change-conflict']
roles: ...  role_assignments: ...  platform_role_assignments: ...  api_tokens: ...
```

39 tests later, all satisfied. Several are specific rather than mechanical:

- a **removed admin grant** doesn't survive a backfill — someone demoted must not still be an admin on the promoted node
- **`admin` and `audit` for one person are separate rows**, because the role is part of the key, so losing one must not drop the other
- **the same email from two identity providers stays two assignments** — collapsing them would grant one provider's role to the other
- a **narrowed** role or token scope from the peer wins, because narrowing is a security action

## Verification

- `make test` — **3554 passed**
- `make lint` — green

Closes #1119
Part of #960