### PR TITLE
fix(1155): follow GCS's pagination, and let a listing be bounded by key

### DIFF
--- a/services/terrapod/storage/azure.py
+++ b/services/terrapod/storage/azure.py
@@ -293,13 +293,32 @@ class AzureStore:
             metadata=dict(props.metadata) if props.metadata else {},
         )
 
-    async def list_prefix(self, prefix: str) -> list[ObjectMeta]:
+    async def list_prefix(
+        self,
+        prefix: str,
+        *,
+        after: str = "",
+        limit: int | None = None,
+    ) -> list[ObjectMeta]:
+        """List objects under `prefix`, in key order.
+
+        Honest about what this bounds and what it does not. Azure's List Blobs
+        has a continuation token but **no arbitrary key cursor**, so `after` is
+        applied as the results stream past: memory and the returned page are
+        bounded, the server-side scan is not. Results arrive lexicographically
+        ordered, so skipping until past `after` is correct — just not free.
+
+        S3 and GCS take the cursor server-side; this is the one backend where a
+        deep cursor still costs a walk.
+        """
         container = await self._get_container_client()
         full_prefix = self._full_key(prefix)
         results: list[ObjectMeta] = []
 
         async for blob in container.list_blobs(name_starts_with=full_prefix):
             key = self._strip_prefix(blob.name)
+            if after and key <= after:
+                continue
             results.append(
                 ObjectMeta(
                     key=key,
@@ -314,6 +333,8 @@ class AzureStore:
                     metadata=dict(blob.metadata) if blob.metadata else {},
                 )
             )
+            if limit is not None and len(results) >= limit:
+                break
 
         return results
 

--- a/services/terrapod/storage/filesystem.py
+++ b/services/terrapod/storage/filesystem.py
@@ -213,7 +213,13 @@ class FilesystemStore:
             metadata=metadata,
         )
 
-    async def list_prefix(self, prefix: str) -> list[ObjectMeta]:
+    async def list_prefix(
+        self,
+        prefix: str,
+        *,
+        after: str = "",
+        limit: int | None = None,
+    ) -> list[ObjectMeta]:
         prefix_path = self._full_path(prefix) if prefix else self._root
         results: list[ObjectMeta] = []
 
@@ -223,12 +229,24 @@ class FilesystemStore:
             return results
 
         prefix_str = prefix if prefix else ""
-        for path in sorted(search_dir.rglob("*")):
-            if path.is_file() and not path.name.endswith(".meta"):
-                key = self._key_from_path(path)
-                if key.startswith(prefix_str):
-                    meta = await self.head(key)
-                    results.append(meta)
+        # Collect keys first, then `head()` only the ones being returned. The old
+        # shape stat'd every file in the tree before any filtering, so a bounded
+        # page still paid for the whole walk. Sorted on the KEY rather than the
+        # Path so the order matches what the object-store backends produce.
+        keys = sorted(
+            self._key_from_path(path)
+            for path in search_dir.rglob("*")
+            if path.is_file() and not path.name.endswith(".meta")
+        )
+
+        for key in keys:
+            if not key.startswith(prefix_str):
+                continue
+            if after and key <= after:
+                continue
+            results.append(await self.head(key))
+            if limit is not None and len(results) >= limit:
+                break
 
         return results
 

--- a/services/terrapod/storage/gcs.py
+++ b/services/terrapod/storage/gcs.py
@@ -365,40 +365,74 @@ class GCSStore:
             metadata=user_metadata,
         )
 
-    async def list_prefix(self, prefix: str) -> list[ObjectMeta]:
+    async def list_prefix(
+        self,
+        prefix: str,
+        *,
+        after: str = "",
+        limit: int | None = None,
+    ) -> list[ObjectMeta]:
+        """List objects under `prefix`, in key order.
+
+        **This follows `nextPageToken`.** The GCS JSON API caps a response at
+        `maxResults` (1000 by default), so a single call returns a partial list
+        with nothing to say it was partial — which silently truncated every
+        caller that asked for a prefix holding more than a thousand objects, the
+        break-glass state index among them.
+
+        `startOffset` narrows server-side, but it is *inclusive*, so `after`
+        still needs the boundary key dropped locally.
+        """
         storage = await self._get_aio_storage()
         full_prefix = self._full_key(prefix)
         results: list[ObjectMeta] = []
 
