### PR TITLE
fix: make source-scan findings actionable and consistent

### DIFF
--- a/scripts/rescan_normalise.py
+++ b/scripts/rescan_normalise.py
@@ -55,20 +55,46 @@ def from_pip_audit(data) -> list[dict]:
     for dep in (data or {}).get("dependencies") or []:
         for v in dep.get("vulns") or []:
             fixes = v.get("fix_versions") or []
+            if not fixes:
+                # Same ignore-unfixed policy as the other two legs: nothing to
+                # bump to means nothing a patch release can do.
+                continue
             out.append({
                 "id": v.get("id", "?"),
                 "package": dep.get("name", "?"),
                 "installed": dep.get("version", "?"),
-                "fixed": ", ".join(fixes) if fixes else "none published",
+                "fixed": ", ".join(fixes),
                 "severity": "HIGH",   # pip-audit does not grade; the gate treats all as actionable
             })
     return out
+
+
+def _npm_fix(v) -> str | None:
+    """The upgrade that resolves this advisory, or None when there isn't one.
+
+    `fixAvailable` is `false` when nothing upstream fixes it yet, an object
+    naming the upgrade when there is one, and `true` when npm can resolve it
+    within the existing ranges.
+    """
+    fix = v.get("fixAvailable")
+    if fix is False or fix is None:
+        return None
+    if isinstance(fix, dict):
+        target = f"{fix.get('name', '?')}@{fix.get('version', '?')}"
+        return f"{target} (major)" if fix.get("isSemVerMajor") else target
+    return "npm audit fix"
 
 
 def from_npm_audit(data, allowlist: set[str]) -> list[dict]:
     out = []
     for name, v in ((data or {}).get("vulnerabilities") or {}).items():
         if v.get("severity") not in ("high", "critical"):
+            continue
+        fixed = _npm_fix(v)
+        if fixed is None:
+            # Match the artifact leg's ignore-unfixed policy. An advisory with
+            # no available fix cannot be actioned by a patch release, and
+            # listing it only pads the report with rows nobody can close.
             continue
         ids = [
             x["url"].rstrip("/").split("/")[-1]
@@ -82,7 +108,7 @@ def from_npm_audit(data, allowlist: set[str]) -> list[dict]:
                 "id": advisory,
                 "package": name,
                 "installed": (v.get("range") or "?"),
-                "fixed": "see advisory",
+                "fixed": fixed,
                 "severity": v.get("severity", "?").upper(),
             })
     return out


### PR DESCRIPTION
Part of #1212. Comes straight out of the first real run, #1214.

## Two problems, both in the source legs

**1. `Fixed in: see advisory`.** The least useful thing a report can say, when its entire purpose is deciding what a patch release should carry. `npm audit` publishes the answer in `fixAvailable` and we weren't reading it.

| `fixAvailable` | Meaning | Now renders as |
|---|---|---|
| `false` | nothing fixes it yet | *(dropped — see below)* |
| object | the upgrade that fixes it | `sharp@0.35.3` |
| object, `isSemVerMajor` | fix crosses a major | `next@16.2.11 (major)` |
| `true` | resolvable in existing ranges | `npm audit fix` |

The major/minor distinction matters here specifically, because it is what decides whether something is patch material at all.

**2. A policy inconsistency.** The artifact leg runs `ignore-unfixed`, so it only reports what can be acted on. Both source legs reported everything, including advisories with no available fix.

That is not a cosmetic mismatch. A patch release cannot carry a fix that does not exist, so those rows pad the report with entries nobody can close — and **a report that cannot be driven to empty is one people stop reading**, which is the failure mode the fingerprint/no-re-notify design exists to avoid. Both source legs now apply the same rule: npm advisories with `fixAvailable: false` and pip-audit vulns with no `fix_versions` are skipped.

## Effect

The report shrinks and its fingerprint changes, so the next run **refreshes #1214 in place** and comments that the set changed — which also exercises the refresh path, since the first run only exercised creation.

## Verification

Tested against npm's documented shapes for all four `fixAvailable` forms plus an allowlisted advisory, confirming the allowlist still drops out and that a `false` never reaches the report.