### PR TITLE
Make HA gate rows 9 and 10 real, and fix the two defects that found

### DIFF
--- a/docs/ha-operations.md
+++ b/docs/ha-operations.md
@@ -104,7 +104,14 @@ The rehearsed path. Everything here is checkable before you touch DNS.
    which is what stops an empty `irreplaceable-missing` being mistaken for a
    verified store. *Rows without blobs is the failure that looks like success.*
 3. **Quiesce the outgoing node** — set `ha.role: follower` on it and roll it. It
-   stops originating writes and stops all scheduled work.
+   stops originating writes, stops all scheduled work, and **retires its
+   in-flight runs**: anything mid-plan or mid-apply ends `errored`, naming the
+   role change as the reason. That last part matters more than it sounds. A run
+   left sitting in `planning` would hold its workspace at the per-workspace
+   serialization gate, and no operator could clear it — `workspace.locked` is
+   untouched, so there is nothing to unlock; the block is the row itself.
+   Retiring them means the workspace is usable on the incoming node straight
+   away, and re-queueing is the recovery.
 4. **Confirm it has stood down.** Its own `/ha` page reports its role. A write
    against it now returns 503.
 5. **Move the shared names** — internal, external, and webhook.
@@ -137,6 +144,11 @@ The same, minus the step you cannot take.
 gone — its Job was launched from a cluster the new leader does not drive. The
 run's workspace is not corrupted, and re-queueing is the recovery. Anything that
 had already reached a terminal state is safe.
+
+There was no chance to quiesce, so those runs are still sitting on the node that
+vanished. It resolves them itself the moment it comes back: a node that starts
+in a different role from the one it last held retires them before it does
+anything else, so it never carries a previous era's work into a new one.
 
 **What you also lose: replication lag.** Writes the leader accepted but had not
 yet been pulled are not on the survivor. This is the honest cost of asynchronous

--- a/helm/terrapod/values-ha-a.yaml
+++ b/helm/terrapod/values-ha-a.yaml
@@ -37,8 +37,41 @@ ingress:
 
 web:
   enabled: false
+# A real execution fleet on each node. Without it the pair can prove that
+# settings and artifacts replicate, but not that a RUN survives a cutover —
+# which is the part of the gate a two-API-node pair could not reach (#1188).
+#
+# Per-node fleets: each listener points at its OWN node, so nothing crosses the
+# boundary and each side's capacity is exercised while that side leads. The
+# shared-fleet topology is exercised separately by re-pointing at the shared
+# Service the harness creates.
 listener:
-  enabled: false
+  enabled: true
+  name: ha-a-listener
+  joinToken: "ha-smoke-join-token-a-not-for-real-use"
+  image:
+    # Built locally by the harness; never pulled.
+    repository: terrapod-listener
+    tag: local
+    pullPolicy: Never
+
+runners:
+  image:
+    # Built by `tilt trigger build-runner-image`; never pulled.
+    repository: terrapod-runner
+    tag: local
+    pullPolicy: Never
+
+# Pre-install so the pool exists before the listener rolls out — otherwise
+# `helm --wait` deadlocks on a listener whose readiness gates on joining a pool
+# that does not exist yet. Same reasoning as the eval profile.
+bootstrap:
+  hook: "pre-install,pre-upgrade"
+  hookWeight: "-3"
+  adminEmail: admin
+  adminPassword: terrapod
+  poolName: ha-a-pool
+  poolToken: "ha-smoke-join-token-a-not-for-real-use"
 
 api:
   replicas: 1

--- a/helm/terrapod/values-ha-a.yaml
+++ b/helm/terrapod/values-ha-a.yaml
@@ -47,6 +47,13 @@ web:
 # Service the harness creates.
 listener:
   enabled: true
+  # Same single-node deadlock the API notes below: the default required
+  # anti-affinity stops a rolling update replacing the listener, because the
+  # new pod cannot schedule until the old one goes and the old one waits for
+  # the new one. It resolves eventually, but it makes every `helm upgrade`
+  # here take minutes. A real pair on real nodes leaves it on.
+  podAntiAffinity:
+    enabled: false
   name: ha-a-listener
   joinToken: "ha-smoke-join-token-a-not-for-real-use"
   image:
@@ -91,6 +98,14 @@ api:
       # arrive is the object-store half of the exercise (#1114).
       filesystem:
         base_url: "http://terrapod-a-api:8000"
+    # The pair re-joins its fleets repeatedly — every table run flips roles at
+    # least twice, and the shared-fleet row deliberately forces a re-join. Two
+    # uses (the shipped default) is right for a real install bootstrapping once;
+    # here it would exhaust on the second run and report a fleet failure that is
+    # really a rig artefact.
+    agent_pools:
+      default_join_token_max_uses: 200
+      default_join_token_ttl_seconds: 604800
     ha:
       role: leader
       node_name: node-a

--- a/helm/terrapod/values-ha-b.yaml
+++ b/helm/terrapod/values-ha-b.yaml
@@ -43,6 +43,13 @@ web:
 # Service the harness creates.
 listener:
   enabled: true
+  # Same single-node deadlock the API notes below: the default required
+  # anti-affinity stops a rolling update replacing the listener, because the
+  # new pod cannot schedule until the old one goes and the old one waits for
+  # the new one. It resolves eventually, but it makes every `helm upgrade`
+  # here take minutes. A real pair on real nodes leaves it on.
+  podAntiAffinity:
+    enabled: false
   name: ha-b-listener
   joinToken: "ha-smoke-join-token-b-not-for-real-use"
   image:
@@ -87,6 +94,14 @@ api:
       # arrive is the object-store half of the exercise (#1114).
       filesystem:
         base_url: "http://terrapod-b-api:8000"
+    # The pair re-joins its fleets repeatedly — every table run flips roles at
+    # least twice, and the shared-fleet row deliberately forces a re-join. Two
+    # uses (the shipped default) is right for a real install bootstrapping once;
+    # here it would exhaust on the second run and report a fleet failure that is
+    # really a rig artefact.
+    agent_pools:
+      default_join_token_max_uses: 200
+      default_join_token_ttl_seconds: 604800
     ha:
       role: follower
       node_name: node-b

--- a/helm/terrapod/values-ha-b.yaml
+++ b/helm/terrapod/values-ha-b.yaml
@@ -33,8 +33,41 @@ ingress:
 
 web:
   enabled: false
+# A real execution fleet on each node. Without it the pair can prove that
+# settings and artifacts replicate, but not that a RUN survives a cutover —
+# which is the part of the gate a two-API-node pair could not reach (#1188).
+#
+# Per-node fleets: each listener points at its OWN node, so nothing crosses the
+# boundary and each side's capacity is exercised while that side leads. The
+# shared-fleet topology is exercised separately by re-pointing at the shared
+# Service the harness creates.
 listener:
-  enabled: false
+  enabled: true
+  name: ha-b-listener
+  joinToken: "ha-smoke-join-token-b-not-for-real-use"
+  image:
+    # Built locally by the harness; never pulled.
+    repository: terrapod-listener
+    tag: local
+    pullPolicy: Never
+
+runners:
+  image:
+    # Built by `tilt trigger build-runner-image`; never pulled.
+    repository: terrapod-runner
+    tag: local
+    pullPolicy: Never
+
+# Pre-install so the pool exists before the listener rolls out — otherwise
+# `helm --wait` deadlocks on a listener whose readiness gates on joining a pool
+# that does not exist yet. Same reasoning as the eval profile.
+bootstrap:
+  hook: "pre-install,pre-upgrade"
+  hookWeight: "-3"
+  adminEmail: admin
+  adminPassword: terrapod
+  poolName: ha-b-pool
+  poolToken: "ha-smoke-join-token-b-not-for-real-use"
 
 api:
   replicas: 1