-        try:
-            blobs = await storage.list_objects(self._bucket_name, params={"prefix": full_prefix})
-        except Exception as e:
-            raise ObjectStoreError(str(e)) from e
+        params: dict[str, str] = {"prefix": full_prefix}
+        if after:
+            params["startOffset"] = self._full_key(after)
+        if limit is not None:
+            # A ceiling on the page, not on the walk — the loop below stops once
+            # `limit` entries have been collected.
+            params["maxResults"] = str(limit)
 
-        for item in blobs.get("items", []):
-            key = self._strip_prefix(item.get("name", ""))
-            size = int(item.get("size", 0))
-            content_type = item.get("contentType", "application/octet-stream")
-            etag = item.get("etag", "").strip('"')
-            updated = item.get("updated", "")
-            last_modified = datetime.now(UTC)
-            if updated:
-                try:
-                    last_modified = datetime.fromisoformat(updated.replace("Z", "+00:00"))
-                except ValueError:
-                    pass
+        while True:
+            try:
+                blobs = await storage.list_objects(self._bucket_name, params=dict(params))
+            except Exception as e:
+                raise ObjectStoreError(str(e)) from e
 
-            results.append(
-                ObjectMeta(
-                    key=key,
-                    size_bytes=size,
-                    content_type=content_type,
-                    etag=etag,
-                    last_modified=last_modified,
+            for item in blobs.get("items", []):
+                key = self._strip_prefix(item.get("name", ""))
+                # `startOffset` is inclusive; the contract is strictly-greater.
+                if after and key <= after:
+                    continue
+                size = int(item.get("size", 0))
+                content_type = item.get("contentType", "application/octet-stream")
+                etag = item.get("etag", "").strip('"')
+                updated = item.get("updated", "")
+                last_modified = datetime.now(UTC)
+                if updated:
+                    try:
+                        last_modified = datetime.fromisoformat(updated.replace("Z", "+00:00"))
+                    except ValueError:
+                        pass
+
+                results.append(
+                    ObjectMeta(
+                        key=key,
+                        size_bytes=size,
+                        content_type=content_type,
+                        etag=etag,
+                        last_modified=last_modified,
+                    )
                 )
-            )
+                if limit is not None and len(results) >= limit:
+                    return results
 
-        return results
+            token = blobs.get("nextPageToken")
+            if not token:
+                return results
+            params["pageToken"] = token
 
     async def presigned_get_url(
         self,

--- a/services/terrapod/storage/protocol.py
+++ b/services/terrapod/storage/protocol.py
@@ -185,14 +185,31 @@ class ObjectStore(Protocol):
         """
         ...
 
-    async def list_prefix(self, prefix: str) -> list[ObjectMeta]:
-        """List objects matching a key prefix.
+    async def list_prefix(
+        self,
+        prefix: str,
+        *,
+        after: str = "",
+        limit: int | None = None,
+    ) -> list[ObjectMeta]:
+        """List objects matching a key prefix, in lexicographic key order.
+
+        **Ordering is part of the contract**, not an accident of the backend: a
+        key cursor is meaningless without it, and every backend already returned
+        keys in this order.
+
+        Passing neither `after` nor `limit` returns every matching object —
+        which callers rely on, so a backend whose API paginates internally must
+        follow its own continuation tokens rather than returning the first page.
 
         Args:
             prefix: Key prefix to filter by.
+            after: Return only keys strictly greater than this one. The cursor
+                for resuming a walk: pass the last key you saw.
+            limit: Stop after this many entries. `None` means no bound.
 
         Returns:
-            List of object metadata entries matching the prefix.
+            Object metadata entries, ordered by key.
         """
         ...
 
@@ -357,10 +374,16 @@ class InstrumentedStore:
             self._record("head", start, error=True)
             raise
 
-    async def list_prefix(self, prefix: str) -> list[ObjectMeta]:
+    async def list_prefix(
+        self,
+        prefix: str,
+        *,
+        after: str = "",
+        limit: int | None = None,
+    ) -> list[ObjectMeta]:
         start = time.monotonic()
         try:
-            result = await self._inner.list_prefix(prefix)
+            result = await self._inner.list_prefix(prefix, after=after, limit=limit)
             self._record("list_prefix", start)
             return result
         except Exception:

--- a/services/terrapod/storage/s3.py
+++ b/services/terrapod/storage/s3.py
@@ -297,13 +297,29 @@ class S3Store:
             metadata=response.get("Metadata", {}),
         )
 
-    async def list_prefix(self, prefix: str) -> list[ObjectMeta]:
+    async def list_prefix(
+        self,
+        prefix: str,
+        *,
+        after: str = "",
+        limit: int | None = None,
+    ) -> list[ObjectMeta]:
         client = await self._get_client()
         full_prefix = self._full_key(prefix)
         results: list[ObjectMeta] = []
 
+        # `StartAfter` is exactly a key cursor, and `MaxItems` bounds the walk
+        # across pages — so a page here costs a page upstream, not a full listing
+        # sliced afterwards. `StartAfter` is compared against the stored key, so
+        # it needs the bucket prefix applied like any other key.
+        params: dict[str, object] = {"Bucket": self._bucket, "Prefix": full_prefix}
+        if after:
+            params["StartAfter"] = self._full_key(after)
+        if limit is not None:
+            params["PaginationConfig"] = {"MaxItems": limit}
+
         paginator = client.get_paginator("list_objects_v2")
-        async for page in paginator.paginate(Bucket=self._bucket, Prefix=full_prefix):
+        async for page in paginator.paginate(**params):
             for obj in page.get("Contents", []):
                 key = self._strip_prefix(obj["Key"])
                 results.append(

--- a/services/tests/storage/test_azure.py
+++ b/services/tests/storage/test_azure.py
@@ -124,6 +124,52 @@ class TestAzureStoreUnit:
         assert meta.content_type == "text/plain"
         assert meta.metadata["key"] == "value"
 
+    async def test_list_prefix_applies_the_cursor_and_the_limit(self, store: AzureStore) -> None:
+        """Azure has no arbitrary key cursor (#1155).
+
+        List Blobs offers a continuation token, not a `StartAfter`, so `after` is
+        applied as results stream past. That bounds memory and the returned page
+        but not the server-side scan — which is a real difference from S3 and GCS
+        and worth pinning so nobody "optimises" the skip away believing the SDK
+        is doing it.
+        """
+
+        def blob(name: str) -> MagicMock:
+            b = MagicMock()
+            b.name = name
+            b.size = 1
+            b.content_settings = None
+            b.etag = '"e"'
+            b.last_modified = datetime(2025, 1, 1, tzinfo=UTC)
+            b.metadata = None
+            return b
+
+        names = [f"terrapod/logs/{c}.txt" for c in "abcde"]
+
+        def make_container() -> MagicMock:
+            container = MagicMock()
+
+            async def _iter(**_kwargs):
+                for n in names:
+                    yield blob(n)
+
+            container.list_blobs = _iter
+            return container
+
+        with patch.object(store, "_get_container_client", return_value=make_container()):
+            everything = await store.list_prefix("logs/")
+        assert [m.key for m in everything] == [f"logs/{c}.txt" for c in "abcde"]
+
+        with patch.object(store, "_get_container_client", return_value=make_container()):
+            after = await store.list_prefix("logs/", after="logs/b.txt")
+        assert [m.key for m in after] == ["logs/c.txt", "logs/d.txt", "logs/e.txt"], (
+            "after is strictly greater — the boundary key is not returned"
+        )
+
+        with patch.object(store, "_get_container_client", return_value=make_container()):
+            page = await store.list_prefix("logs/", after="logs/a.txt", limit=2)
+        assert [m.key for m in page] == ["logs/b.txt", "logs/c.txt"]
+
     async def test_put_stream_staged_blocks(self, store: AzureStore) -> None:
         mock_container = _make_mock_container()
         mock_blob_client = mock_container.get_blob_client.return_value

--- a/services/tests/storage/test_conformance.py
+++ b/services/tests/storage/test_conformance.py
@@ -73,6 +73,49 @@ async def _conformance_list_prefix(store: ObjectStore) -> None:
     assert "conformance/other/gamma.txt" not in keys
 
 
+async def _conformance_list_paging(store: ObjectStore) -> None:
+    """Test: `after` and `limit` bound a listing, in key order.
+
+    Run against every backend rather than unit-tested per backend, because the
+    whole point of putting the cursor in the protocol is that a caller can page
+    without knowing which backend is underneath. The mechanisms differ wildly —
+    S3 `StartAfter`, GCS `startOffset` + `nextPageToken`, an Azure skip-while, a
+    filesystem sort — so only a shared test says they agree.
+    """
+    prefix = "conformance/paging/"
+    keys = [f"{prefix}{i:02d}.txt" for i in range(6)]
+    for key in keys:
+        await store.put(key, b"x")
+
+    everything = [m.key for m in await store.list_prefix(prefix)]
+    assert everything == keys, "listing must be in lexicographic key order"
+
+    first_two = [m.key for m in await store.list_prefix(prefix, limit=2)]
+    assert first_two == keys[:2]
+
+    # `after` is strictly greater: the boundary key itself is not returned.
+    after_first = [m.key for m in await store.list_prefix(prefix, after=keys[0])]
+    assert after_first == keys[1:]
+
+    page = [m.key for m in await store.list_prefix(prefix, after=keys[1], limit=2)]
+    assert page == keys[2:4]
+
+    # Walking with the cursor visits every key exactly once, which is what a
+    # resumable backfill depends on.
+    walked: list[str] = []
+    cursor = ""
+    while True:
+        batch = await store.list_prefix(prefix, after=cursor, limit=2)
+        if not batch:
+            break
+        walked.extend(m.key for m in batch)
+        cursor = batch[-1].key
+    assert walked == keys
+
+    # Past the end is empty, not a wrap-around.
+    assert await store.list_prefix(prefix, after=keys[-1]) == []
+
+
 async def _conformance_put_stream_get_stream(store: ObjectStore) -> None:
     """Test: put_stream/get_stream roundtrip produces identical data."""
 
@@ -147,6 +190,9 @@ class TestFilesystemConformance:
     async def test_list_prefix(self, conformance_fs_store: FilesystemStore) -> None:
         await _conformance_list_prefix(conformance_fs_store)
 
+    async def test_list_paging(self, conformance_fs_store: FilesystemStore) -> None:
+        await _conformance_list_paging(conformance_fs_store)
+
     async def test_put_stream_get_stream(self, conformance_fs_store: FilesystemStore) -> None:
         await _conformance_put_stream_get_stream(conformance_fs_store)
 
@@ -210,6 +256,9 @@ class TestS3Conformance:
 
     async def test_list_prefix(self, conformance_s3_store: object) -> None:
         await _conformance_list_prefix(conformance_s3_store)  # type: ignore[arg-type]
+
+    async def test_list_paging(self, conformance_s3_store: object) -> None:
+        await _conformance_list_paging(conformance_s3_store)  # type: ignore[arg-type]
 
     async def test_put_stream_get_stream(self, conformance_s3_store: object) -> None:
         await _conformance_put_stream_get_stream(conformance_s3_store)  # type: ignore[arg-type]

--- a/services/tests/storage/test_gcs.py
+++ b/services/tests/storage/test_gcs.py
@@ -121,6 +121,110 @@ class TestGCSStoreUnit:
             assert results[0].key == "logs/a.txt"
             assert results[1].key == "logs/b.txt"
 
+    async def test_list_prefix_follows_every_page(self, store: GCSStore) -> None:
+        """The bug this fixes (#1155).
+
+        The GCS JSON API caps a response at `maxResults` (1000 by default) and
+        hands back a `nextPageToken`. The previous implementation called
+        `list_objects` once and ignored the token, so **any prefix holding more
+        than a thousand objects returned a partial list with nothing to say it
+        was partial** — including `state/`, which the break-glass recovery index
+        is built from, and `vcs_archives/`, which the retention sweep walks.
+        """
+
+        def page(names: list[str], token: str | None) -> dict:
+            body: dict = {
+                "items": [
+                    {
+                        "name": n,
+                        "size": "1",
+                        "contentType": "text/plain",
+                        "etag": "e",
+                        "updated": "2025-01-01T00:00:00Z",
+                    }
+                    for n in names
+                ]
+            }
+            if token:
+                body["nextPageToken"] = token
+            return body
+
+        mock_storage = AsyncMock()
+        mock_storage.list_objects.side_effect = [
+            page(["terrapod/logs/a.txt", "terrapod/logs/b.txt"], "tok-1"),
+            page(["terrapod/logs/c.txt"], "tok-2"),
+            page(["terrapod/logs/d.txt"], None),
+        ]
+
+        with patch.object(store, "_get_aio_storage", return_value=mock_storage):
+            results = await store.list_prefix("logs/")
+
+        assert [m.key for m in results] == [
+            "logs/a.txt",
+            "logs/b.txt",
+            "logs/c.txt",
+            "logs/d.txt",
+        ]
+        assert mock_storage.list_objects.await_count == 3
+        # Each continuation carries the token the previous page returned.
+        tokens = [
+            call.kwargs["params"].get("pageToken")
+            for call in mock_storage.list_objects.await_args_list
+        ]
+        assert tokens == [None, "tok-1", "tok-2"]
+
+    async def test_list_prefix_narrows_server_side_with_start_offset(self, store: GCSStore) -> None:
+        """`startOffset` keeps the cursor server-side rather than filtering a
+        full listing locally — and because it is *inclusive*, the boundary key
+        still has to be dropped to honour strictly-greater."""
+        mock_storage = AsyncMock()
+        mock_storage.list_objects.return_value = {
+            "items": [
+                {
+                    "name": f"terrapod/logs/{n}",
+                    "size": "1",
+                    "contentType": "text/plain",
+                    "etag": "e",
+                    "updated": "2025-01-01T00:00:00Z",
+                }
+                for n in ("a.txt", "b.txt")
+            ]
+        }
+
+        with patch.object(store, "_get_aio_storage", return_value=mock_storage):
+            results = await store.list_prefix("logs/", after="logs/a.txt")
+
+        params = mock_storage.list_objects.await_args.kwargs["params"]
+        assert params["startOffset"] == "terrapod/logs/a.txt"
+        assert [m.key for m in results] == ["logs/b.txt"], (
+            "startOffset is inclusive, so the boundary key must be dropped"
+        )
+
+    async def test_list_prefix_stops_at_the_limit_across_pages(self, store: GCSStore) -> None:
+        """`maxResults` bounds a page; the walk has to bound itself."""
+        mock_storage = AsyncMock()
+        mock_storage.list_objects.return_value = {
+            "items": [
+                {
+                    "name": f"terrapod/logs/{n}.txt",
+                    "size": "1",
+                    "contentType": "text/plain",
+                    "etag": "e",
+                    "updated": "2025-01-01T00:00:00Z",
+                }
+                for n in ("a", "b", "c")
+            ],
+            # A token that would go on forever if the limit were not honoured.
+            "nextPageToken": "more",
+        }
+
+        with patch.object(store, "_get_aio_storage", return_value=mock_storage):
+            results = await store.list_prefix("logs/", limit=2)
+
+        assert [m.key for m in results] == ["logs/a.txt", "logs/b.txt"]
+        assert mock_storage.list_objects.await_count == 1
+        assert mock_storage.list_objects.await_args.kwargs["params"]["maxResults"] == "2"
+
     async def test_put_stream_uses_sync_client(self, store: GCSStore) -> None:
         mock_blob = MagicMock()
         mock_blob.upload_from_file = MagicMock()


### PR DESCRIPTION
Groundwork for the copying half of #1114 that turned up a real bug on the way.

## The bug: GCS silently truncated any listing past 1000 objects

`storage/gcs.py::list_prefix` called `list_objects` once and **never followed `nextPageToken`**. The GCS JSON API caps a response at `maxResults` (1000 by default), so any prefix holding more than a thousand objects came back partial with nothing to say it was partial.

`artifact_retention_service` documents the contract the other backends honour — *"`list_prefix` returns ALL entries under the prefix in one call"* — so this was one backend quietly violating a stated invariant, not an under-specified corner.

What it cost on GCS:

- **`cli/restore_verify.py` builds the break-glass recovery index from `list_prefix("state/")`.** An estate with more than a thousand state versions got an index that *looks authoritative* while omitting most of it — the precise failure `docs/disaster-recovery.md` warns about.
- **The `vcs_archives/` retention sweep** left everything past the first thousand un-swept, and reported success.
- **Blob readiness (#1148)** would have called a truncated listing a clean class.

## And a key cursor, pushed into the backends

`list_prefix(prefix, *, after="", limit=None)` — strictly greater than `after`, lexicographic order, at most `limit`. Ordering is promoted from something every backend happened to do into part of the contract, since a cursor is meaningless without it.

Implemented natively per backend, because the point is that **a page costs a page** rather than a full listing sliced afterwards:

| Backend | Mechanism |
|---|---|
| S3 | `StartAfter` (exactly a key cursor) + `PaginationConfig.MaxItems` |
| GCS | `startOffset` + `maxResults`, plus the token walk above. `startOffset` is *inclusive*, so the boundary key is still dropped locally |
| Azure | List Blobs has a continuation token but no arbitrary key cursor, so this one skips-while and stops at the limit — **memory and the page are bounded, the server-side scan is not.** Stated plainly in the docstring rather than implying parity with the other two |
| Filesystem | sort the keys, then `head()` only the ones being returned. The old shape stat'd every file in the tree before filtering, so even a bounded page paid for the whole walk |

**Existing callers are unaffected** — they pass no cursor, and the default is the previous behaviour. Except on GCS, where they stop being wrong.

## Tests

Six, and **each was run against the previous implementation to confirm it fails there**:

| Test | What it pins |
|---|---|
| `test_list_prefix_follows_every_page` (GCS) | the bug — three pages, three calls, tokens threaded |
| `test_list_prefix_narrows_server_side_with_start_offset` (GCS) | cursor goes to the server; inclusive boundary dropped |
| `test_list_prefix_stops_at_the_limit_across_pages` (GCS) | the walk bounds itself, not just the page |
| `test_list_paging` (**filesystem + S3, shared conformance**) | ordering, `after`, `limit`, a full cursor walk visiting each key once, empty past the end |
| `test_list_prefix_applies_the_cursor_and_the_limit` (Azure) | the skip-while, and that nobody later "optimises" it away believing the SDK does it |

The paging behaviour is deliberately a **shared conformance test across backends** rather than per-backend units: the point of putting the cursor in the protocol is that a caller can page without knowing what's underneath, and the four mechanisms differ enough that only a shared test says they agree. It runs against real LocalStack for S3.

Azure also had **no listing test at all** before this.

## Verification

`make test` — **3882 passed**, including the S3 conformance suite against LocalStack.

Closes #1155
Part of #1114