### PR TITLE
Put the semgrep suppression where semgrep will read it

### DIFF
--- a/services/tests/services/test_replication_registry_artifacts.py
+++ b/services/tests/services/test_replication_registry_artifacts.py
@@ -94,10 +94,12 @@ class TestGPGKeys:
         `gpg_key_service` and has no caller, because Terrapod does not re-sign.
         Sending a signing key would widen what a compromised peer costs in
         exchange for a capability neither node uses."""
-        # nosemgrep: generic.secrets.security.detected-pgp-private-key-block.detected-pgp-private-key-block
         # Not a key — the body is literally the word "secret". It has to LOOK
         # like one for the assertions below to mean anything, which is exactly
-        # the shape the secret scanner is built to flag.
+        # the shape the secret scanner is built to flag. The suppression has to
+        # sit on the line DIRECTLY above the finding; a comment in between
+        # silently breaks it.
+        # nosemgrep: generic.secrets.security.detected-pgp-private-key-block.detected-pgp-private-key-block
         key = self._key(private_key="-----BEGIN PGP PRIVATE KEY BLOCK-----\nsecret\n-----END-----")
 
         payload = replication.serialize_row(GPG_KEYS, key)


### PR DESCRIPTION
Follow-up to #1204. The `nosemgrep` comment went two lines above the finding, with the explanation in between — and semgrep only honours it on the line **directly** above. So alert 380 stayed open through a green `main` build: the suppression looked applied and did nothing.

Caught by running the scanner rather than assuming the open alert was just indexing lag:

```
before:  findings: 1   generic.secrets…detected-pgp-private-key-block  line 101
after:   findings: 0
```

Same rule set the CI SAST job uses (`p/secrets`, semgrep 1.117).