--- a/scripts/ha-smoke.sh
+++ b/scripts/ha-smoke.sh
@@ -9,6 +9,7 @@
 #   scripts/ha-smoke.sh verify  assert the pair actually converges
 #   scripts/ha-smoke.sh reverse swap the roles and assert it works both ways
 #   scripts/ha-smoke.sh table   walk the #960 release-gate table, honestly
+#   scripts/ha-smoke.sh table 10   …or just one row, while working on it
 #   scripts/ha-smoke.sh down    remove node B
 #
 # The peer link runs over in-cluster Service DNS. That is not a shortcut:
@@ -54,18 +55,34 @@ cmd_up() {
   done
   ok "peer secrets present in both namespaces"
 
-  # Both nodes run the image Tilt already built — no separate build, and it
-  # guarantees the pair is the same code. The dev stack itself is untouched.
-  # Both nodes run the images Tilt already built. The migrations job is a
-  # SEPARATE image from the API — pinning only the API leaves the pre-install
+  # Both nodes run what Tilt already built — no separate build, and it
+  # guarantees the pair is the same code as the dev stack. The migrations job is
+  # a SEPARATE image from the API: pinning only the API leaves the pre-install
   # hook pulling from GHCR, which on a local cluster never succeeds and shows up
   # as an inscrutable "Job in progress" timeout.
-  local api_image mig_image
-  api_image=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^terrapod-api:tilt-' | head -1)
-  mig_image=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^terrapod-migrations:tilt-' | head -1)
-  [[ -n "$api_image" && -n "$mig_image" ]] \
+  #
+  # But the pair does NOT run the `tilt-<hash>` tags directly. Those move: edit
+  # a source file and Tilt rebuilds under a new hash, and the tag the pair
+  # pinned can stop resolving — with `pullPolicy: Never` that is
+  # `ErrImageNeverPull` on a pre-upgrade hook, i.e. a helm timeout minutes later
+  # blaming a Job for something that is really a vanished tag. So the images are
+  # re-tagged into a namespace the pair owns and Tilt never touches.
+  local api_src mig_src
+  api_src=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^terrapod-api:tilt-' | head -1)
+  mig_src=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^terrapod-migrations:tilt-' | head -1)
+  [[ -n "$api_src" && -n "$mig_src" ]] \
     || fail "no tilt-built images — run 'tilt up' once so the pair has something to run"
-  info "pair on $api_image + $mig_image"
+
+  # Re-tag unless the caller has already staged its own build under :ha (which
+  # is how a fix is tried on the pair before it exists in the dev stack).
+  local api_image="terrapod-api:ha" mig_image="terrapod-migrations:ha"
+  if [[ "${HA_KEEP_IMAGES:-}" != "1" ]]; then
+    docker tag "$api_src" "$api_image"
+    docker tag "$mig_src" "$mig_image"
+    info "pinned $api_src -> $api_image, $mig_src -> $mig_image"
+  else
+    info "HA_KEEP_IMAGES=1 — reusing whatever is tagged $api_image / $mig_image"
+  fi
 
   local node ns
   for node in a b; do
@@ -320,7 +337,7 @@ case "${1:-}" in
   up) cmd_up ;;
   verify) cmd_verify ;;
   reverse) cmd_reverse ;;
-  table) python3 "$REPO_ROOT/scripts/ha_smoke_table.py" ;;
+  table) shift; python3 "$REPO_ROOT/scripts/ha_smoke_table.py" "$@" ;;
   down) cmd_down ;;
-  *) print "usage: $0 {up|verify|reverse|table|down}"; exit 2 ;;
+  *) print "usage: $0 {up|verify|reverse|table [row...]|down}"; exit 2 ;;
 esac

--- a/scripts/ha_smoke_table.py
+++ b/scripts/ha_smoke_table.py
@@ -565,6 +565,8 @@ print('USES', tok.use_count if tok else -1)
     # the order it happens in: the fleet has been addressing the shared name all
     # along, and the cutover is what changes the answer underneath it.
     _point_shared_name_at(NS_A)
+    rejoined = False
+    uses_after = uses_before
     try:
         set_role_and_listener(NS_A, role="leader", api_url=f"http://{_SHARED_SVC}:8000")
 
@@ -590,6 +592,9 @@ print('USES', tok.use_count if tok else -1)
 """)
         uses_after = int(after.split("USES ")[-1].splitlines()[0])
     finally:
+        # Undo only what this row changed. The roles are put back by main(),
+        # always and for every invocation, so a single-row run cannot leave the
+        # pair with two leaders for the next one to trip over.
         set_role_and_listener(NS_A, role="leader", api_url="")
         _point_shared_name_at(NS_A)
 
@@ -641,10 +646,18 @@ def main() -> int:
     scope = f" (rows {', '.join(wanted)})" if wanted else ""
     print(f"{CYAN}==>{RESET} #960 release-gate table against {NS_A} / {NS_B}{scope}\n")
 
-    for name, fn in ROWS.items():
-        if wanted and name not in wanted:
-            continue
-        fn(stamp)  # type: ignore[operator]
+    try:
+        for name, fn in ROWS.items():
+            if wanted and name not in wanted:
+                continue
+            fn(stamp)  # type: ignore[operator]
+    finally:
+        # Always, including on the way out of a failure and including a
+        # single-row run. A row that leaves the pair with two leaders makes the
+        # NEXT run open by reporting replication as broken, which is true and
+        # completely misleading — the cause is two rows earlier and in a
+        # different invocation.
+        reset_roles()
 
     if not wanted or "13" in wanted:
         # Recorded, not silently omitted. The data half is already proven — the
@@ -661,9 +674,6 @@ def main() -> int:
         record("13", "terraform init against a private module and provider on B", "SKIP",
                "needs a config-version tarball on B and a runner that can fetch a "
                "terraform binary; the rows and blobs themselves are verified (#1114)")
-
-    if not wanted:
-        reset_roles()
 
     failed = [r for r in results if r[2] == "FAIL"]
     skipped = [r for r in results if r[2] == "SKIP"]

--- a/scripts/ha_smoke_table.py
+++ b/scripts/ha_smoke_table.py
@@ -12,6 +12,7 @@ Run:  scripts/ha-smoke.sh table
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import time
@@ -30,19 +31,33 @@ def _k(*args: str, check: bool = True) -> str:
         ["kubectl", "--context", CTX, *args], capture_output=True, text=True
     )
     if check and out.returncode != 0:
-        raise RuntimeError(f"kubectl {' '.join(args)} failed:\n{out.stderr[-2000:]}")
+        raise RuntimeError(f"kubectl {' '.join(args)} failed:\n{_trim(out.stderr)}")
     return out.stdout
 
 
+def _trim(text: str, head: int = 1500, tail: int = 1200) -> str:
+    """Keep both ends. A Python traceback names the exception at the end of the
+    message and SQLAlchemy then prints the whole statement after it, so keeping
+    only the tail throws away the one line that says what went wrong."""
+    if len(text) <= head + tail:
+        return text
+    return f"{text[:head]}\n  … {len(text) - head - tail} characters elided …\n{text[-tail:]}"
+
+
 PRELUDE = """
-import asyncio, sys, json
+import asyncio, sys, json, uuid
 from sqlalchemy import select, delete, func
 from terrapod.db.session import get_db_session, init_db
+from terrapod.redis.client import init_redis
 from terrapod.db import models as m
-from terrapod.services import replication
+from terrapod.services import replication, run_service, pool_set, agent_pool_service
 
 async def main():
     await init_db()
+    # Redis as well as the database: the listener registry lives there, so a
+    # snippet that asks "which listeners has this node got" needs it, and the
+    # cost on the snippets that do not is one connection.
+    await init_redis()
     # The outbox is installed by the API's startup, and this is not that
     # process. Without it a row lands and no event is ever recorded, and the
     # pair looks broken when it is not.
