### PR TITLE
chore(1195): strip MinIO — the upstream project is abandoned

### DIFF
--- a/migrate/cmd/terrapod-migrate/apply.go
+++ b/migrate/cmd/terrapod-migrate/apply.go
@@ -45,8 +45,8 @@ func applyCmd(args []string) int {
 		// ~/.aws/credentials with AWS_PROFILE, AWS SSO, IAM roles,
 		// IRSA, EC2/ECS instance metadata) — same chain every other
 		// AWS-aware tool uses. We do not reinvent it.
-		s3Endpoint  = fs.String("s3-endpoint-url", os.Getenv("AWS_ENDPOINT_URL_S3"), "S3 endpoint override (e.g. http://localhost:9000 for minio; or AWS_ENDPOINT_URL_S3)")
-		s3PathStyle = fs.Bool("s3-force-path-style", os.Getenv("AWS_S3_FORCE_PATH_STYLE") == "true", "Use S3 path-style addressing (required for minio)")
+		s3Endpoint  = fs.String("s3-endpoint-url", os.Getenv("AWS_ENDPOINT_URL_S3"), "S3 endpoint override (e.g. http://localhost:4566 for LocalStack, or a VPC endpoint; or AWS_ENDPOINT_URL_S3)")
+		s3PathStyle = fs.Bool("s3-force-path-style", os.Getenv("AWS_S3_FORCE_PATH_STYLE") == "true", "Use S3 path-style addressing (required by most non-AWS S3 endpoints)")
 		s3Region    = fs.String("s3-region", "", "S3 region override (default: AWS_REGION env, or read from backend HCL)")
 		target      = fs.String("target", os.Getenv("TERRAPOD_HOSTNAME"), "Terrapod base URL (or TERRAPOD_HOSTNAME)")
 		token       = fs.String("token", os.Getenv("TERRAPOD_TOKEN"), "Terrapod API token (or TERRAPOD_TOKEN)")

--- a/migrate/internal/sources/atlantis/state.go
+++ b/migrate/internal/sources/atlantis/state.go
@@ -4,7 +4,7 @@
 // package, finds the backend declaration, and downloads the current
 // state via the appropriate native cloud-vendor SDK.
 //
-// Supported backends today: local, s3 (incl. minio via --s3-endpoint-
+// Supported backends today: local, s3 (incl. non-AWS endpoints via --s3-endpoint-
 // url-equivalent on the operator's AWS_CONFIG), gcs, azurerm. Other
 // kinds (consul, etcd, http, ...) are surfaced as skipped items in
 // the report — the operator migrates state for those by hand.
@@ -39,23 +39,23 @@ import (
 // inside this tool would just produce a worse version.
 //
 // The fields below are the *non-credential* overrides the chains
-// can't infer: a custom endpoint URL (minio / LocalStack / VPC
-// endpoint) and S3 path-style addressing (mandatory for minio).
-// For minio smoke tests, operators point AWS_ACCESS_KEY_ID /
-// AWS_SECRET_ACCESS_KEY (or an AWS_PROFILE) at the minio creds —
+// can't infer: a custom endpoint URL (LocalStack / VPC
+// endpoint) and S3 path-style addressing (mandatory for most of them).
+// For local smoke tests, operators point AWS_ACCESS_KEY_ID /
+// AWS_SECRET_ACCESS_KEY (or an AWS_PROFILE) at the endpoint's creds —
 // the SDK picks them up the same way it would for real S3.
 type StateOptions struct {
 	// S3Endpoint, if set, overrides the AWS S3 endpoint URL. Set
-	// this to the minio endpoint URL (e.g. "http://localhost:9000")
-	// for smoke tests against minio.
+	// this to the endpoint URL (e.g. "http://localhost:4566")
+	// for smoke tests against a local S3 endpoint.
 	S3Endpoint string
 
 	// S3ForcePathStyle uses path-style addressing (bucket in path
-	// rather than subdomain). Required for minio; AWS S3 itself
+	// rather than subdomain). Required by most non-AWS endpoints; AWS S3 itself
 	// works either way.
 	S3ForcePathStyle bool
 
-	// S3Region overrides the resolved region. Useful for minio
+	// S3Region overrides the resolved region. Useful for local
 	// (whose region is arbitrary) and for explicit pinning when the
 	// backend HCL omits a region.
 	S3Region string
@@ -211,7 +211,7 @@ func readLocalState(projectDir, configuredPath string) ([]byte, error) {
 	return raw, nil
 }
 
-// ── S3 backend (also minio) ──────────────────────────────────────────
+// ── S3 backend (also non-AWS S3 endpoints) ───────────────────────────
 
 func readS3State(ctx context.Context, settings map[string]string, opts StateOptions) ([]byte, error) {
 	bucket := settings["bucket"]

--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -21,12 +21,12 @@ Both smokes read the token from the credentials file (or
 `$TERRAPOD_TOKEN`).
 
 You also need:
-- `docker compose` (for minio in the migrate smoke)
+- `docker compose` (for LocalStack in the migrate smoke)
 - `tofu` or `terraform` on PATH
 - `go` (for building the migrator + provider locally)
 - `git` (the migrate smoke seeds a fake clone)
 
-## `smoke-migrate-s3.sh` — terrapod-migrate end-to-end against minio
+## `smoke-migrate-s3.sh` — terrapod-migrate end-to-end against LocalStack
 
 ```sh
 scripts/smoke/smoke-migrate-s3.sh
@@ -34,22 +34,22 @@ scripts/smoke/smoke-migrate-s3.sh
 
 What it does:
 
-1. `docker compose up` — boots minio at `127.0.0.1:9100`
+1. `docker compose up` — boots LocalStack at `127.0.0.1:4666`
 2. Generates a one-project Atlantis fixture with an S3-backed terraform module
-3. Runs `terraform apply` to seed minio with real state
+3. Runs `terraform apply` to seed LocalStack with real state
 4. Builds the migrator from current source
 5. Runs `terrapod-migrate apply --dry-run` then `--apply`
 6. Runs `terrapod-migrate verify` (confirms workspace + state landed on Terrapod)
 7. Runs `terrapod-migrate cutover --write-handover` (writes MIGRATION-HANDOVER.md)
 8. Re-runs `apply` to confirm state migration is idempotent (must report `state: "unchanged"` for every workspace)
 
-Leaves minio running so you can iterate; tear down with:
+Leaves LocalStack running so you can iterate; tear down with:
 
 ```sh
 docker compose -f scripts/smoke/docker-compose.yml down -v
 ```
 
-The minio bucket is wiped on `down -v`. The fixture and state file live in `/tmp/terrapod-smoke-*` — also wiped on reboot.
+The LocalStack bucket is wiped on `down -v`. The fixture and state file live in `/tmp/terrapod-smoke-*` — also wiped on reboot.
 
 ## `smoke-provider.sh` — terraform-provider-terrapod against Tilt
 
@@ -99,7 +99,7 @@ you can re-run the smoke without colliding with leftover resources.
 ```
 scripts/smoke/
 ├── README.md                  # this file
-├── docker-compose.yml         # minio service + bucket-init container
+├── docker-compose.yml         # LocalStack service + bucket-init container
 ├── seed-fixture.sh            # generates the migrate-smoke atlantis fixture
 ├── smoke-migrate-s3.sh        # the migrate smoke driver
 ├── smoke-provider.sh          # the provider smoke driver

--- a/scripts/smoke/docker-compose.yml
+++ b/scripts/smoke/docker-compose.yml
@@ -1,51 +1,39 @@
 # Smoke-test infra for terrapod-migrate.
 #
-# Two services:
-#   minio    — S3-compatible object store. Stand-in for AWS S3 in
-#              the Atlantis state-migration smoke (the migrator
-#              reads from minio via aws-sdk-go-v2 + --s3-endpoint-url).
-#   minio-init — One-shot container that creates a bucket the
-#                fixture uses for state storage.
+#   localstack — a local S3 endpoint standing in for AWS S3 in the Atlantis
+#                state-migration smoke. The migrator reads from it with
+#                aws-sdk-go-v2 plus --s3-endpoint-url, exactly as it would
+#                against any non-AWS endpoint.
 #
-# Networking: minio listens on host:9100 (S3) and host:9101 (console).
-# The 9000/9001 defaults clash with too many other dev tools — using
-# 9100/9101 keeps this isolated.
+# LocalStack rather than MinIO deliberately (#1195): MinIO's upstream is
+# abandoned, and `docker-compose.test.yml` already uses LocalStack for this
+# same job. One fake for one purpose.
+#
+# The bucket is created by an init hook LocalStack runs when it becomes ready,
+# so there is no second container to orchestrate and no "did the init run yet"
+# race for the caller to think about.
+#
+# Networking: 127.0.0.1:4666, shifted off LocalStack's default 4566 so this
+# harness cannot collide with a LocalStack someone already has running.
 #
 # Start with: docker compose -f scripts/smoke/docker-compose.yml up -d
 # Tear down:  docker compose -f scripts/smoke/docker-compose.yml down -v
 
 services:
-  minio:
-    image: minio/minio:latest
-    container_name: terrapod-smoke-minio
-    command: server /data --console-address ":9001"
+  localstack:
+    image: ${LOCALSTACK_IMAGE:-localstack/localstack:4}
+    container_name: terrapod-smoke-localstack
     environment:
-      MINIO_ROOT_USER: minio-smoke
-      MINIO_ROOT_PASSWORD: minio-smoke-secret
+      SERVICES: s3
+      DEFAULT_REGION: us-east-1
     ports:
-      - "127.0.0.1:9100:9000"
-      - "127.0.0.1:9101:9001"
+      - "127.0.0.1:4666:4566"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/live"]
+      # `s3` reaching "running" is the signal the bucket hook can have run —
+      # a plain port check would go green before S3 could serve anything.
+      test: ["CMD-SHELL", "curl -sf http://localhost:4566/_localstack/health | grep -q '\"s3\": \"running\"'"]
       interval: 2s
       timeout: 5s
       retries: 30
     volumes:
-      - minio-data:/data
-
-  # Run once after minio is healthy; creates the smoke bucket and exits.
-  minio-init:
-    image: minio/mc:latest
-    container_name: terrapod-smoke-minio-init
-    depends_on:
-      minio:
-        condition: service_healthy
-    entrypoint: ["/bin/sh", "-c"]
-    command: |
-      "set -euo pipefail;
-       mc alias set smoke http://minio:9000 minio-smoke minio-smoke-secret;
-       mc mb --ignore-existing smoke/tfstate;
-       echo 'bucket smoke/tfstate is ready';"
-
-volumes:
-  minio-data:
+      - ./localstack-init:/etc/localstack/init/ready.d:ro

--- a/scripts/smoke/localstack-init/01-create-bucket.sh
+++ b/scripts/smoke/localstack-init/01-create-bucket.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Runs inside LocalStack once S3 is ready (init/ready.d), creating the bucket
+# the fixture writes its terraform state into.
+#
+# Idempotent: `up` on an existing volume re-runs this, and a second `mb` of an
+# existing bucket must not fail the boot.
+set -eu
+awslocal s3 mb s3://tfstate 2>/dev/null || true
+echo "smoke bucket s3://tfstate is ready"

--- a/scripts/smoke/seed-fixture.sh
+++ b/scripts/smoke/seed-fixture.sh
@@ -7,7 +7,7 @@
 #   <fixture>/.git                      — initialised + a fake origin URL
 #
 # After `terraform apply` is run in <fixture>/example, the state lives
-# in minio (s3://tfstate/example/terraform.tfstate) and the migrator
+# in LocalStack (s3://tfstate/example/terraform.tfstate) and the migrator
 # can read it via the same AWS SDK code path that real S3 uses.
 #
 # Usage: scripts/smoke/seed-fixture.sh <dest-dir>


### PR DESCRIPTION
Closes #1195.

MinIO stood in for S3 in the `terrapod-migrate` smoke harness. Its upstream is abandoned, which turns a convenient fake into carried risk: no security fixes, nobody to report to, and a `:latest` tag whose behaviour can move with no one minding it.

It was also **inconsistent with the project twice over**:

- `docs/architecture.md` and `docs/known-limitations.md` both state there is no MinIO dependency. True of the product — but a contributor grepping the repo found one anyway, in a harness the README tells them to run.
- `docker-compose.test.yml` already used **LocalStack** for exactly this job. Two fakes for one purpose is the sort of thing nobody notices until they are debugging the wrong one.

## What changed

**The smoke stack** is LocalStack, matching the test stack. Two improvements fell out of the swap rather than being bolted on:

- **Bucket creation moved from a second container into an init hook.** The old setup ran `minio-init` as a one-shot after polling for health, with a comment explaining why `--wait` misread its exit-0 as failure. Now the healthcheck passing *is* the ready signal — no sequencing, and no window where S3 answers but the bucket is absent. The driver still asserts the bucket exists, so a broken hook fails there rather than three steps later inside a terraform error.
- **Port 4666**, shifted off LocalStack's default, so the harness cannot collide with a LocalStack someone already has running — the same reasoning the old file gave for avoiding 9000/9001.

**In `migrate/`**, `--s3-endpoint-url` and `--s3-force-path-style` are **untouched**. They exist for *any* non-AWS S3 endpoint — LocalStack, a VPC endpoint, whatever an operator runs — and that is the correct feature. Only the minio-as-the-example wording in their help text and comments changes.

**Left exactly as they are**: the architecture and known-limitations statements that Terrapod does not bundle MinIO. Those were always right.

## Verified by booting it, not by reading it

```
terrapod-smoke-localstack  running  Up (healthy)
init hook            → s3://tfstate created
aws s3 cp ↑↓         → 53 bytes, content matches byte for byte
s3api head-object    → path-style addressing works (what the migrator uses)
docker compose restart → hook re-runs, boot succeeds, bucket intact
```

The idempotency check matters: the old two-container setup handled re-runs explicitly, so the replacement had to as well rather than failing the boot on a second `up`.

`go build ./...` and `go vet ./...` clean in `migrate/`. The mirror guard from #1194 passes — the new image reference is overridable, so a contributor still pulls upstream by default.