### PR TITLE
feat(1165): say how far behind replication is, not just when it last ran

### DIFF
--- a/alembic/versions/7359beafb7c0_replication_lag.py
+++ b/alembic/versions/7359beafb7c0_replication_lag.py
@@ -1,0 +1,43 @@
+"""Record how far behind replication is, not just how long ago it ran (#1165).
+
+Two nullable columns on the event-stream cursor. Both are things the follower
+cannot work out alone: its page from the leader is capped at `limit`, so a full
+page means "there is more" and nothing at all about how much more. The leader
+now reports its newest event id and the timestamp of the oldest event it is
+handing back, and the follower keeps them here.
+
+Nullable rather than defaulted to zero: a node that has never pulled, or whose
+peer predates this, genuinely has no answer — and "0 events behind" would be a
+confident lie in exactly the situation where an operator is about to act on it.
+
+Purely additive. A node running older code ignores both columns; a node running
+this one against a peer that does not send the fields leaves them null and says
+"unknown" rather than inventing a number.
+
+Revision ID: 7359beafb7c0
+Revises: 3a28d99d188a
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "7359beafb7c0"
+down_revision: str | None = "3a28d99d188a"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "replication_cursors",
+        sa.Column("peer_latest_position", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "replication_cursors",
+        sa.Column("oldest_unapplied_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("replication_cursors", "oldest_unapplied_at")
+    op.drop_column("replication_cursors", "peer_latest_position")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3856,9 +3856,14 @@ external name cannot pin leadership to a stale answer.
 
 ### `GET /api/terrapod/v1/ha/status`
 
-**Requires `admin` or `audit`.** Whether this node is converging with its peer —
-the question to answer before moving DNS. Computed entirely from local state, so
-it still works when the peer is the thing that has broken.
+**Requires authentication; the in-cluster half additionally requires `admin` or
+`audit`.** Whether this node is converging with its peer — the question to
+answer before moving DNS. Computed entirely from local state, so it still works
+when the peer is the thing that has broken.
+
+The node's own disposition (role, peer, sync state) is readable by **any
+authenticated user**: hiding "you are talking to a follower" from the person
+whose next write is about to be refused with a 503 is the opposite of useful.
 
 | Attribute | Meaning |
 |---|---|
@@ -3870,11 +3875,17 @@ it still works when the peer is the thing that has broken.
 | `backfilling-classes` | Classes still being pulled in full. **Non-empty means not in sync**, however recent the last pull |
 | `events-retained`, `oldest-event-age-seconds` | Leader side: as the oldest event approaches `retention-seconds`, the follower is close to having to backfill from scratch |
 | `retention-seconds` | The retained event window |
+| `events-behind` | How many events outstanding as of the last successful pull. **`null` is unknown** (never pulled, or a peer that does not report it) and is NOT the same as `0`, which means caught up |
+| `behind-seconds` | How old the oldest un-applied change was at that same pull. Null when caught up or unknown |
 | `replicated-classes` | What a failover would carry |
 
-There is deliberately no "N events behind": that needs the peer's latest event
-id, and seconds-since-the-last-successful-pull is more honest — a pull that
-returned nothing means caught up as of then.
+`events-behind` needs the peer's latest event id, which the follower cannot
+derive alone — its page is capped at the batch size, so a full page means "there
+is more" and nothing about how much more. The leader therefore reports its
+newest event id (and the timestamp of the oldest event in the page) on every
+events response, and the follower stores both alongside its cursor. Both figures
+describe **the last successful pull**, not this instant — pair them with
+`seconds-since-last-sync` to know how old the answer is.
 
 The same response also reports this node's **in-cluster** HA posture, because a
 pair that replicates flawlessly is still not highly available if it is serving
@@ -3882,6 +3893,7 @@ from one API pod:
 
 | Attribute | Meaning |
 |---|---|
+| `components-restricted` | True when the caller lacks `admin`/`audit`. The component fields below are then empty because they were **not read**, which is deliberately distinct from `components-unavailable-reason` ("the cluster could not be read") and from an empty list ("nothing is running") |
 | `components` | Per component: `ready` and `desired` replicas, the `nodes` and `zones` they occupy, and the PodDisruptionBudget covering them. API and web come from Kubernetes; listeners come from their Redis heartbeats, since a listener may be in another cluster entirely |
 | `single-replica-components` | Components on exactly one ready replica |
 | `schedulable-nodes`, `cluster-zones` | The spread that *was* available. Null when the node read is declined or the environment is unzoned — null means unknown, never one |

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -403,10 +403,30 @@ end of the retained event window and having to backfill from scratch. That is
 the early warning — it costs nothing to watch and it precedes the problem by
 days.
 
-There is deliberately no "N events behind". That needs the peer's latest event
-id, and seconds-since-the-last-successful-pull is the more honest number: a pull
-that returned nothing means caught up *as of then*, which is the question being
-asked.
+### How far behind, concretely
+
+`events-behind` and `behind-seconds` answer the question the sync timestamp
+cannot: not "when did it last work" but **how much is outstanding**.
+
+The follower cannot work this out alone — its page from the leader is capped at
+the batch size, so a full page means "there is more" and nothing about how much
+more. So the leader says: every events response now carries its newest event id
+and the timestamp of the oldest event it is handing back, and the follower keeps
+both alongside its cursor.
+
+Two properties to read them by:
+
+- **Null is not zero.** A node that has never pulled, or whose peer runs older
+  code, reports `null` — *unknown*. Zero means *caught up*. An operator reads a
+  zero as "fine" and would be right only half the time if the two were
+  conflated.
+- **They describe the last successful pull, not this instant.** That is
+  deliberate: the status endpoint answers from local state so it still works
+  when the peer is the thing that has broken, which is when it is read. Pair
+  them with seconds-since-last-pull to know how old the answer is.
+
+A node mid-backfill is still **not in sync** whatever these say — the rule above
+is unchanged, and it takes precedence.
 
 ## The other half: is any component a single point of failure?
 

--- a/services/terrapod/api/routers/ha.py
+++ b/services/terrapod/api/routers/ha.py
@@ -129,6 +129,18 @@ async def status(
                 "last-sync-at": _iso(state.last_sync_at),
                 "seconds-since-last-sync": since_sync,
                 "backfilling-classes": state.backfilling,
+                # How far behind, concretely (#1165). Null is "unknown" — never
+                # pulled, or a peer that does not report it — and is
+                # deliberately NOT the same as 0, which means caught up. Both
+                # describe the last successful pull rather than this instant,
+                # which is the honest thing they can describe without asking the
+                # peer on the status path.
+                "events-behind": state.events_behind,
+                "behind-seconds": (
+                    int((now - state.oldest_unapplied_at.astimezone(UTC)).total_seconds())
+                    if state.oldest_unapplied_at
+                    else None
+                ),
                 "in-sync": cfg.replication.enabled
                 and not state.backfilling
                 and since_sync is not None,

--- a/services/terrapod/api/routers/replication.py
+++ b/services/terrapod/api/routers/replication.py
@@ -12,6 +12,8 @@ point: a peer can read entities an ordinary user could not, so the identity is
 deliberately not expressible as a set of roles somebody could be granted.
 """
 
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,6 +21,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from terrapod.api.dependencies import PeerIdentity, get_peer_identity
 from terrapod.db.session import get_db
 from terrapod.services import blob_classes, replication