@@ -81,6 +96,23 @@ def scale(ns: str, replicas: int) -> None:
             time.sleep(2)
 
 
+def _helm(ns: str, *overrides: str, timeout: str = "8m") -> None:
+    """`helm upgrade` on one node of the pair, with helm's own error on failure.
+
+    `subprocess.run(check=True)` raises a CalledProcessError whose message is
+    the argv and nothing else, so a failed upgrade used to report only that it
+    had failed — which is no use at 03:00 or in a table run.
+    """
+    out = subprocess.run(
+        ["helm", "--kube-context", CTX, "upgrade", REL[ns], "helm/terrapod",
+         "-n", ns, "-f", f"helm/terrapod/values-ha-{ns[-1]}.yaml",
+         *overrides, "--reuse-values", "--wait", "--timeout", timeout],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"helm upgrade {REL[ns]} failed:\n{_trim(out.stderr or out.stdout)}")
+
+
 def set_role(ns: str, role: str) -> None:
     """Flip a node's role the way an operator would — through Helm.
 
@@ -90,14 +122,25 @@ def set_role(ns: str, role: str) -> None:
     Drop the stale ownership (`kubectl patch deploy … --type=json -p
     '[{"op":"remove","path":"/metadata/managedFields"}]'`) and upgrade again.
     Roll images through Helm on this pair and it never arises.
+
+    Note the explicit `--set` alongside `-f`: `--reuse-values` does NOT protect
+    a value the values file also sets. The file is re-applied over the reused
+    values, so `helm upgrade -f values-ha-a.yaml --reuse-values` on its own puts
+    node A back to `role: leader` no matter what it was before — quietly, and
+    only visible in the rendered ConfigMap.
     """
-    subprocess.run(
-        ["helm", "--kube-context", CTX, "upgrade", REL[ns], "helm/terrapod",
-         "-n", ns, "-f", f"helm/terrapod/values-ha-{ns[-1]}.yaml",
-         "--set", f"api.config.ha.role={role}", "--reuse-values",
-         "--wait", "--timeout", "5m"],
-        check=True, capture_output=True, text=True,
-    )
+    _helm(ns, "--set", f"api.config.ha.role={role}")
+
+
+def set_role_and_listener(ns: str, *, role: str, api_url: str) -> None:
+    """`set_role`, plus the listener's view of where the API lives.
+
+    Slower than it looks: changing `listener.apiUrl` replaces the listener pod,
+    and on this single-node cluster the outgoing one has to finish terminating
+    before the new one can schedule. Hence the longer timeout.
+    """
+    _helm(ns, "--set", f"api.config.ha.role={role}", "--set", f"listener.apiUrl={api_url}",
+          timeout="10m")
 
 
 def record(row: str, name: str, verdict: str, detail: str = "") -> None:
@@ -302,47 +345,333 @@ def row_7_unplanned_failover(stamp: str) -> None:
            "PASS" if ok else "FAIL")
 
 
-def restore(stamp: str) -> None:
+def reset_roles() -> None:
+    """Back to the pair's canonical arrangement: A leads, B follows."""
     set_role(NS_A, "leader")
     set_role(NS_B, "follower")
+
+
+def restore(stamp: str) -> None:
+    reset_roles()
     name = f"ha-failback-{stamp}"
     make_ws(NS_A, name)
     record("6b", "Fail back to A and re-converge",
            "PASS" if poll(NS_B, sees_ws(name), tries=30) else "FAIL")
 
 
