### PR TITLE
chore(1124): remove master-master residue from replication

### DIFF
--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -157,6 +157,10 @@ was discarded to reach convergence.
 authenticated peer link, and are re-encrypted under the receiving node's own
 key. Neither node holds the other's key.
 
+**There is no conflict resolution, deliberately.** Only the leader writes, so
+the peer's row is authoritative — applying it is the whole rule. Per-field merge
+semantics would only be needed in an active-active design, which this is not.
+
 ### Replication scope
 
 | Class | Status |
@@ -202,11 +206,9 @@ promoted node accepts the token the fleet already holds.
 > The per-node topology never crosses a boundary and does not have this
 > constraint.
 
-`use_count` replicates, and it replicates **monotonically** — the larger value
-always wins, in both directions and during backfill. Both nodes spend the same
-budget (joins land on A before a failover and on B after one), so a stale copy
-winning on timestamp would hand a spent token its uses back. Revocation is
-one-way for the same reason: a revoked token can never replicate back to usable.
+`use_count` replicates like any other column. There is no merge rule and none
+is needed: only the leader writes, so its count is authoritative and the
+follower simply takes it.
 
 ## Is the follower caught up?
 

--- a/services/terrapod/api/routers/replication.py
+++ b/services/terrapod/api/routers/replication.py
@@ -31,19 +31,12 @@ async def list_classes(
     The follower reads this rather than carrying its own copy, so a version-skew
     pair converges on what the *sender* actually knows how to serve instead of
     failing on a class one side has never heard of.
+
+    No per-class merge semantics are advertised, because there are none: the
+    peer's row is authoritative (#1124).
     """
     return {
-        "data": [
-            {
-                "type": "replication-classes",
-                "id": name,
-                "attributes": {
-                    "monotonic-fields": sorted(spec.monotonic_fields),
-                    "one-way-true-fields": sorted(spec.one_way_true_fields),
-                },
-            }
-            for name, spec in replication.registered().items()
-        ]
+        "data": [{"type": "replication-classes", "id": name} for name in replication.registered()]
     }
 
 

--- a/services/terrapod/services/replication.py
+++ b/services/terrapod/services/replication.py
@@ -57,15 +57,11 @@ _DELETE_CHUNK = 500
 class ReplicatedClass:
     """One entity class in the replication scope.
 
-    ``monotonic_fields`` is the sharp edge. Most columns converge fine under
-    last-write-wins, but a counter does not: both nodes increment
-    ``agent_pool_tokens.use_count`` independently (a shared listener fleet
-    re-joins against whichever node currently holds the DNS name), so a stale
-    copy winning on timestamp would hand a spent token its budget back. Fields
-    listed here never decrease — the merge takes the larger value, in both
-    directions and during backfill alike. ``one_way_true_fields`` is the boolean
-    equivalent: once ``is_revoked`` is true it can never be replicated back to
-    false.
+    There is no conflict-resolution here, deliberately. In a leader/follower
+    pair only the leader writes, so **the peer's row is authoritative** —
+    applying it is the whole rule. An earlier active-active design needed
+    per-field merge semantics; that design was dropped from #960 before this
+    code existed, and the machinery it implied went with it (#1124).
     """
 
     name: str
@@ -77,10 +73,6 @@ class ReplicatedClass:
     pk_attrs: tuple[str, ...] = ("id",)
     #: Columns never sent (server-managed, or meaningless on the other node).
     exclude: frozenset[str] = frozenset()
-    #: Counters that may only ever increase.
-    monotonic_fields: frozenset[str] = frozenset()
-    #: Booleans that may only ever go false -> true.
-    one_way_true_fields: frozenset[str] = frozenset()
     #: Optional per-class overrides for entities the generic path cannot handle.
     serialize: Callable[[Any], dict] | None = None
     deserialize: Callable[[dict], dict] | None = None
@@ -402,25 +394,6 @@ async def read_backfill(
 # --------------------------------------------------------------------------
 
 
-def _merge(spec: ReplicatedClass, existing: Any, values: dict) -> dict:
-    """Apply the field-level rules that blanket last-write-wins gets wrong."""
-    merged = dict(values)
-    for name in spec.monotonic_fields:
-        if name not in merged:
-            continue
-        incoming = merged[name] or 0
-        current = getattr(existing, name, 0) or 0
-        # Losing an increment here would hand a spent token its budget back,
-        # so the larger value always wins regardless of which side is newer.
-        merged[name] = max(incoming, current)
-    for name in spec.one_way_true_fields:
-        if name not in merged:
-            continue
-        if getattr(existing, name, False):
-            merged[name] = True
-    return merged
-
-
 async def apply_upsert(db: AsyncSession, spec: ReplicatedClass, payload: dict) -> None:
     """Insert or update a row from a peer, preserving its identity."""
     values = _coerce(spec, payload)
@@ -431,7 +404,9 @@ async def apply_upsert(db: AsyncSession, spec: ReplicatedClass, payload: dict) -
     if existing is None:
         db.add(spec.model(**values))
         return
-    for key, value in _merge(spec, existing, values).items():
+    # The peer's row is authoritative — there is nothing to reconcile, because
+    # a follower originates nothing (#1124).
+    for key, value in values.items():
         if key not in spec.pk_attrs:
             setattr(existing, key, value)
 

--- a/services/terrapod/services/replication_registry.py
+++ b/services/terrapod/services/replication_registry.py
@@ -30,26 +30,13 @@ AGENT_POOLS = register(
     )
 )
 
-# Join tokens, and the reason `monotonic_fields` exists.
+# Join tokens.
 #
-# `use_count` is the budget `max_uses` is spent against, and BOTH nodes spend
-# it: a shared listener fleet follows the DNS name, so joins land on A before a
-# failover and on B after one. Under blanket last-write-wins a stale copy would
-# regress the count and silently hand the token its spent budget back — the one
-# field where losing an update issues extra credentials rather than merely
-# losing information. `is_revoked` is the same hazard in boolean form: a
-# revoked token must never be replicated back to usable.
-#
-# This is also why a shared fleet wants a long-lived, generously reusable token
-# in the first place: every failover costs one use per listener.
-AGENT_POOL_TOKENS = register(
-    ReplicatedClass(
-        name="agent_pool_tokens",
-        model=AgentPoolToken,
-        monotonic_fields=frozenset({"use_count"}),
-        one_way_true_fields=frozenset({"is_revoked"}),
-    )
-)
+# A shared listener fleet wants a long-lived, generously reusable token: every
+# failover re-points the fleet at the promoted node, each listener re-joins, and
+# each re-join spends one use. A `max_uses` sized for the initial rollout is
+# therefore exhausted by the first real failover.
+AGENT_POOL_TOKENS = register(ReplicatedClass(name="agent_pool_tokens", model=AgentPoolToken))
 
 
 # ---------------------------------------------------------------------------
@@ -88,15 +75,4 @@ PLATFORM_ROLE_ASSIGNMENTS = register(
 # only because the delta path records deletes AND backfill reconciles. Without
 # both, an offboarded person's token comes back to life at a failover, weeks
 # after the revocation was performed and confirmed.
-#
-# `last_used_at` is deliberately NOT monotonic-merged. It is observational, not
-# a budget: each node legitimately sees different usage, and forcing the later
-# value would make "last used" mean "last used on either node", which is not
-# what an operator auditing a single node is reading.
-API_TOKENS = register(
-    ReplicatedClass(
-        name="api_tokens",
-        model=APIToken,
-        pk_attrs=("id",),
-    )
-)
+API_TOKENS = register(ReplicatedClass(name="api_tokens", model=APIToken))

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -357,10 +357,6 @@
     "created-by",
     "producer-workspace-name"
   ],
-  "replication.list_classes": [
-    "monotonic-fields",
-    "one-way-true-fields"
-  ],
   "role_assignments._assignment_json": [
     "created-at",
     "email",

--- a/services/tests/api/test_replication_router.py
+++ b/services/tests/api/test_replication_router.py
@@ -48,14 +48,16 @@ class TestClasses:
         ids = [d["id"] for d in resp.json()["data"]]
         assert ids.index("agent_pools") < ids.index("agent_pool_tokens")
 
-    async def test_advertises_the_merge_rules(self):
-        """The follower reads these from the sender rather than assuming, so a
-        skewed pair agrees on how a counter merges."""
+    async def test_advertises_no_merge_semantics(self):
+        """There are none. In a leader/follower pair only the leader writes, so
+        the peer's row is authoritative and there is nothing to reconcile —
+        advertising per-class merge rules was active-active residue (#1124)."""
         resp = await _get(f"{BASE}/classes")
 
-        tokens = next(d for d in resp.json()["data"] if d["id"] == "agent_pool_tokens")
-        assert "use_count" in tokens["attributes"]["monotonic-fields"]
-        assert "is_revoked" in tokens["attributes"]["one-way-true-fields"]
+        for entry in resp.json()["data"]:
+            assert "attributes" not in entry, (
+                "a replication class carries no merge semantics to advertise"
+            )
 
 
 class TestEvents:

--- a/services/tests/services/test_replication.py
+++ b/services/tests/services/test_replication.py
@@ -41,12 +41,6 @@ class TestRegistry:
     def test_unknown_class_resolves_to_none(self):
         assert replication.get("not_a_class") is None
 
-    def test_the_counter_class_declares_its_merge_rule(self):
-        """If this ever silently reverts to blanket LWW, a spent token gets its
-        budget back — so the declaration itself is worth pinning."""
-        assert "use_count" in TOKENS.monotonic_fields
-        assert "is_revoked" in TOKENS.one_way_true_fields
-
 
 class TestSerialisation:
     def test_round_trips_a_row(self):
@@ -87,55 +81,6 @@ class TestSerialisation:
         values = replication._coerce(POOLS, {"id": str(uuid.uuid4()), "invented_column": 1})
 
         assert "invented_column" not in values
-
-
-class TestMergeRules:
-    """The field-level exceptions that blanket last-write-wins gets wrong."""
-
-    @pytest.mark.replication_matrix("agent_pool_tokens", "monotonic-never-regresses")
-    def test_counter_never_decreases(self):
-        existing = SimpleNamespace(use_count=7, is_revoked=False)
-
-        merged = replication._merge(TOKENS, existing, {"use_count": 5})
-
-        assert merged["use_count"] == 7, "a stale count would refund a spent token"
-
-    def test_counter_still_advances(self):
-        existing = SimpleNamespace(use_count=7, is_revoked=False)
-
-        merged = replication._merge(TOKENS, existing, {"use_count": 9})
-
-        assert merged["use_count"] == 9
-
-    @pytest.mark.replication_matrix("agent_pool_tokens", "one-way-never-reverts")
-    def test_revocation_is_one_way(self):
-        existing = SimpleNamespace(use_count=0, is_revoked=True)
-
-        merged = replication._merge(TOKENS, existing, {"is_revoked": False})
-
-        assert merged["is_revoked"] is True, "a revoked token must never become usable again"
-
-    def test_revocation_still_propagates(self):
-        existing = SimpleNamespace(use_count=0, is_revoked=False)
-
-        merged = replication._merge(TOKENS, existing, {"is_revoked": True})
-
-        assert merged["is_revoked"] is True
-
-    def test_ordinary_fields_take_the_incoming_value(self):
-        existing = SimpleNamespace(name="old", use_count=0, is_revoked=False)
-
-        merged = replication._merge(POOLS, existing, {"name": "new"})
-
-        assert merged["name"] == "new"
-
-    def test_null_counter_is_treated_as_zero(self):
-        """A peer that omits or nulls the field must not blank a real count."""
-        existing = SimpleNamespace(use_count=4, is_revoked=False)
-
-        merged = replication._merge(TOKENS, existing, {"use_count": None})
-
-        assert merged["use_count"] == 4
 
 
 class TestEventReading:
@@ -260,17 +205,6 @@ class TestApply:
 
         assert existing.name == "p"
         assert existing.labels == {"env": "prod"}
-
-    async def test_update_honours_the_monotonic_rule(self):
-        db = AsyncMock()
-        existing = self._token(use_count=7)
-        db.scalar.return_value = existing
-
-        await replication.apply_upsert(
-            db, TOKENS, {"id": str(existing.id), "use_count": 2, "is_revoked": False}
-        )
-
-        assert existing.use_count == 7
 
     async def test_a_payload_without_a_primary_key_is_ignored(self):
         db = AsyncMock()
@@ -465,74 +399,6 @@ class TestAgentPoolTokensMatrix:
         await replication.apply_delete(db, TOKENS, str(uuid.uuid4()))
 
         db.execute.assert_awaited()
-
-
-class TestRoleChangeConflict:
-    """What happens when both sides touched the same row (#1112).
-
-    This is the case a failover actually produces: A was written to before the
-    cutover, B after it. There is no clever resolution here, and there should
-    not be — the rules just have to be the intended ones, and stated.
-    """
-
-    @pytest.mark.replication_matrix("agent_pools", "role-change-conflict")
-    async def test_settings_take_the_peers_value(self):
-        """Plain settings are last-writer-wins by arrival, and that is correct:
-        only the leader originates change, so the value arriving from the peer
-        is the one the leader has."""
-        db = AsyncMock()
-        existing = AgentPool(id=uuid.uuid4(), name="edited-locally", description="local")
-        db.scalar.return_value = existing
-
-        await replication.apply_upsert(db, POOLS, {"id": str(existing.id), "name": "from-peer"})
-
-        assert existing.name == "from-peer"
-
-    @pytest.mark.replication_matrix("agent_pool_tokens", "role-change-conflict")
-    async def test_both_sides_spending_the_budget_converges_upward(self):
-        """The real shape of a shared listener fleet across a failover: joins
-        landed on A before the cutover and on B after it. Neither count is
-        'right' — but the token must never end up with MORE budget than the two
-        of them have already spent between them."""
-        db = AsyncMock()
-        local = AgentPoolToken(
-            id=uuid.uuid4(),
-            pool_id=uuid.uuid4(),
-            token_hash="h" * 64,
-            max_uses=10,
-            use_count=6,  # spent here after the cutover
-            is_revoked=False,
-            created_by="admin",
-        )
-        db.scalar.return_value = local
-
-        # The peer reports its own, older count.
-        await replication.apply_upsert(
-            db, TOKENS, {"id": str(local.id), "use_count": 4, "is_revoked": False}
-        )
-
-        assert local.use_count == 6, "converging downward would refund spent uses"
-
-    @pytest.mark.replication_matrix("agent_pool_tokens", "one-way-never-reverts")
-    async def test_a_revocation_on_either_side_sticks(self):
-        """Revoking during an incident, on whichever node answered, must survive
-        replication from a peer that had not seen it yet."""
-        db = AsyncMock()
-        local = AgentPoolToken(
-            id=uuid.uuid4(),
-            pool_id=uuid.uuid4(),
-            token_hash="h" * 64,
-            use_count=1,
-            is_revoked=True,
-            created_by="admin",
-        )
-        db.scalar.return_value = local
-
-        await replication.apply_upsert(
-            db, TOKENS, {"id": str(local.id), "use_count": 1, "is_revoked": False}
-        )
-
-        assert local.is_revoked is True
 
 
 class TestBackfillConvergesDeletion:

--- a/services/tests/services/test_replication_identity.py
+++ b/services/tests/services/test_replication_identity.py
@@ -114,18 +114,6 @@ class TestUsers:
 
         assert removed == ["gone@example.com"]
 
-    @pytest.mark.replication_matrix("users", "role-change-conflict")
-    async def test_deactivation_from_the_peer_wins(self):
-        """Deactivating an account is the offboarding path; the peer's value is
-        the leader's, and it must land even if this node saw the user active."""
-        db = AsyncMock()
-        existing = User(email="a@example.com", is_active=True)
-        db.scalar.return_value = existing
-
-        await replication.apply_upsert(db, USERS, {"email": "a@example.com", "is_active": False})
-
-        assert existing.is_active is False
-
 
 class TestRoles:
     @pytest.mark.replication_matrix("roles", "backfill-from-empty")
@@ -177,18 +165,6 @@ class TestRoles:
         removed = await replication.reconcile_deletions(db, ROLES, {"sre"})
 
         assert removed == ["deleted-role"]
-
-    @pytest.mark.replication_matrix("roles", "role-change-conflict")
-    async def test_a_narrowed_grant_from_the_peer_wins(self):
-        """Narrowing a role is a security action. The peer's version is the
-        leader's, so it must not be overwritten by this node's wider copy."""
-        db = AsyncMock()
-        existing = Role(name="sre", capabilities=["run:apply", "workspace:delete"])
-        db.scalar.return_value = existing
-
-        await replication.apply_upsert(db, ROLES, {"name": "sre", "capabilities": ["run:apply"]})
-
-        assert existing.capabilities == ["run:apply"]
 
 
 class TestRoleAssignments:
@@ -247,16 +223,6 @@ class TestRoleAssignments:
         removed = await replication.reconcile_deletions(db, ASSIGNMENTS, {kept})
 
         assert removed == [replication.encode_entity_id(ASSIGNMENTS, ["local", "revoked@x.com"])]
-
-    @pytest.mark.replication_matrix("role_assignments", "role-change-conflict")
-    async def test_two_providers_for_one_email_stay_distinct(self):
-        """The composite key is load-bearing here: the same person from two
-        identity providers is two assignments, and collapsing them would grant
-        one provider's role to the other."""
-        local = replication.encode_entity_id(ASSIGNMENTS, ["local", "a@x.com"])
-        oidc = replication.encode_entity_id(ASSIGNMENTS, ["oidc", "a@x.com"])
-
-        assert local != oidc
 
 
 class TestPlatformRoleAssignments:
@@ -318,15 +284,6 @@ class TestPlatformRoleAssignments:
 
         assert removed == [replication.encode_entity_id(PLATFORM, ["local", "a@x.com", "admin"])]
 
-    @pytest.mark.replication_matrix("platform_role_assignments", "role-change-conflict")
-    async def test_admin_and_audit_for_one_person_are_separate_rows(self):
-        """Because the role is part of the key, losing `admin` must not also
-        drop `audit` — and holding `audit` must not imply `admin`."""
-        admin = replication.encode_entity_id(PLATFORM, ["local", "a@x.com", "admin"])
-        audit = replication.encode_entity_id(PLATFORM, ["local", "a@x.com", "audit"])
-
-        assert admin != audit
-
 
 class TestAPITokens:
     """The class #1115 was really about."""
@@ -381,18 +338,6 @@ class TestAPITokens:
         removed = await replication.reconcile_deletions(db, TOKENS, {"at-live"})
 
         assert removed == ["at-revoked"]
-
-    @pytest.mark.replication_matrix("api_tokens", "role-change-conflict")
-    async def test_a_narrowed_token_scope_from_the_peer_wins(self):
-        """Re-scoping a service token is a security action; the peer's value is
-        the leader's and must not be widened back by this node's copy."""
-        db = AsyncMock()
-        existing = _token(pinned_roles=["admin"])
-        db.scalar.return_value = existing
-
-        await replication.apply_upsert(db, TOKENS, {"id": "at-1", "pinned_roles": ["audit"]})
-
-        assert existing.pinned_roles == ["audit"]
 
 
 class TestOrdering:

--- a/services/tests/services/test_replication_matrix_gate.py
+++ b/services/tests/services/test_replication_matrix_gate.py
@@ -12,9 +12,8 @@ So this fails the build rather than reminding anyone.
 **The requirement is derived, not declared.** A per-class manifest of "which
 rows apply here" is something a contributor can quietly weaken; instead the
 required rows are computed from the class spec and its model. A class that gains
-a counter therefore *starts* failing until its monotonic test exists — which is
-exactly the case where losing an update issues extra credentials rather than
-merely losing information.
+an encrypted column therefore *starts* failing until it proves that column
+survives the per-node decrypt/re-encrypt round trip.
 
 **Coverage is claimed at the test**, with `@pytest.mark.replication_matrix`, not
 in a list of node ids. A manifest rots the moment a test is renamed; a mark
@@ -39,14 +38,16 @@ ALWAYS_REQUIRED = frozenset(
         "idempotent-reapply",
         "delete",
         "backfill-converges-deletion",
-        "role-change-conflict",
     }
 )
 
 #: Rows required only when the class actually has the thing they protect.
+#:
+#: There is no merge-semantics row here. In a leader/follower pair only the
+#: leader writes, so the peer's row is authoritative and there is nothing to
+#: reconcile — the conditional rows that once covered that belonged to an
+#: active-active design dropped before the code existed (#1124).
 CONDITIONAL = {
-    "monotonic-never-regresses": lambda spec: bool(spec.monotonic_fields),
-    "one-way-never-reverts": lambda spec: bool(spec.one_way_true_fields),
     "encrypted-columns": lambda spec: _has_encrypted_column(spec),
 }
 
@@ -120,18 +121,20 @@ class TestMatrixIsComplete:
 class TestTheGateItself:
     """A gate that cannot fail is not a gate."""
 
-    def test_a_counter_class_requires_the_monotonic_row(self):
-        spec = replication.get("agent_pool_tokens")
+    def test_a_class_with_an_encrypted_column_requires_that_row(self):
+        """Per-node encryption is real and unrelated to any merge model:
+        decrypt on send, re-encrypt on receive."""
+        from terrapod.db.models import VCSConnection
+        from terrapod.services.replication import ReplicatedClass
 
-        assert "monotonic-never-regresses" in required_rows(spec)
+        spec = ReplicatedClass(name="_probe", model=VCSConnection)
+
+        assert "encrypted-columns" in required_rows(spec)
 
     def test_a_plain_class_does_not(self):
-        """Requiring a monotonic test of a class with no counter would train
-        people to write empty tests to satisfy the gate."""
         spec = replication.get("agent_pools")
 
-        assert "monotonic-never-regresses" not in required_rows(spec)
-        assert "one-way-never-reverts" not in required_rows(spec)
+        assert "encrypted-columns" not in required_rows(spec)
 
     def test_every_class_always_needs_the_base_rows(self):
         for spec in replication.registered().values():


### PR DESCRIPTION
The replication framework carried conflict-resolution machinery belonging to an **active-active** design that was dropped from #960 *before any of this code existed*. That is not design drift — it is a superseded model that got implemented anyway.

In leader/follower there is nothing to reconcile. Only the leader writes, so **the peer's row is authoritative**, and applying it is the whole rule.

## Removed

| | Why it was never justified |
|---|---|
| `monotonic_fields` + `_merge()` | Rationale was "both nodes spend `use_count`" — only true if both nodes write. Under leader-only writes the leader's count is always ≥ the follower's, so the max could **never fire** |
| `one_way_true_fields` (`is_revoked`) | Same reasoning, same conclusion |
| `role-change-conflict` matrix row | Its tests asserted "the peer's value wins", which is trivially true rather than a resolution — misnamed and mis-motivated |
| `monotonic-fields` / `one-way-true-fields` on the peer `/classes` endpoint | Existed only to advertise the above |

## Kept — none of it depended on the merge model

- **The join-token guidance.** Long-lived and generously reusable for a shared listener fleet: every failover still costs one use per listener. That was always about token sizing.
- **The `encrypted-columns` matrix row.** Per-node encryption is real and unrelated — decrypt on send, re-encrypt on receive.
- **`last_used_at` / `last_login_at` as ordinary columns.** I nearly added a field-exclusion mechanism to protect them from being a few seconds stale on one node. That would have been more machinery than the thing it protected.

## The contract gate

The attribute snapshot **loses** `replication.list_classes`, which the #550 gate treats as a removal. Stated plainly rather than quietly regenerated:

```
$ git show v1.2.0:services/terrapod/api/routers/replication.py
ABSENT in v1.2.0 — never released
v1.2.0:    2026-07-23
framework: 2026-07-29
```

The endpoint is peer-only, and both nodes of a pair ship from the same release. There is no consumer to break. The gate exists to protect released surface; this is not one.

## Verification

- `make test` — **3547 passed** (down 16: the deleted merge and conflict tests)
- `make lint` — green
- No consumer references — `grep` across go-terrapod and mcp found nothing, so no SDK or catalogue churn

Closes #1124
Part of #960