### PR TITLE
fix(1175): replicate the rows that name the objects, not just the objects

### DIFF
--- a/scripts/ha-smoke.sh
+++ b/scripts/ha-smoke.sh
@@ -191,6 +191,70 @@ asyncio.run(main())
 " 2>/dev/null | tail -1)
   [[ "$code" == "503" ]] || fail "follower answered $code to a mutating request, expected 503"
   ok "follower returns 503 on writes"
+
+  # The row and the object are two halves of one artifact, and they were built
+  # and tested separately. Each was correct on its own terms; nothing asserted
+  # the pair. #1175 was exactly that gap - the state file arrived on the
+  # follower and no row pointed at it, so a promoted node would have planned the
+  # whole estate as a first-time create.
+  info "state arrives as BOTH a row and an object"
+  local sname="ha-state-$(date +%s)"
+  local skey
+  skey=$(api_a python -c "
+import asyncio, uuid
+from terrapod.db.session import get_db_session, init_db
+from terrapod.db.models import Workspace, StateVersion
+from terrapod.services import replication
+from terrapod.storage import get_storage, init_storage, keys
+
+async def main():
+    await init_db(); await init_storage()
+    replication.install_outbox_hooks()
+    async with get_db_session() as db:
+        ws = Workspace(name='$sname'); db.add(ws); await db.flush()
+        sv = StateVersion(workspace_id=ws.id, serial=1, md5='0'*32, lineage=str(uuid.uuid4()))
+        db.add(sv); await db.flush()
+        key = keys.state_key(str(ws.id), str(sv.id))
+        await db.commit()
+    await get_storage().put(key, b'{\"version\":4,\"serial\":1}')
+    print(key)
+asyncio.run(main())
+" 2>/dev/null | tail -1)
+  [[ -n "$skey" ]] || fail "could not write a state version on the leader"
+
+  local got=""
+  for i in {1..40}; do
+    got=$(api_b python -c "
+import asyncio
+from sqlalchemy import select
+from terrapod.db.session import get_db_session, init_db
+from terrapod.db.models import Workspace, StateVersion
+from terrapod.storage import get_storage, init_storage
+
+async def main():
+    await init_db(); await init_storage()
+    async with get_db_session() as db:
+        ws = await db.scalar(select(Workspace).where(Workspace.name == '$sname'))
+        rows = 0
+        if ws:
+            rows = len((await db.scalars(select(StateVersion).where(StateVersion.workspace_id == ws.id))).all())
+    try:
+        await get_storage().get('$skey'); blob = 1
+    except Exception:
+        blob = 0
+    print(f'{rows}:{blob}')
+asyncio.run(main())
+" 2>/dev/null | tail -1)
+    [[ "$got" == "1:1" ]] && break
+    sleep 3
+  done
+
+  case "$got" in
+    1:1) ok "the state version arrived as a row AND an object" ;;
+    0:1) fail "the object copied but no row names it - a promoted node would plan the estate as a first-time create (#1175)" ;;
+    1:0) fail "the row replicated but its object did not - the workspace lists a version that cannot be read" ;;
+    *)   fail "state reached the follower as neither a row nor an object (got '$got')" ;;
+  esac
 }
 
 cmd_reverse() {

--- a/services/terrapod/services/replication_registry.py
+++ b/services/terrapod/services/replication_registry.py
@@ -16,6 +16,7 @@ from terrapod.db.models import (
     APIToken,
     AutodiscoveryRule,
     CatalogItem,
+    ConfigurationVersion,
     ExecutionHook,
     ExecutionHookWorkspace,
     ModuleWorkspaceLink,
@@ -29,6 +30,7 @@ from terrapod.db.models import (
     RoleAssignment,
     RunTask,
     RunTrigger,
+    StateVersion,
     User,
     Variable,
     VariableSet,
@@ -305,6 +307,69 @@ RUN_TRIGGERS = register(ReplicatedClass(name="run_triggers", model=RunTrigger))
 WORKSPACE_REMOTE_STATE_CONSUMERS = register(
     ReplicatedClass(name="workspace_remote_state_consumers", model=WorkspaceRemoteStateConsumer)
 )
+
+
+# ---------------------------------------------------------------------------
+# The artifact plane (#1175)
+#
+# Everything above describes how the estate is CONFIGURED. These two describe
+# what it has actually DONE, and they are the rows that name objects in the
+# store.
+#
+# They were absent while the object store was unreplicated, which was coherent:
+# a row naming a blob this node does not hold is a promise it cannot keep. #1114
+# copies the blobs, which inverts the argument — the object now arrives and
+# nothing points at it. A live pair showed exactly that: the state file present
+# on the follower, the workspace present, and zero state versions.
+#
+# That is the worse of the two failures. An absent state version reads as "this
+# workspace has never run", so a promoted node does not error — it plans the
+# entire estate as a first-time create. The operator sees a plan, not a fault.
+# ---------------------------------------------------------------------------
+
+# Every state version, not only the current one: rollback is a shipped feature,
+# so a node holding only HEAD has silently lost rollback depth while looking
+# perfectly healthy. Matches what `blob_classes._resolve_state` already copies.
+#
+# `run_id` is excluded because `runs` is deliberately not replicated (below).
+# The column is a nullable FK with ON DELETE SET NULL, so carrying it would make
+# the insert fail on the follower against a run that is not there — trading a
+# missing provenance link for a missing state version.
+STATE_VERSIONS = register(
+    ReplicatedClass(
+        name="state_versions",
+        model=StateVersion,
+        exclude=frozenset({"run_id"}),
+    )
+)
+
+# The tarball's row. #1114 calls this the sharpest omission and it is right: a
+# VCS-connected workspace can refetch its configuration, but a CLI-uploaded,
+# catalog-provisioned or migrated one cannot — this tarball is the only copy.
+# Losing the row means those workspaces can never run again, while the UI still
+# lists them as healthy.
+CONFIGURATION_VERSIONS = register(
+    ReplicatedClass(name="configuration_versions", model=ConfigurationVersion)
+)
+
+
+# ---------------------------------------------------------------------------
+# What is deliberately NOT replicated, and why
+#
+# `runs` — a run row is not history, it is a live execution: `job_name`, the
+# claiming pool, and the state the reconciler drives against a Kubernetes Job it
+# can see. Replicating it hands the follower runs it believes itself to be
+# executing, and a reconciler that will act on them. The run LOG and plan
+# artifacts are history worth keeping and are copied as blobs; the row that
+# drives execution is not, and a promoted node starting with an empty run queue
+# is the correct outcome rather than a gap.
+#
+# `registry_*_versions` and the provider platform rows are a separate question
+# with the same shape as the two above, and are tracked in #1175 rather than
+# folded in here: a provider version is client-signed and immutable, so its row
+# has to carry signature metadata that wants its own thought, and it needs
+# `registry_providers` and `gpg_keys` registered ahead of it.
+# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------

--- a/services/tests/services/test_replication_artifacts.py
+++ b/services/tests/services/test_replication_artifacts.py
@@ -1,0 +1,230 @@
+"""The artifact plane: the rows that name objects in the store (#1175).
+
+Everything else replicated describes how the estate is CONFIGURED. These two
+describe what it has actually DONE, and they were missing while the object store
+was unreplicated — which was coherent at the time, because a row naming a blob
+this node does not hold is a promise it cannot keep.
+
+#1114 copies the blobs, and that inverts the argument. A live pair showed the
+consequence directly: the state file present on the follower, the workspace
+present, and zero state versions pointing at it.
+
+That is the worse of the two failure directions. An absent state version reads
+as "this workspace has never run", so a promoted node does not error — it plans
+the whole estate as a first-time create, and the operator sees a plan rather
+than a fault.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from terrapod.db.models import ConfigurationVersion, StateVersion
+from terrapod.services import replication, replication_registry
+
+STATE_VERSIONS = replication_registry.STATE_VERSIONS
+CONFIG_VERSIONS = replication_registry.CONFIGURATION_VERSIONS
+
+WS_ID = uuid.uuid4()
+
+
+def _rows_db(rows):
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    db.execute.return_value = result
+    return db
+
+
+def _keys_db(keys):
+    db = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = keys
+    db.execute.return_value = result
+    return db
+
+
+def _state(**kw):
+    base = {
+        "id": uuid.uuid4(),
+        "workspace_id": WS_ID,
+        "serial": 1,
+        "lineage": str(uuid.uuid4()),
+        "md5": "0" * 32,
+        "sha256": "a" * 64,
+        "state_size": 42,
+        "created_by": "admin",
+        "created_at": datetime.now(UTC),
+    }
+    base.update(kw)
+    return StateVersion(**base)
+
+
+def _config(**kw):
+    base = {
+        "id": uuid.uuid4(),
+        "workspace_id": WS_ID,
+        "source": "tfe-api",
+        "speculative": False,
+        "created_at": datetime.now(UTC),
+    }
+    base.update(kw)
+    return ConfigurationVersion(**base)
+
+
+class TestStateVersionsCarryTheHistory:
+    @pytest.mark.replication_matrix("state_versions", "backfill-from-empty")
+    async def test_backfill_carries_every_version_not_only_the_latest(self):
+        """Rollback is a shipped feature. A node holding only HEAD has lost
+        rollback depth and looks perfectly healthy doing it."""
+        db = _rows_db([_state(serial=1), _state(serial=2), _state(serial=3)])
+
+        page = await replication.read_backfill(db, STATE_VERSIONS)
+
+        assert [row["serial"] for row in page] == [1, 2, 3]
+
+    @pytest.mark.replication_matrix("state_versions", "delta-apply")
+    async def test_a_new_version_applies(self):
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.scalar.return_value = None
+        sv = _state(serial=7)
+
+        await replication.apply_upsert(
+            db, STATE_VERSIONS, replication.serialize_row(STATE_VERSIONS, sv)
+        )
+
+        added = db.add.call_args[0][0]
+        assert added.id == sv.id, "a replicated version must keep the peer's id"
+        assert added.serial == 7
+
+    @pytest.mark.replication_matrix("state_versions", "idempotent-reapply")
+    async def test_reapplying_changes_nothing(self):
+        db = AsyncMock()
+        existing = _state(serial=4)
+        db.scalar.return_value = existing
+        payload = replication.serialize_row(STATE_VERSIONS, existing)
+
+        await replication.apply_upsert(db, STATE_VERSIONS, payload)
+        await replication.apply_upsert(db, STATE_VERSIONS, payload)
+
+        assert existing.serial == 4
+        assert existing.md5 == "0" * 32
+
+    @pytest.mark.replication_matrix("state_versions", "delete")
+    async def test_deleting_a_version_applies(self):
+        db = AsyncMock()
+        sv = _state()
+
+        await replication.apply_delete(db, STATE_VERSIONS, str(sv.id))
+
+        assert db.execute.await_count == 1
+
+    @pytest.mark.replication_matrix("state_versions", "backfill-converges-deletion")
+    async def test_backfill_removes_versions_the_peer_no_longer_has(self):
+        """State versions are prunable. A follower that only ever adds keeps
+        serving a version the leader deliberately removed — and rollback would
+        offer it."""
+        keep, gone = str(uuid.uuid4()), str(uuid.uuid4())
+        db = _keys_db([(keep,), (gone,)])
+
+        removed = await replication.reconcile_deletions(db, STATE_VERSIONS, {keep})
+
+        assert removed == [gone]
+
+
+class TestTheRunLinkIsNotCarried:
+    """`runs` is deliberately unreplicated — a run row is a live execution, not
+    history. Carrying `run_id` would fail the insert against a run that is not
+    there, trading a missing provenance link for a missing state version."""
+
+    def test_run_id_is_excluded_from_the_wire(self):
+        sv = _state(run_id=uuid.uuid4())
+
+        payload = replication.serialize_row(STATE_VERSIONS, sv)
+
+        assert "run_id" not in payload
+
+    def test_the_version_still_carries_everything_that_identifies_it(self):
+        sv = _state(run_id=uuid.uuid4())
+
+        payload = replication.serialize_row(STATE_VERSIONS, sv)
+
+        for field in ("id", "workspace_id", "serial", "lineage", "md5", "sha256"):
+            assert field in payload, f"{field} is how the node finds and trusts the object"
+
+    def test_runs_are_not_a_replicated_class(self):
+        # Pinned so that registering `runs` becomes a deliberate act with the
+        # reconciler consequences thought through, rather than a tidy-up.
+        assert "runs" not in replication.registered()
+
+
+class TestConfigurationVersions:
+    @pytest.mark.replication_matrix("configuration_versions", "backfill-from-empty")
+    async def test_backfill_carries_the_versions(self):
+        db = _rows_db([_config(source="tfe-api"), _config(source="vcs")])
+
+        page = await replication.read_backfill(db, CONFIG_VERSIONS)
+
+        assert {row["source"] for row in page} == {"tfe-api", "vcs"}
+
+    @pytest.mark.replication_matrix("configuration_versions", "delta-apply")
+    async def test_a_new_version_applies(self):
+        """A CLI-uploaded or catalog-provisioned workspace has no other copy of
+        its configuration — losing this row means it can never run again, while
+        the UI still lists it as healthy."""
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.scalar.return_value = None
+        cv = _config(source="tfe-api")
+
+        await replication.apply_upsert(
+            db, CONFIG_VERSIONS, replication.serialize_row(CONFIG_VERSIONS, cv)
+        )
+
+        added = db.add.call_args[0][0]
+        assert added.id == cv.id
+        assert added.source == "tfe-api"
+
+    @pytest.mark.replication_matrix("configuration_versions", "idempotent-reapply")
+    async def test_reapplying_changes_nothing(self):
+        db = AsyncMock()
+        existing = _config(speculative=True)
+        db.scalar.return_value = existing
+        payload = replication.serialize_row(CONFIG_VERSIONS, existing)
+
+        await replication.apply_upsert(db, CONFIG_VERSIONS, payload)
+        await replication.apply_upsert(db, CONFIG_VERSIONS, payload)
+
+        assert existing.speculative is True
+
+    @pytest.mark.replication_matrix("configuration_versions", "delete")
+    async def test_deleting_a_version_applies(self):
+        db = AsyncMock()
+        cv = _config()
+
+        await replication.apply_delete(db, CONFIG_VERSIONS, str(cv.id))
+
+        assert db.execute.await_count == 1
+
+    @pytest.mark.replication_matrix("configuration_versions", "backfill-converges-deletion")
+    async def test_backfill_removes_versions_the_peer_no_longer_has(self):
+        keep, gone = str(uuid.uuid4()), str(uuid.uuid4())
+        db = _keys_db([(keep,), (gone,)])
+
+        removed = await replication.reconcile_deletions(db, CONFIG_VERSIONS, {keep})
+
+        assert removed == [gone]
+
+
+class TestOrdering:
+    """Both classes are children of `workspaces`, so they must register after it
+    or backfill inserts against a parent that is not there yet."""
+
+    def test_both_come_after_workspaces(self):
+        names = list(replication.registered())
+
+        assert names.index("workspaces") < names.index("state_versions")
+        assert names.index("workspaces") < names.index("configuration_versions")


### PR DESCRIPTION
A live pair had the state file on the follower, the workspace on the follower, and **zero state versions pointing at it**.

That is the worse of the two directions this can fail in. An absent state version reads as "this workspace has never run", so a promoted node does not error — it plans the entire estate as a first-time create. The operator sees a plan, not a fault.

## Why it was like that

The 27 replicated classes describe how the estate is **configured**. Nothing described what it had **done**.

That was coherent while the object store was unreplicated — a row naming a blob this node does not hold is a promise it cannot keep, which is exactly the rationale already recorded in the registry against `registry_module_versions`. #1114 copies the blobs, and that inverts the argument: the object now arrives and nothing points at it.

## What joins the scope

- **`state_versions`** — every version, not only the current one, matching what `blob_classes._resolve_state` already copies. Rollback is a shipped feature, so a node holding only HEAD has lost rollback depth while looking perfectly healthy.
- **`configuration_versions`** — #1114 calls this the sharpest omission and it is right. A VCS-connected workspace can refetch its configuration; a CLI-uploaded, catalog-provisioned or migrated one cannot. Losing the row means those workspaces can never run again, while the UI still lists them as healthy.

## What deliberately does not

**`runs`.** A run row is not history, it is a live execution: `job_name`, the claiming pool, and the state a reconciler drives against a Kubernetes Job it can see. Replicating it hands the follower runs it believes itself to be executing, and a reconciler that will act on them. The run's log and plan artifacts *are* history worth keeping and are copied as blobs; the row that drives execution is not. A promoted node starting with an empty run queue is the correct outcome rather than a gap.

`state_versions.run_id` is excluded for the same reason — it is a nullable FK to that unreplicated table, so carrying it would fail the insert on the follower, trading a missing provenance link for a missing state version.

**The registry version rows** are the same shape and stay in #1175: a provider version is client-signed and immutable, so its row carries signature metadata that wants its own thought, and it needs `registry_providers` and `gpg_keys` registered ahead of it.

## The assertion that was missing

The row half and the blob half were built and tested separately, and each was correct on its own terms. Nothing asserted the *pair* — that for every copied object there is a row on the receiving node naming it.

`scripts/ha-smoke.sh` now does, and distinguishes the two failures rather than timing out generically:

```
0:1 → the object copied but no row names it — a promoted node would plan
      the estate as a first-time create (#1175)
1:0 → the row replicated but its object did not — the workspace lists a
      version that cannot be read
```

Both new classes carry the full matrix the gate derives (backfill-from-empty, delta-apply, idempotent-reapply, delete, backfill-converges-deletion), plus tests pinning that `run_id` never reaches the wire and that `runs` is not a replicated class — so registering it later becomes a deliberate act with the reconciler consequences thought through, rather than a tidy-up.

**Verified live on a real two-node pair:** `ok  the state version arrived as a row AND an object`.

`make test`: 3990 passed. No contract snapshot moved — this is registration and tests, no schema or route change.

Part of #1175. Part of #960.