### PR TITLE
feat: re-scan supported releases and raise an issue on new findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,12 +568,17 @@ jobs:
         # releases against current reasoning — cannot drift from this gate.
         run: |
           pip install pip-audit
-          ignores=()
+          # POSIX sh, not bash: this job runs in a slim container whose shell
+          # has no arrays. $ignores is intentionally unquoted below so the
+          # accumulated flags word-split into separate arguments.
+          ignores=""
           while read -r line; do
-            line="${line%%#*}"; line="$(echo "$line" | tr -d '[:space:]')"
-            [ -n "$line" ] && ignores+=(--ignore-vuln "$line")
+            line="${line%%#*}"
+            line="$(echo "$line" | tr -d '[:space:]')"
+            [ -n "$line" ] && ignores="$ignores --ignore-vuln $line"
           done < pentest/pip-audit-ignore.txt
-          pip-audit -r services/requirements.txt --strict --desc "${ignores[@]}"
+          # shellcheck disable=SC2086
+          pip-audit -r services/requirements.txt --strict --desc $ignores
 
   # ── Dependency Audit (npm) ────────────────────────────
   npm-audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,15 +562,18 @@ jobs:
         run: poetry export -f requirements.txt -o requirements.txt --without-hashes
         working-directory: services
       - name: Run pip-audit
-        # PYSEC-2025-183 (pyjwt): disputed by the supplier — the advisory
-        # concerns weak HMAC keys, but key length is controlled by the
-        # application that uses the library, not by the library. No fix
-        # version is published. Suppress until a fix lands or the dispute
-        # is resolved upstream.
+        # Accepted advisories live in pentest/pip-audit-ignore.txt, each with
+        # its reasoning and exit condition. Read from the file rather than
+        # inlined here so that release-rescan.yml — which re-checks supported
+        # releases against current reasoning — cannot drift from this gate.
         run: |
           pip install pip-audit
-          pip-audit -r services/requirements.txt --strict --desc \
-            --ignore-vuln PYSEC-2025-183
+          ignores=()
+          while read -r line; do
+            line="${line%%#*}"; line="$(echo "$line" | tr -d '[:space:]')"
+            [ -n "$line" ] && ignores+=(--ignore-vuln "$line")
+          done < pentest/pip-audit-ignore.txt
+          pip-audit -r services/requirements.txt --strict --desc "${ignores[@]}"
 
   # ── Dependency Audit (npm) ────────────────────────────
   npm-audit:
@@ -590,27 +593,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run npm audit
-        # Fail on any high/critical advisory EXCEPT explicitly-allowlisted ones
-        # (mirrors pip-audit's --ignore-vuln and trivy's .trivyignore). Each
-        # allowlisted advisory is build/lint-only, non-reachable, and awaiting a
-        # fix that only lands via a major toolchain upgrade — keep each with a
-        # reason + tracking issue, and drop it the moment the upgrade is taken:
-        #   GHSA-mh99-v99m-4gvg  brace-expansion ReDoS — a devDependency only
-        #     (eslint -> minimatch -> brace-expansion; never sees runtime/user
-        #     input). Patched only in brace-expansion 5.0.8, whose new export
-        #     shape breaks the eslint chain's minimatch. Tracked in #1058.
-        #     RE-TESTED 2026-08-01 against eslint 10.8.0, which was the
-        #     presumed fix path: it does NOT resolve this. `npm run lint` on
-        #     eslint 10.8.0 dies with the same
-        #     `(0, brace_expansion_1.expand) is not a function` inside
-        #     @eslint/config-array's bundled minimatch. So the upgrade is not
-        #     an available fix today — don't re-run that experiment without
-        #     first checking @eslint/config-array's minimatch pin upstream.
+        # Fail on any high/critical advisory except those allowlisted in
+        # pentest/npm-audit-allow.txt, which carries the reasoning and exit
+        # condition for each (mirrors pip-audit's ignore file and trivy's
+        # .trivyignore). Shared with release-rescan.yml so the two cannot drift.
         run: |
           npm audit --audit-level=high --json > audit.json || true
           node -e '
             const a = require("./audit.json");
