### PR TITLE
fix: keep code findings out of the public re-scan issue

### DIFF
--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -263,6 +263,10 @@ jobs:
           python3 current/scripts/rescan_normalise.py npm-audit npm.json \
             "${{ matrix.tag }}" "source:frontend" "finding-npm.json" \
             current/pentest/npm-audit-allow.txt
+          # Count only — so the public report can say code findings exist and
+          # point at code scanning, without publishing what they are.
+          python3 current/scripts/rescan_normalise.py semgrep-count semgrep.sarif \
+            "${{ matrix.tag }}" "source:semgrep" "codecount.json"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -271,6 +275,7 @@ jobs:
           path: |
             finding-pip.json
             finding-npm.json
+            codecount.json
           retention-days: 7
 
   report:

--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -234,7 +234,26 @@ jobs:
               --exclude-rule "python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5" \
               --exclude-rule "python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure" \
               --exclude-rule "python.flask.security.audit.directly-returned-format-string.directly-returned-format-string" \
-              --json --output /out/semgrep.json || true
+              --sarif --output /out/semgrep.sarif || true
+
+      # Code findings go to code scanning, NOT to the report. A Semgrep hit in
+      # Terrapod's own source is a potential undisclosed vulnerability in
+      # Terrapod, and the report is published as a public issue — auto-posting
+      # one there would breach the private-disclosure process SECURITY.md sets
+      # out, on a schedule, for a release people are running. Code scanning
+      # alerts are visible only to write-access users, which is the correct
+      # audience. This is also why Semgrep emits SARIF above and is never
+      # uploaded as a workflow artifact: on a public repository, artifacts and
+      # job logs are world-readable.
+      - name: Upload code findings to code scanning (private)
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        with:
+          sarif_file: semgrep.sarif
+          category: release-rescan-${{ matrix.tag }}
+          ref: refs/tags/${{ matrix.tag }}
+          sha: ${{ github.sha }}
 
       - name: Normalise
         run: |
@@ -244,13 +263,14 @@ jobs:
           python3 current/scripts/rescan_normalise.py npm-audit npm.json \
             "${{ matrix.tag }}" "source:frontend" "finding-npm.json" \
             current/pentest/npm-audit-allow.txt
-          python3 current/scripts/rescan_normalise.py semgrep semgrep.json \
-            "${{ matrix.tag }}" "source:semgrep" "finding-semgrep.json"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rescan-${{ matrix.tag }}-source
-          path: finding-*.json
+          # finding-pip / finding-npm only. Never semgrep.sarif — see above.
+          path: |
+            finding-pip.json
+            finding-npm.json
           retention-days: 7
 
   report:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -682,6 +682,33 @@ git commit --allow-empty -m "chore: rebuild v1.1.x against a refreshed base imag
   ignore files describe what we accept *now*; they are read from the current
   branch by both the release gate and the re-scan, and an older line does not
   carry its own copy.
+- **A security-driven patch is still a release.** Being prompted by a scanner
+  earns it no shortcut: it goes through the same pre-release process as any
+  other patch, including the independent third-party review. A patch cut in a
+  hurry against a supported line that people are already running is, if
+  anything, the one you least want to skip checks on.
+- **Say what it fixes.** The release notes name the advisories the patch
+  clears, so an operator can match them against their own scan output without
+  guessing. That is the whole reason they are running a scanner.
+
+### Where findings are published
+
+The re-scan raises a **public issue** for dependency findings and sends code
+findings to **code scanning**, and the split is deliberate.
+
+Dependency findings are already public — published advisories against public
+dependency versions of a public project, reproducible by anyone with
+`trivy image ghcr.io/…/terrapod-api:vX.Y.Z`. Publishing them tells operators
+what is in the version they are running, and withholding them would protect
+nobody.
+
+A static-analysis hit in **Terrapod's own source** is the opposite: a potential
+undisclosed vulnerability, and [`SECURITY.md`](SECURITY.md) asks people not to
+open a public issue for those. Auto-posting one would breach our own disclosure
+process on a schedule. Code scanning alerts are visible only to write-access
+users, which is the right audience. **On a public repository, Actions logs and
+artifacts are world-readable too** — which is why the Semgrep step emits SARIF
+and is never uploaded as an artifact.
 
 ## Content hygiene (hard requirements)
 

--- a/docs/cve-policy.md
+++ b/docs/cve-policy.md
@@ -53,7 +53,22 @@ roughly weekly. When a fix lands upstream — usually as a base-image or
 dependency refresh — the next scheduled release picks it up, typically within
 days, with no action required from you beyond upgrading.
 
