### PR TITLE
feat(1121): report whether the follower is caught up

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3837,6 +3837,52 @@ Deletes the catalog instance's workspace record **without** destroying its infra
 
 ---
 
+## High Availability
+
+Leader/follower pair endpoints (#960). See [High availability](high-availability.md).
+
+### `GET /api/terrapod/v1/ha/whoami`
+
+**Unauthenticated by necessity** — this is what a node probes against the shared
+DNS name to discover whether it owns that name, and the probe runs before any
+trust exists between the two nodes. It discloses only an operator-chosen node
+name and a role. `Cache-Control: no-store`, so a CDN or WAF in front of the
+external name cannot pin leadership to a stale answer.
+
+```json
+{"data": {"type": "ha-nodes", "id": "node-a",
+          "attributes": {"node-id": "node-a", "role": "leader"}}}
+```
+
+### `GET /api/terrapod/v1/ha/status`
+
+**Requires `admin` or `audit`.** Whether this node is converging with its peer —
+the question to answer before moving DNS. Computed entirely from local state, so
+it still works when the peer is the thing that has broken.
+
+| Attribute | Meaning |
+|---|---|
+| `role`, `node-id` | This node's identity and current role |
+| `peer-configured` | False on an ordinary single node; the rest then does not apply |
+| `replication-enabled` | Whether this node pulls from a peer |
+| `in-sync` | **The summary.** True only when a pull has succeeded *and* no class is mid-backfill |
+| `last-sync-at`, `seconds-since-last-sync` | The last successful pull. Null when it has never synced |
+| `backfilling-classes` | Classes still being pulled in full. **Non-empty means not in sync**, however recent the last pull |
+| `events-retained`, `oldest-event-age-seconds` | Leader side: as the oldest event approaches `retention-seconds`, the follower is close to having to backfill from scratch |
+| `retention-seconds` | The retained event window |
+| `replicated-classes` | What a failover would carry |
+
+There is deliberately no "N events behind": that needs the peer's latest event
+id, and seconds-since-the-last-successful-pull is more honest — a pull that
+returned nothing means caught up as of then.
+
+### Peer-only endpoints
+
+`/api/terrapod/v1/ha/replication/*` are consumed **by the peer node**, not by
+users or tooling. They accept a `peer` token and nothing else, and no other
+endpoint accepts one — a peer can read entities an ordinary user cannot, so that
+visibility is deliberately not expressible as roles somebody could be granted.
+
 ## Common Response Codes
 
 | Code | Meaning |

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -208,9 +208,32 @@ budget (joins land on A before a failover and on B after one), so a stale copy
 winning on timestamp would hand a spent token its uses back. Revocation is
 one-way for the same reason: a revoked token can never replicate back to usable.
 
+## Is the follower caught up?
+
+`GET /api/terrapod/v1/ha/status` (admin or audit), `terrapod_ha_status` over MCP,
+or `GetHAStatus` in go-terrapod. Answered entirely from local state, so it still
+works when the peer is the thing that has broken — which is when you are reading
+it.
+
+On the **follower**, `in-sync` is the summary. It is false unless a pull has
+succeeded *and* no class is mid-backfill: **a node backfilling is not in sync
+however recent its last cycle**, and reading only the timestamp would give a
+green light to a node still pulling a whole class.
+
+On the **leader**, compare `oldest-event-age-seconds` against
+`retention-seconds`. As those converge the follower is close to falling off the
+end of the retained event window and having to backfill from scratch. That is
+the early warning — it costs nothing to watch and it precedes the problem by
+days.
+
+There is deliberately no "N events behind". That needs the peer's latest event
+id, and seconds-since-the-last-successful-pull is the more honest number: a pull
+that returned nothing means caught up *as of then*, which is the question being
+asked.
+
 ## Performing a failover
 
-1. Confirm the standby is caught up.
+1. Confirm the standby is caught up (above).
 2. Move the DNS record to the standby.
 3. Wait for DNS cache to expire — this, not the probe interval, is what governs
    the overlap.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -116,6 +116,10 @@ scrape_configs:
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
+| `terrapod_replication_seconds_since_last_sync` | Gauge | — | Seconds since the last successful pull from the HA peer (follower side) |
+| `terrapod_replication_backfilling_classes` | Gauge | — | Classes mid-backfill. **Non-zero means NOT in sync**, however recent the last pull |
+| `terrapod_replication_events_retained` | Gauge | — | Outbox events inside the retention window |
+| `terrapod_replication_oldest_event_age_seconds` | Gauge | — | Age of the oldest retained event. Approaching `ha.replication.retention_days` means the follower is close to having to backfill from scratch |
 | `terrapod_runs_created_total` | Counter | source, plan_only | Runs created |
 | `terrapod_runs_transitioned_total` | Counter | from_status, to_status | Run state transitions |
 | `terrapod_runs_terminal_total` | Counter | status | Runs reaching terminal state |

--- a/go-terrapod/ha.go
+++ b/go-terrapod/ha.go
@@ -1,0 +1,94 @@
+package terrapod
+
+import "context"
+
+// HAStatus is a node's own view of whether it is converging with its peer.
+//
+// Every field is answered from that node's local state — there is no call to
+// the peer — so it stays fast and still works when the peer is the thing that
+// has broken, which is when somebody is reading it.
+//
+// The two sides of a pair watch different fields:
+//
+//   - A follower watches SecondsSinceLastSync and BackfillingClasses. A node
+//     mid-backfill is NOT in sync, however recent its last cycle.
+//   - A leader watches OldestEventAgeSeconds against RetentionSeconds. As those
+//     converge its follower is close to falling off the end of the retained
+//     window and having to backfill from scratch.
+//
+// There is deliberately no "N events behind": that needs the peer's latest
+// event id, and seconds-since-last-successful-pull is the more honest number.
+// A completed pull that returned nothing means caught up as of then.
+type HAStatus struct {
+	NodeID             string `json:"node-id"`
+	Role               string `json:"role"`
+	PeerConfigured     bool   `json:"peer-configured"`
+	ReplicationEnabled bool   `json:"replication-enabled"`
+
+	// Follower side.
+	LastSyncAt           string   `json:"last-sync-at,omitempty"`
+	SecondsSinceLastSync int64    `json:"seconds-since-last-sync,omitempty"`
+	BackfillingClasses   []string `json:"backfilling-classes,omitempty"`
+	InSync               bool     `json:"in-sync"`
+
+	// Leader side — the follower's margin before it must backfill.
+	EventsRetained        int64    `json:"events-retained"`
+	OldestEventAgeSeconds int64    `json:"oldest-event-age-seconds,omitempty"`
+	RetentionSeconds      int64    `json:"retention-seconds"`
+	ReplicatedClasses     []string `json:"replicated-classes,omitempty"`
+}
+
+// HANode is a node's identity and the role it currently holds.
+type HANode struct {
+	NodeID string `json:"node-id"`
+	Role   string `json:"role"`
+}
+
+// GetHAStatus reports whether this node is converging with its peer.
+//
+// Requires admin or audit.
+func (c *Client) GetHAStatus(ctx context.Context) (*HAStatus, error) {
+	body, err := c.Get(ctx, "/api/terrapod/v1/ha/status")
+	if err != nil {
+		return nil, err
+	}
+	res, err := ParseResource(body)
+	if err != nil {
+		return nil, err
+	}
+	return &HAStatus{
+		NodeID:                GetStringAttr(res, "node-id"),
+		Role:                  GetStringAttr(res, "role"),
+		PeerConfigured:        GetBoolAttr(res, "peer-configured"),
+		ReplicationEnabled:    GetBoolAttr(res, "replication-enabled"),
+		LastSyncAt:            GetStringAttr(res, "last-sync-at"),
+		SecondsSinceLastSync:  GetIntAttr(res, "seconds-since-last-sync"),
+		BackfillingClasses:    GetListAttr(res, "backfilling-classes"),
+		InSync:                GetBoolAttr(res, "in-sync"),
+		EventsRetained:        GetIntAttr(res, "events-retained"),
+		OldestEventAgeSeconds: GetIntAttr(res, "oldest-event-age-seconds"),
+		RetentionSeconds:      GetIntAttr(res, "retention-seconds"),
+		ReplicatedClasses:     GetListAttr(res, "replicated-classes"),
+	}, nil
+}
+
+// WhoAmI reports this node's identity and role.
+//
+// This is the endpoint a node probes against the shared DNS name to work out
+// whether it owns that name: if the answer names itself, it is the leader. It
+// is unauthenticated on the server, because the probe runs before any trust
+// exists between the two nodes.
+func (c *Client) WhoAmI(ctx context.Context) (*HANode, error) {
+	body, err := c.Get(ctx, "/api/terrapod/v1/ha/whoami")
+	if err != nil {
+		return nil, err
+	}
+	res, err := ParseResource(body)
+	if err != nil {
+		return nil, err
+	}
+	return &HANode{
+		NodeID: GetStringAttr(res, "node-id"),
+		Role:   GetStringAttr(res, "role"),
+	}, nil
+}

--- a/go-terrapod/ha_test.go
+++ b/go-terrapod/ha_test.go
@@ -1,0 +1,121 @@
+package terrapod
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newHAFixture(t *testing.T, statusBody string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		switch r.URL.Path {
+		case "/api/terrapod/v1/ha/status":
+			_, _ = w.Write([]byte(statusBody))
+		case "/api/terrapod/v1/ha/whoami":
+			_, _ = w.Write([]byte(`{"data":{"id":"node-a","type":"ha-nodes",
+			  "attributes":{"node-id":"node-a","role":"leader"}}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+const followerCaughtUp = `{"data":{"id":"node-b","type":"ha-status","attributes":{
+  "node-id":"node-b","role":"follower","peer-configured":true,"replication-enabled":true,
+  "last-sync-at":"2026-07-29T10:00:00Z","seconds-since-last-sync":42,
+  "backfilling-classes":[],"in-sync":true,
+  "events-retained":17,"oldest-event-age-seconds":3600,"retention-seconds":604800,
+  "replicated-classes":["agent_pools","users"]}}}`
+
+const followerBackfilling = `{"data":{"id":"node-b","type":"ha-status","attributes":{
+  "node-id":"node-b","role":"follower","peer-configured":true,"replication-enabled":true,
+  "last-sync-at":"2026-07-29T10:00:00Z","seconds-since-last-sync":5,
+  "backfilling-classes":["api_tokens","users"],"in-sync":false,
+  "events-retained":0,"retention-seconds":604800}}}`
+
+func TestGetHAStatusCaughtUp(t *testing.T) {
+	c := newHAFixture(t, followerCaughtUp)
+
+	got, err := c.GetHAStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetHAStatus: %v", err)
+	}
+	if got.Role != "follower" || !got.InSync {
+		t.Fatalf("role=%q in-sync=%v", got.Role, got.InSync)
+	}
+	if got.SecondsSinceLastSync != 42 {
+		t.Fatalf("seconds-since-last-sync = %d", got.SecondsSinceLastSync)
+	}
+	if len(got.ReplicatedClasses) != 2 {
+		t.Fatalf("replicated-classes = %v", got.ReplicatedClasses)
+	}
+}
+
+// A node mid-backfill is NOT in sync however recent its last cycle — reading
+// only the timestamp would say it is, which is the wrong answer to give
+// somebody about to move DNS.
+func TestGetHAStatusBackfillingIsNotInSync(t *testing.T) {
+	c := newHAFixture(t, followerBackfilling)
+
+	got, err := c.GetHAStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetHAStatus: %v", err)
+	}
+	if got.InSync {
+		t.Fatal("a node with classes mid-backfill must not report in-sync")
+	}
+	if got.SecondsSinceLastSync != 5 {
+		t.Fatalf("last sync was recent but the node is still backfilling: %d", got.SecondsSinceLastSync)
+	}
+	if len(got.BackfillingClasses) != 2 {
+		t.Fatalf("backfilling-classes = %v", got.BackfillingClasses)
+	}
+}
+
+// The leader's early warning: as the oldest retained event approaches the
+// retention window, the follower is close to having to backfill from scratch.
+func TestGetHAStatusRetentionMargin(t *testing.T) {
+	c := newHAFixture(t, followerCaughtUp)
+
+	got, err := c.GetHAStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetHAStatus: %v", err)
+	}
+	if got.OldestEventAgeSeconds >= got.RetentionSeconds {
+		t.Fatalf("oldest=%d retention=%d", got.OldestEventAgeSeconds, got.RetentionSeconds)
+	}
+}
+
+func TestWhoAmI(t *testing.T) {
+	c := newHAFixture(t, followerCaughtUp)
+
+	got, err := c.WhoAmI(context.Background())
+	if err != nil {
+		t.Fatalf("WhoAmI: %v", err)
+	}
+	if got.NodeID != "node-a" || got.Role != "leader" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestGetHAStatusPropagatesErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors":[{"detail":"admin or audit required"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c, _ := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+
+	if _, err := c.GetHAStatus(context.Background()); err == nil {
+		t.Fatal("expected an error for a non-admin caller")
+	}
+}

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -351,6 +351,20 @@ field GPGKey.Namespace string `json:"namespace,omitempty"`
 field GPGKey.Source string `json:"source,omitempty"`
 field GPGKey.SourceURL string `json:"source-url,omitempty"`
 field GPGKey.UpdatedAt string `json:"updated-at,omitempty"`
+field HANode.NodeID string `json:"node-id"`
+field HANode.Role string `json:"role"`
+field HAStatus.BackfillingClasses []string `json:"backfilling-classes,omitempty"`
+field HAStatus.EventsRetained int64 `json:"events-retained"`
+field HAStatus.InSync bool `json:"in-sync"`
+field HAStatus.LastSyncAt string `json:"last-sync-at,omitempty"`
+field HAStatus.NodeID string `json:"node-id"`
+field HAStatus.OldestEventAgeSeconds int64 `json:"oldest-event-age-seconds,omitempty"`
+field HAStatus.PeerConfigured bool `json:"peer-configured"`
+field HAStatus.ReplicatedClasses []string `json:"replicated-classes,omitempty"`
+field HAStatus.ReplicationEnabled bool `json:"replication-enabled"`
+field HAStatus.RetentionSeconds int64 `json:"retention-seconds"`
+field HAStatus.Role string `json:"role"`
+field HAStatus.SecondsSinceLastSync int64 `json:"seconds-since-last-sync,omitempty"`
 field ImpactGraph.Edges []ImpactGraphEdge `json:"edges"`
 field ImpactGraph.Meta ImpactGraphMeta `json:"meta"`
 field ImpactGraph.Nodes []ImpactGraphNode `json:"nodes"`
@@ -1043,6 +1057,7 @@ method (*Client) GetEncryptionStatus(ctx context.Context) (*EncryptionStatus, er
 method (*Client) GetEstateGraph(ctx context.Context) (*EstateGraph, error)
 method (*Client) GetExecutionHook(ctx context.Context, id string) (*ExecutionHook, error)
 method (*Client) GetGPGKey(ctx context.Context, id string) (*GPGKey, error)
+method (*Client) GetHAStatus(ctx context.Context) (*HAStatus, error)
 method (*Client) GetModuleInterface(ctx context.Context, name, provider, version string) (*ModuleInterface, error)
 method (*Client) GetModuleWorkspaceLink(ctx context.Context, moduleName, moduleProvider, linkID string) (*ModuleWorkspaceLink, error)
 method (*Client) GetNotificationConfiguration(ctx context.Context, id string) (*NotificationConfiguration, error)
@@ -1169,6 +1184,7 @@ method (*Client) UploadProviderSignature(ctx context.Context, name, version stri
 method (*Client) UploadStateContent(ctx context.Context, stateVersionID string, raw []byte) error
 method (*Client) VersionCheck(ctx context.Context) error
 method (*Client) WarmCacheBulk(ctx context.Context, req BulkWarmRequest) (*BulkWarmResponse, error)
+method (*Client) WhoAmI(ctx context.Context) (*HANode, error)
 method (*ConflictError) Error() string
 method (*NotFoundError) Error() string
 method (*ValidationError) Error() string
@@ -1234,6 +1250,8 @@ type EstateGraphMeta struct
 type EstateNode struct
 type ExecutionHook struct
 type GPGKey struct
+type HANode struct
+type HAStatus struct
 type ImpactGraph struct
 type ImpactGraphEdge struct
 type ImpactGraphMeta struct

--- a/mcp/internal/mcpserver/observe.go
+++ b/mcp/internal/mcpserver/observe.go
@@ -201,6 +201,20 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 		return nil, e, nil
 	})
 
+	// ── terrapod_ha_status ───────────────────────────────────────────
+	type haStatusIn struct{}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "terrapod_ha_status",
+		Description: "Report whether this Terrapod node is converging with its HA peer — the question to answer BEFORE a failover. Answered from local state only, so it still works when the peer is the thing that has broken. On a FOLLOWER read `in-sync`, `seconds-since-last-sync` and `backfilling-classes`: a node mid-backfill is NOT in sync however recent its last sync, so treat a non-empty `backfilling-classes` as not-ready regardless of the timestamp. On a LEADER compare `oldest-event-age-seconds` against `retention-seconds`: as they converge the follower is close to falling off the retained event window and having to backfill from scratch. `peer-configured` false means this is an ordinary single node and none of the rest applies. There is deliberately no 'N events behind' — seconds since the last SUCCESSFUL pull is the honest number, because a pull that returned nothing means caught up as of then.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ haStatusIn) (*mcp.CallToolResult, *terrapod.HAStatus, error) {
+		st, err := c.GetHAStatus(ctx)
+		if err != nil {
+			return errResult(err), nil, nil
+		}
+		return nil, st, nil
+	})
+
 	// ── terrapod_workspace_architecture_critique ─────────────────────
 	type wsCritiqueIn struct {
 		WorkspaceID string `json:"workspace_id" jsonschema:"the workspace id (ws-...) whose current-state architecture critique to fetch"`

--- a/mcp/internal/mcpserver/tool_catalogue.json
+++ b/mcp/internal/mcpserver/tool_catalogue.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "terrapod_ha_status",
+    "read_only": true,
+    "input_schema": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  {
     "name": "terrapod_onboard_availability",
     "read_only": true,
     "input_schema": {

--- a/services/terrapod/api/metrics.py
+++ b/services/terrapod/api/metrics.py
@@ -369,3 +369,33 @@ async def metrics_middleware(request: Request, call_next):  # type: ignore[no-un
 async def metrics_endpoint(request: Request) -> Response:
     """Serve Prometheus metrics in exposition format."""
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+# ── Replication (#960 phase 3, #1121) ────────────────────────────────────
+#
+# The follower's own view of whether it is converging, and the leader's view of
+# how much margin its follower has. Both are answered from local state — a
+# metric that needs the peer stops working exactly when the peer is the
+# problem, which is when it is being read.
+
+REPLICATION_SECONDS_SINCE_SYNC = Gauge(
+    "terrapod_replication_seconds_since_last_sync",
+    "Seconds since the last successful pull from the peer (follower side)",
+)
+
+REPLICATION_BACKFILLING_CLASSES = Gauge(
+    "terrapod_replication_backfilling_classes",
+    "Entity classes currently mid-backfill. Non-zero means NOT in sync, "
+    "however recent the last cycle",
+)
+
+REPLICATION_EVENTS_RETAINED = Gauge(
+    "terrapod_replication_events_retained",
+    "Outbox events still inside the retention window",
+)
+
+REPLICATION_OLDEST_EVENT_AGE = Gauge(
+    "terrapod_replication_oldest_event_age_seconds",
+    "Age of the oldest retained outbox event. Approaching the retention window "
+    "means the follower is close to falling off the end and having to backfill",
+)

--- a/services/terrapod/api/routers/ha.py
+++ b/services/terrapod/api/routers/ha.py
@@ -15,9 +15,15 @@ It also serves the operator directly: "what does this node currently think it
 is" should be answerable without reading logs.
 """
 
-from fastapi import APIRouter, Response
+from datetime import UTC, datetime
 
-from terrapod.services import ha_role
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.api.dependencies import AuthenticatedUser, require_admin_or_audit
+from terrapod.config import settings
+from terrapod.db.session import get_db
+from terrapod.services import ha_role, replication
 
 router = APIRouter(prefix="/ha", tags=["ha"])
 
@@ -34,6 +40,78 @@ async def whoami(response: Response) -> dict:
             "attributes": {
                 "node-id": node,
                 "role": await ha_role.get_role(),
+            },
+        }
+    }
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z") if value else None
+
+
+@router.get("/status")
+async def status(
+    _user: AuthenticatedUser = Depends(require_admin_or_audit),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Whether this node is converging with its peer, and how much margin it has.
+
+    Answered entirely from local state — no call to the peer. That keeps the
+    endpoint fast, and keeps it working when the peer is the thing that has
+    broken, which is exactly when somebody is reading it.
+
+    The two sides of a pair need different numbers:
+
+    - a **follower** needs to know its last pull succeeded and that no class is
+      still mid-backfill (a node backfilling is not in sync, however recent its
+      last cycle);
+    - a **leader** needs to know how much margin its follower has — the oldest
+      retained event creeping toward the retention window means the follower is
+      close to falling off the end and having to backfill from scratch.
+
+    Deliberately no "N events behind": that needs the peer's latest event id,
+    and seconds-since-last-successful-pull is the more honest number anyway. A
+    completed pull that returned nothing means caught up *as of then*, which is
+    what a human is actually asking.
+    """
+    node = ha_role.node_id()
+    role = await ha_role.get_role()
+    cfg = settings.ha
+    state = await replication.read_status(db)
+
+    now = datetime.now(UTC)
+    since_sync = (
+        int((now - state.last_sync_at.astimezone(UTC)).total_seconds())
+        if state.last_sync_at
+        else None
+    )
+    oldest_age = (
+        int((now - state.oldest_event_at.astimezone(UTC)).total_seconds())
+        if state.oldest_event_at
+        else None
+    )
+
+    return {
+        "data": {
+            "type": "ha-status",
+            "id": node or "unnamed",
+            "attributes": {
+                "node-id": node,
+                "role": role,
+                "peer-configured": bool(cfg.peer.url),
+                "replication-enabled": cfg.replication.enabled,
+                # Follower side.
+                "last-sync-at": _iso(state.last_sync_at),
+                "seconds-since-last-sync": since_sync,
+                "backfilling-classes": state.backfilling,
+                "in-sync": cfg.replication.enabled
+                and not state.backfilling
+                and since_sync is not None,
+                # Leader side — the follower's margin before it must backfill.
+                "events-retained": state.events_retained,
+                "oldest-event-age-seconds": oldest_age,
+                "retention-seconds": cfg.replication.retention_days * 86400,
+                "replicated-classes": sorted(replication.registered()),
             },
         }
     }

--- a/services/terrapod/services/replication.py
+++ b/services/terrapod/services/replication.py
@@ -35,7 +35,7 @@ from decimal import Decimal
 from typing import Any
 
 import structlog
-from sqlalchemy import and_, delete, or_, select, tuple_
+from sqlalchemy import and_, delete, func, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
@@ -516,3 +516,44 @@ async def purge_old_events(db: AsyncSession, retention_days: int) -> int:
     if count:
         logger.info("Purged replication events", count=count, retention_days=retention_days)
     return count
+
+
+# --------------------------------------------------------------------------
+# Status
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class ReplicationStatus:
+    """What this node can say about replication without asking the peer.
+
+    Deliberately answerable locally: the status path stays fast, and it still
+    works when the peer is the thing that has broken — which is precisely when
+    an operator is looking at it.
+    """
+
+    #: Follower side: when the last pull completed, and whether any class is
+    #: still mid-backfill. A node backfilling is NOT in sync, however recent
+    #: its last cycle.
+    last_sync_at: datetime | None = None
+    backfilling: list[str] = field(default_factory=list)
+    #: Leader side: how much margin the follower has before its cursor falls
+    #: off the retained window and it has to backfill from scratch.
+    events_retained: int = 0
+    oldest_event_at: datetime | None = None
+
+
+async def read_status(db: AsyncSession) -> ReplicationStatus:
+    from terrapod.db.models import ReplicationCursor
+
+    cursors = (await db.execute(select(ReplicationCursor))).scalars().all()
+    stream = next((c for c in cursors if c.entity_class == EVENT_STREAM), None)
+
+    return ReplicationStatus(
+        last_sync_at=stream.updated_at if stream else None,
+        backfilling=sorted(
+            c.entity_class for c in cursors if c.backfilling and c.entity_class != EVENT_STREAM
+        ),
+        events_retained=await db.scalar(select(func.count()).select_from(ReplicationEvent)) or 0,
+        oldest_event_at=await db.scalar(select(func.min(ReplicationEvent.occurred_at))),
+    )

--- a/services/terrapod/services/replication_sync.py
+++ b/services/terrapod/services/replication_sync.py
@@ -293,11 +293,41 @@ async def sync_cycle() -> None:
 
 
 async def purge_cycle() -> None:
-    """Trim the outbox on the node that produces events."""
+    """Trim the outbox, and refresh the replication gauges.
+
+    The gauges ride this task rather than getting their own: both nodes of a
+    pair run it, the numbers are cheap, and an hourly refresh matches what they
+    describe — retention margin moves in days, and "seconds since last sync" is
+    computed from a timestamp rather than sampled.
+    """
     from terrapod.db.session import get_db_session
 
     async with get_db_session() as db:
         await replication.purge_old_events(db, settings.ha.replication.retention_days)
+        await _refresh_metrics(db)
+
+
+async def _refresh_metrics(db: AsyncSession) -> None:
+    from terrapod.api.metrics import (
+        REPLICATION_BACKFILLING_CLASSES,
+        REPLICATION_EVENTS_RETAINED,
+        REPLICATION_OLDEST_EVENT_AGE,
+        REPLICATION_SECONDS_SINCE_SYNC,
+    )
+
+    state = await replication.read_status(db)
+    now = datetime.now(UTC)
+
+    REPLICATION_BACKFILLING_CLASSES.set(len(state.backfilling))
+    REPLICATION_EVENTS_RETAINED.set(state.events_retained)
+    if state.last_sync_at:
+        REPLICATION_SECONDS_SINCE_SYNC.set(
+            (now - state.last_sync_at.astimezone(UTC)).total_seconds()
+        )
+    if state.oldest_event_at:
+        REPLICATION_OLDEST_EVENT_AGE.set(
+            (now - state.oldest_event_at.astimezone(UTC)).total_seconds()
+        )
 
 
 __all__ = [

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -186,6 +186,20 @@
     "source-url",
     "updated-at"
   ],
+  "ha.status": [
+    "backfilling-classes",
+    "events-retained",
+    "in-sync",
+    "last-sync-at",
+    "node-id",
+    "oldest-event-age-seconds",
+    "peer-configured",
+    "replicated-classes",
+    "replication-enabled",
+    "retention-seconds",
+    "role",
+    "seconds-since-last-sync"
+  ],
   "ha.whoami": [
     "node-id",
     "role"

--- a/services/tests/api/api_route_contract.json
+++ b/services/tests/api/api_route_contract.json
@@ -86,6 +86,7 @@
   "GET /api/terrapod/v1/ha/replication/classes",
   "GET /api/terrapod/v1/ha/replication/entities/{entity_class}/{entity_id}",
   "GET /api/terrapod/v1/ha/replication/events ?after,limit",
+  "GET /api/terrapod/v1/ha/status",
   "GET /api/terrapod/v1/ha/whoami",
   "GET /api/terrapod/v1/labels",
   "GET /api/terrapod/v1/labels/{key}",

--- a/services/tests/api/test_ha_status.py
+++ b/services/tests/api/test_ha_status.py
@@ -1,0 +1,153 @@
+"""The replication status endpoint (#1121).
+
+Before this, an operator could not answer "is my follower caught up?" — the one
+question worth asking before moving DNS. These pin the answers it gives, and as
+much the ones it refuses to give.
+
+Everything is computed from local state. A status endpoint that calls the peer
+stops working exactly when the peer is the problem, which is when it is read.
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from terrapod.api.dependencies import require_admin_or_audit
+from terrapod.api.routers.ha import router
+from terrapod.db.session import get_db
+from terrapod.services.replication import ReplicationStatus
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/terrapod/v1")
+    app.dependency_overrides[require_admin_or_audit] = lambda: SimpleNamespace(email="a@x.com")
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    return app
+
+
+def _ha(role="leader", peer_url="https://peer", enabled=True, retention_days=7):
+    return SimpleNamespace(
+        role=role,
+        node_name="node-a",
+        peer=SimpleNamespace(url=peer_url),
+        replication=SimpleNamespace(enabled=enabled, retention_days=retention_days),
+    )
+
+
+async def _get(state: ReplicationStatus, ha=None):
+    cfg = ha or _ha()
+    with (
+        patch("terrapod.services.replication.read_status", new_callable=AsyncMock) as mock_state,
+        patch("terrapod.api.routers.ha.settings") as mock_settings,
+        patch("terrapod.services.ha_role.get_role", new_callable=AsyncMock) as mock_role,
+    ):
+        mock_state.return_value = state
+        mock_settings.ha = cfg
+        mock_role.return_value = cfg.role
+        transport = ASGITransport(app=_app())
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.get("/api/terrapod/v1/ha/status")
+
+
+class TestFollowerConvergence:
+    async def test_a_recent_sync_with_no_backfill_is_in_sync(self):
+        resp = await _get(
+            ReplicationStatus(last_sync_at=datetime.now(UTC) - timedelta(seconds=30)),
+            ha=_ha(role="follower"),
+        )
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["in-sync"] is True
+        assert 25 <= attrs["seconds-since-last-sync"] <= 60
+
+    async def test_backfilling_is_not_in_sync_however_recent_the_pull(self):
+        """The failure this endpoint exists to prevent: reading only the
+        timestamp would tell somebody about to move DNS that a node still
+        pulling a whole class is ready."""
+        resp = await _get(
+            ReplicationStatus(last_sync_at=datetime.now(UTC), backfilling=["api_tokens", "users"]),
+            ha=_ha(role="follower"),
+        )
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["in-sync"] is False
+        assert attrs["seconds-since-last-sync"] < 5
+        assert attrs["backfilling-classes"] == ["api_tokens", "users"]
+
+    async def test_a_node_that_has_never_synced_is_not_in_sync(self):
+        resp = await _get(ReplicationStatus(), ha=_ha(role="follower"))
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["in-sync"] is False
+        assert attrs["last-sync-at"] is None
+        assert attrs["seconds-since-last-sync"] is None
+
+    async def test_replication_off_is_never_in_sync(self):
+        """A node not replicating cannot be caught up — saying so would be a
+        green light on a node receiving nothing."""
+        resp = await _get(ReplicationStatus(last_sync_at=datetime.now(UTC)), ha=_ha(enabled=False))
+
+        assert resp.json()["data"]["attributes"]["in-sync"] is False
+
+
+class TestLeaderMargin:
+    async def test_reports_the_retention_window_and_oldest_event(self):
+        """The leader's early warning: as these converge, the follower is close
+        to falling off the end and having to backfill from scratch."""
+        resp = await _get(
+            ReplicationStatus(
+                events_retained=1200, oldest_event_at=datetime.now(UTC) - timedelta(days=6)
+            )
+        )
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["events-retained"] == 1200
+        assert attrs["retention-seconds"] == 7 * 86400
+        assert attrs["oldest-event-age-seconds"] > 5 * 86400
+
+    async def test_an_empty_outbox_reports_no_age(self):
+        resp = await _get(ReplicationStatus())
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["events-retained"] == 0
+        assert attrs["oldest-event-age-seconds"] is None
+
+
+class TestSingleNode:
+    async def test_reports_that_there_is_no_peer(self):
+        """A single node must be legible as such, not as a pair failing to
+        converge."""
+        resp = await _get(ReplicationStatus(), ha=_ha(peer_url="", enabled=False))
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["peer-configured"] is False
+        assert attrs["replication-enabled"] is False
+
+
+class TestScope:
+    async def test_lists_the_replicated_classes(self):
+        """So an operator can see what a failover would and would not carry."""
+        classes = (await _get(ReplicationStatus())).json()["data"]["attributes"][
+            "replicated-classes"
+        ]
+
+        assert "api_tokens" in classes
+        assert "agent_pools" in classes
+
+
+class TestNoPeerCall:
+    def test_status_is_answered_without_reaching_the_peer(self):
+        """A status endpoint that calls the peer stops working exactly when the
+        peer is the problem. Asserted structurally — the regression would be
+        silent until an incident."""
+        import inspect
+
+        from terrapod.api.routers import ha
+
+        source = inspect.getsource(ha)
+        assert "httpx" not in source
+        assert "arequest_with_retry" not in source


### PR DESCRIPTION
Replication worked and was **completely invisible** — no status endpoint, no metric, nothing in go-terrapod or MCP. The only routes were `whoami` and the peer-only reads.

So an operator could not answer *"is my follower caught up?"*, which is the one question worth asking before moving DNS. Replicating more classes is worth less than being able to see the ones already replicating.

## `GET /api/terrapod/v1/ha/status`

Admin or audit. Answered **entirely from local state** — a status endpoint that calls the peer stops working exactly when the peer is the thing that has broken, which is when somebody reads it. Asserted structurally, because that regression would be silent until an incident.

The two sides of a pair need different numbers:

**Follower — am I converging?** `in-sync` is the summary, and it is false unless a pull has succeeded **and** no class is mid-backfill.

> A node backfilling is not in sync however recent its last cycle. Reading only the timestamp would give a green light to a node still pulling a whole class — that is the specific failure this endpoint exists to prevent, and it has its own test.

**Leader — how much margin does my follower have?** `oldest-event-age-seconds` against `retention-seconds`. As those converge the follower is close to falling off the retained event window and having to backfill from scratch. That early warning did not exist before, costs nothing to watch, and precedes the problem by days.

Deliberately **no "N events behind"**: that needs the peer's latest event id, and seconds-since-the-last-successful-pull is the more honest number anyway — a pull that returned nothing means caught up *as of then*, which is what a human is actually asking.

## Metrics

Four gauges, riding the existing purge cycle rather than getting their own task — both nodes of a pair run it, the numbers are cheap, and an hourly refresh matches what they describe (retention margin moves in days; seconds-since-sync is computed from a timestamp, not sampled).

## Consumers

`GetHAStatus` / `WhoAmI` in go-terrapod, and an MCP `terrapod_ha_status` tool whose description tells an agent the trap explicitly: treat a non-empty `backfilling-classes` as not-ready **regardless of the timestamp**.

Surface and catalogue goldens regenerate additively; route and attribute snapshots likewise — **zero removal lines**.

## Not here on purpose

**The web surface**, so it can get a live look at terrapod.local rather than being merged on a passing build.

**In-cluster component replicas** — filed as #1122. A pair that replicates perfectly is still not HA if it serves from one API pod, and I was wrong earlier to call web replicas unknowable: that was a statement about RBAC we write ourselves, not about the world. The API SA currently has no Role at all while the listener already has one; #1122 fixes that properly.

## Verification

- `make test` — **3563 passed**
- `make lint` — green
- `go build`/`go test` in go-terrapod and mcp

Closes #1121
Part of #960