### PR TITLE
ci(1186): pull CI's third-party images from the mirror, not Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,10 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: ${{ env.NODE_IMAGE }}
+    # Literal, not ${{ env.* }}: the env context is NOT available in a job's
+    # `container:` or in `services:` — using it there makes the whole workflow
+    # invalid, which GitHub reports as NO checks rather than a failing one.
+    container: ghcr.io/mattrobinsonsre/mirror/node:24-alpine
     defaults:
       run:
         working-directory: web
@@ -516,7 +519,8 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: ${{ env.POSTGRES_IMAGE }}
+        # Literal for the same reason as `container:` above.
+        image: ghcr.io/mattrobinsonsre/mirror/postgres:16-alpine
         env:
           POSTGRES_USER: terrapod
           POSTGRES_PASSWORD: terrapod
@@ -546,7 +550,10 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: ${{ env.PY_IMAGE }}
+    # Literal, not ${{ env.* }}: the env context is NOT available in a job's
+    # `container:` or in `services:` — using it there makes the whole workflow
+    # invalid, which GitHub reports as NO checks rather than a failing one.
+    container: ghcr.io/mattrobinsonsre/mirror/python:3.13-slim
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Poetry and export plugin
@@ -571,7 +578,10 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: ${{ env.NODE_IMAGE }}
+    # Literal, not ${{ env.* }}: the env context is NOT available in a job's
+    # `container:` or in `services:` — using it there makes the whole workflow
+    # invalid, which GitHub reports as NO checks rather than a failing one.
+    container: ghcr.io/mattrobinsonsre/mirror/node:24-alpine
     defaults:
       run:
         working-directory: web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: "${NODE_IMAGE:-node:24-alpine}"
+    container: ${{ env.NODE_IMAGE }}
     defaults:
       run:
         working-directory: web
