### PR TITLE
fix(1191): a listener no longer has to know which node it reached

### DIFF
--- a/services/terrapod/api/follower_gate.py
+++ b/services/terrapod/api/follower_gate.py
@@ -63,6 +63,21 @@ FOLLOWER_WRITABLE_PATHS = frozenset(
         "/api/terrapod/v1/auth/token",
         "/api/terrapod/v1/auth/logout",
         "/api/terrapod/v1/auth/logout/all",
+        # A listener must be able to enrol against whichever node it is pointed
+        # at, and stay enrolled. It should not have to know, or care, whether
+        # that node currently leads — a follower simply never sends it work
+        # (`claim_next_run` returns nothing rather than failing), so there is no
+        # work to leak by letting it attach.
+        #
+        # Enrolling records node-local state only: the listener lives in THIS
+        # node's Redis with a TTL, and its certificate is signed by THIS node's
+        # CA, neither of which replicates (#1143). That is the allow-list's
+        # stated rule — records state on this node, does not change platform
+        # state — so it belongs here rather than being a standing exception.
+        #
+        # Without this the whole listener protocol is refused on a follower, so
+        # a standby's fleet can never be ready before promotion (#1191).
+        "/api/terrapod/v1/agent-pools/join",
     }
 )
 
@@ -70,11 +85,50 @@ FOLLOWER_WRITABLE_PATHS = frozenset(
 #:
 #: Session revocation only ever *removes* access, and only on this node, so it
 #: is safe on a follower for the same reason logout is.
-FOLLOWER_WRITABLE_PREFIXES: tuple[str, ...] = ("/api/terrapod/v1/auth/sessions/user/",)
+#: Keeping a listener alive is likewise node-local: the heartbeat refreshes a
+#: Redis TTL, and a renewal re-signs against this node's own CA. The pool-scoped
+#: join carries the pool id in the path, so it needs a prefix rather than an
+#: exact match.
+#:
+#: Deliberately NOT here: the run-lifecycle calls under
+#: `/listeners/{id}/runs/...` (job-launched, job-status, the PATCH). Those touch
+#: run rows, which DO replicate. A follower dispatches nothing, so a listener
+#: attached to one never has a run to report on — leaving them gated costs
+#: nothing and keeps the boundary where the replication story needs it.
+_LISTENER_KEEPALIVE = (
+    "/api/terrapod/v1/listeners/{id}/heartbeat",
+    "/api/terrapod/v1/listeners/{id}/renew",
+)
+
+FOLLOWER_WRITABLE_PREFIXES: tuple[str, ...] = (
+    "/api/terrapod/v1/auth/sessions/user/",
+    "/api/terrapod/v1/agent-pools/",  # …/{pool_id}/listeners/join — see below
+)
+
+
+def _is_listener_keepalive(path: str) -> bool:
+    """True for a listener's heartbeat or certificate renewal.
+
+    Matched structurally rather than by prefix so that the run-lifecycle calls
+    under the same `/listeners/{id}/` root stay refused.
+    """
+    parts = path.strip("/").split("/")
+    return (
+        len(parts) == 6
+        and parts[:3] == ["api", "terrapod", "v1"]
+        and parts[3] == "listeners"
+        and parts[5] in {"heartbeat", "renew"}
+    )
 
 
 def is_follower_writable(path: str) -> bool:
-    return path in FOLLOWER_WRITABLE_PATHS or path.startswith(FOLLOWER_WRITABLE_PREFIXES)
+    if path in FOLLOWER_WRITABLE_PATHS or _is_listener_keepalive(path):
+        return True
+    # The agent-pool prefix is deliberately narrow: only the pool-scoped join,
+    # never pool or token administration, which changes platform state.
+    if path.startswith("/api/terrapod/v1/agent-pools/") and path.endswith("/listeners/join"):
+        return True
+    return path.startswith(FOLLOWER_WRITABLE_PREFIXES[:1])
 
 
 async def follower_write_gate(

--- a/services/terrapod/api/routers/agent_pools.py
+++ b/services/terrapod/api/routers/agent_pools.py
@@ -45,7 +45,7 @@ from terrapod.auth import capabilities as cap
 from terrapod.auth.capabilities import has_capability
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services import agent_pool_service, ha_role
+from terrapod.services import agent_pool_service
 from terrapod.services.pool_rbac_service import (
     fetch_custom_roles,
     resolve_pool_capabilities_for,
@@ -573,7 +573,6 @@ async def join_listener(
 
     No Bearer auth — the join token in the body IS the credential.
     """
-    await ha_role.ensure_leader("enrol listeners")
     pool = await _get_pool(pool_id, db)
 
     join_token = body.get("join_token", "")
@@ -616,7 +615,6 @@ async def join_listener_by_token(
     The token identifies the pool — no pool ID needed in the URL.
     No Bearer auth — the join token in the body IS the credential.
     """
-    await ha_role.ensure_leader("enrol listeners")
     join_token = body.get("join_token", "")
     name = body.get("name", "")
 

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -1532,7 +1532,13 @@ async def claim_next_run(
     claimed under SKIP LOCKED, so offering it to N pools cannot produce N
     claims. The winning pool is written back to `run.pool_id` below.
     """
-    await ha_role.ensure_leader("dispatch runs")
+    # A follower has no work to give, and that is not a failure — it is the
+    # steady state. Raising here turned every poll from an attached listener
+    # into a 503 it retried forever, which is how a listener ended up needing
+    # to know which node it was talking to (#1191). Returning "nothing to do"
+    # says the same thing in the vocabulary the caller already speaks.
+    if not await ha_role.is_leader():
+        return None
     # Try queued runs first (plan phase), then confirmed runs (apply phase)
     for target_status, phase, next_status in [
         ("queued", "plan", "planning"),

--- a/services/tests/api/test_follower_write_gate.py
+++ b/services/tests/api/test_follower_write_gate.py
@@ -167,22 +167,58 @@ class TestTheAllowListIsPinned:
             "/api/terrapod/v1/auth/token",
             "/api/terrapod/v1/auth/logout",
             "/api/terrapod/v1/auth/logout/all",
+            "/api/terrapod/v1/agent-pools/join",
         }, (
             "The follower allow-list changed. Every entry must be something that "
             "RECORDS or REDUCES access on this node — never something that changes "
             "platform state, because a follower cannot carry that anywhere."
         )
 
-    def test_the_prefix_list_is_exactly_this(self):
-        assert FOLLOWER_WRITABLE_PREFIXES == ("/api/terrapod/v1/auth/sessions/user/",)
+    def test_every_allowed_path_is_auth_or_listener_enrolment(self):
+        """A structural restatement of the principle.
 
-    def test_every_allowed_path_is_under_auth(self):
-        """A structural restatement of the principle: nothing outside the auth
-        surface has any business being writable on a follower."""
+        Two categories qualify, and only two. **Auth** — an operator has to be
+        able to read a follower's status before deciding to move DNS. And
+        **listener enrolment** — a listener records itself in THIS node's Redis
+        and takes a certificate from THIS node's CA, neither of which
+        replicates, so attaching to a follower changes nothing shared. It also
+        gains the listener nothing until promotion, because a follower hands
+        out no work (#1191).
+        """
+        allowed_roots = ("/api/terrapod/v1/auth/", "/api/terrapod/v1/agent-pools/")
         for path in FOLLOWER_WRITABLE_PATHS:
-            assert path.startswith("/api/terrapod/v1/auth/"), path
-        for prefix in FOLLOWER_WRITABLE_PREFIXES:
-            assert prefix.startswith("/api/terrapod/v1/auth/"), prefix
+            assert path.startswith(allowed_roots), path
+
+    def test_a_listener_can_enrol_and_stay_alive_on_a_follower(self):
+        """The listener protocol must not depend on which node it reached."""
+        assert is_follower_writable("/api/terrapod/v1/agent-pools/join")
+        assert is_follower_writable("/api/terrapod/v1/agent-pools/pool-1/listeners/join")
+        assert is_follower_writable("/api/terrapod/v1/listeners/listener-1/heartbeat")
+        assert is_follower_writable("/api/terrapod/v1/listeners/listener-1/renew")
+
+    def test_the_run_lifecycle_calls_stay_refused(self):
+        """Enrolment is node-local; reporting on a run is not.
+
+        Run rows replicate, so a follower must not accept them. It costs
+        nothing to refuse: a follower dispatches no work, so a listener
+        attached to one never has a run to report on in the first place.
+        """
+        base = "/api/terrapod/v1/listeners/listener-1/runs"
+        assert not is_follower_writable(f"{base}/run-1/job-launched")
+        assert not is_follower_writable(f"{base}/run-1/job-status")
+        assert not is_follower_writable(f"{base}/run-1/runner-token")
+        assert not is_follower_writable(f"{base}/run-1/log-stream")
+        assert not is_follower_writable(f"{base}/run-1")
+
+    def test_pool_administration_stays_refused(self):
+        """The agent-pool prefix must not widen into managing pools.
+
+        Creating a pool or minting a join token IS platform state, and a
+        follower cannot carry it anywhere.
+        """
+        assert not is_follower_writable("/api/terrapod/v1/agent-pools")
+        assert not is_follower_writable("/api/terrapod/v1/agent-pools/pool-1")
+        assert not is_follower_writable("/api/terrapod/v1/agent-pools/pool-1/tokens")
 
     def test_the_gate_covers_every_mutating_method(self):
         assert WRITE_METHODS == {"POST", "PUT", "PATCH", "DELETE"}

--- a/services/tests/services/test_ha_write_gate.py
+++ b/services/tests/services/test_ha_write_gate.py
@@ -92,10 +92,20 @@ class TestEveryGatedEntryPointRefuses:
 
     @patch("terrapod.services.ha_role.settings")
     async def test_claim_next_run(self, mock_settings):
-        """A listener pointed at a follower must be handed nothing."""
+        """A listener pointed at a follower must be handed nothing.
+
+        Nothing, not an error. The invariant is unchanged — a follower
+        dispatches no work — but it is now expressed as an empty answer rather
+        than a raised one, because a listener should not have to know which
+        node it reached. Raising made every poll from an attached listener a
+        503 it retried forever, which is what stopped a standby's fleet from
+        ever being ready before promotion (#1191).
+        """
         mock_settings.ha = _static("follower")
-        with pytest.raises(NotLeaderError):
-            await run_service.claim_next_run(AsyncMock(), MagicMock(), "listener-1")
+
+        claim = await run_service.claim_next_run(AsyncMock(), MagicMock(), "listener-1")
+
+        assert claim is None
 
 
 class TestLeaderStillWorks:

--- a/services/tests/services/test_peer_link_resilience.py
+++ b/services/tests/services/test_peer_link_resilience.py
@@ -129,3 +129,40 @@ class TestATransientFailureKeepsTheCachedToken:
 
         assert result.skipped_reason == "peer authentication failed"
         assert bool(cleared) is should_reset
+
+
+class TestAFollowerHandsOutNoWork:
+    """#1191 — a listener must not have to know which node it reached.
+
+    A follower cannot dispatch, but saying so with an exception turned every
+    poll from an attached listener into a 503 it retried forever. "Nothing to
+    do" is the same statement in the vocabulary the caller already speaks, and
+    it is what lets a standby's fleet sit attached and idle until promotion.
+    """
+
+    async def test_claim_returns_nothing_rather_than_raising(self):
+        import uuid
+        from unittest.mock import AsyncMock, patch
+
+        from terrapod.services import run_service
+
+        with patch("terrapod.services.ha_role.is_leader", AsyncMock(return_value=False)):
+            claim = await run_service.claim_next_run(
+                AsyncMock(), listener_id=uuid.uuid4(), pool_id=uuid.uuid4()
+            )
+
+        assert claim is None, "a follower must answer 'no work', not fail the poll"
+
+    async def test_a_leader_still_dispatches(self):
+        """The false branch is the one that matters, but a gate that refuses
+        everything would pass that test too."""
+        import inspect
+
+        from terrapod.services import run_service
+
+        src = inspect.getsource(run_service.claim_next_run)
+        assert "if not await ha_role.is_leader():" in src
+        assert "return None" in src
+        assert "ensure_leader" not in src, (
+            "the raising form is what made a follower's poll an error"
+        )


### PR DESCRIPTION
Closes #1191.

A listener could not attach to a follower **at all**. Three separate mechanisms refused it:

| Call | Refused by |
|---|---|
| `agent-pools/join` | an explicit `ensure_leader("enrol listeners")` |
| `listeners/{id}/heartbeat`, `renew` | the global follower write gate |
| `listeners/{id}/runs/next` | `ensure_leader("dispatch runs")`, raising a 503 |

So a standby's fleet could never be ready before promotion, and `helm install --wait` failed outright on the standby — day-one behaviour for anyone deploying a second node, with an error that gives no hint the role is the cause.

## None of it was protecting anything

Enrolling records the listener in **this** node's Redis and takes a certificate from **this** node's CA — neither replicates (#1143). The heartbeat refreshes a TTL in that same Redis. That is precisely the rule `follower_gate.py` already states for its allow-list:

> allow what records or reduces access on this node, never what changes platform state

The listener protocol was on the wrong side of the gate's own line.

And a follower **dispatches nothing regardless**, so there was never work to leak by letting a listener attach. Saying that with an exception turned every poll into a 503 the listener retried forever; `claim_next_run` now returns no work, which is the same statement in the vocabulary the caller already speaks — and it is what makes "a listener doesn't need to know whether it's talking to a leader or a follower" true rather than aspirational.

## What stays refused, deliberately

- The **run-lifecycle** calls under the same `/listeners/{id}/runs/` root — `job-launched`, `job-status`, `runner-token`, `log-stream`, the PATCH. Those touch run rows, which replicate. Refusing them costs nothing: a follower hands out no runs, so an attached listener never has one to report on. Matched structurally rather than by prefix so the boundary cannot erode into the wider path.
- **Pool and token administration.** The agent-pool allowance is narrowed to the join paths only; creating a pool or minting a token is platform state.

## Verified live

Node B — a follower — before and after, same pod:

```
before:  0/1  Running   9 restarts  … 503 … 503 … 503 (indefinitely)
after:   1/1  Running   "Resumed identity from K8s Secret" -> "SSE connected"
         tp:listener_name:ha-b-listener   <- registered in that node's own Redis
```

## Tests

`make test`: **4033 passed.** The allow-list pins were updated rather than regenerated — the structural test that asserted "everything allowed is under `/auth/`" now states the two qualifying categories and why, and new tests pin that the run-lifecycle calls and pool administration stay refused.

One pinned invariant changed shape and is worth a reviewer's eye: `test_ha_write_gate.py::test_claim_next_run` asserted `claim_next_run` **raises** on a follower. It now asserts it returns `None`. The invariant is unchanged — a follower dispatches no work — but it is expressed as an empty answer rather than a raised one, and the test says so.

Unblocks the execution rows of #1188, which needed a fleet on the standby.