### PR TITLE
ci(1186): mirror the third-party images CI pulls into GHCR

### DIFF
--- a/.github/mirror-images.txt
+++ b/.github/mirror-images.txt
@@ -1,0 +1,31 @@
+# Third-party images CI pulls, mirrored into GHCR (#1186).
+#
+# Docker Hub rate-limits anonymous pulls per source IP, and GitHub-hosted
+# runners share address space, so a pull here fails at whatever frequency the
+# shared pool dictates — four red PRs in one morning, none of them the change's
+# fault. A red check has to mean "the change is wrong"; every avoidable
+# infrastructure red erodes that, and the erosion is the real cost.
+#
+# The mirror workflow copies each of these to
+#   ghcr.io/<owner>/mirror/<repo-with-slashes-flattened>:<tag>
+# by digest, preserving the multi-arch index — it is a copy, not a rebuild.
+#
+# CONSUMPTION IS OPT-IN. Every call site keeps its Docker Hub reference as the
+# default and reads an override, which only CI sets. So a contributor building
+# locally is unaffected and needs no access to our GHCR packages, while CI
+# stops depending on a third-party registry being reachable for jobs that have
+# nothing to do with it.
+#
+# Adding an image here is not enough on its own — wire the override at the call
+# site too, or the mirror copy sits unused.
+
+python:3.13-slim
+node:26-alpine
+node:24-alpine
+postgres:16-alpine
+redis:7-alpine
+registry:2
+alpine/helm:3.17.2
+semgrep/semgrep:1.117
+localstack/localstack:4
+moby/buildkit:buildx-stable-1

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,0 +1,95 @@
+name: Mirror third-party images
+
+# Copies the images in .github/mirror-images.txt from Docker Hub into GHCR, so
+# CI does not depend on a third-party registry being reachable for jobs that
+# have nothing to do with it (#1186).
+#
+# A copy, not a rebuild: `imagetools create` republishes the source manifest by
+# digest, so the multi-arch index and every layer digest are preserved and the
+# mirrored image is bit-identical to what Docker Hub served.
+
+on:
+  schedule:
+    # Weekly. The tags are pinned, so this is about the mirror still existing
+    # and picking up rebuilt-in-place tags, not about chasing new versions.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+  pull_request:
+    # Validate the list itself when it changes — a typo here would otherwise
+    # surface as a missing mirror on the next scheduled run, long after review.
+    paths:
+      - .github/mirror-images.txt
+      - .github/workflows/mirror-images.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-images
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: Mirror to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Resolve the list
+        id: list
+        run: |
+          # Comments and blank lines out; anything left must look like repo:tag.
+          images=$(grep -vE '^\s*(#|$)' .github/mirror-images.txt)
+          if [ -z "$images" ]; then echo "the image list is empty"; exit 1; fi
+          bad=$(echo "$images" | grep -vE '^[a-z0-9._/-]+:[a-zA-Z0-9._-]+$' || true)
+          if [ -n "$bad" ]; then
+            echo "not a repo:tag reference:"; echo "$bad"; exit 1
+          fi
+          echo "count=$(echo "$images" | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          { echo "images<<EOF"; echo "$images"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+        if: github.event_name != 'pull_request'
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy each image
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGES: ${{ steps.list.outputs.images }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          failed=""
+          while IFS= read -r src; do
+            [ -n "$src" ] || continue
+            repo="${src%:*}"; tag="${src##*:}"
+            # Flatten the path so alpine/helm and a hypothetical other "helm"
+            # cannot collide in one flat mirror namespace.
+            flat="${repo//\//-}"
+            dst="ghcr.io/${OWNER,,}/mirror/${flat}:${tag}"
+            echo "::group::$src -> $dst"
+            if docker buildx imagetools create --tag "$dst" "docker.io/${src}"; then
+              docker buildx imagetools inspect "$dst" --format '{{json .Manifest.Digest}}'
+            else
+              # One image failing must not hide the rest — report them all, then
+              # fail once, so a single upstream hiccup does not mask a real typo.
+              echo "FAILED: $src"
+              failed="${failed} ${src}"
+            fi
+            echo "::endgroup::"
+          done <<< "$IMAGES"
+          if [ -n "$failed" ]; then
+            echo "could not mirror:${failed}"
+            exit 1
+          fi
+          echo "mirrored ${{ steps.list.outputs.count }} images"


### PR DESCRIPTION
Part one of two for #1186. This adds the mirror; **nothing consumes it yet**, because the mirror has to exist before anything points at it.

## Why

Four red PRs in one morning, none of them the change's fault:

| Job | Failed pulling |
|---|---|
| Build terrapod-api / runner / migrations | buildx setup, from `registry-1.docker.io` |
| SAST | `semgrep/semgrep:1.117` |
| Python Test (integration) | `docker.io/library/python:3.13-slim` |
| Eval Boot (k3d) | `docker.io/library/registry:2` |

Every one failed **before any Terrapod code ran**, and one was on a **docs-only** PR.

Anonymous Docker Hub pulls are rate-limited per source IP and GitHub-hosted runners share address space, so this is not a transient to wait out — it recurs at whatever frequency the shared pool dictates. Each occurrence costs someone the time to open the log and confirm it was not their change, and it trains exactly the reflex this project bans: calling a red check "unrelated" without evidence. A red check has to mean *the change is wrong*, and every avoidable infrastructure red erodes that.

## What this does

`.github/mirror-images.txt` is the list; `.github/workflows/mirror-images.yml` copies each entry to `ghcr.io/<owner>/mirror/<flattened-repo>:<tag>`.

- **A copy, not a rebuild.** `imagetools create` republishes the source manifest **by digest**, so the multi-arch index and every layer digest are preserved and the mirrored image is bit-identical to what Docker Hub served.
- **Paths are flattened** (`alpine/helm` → `alpine-helm`), so two upstream repos that share a leaf name cannot collide in one flat mirror namespace.
- **The list is validated on pull request** when it changes. A typo would otherwise surface as a missing mirror on the next scheduled run, long after anyone was looking at it.
- **One image failing reports and continues**, then fails once at the end — a single upstream hiccup must not mask a real mistake in the list.
- Weekly, plus manual dispatch. The tags are pinned, so the schedule is about the mirror still existing and picking up rebuilt-in-place tags, not about chasing versions.

## Consumption is deliberately opt-in

The follow-up PR wires the call sites so that **every one keeps its Docker Hub reference as the default** and reads an override that only CI sets — Dockerfiles via an `ARG BASE_IMAGE`, scripts and compose via `${VAR:-upstream}`.

That means a contributor building locally is completely unaffected and needs no access to these packages, while CI stops depending on a third-party registry being reachable for jobs that have nothing to do with it. It also means this PR is inert: if the mirror workflow were removed tomorrow, nothing would break.

Part of #1186.