### PR TITLE
fix(1181): namespace-qualify cluster-scoped names so two installs can share a cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,6 +686,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Two installs in one cluster cannot collide on a cluster-scoped name
+        run: |
+          # Terrapod is single-organization, so separating business units means
+          # running an instance per tenant — two in one cluster is a topology we
+          # recommend. A cluster-scoped object has no namespace to disambiguate
+          # it, so the SAME release name in two namespaces must still render
+          # distinct names, or one install silently breaks the other (#1181).
+          render() {
+            docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+              template terrapod helm/terrapod --namespace "$1" \
+              --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+              --set redis.url=redis://redis:6379 \
+            | awk '/^kind: Cluster|^kind: PriorityClass|^kind: .*WebhookConfiguration/ {k=1}
+                   k && /^  name:/ {print $2; k=0}'
+          }
+          a=$(render bu-alpha)
+          b=$(render bu-beta)
+          echo "bu-alpha: $a"
+          echo "bu-beta:  $b"
+          if [ -z "$a" ]; then echo "no cluster-scoped objects found — check the awk filter"; exit 1; fi
+          if [ -n "$(comm -12 <(echo "$a" | sort) <(echo "$b" | sort))" ]; then
+            echo "FAIL: a cluster-scoped name is identical across namespaces."
+            echo "Use the terrapod.clusterScopedName helper, not terrapod.fullname."
+            exit 1
+          fi
+
       - name: Stock install renders a working stack (web + Ingress + bootstrap)
         run: |
           out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,8 @@ Terrapod is deliberately **single-organization**: there is exactly one implicit 
 
 **What you give up, and why it's worth it.** You cannot present several *named* organizations through one endpoint. In exchange, the platform sheds an entire axis of complexity — no org column on every table, no org-scoped RBAC and membership, no org switcher — that a single-company, self-hosted deployment does not need. If your requirement is truly multi-tenant (separate, mutually-distrusting tenants), run an instance per tenant; if it is segmentation within one company, labels already do it.
 
+**Running several instances in one cluster is supported.** Each install is a separate release in its own namespace, with its own database, object storage and Redis — nothing is shared, and the namespace is the boundary. Give each install its **own release name** as well; the chart namespace-qualifies the cluster-scoped objects it creates (a `ClusterRole` and binding for reading nodes), so identical release names in different namespaces no longer collide, but distinct release names keep every object name obviously attributable to one install.
+
 ---
 
 ## System Components

--- a/helm/terrapod/templates/_helpers.tpl
+++ b/helm/terrapod/templates/_helpers.tpl
@@ -22,6 +22,27 @@ Create a default fully qualified app name.
 {{- end }}
 
 {{/*
+Name for a CLUSTER-SCOPED object. Use this for every ClusterRole,
+ClusterRoleBinding, PriorityClass, webhook configuration — anything without a
+namespace — and never `terrapod.fullname` on its own.
+
+Terrapod is single-organization by design, so separating business units means
+running an instance per tenant, and two instances in one cluster is a topology
+we actively recommend. `terrapod.fullname` is derived from the release name, so
+two installs in different namespaces that share one — `helm install terrapod` in
+each, the obvious thing to do — render the IDENTICAL cluster-scoped object.
+
+Then either the second install fails outright (the object is owned by another
+release), or, if it is adopted, the binding's subjects are replaced and the first
+install silently loses the permission; and `helm uninstall` of either deletes the
+shared object out from under the one still running. Qualifying with the namespace
+makes the name unique by construction rather than by operator convention (#1181).
+*/}}
+{{- define "terrapod.clusterScopedName" -}}
+{{- printf "%s-%s" (include "terrapod.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "terrapod.chart" -}}

--- a/helm/terrapod/templates/rbac-api.yaml
+++ b/helm/terrapod/templates/rbac-api.yaml
@@ -72,7 +72,7 @@ on Nodes.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "terrapod.fullname" . }}-node-reader
+  name: {{ include "terrapod.clusterScopedName" . }}-node-reader
   labels:
     {{- include "terrapod.labels" . | nindent 4 }}
 rules:
@@ -83,13 +83,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "terrapod.fullname" . }}-node-reader
+  name: {{ include "terrapod.clusterScopedName" . }}-node-reader
   labels:
     {{- include "terrapod.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "terrapod.fullname" . }}-node-reader
+  name: {{ include "terrapod.clusterScopedName" . }}-node-reader
 subjects:
   - kind: ServiceAccount
     name: {{ include "terrapod.serviceAccountName" . }}


### PR DESCRIPTION
Terrapod is single-organization by design, so separating business units means **running an instance per tenant** — the deployment is the tenant boundary. Two instances in one cluster is therefore a topology we actively recommend, and the chart did not quite support it.

`templates/rbac-api.yaml` renders a **cluster-scoped** `ClusterRole` + `ClusterRoleBinding` named from `terrapod.fullname`, which is derived from the release name and carries no namespace — and a cluster-scoped object has no namespace to disambiguate it. Two installs in separate namespaces that share a release name, the obvious `helm install terrapod …` in each, rendered the identical object:

```
release=terrapod ns=bu-alpha  ->  ClusterRoleBinding terrapod-node-reader  subject=terrapod@bu-alpha
release=terrapod ns=bu-beta   ->  ClusterRoleBinding terrapod-node-reader  subject=terrapod@bu-beta
```

Three ways that goes wrong, in increasing order of nastiness:

1. The second `helm install` **fails outright** — the object is owned by another release. Loud, and the least harmful.
2. Adopted or force-applied, the binding's subjects are **replaced**, so the first install's ServiceAccount silently loses node read and its component-status node view degrades on an instance nobody touched.
3. `helm uninstall` of **either** deletes the shared ClusterRole and binding, breaking the one still running. Nothing reports it.

Distinct release names avoid all of it, but that was an **undocumented constraint on a topology we recommend**, discoverable only when it bit.

## The fix

A `terrapod.clusterScopedName` helper appends the namespace, so the name is unique **by construction** rather than by operator convention:

```
bu-alpha: terrapod-bu-alpha-node-reader
bu-beta:  terrapod-bu-beta-node-reader
```

This is the only cluster-scoped pair the chart renders — the `-component-status` `Role`/`RoleBinding` alongside it are namespaced and were never at risk. The helper exists so the **next** cluster-scoped resource uses it, and a new `helm-smoke` check enforces that: it renders the chart under two namespaces with the same release name and fails if any cluster-scoped name repeats. Verified locally — it passes on this branch, and the awk filter covers `Cluster*`, `PriorityClass` and webhook configurations, so a future one is caught rather than assumed.

`helm lint` passes and all three value profiles (`values`, `values-local`, `values-eval`) still render.

## Upgrade note

The rename means Helm replaces the old objects rather than updating them. They carry read-only auxiliary permissions (reading nodes for the HA component-status view), so the window is a brief degrade of that panel, not an outage — worth a line in the release notes.

The multi-install story is now stated explicitly in `docs/architecture.md`, next to the single-organization rationale that leads operators to it.

Closes #1181.