-## Released images are immutable, and are never rescanned
+## Supported releases are re-scanned, and findings are published
+
+A scheduled job re-scans the releases we still support — the published images
+and the source at the tag — against current advisory data and current rules, and
+raises a **public issue** listing what it finds. So a newly-fixable
+vulnerability in a release you are running should reach us before it reaches
+you, rather than the other way round.
+
+Those findings are published because they are already public: advisories against
+public dependency versions, which your own scanner will report too. Findings in
+Terrapod's *own source* are handled differently — they go to private code
+scanning and follow the disclosure process in [`SECURITY.md`](../SECURITY.md),
+because an undisclosed vulnerability in Terrapod is not ours to publish before
+it is fixed.
+
+## Released images are immutable, and are never re-built
 
 A published `vX.Y.Z` image is a fixed set of bytes. When a fix ships for
 something inside it, that image does not change; the *next* release contains the
@@ -64,6 +79,10 @@ fixable when it was built. This is not drift and not an oversight — it is what
 immutable artifacts mean. **If a scan of a Terrapod release shows fixable
 HIGH/CRITICAL findings, the first thing to check is whether a newer release
 already clears them.** It usually has.
+
+Where it hasn't, the answer is a patch release for that line rather than a
+silent rebuild of the tag you already have: the bytes behind `vX.Y.Z` never
+change, so a fix always arrives as a new version number.
 
 ## The accepted-risk register
 

--- a/scripts/rescan_normalise.py
+++ b/scripts/rescan_normalise.py
@@ -135,6 +135,22 @@ def from_semgrep(data) -> list[dict]:
     return out
 
 
+def count_semgrep_sarif(data) -> int:
+    """How many error-level results, and nothing else.
+
+    A count is not a disclosure — the detail is. This exists so the public
+    report can say "3 code findings on v1.1.1, see code scanning" instead of
+    staying silent about them, which would leave a maintainer reading the issue
+    with no idea they existed.
+    """
+    total = 0
+    for run in (data or {}).get("runs") or []:
+        for r in run.get("results") or []:
+            if (r.get("level") or "").lower() == "error":
+                total += 1
+    return total
+
+
 def main() -> int:
     if len(sys.argv) < 6:
         print(__doc__, file=sys.stderr)
@@ -156,6 +172,14 @@ def main() -> int:
         findings, report_kind = from_npm_audit(data, allow), "dependency"
     elif kind == "semgrep":
         findings, report_kind = from_semgrep(data), "code"
+    elif kind == "semgrep-count":
+        # Count only. Deliberately does not go through the findings path.
+        pathlib.Path(out).write_text(json.dumps({
+            "release": release,
+            "code_findings": count_semgrep_sarif(data),
+        }, indent=2))
+        print(f"{label}: {count_semgrep_sarif(data)} code finding(s) (count only)")
+        return 0
     else:
         print(f"unknown scanner {kind!r}", file=sys.stderr)
         return 2

--- a/scripts/rescan_report.py
+++ b/scripts/rescan_report.py
@@ -120,8 +120,12 @@ def render(reports: list[dict], scanned: list[str]) -> tuple[str, str, bool]:
         "release gate uses `ignore-unfixed`, so a vulnerability only becomes "
         "actionable once upstream publishes a fix. Everything below has a fix "
         "available *now* that did not exist, or was not yet taken, when the "
-        "release was cut. Code findings can also appear because the rule set has "
-        "improved since.",
+        "release was cut.",
+        "",
+        "**This report covers dependency findings only.** Code findings from the "
+        "source scan go to code scanning, which is visible to write-access users "
+        "rather than the world — a static-analysis hit in Terrapod's own source is "
+        "a potential undisclosed vulnerability, and this issue is public.",
         "",
         f"Scanned: {', '.join(scanned) if scanned else '(none)'}",
         "",

--- a/scripts/rescan_report.py
+++ b/scripts/rescan_report.py
@@ -28,10 +28,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import pathlib
 import sys
 
 MARKER = "terrapod-release-rescan"
+
+# Issue bodies do not resolve relative links the way a file in the repo does,
+# so every link here is absolute, built from the repository the run belongs to.
+_REPO = os.environ.get("GITHUB_REPOSITORY", "mattrobinsonsre/terrapod")
+_REPO_URL = f"https://github.com/{_REPO}"
 
 # Report copy lives here rather than inline in the list literals below.
 # Implicit concatenation inside a list is how a missing comma silently merges