-            const allow = new Set(["GHSA-mh99-v99m-4gvg"]);
+            const allow = new Set(
+              require("fs").readFileSync("../pentest/npm-audit-allow.txt", "utf8")
+                .split("\n").map((l) => l.split("#")[0].trim()).filter(Boolean),
+            );
             const bad = [];
             for (const [name, v] of Object.entries(a.vulnerabilities || {})) {
               if (!["high", "critical"].includes(v.severity)) continue;

--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -1,0 +1,307 @@
+name: Release Re-scan
+
+# Re-scans the releases we still support against *current* advisory data and
+# *current* rules, and raises an issue when something actionable appears (#1212).
+#
+# The release-time gate in ci.yml uses `ignore-unfixed`, so a vulnerability
+# becomes visible to it only once upstream publishes a fix. A released image is
+# immutable and nothing re-checks it, so without this the first we hear about a
+# newly-fixable CVE in a shipped release is when an operator scans it and opens
+# an issue — which is exactly how #1206 reached us.
+#
+# It also makes an existing promise operable: SECURITY.md offers "security fixes
+# only" for the previous minor, and until now nothing told us a fix was needed.
+#
+# Two scan families:
+#   artifacts — Trivy against the published images, per architecture
+#   source    — pip-audit, npm audit and Semgrep against the source at the tag
+#
+# Both apply TODAY'S suppressions and TODAY'S rules deliberately. The current
+# accepted-risk register is the reasoning we stand behind now: an entry we have
+# since dropped must not go on suppressing a finding in a version we still
+# support, and a rule we have since added is the entire point of re-scanning.
+#
+# This is a reporter, not a gate. It does not fail on findings — the release-time
+# `scan-images` job is the gate, and a permanently red scheduled job is the same
+# failure mode as a noisy one: muted, then ignored when it matters.
+
+on:
+  schedule:
+    # Wednesdays, offset from pricesheet.yml (Mondays 06:17) so two scheduled
+    # jobs are not competing for runners or attention on the same morning.
+    - cron: "23 5 * * 3"
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: "Comma-separated tags to scan (blank = latest patch of the supported minors)"
+        required: false
+        default: ""
+      minors:
+        description: "How many recent minors to cover when tags is blank"
+        required: false
+        default: "2"
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io/mattrobinsonsre
+  SEMGREP_IMAGE: semgrep/semgrep:1.117
+
+jobs:
+  discover:
+    name: Discover supported releases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tags: ${{ steps.pick.outputs.tags }}
+      list: ${{ steps.pick.outputs.list }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Pick the latest patch of each supported minor
+        id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAGS: ${{ inputs.tags }}
+          INPUT_MINORS: ${{ inputs.minors || '2' }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq '.[] | select(.draft == false) | .tag_name' > all-tags.txt || true
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os, re
+
+          explicit = [t.strip() for t in os.environ.get("INPUT_TAGS", "").split(",") if t.strip()]
+          if explicit:
+              tags = explicit
+          else:
+              # Group semver release tags by minor, keep the highest patch in
+              # each, then take the N most recent minors. Non-semver tags (the
+              # rolling `pricesheet` release) are skipped rather than sorted.
+              latest: dict[tuple[int, int], tuple[int, str]] = {}
+              for line in open("all-tags.txt"):
+                  m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", line.strip())
+                  if not m:
+                      continue
+                  major, minor, patch = (int(g) for g in m.groups())
+                  key = (major, minor)
+                  if key not in latest or patch > latest[key][0]:
+                      latest[key] = (patch, line.strip())
+              n = int(os.environ.get("INPUT_MINORS") or 2)
+              ordered = sorted(latest, reverse=True)[:n]
+              tags = [latest[k][1] for k in ordered]
+
+          print(f"tags={json.dumps(tags)}")
+          print(f"list={' '.join(tags)}")
+          PY
+          echo "Selected: $(grep '^list=' "$GITHUB_OUTPUT" | tail -1)"
+
+  artifacts:
+    name: Scan ${{ matrix.image }} ${{ matrix.tag }} (${{ matrix.arch }})
+    needs: discover
+    if: needs.discover.outputs.tags != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.discover.outputs.tags) }}
+        image: [terrapod-api, terrapod-web, terrapod-runner, terrapod-listener, terrapod-migrations]
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Log in to GHCR
+        uses: ./.github/actions/ghcr-login
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+
+      - name: Trivy
+        continue-on-error: true   # a missing image for an older tag must not sink the run
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          # A released tag is a multi-arch manifest; without this Trivy resolves
+          # to the runner's own platform and the arm64 leg scans amd64.
+          TRIVY_PLATFORM: linux/${{ matrix.arch }}
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}:${{ matrix.tag }}
+          format: json
+          output: raw.json
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: pentest/trivy/.trivyignore
+          exit-code: '0'          # reporter, not a gate
+
+      - name: Normalise
+        run: |
+          python3 scripts/rescan_normalise.py trivy raw.json \
+            "${{ matrix.tag }}" "image:${{ matrix.image }} (${{ matrix.arch }})" \
+            "finding.json"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rescan-${{ matrix.tag }}-${{ matrix.image }}-${{ matrix.arch }}
+          path: finding.json
+          retention-days: 7
+
+  source:
+    name: Scan source ${{ matrix.tag }}
+    needs: discover
+    if: needs.discover.outputs.tags != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.discover.outputs.tags) }}
+    steps:
+      # The released source...
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ matrix.tag }}
+          path: release
+      # ...scanned with current rules and current suppressions. Two checkouts
+      # rather than one, because "old code, today's opinion of it" is the whole
+      # point and conflating them would silently scan old code with old rules.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: current
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.13'
+
+      - name: pip-audit
+        continue-on-error: true
+        working-directory: release/services
+        run: |
+          set -uo pipefail
+          pip install --quiet poetry poetry-plugin-export pip-audit
+          poetry export -f requirements.txt -o requirements.txt --without-hashes
+          ignores=()
+          while read -r line; do
+            line="${line%%#*}"; line="$(echo "$line" | tr -d '[:space:]')"
+            [ -n "$line" ] && ignores+=(--ignore-vuln "$line")
+          done < "$GITHUB_WORKSPACE/current/pentest/pip-audit-ignore.txt"
+          pip-audit -r requirements.txt --format json --output "$GITHUB_WORKSPACE/pip.json" \
+            "${ignores[@]}" || true
+
+      # No setup-node: the runner's preinstalled Node is sufficient. `npm audit`
+      # resolves the lockfile and queries the advisory API — it does not build
+      # anything, so pinning a major here would add an action dependency for no
+      # behavioural difference.
+      - name: npm audit
+        continue-on-error: true
+        working-directory: release/web
+        run: |
+          set -uo pipefail
+          # --ignore-scripts: we only need the resolved tree, not a working
+          # build, and native postinstalls on an older lockfile are a slow way
+          # to fail for reasons that have nothing to do with security.
+          npm ci --ignore-scripts --no-audit --no-fund > /dev/null 2>&1 || true
+          npm audit --audit-level=high --json > "$GITHUB_WORKSPACE/npm.json" || true
+
+      - name: Semgrep
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE/release:/src" \
+            -v "$GITHUB_WORKSPACE/current/pentest:/rules" \
+            -v "$GITHUB_WORKSPACE:/out" \
+            "${SEMGREP_IMAGE}" \
+            semgrep scan /src \
+              --config "p/python" \
+              --config "p/owasp-top-ten" \
+              --config "p/secrets" \
+              --config "/rules/semgrep/.semgrep.yml" \
+              --exclude "web/node_modules" \
+              --exclude ".next" \
+              --exclude "dist" \
+              --exclude "alembic/versions" \
+              --exclude "reports" \
+              --exclude "services/ai_eval" \
+              --exclude-rule "python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5" \
+              --exclude-rule "python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure" \
+              --exclude-rule "python.flask.security.audit.directly-returned-format-string.directly-returned-format-string" \
+              --json --output /out/semgrep.json || true
+
+      - name: Normalise
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          python3 current/scripts/rescan_normalise.py pip-audit pip.json \
+            "${{ matrix.tag }}" "source:python" "finding-pip.json"
+          python3 current/scripts/rescan_normalise.py npm-audit npm.json \
+            "${{ matrix.tag }}" "source:frontend" "finding-npm.json" \
+            current/pentest/npm-audit-allow.txt
+          python3 current/scripts/rescan_normalise.py semgrep semgrep.json \
+            "${{ matrix.tag }}" "source:semgrep" "finding-semgrep.json"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rescan-${{ matrix.tag }}-source
+          path: finding-*.json
+          retention-days: 7
+
+  report:
+    name: Report
+    needs: [discover, artifacts, source]
+    if: always() && needs.discover.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: findings
+          pattern: rescan-*
+
+      - name: Build the report
+        id: build
+        run: |
+          python3 scripts/rescan_report.py findings body.md \
+            ${{ needs.discover.outputs.list }} >> "$GITHUB_OUTPUT"
+
+      - name: Open or refresh the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "Security: findings in supported releases"
+          HAS_FINDINGS: ${{ steps.build.outputs.has_findings }}
+          FINGERPRINT: ${{ steps.build.outputs.fingerprint }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,body --jq '.[0] // empty')
+
+          if [ "$HAS_FINDINGS" != "true" ]; then
+            # Nothing actionable. Leave any open issue alone rather than
+            # auto-closing it: a human may still be mid-patch-release on it, and
+            # a findings list that empties because a scan leg was skipped should
+            # not read as "resolved".
+            echo "No findings. Nothing to raise."
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            number=$(echo "$existing" | jq -r '.number')
+            if echo "$existing" | jq -r '.body' | grep -q "terrapod-release-rescan:$FINGERPRINT"; then
+              echo "Issue #$number already reports this exact finding set — not re-notifying."
+              exit 0
+            fi
+            gh issue edit "$number" --body-file body.md
+            gh issue comment "$number" --body \
+              "The finding set changed on the latest re-scan — body updated above."
+            echo "Refreshed issue #$number"
+          else
+            gh issue create --title "$TITLE" --body-file body.md --label security 2>/dev/null \
+              || gh issue create --title "$TITLE" --body-file body.md
+          fi

