### PR TITLE
fix(1156): a cancelled poll no longer takes every workspace on that repo with it

### DIFF
--- a/services/terrapod/services/replication.py
+++ b/services/terrapod/services/replication.py
@@ -83,9 +83,6 @@ _REGISTRY: dict[str, ReplicatedClass] = {}
 _BY_MODEL: dict[type, ReplicatedClass] = {}
 
 
-_loaded = False
-
-
 def _ensure_loaded() -> None:
     """Import the registry module so the scope is populated.
 
@@ -96,10 +93,9 @@ def _ensure_loaded() -> None:
     instead. The registry is a fixed module in this repo, not a plugin system,
     so there is nothing to discover and no ordering to get wrong.
     """
-    global _loaded
-    if _loaded:
-        return
-    _loaded = True
+    # No once-guard: Python already memoises imports, so a second call is a
+    # `sys.modules` dict lookup. A hand-rolled flag would only be another thing
+    # able to be wrong.
     from terrapod.services import replication_registry  # noqa: F401
 
 

--- a/services/terrapod/services/vcs_metadata_cache.py
+++ b/services/terrapod/services/vcs_metadata_cache.py
@@ -17,8 +17,22 @@ instance is created for each poll cycle and discarded with it.
 
 It also **single-flights**: workspaces are polled concurrently under a
 semaphore, so without it the first N concurrent pollers for one repo would each
-fire before any of them populated the cache. Callers share one in-flight task
-rather than racing.
+fire before any of them populated the cache. Concurrent callers for one key
+queue on a per-key lock, so exactly one request goes out and the rest read the
+result it left behind.
+
+The fetch deliberately runs **inside the first caller's own coroutine** rather
+than in a shared task, because a shared task makes cancellation contagious.
+``Task.cancel()`` cancels whatever the task is awaiting, so cancelling *one*
+caller cancelled the task every other caller for that key was waiting on — and
+left a cancelled task in the cache, so every later caller inherited it too. With
+workspaces polled concurrently under a semaphore, one workspace's poll being
+cancelled took every other workspace on that repository with it, and then every
+workspace on that repository for the rest of the cycle.
+
+A lock keeps a cancellation the property of the caller it happened to: the
+waiters simply acquire the lock next and try, and nothing is cached, so the key
+is not poisoned.
 
 Failures are shared too, which is intentional. When a repo's metadata call
 fails, every workspace on that repo would have failed the same way; sharing the
@@ -48,26 +62,47 @@ class VCSMetadataCache:
     """Single-flight memoisation of provider metadata calls for one poll cycle."""
 
     def __init__(self) -> None:
-        self._tasks: dict[MetaKey, asyncio.Task] = {}
+        #: Settled outcomes. An `Exception` value is a shared failure, which is
+        #: as much a result as a success — see the module docstring.
+        self._outcomes: dict[MetaKey, object] = {}
+        self._locks: dict[MetaKey, asyncio.Lock] = {}
         self.hits = 0
         self.misses = 0
 
     async def get_or_fetch(self, key: MetaKey, fetch: Callable[[], Awaitable[T]]) -> T:
         """Return the cached result for ``key``, or run ``fetch`` to produce it.
 
-        Concurrent callers for the same key await one shared task. The result —
-        including an exception — is shared by all of them.
+        Concurrent callers for the same key queue on a per-key lock, so exactly
+        one request goes out. The result — including an exception — is shared by
+        all of them.
         """
-        task = self._tasks.get(key)
-        if task is None:
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+
+        async with lock:
+            if key in self._outcomes:
+                self.hits += 1
+                outcome = self._outcomes[key]
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return outcome  # type: ignore[return-value]
+
             self.misses += 1
-            # create_task (not a bare coroutine) so concurrent callers can all
-            # await the same handle; awaiting one coroutine twice is an error.
-            task = asyncio.create_task(fetch())
-            self._tasks[key] = task
-        else:
-            self.hits += 1
-        return await task
+            try:
+                result = await fetch()
+            except Exception as exc:
+                # Cached so the other workspaces on this repo do not each go and
+                # fail the same way — which matters most during a rate-limit
+                # event, when extra calls are precisely what there is no room
+                # for. `CancelledError` is a BaseException and so is deliberately
+                # NOT cached: a cancelled caller is not a failed repo, and the
+                # next caller should try rather than inherit the cancellation.
+                self._outcomes[key] = exc
+                raise
+            self._outcomes[key] = result
+            return result
 
     def stats(self) -> dict[str, int]:
         """Hit/miss counters, for logging how much upstream traffic was saved."""

--- a/services/tests/services/test_vcs_metadata_cache.py
+++ b/services/tests/services/test_vcs_metadata_cache.py
@@ -154,3 +154,101 @@ class TestIsolation:
         second = VCSMetadataCache()
         assert await second.get_or_fetch(key, fetch) == "sha-2"
         assert calls == 2
