### PR TITLE
fix: give the source job permission to upload SARIF

### DIFF
--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -156,6 +156,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to upload SARIF. Its absence is why code findings never
+      # reached code scanning: the step "succeeded" and warned in its log,
+      # because continue-on-error swallowed the failure.
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -253,6 +257,7 @@ jobs:
       # uploaded as a workflow artifact: on a public repository, artifacts and
       # job logs are world-readable.
       - name: Upload code findings to code scanning (private)
+        id: sarif
         if: always()
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
@@ -275,7 +280,19 @@ jobs:
           python3 current/scripts/rescan_normalise.py semgrep-count semgrep.sarif \
             "${{ matrix.tag }}" "source:semgrep" "codecount.json"
 
+      # A silent upload failure is how this went unnoticed for three runs.
+      # continue-on-error stays — one broken scanner must not sink the run —
+      # but the outcome is now stated rather than buried in a warning.
+      - name: Fail visibly if code findings could not be recorded
+        if: always() && steps.sarif.outcome == 'failure'
+        run: |
+          echo "::error::SARIF upload FAILED for ${{ matrix.tag }}. Code findings" \
+               "were found but are NOT in code scanning. The advisory and issue" \
+               "will point at a page that does not have them."
+          exit 1
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
         with:
           name: rescan-${{ matrix.tag }}-source
           # finding-pip / finding-npm only. Never semgrep.sarif — see above.


### PR DESCRIPTION
Part of #1212.

## A second cause, hidden the same way as the first

Code findings *still* weren't reaching code scanning after the `ref`/`sha` fix. The remaining cause: the `source` job declares its own `permissions:` and had only `contents: read`. Uploading SARIF needs `security-events: write` — which I'd put on the throwaway probe workflow and never on this one.

```
##[warning] This run of the CodeQL Action does not have permission to access
the CodeQL Action API endpoints … ensure the workflow has at least the
'security-events: read' permission. Resource not accessible by integration
```

**The reason it took three runs to spot is the more useful lesson.** `continue-on-error: true` made the step report **success** while the action wrote its refusal into the log as a *warning*. That's the same masking that hid the `ref`/`sha` mismatch — two distinct bugs, invisible for the same reason.

## What changed

`continue-on-error` **stays** — one broken scanner mustn't sink a run that's otherwise producing findings. But the outcome is now asserted rather than buried: a failed upload emits `::error::` and fails the job, saying plainly that the advisory and issue are about to point at a code scanning page **that doesn't contain the findings**. A link to nothing is worse than no link.

The artifact upload gains `if: always()`, so a SARIF failure doesn't also cost us the dependency findings that did succeed.

## Confirmed fixed in the same run

| | Before | Now |
|---|---|---|
| Semgrep count, v1.1.1 | **0** (read `result.level`) | **6** |
| Upload `sha` | `8264d79…` (main HEAD) | `8675262…` (the tag's commit) |