--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -184,13 +184,17 @@ jobs:
           set -uo pipefail
           pip install --quiet poetry poetry-plugin-export pip-audit
           poetry export -f requirements.txt -o requirements.txt --without-hashes
-          ignores=()
+          # Same POSIX form as the ci.yml gate — one shape to reason about,
+          # and it does not depend on which shell the runner resolves.
+          ignores=""
           while read -r line; do
-            line="${line%%#*}"; line="$(echo "$line" | tr -d '[:space:]')"
-            [ -n "$line" ] && ignores+=(--ignore-vuln "$line")
+            line="${line%%#*}"
+            line="$(echo "$line" | tr -d '[:space:]')"
+            [ -n "$line" ] && ignores="$ignores --ignore-vuln $line"
           done < "$GITHUB_WORKSPACE/current/pentest/pip-audit-ignore.txt"
-          pip-audit -r requirements.txt --format json --output "$GITHUB_WORKSPACE/pip.json" \
-            "${ignores[@]}" || true
+          # shellcheck disable=SC2086
+          pip-audit -r requirements.txt --format json \
+            --output "$GITHUB_WORKSPACE/pip.json" $ignores || true
 
       # No setup-node: the runner's preinstalled Node is sufficient. `npm audit`
       # resolves the lockfile and queries the advisory API — it does not build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -618,6 +618,71 @@ multi-language implementation ships in the same PR**:
   flaky test: prove it's flaky, then **fix the flake** — re-running until green
   just hides it for the next person.
 