+def _listener_names(ns: str) -> list[str]:
+    """The listeners this node currently has registered, from its own Redis."""
+    out = run(
+        ns,
+        "names = []\n"
+        "for p in (await db.execute(select(m.AgentPool))).scalars().all():\n"
+        "    for lst in await agent_pool_service.list_listeners(str(p.id)):\n"
+        "        names.append(lst.get('name') or '')\n"
+        "print('LISTENERS', json.dumps(sorted(n for n in names if n)))",
+        check=False,
+    )
+    try:
+        return json.loads(out.split("LISTENERS ")[-1].splitlines()[0])
+    except (ValueError, IndexError):
+        return []
+
+
+def _scale_listener(ns: str, replicas: int) -> None:
+    _k("-n", ns, "scale", f"deploy/{REL[ns]}-listener", f"--replicas={replicas}")
+    if replicas:
+        _k("-n", ns, "rollout", "status", f"deploy/{REL[ns]}-listener", "--timeout=180s")
+
+
+# The run held across the cutover asks for more CPU than the cluster has, so its
+# Job is created and its pod never schedules. That is a real in-flight run — the
+# platform waiting on capacity is an ordinary thing — and it removes the race
+# against a runner that would otherwise exit within a second or two of starting.
+# The reconciler's own unschedulable timeout is 300s, which is an order of
+# magnitude more than a demotion needs.
+_UNSCHEDULABLE_CPU = "64"
+
+
+def _delete_pinned_jobs() -> None:
+    """Remove the Jobs whose pods were never going to schedule.
+
+    The listener admits work against the count of *running* Jobs (#749), and a
+    Job stuck Pending on capacity counts. Since #1198 the reconciler reaps these
+    itself once the launch timeout expires, but row 9 cuts over long before
+    that, so the row would otherwise hand the next one a listener at capacity —
+    which is exactly how row 9 failed the first time it ran, reporting "no
+    listener claimed the run" for a reason that had nothing to do with the
+    cutover.
+    """
+    for ns in (NS_A, NS_B):
+        names = _k("-n", ns, "get", "job", "-o",
+                   "jsonpath={.items[*].metadata.name}", check=False).split()
+        for name in names:
+            pending = _k("-n", ns, "get", "pod", "--selector", f"job-name={name}",
+                         "-o", "jsonpath={.items[*].status.phase}", check=False)
+            if "Pending" in pending:
+                _k("-n", ns, "delete", "job", name, "--ignore-not-found", check=False)
+
+
+def row_9_cutover_midrun(stamp: str) -> None:
+    """A genuinely in-flight run, held across a demotion.
+
+    Row 14 seeds a run row and calls the retirement predicate directly. This one
+    is claimed by a real listener over SSE and backed by a real Kubernetes Job,
+    which is the difference that matters: it exercises the *wiring*, not the
+    predicate. That distinction is what found #1197 — the predicate had a single
+    caller, reachable only under `ha.role: auto`, so the demotion step the
+    operations runbook prescribes never reached it and the node's in-flight runs
+    stayed `planning` for as long as it remained a follower.
+    """
+    reset_roles()
+    ws = f"ha-midrun-{stamp}"
+    pools = run(
+        NS_A,
+        "ids = [str(p.id) for p in (await db.execute(select(m.AgentPool))).scalars().all()]\n"
+        "print('POOLS', json.dumps(ids))",
+    )
+    pool_ids = json.loads(pools.split("POOLS ")[-1].splitlines()[0])
+    if not pool_ids:
+        record("9", "Cut over mid-run", "FAIL", "node A has no agent pool to route to")
+        return
+
+    run(
+        NS_A,
+        f"ws = m.Workspace(name='{ws}', execution_mode='agent',"
+        f" resource_cpu='{_UNSCHEDULABLE_CPU}')\n"
+        f"pool_set.set_workspace_pools(ws, {pool_ids!r})\n"
+        "db.add(ws)\n"
+        "await db.flush()\n"
+        "run_row = await run_service.create_run(db, ws, message='row 9')\n"
+        "await run_service.queue_run(db, run_row)\n"
+        "await db.commit()\n"
+        "print('RUN', run_row.id)",
+    )
+
+    claimed = f"""
+row = await db.scalar(select(m.Run).join(m.Workspace)
+                      .where(m.Workspace.name == '{ws}')
+                      .order_by(m.Run.created_at.desc()).limit(1))
+print('OK' if row is not None and row.status == 'planning' and row.job_name else 'no')
+"""
+    if not poll(NS_A, claimed, tries=15, delay=2.0):
+        record("9", "Cut over mid-run", "FAIL",
+               "no listener claimed the run, so there was nothing in flight to cut over")
+        return
+
+    set_role(NS_A, "follower")
+
+    verdict = run(NS_A, f"""
+row = await db.scalar(select(m.Run).join(m.Workspace)
+                      .where(m.Workspace.name == '{ws}')
+                      .order_by(m.Run.created_at.desc()).limit(1))
+wsrow = await db.scalar(select(m.Workspace).where(m.Workspace.name == '{ws}'))
+print('VERDICT', json.dumps({{
+    'status': row.status,
+    'by_role_change': 'role changed' in (row.error_message or ''),
+    'workspace_locked': bool(wsrow.locked),
+}}))
+""")
+    state = json.loads(verdict.split("VERDICT ")[-1].splitlines()[0])
+    retired = state["status"] == "errored" and state["by_role_change"]
+
+    # The other half of the row: the workspace must be immediately usable on the
+    # node that took over. A frozen `planning` row would hold the per-workspace
+    # serialization gate, and no operator can clear it — `workspace.locked` is
+    # untouched, so there is nothing to unlock. Re-pointing at the surviving
+    # fleet is the per-node-fleet cutover step, not a workaround.
+    set_role(NS_B, "leader")
+    poll(NS_B, sees_ws(ws), tries=30)
+    run(NS_B, f"""
+wsrow = await db.scalar(select(m.Workspace).where(m.Workspace.name == '{ws}'))
+wsrow.resource_cpu = '1'
+ids = [str(p.id) for p in (await db.execute(select(m.AgentPool))).scalars().all()]
+pool_set.set_workspace_pools(wsrow, ids)
+await db.flush()
+run_row = await run_service.create_run(db, wsrow, message='row 9 requeue')
+await run_service.queue_run(db, run_row)
+await db.commit()
+print('REQUEUED', run_row.id)
+""", check=False)
+    requeued = poll(NS_B, f"""
+row = await db.scalar(select(m.Run).join(m.Workspace)
+                      .where(m.Workspace.name == '{ws}', m.Run.message == 'row 9 requeue')
+                      .order_by(m.Run.created_at.desc()).limit(1))
+print('OK' if row is not None and row.status in ('planning', 'planned', 'errored') else 'no')
+""", tries=20, delay=3.0)
+
+    _delete_pinned_jobs()
+
+    ok = retired and not state["workspace_locked"] and requeued
+    record("9", "Cut over mid-run", "PASS" if ok else "FAIL",
+           f"in-flight run → {state['status']}"
+           + (" by the role change" if state["by_role_change"] else " by something else")
+           + (", workspace not locked" if not state["workspace_locked"] else ", WORKSPACE LEFT LOCKED")
+           + (", re-queue dispatched on the promoted node" if requeued
+              else ", RE-QUEUE NEVER DISPATCHED"))
+
+
+_SHARED_SVC = "terrapod-shared-api"
+
+
+def _point_shared_name_at(target_ns: str) -> None:
+    """Move the shared name, the way moving DNS moves it.
+
+    An ExternalName Service is the closest thing this rig has to a name whose
+    answer changes: the listener's configuration never changes, only what its
+    hostname resolves to — which is exactly the shared-fleet topology.
+    """
+    manifest = f"""
+apiVersion: v1
+kind: Service
+metadata:
+  name: {_SHARED_SVC}
+  namespace: {NS_A}
+spec:
+  type: ExternalName
+  externalName: {REL[target_ns]}-api.{target_ns}.svc.cluster.local
+"""
+    subprocess.run(
+        ["kubectl", "--context", CTX, "apply", "-f", "-"],
+        input=manifest, text=True, check=True, capture_output=True,
+    )
+
+
+def row_10_listener_topologies(stamp: str) -> None:
+    """Both fleets, and a re-join that needs no operator.
+
+    Per-node is the pair's steady state and is already proven by row 9 — node A's
+    listener claimed that run against node A. This exercises the other topology:
+    one fleet addressing a *shared* name, which after a cutover finds itself
+    talking to a node whose CA never issued its certificate. It must recover on
+    its own, and the mechanism it recovers by is the join token, which is why the
+    assertion is that a token's `use_count` moved rather than merely that a
+    listener reappeared.
+    """
+    reset_roles()
+    per_node = _listener_names(NS_A)
+    if not per_node:
+        record("10", "Cut over with each listener topology", "FAIL",
+               "node A's own fleet is not registered, so neither topology can be judged")
+        return
+
+    before = run(NS_B, """
+tok = await db.scalar(select(m.AgentPoolToken).order_by(m.AgentPoolToken.created_at))
+print('USES', tok.use_count if tok else -1)
+""")
+    uses_before = int(before.split("USES ")[-1].splitlines()[0])
+
+    # Establish the shared-fleet topology *before* the cutover, because that is
+    # the order it happens in: the fleet has been addressing the shared name all
+    # along, and the cutover is what changes the answer underneath it.
+    _point_shared_name_at(NS_A)
+    try:
+        set_role_and_listener(NS_A, role="leader", api_url=f"http://{_SHARED_SVC}:8000")
+
+        # The cutover. Demoting A rolls its API, which drops the fleet's SSE
+        # connection — that is what makes it resolve the name again and find B.
+        # A shared fleet that never lost its connection would have no reason to
+        # look, which is why the demotion has to come after the re-pointing and
+        # not before.
+        set_role(NS_B, "leader")
+        _point_shared_name_at(NS_B)
+        set_role(NS_A, "follower")
+
+        rejoined = False
+        for _ in range(40):
+            if any(n.startswith("ha-a-listener") for n in _listener_names(NS_B)):
+                rejoined = True
+                break
+            time.sleep(6)
+
+        after = run(NS_B, """
+tok = await db.scalar(select(m.AgentPoolToken).order_by(m.AgentPoolToken.created_at))
+print('USES', tok.use_count if tok else -1)
+""")
+        uses_after = int(after.split("USES ")[-1].splitlines()[0])
+    finally:
+        set_role_and_listener(NS_A, role="leader", api_url="")
+        _point_shared_name_at(NS_A)
+
+    ok = rejoined and uses_after > uses_before
+    record("10", "Cut over with each listener topology", "PASS" if ok else "FAIL",
+           "per-node fleet claimed row 9's run; shared fleet "
+           + ("re-joined the promoted node unattended" if rejoined else "NEVER RE-JOINED")
+           + f", token use_count {uses_before}→{uses_after}")
+
+
+# Every row, in the order the table runs them. Named so a single row can be
+# re-run while it is being worked on — a full pass takes the better part of an
+# hour, which is far too slow a loop to develop a row against.
+ROWS: dict[str, object] = {
+    "2": row_2_deltas,
+    "1": row_1_backfill,
+    "3": row_3_brief_outage,
+    "4": row_4_past_retention,
+    "5": row_5_peer_outage,
+    "8": row_8_follower_inert,
+    "11": row_11_sensitive,
+    "12": row_12_token,
+    "14": row_14_stale_runs,
+    "6": row_6_planned_failover,
+    "7": row_7_unplanned_failover,
+    "6b": restore,
+    # Last, because they leave and restore the pair's roles and its listener
+    # wiring, and because they are the slowest rows by a wide margin.
+    "9": row_9_cutover_midrun,
+    "10": row_10_listener_topologies,
+}
+
+
 def main() -> int:
-    stamp = _k("-n", NS_A, "get", "ns", NS_A, "-o", "jsonpath={.metadata.uid}")[:8]
-    print(f"{CYAN}==>{RESET} #960 release-gate table against {NS_A} / {NS_B}\n")
+    wanted = [a for a in sys.argv[1:] if not a.startswith("-")]
+    unknown = [w for w in wanted if w not in ROWS and w != "13"]
+    if unknown:
+        print(f"unknown row(s): {', '.join(unknown)}; known: {', '.join(ROWS)}")
+        return 2
 
-    row_2_deltas(stamp)
-    row_1_backfill(stamp)
-    row_3_brief_outage(stamp)
-    row_4_past_retention(stamp)
-    row_5_peer_outage(stamp)
-    row_8_follower_inert(stamp)
-    row_11_sensitive(stamp)
-    row_12_token(stamp)
-    row_14_stale_runs(stamp)
-    row_6_planned_failover(stamp)
-    row_7_unplanned_failover(stamp)
-    restore(stamp)
+    # The namespace UID identifies the pair; the clock suffix identifies the
+    # run. Without the suffix a second table run against a live pair collides on
+    # the first name it re-creates, and the pair is meant to be re-runnable —
+    # rows 1 and 3 clear the follower, never the leader.
+    stamp = (
+        _k("-n", NS_A, "get", "ns", NS_A, "-o", "jsonpath={.metadata.uid}")[:8]
+        + f"-{int(time.time()) % 100000:05d}"
+    )
+    scope = f" (rows {', '.join(wanted)})" if wanted else ""
+    print(f"{CYAN}==>{RESET} #960 release-gate table against {NS_A} / {NS_B}{scope}\n")
 
-    # Recorded, not silently omitted. Each needs execution infrastructure the
-    # pair deliberately does not deploy — two API nodes, no listeners, no
-    # runners — so claiming them would be claiming something never observed.
-    record("9", "Cut over mid-run", "SKIP",
-           "needs a run in flight: a listener and a runner Job in the pair")
-    record("10", "Cut over with each listener topology", "SKIP",
-           "needs a listener fleet and certificate portability across both topologies")
-    record("13", "terraform init against a private module and provider on B", "SKIP",
-           "rows and blobs are verified present on B (#1114); the CLI leg needs a "
-           "terraform binary pointed at the promoted node")
+    for name, fn in ROWS.items():
+        if wanted and name not in wanted:
+            continue
+        fn(stamp)  # type: ignore[operator]
+
+    if not wanted or "13" in wanted:
+        # Recorded, not silently omitted. The data half is already proven — the
+        # registry rows and their blobs are confirmed present on the promoted
+        # node (#1114) — so what is missing is a client actually installing from
+        # it. Terraform's registry discovery is HTTPS-only with no plaintext
+        # fallback, and the pair runs with `ingress.enabled: false` and no
+        # certificate, so an `init` from outside the cluster has nothing to
+        # connect to. The route in is a real run on the promoted node whose
+        # configuration sources the private module: the runner writes a
+        # CLI-config `host` block redirecting the public hostname to its
+        # plaintext internal API, which is precisely the mechanism that makes
+        # this work in a split or HTTP-internal deployment.
+        record("13", "terraform init against a private module and provider on B", "SKIP",
+               "needs a config-version tarball on B and a runner that can fetch a "
+               "terraform binary; the rows and blobs themselves are verified (#1114)")
+
+    if not wanted:
+        reset_roles()
 
     failed = [r for r in results if r[2] == "FAIL"]
     skipped = [r for r in results if r[2] == "SKIP"]
     passed = [r for r in results if r[2] == "PASS"]
-    print(f"\n{CYAN}==>{RESET} {len(passed)} passed, {len(failed)} failed, {len(skipped)} not exercised")
+    print(
+        f"\n{CYAN}==>{RESET} {len(passed)} passed, {len(failed)} failed, "
+        f"{len(skipped)} not exercised"
+    )
     return 1 if failed else 0
 
 

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -432,6 +432,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # This task must NOT be leadership-gated when the enforcement phase lands:
     # a follower has to keep probing or it can never discover that it has
     # become the leader.
+
+    # A demotion by `helm upgrade --set api.config.ha.role=follower` — the step
+    # the operations runbook prescribes — is only observable at startup, because
+    # under a static role the probe below never runs. So the retirement
+    # predicate has to be reached from here as well, or this node's in-flight
+    # runs sit in `planning` for as long as it stays a follower (#1197). It is a
+    # no-op on an ordinary restart that did not change the role.
+    from terrapod.services.ha_role import reconcile_role_on_startup
+
+    await reconcile_role_on_startup()
+
     if settings.ha.role == "auto":
         from terrapod.services.ha_role import probe_cycle
 

--- a/services/terrapod/services/ha_role.py
+++ b/services/terrapod/services/ha_role.py
@@ -46,6 +46,12 @@ _PREFIX = "tp:ha"
 _ROLE_KEY = f"{_PREFIX}:role"
 _STREAK_KEY = f"{_PREFIX}:streak"
 _PROBED_AT_KEY = f"{_PREFIX}:probed_at"
+# The last role this node is known to have *held*, as opposed to the role it
+# currently resolves to. Under `auto` those are the same key's job; under a
+# static role there is no key at all, so a demotion by `helm upgrade --set
+# api.config.ha.role=follower` would otherwise be invisible to the process that
+# comes up afterwards (#1197).
+_LAST_ROLE_KEY = f"{_PREFIX}:last_role"
 
 # A probe is a single attempt with a short timeout, deliberately *not* wrapped
 # in the shared retry helper. Retrying inside one probe would blur the
@@ -145,6 +151,7 @@ async def probe_cycle() -> None:
     if count >= settings.ha.probe_threshold:
         await redis.set(_ROLE_KEY, wanted)
         await redis.delete(_STREAK_KEY)
+        await redis.set(_LAST_ROLE_KEY, wanted)
         await _retire_runs_on_role_change(previous=current, role=wanted)
         logger.warning(
             "HA role changed",
@@ -165,6 +172,50 @@ async def probe_cycle() -> None:
         )
 
     await redis.set(_PROBED_AT_KEY, str(time.time()))
+
+
+async def reconcile_role_on_startup() -> None:
+    """Retire in-flight runs if this node booted into a different role (#1197).
+
+    The probe handles a role change that happens *while the node is running*,
+    and only under `auto`. A static role can only change across a restart —
+    `helm upgrade --set api.config.ha.role=follower`, which is the demotion step
+    the operations runbook actually tells people to perform — so without this
+    the retirement predicate is never reached on the documented path.
+
+    What that costs is a run left in `planning` for as long as the node stays a
+    follower, holding its workspace at the per-workspace serialization gate. It
+    cannot even time out there: `_check_stale` resolves through
+    `transition_run`, which a follower refuses. A later promotion does
+    eventually shed it — after another reconciler timeout — but "eventually,
+    once you promote it again" is not a property to rely on, and a node parked
+    as standby for a week holds those rows for a week.
+
+    The trigger is strictly *the recorded role differs from the current one*,
+    never *the process started*. A rolling restart on an unchanged role must
+    retire nothing — the sibling replica is still driving those runs and their
+    Jobs are still executing.
+
+    No recorded role at all means this is a first boot, or a Redis that lost its
+    data. Both record and do nothing: "cannot tell" must not become "kill the
+    runs".
+
+    Safe to run on every replica. Retirement is one idempotent bulk `UPDATE`, so
+    whichever replica gets there first does the work and the rest find nothing.
+    """
+    role = await get_role()
+    try:
+        redis = get_redis_client()
+        recorded = await redis.get(_LAST_ROLE_KEY)
+        previous = recorded.decode() if isinstance(recorded, bytes) else (recorded or "")
+        if previous and previous != role:
+            logger.warning("Node booted into a different role", previous=previous, role=role)
+            await _retire_runs_on_role_change(previous=previous, role=role)
+        await redis.set(_LAST_ROLE_KEY, role)
+    except Exception:
+        # Never block startup on this. Failing to retire leaves the pre-#1197
+        # behaviour, which is inert rather than harmful.
+        logger.warning("Could not reconcile the node's role at startup", exc_info=True)
 
 
 async def last_probe_age_seconds() -> float | None:

