### PR TITLE
feat: record re-scan findings in draft advisories, not a public issue

### DIFF
--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -173,6 +173,13 @@ jobs:
         with:
           path: current
 
+      # The tag's OWN commit. Passing github.sha (main's HEAD) with a tag ref
+      # is a mismatched pair: GitHub accepts the upload, reports success, and
+      # discards the analysis. Nothing ever reached code scanning.
+      - name: Resolve the tag's commit
+        id: tagsha
+        run: echo "sha=$(git -C release rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
@@ -253,7 +260,7 @@ jobs:
           sarif_file: semgrep.sarif
           category: release-rescan-${{ matrix.tag }}
           ref: refs/tags/${{ matrix.tag }}
-          sha: ${{ github.sha }}
+          sha: ${{ steps.tagsha.outputs.sha }}
 
       - name: Normalise
         run: |
@@ -294,11 +301,19 @@ jobs:
           path: findings
           pattern: rescan-*
 
-      - name: Build the report
+      # Findings go into a DRAFT advisory per release — private to
+      # maintainers. Never published: publishing is irreversible and would make
+      # an unfixed vulnerability public, so it stays a human act at patch time.
+      - name: Record findings in draft advisories
+        env:
+          ADVISORY_TOKEN: ${{ secrets.SECURITY_ADVISORY_AUTH }}
+        run: python3 scripts/rescan_advisory.py findings advisory-urls.json
+
+      - name: Build the public notification
         id: build
         run: |
-          python3 scripts/rescan_report.py findings body.md \
-            ${{ needs.discover.outputs.list }} >> "$GITHUB_OUTPUT"
+          python3 scripts/rescan_report.py findings body.md advisory-urls.json \
+            >> "$GITHUB_OUTPUT"
 
       - name: Open or refresh the tracking issue
         env:
@@ -322,14 +337,17 @@ jobs:
 
           if [ -n "$existing" ]; then
             number=$(echo "$existing" | jq -r '.number')
-            if echo "$existing" | jq -r '.body' | grep -q "terrapod-release-rescan:$FINGERPRINT"; then
-              echo "Issue #$number already reports this exact finding set — not re-notifying."
-              exit 0
-            fi
+            # Always refresh the body; only COMMENT when the set changed. These
+            # are two decisions, and gating both on the fingerprint once left
+            # the issue showing stale content after the tooling improved.
             gh issue edit "$number" --body-file body.md
-            gh issue comment "$number" --body \
-              "The finding set changed on the latest re-scan — body updated above."
-            echo "Refreshed issue #$number"
+            if echo "$existing" | jq -r '.body' | grep -q "terrapod-release-rescan:$FINGERPRINT"; then
+              echo "Issue #$number refreshed; finding set unchanged, not re-notifying."
+            else
+              gh issue comment "$number" --body \
+                "The finding set changed on the latest re-scan. Details are in the draft advisories."
+              echo "Refreshed issue #$number and notified"
+            fi
           else
             gh issue create --title "$TITLE" --body-file body.md --label security 2>/dev/null \
               || gh issue create --title "$TITLE" --body-file body.md

