### PR TITLE
fix(1177): let CI date the package-refresh, so security patches stop waiting on a human

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       is_tag: ${{ steps.meta.outputs.is_tag }}
       is_pr: ${{ steps.meta.outputs.is_pr }}
       version: ${{ steps.meta.outputs.version }}
+      pkg_refresh: ${{ steps.meta.outputs.pkg_refresh }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -41,6 +42,16 @@ jobs:
         run: |
           sha_short="${GITHUB_SHA::7}"
           echo "sha_short=$sha_short" >> "$GITHUB_OUTPUT"
+
+          # Busts the images' apt-upgrade layer once a day, so Debian security
+          # patches published since the last build actually land. The Dockerfiles
+          # carry a hardcoded default for local builds; leaving CI on that default
+          # meant the layer stayed cached from whenever a human last bumped it,
+          # and the upgrade silently stopped upgrading (#1177).
+          #
+          # Daily rather than per-run deliberately: $GITHUB_RUN_ID would rebuild
+          # every image on every build and throw the cache away entirely.
+          echo "pkg_refresh=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
           is_tag=false
           is_pr=false
@@ -1238,6 +1249,8 @@ jobs:
           push: ${{ needs.prepare.outputs.is_pr != 'true' }}
           load: ${{ needs.prepare.outputs.is_pr == 'true' }}
           tags: ${{ env.REGISTRY }}/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-amd64
+          build-args: |
+            PKG_REFRESH=${{ needs.prepare.outputs.pkg_refresh }}
           cache-from: type=gha,scope=${{ matrix.image }}-amd64
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-amd64
 
@@ -1313,6 +1326,8 @@ jobs:
           push: ${{ needs.prepare.outputs.is_pr != 'true' }}
           load: ${{ needs.prepare.outputs.is_pr == 'true' }}
           tags: ${{ env.REGISTRY }}/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-arm64
+          build-args: |
+            PKG_REFRESH=${{ needs.prepare.outputs.pkg_refresh }}
           cache-from: type=gha,scope=${{ matrix.image }}-arm64
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-arm64
 

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -49,16 +49,18 @@ FROM python:3.13-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # Runtime-only system libraries (no gcc, no -dev headers)
-# apt-get upgrade picks up security patches for base OS packages (e.g. glibc)
 # `git` is required for VCS sparse fetch (subprocess driver in services/git_fetch.py).
+# The distro publishes security patches continuously, but this layer caches: an
+# unchanged RUN keeps whatever package versions were current when the cache entry
+# was written. PKG_REFRESH is what invalidates it.
 #
-# Bump APT_REFRESH to invalidate the cached layer and re-pull Debian
-# security patches (e.g. libnghttp2-14 1.64.0-1.1+deb13u1 for
-# CVE-2026-27135). Without this the apt-upgrade layer is reused from
-# before the patch was published — same cache-staleness issue the
-# runner image's APK_REFRESH solves.
-ARG APT_REFRESH=2026-07-13
-RUN echo "apt-refresh=${APT_REFRESH}" \
+# CI passes today's date, so the upgrade re-runs on the first build of each day
+# with nobody needing to remember anything. The default below is for local
+# builds and is deliberately NOT what keeps CI current — a hand-bumped constant
+# works only until someone forgets, which is how five already-patched libexpat
+# CVEs stayed in the images for 18 days (#1177).
+ARG PKG_REFRESH=2026-07-13
+RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     git \

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -19,10 +19,17 @@ RUN pip install --no-cache-dir .
 FROM python:3.13-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
-# Bump APT_REFRESH to bust the cached apt layer and re-pull Debian
-# security patches (CVE-2026-27135 etc.) — see Dockerfile.api.
-ARG APT_REFRESH=2026-07-13
-RUN echo "apt-refresh=${APT_REFRESH}" \
+# The distro publishes security patches continuously, but this layer caches: an
+# unchanged RUN keeps whatever package versions were current when the cache entry
+# was written. PKG_REFRESH is what invalidates it.
+#
+# CI passes today's date, so the upgrade re-runs on the first build of each day
+# with nobody needing to remember anything. The default below is for local
+# builds and is deliberately NOT what keeps CI current — a hand-bumped constant
+# works only until someone forgets, which is how five already-patched libexpat
+# CVEs stayed in the images for 18 days (#1177).
+ARG PKG_REFRESH=2026-07-13
+RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -18,11 +18,18 @@ RUN pip install --no-cache-dir .
 FROM python:3.13-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
-# Pick up post-publish Debian security patches. Bump APT_REFRESH to
-# bust the cached apt layer and re-pull patches (CVE-2026-27135 etc.) —
 # see Dockerfile.api. No new packages installed — just upgrades.
-ARG APT_REFRESH=2026-07-13
-RUN echo "apt-refresh=${APT_REFRESH}" \
+# The distro publishes security patches continuously, but this layer caches: an
+# unchanged RUN keeps whatever package versions were current when the cache entry
+# was written. PKG_REFRESH is what invalidates it.
+#
+# CI passes today's date, so the upgrade re-runs on the first build of each day
+# with nobody needing to remember anything. The default below is for local
+# builds and is deliberately NOT what keeps CI current — a hand-bumped constant
+# works only until someone forgets, which is how five already-patched libexpat
+# CVEs stayed in the images for 18 days (#1177).
+ARG PKG_REFRESH=2026-07-13
+RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -77,10 +77,17 @@ RUN pip install --no-cache-dir .
 FROM python:3.13-slim
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
-# Bump APT_REFRESH to bust the cached apt layer and re-pull Debian
-# security patches. See Dockerfile.api for the same pattern.
-ARG APT_REFRESH=2026-07-13
-RUN echo "apt-refresh=${APT_REFRESH}" \
+# The distro publishes security patches continuously, but this layer caches: an
+# unchanged RUN keeps whatever package versions were current when the cache entry
+# was written. PKG_REFRESH is what invalidates it.
+#
+# CI passes today's date, so the upgrade re-runs on the first build of each day
+# with nobody needing to remember anything. The default below is for local
+# builds and is deliberately NOT what keeps CI current — a hand-bumped constant
+# works only until someone forgets, which is how five already-patched libexpat
+# CVEs stayed in the images for 18 days (#1177).
+ARG PKG_REFRESH=2026-07-13
+RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
         git \
         openssh-client \

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -48,7 +48,13 @@ COPY --from=builder /app/public ./public
 
 # Remove npm and its bundled dependencies (not needed at runtime;
 # eliminates CVEs in npm-internal minimatch, tar, etc.)
-RUN apk upgrade --no-cache \
+#
+# PKG_REFRESH exists for the `apk upgrade` above it, for the same reason the
+# Debian images carry one: this layer caches, so without something that changes
+# the upgrade silently stops upgrading. CI passes today's date (#1177).
+ARG PKG_REFRESH=2026-07-13
+RUN echo "pkg-refresh=${PKG_REFRESH}" \
+    && apk upgrade --no-cache \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
     && addgroup -g 1001 -S nodejs \
     && adduser -S nextjs -u 1001 -G nodejs \


### PR DESCRIPTION
Five HIGH `libexpat1` CVEs failed the scans on #1176 — a PR that adds only Python and a shell script. All five were **already patched upstream**; the images had simply not picked the patch up.

## What was actually wrong

The cache-bust exists and is correctly plumbed — the `ARG` is referenced by the `RUN` it guards, so changing it does invalidate the layer:

```dockerfile
ARG APT_REFRESH=2026-07-13
RUN echo "apt-refresh=${APT_REFRESH}" \
    && apt-get update && apt-get upgrade -y && ...
```

Two things made it inert:

1. the value is a **hardcoded constant**, last bumped 18 days earlier;
2. **CI passed no `build-args` at all**, so every build used that stale default.

The instruction to bump it lived in a comment, which makes patching a chore somebody has to remember on a cadence nobody owns. And it fails silently, because the Dockerfile still *says* it upgrades. `libexpat 2.8.2-1~deb13u1` was published inside that window and never landed.

*(My first read of this was wrong — I assumed the caching had gone unnoticed. It had not; the mechanism was deliberate. The defect is narrower and more human, and #1177 is corrected to say so.)*

## Fix

CI supplies **today's date**, so the upgrade re-runs on the first build of each day with nobody in the loop.

- **Daily, not per-run.** `github.run_id` would bust the layer on every build and throw the cache away entirely — trading one problem for a slower one.
- **One value for both architectures**, taken from a single `prepare` output, so a build straddling midnight cannot produce two images with different package sets.
- **Renamed `APT_REFRESH` → `PKG_REFRESH`** and extended it to `Dockerfile.web`, which runs `apk upgrade` with no guard at all and had the same staleness for the same reason. One build-arg now covers all five images.
- The Dockerfile default stays for local builds, and the comments now say plainly that it is *not* what keeps CI current.

## Verified

Built the api image both ways:

| | `libexpat1` |
|---|---|
| today's `PKG_REFRESH` (local build) | **`2.8.2-1~deb13u1`** — patched |
| unmodified code (CI's own scan) | `2.7.1-2` — the five HIGH findings |

The second row is the negative control, produced by CI itself before this change.

## Expected effect

The next build of each image rebuilds from the apt layer down and should clear all five findings **without any `.trivyignore` entry**, since a fix exists. Step G of the pre-release audit exists to stop ignore-entries accumulating as silent debt; this is the same shape one level down, where the *patching* was the debt.

Closes #1177.