--- a/services/terrapod/services/run_reconciler.py
+++ b/services/terrapod/services/run_reconciler.py
@@ -411,6 +411,44 @@ async def _handle_failed(db: AsyncSession, run: Run, error_message: str) -> None
     logger.info("Run errored", run_id=str(run.id), reason=error_message)
 
 
+async def _reap_abandoned_job(run: Run) -> None:
+    """Delete the Job of a run the reconciler is abandoning (#1198).
+
+    Only for the paths where the Job is **not** terminal — a pod that never
+    scheduled, or a Job we have stopped waiting on. Those keep counting toward
+    `count_active_runner_jobs`, which is what the listener admits work against,
+    so a Job left behind here holds a capacity slot for the rest of the
+    listener's life: at the shipped `maxConcurrent: 3`, three of them and the
+    pool never claims again. Nothing reaps them on its own either —
+    `ttlSecondsAfterFinished` only applies to a Job that finished, and one whose
+    pod never ran never does.
+
+    Not called from the ordinary failed-Job path. That Job is terminal, so it
+    occupies nothing, the TTL controller collects it on schedule, and leaving it
+    lets an operator `kubectl describe` it while the failure is still fresh.
+
+    Reuses the cancel path rather than adding machinery: the listener already
+    deletes the Job on `cancel_job`, and doing it twice is harmless. (That is
+    what made `publish_cancel_job` public — it has a second caller now, and it
+    is a cleanup primitive rather than a detail of the user-cancel flow.)
+
+    Reaping a Job that may still be mid-apply is deliberate, not an oversight.
+    The run has already been errored and its workspace unlocked by this point,
+    so the alternative is terraform continuing to mutate real infrastructure
+    with nothing watching it and a later run free to race it. Deleting the Job
+    is the same path a user-initiated cancel takes, which gives the runner its
+    termination grace period to interrupt terraform and upload state.
+    """
+    if not run.job_name:
+        return
+    from terrapod.services.run_service import publish_cancel_job
+
+    try:
+        await publish_cancel_job(run)
+    except Exception:  # never let cleanup mask the failure being reported
+        logger.warning("Could not reap the abandoned Job", run_id=str(run.id), exc_info=True)
+
+
 async def _check_unschedulable(db: AsyncSession, run: Run) -> None:
     """Fail a run whose pod has been Unschedulable past the launch grace, with
     an explicit "insufficient cluster resources" reason (#748).
@@ -436,6 +474,7 @@ async def _check_unschedulable(db: AsyncSession, run: Run) -> None:
         f"room. Reduce the request, free capacity, or add a node."
     )
     await _handle_failed(db, run, msg)
+    await _reap_abandoned_job(run)
     logger.warning(
         "Run errored: pod unschedulable past grace",
         run_id=str(run.id),
@@ -480,6 +519,7 @@ async def _check_stale(db: AsyncSession, run: Run) -> None:
             await _handle_failed(
                 db, run, f"Drift run exceeded max duration ({cfg.drift_max_duration_seconds}s)"
             )
+            await _reap_abandoned_job(run)
             logger.warning(
                 "Drift run errored: max duration exceeded",
                 run_id=str(run.id),
@@ -497,6 +537,7 @@ async def _check_stale(db: AsyncSession, run: Run) -> None:
 
     if now - phase_start > timeout:
         await _handle_failed(db, run, f"{message_prefix} — no progress for >{timeout}")
+        await _reap_abandoned_job(run)
         if run.job_name is None:
             from terrapod.api.metrics import LISTENER_PRELAUNCH_TIMEOUTS
 

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -1364,7 +1364,7 @@ async def cancel_run(
     # before transitioning so a same-tick run_status_change observer
     # sees the cancel intent reflected when it polls. The publish path
     # is wrapped — SSE plumbing failures must never break the cancel.
-    await _publish_cancel_job(run)
+    await publish_cancel_job(run)
 
     return await transition_run(db, run, target)
 
@@ -1446,7 +1446,7 @@ async def resolve_canceling_run(db: AsyncSession, run: Run, *, job_status: str) 
     return run
 
 
-async def _publish_cancel_job(run: Run) -> None:
+async def publish_cancel_job(run: Run) -> None:
     """Send a `cancel_job` SSE event to the pool's listeners.
 
     The reconciler's check_job_status / stream_logs events publish on

--- a/services/tests/services/test_ha_role.py
+++ b/services/tests/services/test_ha_role.py
@@ -188,3 +188,152 @@ class TestProbeCycle:
         await ha_role.probe_cycle()
 
         redis.set.assert_any_await(ha_role._STREAK_KEY, "leader:1")