--- a/scripts/rescan_advisory.py
+++ b/scripts/rescan_advisory.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Keep a draft security advisory per supported release in step (#1212).
+
+The re-scan finds vulnerabilities in releases people are running. Those details
+do not belong in a public issue before a fix exists, and code scanning is
+branch-shaped so it cannot hold per-tag findings. A **draft** repository
+security advisory can: private to maintainers, arbitrary markdown, and already
+the place GitHub expects work-in-progress disclosure to live.
+
+    rescan_advisory.py <findings-dir> <urls-out.json>
+
+**It only ever creates and updates drafts. It never publishes.** Publishing is
+irreversible and makes an unfixed vulnerability public, so it stays a deliberate
+human act at patch-release time. A scheduled job holding a token that can
+publish must not be one keystroke from doing it by accident.
+
+Requires a token with `Repository security advisories: write` —
+`GITHUB_TOKEN` cannot do this (verified: 403 on both valid and invalid
+payloads). Failures are loud: a security channel that degrades quietly is
+worse than one that is obviously broken.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+MARKER = "terrapod-release-rescan-advisory"
+
+
+def _request(method: str, url: str, token: str, body: dict | None = None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if data:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, json.loads(resp.read() or b"null")
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        raise SystemExit(
+            f"{method} {url} failed: HTTP {e.code}\n{detail}\n\n"
+            "If this is 403, the token lacks 'Repository security advisories: "
+            "write'. GITHUB_TOKEN cannot create advisories."
+        ) from e
+
+
+def load(directory: pathlib.Path) -> dict[str, list[dict]]:
+    """release -> deduplicated findings."""
+    out: dict[str, dict[str, dict]] = {}
+    for path in sorted(directory.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not (isinstance(data, dict) and "release" in data and "findings" in data):
+            continue
+        bucket = out.setdefault(data["release"], {})
+        for f in data.get("findings") or []:
+            bucket.setdefault(f"{f.get('id')}|{f.get('package')}", f)
+    return {r: list(v.values()) for r, v in out.items()}
+
+
+def describe(release: str, findings: list[dict], code_count: int) -> str:
+    lines = [
+        f"<!-- {MARKER}:{release} -->",
+        "",
+        f"Findings in **{release}**, raised automatically by the release "
+        "re-scan (`.github/workflows/release-rescan.yml`).",
+        "",
+        "This is a **draft** — private to maintainers, and not published. It "
+        "becomes the public record when the patch release that fixes it ships.",
+        "",
+        "Everything below has a fix available upstream *now* that did not "
+        "exist, or was not taken, when this release was cut.",
+        "",
+        "| Severity | Package | Installed | Fixed in | Advisory |",
+        "|---|---|---|---|---|",
+    ]
+    for f in sorted(findings, key=lambda x: (x.get("severity", ""), x.get("id", ""))):
+        lines.append(
+            f"| {f.get('severity', '?')} | `{f.get('package', '?')}` "
+            f"| {f.get('installed', '?')} | **{f.get('fixed', '?')}** "
+            f"| {f.get('id', '?')} |"
+        )
+    if code_count:
+        lines += [
+            "",
+            f"Plus **{code_count} code finding(s)** from static analysis of the "
+            "source at this tag — see code scanning.",
+        ]
+    return "\n".join(lines)
+
+
+def vulnerabilities(findings: list[dict]) -> list[dict]:
+    """The API's required `vulnerabilities` array, one entry per package."""
+    seen: dict[str, dict] = {}
+    for f in findings:
+        name = f.get("package", "?")
+        if name in seen:
+            continue
+        seen[name] = {
+            "package": {"ecosystem": f.get("ecosystem", "other"), "name": name},
+            "vulnerable_version_range": str(f.get("installed", "")) or None,
+            "patched_versions": str(f.get("fixed", "")) or None,
+        }
+    return list(seen.values())
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    directory, urls_out = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+
+    by_release = load(directory)
+    code_counts: dict[str, int] = {}
+    for path in directory.rglob("*.json"):
+        try:
+            d = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(d, dict) and "code_findings" in d:
+            code_counts[d["release"]] = code_counts.get(d["release"], 0) + int(d["code_findings"])
+
+    if not any(by_release.values()) and not any(code_counts.values()):
+        print("nothing to record")
+        urls_out.write_text("{}")
+        return 0
+
+    # Token demanded only once there is something to write. A clean scan must
+    # not fail for want of a credential it never needed.
+    token = os.environ.get("ADVISORY_TOKEN", "").strip()
+    if not token:
+        raise SystemExit(
+            "ADVISORY_TOKEN is empty but there are findings to record. Failing "
+            "rather than silently dropping them — a security channel that "
+            "degrades quietly is worse than one that is obviously broken."
+        )
+    repo = os.environ["GITHUB_REPOSITORY"]
+
+    _, existing = _request("GET", f"{API}/repos/{repo}/security-advisories?per_page=100", token)
+    drafts = {
+        a["summary"]: a
+        for a in (existing or [])
+        if a.get("state") == "draft" and a.get("summary")
+    }
+
+    urls: dict[str, str] = {}
+    for release in sorted(set(by_release) | set(code_counts), reverse=True):
+        findings = by_release.get(release, [])
+        code = code_counts.get(release, 0)
+        if not findings and not code:
+            continue
+        summary = f"Findings in {release}"
+        payload = {
+            "summary": summary,
+            "description": describe(release, findings, code),
+            # A package entry is required even when only code findings exist,
+            # so name the release itself rather than inventing a package.
+            "vulnerabilities": vulnerabilities(findings) or [
+                {"package": {"ecosystem": "other", "name": f"terrapod {release}"}}
+            ],
+            "severity": "high",
+        }
+        if summary in drafts:
+            ghsa = drafts[summary]["ghsa_id"]
+            _, adv = _request(
+                "PATCH", f"{API}/repos/{repo}/security-advisories/{ghsa}", token, payload
+            )
+            print(f"{release}: refreshed draft {ghsa}")
+        else:
+            _, adv = _request(
+                "POST", f"{API}/repos/{repo}/security-advisories", token, payload
+            )
+            print(f"{release}: created draft {adv.get('ghsa_id')}")
+        urls[release] = adv.get("html_url", "")
+
+    urls_out.write_text(json.dumps(urls, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rescan_normalise.py
+++ b/scripts/rescan_normalise.py
@@ -36,9 +36,24 @@ def _read(path: pathlib.Path):
         return None
 
 
+# GitHub advisories accept a fixed set of ecosystems; anything we cannot map
+# confidently is "other", which is accurate rather than a guess.
+_TRIVY_ECOSYSTEM = {
+    "gobinary": "go",
+    "gomod": "go",
+    "node-pkg": "npm",
+    "npm": "npm",
+    "yarn": "npm",
+    "python-pkg": "pip",
+    "pip": "pip",
+    "poetry": "pip",
+}
+
+
 def from_trivy(data) -> list[dict]:
     out = []
     for result in (data or {}).get("Results") or []:
+        ecosystem = _TRIVY_ECOSYSTEM.get(result.get("Type", ""), "other")
         for v in result.get("Vulnerabilities") or []:
             out.append({
                 "id": v.get("VulnerabilityID", "?"),
@@ -46,6 +61,7 @@ def from_trivy(data) -> list[dict]:
                 "installed": v.get("InstalledVersion", "?"),
                 "fixed": v.get("FixedVersion", "?"),
                 "severity": v.get("Severity", "?"),
+                "ecosystem": ecosystem,
             })
     return out
 
@@ -65,6 +81,7 @@ def from_pip_audit(data) -> list[dict]:
                 "installed": dep.get("version", "?"),
                 "fixed": ", ".join(fixes),
                 "severity": "HIGH",   # pip-audit does not grade; the gate treats all as actionable
+                "ecosystem": "pip",
             })
     return out
 
@@ -110,6 +127,7 @@ def from_npm_audit(data, allowlist: set[str]) -> list[dict]:
                 "installed": (v.get("range") or "?"),
                 "fixed": fixed,
                 "severity": v.get("severity", "?").upper(),
+                "ecosystem": "npm",
             })
     return out
 
@@ -145,8 +163,17 @@ def count_semgrep_sarif(data) -> int:
     """
     total = 0
     for run in (data or {}).get("runs") or []:
+        # Build ruleId -> level from the driver, because Semgrep puts severity
+        # on the rule definition and usually omits it on the result. Reading
+        # result["level"] alone counted 0 while Semgrep reported 8.
+        levels = {}
+        for rule in ((run.get("tool") or {}).get("driver") or {}).get("rules") or []:
+            lvl = ((rule.get("defaultConfiguration") or {}).get("level") or "").lower()
+            if rule.get("id"):
+                levels[rule["id"]] = lvl
         for r in run.get("results") or []:
-            if (r.get("level") or "").lower() == "error":
+            level = (r.get("level") or levels.get(r.get("ruleId", ""), "") or "").lower()
+            if level == "error":
                 total += 1
     return total
 

--- a/scripts/rescan_report.py
+++ b/scripts/rescan_report.py
@@ -1,27 +1,22 @@
 #!/usr/bin/env python3
-"""Aggregate release re-scan findings into an issue body (#1212).
+"""Build the public notification for the release re-scan (#1212).
 
-Every scanner in the re-scan workflow normalises its output to one JSON file
-per (release, source) with a common shape, and this collapses the lot into a
-single report:
+This issue is **public**, so it deliberately carries no detail: no advisory
+ids, no package versions, not even which releases are affected. Naming a
+supported release alongside what is wrong with it is a map for anyone deciding
+where to look, and the people who need the detail are maintainers — who can
+read it in the draft advisory.
 
-    {"release": "v1.1.1",
-     "source": "image:terrapod-api (amd64)",
-     "kind": "dependency" | "code",
-     "findings": [{...}]}
+    draft security advisory   the findings, per release   private
+    code scanning             static-analysis findings    private
+    this issue                "there is something to do"  public
 
-Two things here matter more than the formatting.
+What it does carry is a fingerprint of the finding set, so an unchanged set
+does not re-notify. The body is refreshed every run regardless: those are two
+different decisions, and conflating them once left the issue displaying stale
+information after the tooling had already improved.
 
-**The fingerprint.** A scheduled job that re-notifies on an unchanged finding
-set gets muted within a week, and then the one time it matters nobody looks. So
-the body carries a fingerprint of the finding *set* (not the run, not the
-timestamp), and the workflow only touches the issue when that changes. Re-runs
-that find the same things are silent by construction rather than by someone
-remembering to check.
-
-**Grouping by release.** The follow-up action is a patch release, and a patch
-release is per-release — so that is the axis the report is organised on, even
-though scanning is organised by image and architecture.
+    rescan_report.py <findings-dir> <out.md> [advisory-urls.json]
 """
 
 from __future__ import annotations
@@ -33,68 +28,36 @@ import pathlib
 import sys
 
 MARKER = "terrapod-release-rescan"
-
-# Issue bodies do not resolve relative links the way a file in the repo does,
-# so every link here is absolute, built from the repository the run belongs to.
 _REPO = os.environ.get("GITHUB_REPOSITORY", "mattrobinsonsre/terrapod")
 _REPO_URL = f"https://github.com/{_REPO}"
 
-# Report copy lives here rather than inline in the list literals below.
-# Implicit concatenation inside a list is how a missing comma silently merges
-# two entries into one and looks exactly like deliberate line-wrapping, so the
-# prose is assembled in parentheses where there is no comma to lose.
-_INTRO = (
-    "Automated re-scan of the releases we still support. Raised by "
-    "`.github/workflows/release-rescan.yml`; the policy it enforces is "
-    f"[docs/cve-policy.md]({_REPO_URL}/blob/main/docs/cve-policy.md)."
-)
-_WHY = (
-    "**Why this can appear on a release that was clean when it shipped:** the "
-    "release gate uses `ignore-unfixed`, so a vulnerability only becomes "
-    "actionable once upstream publishes a fix. Everything below has a fix "
-    "available *now* that did not exist, or was not yet taken, when the "
-    "release was cut."
-)
-_SCOPE = (
-    "**This report covers dependency findings only.** Code findings from the "
-    "source scan go to code scanning, which is visible to write-access users "
-    "rather than the world — a static-analysis hit in Terrapod's own source is "
-    "a potential undisclosed vulnerability, and this issue is public."
-)
-_CLEAN = (
-    "Every supported release is clean against current advisory data and "
-    "current rules, with the accepted-risk register applied."
-)
-_TRIAGE_HEAD = (
-    "Each release above needs a judgement call, not an automatic patch. Worth "
-    "checking in this order:"
-)
-_TRIAGE_FIXED = (
-    "1. **Is it already fixed on `main`?** If so the fix needs backporting "
-    "to that release line, which is what the patch release carries."
-)
-_TRIAGE_REACHABLE = (
-    "2. **Is it reachable in the way Terrapod uses the component?** If not, "
-    "it belongs in the accepted-risk register with its reasoning and exit "
-    "condition — not silently ignored, and not patched for appearance."
-)
-_TRIAGE_URGENCY = (
-    "3. **Does it warrant a patch release on its own**, or can it wait for "
-    "the next scheduled one? Cadence is roughly weekly; an unreachable "
-    "medium-impact finding can reasonably wait, a reachable critical one "
-    "cannot."
-)
-_TRIAGE = [_TRIAGE_FIXED, _TRIAGE_REACHABLE, _TRIAGE_URGENCY]
-_FOOTER = (
-    "This issue is refreshed in place while the finding set is unchanged, so "
-    "it will not re-notify on every run."
-)
 
-
-def load_code_counts(directory: pathlib.Path) -> dict[str, int]:
-    """release -> number of code findings, from the count-only files."""
-    counts: dict[str, int] = {}
+def load(directory: pathlib.Path) -> list[dict]:
+    """Dependency findings only. Code findings are refused, not skipped."""
+    reports = []
     for path in sorted(directory.rglob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"skipping unreadable {path}: {exc}", file=sys.stderr)
+            continue
+        # Must carry findings: the count-only files also have a "release", and
+        # accepting one registers the release as present-but-empty.
+        if not (isinstance(data, dict) and "release" in data and "findings" in data):
+            continue
+        if data.get("kind") == "code":
+            print(
+                f"REFUSING code-kind findings from {path}: this issue is public",
+                file=sys.stderr,
+            )
+            continue
+        reports.append(data)
+    return reports
+
+
+def code_counts(directory: pathlib.Path) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for path in directory.rglob("*.json"):
         try:
             data = json.loads(path.read_text())
         except (json.JSONDecodeError, OSError):
@@ -104,156 +67,104 @@ def load_code_counts(directory: pathlib.Path) -> dict[str, int]:
     return counts
 
 
-def load(directory: pathlib.Path) -> list[dict]:
-    reports = []
-    for path in sorted(directory.rglob("*.json")):
-        try:
-            data = json.loads(path.read_text())
-        except (json.JSONDecodeError, OSError) as exc:
-            print(f"skipping unreadable {path}: {exc}", file=sys.stderr)
-            continue
-        # Must carry findings. The count-only files also have a "release", and
-        # accepting one here registers the release as present-but-empty, which
-        # is enough to hide a code-only release from the branch that reports it.
-        if not (isinstance(data, dict) and "release" in data and "findings" in data):
-            continue
-        if data.get("kind") == "code":
-            # The workflow sends code findings to code scanning and never here,
-            # but this report is published as a PUBLIC issue — so refuse them at
-            # the door rather than relying on the caller to have got it right.
-            # Silently dropping would be worse: it would look like the scan
-            # found nothing.
-            print(
-                f"REFUSING code-kind findings from {path}: this report is public, "
-                "and code findings belong in code scanning",
-                file=sys.stderr,
-            )
-            continue
-        reports.append(data)
-    return reports
+def fingerprint(reports: list[dict], counts: dict[str, int]) -> str:
+    """Identity of the finding set — computed, never displayed.
 
-
-def fingerprint(reports: list[dict]) -> str:
-    """Identity of the finding *set*, stable across runs and orderings.
-
-    Deliberately excludes the source: the same CVE found in five images of one
-    release is one problem to fix, and letting the image list move the
-    fingerprint would re-notify on noise (an image list changing between
-    releases, a scan legitimately skipped).
+    Excludes which image or architecture saw a finding: the same advisory
+    across five images is one thing to fix, and letting the image list move the
+    fingerprint would re-notify on noise.
     """
-    keys = set()
-    for report in reports:
-        for finding in report.get("findings") or []:
-            keys.add(f"{report['release']}|{finding.get('id', '')}")
-    digest = hashlib.sha256("\n".join(sorted(keys)).encode()).hexdigest()[:16]
-    return digest
+    keys = {
+        f"{r['release']}|{f.get('id', '')}"
+        for r in reports
+        for f in (r.get("findings") or [])
+    }
+    keys |= {f"{rel}|code:{n}" for rel, n in counts.items() if n}
+    return hashlib.sha256("\n".join(sorted(keys)).encode()).hexdigest()[:16]
 
 
-def _code_pointer(release: str, count: int) -> str:
-    """Say that code findings exist and where, without saying what they are."""
-    return (
-        f"> **{count} code finding(s)** from the source scan of `{release}`, "
-        "not listed here. Details are in "
-        f"[code scanning]({_REPO_URL}/security/code-scanning?query=is%3Aopen) "
-        "under the "
-        f"`release-rescan-{release}` category — this issue is public, and a "
-        "static-analysis hit in Terrapod's own source is a potential "
-        "undisclosed vulnerability."
-    )
-
-
-def _dependency_table(findings: list[dict]) -> list[str]:
-    lines = [
-        "| Severity | Package | Installed | Fixed in | Advisory | Seen in |",
-        "|---|---|---|---|---|---|",
-    ]
-    for f in sorted(findings, key=lambda x: (x.get("severity", ""), x.get("id", ""))):
-        where = ", ".join(sorted(set(f.get("sources") or [])))
-        lines.append(
-            f"| {f.get('severity', '?')} | `{f.get('package', '?')}` "
-            f"| {f.get('installed', '?')} | **{f.get('fixed', '?')}** "
-            f"| {f.get('id', '?')} | {where} |"
-        )
-    return lines
-
-
-
-def merge(reports: list[dict]) -> dict[str, dict[str, list[dict]]]:
-    """release -> kind -> findings, deduplicated, recording where each was seen."""
-    out: dict[str, dict[str, dict[str, dict]]] = {}
-    for report in reports:
-        release = report["release"]
-        kind = report.get("kind", "dependency")
-        source = report.get("source", "?")
-        bucket = out.setdefault(release, {}).setdefault(kind, {})
-        for finding in report.get("findings") or []:
-            key = f"{finding.get('id')}|{finding.get('package')}"
-            entry = bucket.setdefault(key, {**finding, "sources": []})
-            entry["sources"].append(source)
-    return {r: {k: list(v.values()) for k, v in kinds.items()} for r, kinds in out.items()}
-
-
-def render(
-    reports: list[dict], scanned: list[str], code_counts: dict[str, int] | None = None
-) -> tuple[str, str, bool]:
-    code_counts = code_counts or {}
-    merged = merge(reports)
-    fp = fingerprint(reports)
-    total = sum(len(f) for kinds in merged.values() for f in kinds.values())
-
-    body = [
-        f"<!-- {MARKER}:{fp} -->",
-        "",
-        _INTRO,
-        "",
-        _WHY,
-        "",
-        _SCOPE,
-        "",
-        f"Scanned: {', '.join(scanned) if scanned else '(none)'}",
-        "",
-    ]
-
-    # Releases with no dependency findings but some code findings still need
-    # saying, or the issue reads as "clean" when it is not.
-    for release in sorted(set(code_counts) - set(merged), reverse=True):
-        if code_counts[release]:
-            body += [f"## {release} — code findings only", "",
-                     _code_pointer(release, code_counts[release]), ""]
-            total += code_counts[release]
-
-    if not total:
-        body += ["## No findings", "", _CLEAN]
-        return "\n".join(body), fp, False
-
-    for release in sorted(merged, reverse=True):
-        kinds = merged[release]
-        count = sum(len(v) for v in kinds.values())
-        body += [f"## {release} — {count} finding(s)", ""]
-        if code_counts.get(release):
-            body += [_code_pointer(release, code_counts[release]), ""]
-        if kinds.get("dependency"):
-            body += ["**Dependencies and packages**", ""]
-            body += _dependency_table(kinds["dependency"])
-            body += [""]
-
-    body += ["## What to do with this", "", _TRIAGE_HEAD, ""]
-    body += _TRIAGE
-    body += ["", _FOOTER]
-    return "\n".join(body), fp, True
+_LEDE = (
+    "The scheduled re-scan of supported releases has findings that need "
+    "attention."
+)
+_WHY_EMPTY = (
+    "**Deliberately no detail here.** This issue is public, and naming a "
+    "supported release together with what is wrong with it tells anyone "
+    "reading exactly where to look. The findings are recorded privately "
+    "instead:"
+)
+_ADVISORIES = (
+    f"- **[Security advisories]({_REPO_URL}/security/advisories)** — a draft "
+    "per affected release: package, installed version, fixed version, advisory "
+    "id. Drafts are visible to maintainers only."
+)
+_CODESCAN = (
+    f"- **[Code scanning]({_REPO_URL}/security/code-scanning)** — static "
+    "analysis findings in Terrapod's own source at that tag."
+)
+_PUBLISH = (
+    "Drafts are published when the patch release that fixes them ships — that "
+    "is what turns them into the operator-facing record."
+)
+_REFS = (
+    f"Policy: [docs/cve-policy.md]({_REPO_URL}/blob/main/docs/cve-policy.md). "
+    "Procedure: *Patching an older release line* in "
+    f"[AGENTS.md]({_REPO_URL}/blob/main/AGENTS.md)."
+)
+_FOOTER = (
+    "Refreshed in place; only notifies when the finding set actually changes."
+)
 
 
 def main() -> int:
     if len(sys.argv) < 3:
-        print("usage: rescan_report.py <findings-dir> <out.md> [tag ...]", file=sys.stderr)
+        print(__doc__, file=sys.stderr)
         return 2
     directory, out = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
-    scanned = sys.argv[3:]
+
     reports = load(directory)
-    body, fp, has_findings = render(reports, scanned, load_code_counts(directory))
-    out.write_text(body)
+    counts = code_counts(directory)
+    total = sum(len(r.get("findings") or []) for r in reports) + sum(counts.values())
+    fp = fingerprint(reports, counts)
+
+    if not total:
+        out.write_text(f"<!-- {MARKER}:{fp} -->\n\nNo findings.\n")
+        print(f"fingerprint={fp}")
+        print("has_findings=false")
+        return 0
+
+    body = [
+        f"<!-- {MARKER}:{fp} -->",
+        "",
+        _LEDE,
+        "",
+        _WHY_EMPTY,
+        "",
+        _ADVISORIES,
+        _CODESCAN,
+        "",
+        _PUBLISH,
+        "",
+        _REFS,
+        "",
+        _FOOTER,
+    ]
+
+    # Advisory URLs are safe to include: a draft is unreadable without
+    # repository access, so the link discloses nothing on its own.
+    if len(sys.argv) > 3 and pathlib.Path(sys.argv[3]).exists():
+        try:
+            urls = json.loads(pathlib.Path(sys.argv[3]).read_text())
+        except (json.JSONDecodeError, OSError):
+            urls = {}
+        live = [u for u in urls.values() if u]
+        if live:
+            body += ["", "Drafts raised or refreshed this run:"]
+            body += [f"- {u}" for u in live]
+
+    out.write_text("\n".join(body) + "\n")
     print(f"fingerprint={fp}")
-    print(f"has_findings={'true' if has_findings else 'false'}")
+    print("has_findings=true")
     return 0
 
 


### PR DESCRIPTION
Part of #1212. Follows closing #1214 as too public.

## The channel

Findings now go into a **draft repository security advisory per supported release** — private to maintainers, carrying package / installed / fixed-in / advisory id, plus the code-finding count.

The public issue keeps **only a pointer**: no advisory ids, no versions, **not even which releases are affected**. Naming a supported release alongside what's wrong with it is a map for whoever's deciding where to look.

**CI never publishes.** Publishing is irreversible and would make an unfixed vulnerability public, so it stays a human act at patch-release time. A scheduled job holding a token that *can* publish must not be one keystroke from doing it by accident.

Verified beforehand rather than assumed — `GITHUB_TOKEN` returns 403 on advisory creation even with `security-events: write`, on both invalid *and* valid payloads; the PAT returns 422 (past auth). That 422 also handed us the real schema: `summary`, `description`, `vulnerabilities` — not `severity`, which is what I'd guessed.

## Three bugs, all found by running it

| Bug | Effect |
|---|---|
| **`ref`/`sha` mismatch** — passed `github.sha` (main's HEAD) with a tag ref | GitHub accepts the pair, reports the step **successful**, and discards the analysis. Nothing had *ever* reached code scanning. |
| **Semgrep counter read `result["level"]`** — Semgrep puts severity on the **rule**, usually omitting it on the result | Reported **0** code findings for v1.1.1 while Semgrep's own summary said **8**. It declared a clean source scan that wasn't — the worst of the three. |
| **Fingerprint gated the body edit**, not just the comment | After the fix-version rendering improved, the live issue kept showing `see advisory` on 15 rows. Body now refreshes every run; the comment still only fires when the set changes. |

## Failure behaviour

The token is demanded **only once there is something to record**, so a clean scan doesn't fail for want of a credential it never needed. Findings *with* no token fail loudly — exit 1, explicit message — because a security channel that degrades quietly is worse than one obviously broken.

## Verification

- Clean scan → no token required, no advisory, `{}` written
- Findings + no token → **exit 1** with a clear message
- Public body → **zero** CVE ids, versions or release names (grepped)
- Semgrep counter → returns 3 against a fixture with rule-level severity, result-level severity, and a warning that must not count