### PR TITLE
docs(1124): drop the removed matrix rows from the written contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,8 +240,7 @@ Routing rules of thumb:
   a class is one line and the outbox picks it up automatically, so it is easy to
   ship one that never converges — and the symptom appears at a failover, not in
   CI. The required rows are **derived** from the class spec and its model (a
-  class declaring `monotonic_fields`, `one_way_true_fields`, or holding an
-  encrypted column gains the matching row automatically), and
+  class holding an encrypted column gains the matching row automatically), and
   `tests/services/test_replication_matrix_gate.py` fails the build until they
   exist. Backfill ships **with** each class, never behind it: adding a second
   node to a running install has no deltas at all, so a class that only handles

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -176,7 +176,7 @@ where a missed deletion is a revoked credential that starts working again.
 Runs and state versions are a separate phase.
 
 Each class carries a full test matrix — backfill from empty, delta apply,
-idempotent re-apply, delete, role-change conflict, plus a monotonic-merge or
+idempotent re-apply, delete, deletion converging through a backfill, plus an
 encrypted-column row where the class has one. The required rows are derived from
 the class definition rather than declared, and CI fails until they exist. A class
 that is registered but not tested does not converge, and the symptom appears at a


### PR DESCRIPTION
Follow-up sweep after #1125.

Two prose references still described `role-change-conflict`, `monotonic_fields` and `one_way_true_fields` as required test-matrix rows — the active-active machinery that PR removed. `AGENTS.md` states the contributor contract and `docs/high-availability.md` states it for operators, so both were describing a model the code no longer has.

The derived rows are now the five that always apply plus `encrypted-columns`.

A sweep for the removed terms across `services/`, `go-terrapod/`, `mcp/` and the docs turns up nothing else — the remaining hits are `time.monotonic()` and GitLab commit-status semantics, both unrelated.

Part of #960