@@ -40,7 +46,7 @@ MARKER = "terrapod-release-rescan"
 _INTRO = (
     "Automated re-scan of the releases we still support. Raised by "
     "`.github/workflows/release-rescan.yml`; the policy it enforces is "
-    "[docs/cve-policy.md](../blob/main/docs/cve-policy.md)."
+    f"[docs/cve-policy.md]({_REPO_URL}/blob/main/docs/cve-policy.md)."
 )
 _WHY = (
     "**Why this can appear on a release that was clean when it shipped:** the "
@@ -85,6 +91,19 @@ _FOOTER = (
 )
 
 
+def load_code_counts(directory: pathlib.Path) -> dict[str, int]:
+    """release -> number of code findings, from the count-only files."""
+    counts: dict[str, int] = {}
+    for path in sorted(directory.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(data, dict) and "code_findings" in data:
+            counts[data["release"]] = counts.get(data["release"], 0) + int(data["code_findings"])
+    return counts
+
+
 def load(directory: pathlib.Path) -> list[dict]:
     reports = []
     for path in sorted(directory.rglob("*.json")):
@@ -93,7 +112,10 @@ def load(directory: pathlib.Path) -> list[dict]:
         except (json.JSONDecodeError, OSError) as exc:
             print(f"skipping unreadable {path}: {exc}", file=sys.stderr)
             continue
-        if not (isinstance(data, dict) and "release" in data):
+        # Must carry findings. The count-only files also have a "release", and
+        # accepting one here registers the release as present-but-empty, which
+        # is enough to hide a code-only release from the branch that reports it.
+        if not (isinstance(data, dict) and "release" in data and "findings" in data):
             continue
         if data.get("kind") == "code":
             # The workflow sends code findings to code scanning and never here,
@@ -127,6 +149,19 @@ def fingerprint(reports: list[dict]) -> str:
     return digest
 
 
+def _code_pointer(release: str, count: int) -> str:
+    """Say that code findings exist and where, without saying what they are."""
+    return (
+        f"> **{count} code finding(s)** from the source scan of `{release}`, "
+        "not listed here. Details are in "
+        f"[code scanning]({_REPO_URL}/security/code-scanning?query=is%3Aopen) "
+        "under the "
+        f"`release-rescan-{release}` category — this issue is public, and a "
+        "static-analysis hit in Terrapod's own source is a potential "
+        "undisclosed vulnerability."
+    )
+
+
 def _dependency_table(findings: list[dict]) -> list[str]:
     lines = [
         "| Severity | Package | Installed | Fixed in | Advisory | Seen in |",
@@ -158,7 +193,10 @@ def merge(reports: list[dict]) -> dict[str, dict[str, list[dict]]]:
     return {r: {k: list(v.values()) for k, v in kinds.items()} for r, kinds in out.items()}
 
 
-def render(reports: list[dict], scanned: list[str]) -> tuple[str, str, bool]:
+def render(
+    reports: list[dict], scanned: list[str], code_counts: dict[str, int] | None = None
+) -> tuple[str, str, bool]:
+    code_counts = code_counts or {}
     merged = merge(reports)
     fp = fingerprint(reports)
     total = sum(len(f) for kinds in merged.values() for f in kinds.values())
@@ -176,6 +214,14 @@ def render(reports: list[dict], scanned: list[str]) -> tuple[str, str, bool]:
         "",
     ]
 
+    # Releases with no dependency findings but some code findings still need
+    # saying, or the issue reads as "clean" when it is not.
+    for release in sorted(set(code_counts) - set(merged), reverse=True):
+        if code_counts[release]:
+            body += [f"## {release} — code findings only", "",
+                     _code_pointer(release, code_counts[release]), ""]
+            total += code_counts[release]
+
     if not total:
         body += ["## No findings", "", _CLEAN]
         return "\n".join(body), fp, False
@@ -184,6 +230,8 @@ def render(reports: list[dict], scanned: list[str]) -> tuple[str, str, bool]:
         kinds = merged[release]
         count = sum(len(v) for v in kinds.values())
         body += [f"## {release} — {count} finding(s)", ""]
+        if code_counts.get(release):
+            body += [_code_pointer(release, code_counts[release]), ""]
         if kinds.get("dependency"):
             body += ["**Dependencies and packages**", ""]
             body += _dependency_table(kinds["dependency"])
@@ -202,7 +250,7 @@ def main() -> int:
     directory, out = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
     scanned = sys.argv[3:]
     reports = load(directory)
-    body, fp, has_findings = render(reports, scanned)
+    body, fp, has_findings = render(reports, scanned, load_code_counts(directory))
     out.write_text(body)
     print(f"fingerprint={fp}")
     print(f"has_findings={'true' if has_findings else 'false'}")

--- a/scripts/rescan_report.py
+++ b/scripts/rescan_report.py
@@ -33,6 +33,57 @@ import sys
 
 MARKER = "terrapod-release-rescan"
 
+# Report copy lives here rather than inline in the list literals below.
+# Implicit concatenation inside a list is how a missing comma silently merges
+# two entries into one and looks exactly like deliberate line-wrapping, so the
+# prose is assembled in parentheses where there is no comma to lose.
+_INTRO = (
+    "Automated re-scan of the releases we still support. Raised by "
+    "`.github/workflows/release-rescan.yml`; the policy it enforces is "
+    "[docs/cve-policy.md](../blob/main/docs/cve-policy.md)."
+)
+_WHY = (
+    "**Why this can appear on a release that was clean when it shipped:** the "
+    "release gate uses `ignore-unfixed`, so a vulnerability only becomes "
+    "actionable once upstream publishes a fix. Everything below has a fix "
+    "available *now* that did not exist, or was not yet taken, when the "
+    "release was cut."
+)
+_SCOPE = (
+    "**This report covers dependency findings only.** Code findings from the "
+    "source scan go to code scanning, which is visible to write-access users "
+    "rather than the world — a static-analysis hit in Terrapod's own source is "
+    "a potential undisclosed vulnerability, and this issue is public."
+)
+_CLEAN = (
+    "Every supported release is clean against current advisory data and "
+    "current rules, with the accepted-risk register applied."
+)
+_TRIAGE_HEAD = (
+    "Each release above needs a judgement call, not an automatic patch. Worth "
+    "checking in this order:"
+)
+_TRIAGE_FIXED = (
+    "1. **Is it already fixed on `main`?** If so the fix needs backporting "
+    "to that release line, which is what the patch release carries."
+)
+_TRIAGE_REACHABLE = (
+    "2. **Is it reachable in the way Terrapod uses the component?** If not, "
+    "it belongs in the accepted-risk register with its reasoning and exit "
+    "condition — not silently ignored, and not patched for appearance."
+)
+_TRIAGE_URGENCY = (
+    "3. **Does it warrant a patch release on its own**, or can it wait for "
+    "the next scheduled one? Cadence is roughly weekly; an unreachable "
+    "medium-impact finding can reasonably wait, a reachable critical one "
+    "cannot."
+)
+_TRIAGE = [_TRIAGE_FIXED, _TRIAGE_REACHABLE, _TRIAGE_URGENCY]
+_FOOTER = (
+    "This issue is refreshed in place while the finding set is unchanged, so "
+    "it will not re-notify on every run."
+)
+
 
 def load(directory: pathlib.Path) -> list[dict]:
     reports = []
@@ -42,8 +93,21 @@ def load(directory: pathlib.Path) -> list[dict]:
         except (json.JSONDecodeError, OSError) as exc:
             print(f"skipping unreadable {path}: {exc}", file=sys.stderr)
             continue
-        if isinstance(data, dict) and "release" in data:
-            reports.append(data)
+        if not (isinstance(data, dict) and "release" in data):
+            continue
+        if data.get("kind") == "code":
+            # The workflow sends code findings to code scanning and never here,
+            # but this report is published as a PUBLIC issue — so refuse them at
+            # the door rather than relying on the caller to have got it right.
+            # Silently dropping would be worse: it would look like the scan
+            # found nothing.
+            print(
+                f"REFUSING code-kind findings from {path}: this report is public, "
+                "and code findings belong in code scanning",
+                file=sys.stderr,
+            )
+            continue
+        reports.append(data)
     return reports
 
 
@@ -78,16 +142,6 @@ def _dependency_table(findings: list[dict]) -> list[str]:
     return lines
 
 
-def _code_table(findings: list[dict]) -> list[str]:
-    lines = ["| Severity | Rule | Location | Seen in |", "|---|---|---|---|"]
-    for f in sorted(findings, key=lambda x: (x.get("severity", ""), x.get("id", ""))):
-        where = ", ".join(sorted(set(f.get("sources") or [])))
-        lines.append(
-            f"| {f.get('severity', '?')} | `{f.get('id', '?')}` "
-            f"| `{f.get('package', '?')}` | {where} |"
-        )
-    return lines
-
 
 def merge(reports: list[dict]) -> dict[str, dict[str, list[dict]]]:
     """release -> kind -> findings, deduplicated, recording where each was seen."""
@@ -112,32 +166,18 @@ def render(reports: list[dict], scanned: list[str]) -> tuple[str, str, bool]:
     body = [
         f"<!-- {MARKER}:{fp} -->",
         "",
-        "Automated re-scan of the releases we still support. Raised by "
-        "`.github/workflows/release-rescan.yml`; the policy it enforces is "
-        "[docs/cve-policy.md](../blob/main/docs/cve-policy.md).",
+        _INTRO,
         "",
-        "**Why this can appear on a release that was clean when it shipped:** the "
-        "release gate uses `ignore-unfixed`, so a vulnerability only becomes "
-        "actionable once upstream publishes a fix. Everything below has a fix "
-        "available *now* that did not exist, or was not yet taken, when the "
-        "release was cut.",
+        _WHY,
         "",
-        "**This report covers dependency findings only.** Code findings from the "
-        "source scan go to code scanning, which is visible to write-access users "
-        "rather than the world — a static-analysis hit in Terrapod's own source is "
-        "a potential undisclosed vulnerability, and this issue is public.",
+        _SCOPE,
         "",
         f"Scanned: {', '.join(scanned) if scanned else '(none)'}",
         "",
     ]
 
     if not total:
-        body += [
-            "## No findings",
-            "",
-            "Every supported release is clean against current advisory data and "
-            "current rules, with the accepted-risk register applied.",
-        ]
+        body += ["## No findings", "", _CLEAN]
         return "\n".join(body), fp, False
 
     for release in sorted(merged, reverse=True):
@@ -148,29 +188,10 @@ def render(reports: list[dict], scanned: list[str]) -> tuple[str, str, bool]:
             body += ["**Dependencies and packages**", ""]
             body += _dependency_table(kinds["dependency"])
             body += [""]
-        if kinds.get("code"):
-            body += ["**Code**", ""]
-            body += _code_table(kinds["code"])
-            body += [""]
 
-    body += [
-        "## What to do with this",
-        "",
-        "Each release above needs a judgement call, not an automatic patch. Worth "
-        "checking in this order:",
-        "",
-        "1. **Is it already fixed on `main`?** If so the fix needs backporting to "
-        "that release line, which is what the patch release carries.",
-        "2. **Is it reachable in the way Terrapod uses the component?** If not, it "
-        "belongs in the accepted-risk register with its reasoning and exit "
-        "condition — not silently ignored, and not patched for appearance.",
-        "3. **Does it warrant a patch release on its own**, or can it wait for the "
-        "next scheduled one? Cadence is roughly weekly; an unreachable medium-"
-        "impact finding can reasonably wait, a reachable critical one cannot.",
-        "",
-        "This issue is refreshed in place while the finding set is unchanged, so "
-        "it will not re-notify on every run.",
-    ]
+    body += ["## What to do with this", "", _TRIAGE_HEAD, ""]
+    body += _TRIAGE
+    body += ["", _FOOTER]
     return "\n".join(body), fp, True
 
 


### PR DESCRIPTION
Part of #1212.

## The flaw

The re-scan raises a public issue containing everything it found. That is right for one class of finding and wrong for the other, and I built it without separating them.

| | Already public? | Right home |
|---|---|---|
| **Dependency findings** | Yes — published advisories against public dependency versions, reproducible by anyone running `trivy image ghcr.io/…/terrapod-api:vX.Y.Z` | Public issue |
| **Code findings** (Semgrep, and CodeQL later) | **No** — a hit in Terrapod's *own* source is a potential undisclosed vulnerability | Code scanning (private) |

`SECURITY.md` asks people not to open a public issue for a security vulnerability. This workflow would have done exactly that — automatically, on a schedule, for a release people are running, before any fix existed.

**Nothing leaked.** The first run found no ERROR-severity Semgrep results, so no `Code` section rendered. That was luck, not design.

## The part I nearly missed

Moving code findings out of the issue body is not sufficient on its own. **On a public repository, Actions artifacts and job logs are world-readable**, so `finding-semgrep.json` was leaking by a second route regardless of what the issue said.

So Semgrep now emits SARIF, uploads to code scanning, and is **never written to an artifact**.

This also settles the CodeQL question deferred when the workflow landed — same route, same reason.

## Process

`AGENTS.md` gains, under *Patching an older release line*:

- **A security-driven patch is still a release.** Being prompted by a scanner earns no shortcut; it goes through the same pre-release process including the independent third-party review. A patch cut in a hurry against a supported line people are already running is the one you least want to skip checks on.
- **Say what it fixes** — release notes name the advisories cleared, so an operator can reconcile against their own scan output. That is the whole reason they are running a scanner.
- **Where findings are published**, and why the split is what it is.

`docs/cve-policy.md` gains the operator-facing version, and its "never rescanned" section is corrected — that is no longer true, and it is a better answer now.