### PR TITLE
docs: a standby's listener fleet attaches before it is needed

### DIFF
--- a/docs/ha-topologies.md
+++ b/docs/ha-topologies.md
@@ -188,11 +188,25 @@ region A: listeners ──▶ terrapod-a.example.com
 region B: listeners ──▶ terrapod-b.example.com
 ```
 
-**Choose this when** the execution clusters are themselves regional, when the
-two sides have different network reachability or different cloud credentials, or
-when you want the standby's capacity proven continuously rather than at the
-failover. It is the simpler operational story: nothing re-points, nothing
-re-joins, and each side's listeners are exercised by whichever node is leading.
+**Choose this when** the execution clusters are themselves regional, or when the
+two sides have different network reachability or different cloud credentials.
+Nothing re-points at a cutover and no listener changes the name it talks to.
+
+> **A standby's fleet cannot join until that node is promoted.**
+>
+> Enrolling a listener is a write, and a follower refuses writes — so a listener
+> pointed at a node that has never led retries indefinitely and never becomes
+> ready, which also makes `helm install --wait` fail on that node
+> ([#1191](https://github.com/mattrobinsonsre/terrapod/issues/1191)).
+>
+> Practical consequence: **neither topology gives you a standby fleet proven
+> before promotion.** They differ in *how* they heal at cutover — the shared
+> fleet re-joins because its certificates stop authenticating, the per-node
+> fleet joins for the first time — not in whether.
+>
+> The workaround, if you want a per-node fleet ready in advance, is to bring the
+> node up **as leader** once so its fleet joins, then demote it. The credentials
+> Secret persists, so the listeners do not re-join afterwards.
 
 The trade is that node B's listeners sit idle while A leads (they are cheap —
 they launch Jobs, they do not run terraform), and each side's pools must be

--- a/docs/ha-topologies.md
+++ b/docs/ha-topologies.md
@@ -204,9 +204,10 @@ Nothing re-points at a cutover and no listener changes the name it talks to.
 > fleet re-joins because its certificates stop authenticating, the per-node
 > fleet joins for the first time — not in whether.
 >
-> The workaround, if you want a per-node fleet ready in advance, is to bring the
-> node up **as leader** once so its fleet joins, then demote it. The credentials
-> Secret persists, so the listeners do not re-join afterwards.
+> There is currently **no workaround**. Joining as leader and then demoting does
+> not help: an already-joined listener's heartbeat is also a write, so it is
+> refused too and the listener expires from the node's Redis a few minutes
+> later. Plan for the standby's fleet to become useful at promotion, not before.
 
 The trade is that node B's listeners sit idle while A leads (they are cheap —
 they launch Jobs, they do not run terraform), and each side's pools must be

--- a/docs/ha-topologies.md
+++ b/docs/ha-topologies.md
@@ -188,26 +188,28 @@ region A: listeners ──▶ terrapod-a.example.com
 region B: listeners ──▶ terrapod-b.example.com
 ```
 
-**Choose this when** the execution clusters are themselves regional, or when the
-two sides have different network reachability or different cloud credentials.
-Nothing re-points at a cutover and no listener changes the name it talks to.
+**Choose this when** the execution clusters are themselves regional, when the
+two sides have different network reachability or different cloud credentials, or
+when you want the standby's execution path proven **before** you need it rather
+than at the failover. Nothing re-points at a cutover and no listener changes the
+name it talks to.
 
-> **A standby's fleet cannot join until that node is promoted.**
+> **A standby's fleet attaches and stays attached, before it is ever needed.**
 >
-> Enrolling a listener is a write, and a follower refuses writes — so a listener
-> pointed at a node that has never led retries indefinitely and never becomes
-> ready, which also makes `helm install --wait` fail on that node
-> ([#1191](https://github.com/mattrobinsonsre/terrapod/issues/1191)).
+> A listener does not have to know whether the node it reached currently leads
+> — it enrols, heartbeats and renews against a follower exactly as it would
+> against a leader, because all of that records state on that node alone. The
+> follower simply hands it no work, so the fleet sits attached and idle until
+> promotion, at which point it is already there.
 >
-> Practical consequence: **neither topology gives you a standby fleet proven
-> before promotion.** They differ in *how* they heal at cutover — the shared
-> fleet re-joins because its certificates stop authenticating, the per-node
-> fleet joins for the first time — not in whether.
+> This is what the dedicated topology buys over the shared one: the standby's
+> execution path is proven — the pool is joined, the certificate is valid, the
+> SSE connection is up — while the shared fleet's equivalent proof only happens
+> at the cutover, when it re-joins.
 >
-> There is currently **no workaround**. Joining as leader and then demoting does
-> not help: an already-joined listener's heartbeat is also a write, so it is
-> refused too and the listener expires from the node's Redis a few minutes
-> later. Plan for the standby's fleet to become useful at promotion, not before.
+> (Before [#1191](https://github.com/mattrobinsonsre/terrapod/issues/1191) this
+> was not true: the whole listener protocol was refused on a follower, so a
+> standby's fleet crash-looped and `helm install --wait` failed on it.)
 
 The trade is that node B's listeners sit idle while A leads (they are cheap —
 they launch Jobs, they do not run terraform), and each side's pools must be


### PR DESCRIPTION
This branch has changed shape twice, because the thing it documents got fixed while it was open. Final state:

`docs/ha-topologies.md` originally told operators that a dedicated per-node listener fleet gives them **"the standby's capacity proven continuously rather than at the failover."** Building the execution rig for #1188 showed that was false: the entire listener protocol was refused on a follower, so a standby's fleet crash-looped and `helm install --wait` failed on that node.

**That is now fixed** (#1191 / #1193). A listener enrols, heartbeats and renews against a follower exactly as it would against a leader — all of that records state on that node alone — and the follower simply hands it no work. So the fleet sits attached and idle until promotion, at which point it is already there.

Which means the page's original *intent* was right and its *fact* was wrong at the time. This restores the claim, now that it holds, and states the mechanism rather than asserting the outcome:

> A listener does not have to know whether the node it reached currently leads … The follower simply hands it no work, so the fleet sits attached and idle until promotion, at which point it is already there.

It also names what this actually buys over the shared topology — the standby's execution path is *proven* (pool joined, certificate valid, SSE up) rather than first exercised at the cutover — and keeps a pointer to what the behaviour was, so someone reading the page against an older deployment is not surprised by their crash-looping listeners.

Docs only.