### PR TITLE
Pin the HA pair's runner image so execution rows can actually run

### DIFF
--- a/helm/terrapod/values-ha-a.yaml
+++ b/helm/terrapod/values-ha-a.yaml
@@ -64,9 +64,12 @@ listener:
 
 runners:
   image:
-    # Built by `tilt trigger build-runner-image`; never pulled.
+    # Same reasoning as the API and migrations images: the pair runs a tag it
+    # owns, re-tagged from what Tilt built, so a rebuild in the dev stack cannot
+    # leave a runner Job in ErrImageNeverPull. `ha-smoke.sh up` does the
+    # re-tagging; `tilt trigger build-runner-image` is what produces the source.
     repository: terrapod-runner
-    tag: local
+    tag: ha
     pullPolicy: Never
 
 # Pre-install so the pool exists before the listener rolls out — otherwise

--- a/helm/terrapod/values-ha-b.yaml
+++ b/helm/terrapod/values-ha-b.yaml
@@ -60,9 +60,12 @@ listener:
 
 runners:
   image:
-    # Built by `tilt trigger build-runner-image`; never pulled.
+    # Same reasoning as the API and migrations images: the pair runs a tag it
+    # owns, re-tagged from what Tilt built, so a rebuild in the dev stack cannot
+    # leave a runner Job in ErrImageNeverPull. `ha-smoke.sh up` does the
+    # re-tagging; `tilt trigger build-runner-image` is what produces the source.
     repository: terrapod-runner
-    tag: local
+    tag: ha
     pullPolicy: Never
 
 # Pre-install so the pool exists before the listener rolls out — otherwise

--- a/scripts/ha-smoke.sh
+++ b/scripts/ha-smoke.sh
@@ -73,15 +73,24 @@ cmd_up() {
   [[ -n "$api_src" && -n "$mig_src" ]] \
     || fail "no tilt-built images — run 'tilt up' once so the pair has something to run"
 
+  # The runner image is built by a Tilt `local_resource` under a fixed `:local`
+  # tag rather than a content hash, so it does not move — but nothing references
+  # it between runs either, which leaves it eligible for kubelet image GC. Same
+  # symptom, so same treatment.
+  local runner_src="terrapod-runner:local"
+  docker image inspect "$runner_src" >/dev/null 2>&1 \
+    || fail "no $runner_src — run 'tilt trigger build-runner-image' so the pair can execute runs"
+
   # Re-tag unless the caller has already staged its own build under :ha (which
   # is how a fix is tried on the pair before it exists in the dev stack).
   local api_image="terrapod-api:ha" mig_image="terrapod-migrations:ha"
   if [[ "${HA_KEEP_IMAGES:-}" != "1" ]]; then
     docker tag "$api_src" "$api_image"
     docker tag "$mig_src" "$mig_image"
-    info "pinned $api_src -> $api_image, $mig_src -> $mig_image"
+    docker tag "$runner_src" "terrapod-runner:ha"
+    info "pinned $api_src -> $api_image, $mig_src -> $mig_image, $runner_src -> terrapod-runner:ha"
   else
-    info "HA_KEEP_IMAGES=1 — reusing whatever is tagged $api_image / $mig_image"
+    info "HA_KEEP_IMAGES=1 — reusing whatever is tagged :ha"
   fi
 
   local node ns


### PR DESCRIPTION
Part of #1200.

The API and migrations images already run under tags the pair owns, because Tilt's `tilt-<hash>` tags move when a source file is edited and `pullPolicy: Never` turns a moved tag into `ErrImageNeverPull`. The runner image was left on `terrapod-runner:local`.

Its tag does not move — a Tilt `local_resource` writes it verbatim — but nothing references it between runs, which leaves it eligible for kubelet image GC all the same. It went missing mid-session, and the next run sat in `planning` for four minutes with its pod in `ErrImageNeverPull`, looking for all the world like a platform stall:

```
tprun-…-plan-b4cw8   0/1   ErrImageNeverPull   4m36s
Warning  ErrImageNeverPull  spec.containers{runner}: Container image
  "terrapod-runner:local" is not present with pull policy of Never
```

`up` now re-tags it alongside the others, and fails early naming the command that produces it (`tilt trigger build-runner-image`) rather than deploying and discovering it several minutes later.

## Why it matters beyond tidiness

The execution rows added in #1199 depend on a runner Job actually starting. A missing runner image makes them fail for a reason they are not testing — which is the failure mode the table exists to avoid, and which already produced one bogus "no listener claimed the run".

Confirmed after the change, with a real config version and a real plan:

```
1 STATUS planning tprun-019fb8f4-9aac-78-plan
2 STATUS planned  tprun-019fb8f4-9aac-78-plan
```

That settles the prerequisite #1200 raises — whether a runner Job in the pair can complete an ordinary plan at all. It can, in about forty seconds, so a row 13 failure can be attributed to the registry rather than to the rig.