### PR TITLE
fix(1180): one unappliable row no longer stops all replication

### DIFF
--- a/services/terrapod/services/replication_sync.py
+++ b/services/terrapod/services/replication_sync.py
@@ -164,6 +164,48 @@ async def _apply_event(
     await replication.apply_upsert(db, spec, resp.json()["data"]["attributes"])
 
 
+async def _try_apply(db: AsyncSession, client: httpx.AsyncClient, token: str, event: dict) -> bool:
+    """Apply one event inside its own savepoint. False when it could not land.
+
+    One row must never be able to stop the stream. Before this, an apply that
+    raised aborted the whole cycle and left the cursor unmoved, so the next
+    cycle re-fetched the same row and failed identically — replication for
+    EVERY class stopped, silently, until someone noticed at a failover (#1180).
+
+    `_apply_event` already reasons this way for a class the peer knows and this
+    node does not ("failing would wedge the whole stream on one unknown row").
+    This is the same argument applied to the rows themselves.
+    """
+    try:
+        async with db.begin_nested():
+            await _apply_event(db, client, token, event)
+        return True
+    except Exception:
+        logger.warning(
+            "Could not apply a replicated row; deferring it",
+            entity_class=event["entity-class"],
+            entity_id=event["entity-id"],
+            op=event["op"],
+            exc_info=True,
+        )
+        return False
+
+
+async def _try_upsert(db: AsyncSession, spec, attributes: dict) -> bool:
+    """Backfill's equivalent of `_try_apply` — one row, one savepoint."""
+    try:
+        async with db.begin_nested():
+            await replication.apply_upsert(db, spec, attributes)
+        return True
+    except Exception:
+        logger.warning(
+            "Could not apply a backfilled row; deferring it",
+            entity_class=spec.name,
+            exc_info=True,
+        )
+        return False
+
+
 async def backfill_class(
     db: AsyncSession, client: httpx.AsyncClient, token: str, entity_class: str
 ) -> int:
@@ -192,6 +234,14 @@ async def backfill_class(
     # judge what is missing.
     from_scratch = not after
     seen: set[str] = set()
+    deferred: list[dict] = []
+
+    # Claim the class as in-progress before the first page. Completion clears
+    # it, so `backfilling` is an unambiguous "this pass never finished" — which
+    # is what `backfill_pending_classes` retries on, and is why a pod restart
+    # part-way through a large class now resumes instead of being forgotten.
+    await _set_cursor(db, entity_class, after or "", backfilling=True)
+    await db.commit()
 
     while True:
         resp = await arequest_with_retry(
@@ -205,9 +255,11 @@ async def backfill_class(
         resp.raise_for_status()
         body = resp.json()
         for row in body["data"]:
-            await replication.apply_upsert(db, spec, row["attributes"])
-            seen.add(str(row["id"]))
-            applied += 1
+            if await _try_upsert(db, spec, row["attributes"]):
+                seen.add(str(row["id"]))
+                applied += 1
+            else:
+                deferred.append(row)
         after = body["meta"]["cursor"]
         # Persist per page so an interrupted backfill resumes rather than
         # restarting a large class from the beginning.
@@ -215,6 +267,34 @@ async def backfill_class(
         await db.commit()
         if body["meta"]["complete"]:
             break
+
+    # One retry pass over the rows that would not land. Ordering within a class
+    # is the usual reason (a row referencing another row of the same class that
+    # had not arrived yet), and retrying resolves it without a dependency graph.
+    if deferred:
+        still: list[dict] = []
+        for row in deferred:
+            if await _try_upsert(db, spec, row["attributes"]):
+                seen.add(str(row["id"]))
+                applied += 1
+            else:
+                still.append(row)
+        deferred = still
+        await db.commit()
+
+    if deferred:
+        # An incomplete pass must not be recorded as finished: leaving
+        # `backfilling` set is what makes the next cycle try this class again.
+        # Reconciliation is skipped for the same reason it is skipped on a
+        # resumed pass — `seen` is not the peer's full set, and acting on a
+        # partial view reads as mass deletion.
+        logger.warning(
+            "Backfill left rows unapplied; the class stays pending",
+            entity_class=entity_class,
+            unapplied=len(deferred),
+            applied=applied,
+        )
+        return applied
 
     removed = 0
     if from_scratch:
@@ -239,10 +319,10 @@ async def backfill_class(
     return applied
 
 
-async def backfill_new_classes(
+async def backfill_pending_classes(
     db: AsyncSession, client: httpx.AsyncClient, token: str
 ) -> list[str]:
-    """Backfill any class this node has never pulled, and say which.
+    """Backfill any class that has never completed a pull, and say which.
 
     A class that is newly REGISTERED has the same problem as a newly ADDED
     node: there are no deltas to carry it. Everything that existed before the
@@ -252,23 +332,27 @@ async def backfill_new_classes(
     Deltas never replay, so without this the class stays empty on the follower
     indefinitely, and the gap only shows at a promotion (#1175).
 
-    Keyed on the absence of a cursor row rather than on a version number, so it
+    "Never completed" covers two states, and both need the same treatment: no
+    cursor row at all (never started), and a cursor still marked `backfilling`
+    (started, never finished — a pod restart part-way, or a pass that could not
+    land every row). Keying on those rather than on a version number means it
     needs nothing declared and cannot be forgotten when the next class is
     registered: registering one is still the whole opt-in.
 
     Cheap in the steady state — one indexed cursor lookup per class per cycle,
-    and nothing to do once each has been pulled once.
+    and nothing to do once each has completed once.
     """
     started: list[str] = []
     for entity_class in replication.registered():
         row = await db.scalar(
             select(ReplicationCursor).where(ReplicationCursor.entity_class == entity_class)
         )
-        if row is not None:
+        if row is not None and not row.backfilling:
             continue
         logger.info(
-            "Backfilling a newly registered class; it has no deltas to carry it",
+            "Backfilling a class that has never completed a pull",
             entity_class=entity_class,
+            resuming=row is not None,
         )
         await backfill_class(db, client, token, entity_class)
         started.append(entity_class)
@@ -336,24 +420,70 @@ async def sync_cycle() -> None:
                 await db.commit()
                 return
 
-            # Before applying deltas: pull anything registered since this node
-            # last ran. A class with no cursor has never been backfilled, and
-            # no delta will ever carry what predates its registration.
-            await backfill_new_classes(db, client, token)
-
             own = settings.ha.node_name
             applied = 0
+            deferred: list[dict] = []
+            # The cursor may only advance across a contiguous run of settled
+            # events: the first deferred one caps it, so it is re-fetched next
+            # cycle rather than lost. Re-applying the events after it costs
+            # nothing — an event is a notification, not a snapshot, so every
+            # apply is an idempotent upsert of the peer's current state.
+            safe_cursor: int | None = None
+            blocked = False
+
             for event in body["data"]:
                 # Origin tags stop the pair echoing changes at each other: a row
                 # this node originated must not be applied back onto itself.
                 if event["origin-node"] and event["origin-node"] == own:
+                    if not blocked:
+                        safe_cursor = event["id"]
                     continue
-                await _apply_event(db, client, token, event)
-                applied += 1
+                if await _try_apply(db, client, token, event):
+                    applied += 1
+                    if not blocked:
+                        safe_cursor = event["id"]
+                else:
+                    deferred.append(event)
+                    blocked = True
 
-            await _set_cursor(db, replication.EVENT_STREAM, str(body["meta"]["cursor"]))
+            # A child whose parent arrives later in the same batch fails on the
+            # first pass and lands on this one, which is the common ordering
+            # case and needs no dependency graph to resolve.
+            if deferred:
+                still: list[dict] = []
+                for event in deferred:
+                    if await _try_apply(db, client, token, event):
+                        applied += 1
+                    else:
+                        still.append(event)
+                deferred = still
+                if not deferred:
+                    safe_cursor = body["meta"]["cursor"]
+
+            if safe_cursor is not None:
+                await _set_cursor(db, replication.EVENT_STREAM, str(safe_cursor))
             _record_lag(await _get_cursor(db, replication.EVENT_STREAM), body["meta"])
+
+            # AFTER the deltas, not before. A class registered since this node
+            # last ran has no deltas to carry it, but its rows routinely point
+            # at parents in ESTABLISHED classes whose own rows are still sitting
+            # unapplied in this batch — backfilling first pulled a configuration
+            # version whose workspace did not exist yet (#1180).
+            await backfill_pending_classes(db, client, token)
             await db.commit()
+
+            if deferred:
+                # Holding the cursor is also what makes this visible without a
+                # new signal: the lag recorded above is peer-latest minus the
+                # cursor, so a row that never lands shows as replication lag
+                # that climbs and does not recover — which the HA page and the
+                # existing gauges already report.
+                logger.warning(
+                    "Replication rows could not be applied; holding the cursor",
+                    unapplied=len(deferred),
+                    classes=sorted({e["entity-class"] for e in deferred}),
+                    cursor_held_at=safe_cursor,
+                )
 
             if applied:
                 logger.info(

--- a/services/tests/services/test_replication_registry_artifacts.py
+++ b/services/tests/services/test_replication_registry_artifacts.py
@@ -458,7 +458,7 @@ class TestNewlyRegisteredClassesBackfill:
             return 0
 
         with patch.object(replication_sync, "backfill_class", fake_backfill):
-            started = await replication_sync.backfill_new_classes(db, AsyncMock(), "tok")
+            started = await replication_sync.backfill_pending_classes(db, AsyncMock(), "tok")
 
         assert "registry_module_versions" in started
         assert "state_versions" in started
@@ -471,7 +471,8 @@ class TestNewlyRegisteredClassesBackfill:
         from terrapod.services import replication_sync
 
         db = AsyncMock()
-        db.scalar.return_value = MagicMock()  # a cursor exists for every class
+        # A cursor exists for every class, and none is mid-backfill.
+        db.scalar.return_value = MagicMock(backfilling=False)
         pulled = []
 
         async def fake_backfill(_db, _client, _token, entity_class):
@@ -479,18 +480,133 @@ class TestNewlyRegisteredClassesBackfill:
             return 0
 
         with patch.object(replication_sync, "backfill_class", fake_backfill):
-            started = await replication_sync.backfill_new_classes(db, AsyncMock(), "tok")
+            started = await replication_sync.backfill_pending_classes(db, AsyncMock(), "tok")
 
         assert started == []
         assert pulled == []
 
-    def test_it_runs_before_deltas_are_applied(self):
-        """Order matters: a delta for a class that has not been backfilled can
-        reference a parent row that is not there yet."""
+    async def test_a_class_stuck_mid_backfill_is_retried(self):
+        """A pass that never finished — a pod restart part-way, or rows that
+        would not land — must be picked up again. Its cursor row exists, so
+        keying on "no cursor" alone would leave it half-populated forever."""
+        from unittest.mock import patch
+
+        from terrapod.services import replication_sync
+
+        db = AsyncMock()
+        db.scalar.return_value = MagicMock(backfilling=True)
+        pulled = []
+
+        async def fake_backfill(_db, _client, _token, entity_class):
+            pulled.append(entity_class)
+            return 0
+
+        with patch.object(replication_sync, "backfill_class", fake_backfill):
+            started = await replication_sync.backfill_pending_classes(db, AsyncMock(), "tok")
+
+        assert "state_versions" in started
+        assert pulled == started
+
+    def test_it_runs_after_deltas_are_applied(self):
+        """The ordering that looks right is the wrong way round (#1180).
+
+        Backfilling first pulled a configuration version whose workspace was
+        still sitting unapplied in the same batch — because the parent of a
+        newly registered child class is usually an ESTABLISHED class, whose
+        rows arrive only as deltas. The reverse hazard (a delta referencing a
+        parent that is only obtainable by backfill) is handled by the per-row
+        savepoint and retry instead, which costs nothing when it does not fire.
+        """
         import inspect as py_inspect
 
         from terrapod.services import replication_sync
 
         source = py_inspect.getsource(replication_sync.sync_cycle)
 
-        assert source.index("backfill_new_classes") < source.index("_apply_event")
+        assert source.index("_try_apply") < source.index("backfill_pending_classes")
+
+
+class TestOneBadRowDoesNotStopTheStream:
+    """#1180 — found on the live pair.
+
+    A foreign-key violation on ONE configuration version aborted the whole
+    cycle. The transaction rolled back, the cursor never moved, and the next
+    cycle re-fetched the same row and failed identically: replication stopped
+    for every class, silently, with the gap only discovered at a failover.
+    """
+
+    async def test_a_failing_row_is_deferred_not_raised(self):
+        from unittest.mock import patch
+
+        from terrapod.services import replication_sync
+
+        db = AsyncMock()
+        # `begin_nested()` returns an async context manager, not a coroutine —
+        # mocking it as one would make the savepoint a no-op and this test a lie.
+        db.begin_nested = MagicMock(return_value=MagicMock())
+        event = {
+            "id": 7,
+            "entity-class": "configuration_versions",
+            "entity-id": "cv-1",
+            "op": "upsert",
+            "origin-node": "leader",
+        }
+
+        async def boom(*_a, **_kw):
+            raise RuntimeError("violates foreign key constraint")
+
+        with patch.object(replication_sync, "_apply_event", boom):
+            ok = await replication_sync._try_apply(db, AsyncMock(), "tok", event)
+
+        assert ok is False, "a row that cannot land must be reported, not raised"
+        db.begin_nested.assert_called_once(), "it must roll back only its own row"
+
+    async def test_a_deferred_row_holds_the_cursor_where_it_is(self):
+        """The cursor may not advance past a row that has not been applied, or
+        the row is lost — the next pull starts after it and nothing replays."""
+        import inspect as py_inspect
+
+        from terrapod.services import replication_sync
+
+        source = py_inspect.getsource(replication_sync.sync_cycle)
+
+        # The advance is conditional on a settled position, never the batch end.
+        assert "if safe_cursor is not None:" in source
+        assert "blocked = True" in source
+        # And the batch end is only taken once nothing is left deferred.
+        assert (
+            'if not deferred:\n                    safe_cursor = body["meta"]["cursor"]' in source
+        )
+
+    async def test_backfill_defers_a_bad_row_rather_than_aborting_the_class(self):
+        from unittest.mock import patch
+
+        from terrapod.services import replication_sync
+
+        db = AsyncMock()
+        db.begin_nested = MagicMock(return_value=MagicMock())
+
+        async def boom(*_a, **_kw):
+            raise RuntimeError("violates foreign key constraint")
+
+        with patch.object(replication_sync.replication, "apply_upsert", boom):
+            ok = await replication_sync._try_upsert(db, MagicMock(name="spec"), {"id": "x"})
+
+        assert ok is False
+
+    def test_an_incomplete_backfill_stays_pending(self):
+        """Leaving `backfilling` set is what makes the class retry; clearing it
+        would record a half-populated class as finished. Reconciliation must be
+        skipped too — a partial view of the peer's rows reads as mass deletion.
+        """
+        import inspect as py_inspect
+
+        from terrapod.services import replication_sync
+
+        source = py_inspect.getsource(replication_sync.backfill_class)
+
+        # The early return on leftovers comes before both reconciliation and
+        # the completion write that clears `backfilling`.
+        leftover = source.index("the class stays pending")
+        assert leftover < source.index("reconcile_deletions")
+        assert leftover < source.index('_set_cursor(db, entity_class, "", backfilling=False)')

--- a/services/tests/services/test_replication_sync.py
+++ b/services/tests/services/test_replication_sync.py
@@ -38,8 +38,21 @@ def _resp(status=200, body=None):
     return r
 
 
+def _db(**kw):
+    """An AsyncMock session whose `begin_nested()` behaves like the real
+    `AsyncSession`'s — an async context manager, not a coroutine.
+
+    Every row now applies inside a savepoint so one bad row cannot stop the
+    stream (#1180). A mock that cannot open one makes every row look unappliable,
+    which is a lie about the code under test rather than a finding.
+    """
+    db = AsyncMock(**kw)
+    db.begin_nested = MagicMock(return_value=MagicMock())
+    return db
+
+
 def _db_with_cursor(position="0"):
-    db = AsyncMock()
+    db = _db()
     db.scalar.return_value = ReplicationCursor(
         entity_class="*", position=position, backfilling=False
     )
@@ -256,7 +269,7 @@ class TestApplyEvent:
         delete event settles it; failing here would wedge the whole stream."""
         mock_settings.ha = _cfg()
         mock_request.return_value = _resp(status=404)
-        db = AsyncMock()
+        db = _db()
 
         await replication_sync._apply_event(
             db,
@@ -272,7 +285,7 @@ class TestApplyEvent:
         """A newer peer replicating a class this node lacks must not wedge the
         stream on one unrecognised row."""
         mock_settings.ha = _cfg()
-        db = AsyncMock()
+        db = _db()
 
         await replication_sync._apply_event(
             db,
@@ -349,7 +362,7 @@ class TestBackfillPaging:
     async def test_an_unknown_class_backfills_nothing(self, mock_settings):
         mock_settings.ha = _cfg()
 
-        count = await replication_sync.backfill_class(AsyncMock(), MagicMock(), "t", "nope")
+        count = await replication_sync.backfill_class(_db(), MagicMock(), "t", "nope")
 
         assert count == 0
 
@@ -359,7 +372,7 @@ class TestBackfillPaging:
         """A join token cannot be inserted before its pool exists."""
         mock_settings.ha = _cfg()
 
-        await replication_sync.backfill_all(AsyncMock(), MagicMock(), "tok")
+        await replication_sync.backfill_all(_db(), MagicMock(), "tok")
 
         order = [c.args[3] for c in mock_class.await_args_list]
         assert order.index("agent_pools") < order.index("agent_pool_tokens")
@@ -482,7 +495,7 @@ class TestBackfillIsRepeatable:
         mock_settings.ha = _cfg()
         mock_reconcile.return_value = []
         cursor = ReplicationCursor(entity_class="agent_pools", position="", backfilling=False)
-        db = AsyncMock()
+        db = _db()
         db.scalar.return_value = cursor
         mock_request.return_value = _resp(
             body={
@@ -504,7 +517,7 @@ class TestBackfillIsRepeatable:
     ):
         mock_settings.ha = _cfg()
         cursor = ReplicationCursor(entity_class="agent_pools", position="", backfilling=False)
-        db = AsyncMock()
+        db = _db()
         db.scalar.return_value = cursor
         mock_request.side_effect = [
             _resp(


### PR DESCRIPTION
Found on the live pair while verifying the artifact plane for #1114. A foreign-key violation on **one** configuration version aborted the entire cycle:

```
Periodic task failed  task=replication_sync
ForeignKeyViolationError: insert or update on table "configuration_versions"
  violates foreign key constraint … Key (workspace_id)=(…) is not present in table "workspaces".
```

The transaction rolled back, so the cursor never advanced, so the next cycle re-fetched the same row and failed identically. Twelve polls later **nothing** had converged — not the state version, not the configuration version, not even the workspace, which has replicated since phase 3. Replication was dead for every class.

The failure shape is the worst available: silent (a log line on the follower, nothing on the leader), unbounded (it never self-heals), and only discovered at a **failover**, when the promoted node turns out to be frozen at whenever the first bad row arrived.

## One row must not be able to stop the stream

Every row now applies inside its own savepoint. A row that cannot land is **deferred**, not raised.

`_apply_event` already reasoned this way for one case — a class the peer knows and this node does not:

> Skipping is correct and additive-safe; **failing would wedge the whole stream on one unknown row**.

That was right, and it was never extended to the rows themselves. This does that.

**The cursor stops at the first deferred event**, so the row is retried next cycle rather than lost. Re-applying the events after it costs nothing: an event is a notification, not a snapshot, so every apply is an idempotent upsert of the peer's current state. A **single retry pass** at the end of the batch settles the ordinary case — a child whose parent arrives later in the same batch — without needing a dependency graph.

Holding the cursor is also what makes this visible without inventing a signal: lag is peer-latest minus cursor, so a row that never lands shows as replication lag that climbs and does not recover, which the HA page and the existing gauges already report.

Backfill gets the same per-row isolation, and an incomplete pass now **stays pending** rather than recording a half-populated class as finished. Reconciliation is skipped for the same reason it is skipped on a resumed pass: a partial view of the peer's rows reads as mass deletion. That also fixes a hole nobody had hit yet — a backfill interrupted by a pod restart now resumes instead of being forgotten, because `backfilling` is finally an unambiguous "never completed".

## The ordering that caused it

`backfill_new_classes` (added in #1175, now `backfill_pending_classes`) ran **before** the delta pass, so it pulled a configuration version whose workspace was still sitting unapplied in the event stream.

The comment argued for that ordering — a delta can reference a parent that has not been backfilled — but the reverse hazard is just as real and fires first, because **the parent of a newly registered child class is usually an established class**, whose rows arrive only as deltas. It moves after the deltas; the reverse case is now covered by the savepoint and retry, which cost nothing when they do not fire.

Fixing only the ordering would have papered over this instance and left the class of bug intact.

## Verified live

The pair was left **wedged** from the failure above. After deploying this — with no intervention, no cursor surgery, nothing reset — it healed itself:

```
Applied replication events  applied=4 cursor=16
```

No deferrals, no task failure, and the follower converged on the next poll across both planes:

```
t1: ws=True state_row=True state_blob=True cv_row=True cv_blob=True
>>> CONVERGED both planes; state bytes on follower = b'{"version":4,"serial":1,"lineage":"probe"}'
```

`make test`: 4028 passed. New regression tests pin the deferral, the held cursor, the backfill isolation, and the corrected ordering — the last of which replaces an assertion that pinned the ordering the wrong way round.

Closes #1180. Part of #960.