+
+
+class TestStartupRoleReconciliation:
+    """A static demotion is only ever observable at startup (#1197).
+
+    `probe_cycle` returns immediately unless the role is `auto`, so before this
+    the retirement predicate was unreachable on the path the operations runbook
+    actually prescribes — `helm upgrade --set api.config.ha.role=follower` —
+    and the node's in-flight runs stayed `planning` for the life of the row.
+    """
+
+    @patch("terrapod.services.ha_role._retire_runs_on_role_change")
+    @patch("terrapod.services.ha_role.get_redis_client")
+    @patch("terrapod.services.ha_role.settings")
+    async def test_demotion_across_a_restart_retires(
+        self, mock_settings, mock_get_redis, mock_retire
+    ):
+        mock_settings.ha = _cfg(role="follower")
+        redis = AsyncMock()
+        redis.get.return_value = b"leader"
+        mock_get_redis.return_value = redis
+
+        await ha_role.reconcile_role_on_startup()
+
+        mock_retire.assert_awaited_once_with(previous="leader", role="follower")
+        redis.set.assert_any_await(ha_role._LAST_ROLE_KEY, "follower")
+
+    @patch("terrapod.services.ha_role._retire_runs_on_role_change")
+    @patch("terrapod.services.ha_role.get_redis_client")
+    @patch("terrapod.services.ha_role.settings")
+    async def test_promotion_across_a_restart_retires(
+        self, mock_settings, mock_get_redis, mock_retire
+    ):
+        """The sharper direction: a node promoted back must not inherit frozen
+        rows from its previous era, because several periodic tasks act on old
+        rows with no upper age bound."""
+        mock_settings.ha = _cfg(role="leader")
+        redis = AsyncMock()
+        redis.get.return_value = b"follower"
+        mock_get_redis.return_value = redis
+
+        await ha_role.reconcile_role_on_startup()
+
+        mock_retire.assert_awaited_once_with(previous="follower", role="leader")
+
+    @patch("terrapod.services.ha_role._retire_runs_on_role_change")
+    @patch("terrapod.services.ha_role.get_redis_client")
+    @patch("terrapod.services.ha_role.settings")
+    async def test_an_ordinary_restart_retires_nothing(
+        self, mock_settings, mock_get_redis, mock_retire
+    ):
+        """The most important negative. A rolling upgrade restarts every replica
+        on an unchanged role; killing the in-flight runs there would make a
+        routine deploy destructive, and the sibling replica is still driving
+        them."""
+        mock_settings.ha = _cfg(role="leader")
+        redis = AsyncMock()
+        redis.get.return_value = b"leader"
+        mock_get_redis.return_value = redis
+
+        await ha_role.reconcile_role_on_startup()
+
+        mock_retire.assert_not_awaited()
+        redis.set.assert_any_await(ha_role._LAST_ROLE_KEY, "leader")
+
+    @patch("terrapod.services.ha_role._retire_runs_on_role_change")
+    @patch("terrapod.services.ha_role.get_redis_client")
+    @patch("terrapod.services.ha_role.settings")
+    async def test_no_recorded_role_records_without_retiring(
+        self, mock_settings, mock_get_redis, mock_retire
+    ):
+        """First boot, or a Redis that lost its data. "Cannot tell" must not
+        become "kill the runs"."""
+        mock_settings.ha = _cfg(role="leader")
+        redis = AsyncMock()
+        redis.get.return_value = None
+        mock_get_redis.return_value = redis
+
+        await ha_role.reconcile_role_on_startup()
+
+        mock_retire.assert_not_awaited()
+        redis.set.assert_any_await(ha_role._LAST_ROLE_KEY, "leader")
+
+    @patch("terrapod.services.ha_role._retire_runs_on_role_change")
+    @patch("terrapod.services.ha_role.get_redis_client")
+    @patch("terrapod.services.ha_role.settings")
+    async def test_unreachable_redis_never_blocks_startup(
+        self, mock_settings, mock_get_redis, mock_retire
+    ):
+        mock_settings.ha = _cfg(role="leader")
+        mock_get_redis.side_effect = RuntimeError("no redis")
+
+        await ha_role.reconcile_role_on_startup()
+
+        mock_retire.assert_not_awaited()
+
+    @patch("terrapod.services.ha_role._retire_runs_on_role_change")
+    @patch("terrapod.services.ha_role._observe")
+    @patch("terrapod.services.ha_role.get_redis_client")
+    @patch("terrapod.services.ha_role.settings")
+    async def test_the_probe_records_the_role_it_moved_to(
+        self, mock_settings, mock_get_redis, mock_observe, mock_retire
+    ):
+        """Both paths write the same key, so a restart straight after a
+        probe-driven change sees no difference and stays quiet."""
+        mock_settings.ha = _cfg(role="auto", node_name="a", internal="https://x", threshold=1)
+        redis = AsyncMock()
+        redis.get.side_effect = [b"follower", None]
+        mock_get_redis.return_value = redis
+        mock_observe.return_value = "a"
+
+        await ha_role.probe_cycle()
+
+        redis.set.assert_any_await(ha_role._LAST_ROLE_KEY, "leader")
+
+
+class TestStartupReconciliationIsWired:
+    """#1197 was a wiring bug, not a logic bug — the predicate was correct and
+    unreachable. A unit test of the predicate would have stayed green through
+    the whole defect, so the invariant worth pinning is that startup calls it.
+    """
+
+    def test_the_lifespan_awaits_it(self):
+        import inspect
+
+        from terrapod.api import app as app_module
+
+        source = inspect.getsource(app_module)
+        assert "await reconcile_role_on_startup()" in source, (
+            "the API lifespan must reconcile this node's role at startup, or a "
+            "demotion by `helm upgrade --set api.config.ha.role=follower` — the "
+            "step the operations runbook prescribes — leaves the node's "
+            "in-flight runs frozen in `planning` (#1197)"
+        )
+
+    def test_it_runs_regardless_of_the_role_mode(self):
+        """Not inside the `role == "auto"` branch. Under a static role the probe
+        never runs at all, which is precisely the case that was broken."""
+        import inspect
+
+        from terrapod.api import app as app_module
+
+        source = inspect.getsource(app_module)
+        call = source.index("await reconcile_role_on_startup()")
+        guard = source.index('if settings.ha.role == "auto":')
+        assert call < guard, (
+            "reconcile_role_on_startup must be called before (and outside) the "
+            "`auto`-only probe registration"
+        )

--- a/services/tests/services/test_run_reconciler.py
+++ b/services/tests/services/test_run_reconciler.py
@@ -880,3 +880,117 @@ class TestPoolQueueDepth:
         db.execute.side_effect = RuntimeError("db down")
         # Must not raise into the reconcile cycle.
         await _refresh_pool_queue_depth(db)
+
+
+# ── Job reaping on abandonment (#1198) ────────────────────────────────
+
+
+class TestAbandonedJobsAreReaped:
+    """A Job whose run the reconciler gives up on must not keep its capacity.
+
+    `count_active_runner_jobs` counts non-terminal Jobs with a **Pending** or
+    Running pod, and the listener admits work against that count. A Job left
+    behind by an unschedulable or abandoned run therefore holds a slot for the
+    life of the listener — nothing else reaps it, because
+    `ttlSecondsAfterFinished` only applies to a Job that finished and one whose
+    pod never scheduled never does. At the shipped `maxConcurrent: 3`, three of
+    them and the pool stops claiming altogether, silently.
+    """
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_service.publish_cancel_job", new_callable=AsyncMock)
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_unschedulable_reaps_the_job(self, mock_handle, mock_cancel, mock_config):
+        mock_config.return_value = MagicMock(launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            plan_started_at=datetime.now(UTC) - timedelta(seconds=400),
+        )
+
+        await _check_unschedulable(db, run)
+
+        mock_handle.assert_awaited_once()
+        mock_cancel.assert_awaited_once_with(run)
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_service.publish_cancel_job", new_callable=AsyncMock)
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_within_grace_reaps_nothing(self, mock_handle, mock_cancel, mock_config):
+        """The scheduler may still place the pod — reaping here would destroy a
+        run that was about to start."""
+        mock_config.return_value = MagicMock(launch_timeout_seconds=300)
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            plan_started_at=datetime.now(UTC) - timedelta(seconds=30),
+        )
+
+        await _check_unschedulable(db, run)
+
+        mock_handle.assert_not_awaited()
+        mock_cancel.assert_not_awaited()
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_service.publish_cancel_job", new_callable=AsyncMock)
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_stale_with_a_job_reaps_it(self, mock_handle, mock_cancel, mock_config):
+        """Also stops terraform running unattended against real infrastructure
+        after we have stopped watching it."""
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS, launch_timeout_seconds=300
+        )
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            job_name="tprun-abc123-plan",
+            plan_started_at=datetime.now(UTC)
+            - timedelta(seconds=DEFAULT_STALE_TIMEOUT_SECONDS)
+            - timedelta(minutes=5),
+        )
+
+        await _check_stale(db, run)
+
+        mock_cancel.assert_awaited_once_with(run)
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_service.publish_cancel_job", new_callable=AsyncMock)
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_no_job_name_reaps_nothing(self, mock_handle, mock_cancel, mock_config):
+        """Pre-launch timeout: the listener never reported a Job, so there is
+        nothing to delete and nothing occupying a slot."""
+        mock_config.return_value = MagicMock(
+            stale_timeout_seconds=DEFAULT_STALE_TIMEOUT_SECONDS, launch_timeout_seconds=300
+        )
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            job_name=None,
+            plan_started_at=datetime.now(UTC) - timedelta(seconds=400),
+        )
+
+        await _check_stale(db, run)
+
+        mock_handle.assert_awaited_once()
+        mock_cancel.assert_not_awaited()
+
+    @patch("terrapod.services.run_reconciler.load_runner_config")
+    @patch("terrapod.services.run_service.publish_cancel_job", new_callable=AsyncMock)
+    @patch("terrapod.services.run_reconciler._handle_failed", new_callable=AsyncMock)
+    async def test_a_failing_reap_never_masks_the_failure(
+        self, mock_handle, mock_cancel, mock_config
+    ):
+        """Cleanup is secondary. If it throws, the run must still be errored and
+        the operator must still get the message that explains why."""
+        mock_config.return_value = MagicMock(launch_timeout_seconds=300)
+        mock_cancel.side_effect = RuntimeError("redis is down")
+        db = AsyncMock()
+        run = _mock_run(
+            status="planning",
+            plan_started_at=datetime.now(UTC) - timedelta(seconds=400),
+        )
+
+        await _check_unschedulable(db, run)
+
+        mock_handle.assert_awaited_once()
+        assert "insufficient cluster resources" in mock_handle.call_args.args[2]

