### PR TITLE
ci(1186): the E2E compose stack was still pulling from Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: No third-party image is pulled straight from Docker Hub
+        run: |
+          # The first pass at the mirror MISSED e2e/docker-compose.e2e.yml, which
+          # duly failed a docs-only PR an hour later on a postgres pull. Grepping
+          # for the shape is cheaper than remembering (#1186).
+          #
+          # The rule is OVERRIDABLE, not mirrored: every call site keeps its
+          # Docker Hub reference as the default so a local run is unaffected and
+          # needs no access to our packages. Only CI sets the override.
+          third_party='postgres|redis|localstack/localstack|node|python|alpine/helm|semgrep/semgrep|aquasec/trivy|registry|moby/buildkit'
+          files=$(git ls-files 'docker-compose*.yml' '*/docker-compose*.yml')
+          if [ -z "$files" ]; then echo "no compose files found — the guard is not looking anywhere"; exit 1; fi
+          echo "checking: $files"
+          bad=$(grep -HnE "^[[:space:]]*image:[[:space:]]*($third_party)[:@]" $files || true)
+          if [ -n "$bad" ]; then
+            echo "These pull straight from Docker Hub, whose anonymous rate limit"
+            echo "turns unrelated PRs red:"
+            echo "$bad"
+            echo
+            echo 'Wrap as ${VAR:-upstream-ref} and add VAR to the env block in'
+            echo "ci.yml. See .github/mirror-images.txt."
+            exit 1
+          fi
+          # And every mirror image ci.yml names must actually be on the list, or
+          # the copy never happens and CI asks GHCR for something absent.
+          listed=$(grep -vE '^\s*(#|$)' .github/mirror-images.txt | sed 's|/|-|g; s|:.*||' | sort -u)
+          used=$(grep -oE 'ghcr\.io/[^/]+/mirror/[a-z0-9-]+:' .github/workflows/ci.yml \
+                 | sed 's|.*/mirror/||; s|:$||' | sort -u)
+          missing=$(comm -13 <(echo "$listed") <(echo "$used"))
+          if [ -n "$missing" ]; then
+            echo "ci.yml points at mirror images not in the list: $missing"; exit 1
+          fi
+          echo "all third-party images are overridable, and every mirror ref is listed"
+
       - name: Two installs in one cluster cannot collide on a cluster-scoped name
         run: |
           # Terrapod is single-organization, so separating business units means

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -4,7 +4,7 @@
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: ${POSTGRES_IMAGE:-postgres:16-alpine}
     environment:
       POSTGRES_USER: terrapod
       POSTGRES_PASSWORD: terrapod
@@ -16,7 +16,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7-alpine
+    image: ${REDIS_IMAGE:-redis:7-alpine}
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 3s


### PR DESCRIPTION
The mirror work (#1189/#1190) missed `e2e/docker-compose.e2e.yml`. It failed a **docs-only** PR an hour later:

```
postgres Error Head "https://registry-1.docker.io/v2/library/postgres/manifests/16-alpine":
  context deadline exceeded
```

Worth being precise about what that was, because the shard is named "E2E Tests" and this project has a standing rule about E2E flakiness: **this was not a Playwright flake.** The shard died in sixty seconds during `Start E2E stack`, before a single test ran. Calling it flaky and re-running would have hidden a gap in my own change.

## The fix

The two images are wrapped exactly as everywhere else — Docker Hub reference as the default, override set only in CI — so a contributor running the E2E stack locally is unaffected and needs no access to our packages. The job already inherits `POSTGRES_IMAGE` / `REDIS_IMAGE` from the workflow-level env block.

## The guard is the point

A grep over **every committed compose file**, in the helm-smoke job. Two checks:

1. No compose file pulls a third-party image without an override.
2. Every `ghcr.io/…/mirror/…` reference in `ci.yml` is actually on `.github/mirror-images.txt` — the converse failure, where CI asks GHCR for something the mirror workflow was never told to copy.

Greping for the shape is cheaper than remembering, and it fails at review time rather than at somebody else's merge.

Verified **under bash**, which is what CI runs — and that mattered: my first local run was in zsh, which doesn't word-split an unquoted variable, so `grep` received all three filenames as one and reported a cheerful false pass. Under bash it reports all three files, passes on this branch, and flags the e2e file when the fix is reverted.

It also surfaced a third compose file I had not looked at, `scripts/smoke/docker-compose.yml`. Left alone deliberately: it is a manual smoke harness, never run in CI, so it cannot turn a PR red. (It does use MinIO, which sits oddly against the storage rule and against `docker-compose.test.yml` using LocalStack for the same job — noted, not touched here.)

Part of #1186.