+## Patching an older release line
+
+Ordinary releases are cut by tagging `main`. A **patch for a line that `main`
+has already moved past** is different, and this is the procedure — introduced
+alongside the scheduled release re-scan (#1212), which is what surfaces the need
+for one.
+
+[`SECURITY.md`](SECURITY.md) offers *"security fixes only"* for the previous
+minor, so this path exists to discharge that promise. The re-scan reports which
+supported releases have actionable findings; this is how you act on one.
+
+**The tag push is the gate.** There is no separate verification step, because a
+cherry-picked commit is a *new* commit: no `sha-<short>` images exist for it, so
+the tag workflow runs the full lint, test and build set before it publishes
+anything. If any of it fails, the `Cleanup Tag` job deletes the tag, no release
+is created and no version images are retagged — so the version is back to
+"never released" and re-tagging the same version after a fix is safe and
+expected.
+
+```sh
+git fetch origin --tags
+git checkout -b release/v1.1 v1.1.1        # branch from the tag, not from main
+git cherry-pick -x <sha> [<sha> ...]        # -x records where each came from
+git push -u origin release/v1.1
+git tag v1.1.2 && git push origin v1.1.2    # this is the gate and the release
+```
+
+Then watch the pipeline through, and verify the published artifacts the same way
+as any release (`docker manifest inspect`, `helm pull`).
+
+### The trap: a patch with nothing to cherry-pick
+
+Some findings need **no code change at all** — a base-image CVE is cleared by
+rebuilding against a refreshed base. It is tempting to tag the existing commit.
+
+**Don't.** The pipeline skips building when `sha-<short>` images already exist
+for that commit, so tagging the commit an existing release already points at
+**retags the old images under a new version number**. The result is a release
+that claims to fix something and ships the identical bytes. The daily
+apt-refresh that would have picked up the fix only applies when a build actually
+runs.
+
+Give it a new commit so a real build happens:
+
+```sh
+git commit --allow-empty -m "chore: rebuild v1.1.x against a refreshed base image"
+```
+
+### Rules
+
+- **Cherry-pick, never merge `main`.** The point is the fix without the features;
+  merging defeats it and turns a patch into an untested minor.
+- **Never merge the release branch back into `main`.** Its commits are already
+  there — that is where they were picked from. Keep the branch; it is where the
+  next patch on that line starts.
+- **`-x` on every cherry-pick.** When someone asks in six months whether a fix is
+  in a line, the recorded origin is the answer.
+- **A patch stays a patch.** If what you are picking needs a schema migration, a
+  config key, or anything else that changes a public surface, it is not patch
+  material — see [Versioning & support](docs/versioning-and-support.md).
+- **Suppressions are not backported.** `pentest/trivy/.trivyignore` and the audit
+  ignore files describe what we accept *now*; they are read from the current
+  branch by both the release gate and the re-scan, and an older line does not
+  carry its own copy.
+
 ## Content hygiene (hard requirements)
 
 These protect the public repository. Git history, PRs, and source are

--- a/pentest/npm-audit-allow.txt
+++ b/pentest/npm-audit-allow.txt
@@ -1,0 +1,26 @@
+# Frontend advisories accepted for Terrapod, one GHSA id per line.
+#
+# Same four rules as pentest/trivy/.trivyignore — prefer the fix, state the
+# reasoning and the exit, re-examine every release, delete when stale. Policy:
+# docs/cve-policy.md.
+#
+# Consumed by the `npm-audit` job in ci.yml (the release gate) and by
+# release-rescan.yml. One file so the two can never drift apart.
+
+# GHSA-mh99-v99m-4gvg — brace-expansion ReDoS.
+#
+# A devDependency only (eslint -> minimatch -> brace-expansion): it never sees
+# runtime or user input, and none of it ships in a published image.
+#
+# Patched only in brace-expansion 5.0.8, whose new export shape breaks the
+# eslint chain's minimatch. RE-TESTED 2026-08-01 against eslint 10.8.0, which
+# was the presumed fix path: it does NOT resolve this — `npm run lint` on
+# eslint 10 dies with the same `(0, brace_expansion_1.expand) is not a
+# function` inside @eslint/config-array's bundled minimatch. Don't re-run that
+# experiment without first checking @eslint/config-array's minimatch pin.
+#
+# Tracked in #1058.
+#
+# EXIT: @eslint/config-array ships a minimatch that works with
+# brace-expansion >= 5.0.8.
+GHSA-mh99-v99m-4gvg

--- a/pentest/pip-audit-ignore.txt
+++ b/pentest/pip-audit-ignore.txt
@@ -1,0 +1,23 @@
+# Python advisories accepted for Terrapod, one id per line.
+#
+# Read pentest/trivy/.trivyignore's header first — the same four rules govern
+# this file: prefer the fix, every entry carries its reasoning and its exit
+# condition, every entry is re-examined every release, and a stale entry is
+# deleted rather than left to shadow a regression. The published policy is
+# docs/cve-policy.md.
+#
+# Consumed by the `python-audit` job in ci.yml (the release gate) and by
+# release-rescan.yml (which re-checks supported releases against *current*
+# reasoning). One file so the two can never drift apart.
+
+# PYSEC-2025-183 — pyjwt.
+#
+# Disputed by the supplier: the advisory concerns weak HMAC keys, but key
+# length is chosen by the application using the library, not by the library.
+# No fix version has been published.
+#
+# Re-verified 2026-08-01: our pin already floats to the latest pyjwt (2.13.0)
+# and the advisory still has no fix, so there is nothing to bump to.
+#
+# EXIT: a fix is published, or the dispute is resolved upstream.
+PYSEC-2025-183

--- a/scripts/rescan_normalise.py
+++ b/scripts/rescan_normalise.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Normalise one scanner's output into the re-scan report shape (#1212).
+
+Four scanners with four unrelated JSON schemas feed one report, so each is
+flattened here rather than in the workflow. Keeping it in a script means the
+shapes can be exercised without pushing a workflow change and waiting for a
+scheduled run.
+
+    rescan_normalise.py <trivy|pip-audit|npm-audit|semgrep> \
+        <input.json> <release> <source-label> <output.json> [allowlist]
+
+Every scanner is run in a mode that already applies our accepted-risk register
+(Trivy reads .trivyignore, pip-audit takes --ignore-vuln), except npm audit,
+which has no native ignore mechanism — its allowlist is applied here from the
+same file the release gate uses.
+
+A missing or unparseable input yields an empty finding list rather than an
+error. A scanner that could not run must not be indistinguishable from a
+scanner that ran and found nothing, so the workflow reports skips separately;
+what this must not do is fail the whole aggregation because one leg was absent.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+
+def _read(path: pathlib.Path):
+    try:
+        text = path.read_text().strip()
+        return json.loads(text) if text else None
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"note: {path} unreadable ({exc}); treating as no findings", file=sys.stderr)
+        return None
+
+
+def from_trivy(data) -> list[dict]:
+    out = []
+    for result in (data or {}).get("Results") or []:
+        for v in result.get("Vulnerabilities") or []:
+            out.append({
+                "id": v.get("VulnerabilityID", "?"),
+                "package": v.get("PkgName", "?"),
+                "installed": v.get("InstalledVersion", "?"),
+                "fixed": v.get("FixedVersion", "?"),
+                "severity": v.get("Severity", "?"),
+            })
+    return out
+
+
+def from_pip_audit(data) -> list[dict]:
+    out = []
+    for dep in (data or {}).get("dependencies") or []:
+        for v in dep.get("vulns") or []:
+            fixes = v.get("fix_versions") or []
+            out.append({
+                "id": v.get("id", "?"),
+                "package": dep.get("name", "?"),
+                "installed": dep.get("version", "?"),
+                "fixed": ", ".join(fixes) if fixes else "none published",
+                "severity": "HIGH",   # pip-audit does not grade; the gate treats all as actionable
+            })
+    return out
+
+
+def from_npm_audit(data, allowlist: set[str]) -> list[dict]:
+    out = []
+    for name, v in ((data or {}).get("vulnerabilities") or {}).items():
+        if v.get("severity") not in ("high", "critical"):
+            continue
+        ids = [
+            x["url"].rstrip("/").split("/")[-1]
+            for x in (v.get("via") or [])
+            if isinstance(x, dict) and x.get("url")
+        ]
+        for advisory in ids:
+            if advisory in allowlist:
+                continue
+            out.append({
+                "id": advisory,
+                "package": name,
+                "installed": (v.get("range") or "?"),
+                "fixed": "see advisory",
+                "severity": v.get("severity", "?").upper(),
+            })
+    return out
+
+
+def from_semgrep(data) -> list[dict]:
+    out = []
+    for r in (data or {}).get("results") or []:
+        extra = r.get("extra") or {}
+        if (extra.get("severity") or "").upper() != "ERROR":
+            continue        # WARNING/INFO are advisory; only ERROR is actionable here
+        start = (r.get("start") or {}).get("line", "?")
+        path = r.get("path", "?")
+        # Paths are absolute inside the scanner container; the repo-relative
+        # form is what a reader needs.
+        path = path.split("/src/", 1)[-1]
+        out.append({
+            "id": r.get("check_id", "?"),
+            "package": f"{path}:{start}",
+            "installed": "-",
+            "fixed": "-",
+            "severity": "ERROR",
+        })
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) < 6:
+        print(__doc__, file=sys.stderr)
+        return 2
+    kind, src, release, label, out = sys.argv[1:6]
+    data = _read(pathlib.Path(src))
+
+    if kind == "trivy":
+        findings, report_kind = from_trivy(data), "dependency"
+    elif kind == "pip-audit":
+        findings, report_kind = from_pip_audit(data), "dependency"
+    elif kind == "npm-audit":
+        allow: set[str] = set()
+        if len(sys.argv) > 6:
+            for line in pathlib.Path(sys.argv[6]).read_text().splitlines():
+                line = line.split("#", 1)[0].strip()
+                if line:
+                    allow.add(line)
+        findings, report_kind = from_npm_audit(data, allow), "dependency"
+    elif kind == "semgrep":
+        findings, report_kind = from_semgrep(data), "code"
+    else:
+        print(f"unknown scanner {kind!r}", file=sys.stderr)
+        return 2
+
+    pathlib.Path(out).write_text(json.dumps({
+        "release": release,
+        "source": label,
+        "kind": report_kind,
+        "findings": findings,
+    }, indent=2))
+    print(f"{label}: {len(findings)} finding(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rescan_report.py
+++ b/scripts/rescan_report.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Aggregate release re-scan findings into an issue body (#1212).
+
+Every scanner in the re-scan workflow normalises its output to one JSON file
+per (release, source) with a common shape, and this collapses the lot into a
+single report:
+
+    {"release": "v1.1.1",
+     "source": "image:terrapod-api (amd64)",
+     "kind": "dependency" | "code",
+     "findings": [{...}]}
+
+Two things here matter more than the formatting.
+
+**The fingerprint.** A scheduled job that re-notifies on an unchanged finding
+set gets muted within a week, and then the one time it matters nobody looks. So
+the body carries a fingerprint of the finding *set* (not the run, not the
+timestamp), and the workflow only touches the issue when that changes. Re-runs
+that find the same things are silent by construction rather than by someone
+remembering to check.
+
+**Grouping by release.** The follow-up action is a patch release, and a patch
+release is per-release — so that is the axis the report is organised on, even
+though scanning is organised by image and architecture.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import sys
+
+MARKER = "terrapod-release-rescan"
+
+
+def load(directory: pathlib.Path) -> list[dict]:
+    reports = []
+    for path in sorted(directory.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"skipping unreadable {path}: {exc}", file=sys.stderr)
+            continue
+        if isinstance(data, dict) and "release" in data:
+            reports.append(data)
+    return reports
+
+
+def fingerprint(reports: list[dict]) -> str:
+    """Identity of the finding *set*, stable across runs and orderings.
+
+    Deliberately excludes the source: the same CVE found in five images of one
+    release is one problem to fix, and letting the image list move the
+    fingerprint would re-notify on noise (an image list changing between
+    releases, a scan legitimately skipped).
+    """
+    keys = set()
+    for report in reports:
+        for finding in report.get("findings") or []:
+            keys.add(f"{report['release']}|{finding.get('id', '')}")
+    digest = hashlib.sha256("\n".join(sorted(keys)).encode()).hexdigest()[:16]
+    return digest
+
+
+def _dependency_table(findings: list[dict]) -> list[str]:
+    lines = [
+        "| Severity | Package | Installed | Fixed in | Advisory | Seen in |",
+        "|---|---|---|---|---|---|",
+    ]
+    for f in sorted(findings, key=lambda x: (x.get("severity", ""), x.get("id", ""))):
+        where = ", ".join(sorted(set(f.get("sources") or [])))
+        lines.append(
+            f"| {f.get('severity', '?')} | `{f.get('package', '?')}` "
+            f"| {f.get('installed', '?')} | **{f.get('fixed', '?')}** "
+            f"| {f.get('id', '?')} | {where} |"
+        )
+    return lines
+
+
+def _code_table(findings: list[dict]) -> list[str]:
+    lines = ["| Severity | Rule | Location | Seen in |", "|---|---|---|---|"]
+    for f in sorted(findings, key=lambda x: (x.get("severity", ""), x.get("id", ""))):
+        where = ", ".join(sorted(set(f.get("sources") or [])))
+        lines.append(
+            f"| {f.get('severity', '?')} | `{f.get('id', '?')}` "
+            f"| `{f.get('package', '?')}` | {where} |"
+        )
+    return lines
+
+
+def merge(reports: list[dict]) -> dict[str, dict[str, list[dict]]]:
+    """release -> kind -> findings, deduplicated, recording where each was seen."""
+    out: dict[str, dict[str, dict[str, dict]]] = {}
+    for report in reports:
+        release = report["release"]
+        kind = report.get("kind", "dependency")
+        source = report.get("source", "?")
+        bucket = out.setdefault(release, {}).setdefault(kind, {})
+        for finding in report.get("findings") or []:
+            key = f"{finding.get('id')}|{finding.get('package')}"
+            entry = bucket.setdefault(key, {**finding, "sources": []})
+            entry["sources"].append(source)
+    return {r: {k: list(v.values()) for k, v in kinds.items()} for r, kinds in out.items()}
+
+
+def render(reports: list[dict], scanned: list[str]) -> tuple[str, str, bool]:
+    merged = merge(reports)
+    fp = fingerprint(reports)
+    total = sum(len(f) for kinds in merged.values() for f in kinds.values())
+
+    body = [
+        f"<!-- {MARKER}:{fp} -->",
+        "",
+        "Automated re-scan of the releases we still support. Raised by "
+        "`.github/workflows/release-rescan.yml`; the policy it enforces is "
+        "[docs/cve-policy.md](../blob/main/docs/cve-policy.md).",
+        "",
+        "**Why this can appear on a release that was clean when it shipped:** the "
+        "release gate uses `ignore-unfixed`, so a vulnerability only becomes "
+        "actionable once upstream publishes a fix. Everything below has a fix "
+        "available *now* that did not exist, or was not yet taken, when the "
+        "release was cut. Code findings can also appear because the rule set has "
+        "improved since.",
+        "",
+        f"Scanned: {', '.join(scanned) if scanned else '(none)'}",
+        "",
+    ]
+
+    if not total:
+        body += [
+            "## No findings",
+            "",
+            "Every supported release is clean against current advisory data and "
+            "current rules, with the accepted-risk register applied.",
+        ]
+        return "\n".join(body), fp, False
+
+    for release in sorted(merged, reverse=True):
+        kinds = merged[release]
+        count = sum(len(v) for v in kinds.values())
+        body += [f"## {release} — {count} finding(s)", ""]
+        if kinds.get("dependency"):
+            body += ["**Dependencies and packages**", ""]
+            body += _dependency_table(kinds["dependency"])
+            body += [""]
+        if kinds.get("code"):
+            body += ["**Code**", ""]
+            body += _code_table(kinds["code"])
+            body += [""]
+
+    body += [
+        "## What to do with this",
+        "",
+        "Each release above needs a judgement call, not an automatic patch. Worth "
+        "checking in this order:",
+        "",
+        "1. **Is it already fixed on `main`?** If so the fix needs backporting to "
+        "that release line, which is what the patch release carries.",
+        "2. **Is it reachable in the way Terrapod uses the component?** If not, it "
+        "belongs in the accepted-risk register with its reasoning and exit "
+        "condition — not silently ignored, and not patched for appearance.",
+        "3. **Does it warrant a patch release on its own**, or can it wait for the "
+        "next scheduled one? Cadence is roughly weekly; an unreachable medium-"
+        "impact finding can reasonably wait, a reachable critical one cannot.",
+        "",
+        "This issue is refreshed in place while the finding set is unchanged, so "
+        "it will not re-notify on every run.",
+    ]
+    return "\n".join(body), fp, True
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: rescan_report.py <findings-dir> <out.md> [tag ...]", file=sys.stderr)
+        return 2
+    directory, out = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+    scanned = sys.argv[3:]
+    reports = load(directory)
+    body, fp, has_findings = render(reports, scanned)
+    out.write_text(body)
+    print(f"fingerprint={fp}")
+    print(f"has_findings={'true' if has_findings else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Part of #1212. Prompted by #1206.

## The gap

The release gate uses `ignore-unfixed`, so a vulnerability becomes visible to it only once upstream publishes a fix. A released image is immutable and nothing re-checks it — so the first we hear about a newly-fixable CVE in a shipped release is when an operator scans it and opens an issue. That is exactly how #1206 reached us.

It also makes an existing promise operable: `SECURITY.md` offers *"security fixes only"* for the previous minor, and until now nothing told us a fix was needed.

## It already found real work

Run locally against the current supported set, with the accepted-risk register applied:

| Release | Findings |
|---|---|
| **v1.2.0** | 4 × `libexpat1` HIGH (2.7.1-2 → **2.8.2-1~deb13u1**) in `api` + `runner` |
| **v1.1.1** | the same 4 × `libexpat1`, plus 4 × `next` (16.2.10 → **16.2.11**) and `sharp` (→ **0.35.0**) in `web` |

All fixable, none suppressed, none visible when those releases were cut. The `libexpat1` set is cleared by a base-image refresh alone; `next`/`sharp` are already fixed on `main`.

## Shape

Two families, over the latest patch of each supported minor (derived from the releases API, not hardcoded):

- **artifacts** — Trivy over all five images, per architecture. A released tag is a multi-arch manifest, so each leg pins `TRIVY_PLATFORM`; without it the arm64 leg silently scans amd64.
- **source** — `pip-audit`, `npm audit`, Semgrep against the source at the tag. **Two checkouts, not one:** the released code, scanned with *today's* rules. Conflating them would scan old code with old rules and miss the point.

## Suppressions can no longer drift

Today's suppressions apply deliberately — the current register is the reasoning we stand behind *now*, so an entry we have since dropped must not go on suppressing a finding in a version we still support.

To make that true rather than aspirational, the pip-audit ignore list and npm allowlist move out of `ci.yml` into `pentest/pip-audit-ignore.txt` and `pentest/npm-audit-allow.txt`, read by **both** workflows. Duplicated suppression lists drift, and a drifted security suppression is the exact failure this change exists to catch. Each entry carries its reasoning and exit condition, matching the `.trivyignore` house style.

## Noise control

It is a **reporter, not a gate** — it never fails on findings. The release-time `scan-images` job is the gate; a permanently red scheduled job is the same failure mode as a noisy one.

For the same reason the issue body carries a **fingerprint of the finding set**, and an unchanged set does not re-notify. A job that pings daily with the same list gets filtered within a week, and then the one time it matters nobody looks.

It also does **not** auto-close an open issue when findings clear: someone may be mid-patch-release on it, and a list that empties because a scan leg was skipped must not read as "resolved".

## Verification and its limits

Verified locally against **real** Trivy output for v1.2.0 and v1.1.1 — that covers the normalisers and the report generator, and produced the table above. Every action is SHA-pinned to a SHA already in use elsewhere in the repo; both workflows parse as valid YAML.

What that does **not** cover is the workflow wiring itself, which can only be exercised by running it. The plan is to `workflow_dispatch` it against v1.1 and v1.2 once merged, then cut patch releases from what it reports.

## Deferred

CodeQL. Its results upload as SARIF tied to a ref, and pushing old-tag results risks polluting the main branch's code-scanning view. Worth settling deliberately rather than bolting on — `pip-audit`, `npm audit` and Semgrep cover the source side meanwhile.

## Also: how to actually ship a patch for an older line

The re-scan reports which supported releases need a fix, and nothing said how to ship one — `SECURITY.md` promises *"security fixes only"* for the previous minor with no procedure behind it. Added to `AGENTS.md`.

There was less to build than expected. Nothing in the release path assumes `main`, and a cherry-picked commit is a **new** commit — so no `sha-<short>` images exist for it, the tag workflow runs the full lint/test/build set, and `Cleanup Tag` deletes the tag if any of it fails. **The tag push is both the gate and the release**, and re-tagging the same version after a fix is safe because a failed pipeline leaves nothing published.

The part worth writing down is the trap, and it is exactly the case the first patch releases hit:

> A base-image CVE needs no code change, so tagging the commit the existing release already points at looks right. It isn't. The pipeline skips building when images already exist for that commit, so it would **retag the identical bytes under a new version and claim a fix**. The daily apt-refresh that would have picked the fix up only runs when a build does.

An empty commit is the fix. Since the `libexpat1` findings above clear on a rebuild alone, this is not a hypothetical.

Also recorded: suppressions are never backported. The ignore files describe what we accept *now*, and both the gate and the re-scan read them from the current branch rather than from the tag.