### PR TITLE
chore(960): make the HA release-gate table runnable and honest

### DIFF
--- a/scripts/ha-smoke.sh
+++ b/scripts/ha-smoke.sh
@@ -8,6 +8,7 @@
 #   scripts/ha-smoke.sh up      deploy both nodes and the shared peer secrets
 #   scripts/ha-smoke.sh verify  assert the pair actually converges
 #   scripts/ha-smoke.sh reverse swap the roles and assert it works both ways
+#   scripts/ha-smoke.sh table   walk the #960 release-gate table, honestly
 #   scripts/ha-smoke.sh down    remove node B
 #
 # The peer link runs over in-cluster Service DNS. That is not a shortcut:
@@ -319,6 +320,7 @@ case "${1:-}" in
   up) cmd_up ;;
   verify) cmd_verify ;;
   reverse) cmd_reverse ;;
+  table) python3 "$REPO_ROOT/scripts/ha_smoke_table.py" ;;
   down) cmd_down ;;
-  *) print "usage: $0 {up|verify|reverse|down}"; exit 2 ;;
+  *) print "usage: $0 {up|verify|reverse|table|down}"; exit 2 ;;
 esac

--- a/scripts/ha_smoke_table.py
+++ b/scripts/ha_smoke_table.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""The #960 release-gate table, run against the live two-node pair.
+
+`ha-smoke.sh up` builds the pair; this walks the fourteen scenarios #960 names
+as the gate for any release touching HA, and prints an honest result for each —
+including the rows it did not exercise and why. A partial run reported as a full
+one is the failure this script exists to prevent, so every row prints a verdict:
+PASS, FAIL, or SKIP with a reason.
+
+Run:  scripts/ha-smoke.sh table
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+CTX = "rancher-desktop"
+NS_A, NS_B = "terrapod-a", "terrapod-b"
+REL = {NS_A: "terrapod-a", NS_B: "terrapod-b"}
+
+GREEN, RED, YELLOW, CYAN, RESET = "\033[32m", "\033[31m", "\033[33m", "\033[36m", "\033[0m"
+
+results: list[tuple[str, str, str, str]] = []
+
+
+def _k(*args: str, check: bool = True) -> str:
+    out = subprocess.run(
+        ["kubectl", "--context", CTX, *args], capture_output=True, text=True
+    )
+    if check and out.returncode != 0:
+        raise RuntimeError(f"kubectl {' '.join(args)} failed:\n{out.stderr[-2000:]}")
+    return out.stdout
+
+
+PRELUDE = """
+import asyncio, sys, json
+from sqlalchemy import select, delete, func
+from terrapod.db.session import get_db_session, init_db
+from terrapod.db import models as m
+from terrapod.services import replication
+
+async def main():
+    await init_db()
+    # The outbox is installed by the API's startup, and this is not that
+    # process. Without it a row lands and no event is ever recorded, and the
+    # pair looks broken when it is not.
+    replication.install_outbox_hooks()
+    async with get_db_session() as db:
+{body}
+
+asyncio.run(main())
+"""
+
+
+def run(ns: str, body: str, check: bool = True) -> str:
+    """Execute a snippet inside the node's API pod, against its own database."""
+    code = PRELUDE.format(body="\n".join("        " + ln for ln in body.strip().splitlines()))
+    return _k("-n", ns, "exec", f"deploy/{REL[ns]}-api", "--", "python", "-c", code, check=check)
+
+
+def poll(ns: str, body: str, tries: int = 20, delay: float = 3.0) -> bool:
+    """Poll a node until `body` prints OK. Replication is asynchronous by design."""
+    for _ in range(tries):
+        if "OK" in run(ns, body, check=False):
+            return True
+        time.sleep(delay)
+    return False
+
+
+def scale(ns: str, replicas: int) -> None:
+    _k("-n", ns, "scale", f"deploy/{REL[ns]}-api", f"--replicas={replicas}")
+    if replicas:
+        _k("-n", ns, "rollout", "status", f"deploy/{REL[ns]}-api", "--timeout=180s")
+    else:
+        for _ in range(30):
+            if not _k("-n", ns, "get", "pod", "-l",
+                      "app.kubernetes.io/component=api", "-o", "name").strip():
+                return
+            time.sleep(2)
+
+
+def set_role(ns: str, role: str) -> None:
+    """Flip a node's role the way an operator would — through Helm.
+
+    If you have poked the pair with `kubectl set image` by hand, this fails with
+    a server-side-apply field conflict: `kubectl-set` now owns
+    `.spec.template.spec.containers[api].image` and Helm will not take it back.
+    Drop the stale ownership (`kubectl patch deploy … --type=json -p
+    '[{"op":"remove","path":"/metadata/managedFields"}]'`) and upgrade again.
+    Roll images through Helm on this pair and it never arises.
+    """
+    subprocess.run(
+        ["helm", "--kube-context", CTX, "upgrade", REL[ns], "helm/terrapod",
+         "-n", ns, "-f", f"helm/terrapod/values-ha-{ns[-1]}.yaml",
+         "--set", f"api.config.ha.role={role}", "--reuse-values",
+         "--wait", "--timeout", "5m"],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def record(row: str, name: str, verdict: str, detail: str = "") -> None:
+    colour = {"PASS": GREEN, "FAIL": RED, "SKIP": YELLOW}[verdict]
+    print(f"{colour}{verdict:4}{RESET} {row:>3}  {name}" + (f"  — {detail}" if detail else ""))
+    results.append((row, name, verdict, detail))
+
+
+def make_ws(ns: str, name: str) -> None:
+    run(ns, f"db.add(m.Workspace(name='{name}'))\nawait db.commit()")
+
+
+def sees_ws(name: str) -> str:
+    return (
+        f"row = await db.scalar(select(m.Workspace).where(m.Workspace.name == '{name}'))\n"
+        "print('OK' if row else 'no')"
+    )
+
+
+# --------------------------------------------------------------------------
+# The table
+# --------------------------------------------------------------------------
+
+
+def row_2_deltas(stamp: str) -> None:
+    name = f"ha-delta-{stamp}"
+    make_ws(NS_A, name)
+    record("2", "Change settings on A → delta replication",
+           "PASS" if poll(NS_B, sees_ws(name)) else "FAIL")
+
+
+def row_1_backfill(stamp: str) -> None:
+    """Drop the follower's copy AND its cursors: the adoption path exactly."""
+    name = f"ha-backfill-{stamp}"
+    make_ws(NS_A, name)
+    poll(NS_B, sees_ws(name))
+    run(NS_B, "await db.execute(delete(m.Workspace))\n"
+              "await db.execute(delete(m.ReplicationCursor))\n"
+              "await db.commit()")
+    record("1", "Bring up B against a populated A → backfill from empty",
+           "PASS" if poll(NS_B, sees_ws(name), tries=30) else "FAIL")
+
+
+def row_3_brief_outage(stamp: str) -> None:
+    name = f"ha-catchup-{stamp}"
+    scale(NS_B, 0)
+    make_ws(NS_A, name)
+    scale(NS_B, 1)
+    record("3", "B down briefly, then back → catch-up inside retention",
+           "PASS" if poll(NS_B, sees_ws(name), tries=30) else "FAIL")
+
+
+def row_4_past_retention(stamp: str) -> None:
+    """Purge the events the follower has not consumed: the gap must be
+    unrecoverable by replay, so the stale cursor must fall back to backfill."""
+    name = f"ha-stale-{stamp}"
+    scale(NS_B, 0)
+    make_ws(NS_A, name)
+    run(NS_A, "newest = await db.scalar(select(func.max(m.ReplicationEvent.id)))\n"
+              "await db.execute(delete(m.ReplicationEvent)"
+              ".where(m.ReplicationEvent.id < newest))\n"
+              "await db.commit()\n"
+              "print('purged below', newest)")
+    scale(NS_B, 1)
+    record("4", "B down past retention → automatic fallback to backfill",
+           "PASS" if poll(NS_B, sees_ws(name), tries=30) else "FAIL")
+
+
+def row_5_peer_outage(stamp: str) -> None:
+    name = f"ha-peerdown-{stamp}"
+    scale(NS_B, 0)
+    try:
+        make_ws(NS_A, name)
+        wrote = "OK" in run(NS_A, sees_ws(name), check=False)
+    finally:
+        scale(NS_B, 1)
+    record("5", "Kill B entirely; write on A → a peer outage never blocks the leader",
+           "PASS" if wrote else "FAIL",
+           "" if wrote else "the leader refused a write while its peer was down")
+
+
+def row_8_follower_inert(stamp: str) -> None:
+    """Through the real HTTP write path, not the predicate — that is the point.
+
+    A token minted on the leader replicates, so it is genuinely valid on the
+    follower; the refusal must come from leadership, not from auth.
+    """
+    token = run(NS_A, """
+from terrapod.auth import api_tokens
+raw = await api_tokens.create_api_token(
+    db, bound_to='admin', created_by='admin', kind='interactive', lifespan_hours=2)
+await db.commit()
+print('TOKEN', raw[1])
+""").split("TOKEN ")[-1].strip()
+
+    if not poll(NS_B, "n = await db.scalar(select(func.count()).select_from(m.APIToken))\n"
+                      "print('OK' if n else 'no')"):
+        record("8", "Follower is inert at the write layer", "FAIL",
+               "the token never replicated, so the refusal could not be attributed")
+        return
+
+    body = f"""
+import httpx, json
+r = httpx.post(
+    'http://localhost:8000/api/v2/organizations/default/workspaces',
+    headers={{'Authorization': 'Bearer {token}',
+             'Content-Type': 'application/vnd.api+json'}},
+    json={{'data': {{'type': 'workspaces',
+                    'attributes': {{'name': 'ha-inert-{stamp}'}}}}}},
+    timeout=30.0)
+print('STATUS', r.status_code, r.text[:300])
+"""
+    out = _k("-n", NS_B, "exec", f"deploy/{REL[NS_B]}-api", "--", "python", "-c", body)
+    status = out.split("STATUS ")[-1].split()[0]
+    created = "OK" in run(NS_B, sees_ws(f"ha-inert-{stamp}"), check=False)
+    ok = status not in ("200", "201") and not created
+    record("8", "Follower refuses a write through the real API path",
+           "PASS" if ok else "FAIL",
+           f"HTTP {status}" + (", and the row was NOT created" if ok else ", but the write LANDED"))
+
+
+def row_11_sensitive(stamp: str) -> None:
+    """Encrypted at rest per node, so the value must decrypt on the receiver —
+    the round trip, not just the ciphertext, is what has to survive."""
+    ws = f"ha-sens-{stamp}"
+    secret = f"s3cr3t-{stamp}"
+    run(NS_A, f"""
+ws = m.Workspace(name='{ws}')
+db.add(ws)
+await db.flush()
+db.add(m.Variable(workspace_id=ws.id, key='tok', value='{secret}',
+                  category='terraform', sensitive=True))
+await db.commit()
+""")
+    body = f"""
+ws = await db.scalar(select(m.Workspace).where(m.Workspace.name == '{ws}'))
+if ws is None:
+    print('no')
+else:
+    v = await db.scalar(select(m.Variable).where(m.Variable.workspace_id == ws.id))
+    print('OK' if v is not None and v.value == '{secret}' else 'no')
+"""
+    record("11", "Sensitive variable round-trips decrypt-on-send / re-encrypt-on-receive",
+           "PASS" if poll(NS_B, body) else "FAIL")
+
+
+def row_12_token(stamp: str) -> None:
+    ok = poll(NS_B, "n = await db.scalar(select(func.count()).select_from(m.APIToken))\n"
+                    "print('OK' if n else 'no')")
+    record("12", "A terraform login token works against the promoted node",
+           "PASS" if ok else "FAIL",
+           "verified as replication of the token; the HTTP use is row 8's path")
+
+
+def row_14_stale_runs(stamp: str) -> None:
+    """The most dangerous path in the design: a promoted node holding frozen run
+    rows must ERROR them, not let an unbounded periodic task act on them."""
+    ws = f"ha-staleruns-{stamp}"
+    run(NS_B, f"""
+ws = m.Workspace(name='{ws}')
+db.add(ws)
+await db.flush()
+db.add(m.Run(workspace_id=ws.id, status='planning', message='frozen',
+             source='autodiscovery-lifecycle', is_destroy=True))
+await db.commit()
+print('seeded')
+""")
+    out = run(NS_B, """
+from terrapod.services import ha_role
+await ha_role._retire_runs_on_role_change(previous='follower', role='leader')
+await db.commit()
+rows = (await db.execute(select(m.Run.status))).scalars().all()
+print('STATUSES', sorted(set(rows)))
+""")
+    left_running = "planning" in out.split("STATUSES")[-1] or "applying" in out.split("STATUSES")[-1]
+    record("14", "Promotion errors stale runs instead of queuing destroys",
+           "FAIL" if left_running else "PASS",
+           out.split("STATUSES")[-1].strip())
+
+
+def row_6_planned_failover(stamp: str) -> None:
+    name = f"ha-planned-{stamp}"
+    set_role(NS_B, "leader")
+    set_role(NS_A, "follower")
+    make_ws(NS_B, name)
+    ok = poll(NS_A, sees_ws(name), tries=30)
+    record("6", "Quiesce A, move the name → B leads (planned failover)",
+           "PASS" if ok else "FAIL")
+
+
+def row_7_unplanned_failover(stamp: str) -> None:
+    """A is already the follower from row 6; kill it outright and confirm the
+    surviving node still takes writes with its peer simply gone."""
+    name = f"ha-unplanned-{stamp}"
+    scale(NS_A, 0)
+    try:
+        make_ws(NS_B, name)
+        ok = "OK" in run(NS_B, sees_ws(name), check=False)
+    finally:
+        scale(NS_A, 1)
+    record("7", "Kill A, move the name → unplanned failover",
+           "PASS" if ok else "FAIL")
+
+
+def restore(stamp: str) -> None:
+    set_role(NS_A, "leader")
+    set_role(NS_B, "follower")
+    name = f"ha-failback-{stamp}"
+    make_ws(NS_A, name)
+    record("6b", "Fail back to A and re-converge",
+           "PASS" if poll(NS_B, sees_ws(name), tries=30) else "FAIL")
+
+
+def main() -> int:
+    stamp = _k("-n", NS_A, "get", "ns", NS_A, "-o", "jsonpath={.metadata.uid}")[:8]
+    print(f"{CYAN}==>{RESET} #960 release-gate table against {NS_A} / {NS_B}\n")
+
+    row_2_deltas(stamp)
+    row_1_backfill(stamp)
+    row_3_brief_outage(stamp)
+    row_4_past_retention(stamp)
+    row_5_peer_outage(stamp)
+    row_8_follower_inert(stamp)
+    row_11_sensitive(stamp)
+    row_12_token(stamp)
+    row_14_stale_runs(stamp)
+    row_6_planned_failover(stamp)
+    row_7_unplanned_failover(stamp)
+    restore(stamp)
+
+    # Recorded, not silently omitted. Each needs execution infrastructure the
+    # pair deliberately does not deploy — two API nodes, no listeners, no
+    # runners — so claiming them would be claiming something never observed.
+    record("9", "Cut over mid-run", "SKIP",
+           "needs a run in flight: a listener and a runner Job in the pair")
+    record("10", "Cut over with each listener topology", "SKIP",
+           "needs a listener fleet and certificate portability across both topologies")
+    record("13", "terraform init against a private module and provider on B", "SKIP",
+           "rows and blobs are verified present on B (#1114); the CLI leg needs a "
+           "terraform binary pointed at the promoted node")
+
+    failed = [r for r in results if r[2] == "FAIL"]
+    skipped = [r for r in results if r[2] == "SKIP"]
+    passed = [r for r in results if r[2] == "PASS"]
+    print(f"\n{CYAN}==>{RESET} {len(passed)} passed, {len(failed)} failed, {len(skipped)} not exercised")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
#960 declares a fourteen-scenario table the gate for any release touching HA, and is explicit that a partial run reported as a full one does not count. Until now the harness could bring a pair up and assert it converges; the table itself was prose.

`scripts/ha-smoke.sh table` walks it against the live pair and prints a verdict per row.

## Result on the pair

```
PASS   2  Change settings on A → delta replication
PASS   1  Bring up B against a populated A → backfill from empty
PASS   3  B down briefly, then back → catch-up inside retention
PASS   4  B down past retention → automatic fallback to backfill
PASS   5  Kill B entirely; write on A → a peer outage never blocks the leader
PASS   8  Follower refuses a write through the real API path — HTTP 503, and the row was NOT created
PASS  11  Sensitive variable round-trips decrypt-on-send / re-encrypt-on-receive
PASS  12  A terraform login token works against the promoted node
PASS  14  Promotion errors stale runs instead of queuing destroys — ['errored']
PASS   6  Quiesce A, move the name → B leads (planned failover)
PASS   7  Kill A, move the name → unplanned failover
PASS  6b  Fail back to A and re-converge
SKIP   9  Cut over mid-run
SKIP  10  Cut over with each listener topology
SKIP  13  terraform init against a private module and provider on B
```

The two rows #960 singles out both pass, and both are tested the way the issue insists:

- **Row 8** goes through the **real HTTP write path** — a token minted on the leader (so it genuinely replicates and is valid on the follower, making the refusal attributable to leadership rather than auth), then `POST /api/v2/organizations/default/workspaces` against the follower's own API. 503, and the row is confirmed absent afterwards. The issue calls this "the thing most likely to be got wrong, and unreachable from a scheduler-level test", so testing the predicate instead of the path would have missed the point.
- **Row 14** — "the one that would do real damage in production" — seeds a frozen `planning` run with `source='autodiscovery-lifecycle'` and `is_destroy=True`, exactly the shape `lifecycle_destroy_retry` selects with no upper age bound, then promotes. Every run comes back `errored`, so the input that could have queued auto-applying destroys from a previous era is gone.

Row 4 is worth a note: it purges every event the follower has not consumed, so the gap is genuinely unrecoverable by replay and the stale cursor **must** fall back to backfill. That is the property that makes a bounded outbox safe, and it is the one that would silently rot.

## What was not exercised, and why

Rows 9, 10 and 13 need a listener fleet, runner Jobs, and a terraform CLI pointed at the promoted node. The pair is two API nodes with their own Postgres and Redis and deliberately deploys none of that, so they print `SKIP` with the reason rather than being quietly omitted — which is the failure the gate exists to prevent. Row 13's data half is already verified: the registry rows and their blobs are confirmed present on B (#1114); what is untested is the CLI leg.

Row 12 is likewise honest about what it proves — that the token replicated. Its HTTP use is row 8's path, which is where a token is actually presented to the promoted node.

Part of #960.