+
+
+class TestOneCallersCancellationStaysItsOwn:
+    """Why the fetch runs in the caller's own coroutine rather than a shared task (#1156).
+
+    A shared `asyncio.Task` makes cancellation contagious. `Task.cancel()`
+    cancels whatever the task is awaiting, so cancelling *one* caller cancelled
+    the task every other caller for that key was waiting on — and left a
+    cancelled task in the cache, so every later caller inherited it too.
+
+    In the poller that is not hypothetical: workspaces are polled concurrently
+    under a semaphore, so one workspace's poll being cancelled (a timeout,
+    shutdown, a task group tearing down) took every other workspace sharing that
+    repository with it, and then every workspace on that repository for the rest
+    of the cycle.
+    """
+
+    async def test_cancelling_one_caller_does_not_cancel_another(self):
+        started = asyncio.Event()
+
+        async def fetch():
+            started.set()
+            await asyncio.sleep(0.05)
+            return "sha"
+
+        cache = VCSMetadataCache()
+        key = ("c", "o", "r", "main")
+        a = asyncio.create_task(cache.get_or_fetch(key, fetch))
+        await started.wait()
+        b = asyncio.create_task(cache.get_or_fetch(key, fetch))
+        await asyncio.sleep(0)  # let B reach its await
+        a.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await a
+
+        assert await b == "sha", (
+            "B was collaterally cancelled by A — it asked about a repository and "
+            "had nothing to do with A"
+        )
+
+    async def test_a_cancelled_caller_does_not_poison_the_key(self):
+        """A cancelled caller is not a failed repository. The next caller should
+        get a real attempt rather than inherit somebody else's cancellation."""
+        attempts = 0
+        release = asyncio.Event()
+
+        async def fetch():
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                release.set()
+                await asyncio.sleep(10)
+            return f"sha-{attempts}"
+
+        cache = VCSMetadataCache()
+        key = ("c", "o", "r", "main")
+        first = asyncio.create_task(cache.get_or_fetch(key, fetch))
+        await release.wait()
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        assert await cache.get_or_fetch(key, fetch) == "sha-2"
+        assert attempts == 2
+
+    async def test_the_lock_is_released_when_a_caller_is_cancelled(self):
+        """The corollary — a cancellation that left the per-key lock held would
+        wedge every later caller for that repository for the rest of the cycle."""
+        release = asyncio.Event()
+
+        async def slow():
+            release.set()
+            await asyncio.sleep(10)
+            return "never"
+
+        async def quick():
+            return "ok"
+
+        cache = VCSMetadataCache()
+        key = ("c", "o", "r", "main")
+        first = asyncio.create_task(cache.get_or_fetch(key, slow))
+        await release.wait()
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        assert await asyncio.wait_for(cache.get_or_fetch(key, quick), timeout=1) == "ok"
+
+    def test_no_raw_task_is_created(self):
+        """The rule this was flagged by (`terrapod-no-raw-background-tasks`)
+        guards a real invariant, so satisfying it is pinned rather than left to
+        the scanner."""
+        import inspect
+
+        source = inspect.getsource(VCSMetadataCache)
+
+        assert "create_task" not in source
+        assert "asyncio.Lock()" in source


### PR DESCRIPTION
Clearing the two open code-scanning alerts. One of them turned out to be hiding a real bug.

## The bug the scanner found by accident

Semgrep flagged the `asyncio.create_task` in the VCS metadata cache under `terrapod-no-raw-background-tasks`. The rule guards a real invariant, and it was pointing at something that is *not* background work — the task is a shared awaitable handle for single-flight memoisation, awaited on the next line. Easy to suppress.

But **`Task.cancel()` cancels whatever the task is currently awaiting.** So cancelling *one* caller cancelled the shared task that every *other* caller for that key was waiting on, and those callers got a `CancelledError` about a repository they had merely asked about. The cancelled task then stayed in the cache, so every later caller for that key inherited the cancellation for the rest of the cycle.

That is not hypothetical in the poller. Workspaces are polled concurrently under a semaphore, so one workspace's poll being cancelled — a timeout, shutdown, a task group tearing down — took **every other workspace sharing that repository** with it, and then **every workspace on that repository until the next cycle**. On a monorepo that is the whole estate going dark for a cycle because one workspace timed out.

I got the mechanism wrong on the first pass (I assumed the task would be *orphaned* by a cancelled caller — it isn't; asyncio propagates the cancel inward) and only found the actual failure mode by reproducing it. The tests below reflect the real one.

## The fix

A per-key `asyncio.Lock` plus a memoised outcome. The fetch runs in the first caller's own coroutine, so a cancellation stays the property of the caller it happened to: the waiters acquire the lock next and try, and nothing is cached, so the key is not poisoned.

`CancelledError` is deliberately **not** cached — it is a `BaseException`, so the `except Exception` that caches shared failures doesn't catch it. A cancelled caller is not a failed repository.

Everything the cache is for behaves as before, because concurrent callers queueing on a lock has the same effect as concurrent callers awaiting one task — one upstream call, everybody gets the result. The seven existing tests (memoisation, single-flight, failure sharing, per-cycle isolation) pass unchanged.

## Tests

Four new ones, and **each was run against the previous implementation to confirm it fails there** rather than assumed to be a regression test:

| Test | Fails before? |
|---|---|
| `test_cancelling_one_caller_does_not_cancel_another` | yes — this is the bug |
| `test_a_cancelled_caller_does_not_poison_the_key` | yes |
| `test_the_lock_is_released_when_a_caller_is_cancelled` | yes |
| `test_no_raw_task_is_created` | yes |

I initially wrote a fifth asserting the fetch didn't outlive a cancelled caller; it passed on *both* implementations, so it was proving nothing and is gone rather than kept for the count.

## Second alert: a once-guard that shouldn't exist

CodeQL reported `_loaded` in `services/replication.py` as an unused global. The report is wrong — it is read one line above where it is written — but the code it points at should not exist. `_ensure_loaded` hand-rolls a once-guard around an import, and Python already memoises imports: the second `from terrapod.services import replication_registry` is a `sys.modules` dict lookup. The flag bought nothing and was one more thing able to be wrong.

## Verification

`make test` — **3876 passed**. Both alerts fixed at the source; nothing suppressed, nothing annotated around.

Closes #1156