--- a/services/tests/services/test_run_service.py
+++ b/services/tests/services/test_run_service.py
@@ -1033,7 +1033,7 @@ class TestCancelWhileApplying:
 
         with (
             patch.object(run_service, "transition_run", new=AsyncMock(side_effect=_transition)),
-            patch.object(run_service, "_publish_cancel_job", new=AsyncMock()) as mock_publish,
+            patch.object(run_service, "publish_cancel_job", new=AsyncMock()) as mock_publish,
         ):
             result = await run_service.cancel_run(db, run)
 
@@ -1073,7 +1073,7 @@ class TestCancelWhileApplying:
 
         with (
             patch.object(run_service, "transition_run", new=AsyncMock(side_effect=_transition)),
-            patch.object(run_service, "_publish_cancel_job", new=AsyncMock()),
+            patch.object(run_service, "publish_cancel_job", new=AsyncMock()),
         ):
             result = await run_service.cancel_run(db, run)
 


### PR DESCRIPTION
Closes #1188, closes #1197, closes #1198. Part of #960.

Rows 9 and 10 of the #960 release-gate table printed `SKIP` because the pair was two API nodes with no execution infrastructure. "Not exercised" is honest but it is not "works", and row 9 is the row where a wrong answer is most expensive: an in-flight run at a cutover is documented as lost, and the claim that it is lost *cleanly* was a design argument rather than an observation.

It was wrong. Making the row real found two defects, both fixed here.

## #1197 — a node demoted through Helm never retired its in-flight runs

`_retire_runs_on_role_change` had exactly one caller, `probe_cycle`, which returns immediately unless `ha.role` is `auto`. So on the demotion step the operations runbook actually prescribes — `helm upgrade --set api.config.ha.role=follower` — the predicate was never reached.

Observed on the pair, with a run genuinely claimed by a listener and backed by a real Job:

```
before demotion:  STATUS planning tprun-019fb87a-683a-75-plan
helm upgrade terrapod-a --set api.config.ha.role=follower   (18s)
after demotion:   STATUS planning tprun-019fb87a-683a-75-plan
+65s:             STATUS planning tprun-019fb87a-683a-75-plan
```

It could not resolve itself either: the reconciler transitions through `transition_run`, which a follower refuses, so not even the stale timeout could move it. The cost is a workspace held at the per-workspace serialization gate for as long as the node stays a follower, with nothing an operator can clear — `workspace.locked` is untouched, so the block is the frozen row itself. A node parked as standby for a week holds those rows for a week.

Startup now compares the role the node boots with against the role it last recorded. That covers both modes: a static role can only change across a restart, and under `auto` it additionally catches a change that happened while the node was down. Two things it deliberately does not do — an ordinary rolling restart on an unchanged role retires nothing (or a routine deploy becomes destructive while the sibling replica is still driving those runs), and no recorded role at all records and does nothing, because "cannot tell" must not become "kill the runs".

## #1198 — an unschedulable Job holds its listener slot for ever

`_check_unschedulable` errors the run and never touches the Job. Its pod stays `Pending` indefinitely; `ttlSecondsAfterFinished` only reaps a Job that *finished*, and one whose pod never scheduled never does. `count_active_runner_jobs` counts Pending, and the listener admits work against that count — so at the shipped `maxConcurrent: 3`, three of these and the pool never claims again.

Silent in both directions, which is what makes it expensive. The runs errored cleanly and told the operator exactly what was wrong, so the incident reads as closed; afterwards the pool just stops claiming, with `At capacity — deferring run claim` at debug level and nothing saying the capacity is held by runs that finished hours ago.

Observed as three terminal runs, three Jobs still counted, and the next run never claimed — surfacing as a bogus "no listener claimed the run" in a test that had nothing to do with scheduling.

Reaped now on the three paths where the reconciler abandons a non-terminal Job. Not on the ordinary failed-Job path: that Job is terminal, occupies nothing, and leaving it lets an operator describe it while the failure is fresh.

## The rows

**Row 9** holds a genuinely in-flight run across a demotion. Row 14 already seeds a run row and calls the predicate directly; the difference is that a real listener claims this one over SSE and a real Job backs it, so it exercises the wiring rather than the predicate — which is precisely the distinction #1197 turned on, since a unit test of the predicate stayed green through the entire defect. The run is pinned in `planning` by asking for more CPU than the cluster has, which is a real in-flight state and removes the race against a runner that would otherwise exit in a second.

**Row 10** runs both listener topologies. The shared fleet is established on an ExternalName Service *before* the cutover, because that is the order it happens in — the fleet has been addressing the shared name all along and the cutover changes the answer underneath it. Demoting the node drops the fleet's connection, which is what makes it resolve the name again; it then meets a node whose CA never issued its certificate and heals itself. The assertion is that a join token's `use_count` moved, not merely that a listener reappeared, since the token is the mechanism [`docs/ha-topologies.md`](docs/ha-topologies.md) tells people to size for.

**Row 13** stays `SKIP`, with a reason that now says something: terraform's registry discovery is HTTPS-only with no plaintext fallback, and the pair runs with no ingress and no certificate, so an `init` from outside the cluster has nothing to connect to. The route in is a real run on the promoted node, whose runner writes the CLI-config `host` block that makes this work in a split deployment. Left for its own change rather than padding this one.

## Verified

Full table, single clean pass, exit 0:

```
PASS   2  Change settings on A → delta replication
PASS   1  Bring up B against a populated A → backfill from empty
PASS   3  B down briefly, then back → catch-up inside retention
PASS   4  B down past retention → automatic fallback to backfill
PASS   5  Kill B entirely; write on A → a peer outage never blocks the leader
PASS   8  Follower refuses a write through the real API path — HTTP 503, and the row was NOT created
PASS  11  Sensitive variable round-trips decrypt-on-send / re-encrypt-on-receive
PASS  12  A terraform login token works against the promoted node
PASS  14  Promotion errors stale runs instead of queuing destroys — ['errored']
PASS   6  Quiesce A, move the name → B leads (planned failover)
PASS   7  Kill A, move the name → unplanned failover
PASS  6b  Fail back to A and re-converge
PASS   9  Cut over mid-run — in-flight run → errored by the role change, workspace not locked, re-queue dispatched on the promoted node
PASS  10  Cut over with each listener topology — per-node fleet claimed row 9's run; shared fleet re-joined the promoted node unattended, token use_count 5→6
SKIP  13  terraform init against a private module and provider on B

==> 14 passed, 0 failed, 1 not exercised
```

`make test` — 4046 passed. `make lint` — green.

## Rig changes that came out of running it

- The pair no longer runs Tilt's `tilt-<hash>` tags. Those move when a source file is edited, and with `pullPolicy: Never` a moved tag is `ErrImageNeverPull` on a pre-upgrade hook — surfacing six minutes later as a helm timeout blaming a Job for what was really a vanished tag.
- Errors say what failed. `subprocess.run(check=True)` raises with the argv and nothing else, and truncating stderr from the end alone keeps SQLAlchemy's statement while discarding the exception line above it.
- A single row can be re-run (`ha-smoke.sh table 10`); a full pass takes the better part of an hour, which is far too slow a loop to develop a row against. The roles are restored in a `finally` for every invocation, because the first version of that selector left the pair with two leaders and the following pass opened by reporting replication as broken.
- The listener's default anti-affinity deadlocks a rolling update on this single node, the same case the API already disables it for.
- Join tokens get headroom: every pass flips roles twice and row 10 forces a re-join, so the shipped default of two uses exhausts on the second run and reports a rig artefact as a fleet failure.