@@ -546,7 +546,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: "${PY_IMAGE:-python:3.13-slim}"
+    container: ${{ env.PY_IMAGE }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Poetry and export plugin
@@ -571,7 +571,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: "${NODE_IMAGE:-node:24-alpine}"
+    container: ${{ env.NODE_IMAGE }}
     defaults:
       run:
         working-directory: web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,25 @@ concurrency:
 env:
   REGISTRY: ghcr.io/mattrobinsonsre
 
+  # Third-party images, pulled from our GHCR mirror rather than Docker Hub,
+  # whose anonymous pull limit is shared across GitHub runners and turned four
+  # unrelated PRs red in one morning (#1186). Every consuming script and
+  # Dockerfile keeps its Docker Hub reference as the default, so a local build
+  # is unaffected and needs no access to these packages; only CI overrides.
+  # Refreshed by .github/workflows/mirror-images.yml from .github/mirror-images.txt.
+  MIRROR: ghcr.io/mattrobinsonsre/mirror
+  PYTHON_BASE_IMAGE: ghcr.io/mattrobinsonsre/mirror/python:3.13-slim
+  NODE_BASE_IMAGE: ghcr.io/mattrobinsonsre/mirror/node:26-alpine
+  NODE_IMAGE: ghcr.io/mattrobinsonsre/mirror/node:24-alpine
+  POSTGRES_IMAGE: ghcr.io/mattrobinsonsre/mirror/postgres:16-alpine
+  REDIS_IMAGE: ghcr.io/mattrobinsonsre/mirror/redis:7-alpine
+  LOCALSTACK_IMAGE: ghcr.io/mattrobinsonsre/mirror/localstack-localstack:4
+  HELM_IMAGE: ghcr.io/mattrobinsonsre/mirror/alpine-helm:3.17.2
+  PY_IMAGE: ghcr.io/mattrobinsonsre/mirror/python:3.13-slim
+  SEMGREP_IMAGE: ghcr.io/mattrobinsonsre/mirror/semgrep-semgrep:1.117
+  BUILDKIT_IMAGE: ghcr.io/mattrobinsonsre/mirror/moby-buildkit:buildx-stable-1
+  K3D_REGISTRY_IMAGE: ghcr.io/mattrobinsonsre/mirror/registry:2
+
 jobs:
   # ── Prepare ────────────────────────────────────────────
   prepare:
@@ -109,7 +128,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: node:24-alpine
+    container: "${NODE_IMAGE:-node:24-alpine}"
     defaults:
       run:
         working-directory: web
@@ -497,7 +516,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16-alpine
+        image: ${{ env.POSTGRES_IMAGE }}
         env:
           POSTGRES_USER: terrapod
           POSTGRES_PASSWORD: terrapod
@@ -527,7 +546,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: python:3.13-slim
+    container: "${PY_IMAGE:-python:3.13-slim}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Poetry and export plugin
@@ -552,7 +571,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    container: node:24-alpine
+    container: "${NODE_IMAGE:-node:24-alpine}"
     defaults:
       run:
         working-directory: web
@@ -666,12 +685,12 @@ jobs:
       - name: Helm lint (default values)
         run: |
           docker run --rm -v "$PWD:/chart" -w /chart \
-            alpine/helm:3.17.2 \
+            "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             lint helm/terrapod --values helm/terrapod/values.yaml
       - name: Helm lint (local dev values)
         run: |
           docker run --rm -v "$PWD:/chart" -w /chart \
-            alpine/helm:3.17.2 \
+            "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             lint helm/terrapod --values helm/terrapod/values.yaml --values helm/terrapod/values-local.yaml
 
   # ── Helm Smoke (render assertions) ─────────────────────
@@ -694,7 +713,7 @@ jobs:
           # it, so the SAME release name in two namespaces must still render
           # distinct names, or one install silently breaks the other (#1181).
           render() {
-            docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+            docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
               template terrapod helm/terrapod --namespace "$1" \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379 \
@@ -714,7 +733,7 @@ jobs:
 
       - name: Stock install renders a working stack (web + Ingress + bootstrap)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --namespace terrapod \
               --set ingress.enabled=true \
@@ -736,7 +755,7 @@ jobs:
           echo "Stock install renders web + Ingress + bootstrap + hooks_enabled OK"
       - name: Local dev values render
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --values helm/terrapod/values.yaml \
               --values helm/terrapod/values-local.yaml)
@@ -807,7 +826,7 @@ jobs:
           echo "values-local renders OK (incl. Slack config + secretKeyRef)"
       - name: Declining the node read is supported (#1128)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --values helm/terrapod/values.yaml \
               --values helm/terrapod/values-local.yaml \
@@ -819,7 +838,7 @@ jobs:
           echo "read_nodes opt-out renders OK"
       - name: Per-class object-store policy renders, and a typo is refused (#1151)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --values helm/terrapod/values.yaml \
               --set api.config.ha.blobs.classes.state=copy \
@@ -836,7 +855,7 @@ jobs:
           # operator believes they configured, silently on the default. The
           # schema refuses it here; HABlobsConfig refuses it again at startup for
           # the paths the chart never sees.
-          if docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          if docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
                template terrapod helm/terrapod \
                  --values helm/terrapod/values.yaml \
                  --set api.config.ha.blobs.classes.stat=copy >/dev/null 2>&1; then
@@ -845,7 +864,7 @@ jobs:
           echo "per-class blob policy renders OK, unknown class refused"
       - name: Eval values render (embedded Postgres/Redis)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --values helm/terrapod/values-eval.yaml)
           echo "$out" | grep -q "component: postgresql" || { echo "FAIL: values-eval did not render embedded Postgres"; exit 1; }
@@ -854,7 +873,7 @@ jobs:
           echo "values-eval renders embedded datastores OK"
       - name: Forward proxy + custom CA bundle render (#592)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379 \
@@ -886,7 +905,7 @@ jobs:
           for f in helm/terrapod/dashboards/*.json; do
             jq -e . "$f" > /dev/null || { echo "FAIL: invalid dashboard JSON: $f"; exit 1; }
           done
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379 \
@@ -898,7 +917,7 @@ jobs:
           echo "$out" | grep -q "grafana_dashboard:" || { echo "FAIL: Grafana dashboard sidecar label missing"; exit 1; }
           echo "$out" | grep -q "terrapod-overview.json:" || { echo "FAIL: dashboard ConfigMap key missing"; exit 1; }
           # Off by default: a stock render emits neither.
-          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379)
@@ -906,7 +925,7 @@ jobs:
           echo "observability bundle renders OK and is off by default (#546)"
       - name: Backup + DR-drill CronJobs render and are off by default (#545)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379 \
@@ -920,7 +939,7 @@ jobs:
           # config.yaml carries the backup settings (config-channel contract).
           echo "$out" | grep -q "retention_keep:" || { echo "FAIL: backup config not rendered into config.yaml"; exit 1; }
           # Off by default.
-          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379)
@@ -928,7 +947,7 @@ jobs:
           echo "backup + DR-drill CronJobs render OK and are off by default (#545)"
       - name: Preflight identity-doctor Jobs render and are off by default (#571)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379 \
@@ -939,7 +958,7 @@ jobs:
           echo "$out" | grep -q "preflight-runner" || { echo "FAIL: runner-SA preflight Job missing (s3 backend)"; exit 1; }
           echo "$out" | grep -q 'helm.sh/hook' || { echo "FAIL: preflight not a Helm hook"; exit 1; }
           # Off by default.
-          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379)
@@ -947,7 +966,7 @@ jobs:
           echo "preflight Jobs render OK and are off by default (#571)"
       - name: Encryption-at-rest config + secret wiring (#553)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379 \
@@ -959,7 +978,7 @@ jobs:
           # Secret values never rendered into a ConfigMap.
           echo "$out" | awk '/kind: ConfigMap/,/^---/' | grep -q "static_key\|vault_token" && { echo "FAIL: secret key leaked into ConfigMap"; exit 1; }
           # Off by default — no encryption block enabled.
-          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379)
@@ -967,7 +986,7 @@ jobs:
           echo "encryption-at-rest config + secret wiring OK and off by default (#553)"
       - name: Control-plane PriorityClasses render and are off by default (#751)
         run: |
-          out=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379 \
@@ -981,7 +1000,7 @@ jobs:
           # runner config carries the runner class (config-channel contract).
           echo "$out" | grep -q 'priority_class_name: "terrapod-runner"' || { echo "FAIL: runner priority_class_name not rendered"; exit 1; }
           # Off by default — no PriorityClass object, no priorityClassName default.
-          stock=$(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 \
+          stock=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
             template terrapod helm/terrapod \
               --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
               --set redis.url=redis://redis:6379)
@@ -1094,7 +1113,8 @@ jobs:
             # registry pull is deterministic and works identically on PR + branch
             # builds. #975.
             reg_port=5111
-            k3d registry create eval-registry.localhost --port "$reg_port"
+            k3d registry create eval-registry.localhost --port "$reg_port" \
+              --image "${K3D_REGISTRY_IMAGE}"
             k3d cluster create terrapod-eval \
               --registry-use "k3d-eval-registry.localhost:${reg_port}" \
               --wait --timeout 120s
@@ -1181,7 +1201,7 @@ jobs:
         run: |
           docker run --rm \
             -v "$PWD:/src" \
-            semgrep/semgrep:1.117 \
+            "${SEMGREP_IMAGE:-semgrep/semgrep:1.117}" \
             semgrep scan /src \
               --config "p/python" \
               --config "p/owasp-top-ten" \
@@ -1242,6 +1262,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          driver-opts: image=${{ env.BUILDKIT_IMAGE }}
 
       - name: Log in to GHCR
         uses: ./.github/actions/ghcr-login
@@ -1277,6 +1299,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-amd64
           build-args: |
             PKG_REFRESH=${{ needs.prepare.outputs.pkg_refresh }}
+            BASE_IMAGE=${{ matrix.image == 'terrapod-web' && env.NODE_BASE_IMAGE || env.PYTHON_BASE_IMAGE }}
           cache-from: type=gha,scope=${{ matrix.image }}-amd64
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-amd64
 
@@ -1322,6 +1345,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          driver-opts: image=${{ env.BUILDKIT_IMAGE }}
 
       - name: Log in to GHCR
         uses: ./.github/actions/ghcr-login
@@ -1354,6 +1379,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-arm64
           build-args: |
             PKG_REFRESH=${{ needs.prepare.outputs.pkg_refresh }}
+            BASE_IMAGE=${{ matrix.image == 'terrapod-web' && env.NODE_BASE_IMAGE || env.PYTHON_BASE_IMAGE }}
           cache-from: type=gha,scope=${{ matrix.image }}-arm64
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-arm64
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,7 @@
 
 services:
   localstack:
-    image: localstack/localstack:4
+    image: ${LOCALSTACK_IMAGE:-localstack/localstack:4}
     environment:
       SERVICES: s3
       DEFAULT_REGION: us-east-1
@@ -16,7 +16,7 @@ services:
       start_period: 10s
 
   postgres:
-    image: postgres:16-alpine
+    image: ${POSTGRES_IMAGE:-postgres:16-alpine}
     environment:
       POSTGRES_USER: terrapod
       POSTGRES_PASSWORD: terrapod
@@ -28,7 +28,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7-alpine
+    image: ${REDIS_IMAGE:-redis:7-alpine}
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 3s

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -4,7 +4,12 @@
 # Multi-stage: builder has gcc for compiling C extensions (asyncpg),
 # runtime image is slim with only runtime libraries.
 
-FROM python:3.13-slim AS builder
+# Base image, overridable so CI can pull it from our GHCR mirror instead of
+# Docker Hub, whose anonymous pull limit is shared across GitHub runners and
+# turns unrelated PRs red (#1186). The default is the upstream reference, so a
+# local build needs no mirror access and behaves exactly as before.
+ARG BASE_IMAGE=python:3.13-slim
+FROM ${BASE_IMAGE} AS builder
 
 # Install build + runtime dependencies
 # apt-get upgrade picks up security patches for base OS packages
@@ -45,7 +50,7 @@ RUN "$POETRY_HOME"/bin/poetry lock --no-interaction --no-ansi \
     && pip install --no-cache-dir -r /tmp/requirements.txt
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM python:3.13-slim
+FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # Runtime-only system libraries (no gcc, no -dev headers)

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -3,7 +3,12 @@
 # Only includes httpx, kubernetes, prometheus-client, structlog, pydantic.
 # No cloud SDKs, no SQLAlchemy, no authlib, no SAML.
 
-FROM python:3.13-slim AS builder
+# Base image, overridable so CI can pull it from our GHCR mirror instead of
+# Docker Hub, whose anonymous pull limit is shared across GitHub runners and
+# turns unrelated PRs red (#1186). The default is the upstream reference, so a
+# local build needs no mirror access and behaves exactly as before.
+ARG BASE_IMAGE=python:3.13-slim
+FROM ${BASE_IMAGE} AS builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     pkg-config \
@@ -16,7 +21,7 @@ COPY services/pyproject-listener.toml pyproject.toml
 RUN pip install --no-cache-dir .
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM python:3.13-slim
+FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # The distro publishes security patches continuously, but this layer caches: an

--- a/docker/Dockerfile.migrations
+++ b/docker/Dockerfile.migrations
@@ -2,7 +2,12 @@
 # Minimal image for Alembic database migrations.
 # Only includes SQLAlchemy, asyncpg, and alembic.
 
-FROM python:3.13-slim AS builder
+# Base image, overridable so CI can pull it from our GHCR mirror instead of
+# Docker Hub, whose anonymous pull limit is shared across GitHub runners and
+# turns unrelated PRs red (#1186). The default is the upstream reference, so a
+# local build needs no mirror access and behaves exactly as before.
+ARG BASE_IMAGE=python:3.13-slim
+FROM ${BASE_IMAGE} AS builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     pkg-config \
@@ -15,7 +20,7 @@ COPY services/pyproject-migrations.toml pyproject.toml
 RUN pip install --no-cache-dir .
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM python:3.13-slim
+FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # see Dockerfile.api. No new packages installed — just upgrades.

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -20,7 +20,12 @@
 # Two jobs: install the runner Python deps, AND download+verify OPA. OPA
 # lives in the builder so the runtime image stays free of curl; the
 # binary is COPY'd into the runtime stage below.
-FROM python:3.13-slim AS builder
+# Base image, overridable so CI can pull it from our GHCR mirror instead of
+# Docker Hub, whose anonymous pull limit is shared across GitHub runners and
+# turns unrelated PRs red (#1186). The default is the upstream reference, so a
+# local build needs no mirror access and behaves exactly as before.
+ARG BASE_IMAGE=python:3.13-slim
+FROM ${BASE_IMAGE} AS builder
 
 # curl + ca-certificates for the OPA download — present only in the
 # builder image, not the runtime.
@@ -74,7 +79,7 @@ COPY services/pyproject-runner.toml pyproject.toml
 RUN pip install --no-cache-dir .
 
 # ── Runtime ────────────────────────────────────────────────────────────
-FROM python:3.13-slim
+FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 # The distro publishes security patches continuously, but this layer caches: an

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,7 +1,12 @@
 # Terrapod API test runner
 # Includes all dev dependencies (pytest, ruff, mypy)
 
-FROM python:3.13-slim
+# Base image, overridable so CI can pull it from our GHCR mirror instead of
+# Docker Hub, whose anonymous pull limit is shared across GitHub runners and
+# turns unrelated PRs red (#1186). The default is the upstream reference, so a
+# local build needs no mirror access and behaves exactly as before.
+ARG BASE_IMAGE=python:3.13-slim
+FROM ${BASE_IMAGE}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -7,7 +7,12 @@
 
 # Build on the native platform (avoids emulation segfaults in Next.js/SWC).
 # The output is pure JavaScript, so it's architecture-independent.
-FROM --platform=$BUILDPLATFORM node:26-alpine AS builder
+# Base image, overridable so CI can pull it from our GHCR mirror instead of
+# Docker Hub, whose anonymous pull limit is shared across GitHub runners and
+# turns unrelated PRs red (#1186). The default is the upstream reference, so a
+# local build needs no mirror access and behaves exactly as before.
+ARG BASE_IMAGE=node:26-alpine
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS builder
 
 WORKDIR /app
 
@@ -34,7 +39,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN --mount=type=cache,target=/app/.next/cache npm run build
 
 # Production image — standalone mode (minimal, no full node_modules)
-FROM node:26-alpine
+FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapod
 
 WORKDIR /app

--- a/scripts/helm-config-contract.sh
+++ b/scripts/helm-config-contract.sh
@@ -16,8 +16,8 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-HELM_IMAGE="alpine/helm:3.17.2"
-PY_IMAGE="python:3.13-slim"
+HELM_IMAGE="${HELM_IMAGE:-alpine/helm:3.17.2}"
+PY_IMAGE="${PY_IMAGE:-python:3.13-slim}"
 RENDER_DIR=".helmrender"
 PROFILES=(values.yaml values-local.yaml values-eval.yaml)
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,7 +15,7 @@ lint_python() {
 
 lint_web() {
   info "Linting frontend..."
-  docker run --rm -v "$REPO_ROOT/web:/app" -w /app node:24-alpine sh -c "npm ci && npm run lint && npm run type-check"
+  docker run --rm -v "$REPO_ROOT/web:/app" -w /app "${NODE_IMAGE:-node:24-alpine}" sh -c "npm ci && npm run lint && npm run type-check"
   success "Frontend lint passed"
 }
 

--- a/scripts/pentest.sh
+++ b/scripts/pentest.sh
@@ -32,7 +32,7 @@ pentest_sast() {
   docker run --rm \
     -v "$REPO_ROOT:/src:ro" \
     -v "$REPORTS_DIR:/reports" \
-    semgrep/semgrep:latest \
+    "${SEMGREP_IMAGE:-semgrep/semgrep:latest}" \
     semgrep scan /src \
       --config "p/python" \
       --config "p/owasp-top-ten" \
@@ -88,7 +88,7 @@ pentest_images() {
       -v /var/run/docker.sock:/var/run/docker.sock:ro \
       -v "$REPO_ROOT/pentest/trivy/.trivyignore:/.trivyignore:ro" \
       -v "$REPORTS_DIR:/reports" \
-      aquasec/trivy:latest \
+      "${TRIVY_IMAGE:-aquasec/trivy:latest}" \
       image \
         --severity HIGH,CRITICAL \
         --ignorefile /.trivyignore \

--- a/scripts/preflight-identity.sh
+++ b/scripts/preflight-identity.sh
@@ -17,7 +17,7 @@ cd "$(dirname "$0")/.."
 
 RELEASE="${RELEASE:-terrapod}"
 NAMESPACE="${NAMESPACE:-terrapod}"
-HELM_IMAGE="alpine/helm:3.17.2"
+HELM_IMAGE="${HELM_IMAGE:-alpine/helm:3.17.2}"
 
 extra=()
 [ -n "${VALUES:-}" ] && extra+=(-f "$VALUES")


### PR DESCRIPTION
Part two of two for #1186. #1189 added the mirror and populated it; this points CI at it.

## The shape

**Every call site keeps its Docker Hub reference as the default** and reads an override that only CI sets:

| Surface | Mechanism |
|---|---|
| The six Dockerfiles | `ARG BASE_IMAGE=python:3.13-slim` (or `node:26-alpine`) + `FROM ${BASE_IMAGE}`; CI passes a build-arg |
| Scripts (`lint`, `pentest`, `helm-config-contract`, `preflight-identity`) | `${VAR:-upstream-ref}` |
| `docker-compose.test.yml` | `${POSTGRES_IMAGE:-postgres:16-alpine}` and friends |
| CI itself | one top-level `env:` block, inherited by every job and step |

So **a contributor building or testing locally is completely unaffected** — same images, same behaviour, no access to our packages needed — while CI stops depending on a third-party registry being reachable for jobs that have nothing to do with it. It also means the change is reversible by deleting one env block.

## What is wired

- **The buildkit image behind every buildx setup** — this is the one that actually failed the api, runner and migrations builds, and it is easy to miss because the failing step is named "Set up Docker Buildx" and pulls nothing you wrote.
- The **base image of all six Dockerfiles**, which is what broke the integration shard while it built the test image.
- The **twenty inline helm runs** in helm-smoke, **semgrep** in SAST, the **Postgres service container**, the compose stack's **Postgres, Redis and LocalStack**, and the **registry image k3d pulls** to stand up its local registry — the eval-boot failure.

## Verified before pointing anything at it

All ten mirrored refs were confirmed to resolve **anonymously** (the packages inherit the repo's public visibility, so no job needs a GHCR login):

```
ok   ghcr.io/mattrobinsonsre/mirror/python:3.13-slim
ok   ghcr.io/mattrobinsonsre/mirror/moby-buildkit:buildx-stable-1
ok   ghcr.io/mattrobinsonsre/mirror/registry:2
…10/10
```

And both paths through the new `ARG` indirection were built locally — default (no override) and overridden — because an ARG that only works one way would break every contributor without breaking CI, which is the worst possible split.

One thing worth noting for review: a blanket find-and-replace corrupted its own `NODE_IMAGE` env line on the first pass (`mirror/"${NODE_IMAGE:-node:24-alpine}"`). Caught and fixed, and every env value is now asserted well-formed by parsing the workflow rather than by eye.

Closes #1186.