### PR TITLE
fix(1140): encrypt the run-task HMAC key and the GPG private key at rest

### DIFF
--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -865,7 +865,13 @@ class GPGKey(Base):
     ascii_armor: Mapped[str] = mapped_column(Text, nullable=False)
     source: Mapped[str] = mapped_column(String(63), nullable=False, default="terrapod")
     source_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
-    private_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # The GPG **private** key, when Terrapod holds one for server-side signing.
+    # The most sensitive column in this table by a wide margin: it is what proves
+    # a published provider came from this registry. EncryptedText over the
+    # existing TEXT column (#1140) — no migration, and the `IS NOT NULL`
+    # predicates that select signing-capable keys still work, because NULL is
+    # preserved rather than encrypted.
+    private_key: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=now_utc, nullable=False
@@ -1963,7 +1969,12 @@ class RunTask(Base):
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     url: Mapped[str] = mapped_column(String(2000), nullable=False)
-    hmac_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # The shared secret Terrapod signs task webhooks with. Anyone holding it can
+    # forge a task result, and a task result gates the apply when the task is
+    # mandatory — so it is exactly as sensitive as the notification token beside
+    # it (#1140). EncryptedText over the existing TEXT column: no migration, and
+    # reads pass legacy plaintext through unchanged.
+    hmac_key: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     stage: Mapped[str] = mapped_column(String(20), nullable=False)  # pre_plan, post_plan, pre_apply
     enforcement_level: Mapped[str] = mapped_column(

--- a/services/tests/db/test_credential_columns_encrypted.py
+++ b/services/tests/db/test_credential_columns_encrypted.py
@@ -1,0 +1,147 @@
+"""Credential columns are encrypted at rest, and the sweep that found the gaps (#1140).
+
+Two columns holding shared secrets sat side by side with opposite treatment:
+`notification_configurations.token` was `EncryptedText`, `run_tasks.hmac_key` was
+plain `Text`. A third — `gpg_keys.private_key`, a GPG **private** key — was also
+plain, and is the most sensitive of the lot: it is what proves a published
+provider came from this registry.
+
+Rather than assert the three fixes one by one, this pins the **rule**: every
+column whose name says it holds a credential is `EncryptedText`. A new one added
+later has to either satisfy the rule or be listed as a considered exception, so
+the next gap fails the build instead of waiting to be noticed.
+"""
+
+from sqlalchemy import inspect as sa_inspect
+
+from terrapod.crypto.types import EncryptedText
+from terrapod.db import models
+
+#: Column names that name a credential. Substring match, deliberately broad —
+#: a false positive costs one line in the exception list below; a false negative
+#: is a secret stored in the clear.
+CREDENTIAL_HINTS = (
+    "hmac_key",
+    "private_key",
+    "client_secret",
+    "webhook_secret",
+    "password",
+    "api_key",
+    "signing_key",
+    "bot_token",
+)
+
+#: Considered exceptions, each with the reason it is not `EncryptedText`.
+#:
+#: `crypto_keys.wrapped_dek` cannot be: it is the key the encryption layer
+#: unwraps at boot, so encrypting it under itself is circular. It is already
+#: KEK-wrapped ciphertext, which is the point.
+#:
+#: `task_stage_results.callback_token` is `String(255)`, so an encryption
+#: envelope could overflow the column — adopting it needs a widen to TEXT first.
+#: It is also short-lived and single-use. Tracked rather than silently skipped.
+EXPECTED_PLAINTEXT = {
+    ("crypto_keys", "wrapped_dek"),
+    ("task_stage_results", "callback_token"),
+}
+
+
+def _credential_columns():
+    """Columns whose name says they hold a recoverable credential.
+
+    A `_hash` suffix is excluded as a class, not case by case. A one-way digest is
+    not a secret to recover, so encrypting it protects nothing — and it would
+    break the comparison that verifies it, since verification works by hashing
+    the candidate and matching the stored value. `users.password_hash` and
+    `oauth_clients.client_secret_hash` are right as they are.
+    """
+    for mapper in models.Base.registry.mappers:
+        table = mapper.local_table
+        if table is None:
+            continue
+        for column in table.columns:
+            name = column.name
+            if name.endswith("_hash"):
+                continue
+            if name.endswith("_token") or name == "token":
+                yield table.name, column
+            elif any(hint in name for hint in CREDENTIAL_HINTS):
+                yield table.name, column
+
+
+class TestCredentialColumnsAreEncrypted:
+    def test_every_credential_column_is_encrypted_or_a_listed_exception(self):
+        plaintext = {
+            (table, column.name)
+            for table, column in _credential_columns()
+            if not isinstance(column.type, EncryptedText)
+        }
+
+        assert plaintext <= EXPECTED_PLAINTEXT, (
+            "Credential columns stored in the clear:\n  "
+            + "\n  ".join(sorted(f"{t}.{c}" for t, c in plaintext - EXPECTED_PLAINTEXT))
+            + "\n\nUse EncryptedText. The DB column is already TEXT for most of these, so "
+            "no migration is needed and reads pass legacy plaintext through unchanged. "
+            "If it genuinely cannot be encrypted, add it to EXPECTED_PLAINTEXT with the "
+            "reason."
+        )
+
+    def test_the_sweep_actually_finds_columns(self):
+        """A rule that matches nothing enforces nothing."""
+        found = {f"{t}.{c.name}" for t, c in _credential_columns()}
+
+        assert len(found) >= 6, found
+        assert "run_tasks.hmac_key" in found
+        assert "gpg_keys.private_key" in found
+        assert "notification_configurations.token" in found
+
+    def test_hashes_are_excluded_rather_than_excused(self):
+        """The `_hash` exclusion is a real rule, not a way past a failure: a
+        one-way digest is not a recoverable secret, and encrypting it would break
+        the comparison that verifies it."""
+        found = {f"{t}.{c.name}" for t, c in _credential_columns()}
+
+        assert "users.password_hash" not in found
+        assert "oauth_clients.client_secret_hash" not in found
+
+    def test_the_exception_list_has_not_grown_silently(self):
+        """Every entry here is a documented decision. Growing it should be a
+        conscious act, not the easy way past a failing assertion."""
+        assert EXPECTED_PLAINTEXT == {
+            ("crypto_keys", "wrapped_dek"),
+            ("task_stage_results", "callback_token"),
+        }
+
+    def test_the_exceptions_still_exist(self):
+        """If one is renamed or dropped, the entry becomes dead weight that
+        silently excuses nothing — or worse, excuses something else later."""
+        tables = {m.local_table.name: m.local_table for m in models.Base.registry.mappers}
+
+        for table_name, column_name in EXPECTED_PLAINTEXT:
+            assert table_name in tables, table_name
+            assert column_name in tables[table_name].columns, f"{table_name}.{column_name}"
+
+
+class TestTheTwoFixes:
+    """Named directly, so the reason each changed is findable from the test name."""
+
+    def test_the_run_task_hmac_key_is_encrypted(self):
+        """Anyone holding it can forge a task result, and a mandatory task's
+        result gates the apply."""
+        column = sa_inspect(models.RunTask).local_table.c["hmac_key"]
+
+        assert isinstance(column.type, EncryptedText)
+
+    def test_the_gpg_private_key_is_encrypted(self):
+        """The most sensitive column in the registry: it is what proves a
+        published provider came from here."""
+        column = sa_inspect(models.GPGKey).local_table.c["private_key"]
+
+        assert isinstance(column.type, EncryptedText)
+
+    def test_null_is_preserved_so_the_signing_key_query_still_works(self):
+        """`gpg_key_service` selects signing-capable keys with
+        `private_key IS NOT NULL`. That only keeps working because the type maps
+        None to NULL rather than encrypting it."""
+        assert EncryptedText().process_bind_param(None, None) is None
+        assert EncryptedText().process_result_value(None, None) is None

--- a/services/tests/services/test_replication_workspace_settings.py
+++ b/services/tests/services/test_replication_workspace_settings.py
@@ -417,6 +417,46 @@ class TestRunTasks:
 
         assert removed == [ID_B]
 
+    @pytest.mark.replication_matrix("run_tasks", "encrypted-columns")
+    async def test_the_hmac_key_survives_the_per_node_round_trip(self):
+        """`hmac_key` became `EncryptedText` in #1140, which is what made the
+        matrix gate start demanding this row — the gate derives it from the model,
+        so a class that gains an encrypted column fails until the round trip is
+        proven.
+
+        The property: the payload carries the key decrypted (the peer cannot use
+        this node's ciphertext), and applying writes it back through the column so
+        the receiving node re-encrypts under its own key."""
+        from sqlalchemy import inspect as sa_inspect
+
+        from terrapod.crypto.types import EncryptedText as _Enc
+
+        column = sa_inspect(RunTask).local_table.c["hmac_key"]
+        assert isinstance(column.type, _Enc)
+
+        assert replication.serialize_row(RUN_TASKS, _run_task())["hmac_key"] == "shared"
+
+        db = AsyncMock()
+        existing = _run_task(hmac_key="theirs")
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(db, RUN_TASKS, {"id": ID_A, "hmac_key": "rotated"})
+
+        assert existing.hmac_key == "rotated"
+
+    async def test_a_task_with_no_hmac_key_stays_without_one(self):
+        """An unsigned task is a real configuration. `None` must stay `None`
+        rather than becoming a string the dispatcher would then sign with."""
+        db = AsyncMock()
+        existing = _run_task(hmac_key="stale")
+        db.scalar.return_value = existing
+
+        await replication.apply_upsert(
+            db, RUN_TASKS, replication.serialize_row(RUN_TASKS, _run_task(hmac_key=None))
+        )
+
+        assert existing.hmac_key is None
+
 
 class TestExecutionHooks:
     @pytest.mark.replication_matrix("execution_hooks", "backfill-from-empty")


### PR DESCRIPTION
Two workspace-scoped credentials sat beside each other with opposite treatment: `notification_configurations.token` was `EncryptedText`, `run_tasks.hmac_key` was plain `Text`.

The HMAC key is what lets Terrapod prove a webhook came from it — so anyone holding it can **forge a task result**, and a task result gates the apply when the task is mandatory.

## The sweep found something worse

The issue asked to check for other credential-shaped columns still plain. `gpg_keys.private_key` was: a GPG **private key**, which is what proves a published provider came from this registry. The most sensitive column in that table by a wide margin.

Both are now `EncryptedText`.

**No migration.** Both DB columns are already `TEXT`, so an envelope cannot overflow them, and the type passes legacy plaintext through on read — adoption is a migration rather than a cutover, and existing rows keep working.

**Checked before changing:** neither column is ever compared in SQL. All access is via the ORM attribute, and the two `private_key IS NOT NULL` predicates that select signing-capable keys still work, because `EncryptedText` maps `None` to NULL rather than encrypting it. There is a test for that specifically.

## The rule, not just the two fixes

A new gate (`tests/db/test_credential_columns_encrypted.py`) walks every mapped column whose name says it holds a credential and requires `EncryptedText` or a listed exception. So the *next* gap fails the build instead of waiting to be noticed.

Writing it immediately found two more — `users.password_hash` and `oauth_clients.client_secret_hash` — and **both are correct as they are**. So `_hash` is excluded as a class, with the reasoning in the code: a one-way digest is not a recoverable secret, and encrypting it would break the comparison that verifies it.

Two genuine exceptions are listed with reasons:
- `crypto_keys.wrapped_dek` — circular. It *is* the key the encryption layer unwraps at boot, and it is already KEK-wrapped ciphertext.
- `task_stage_results.callback_token` — `String(255)`, so an envelope could overflow it; adopting it needs a widen to TEXT first. Short-lived and single-use. Tracked here rather than silently skipped.

## The matrix gate caught the follow-on itself

`run_tasks` is a replicated class (#1141), so gaining an encrypted column made the replication matrix gate **derive** a required `encrypted-columns` row and fail until the per-node decrypt/re-encrypt round trip was proven. Exactly what that gate was built for. That test is included, plus one asserting a task with no HMAC key stays without one — `None` must not become a string the dispatcher would then sign with.

## Verification

- `make test` — 3774 passed (8 new in the credential gate, 2 in the replication matrix).
- `make lint`. No contract snapshots move: column *types* changed, not names or API shapes.

Closes #1140.