+
+
+def _iso(value: datetime | None) -> str | None:
+    """RFC3339 with a trailing Z, per the house rule — never `+00:00`."""
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z") if value else None
+
 
 router = APIRouter(prefix="/ha/replication", tags=["ha"])
 
@@ -55,11 +63,21 @@ async def list_events(
     caller must backfill instead. Reporting it here — rather than returning an
     innocent-looking empty page — is what stops a lagging follower from
     believing it is in sync.
+
+    ``meta.latest-id`` and ``meta.oldest-unapplied-at`` let the caller say how
+    far behind it is (#1165), which it cannot work out alone: the page it
+    receives is capped at ``limit``, so a full page means "there is more" and
+    nothing about how much more. Both are additive.
     """
     page = await replication.read_events(db, after=after, limit=limit)
     return {
         "data": page.events,
-        "meta": {"cursor": page.cursor, "stale-cursor": page.stale_cursor},
+        "meta": {
+            "cursor": page.cursor,
+            "stale-cursor": page.stale_cursor,
+            "latest-id": page.latest_id,
+            "oldest-unapplied-at": _iso(page.oldest_unapplied_at),
+        },
     }
 
 

--- a/services/terrapod/db/models.py
+++ b/services/terrapod/db/models.py
@@ -2852,6 +2852,18 @@ class ReplicationCursor(Base):
     # Set while a backfill is running, cleared when the class is caught up. The
     # follower must not report itself in sync mid-backfill.
     backfilling: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # What the peer said its newest event was, at the last successful pull
+    # (#1165). Stored rather than derived because the follower cannot work it
+    # out alone: its page is capped, so a full page means "there is more" and
+    # nothing about how much more. Nullable — a node that has never pulled, or
+    # whose peer predates this, has no answer rather than a misleading zero.
+    peer_latest_position: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # When the oldest event this node had NOT yet applied was recorded, as of
+    # that same pull. Turns a count of events into a duration. Null when caught
+    # up.
+    oldest_unapplied_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=now_utc, onupdate=now_utc
     )

--- a/services/terrapod/services/replication.py
+++ b/services/terrapod/services/replication.py
@@ -334,6 +334,14 @@ class EventPage:
     #: True when the requested cursor predates the retained window, so the
     #: caller has a gap it cannot close by replaying and must backfill.
     stale_cursor: bool = False
+    #: The newest event id on this node, so the caller can say how far behind
+    #: it is rather than only how long ago it last succeeded (#1165). One
+    #: `max(id)` on an indexed primary key — cheap enough to send every cycle.
+    latest_id: int = 0
+    #: When the oldest event in THIS page was recorded — which, at the moment
+    #: the page is built, is the oldest change the caller has not yet applied.
+    #: Turns a count into a duration. None when the caller is already caught up.
+    oldest_unapplied_at: datetime | None = None
 
 
 async def read_events(db: AsyncSession, after: int, limit: int = 500) -> EventPage:
@@ -354,6 +362,8 @@ async def read_events(db: AsyncSession, after: int, limit: int = 500) -> EventPa
         .scalars()
         .all()
     )
+    latest_id = await db.scalar(select(func.max(ReplicationEvent.id))) or 0
+
     return EventPage(
         events=[
             {
@@ -368,6 +378,8 @@ async def read_events(db: AsyncSession, after: int, limit: int = 500) -> EventPa
         ],
         cursor=rows[-1].id if rows else after,
         stale_cursor=stale,
+        latest_id=latest_id,
+        oldest_unapplied_at=rows[0].occurred_at if rows else None,
     )
 
 
@@ -532,6 +544,13 @@ class ReplicationStatus:
     #: off the retained window and it has to backfill from scratch.
     events_retained: int = 0
     oldest_event_at: datetime | None = None
+    #: Follower side: how far behind this node was at the last successful pull
+    #: (#1165). None means unknown — never pulled, or a peer that does not
+    #: report it. Deliberately distinct from 0, which means caught up.
+    events_behind: int | None = None
+    #: When the oldest change this node had not applied was recorded, as of that
+    #: same pull. None when caught up (or unknown).
+    oldest_unapplied_at: datetime | None = None
 
 
 async def read_status(db: AsyncSession) -> ReplicationStatus:
@@ -540,8 +559,17 @@ async def read_status(db: AsyncSession) -> ReplicationStatus:
     cursors = (await db.execute(select(ReplicationCursor))).scalars().all()
     stream = next((c for c in cursors if c.entity_class == EVENT_STREAM), None)
 
+    behind: int | None = None
+    if stream is not None and stream.peer_latest_position:
+        # Clamped at zero: the peer's newest id is from the last pull, so a
+        # local cursor that has since moved past it would otherwise produce a
+        # negative "behind", which is not a thing.
+        behind = max(0, int(stream.peer_latest_position) - int(stream.position or 0))
+
     return ReplicationStatus(
         last_sync_at=stream.updated_at if stream else None,
+        events_behind=behind,
+        oldest_unapplied_at=stream.oldest_unapplied_at if stream else None,
         backfilling=sorted(
             c.entity_class for c in cursors if c.backfilling and c.entity_class != EVENT_STREAM
         ),

--- a/services/terrapod/services/replication_sync.py
+++ b/services/terrapod/services/replication_sync.py
@@ -105,6 +105,27 @@ async def _set_cursor(
     row.updated_at = datetime.now(UTC)
 
 
+def _record_lag(row, meta: dict) -> None:
+    """Keep what the peer said about the end of its stream (#1165).
+
+    Written from the SAME response the cursor advances from, so the pair is
+    always consistent: `peer_latest_position` minus the cursor is how far behind
+    this node was at the moment of that pull, and it is honest about being a
+    statement about that moment rather than a live measurement.
+
+    A peer that does not send the fields (older code) leaves them untouched
+    rather than zeroed — "unknown" and "caught up" must not look the same.
+    """
+    latest = meta.get("latest-id")
+    if latest is not None:
+        row.peer_latest_position = str(latest)
+    if "oldest-unapplied-at" in meta:
+        raw = meta["oldest-unapplied-at"]
+        row.oldest_unapplied_at = (
+            datetime.fromisoformat(raw.replace("Z", "+00:00")) if raw else None
+        )
+
+
 # --------------------------------------------------------------------------
 # The cycle
 # --------------------------------------------------------------------------
@@ -268,6 +289,7 @@ async def sync_cycle() -> None:
                 logger.info("Replication cursor is stale; backfilling", after=after)
                 await backfill_all(db, client, token)
                 await _set_cursor(db, replication.EVENT_STREAM, str(body["meta"]["cursor"]))
+                _record_lag(await _get_cursor(db, replication.EVENT_STREAM), body["meta"])
                 await db.commit()
                 return
 
@@ -282,6 +304,7 @@ async def sync_cycle() -> None:
                 applied += 1
 
             await _set_cursor(db, replication.EVENT_STREAM, str(body["meta"]["cursor"]))
+            _record_lag(await _get_cursor(db, replication.EVENT_STREAM), body["meta"])
             await db.commit()
 
             if applied:

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -198,11 +198,13 @@
   ],
   "ha.status": [
     "backfilling-classes",
+    "behind-seconds",
     "cluster-zones",
     "components",
     "components-restricted",
     "components-sampled-at",
     "components-unavailable-reason",
+    "events-behind",
     "events-retained",
     "ha-findings",
     "in-sync",

--- a/services/tests/api/test_ha_status.py
+++ b/services/tests/api/test_ha_status.py
@@ -206,3 +206,48 @@ class TestWhoMaySeeWhat:
         resp = await _get(ReplicationStatus(), roles=["admin"])
 
         assert resp.json()["data"]["attributes"]["components-restricted"] is False
+
+
+class TestHowFarBehind:
+    """#1165 — "not in sync" is not an answer to "how far behind?".
+
+    The distinction these pin is `None` vs `0`. Unknown and caught-up must never
+    render the same, because an operator reads one as "fine" and would be right
+    only half the time.
+    """
+
+    async def test_a_node_that_has_never_pulled_says_unknown_not_zero(self):
+        resp = await _get(ReplicationStatus(), ha=_ha(role="follower"))
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["events-behind"] is None
+        assert attrs["behind-seconds"] is None
+
+    async def test_caught_up_is_zero_not_unknown(self):
+        resp = await _get(
+            ReplicationStatus(last_sync_at=datetime.now(UTC), events_behind=0),
+            ha=_ha(role="follower"),
+        )
+
+        assert resp.json()["data"]["attributes"]["events-behind"] == 0
+
+    async def test_behind_reports_the_count(self):
+        resp = await _get(
+            ReplicationStatus(last_sync_at=datetime.now(UTC), events_behind=42),
+            ha=_ha(role="follower"),
+        )
+
+        assert resp.json()["data"]["attributes"]["events-behind"] == 42
+
+    async def test_the_age_of_the_oldest_unapplied_change_is_a_duration(self):
+        resp = await _get(
+            ReplicationStatus(
+                last_sync_at=datetime.now(UTC),
+                events_behind=3,
+                oldest_unapplied_at=datetime.now(UTC) - timedelta(minutes=5),
+            ),
+            ha=_ha(role="follower"),
+        )
+
+        behind = resp.json()["data"]["attributes"]["behind-seconds"]
+        assert 290 <= behind <= 310, behind

--- a/services/tests/integration/test_replication_lag.py
+++ b/services/tests/integration/test_replication_lag.py
@@ -1,0 +1,130 @@
+"""How far behind is the follower? (#1165)
+
+An integration test rather than a mocked one: the whole point of these fields
+is that they come from real aggregate queries over real rows, and a mocked
+session would assert nothing about whether `max(id)` and "the first row of this
+page" are the values a follower can actually use.
+
+The property under test is that a follower CANNOT answer "how far behind am I"
+from its own page. The page is capped at `limit`, so a full page means "there
+is more" and nothing at all about how much more — which is why the leader has
+to say.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from terrapod.db.models import ReplicationEvent
+from terrapod.db.session import get_db_session
+from terrapod.services import replication
+
+
+async def _seed(count: int, *, first_age_minutes: int = 0) -> None:
+    async with get_db_session() as db:
+        base = datetime.now(UTC) - timedelta(minutes=first_age_minutes)
+        for i in range(count):
+            db.add(
+                ReplicationEvent(
+                    entity_class="workspaces",
+                    entity_id=f"ws-{i}",
+                    op="upsert",
+                    occurred_at=base + timedelta(seconds=i),
+                )
+            )
+        await db.commit()
+
+
+class TestTheLeaderSaysWhereItsStreamEnds:
+    async def test_a_capped_page_still_reports_the_newest_event_id(self, app):
+        await _seed(5)
+
+        async with get_db_session() as db:
+            page = await replication.read_events(db, after=0, limit=2)
+
+        assert len(page.events) == 2, "capped — this is the situation being solved"
+        assert page.cursor < page.latest_id, (
+            "the cursor alone cannot say how far behind; that is why latest_id exists"
+        )
+        assert page.latest_id == 5
+
+    async def test_the_oldest_unapplied_timestamp_is_the_first_row_handed_back(self, app):
+        await _seed(3, first_age_minutes=10)
+
+        async with get_db_session() as db:
+            page = await replication.read_events(db, after=0, limit=10)
+
+        assert page.oldest_unapplied_at is not None
+        age = (datetime.now(UTC) - page.oldest_unapplied_at.astimezone(UTC)).total_seconds()
+        assert 570 <= age <= 630, age
+
+    async def test_a_caught_up_caller_has_nothing_outstanding(self, app):
+        await _seed(1)
+
+        async with get_db_session() as db:
+            latest = (await replication.read_events(db, after=0, limit=10)).latest_id
+            page = await replication.read_events(db, after=latest, limit=10)
+
+        assert page.events == []
+        # Distinct from "age unknown": there is nothing outstanding to be old.
+        assert page.oldest_unapplied_at is None
+        assert page.latest_id == latest
+
+    async def test_an_empty_outbox_reports_zero_rather_than_nothing(self, app):
+        async with get_db_session() as db:
+            page = await replication.read_events(db, after=0, limit=10)
+
+        assert page.latest_id == 0
+        assert page.oldest_unapplied_at is None
+
+
+class TestTheFollowerTurnsThatIntoAnAnswer:
+    """`read_status` is what the HA page and the indicator actually read."""
+
+    async def _cursor(self, position: str, peer_latest: str | None, oldest=None):
+        from terrapod.db.models import ReplicationCursor
+
+        async with get_db_session() as db:
+            db.add(
+                ReplicationCursor(
+                    entity_class=replication.EVENT_STREAM,
+                    position=position,
+                    peer_latest_position=peer_latest,
+                    oldest_unapplied_at=oldest,
+                )
+            )
+            await db.commit()
+
+    async def test_never_pulled_is_unknown_not_zero(self, app):
+        # The distinction the whole feature rests on: an operator reads 0 as
+        # "fine", and would be wrong exactly when it matters.
+        await self._cursor("0", None)
+
+        async with get_db_session() as db:
+            status = await replication.read_status(db)
+
+        assert status.events_behind is None
+
+    async def test_caught_up_is_zero(self, app):
+        await self._cursor("40", "40")
+
+        async with get_db_session() as db:
+            status = await replication.read_status(db)
+
+        assert status.events_behind == 0
+
+    async def test_behind_is_the_difference(self, app):
+        await self._cursor("40", "58")
+
+        async with get_db_session() as db:
+            status = await replication.read_status(db)
+
+        assert status.events_behind == 18
+
+    async def test_a_cursor_past_the_last_reported_peak_clamps_at_zero(self, app):
+        # The peer's newest id is from the LAST pull; the local cursor can have
+        # moved on since. Negative "behind" is not a thing.
+        await self._cursor("60", "58")
+
+        async with get_db_session() as db:
+            status = await replication.read_status(db)
+
+        assert status.events_behind == 0

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "منذ آخر جلب",
       "backfilling": "أصناف قيد الاستكمال",
       "retained": "الأحداث المحفوظة",
-      "oldestEvent": "أقدم حدث / مدة الحفظ"
+      "oldestEvent": "أقدم حدث / مدة الحفظ",
+      "behind": "التأخر",
+      "caughtUp": "محدّثة",
+      "behindCount": "{count, plural, zero {لا أحداث} one {حدث واحد} two {حدثان} few {# أحداث} many {# حدثاً} other {# حدث}} ({age})"
     },
     "components": {
       "title": "الجاهزية داخل العنقود",

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Od posledního stažení",
       "backfilling": "Doplňované třídy",
       "retained": "Uchované události",
-      "oldestEvent": "Nejstarší událost / uchování"
+      "oldestEvent": "Nejstarší událost / uchování",
+      "behind": "Pozadu o",
+      "caughtUp": "Aktuální",
+      "behindCount": "{count, plural, one {# událost} few {# události} many {# události} other {# událostí}} ({age})"
     },
     "components": {
       "title": "Připravenost v clusteru",

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Ers y tyniad diwethaf",
       "backfilling": "Dosbarthiadau sy'n llenwi'n ôl",
       "retained": "Digwyddiadau a gedwir",
-      "oldestEvent": "Digwyddiad hynaf / cadw"
+      "oldestEvent": "Digwyddiad hynaf / cadw",
+      "behind": "Ar ei hôl hi o",
+      "caughtUp": "Yn gyfredol",
+      "behindCount": "{count, plural, one {# digwyddiad} other {# digwyddiad}} ({age})"
     },
     "components": {
       "title": "Parodrwydd yn y clwstwr",

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Siden seneste hentning",
       "backfilling": "Klasser der efterfylder",
       "retained": "Bevarede hændelser",
-      "oldestEvent": "Ældste hændelse / opbevaring"
+      "oldestEvent": "Ældste hændelse / opbevaring",
+      "behind": "Bagud med",
+      "caughtUp": "Ajour",
+      "behindCount": "{count, plural, one {# hændelse} other {# hændelser}} ({age})"
     },
     "components": {
       "title": "Parathed i klyngen",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Seit dem letzten Abruf",
       "backfilling": "Klassen im Nachladen",
       "retained": "Aufbewahrte Ereignisse",
-      "oldestEvent": "Ältestes Ereignis / Aufbewahrung"
+      "oldestEvent": "Ältestes Ereignis / Aufbewahrung",
+      "behind": "Rückstand",
+      "caughtUp": "Aufgeholt",
+      "behindCount": "{count, plural, one {# Ereignis} other {# Ereignisse}} ({age})"
     },
     "components": {
       "title": "Bereitschaft im Cluster",

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "51nc3 l457 pull",
       "backfilling": "B4ckf1ll1ng cl45535",
       "retained": "3v3n75 r3741n3d",
-      "oldestEvent": "0ld357 3v3n7 / r373n710n"
+      "oldestEvent": "0ld357 3v3n7 / r373n710n",
+      "behind": "B3h1nd by",
+      "caughtUp": "C4ugh7 up",
+      "behindCount": "{count, plural, one {# event} other {# events}} ({age})"
     },
     "components": {
       "title": "1n-clu573r r34d1n355",

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Sinse last pull",
       "backfilling": "Clasez fillin in",
       "retained": "Eventz keptid",
-      "oldestEvent": "Oldist evnt / keepin tiem"
+      "oldestEvent": "Oldist evnt / keepin tiem",
+      "behind": "Behind by",
+      "caughtUp": "All caught up",
+      "behindCount": "{count, plural, one {# evnt} other {# evntz}} ({age})"
     },
     "components": {
       "title": "Reddynes in da clustr",

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Since last marklar",
       "backfilling": "Backfilling marklars",
       "retained": "Marklars retained",
-      "oldestEvent": "Oldest marklar / marklar"
+      "oldestEvent": "Oldest marklar / marklar",
+      "behind": "Behind by",
+      "caughtUp": "Caught up",
+      "behindCount": "{count, plural, one {# marklar} other {# marklars}} ({age})"
     },
     "components": {
       "title": "In-marklar marklar",

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Since the last fetch",
       "backfilling": "Holds still fillin'",
       "retained": "Log entries kept",
-      "oldestEvent": "Oldest entry / how long she be kept"
+      "oldestEvent": "Oldest entry / how long she be kept",
+      "behind": "Astern by",
+      "caughtUp": "Abreast",
+      "behindCount": "{count, plural, one {# entry} other {# entries}} ({age})"
     },
     "components": {
       "title": "Readiness aboard the fleet",

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Since the last pull",
       "backfilling": "Classes backfilling",
       "retained": "Events retained",
-      "oldestEvent": "Event, oldest / retention"
+      "oldestEvent": "Event, oldest / retention",
+      "behind": "Behind by",
+      "caughtUp": "Caught up",
+      "behindCount": "{count, plural, one {# event} other {# events}} ({age})"
     },
     "components": {
       "title": "Readiness within the cluster",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Since last pull",
       "backfilling": "Backfilling classes",
       "retained": "Events retained",
-      "oldestEvent": "Oldest event / retention"
+      "oldestEvent": "Oldest event / retention",
+      "behind": "Behind by",
+      "caughtUp": "Caught up",
+      "behindCount": "{count, plural, one {# event} other {# events}} ({age})"
     },
     "components": {
       "title": "In-cluster readiness",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Desde la última descarga",
       "backfilling": "Clases rellenándose",
       "retained": "Eventos conservados",
-      "oldestEvent": "Evento más antiguo / retención"
+      "oldestEvent": "Evento más antiguo / retención",
+      "behind": "Por detrás",
+      "caughtUp": "Al día",
+      "behindCount": "{count, plural, one {# evento} other {# eventos}} ({age})"
     },
     "components": {
       "title": "Disponibilidad en el clúster",

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "از آخرین دریافت",
       "backfilling": "کلاس‌های در حال تکمیل",
       "retained": "رویدادهای نگه‌داشته‌شده",
-      "oldestEvent": "قدیمی‌ترین رویداد / نگه‌داری"
+      "oldestEvent": "قدیمی‌ترین رویداد / نگه‌داری",
+      "behind": "عقب‌ماندگی",
+      "caughtUp": "به‌روز",
+      "behindCount": "{count} رویداد ({age})"
     },
     "components": {
       "title": "آمادگی درون خوشه",

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Viimeisimmästä hausta",
       "backfilling": "Täydentyvät luokat",
       "retained": "Säilytetyt tapahtumat",
-      "oldestEvent": "Vanhin tapahtuma / säilytys"
+      "oldestEvent": "Vanhin tapahtuma / säilytys",
+      "behind": "Jäljessä",
+      "caughtUp": "Ajan tasalla",
+      "behindCount": "{count, plural, one {# tapahtuma} other {# tapahtumaa}} ({age})"
     },
     "components": {
       "title": "Valmius klusterissa",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Depuis le dernier tirage",
       "backfilling": "Classes en rattrapage",
       "retained": "Événements conservés",
-      "oldestEvent": "Événement le plus ancien / rétention"
+      "oldestEvent": "Événement le plus ancien / rétention",
+      "behind": "En retard de",
+      "caughtUp": "À jour",
+      "behindCount": "{count, plural, one {# événement} other {# événements}} ({age})"
     },
     "components": {
       "title": "Disponibilité dans le cluster",

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "מאז המשיכה האחרונה",
       "backfilling": "מחלקות בהשלמה",
       "retained": "אירועים שנשמרו",
-      "oldestEvent": "האירוע הישן ביותר / שמירה"
+      "oldestEvent": "האירוע הישן ביותר / שמירה",
+      "behind": "פיגור",
+      "caughtUp": "מעודכן",
+      "behindCount": "{count, plural, one {אירוע אחד} two {שני אירועים} other {# אירועים}} ({age})"
     },
     "components": {
       "title": "מוכנות בתוך האשכול",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Dall'ultimo prelievo",
       "backfilling": "Classi in recupero",
       "retained": "Eventi conservati",
-      "oldestEvent": "Evento più vecchio / conservazione"
+      "oldestEvent": "Evento più vecchio / conservazione",
+      "behind": "In ritardo di",
+      "caughtUp": "Allineato",
+      "behindCount": "{count, plural, one {# evento} other {# eventi}} ({age})"
     },
     "components": {
       "title": "Prontezza nel cluster",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "前回の取得からの経過",
       "backfilling": "バックフィル中のクラス",
       "retained": "保持中のイベント",
-      "oldestEvent": "最古のイベント / 保持期間"
+      "oldestEvent": "最古のイベント / 保持期間",
+      "behind": "遅延",
+      "caughtUp": "追いついています",
+      "behindCount": "{count} 件 ({age})"
     },
     "components": {
       "title": "クラスター内の準備状況",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "마지막 가져오기 이후",
       "backfilling": "백필 중인 클래스",
       "retained": "보관된 이벤트",
-      "oldestEvent": "가장 오래된 이벤트 / 보관 기간"
+      "oldestEvent": "가장 오래된 이벤트 / 보관 기간",
+      "behind": "지연",
+      "caughtUp": "최신 상태",
+      "behindCount": "{count}건 ({age})"
     },
     "components": {
       "title": "클러스터 내 준비 상태",

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Ab ultima tractione",
       "backfilling": "Classes replentes",
       "retained": "Eventus retenti",
-      "oldestEvent": "Eventus vetustissimus / retentio"
+      "oldestEvent": "Eventus vetustissimus / retentio",
+      "behind": "Retro",
+      "caughtUp": "Aequatus",
+      "behindCount": "{count, plural, one {# eventus} other {# eventus}} ({age})"
     },
     "components": {
       "title": "Paratio in glomere",

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Siden siste henting",
       "backfilling": "Klasser som etterfyller",
       "retained": "Bevarte hendelser",
-      "oldestEvent": "Eldste hendelse / oppbevaring"
+      "oldestEvent": "Eldste hendelse / oppbevaring",
+      "behind": "Bak med",
+      "caughtUp": "À jour",
+      "behindCount": "{count, plural, one {# hendelse} other {# hendelser}} ({age})"
     },
     "components": {
       "title": "Beredskap i klyngen",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Sinds het laatste ophalen",
       "backfilling": "Klassen die bijwerken",
       "retained": "Bewaarde gebeurtenissen",
-      "oldestEvent": "Oudste gebeurtenis / bewaartermijn"
+      "oldestEvent": "Oudste gebeurtenis / bewaartermijn",
+      "behind": "Achter met",
+      "caughtUp": "Bij",
+      "behindCount": "{count, plural, one {# gebeurtenis} other {# gebeurtenissen}} ({age})"
     },
     "components": {
       "title": "Gereedheid in het cluster",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Od ostatniego pobrania",
       "backfilling": "Klasy w uzupełnianiu",
       "retained": "Zachowane zdarzenia",
-      "oldestEvent": "Najstarsze zdarzenie / retencja"
+      "oldestEvent": "Najstarsze zdarzenie / retencja",
+      "behind": "W tyle o",
+      "caughtUp": "Aktualne",
+      "behindCount": "{count, plural, one {# zdarzenie} few {# zdarzenia} many {# zdarzeń} other {# zdarzenia}} ({age})"
     },
     "components": {
       "title": "Gotowość w klastrze",

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Desde a última busca",
       "backfilling": "Classes em backfill",
       "retained": "Eventos retidos",
-      "oldestEvent": "Evento mais antigo / retenção"
+      "oldestEvent": "Evento mais antigo / retenção",
+      "behind": "Atrasado em",
+      "caughtUp": "Em dia",
+      "behindCount": "{count, plural, one {# evento} other {# eventos}} ({age})"
     },
     "components": {
       "title": "Prontidão no cluster",

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Desde a última obtenção",
       "backfilling": "Classes em recuperação",
       "retained": "Eventos retidos",
-      "oldestEvent": "Evento mais antigo / retenção"
+      "oldestEvent": "Evento mais antigo / retenção",
+      "behind": "Atrasado em",
+      "caughtUp": "Em dia",
+      "behindCount": "{count, plural, one {# evento} other {# eventos}} ({age})"
     },
     "components": {
       "title": "Prontidão no cluster",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "С последней выборки",
       "backfilling": "Классы в дозагрузке",
       "retained": "Сохранённые события",
-      "oldestEvent": "Самое старое событие / хранение"
+      "oldestEvent": "Самое старое событие / хранение",
+      "behind": "Отставание",
+      "caughtUp": "Актуально",
+      "behindCount": "{count, plural, one {# событие} few {# события} many {# событий} other {# события}} ({age})"
     },
     "components": {
       "title": "Готовность в кластере",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Sedan senaste hämtningen",
       "backfilling": "Klasser som fyller på",
       "retained": "Bevarade händelser",
-      "oldestEvent": "Äldsta händelse / bevarande"
+      "oldestEvent": "Äldsta händelse / bevarande",
+      "behind": "Efter med",
+      "caughtUp": "Ikapp",
+      "behindCount": "{count, plural, one {# händelse} other {# händelser}} ({age})"
     },
     "components": {
       "title": "Beredskap i klustret",

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Qav qelmeH poH",
       "backfilling": "teblI'bogh Seghmey",
       "retained": "polbogh wanI'mey",
-      "oldestEvent": "wanI' qan law' / polmeH poH"
+      "oldestEvent": "wanI' qan law' / polmeH poH",
+      "behind": "tlha'",
+      "caughtUp": "rurchu'",
+      "behindCount": "{count} wanI'mey ({age})"
     },
     "components": {
       "title": "ghomDaq ghuHtaHghach",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Son çekimden bu yana",
       "backfilling": "Geri dolan sınıflar",
       "retained": "Saklanan olaylar",
-      "oldestEvent": "En eski olay / saklama"
+      "oldestEvent": "En eski olay / saklama",
+      "behind": "Geride",
+      "caughtUp": "Güncel",
+      "behindCount": "{count} olay ({age})"
     },
     "components": {
       "title": "Küme içi hazırlık",

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "Від останнього завантаження",
       "backfilling": "Класи в довантаженні",
       "retained": "Збережені події",
-      "oldestEvent": "Найстаріша подія / зберігання"
+      "oldestEvent": "Найстаріша подія / зберігання",
+      "behind": "Відставання",
+      "caughtUp": "Актуально",
+      "behindCount": "{count, plural, one {# подія} few {# події} many {# подій} other {# події}} ({age})"
     },
     "components": {
       "title": "Готовність у кластері",

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "距上次拉取",
       "backfilling": "回填中的类别",
       "retained": "保留的事件",
-      "oldestEvent": "最早事件 / 保留期"
+      "oldestEvent": "最早事件 / 保留期",
+      "behind": "落后",
+      "caughtUp": "已追平",
+      "behindCount": "{count} 个事件（{age}）"
     },
     "components": {
       "title": "集群内就绪情况",

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -2889,7 +2889,10 @@
       "sinceSync": "距上次拉取",
       "backfilling": "回補中的類別",
       "retained": "保留的事件",
-      "oldestEvent": "最早事件 / 保留期"
+      "oldestEvent": "最早事件 / 保留期",
+      "behind": "落後",
+      "caughtUp": "已追平",
+      "behindCount": "{count} 個事件（{age}）"
     },
     "components": {
       "title": "叢集內就緒情況",

--- a/web/src/app/ha/page.tsx
+++ b/web/src/app/ha/page.tsx
@@ -64,6 +64,8 @@ interface HAStatus {
   'last-sync-at': string | null
   'seconds-since-last-sync': number | null
   'backfilling-classes': string[]
+  'events-behind': number | null
+  'behind-seconds': number | null
   'in-sync': boolean
   'events-retained': number
   'oldest-event-age-seconds': number | null
@@ -238,6 +240,22 @@ export default function HAPage() {
                         <dt className="text-slate-400">{t('replication.sinceSync')}</dt>
                         <dd className="tabular-nums">
                           {duration(status['seconds-since-last-sync'])}
+                        </dd>
+                      </div>
+                      <div className="flex justify-between gap-4">
+                        <dt className="text-slate-400">{t('replication.behind')}</dt>
+                        <dd className="tabular-nums">
+                          {/* Null is unknown — never pulled, or a peer that
+                              does not report it — and must not render as the
+                              zero that means caught up. */}
+                          {status['events-behind'] === null
+                            ? '—'
+                            : status['events-behind'] === 0
+                              ? t('replication.caughtUp')
+                              : t('replication.behindCount', {
+                                  count: status['events-behind'],
+                                  age: duration(status['behind-seconds']),
+                                })}
                         </dd>
                       </div>
                       <div className="flex justify-between gap-4">


### PR DESCRIPTION
The HA page could tell you a pull succeeded four seconds ago and that a class was backfilling. It could not tell you the thing an operator actually wants before moving DNS: **how much is outstanding**.

## Why it was missing, and what changed

The follower cannot work it out alone. Its page from the leader is capped at the batch size, so a full page means "there is more" and nothing whatsoever about how much more. The fix is not cleverness on the follower — it is for the leader to **say**.

Every events response now carries the leader's newest event id and the `occurred_at` of the oldest event in the page (which, at that instant, is the oldest change the caller has not applied). The follower stores both alongside its cursor, **from the same response the cursor advances from**, so the pair can never disagree.

`/ha/status` gains `events-behind` and `behind-seconds`, and the page shows them.

## The two properties it rests on

- **Null is not zero.** A node that has never pulled, or whose peer runs older code, reports `null` — *unknown*. Zero means *caught up*. An operator reads a zero as "fine" and would be right only half the time if those were conflated, so they stay distinct everywhere: in the column, in the API, and on the page, which renders unknown as an em dash rather than a reassuring number.
- **They describe the last successful pull, not this instant.** Deliberate: the status endpoint answers from local state so it still works when the peer is the thing that has broken, which is exactly when it is read. Pair them with `seconds-since-last-sync` to know how old the answer is.

A node mid-backfill is still **not in sync** whatever these say. That rule is unchanged and takes precedence.

## Additive throughout

Two nullable columns (expand only — nothing dropped, nothing to acknowledge in the contraction ledger), two new response attributes, two new meta keys. An older peer simply does not send the keys, in which case the follower leaves the fields null and says "unknown" rather than inventing a number.

## Tests

Integration, not mocked — the point of these fields is that they come from real aggregate queries over real rows, and a mocked session would assert nothing about whether `max(id)` and "the first row of this page" are values a follower can actually use. Covers the capped-page case that motivates the whole thing (`cursor < latest_id`), the caught-up case (nothing outstanding is not "age unknown"), the empty outbox, and on the follower side: never-pulled → null, caught up → 0, behind → the difference, and a local cursor past the last reported peak clamping at zero rather than going negative.

Plus router tests that null and zero survive serialization distinctly.

## Also

Two docs said the opposite of the code — `high-availability.md` and `api-reference.md` both stated there is "deliberately no N events behind". Corrected, with the reasoning that replaced it. `components-restricted` from #1166 is now documented in api-reference too.

`scripts/lint.sh` and the full `tests/api` + `tests/db` + the new integration suite pass; `tsc`, `i18n:check`, `i18n:lint` and `next build` clean; i18n across all 32 locales.

Closes #1165
Part of #960