### PR TITLE
feat(1208): fetch opa, trivy and checkov instead of shipping them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -952,7 +952,14 @@ jobs:
           echo "$out" | grep -q "component: postgresql" || { echo "FAIL: values-eval did not render embedded Postgres"; exit 1; }
           echo "$out" | grep -q "component: redis" || { echo "FAIL: values-eval did not render embedded Redis"; exit 1; }
           echo "$out" | grep -q "kind: PersistentVolumeClaim" || { echo "FAIL: embedded Postgres PVC missing"; exit 1; }
-          echo "values-eval renders embedded datastores OK"
+          # Platform tools (#1208): the eval profile must still pin opa/trivy/checkov,
+          # or a one-command eval silently loses policy evaluation and security
+          # scanning the moment someone tries them. The eval stack fetches them on
+          # first use — the same egress it already needs for the provider and
+          # binary caches — so what has to hold here is that it knows WHAT to fetch.
+          echo "$out" | grep -q "opa_version:" || { echo "FAIL: values-eval renders no opa_version — eval would lose policy evaluation (#1208)"; exit 1; }
+          echo "$out" | grep -q "checkov_version:" || { echo "FAIL: values-eval renders no checkov_version — eval would lose security scanning (#1208)"; exit 1; }
+          echo "values-eval renders embedded datastores + platform-tool versions OK"
       - name: Forward proxy + custom CA bundle render (#592)
         run: |
           out=$(docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -74,21 +74,13 @@ RUN echo "pkg-refresh=${PKG_REFRESH}" \
     libxmlsec1-openssl \
     && rm -rf /var/lib/apt/lists/*
 
-# OPA (Open Policy Agent) — the policy-as-code evaluation engine (#343).
-# Pinned, statically-linked binary, verified against its published SHA256.
-# Bumped deliberately with Terrapod releases (the operator controls the
-# OPA version via the image tag — see docs/policies.md). TARGETARCH is set
-# by buildx; fall back to dpkg for a plain `docker build`.
-ARG TARGETARCH
-ARG OPA_VERSION=1.19.0
-RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
-    && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
-    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /usr/local/bin/opa "${BASE}/opa_linux_${ARCH}_static" \
-    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/opa.sha256 "${BASE}/opa_linux_${ARCH}_static.sha256" \
-    && echo "$(cut -d' ' -f1 /tmp/opa.sha256)  /usr/local/bin/opa" | sha256sum -c - \
-    && rm /tmp/opa.sha256 \
-    && chmod 0755 /usr/local/bin/opa \
-    && /usr/local/bin/opa version
+# OPA is deliberately NOT baked in (#1208). The API uses it for one thing —
+# `opa check`, the write-time Rego syntax check — and it now fetches it on
+# demand to the ephemeral PVC, so the version is a Helm value
+# (registry.platform_tools.opa_version) instead of something frozen into this
+# image, and OPA's vendored Go modules stop being reported against Terrapod's
+# artifacts. The fetch degrades rather than failing: see
+# terrapod/services/api_opa.py.
 
 # terrapod-query — the tofu-native discovery engine (#823), pre-built for this
 # arch by the build-query CI job (or the local Tilt/Make go build) and staged at

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -9,7 +9,11 @@
 #   - git + openssh-client + ca-certificates — for module sources
 #     resolved by `tofu init` (terraform's `git::ssh://...` /
 #     `git::https://...` schemes shell out to system git)
-#   - opa — for the runner-side OPA policy evaluation (#343)
+#
+# opa, trivy and checkov are NOT here (#1208). They are pulled through the
+# binary cache at run time, and only when a run needs them, so their version
+# is an operator-set Helm value and their vendored modules stop being
+# reported against Terrapod's own artifacts.
 #
 # Other tools the bash era pulled in (curl, jq, tar, unzip, openssl) are
 # no longer installed. The Python phase modules use httpx for HTTP,
@@ -17,62 +21,14 @@
 # TLS stack.
 
 # ── Builder ────────────────────────────────────────────────────────────
-# Two jobs: install the runner Python deps, AND download+verify OPA. OPA
-# lives in the builder so the runtime image stays free of curl; the
-# binary is COPY'd into the runtime stage below.
+# One job now: install the runner Python deps. The tool downloads that used
+# to live here moved to run time (#1208), which is also why curl is gone.
 # Base image, overridable so CI can pull it from our GHCR mirror instead of
 # Docker Hub, whose anonymous pull limit is shared across GitHub runners and
 # turns unrelated PRs red (#1186). The default is the upstream reference, so a
 # local build needs no mirror access and behaves exactly as before.
 ARG BASE_IMAGE=python:3.13-slim
 FROM ${BASE_IMAGE} AS builder
-
-# curl + ca-certificates for the OPA download — present only in the
-# builder image, not the runtime.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-ARG TARGETARCH
-ARG OPA_VERSION=1.19.0
-# GitHub Releases intermittently 5xx; --retry-all-errors covers 5xx as
-# well as transport errors. 6 attempts × 4s base = ~25s ceiling.
-RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
-    && BASE="https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}" \
-    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/opa "${BASE}/opa_linux_${ARCH}_static" \
-    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/opa.sha256 "${BASE}/opa_linux_${ARCH}_static.sha256" \
-    && echo "$(cut -d' ' -f1 /tmp/opa.sha256)  /tmp/opa" | sha256sum -c - \
-    && rm /tmp/opa.sha256 \
-    && chmod 0755 /tmp/opa
-
-# Trivy (Go binary) — IaC config scanner for the security-scan phase (#1036).
-# Downloaded + checksum-verified here; COPY'd into the runtime so it stays free
-# of curl, exactly like OPA.
-ARG TRIVY_VERSION=0.72.0
-RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
-    && case "$ARCH" in \
-        amd64) TARCH="Linux-64bit" ;; \
-        arm64) TARCH="Linux-ARM64" ;; \
-        *) echo "unsupported arch: $ARCH" && exit 1 ;; \
-    esac \
-    && BASE="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}" \
-    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/trivy.tar.gz "${BASE}/trivy_${TRIVY_VERSION}_${TARCH}.tar.gz" \
-    && curl -fsSL --retry 6 --retry-delay 4 --retry-all-errors -o /tmp/trivy.sums "${BASE}/trivy_${TRIVY_VERSION}_checksums.txt" \
-    && EXPECTED="$(grep "trivy_${TRIVY_VERSION}_${TARCH}.tar.gz" /tmp/trivy.sums | cut -d' ' -f1)" \
-    && echo "${EXPECTED}  /tmp/trivy.tar.gz" | sha256sum -c - \
-    && tar -xzf /tmp/trivy.tar.gz -C /tmp trivy \
-    && chmod 0755 /tmp/trivy \
-    && rm /tmp/trivy.tar.gz /tmp/trivy.sums
-
-# Checkov (plan-fed IaC misconfig scanner, #1036) — the default/recommended
-# engine. Installed into an ISOLATED venv so its large, tightly-pinned
-# dependency tree can never collide with the runner's own deps. The scan phase
-# invokes the `checkov` CLI (subprocess), not the library, so a self-contained
-# venv is all it needs. Multi-arch: pip builds for the target arch (checkov's
-# standalone binary is x86_64-only, hence the venv).
-RUN python -m venv /opt/checkov \
-    && /opt/checkov/bin/pip install --no-cache-dir checkov \
-    && /opt/checkov/bin/checkov --version
 
 WORKDIR /build
 COPY services/pyproject-runner.toml pyproject.toml
@@ -98,18 +54,6 @@ RUN echo "pkg-refresh=${PKG_REFRESH}" \
         openssh-client \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-
-# OPA from the builder stage. Verified there; just copy it.
-COPY --from=builder /tmp/opa /usr/local/bin/opa
-RUN /usr/local/bin/opa version
-
-# Security-scan engines (#1036). Trivy is a single verified Go binary; Checkov
-# is the isolated venv from the builder, exposed via a CLI symlink (the venv's
-# absolute /opt/checkov path is preserved so its python shebang resolves).
-COPY --from=builder /tmp/trivy /usr/local/bin/trivy
-RUN /usr/local/bin/trivy --version
-COPY --from=builder /opt/checkov /opt/checkov
-RUN ln -s /opt/checkov/bin/checkov /usr/local/bin/checkov && /usr/local/bin/checkov --version
 
 # terrapod-query — tofu-native discovery engine (#823), pre-built for this arch
 # by the build-query CI job (or the local go build) and staged in the build

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -20,10 +20,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxmlsec1-openssl \
     && rm -rf /var/lib/apt/lists/*
 
-# OPA — so the policy-engine tests (#343) exercise the real binary
-# rather than skipping. Kept in sync with docker/Dockerfile.api; both
-# pin and verify the same OPA_VERSION + SHA256 so a bump in one without
-# the other can't silently land an unverified binary in either image.
+# OPA — so the policy-engine tests (#343) exercise the real binary rather than
+# skipping. This is the ONE image that still bakes it in: the api and runner
+# images fetch it at run time now (#1208), but a test image that did the same
+# would need upstream reach on every CI run to test a code path that has nothing
+# to do with fetching. Not a published image, so it carries no CVE surface for
+# operators. Keep the version roughly in step with
+# `registry.platform_tools.opa_version` in values.yaml — the tests exercise
+# `opa check` behaviour, so a large drift would test something operators do not
+# run.
 ARG TARGETARCH
 ARG OPA_VERSION=1.19.0
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \

--- a/services/terrapod/api/routers/policy_sets.py
+++ b/services/terrapod/api/routers/policy_sets.py
@@ -434,7 +434,17 @@ async def _validate_rego(rego: str) -> None:
             ),
         )
     err = await policy_engine.check_rego(rego)
-    if err is not None:
+    if err == policy_engine.VALIDATION_UNAVAILABLE:
+        # OPA could not be obtained (#1208). Warn and accept: refusing the write
+        # would leave the operator unable to edit any policy because of an
+        # unrelated fetch failure, and the check being skipped is a *syntax*
+        # check — the runner still evaluates this Rego, and fails closed if it
+        # does not compile there.
+        logger.warning(
+            "accepting policy Rego without write-time validation — OPA unavailable",
+            policy_len=len(rego),
+        )
+    elif err is not None:
         raise HTTPException(status_code=422, detail=f"Rego failed to compile: {err}")
 
 

--- a/services/terrapod/runner/phases/opa.py
+++ b/services/terrapod/runner/phases/opa.py
@@ -37,6 +37,7 @@ from pathlib import Path
 import httpx
 import structlog
 
+from terrapod.runner.phases import platform_tool
 from terrapod.runner.runner_config import RunnerConfig
 
 logger = structlog.get_logger("runner.opa")
@@ -339,17 +340,36 @@ def evaluate_policies(
     *,
     plan_json: Path,
     work_dir: Path,
-    opa_binary: str = "opa",
+    opa_binary: str | None = None,
     client: httpx.Client | None = None,
 ) -> int:
     """Drive the whole OPA phase. Returns the number of policy sets
     evaluated (0 = nothing applicable, caller may skip). Raises
-    PolicyEvaluationError on FATAL bundle-fetch / POST failures."""
+    PolicyEvaluationError on FATAL bundle-fetch / POST failures.
+
+    `opa_binary` defaults to fetching OPA from the binary cache (#1208) — but
+    only *after* the bundle turns out to have applicable sets, so a run with no
+    policy never pays for a download it will not use. Tests pass an explicit
+    path."""
     bundle = fetch_policy_bundle(cfg, client=client)
     policy_sets = bundle.get("policy_sets") or []
     if not policy_sets:
         logger.info("no applicable policy sets — skipping evaluation")
         return 0
+
+    if opa_binary is None:
+        # FATAL, deliberately. OPA is no longer baked into the runner image, so
+        # there is nothing on PATH to fall back to — and even if there were,
+        # letting a policy set go unevaluated because its engine did not arrive
+        # would pass a gate that was supposed to block. Failing the run is the
+        # only safe reading of "we could not evaluate your policy".
+        try:
+            opa_binary = str(platform_tool.ensure_tool(cfg, "opa", client=client))
+        except platform_tool.PlatformToolError as exc:
+            raise PolicyEvaluationError(
+                f"{len(policy_sets)} policy set(s) apply to this run but OPA could "
+                f"not be obtained, so they cannot be evaluated: {exc}"
+            ) from exc
 
     work_dir.mkdir(parents=True, exist_ok=True)
     context_path = work_dir / "policy-context.json"

--- a/services/terrapod/runner/phases/platform_tool.py
+++ b/services/terrapod/runner/phases/platform_tool.py
@@ -1,0 +1,212 @@
+"""Phase: fetch a platform tool (opa / trivy / checkov) from the binary cache (#1208).
+
+These three used to be baked into the runner image. They are now pulled through
+the same cache that serves terraform/tofu, so the version is an operator-set Helm
+value and an upstream fix reaches a deployment with a `helm upgrade` instead of
+waiting for a Terrapod release.
+
+**Fetch lazily, and only what the run needs.** `opa` is fetched only once the
+policy bundle turns out to contain applicable sets; `trivy` only when it is the
+selected scan engine. Most runs fetch neither, and none of them pays for a tool
+it will not execute.
+
+**The policy path fails closed.** `ensure_tool` raises rather than returning a
+bare name to fall back on. A policy that cannot be evaluated because its binary
+did not arrive must block the run — quietly passing a gate would be a worse
+defect than the CVE exposure this change removes. The caller decides severity:
+`opa.py` treats the raise as fatal, the scan phase records an errored result and
+lets the server's fail-closed gate handle it.
+
+The archive shapes are declared here rather than imported from
+`services/platform_tools.py`, because the server module imports `terrapod.config`
+which the runner image deliberately does not carry. The two are kept honest by
+`tests/runner/test_platform_tool.py`, which imports both and asserts they agree.
+"""
+
+from __future__ import annotations
+
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import structlog
+
+from terrapod.runner.download import download_to_file
+from terrapod.runner.runner_config import RunnerConfig
+
+logger = structlog.get_logger("runner.phase.platform_tool")
+
+
+class PlatformToolError(RuntimeError):
+    """The tool could not be fetched or unpacked.
+
+    Never swallowed into a bare-name fallback: there is no binary on PATH to
+    fall back to any more, so pretending otherwise would surface as a confusing
+    "not found" at exec time instead of the real cause.
+    """
+
+
+@dataclass(frozen=True)
+class _Unpack:
+    """What the cached object holds and where the executable is inside it."""
+
+    kind: str  # "raw" | "targz" | "zip"
+    member: str  # path within the archive ("" for raw)
+
+
+UNPACK: dict[str, _Unpack] = {
+    "opa": _Unpack(kind="raw", member=""),
+    "trivy": _Unpack(kind="targz", member="trivy"),
+    "checkov": _Unpack(kind="zip", member="dist/checkov"),
+}
+
+
+def _versions_url(cfg: RunnerConfig) -> str:
+    return f"{cfg.api_url}/api/terrapod/v1/platform-tools"
+
+
+def _cache_url(cfg: RunnerConfig, tool: str, version: str) -> str:
+    return f"{cfg.api_url}/api/terrapod/v1/binary-cache/{tool}/{version}/{cfg.os}/{cfg.arch}"
+
+
+def fetch_versions(cfg: RunnerConfig, *, client: httpx.Client | None = None) -> dict[str, str]:
+    """The versions this deployment pins, keyed by tool.
+
+    One small read per Job — the caller memoises. Raises PlatformToolError on
+    anything unusable: without a version there is nothing to ask the cache for,
+    and guessing one would fetch the wrong binary rather than fail.
+    """
+    own = client is None
+    c = client or httpx.Client(timeout=30)
+    try:
+        headers = {"Authorization": f"Bearer {cfg.auth_token}"} if cfg.auth_token else {}
+        resp = c.get(_versions_url(cfg), headers=headers)
+        if resp.status_code != 200:
+            raise PlatformToolError(
+                f"could not read the pinned platform-tool versions from the API "
+                f"(HTTP {resp.status_code})"
+            )
+        attrs = (resp.json().get("data") or {}).get("attributes") or {}
+    except PlatformToolError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — network/JSON, all equally fatal here
+        raise PlatformToolError(f"could not read the pinned platform-tool versions: {exc}") from exc
+    finally:
+        if own:
+            c.close()
+
+    versions = {tool: attrs.get(f"{tool}-version", "") for tool in ("opa", "trivy", "checkov")}
+    if not any(versions.values()):
+        raise PlatformToolError(
+            "the API reported no platform-tool versions — the deployment's "
+            "registry.platform_tools config is missing or empty"
+        )
+    return versions
+
+
+def _extract(archive: Path, spec: _Unpack, dest: Path) -> None:
+    """Pull the executable out of whatever upstream shipped."""
+    if spec.kind == "raw":
+        archive.replace(dest)
+        return
+
+    if spec.kind == "targz":
+        try:
+            with tarfile.open(archive, "r:gz") as tf:
+                member = tf.extractfile(spec.member)
+                if member is None:
+                    raise PlatformToolError(f"{spec.member} not found in {archive.name}")
+                dest.write_bytes(member.read())
+        except (tarfile.TarError, OSError) as exc:
+            raise PlatformToolError(f"could not extract {archive.name}: {exc}") from exc
+        return
+
+    try:
+        with zipfile.ZipFile(archive) as zf:
+            dest.write_bytes(zf.read(spec.member))
+    except (zipfile.BadZipFile, KeyError, OSError) as exc:
+        raise PlatformToolError(f"could not extract {archive.name}: {exc}") from exc
+
+
+def ensure_tool(
+    cfg: RunnerConfig,
+    tool: str,
+    *,
+    versions: dict[str, str] | None = None,
+    tmp_dir: Path = Path("/tmp"),
+    bin_dir: Path = Path("/tmp/bin"),
+    client: httpx.Client | None = None,
+) -> Path:
+    """Fetch `tool` if it isn't already on disk, and return its path.
+
+    Idempotent within a Job: the plan and apply phases of the same run reuse the
+    first fetch. Raises PlatformToolError on any failure — see the module
+    docstring for why there is no fallback.
+    """
+    if tool not in UNPACK:
+        raise PlatformToolError(f"not a platform tool: {tool!r}")
+
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    dest = bin_dir / tool
+    if dest.exists():
+        return dest
+
+    if not cfg.api_url:
+        raise PlatformToolError(
+            f"cannot fetch {tool}: no Terrapod API URL is configured for this runner"
+        )
+
+    resolved = (versions or fetch_versions(cfg, client=client)).get(tool, "")
+    if not resolved:
+        raise PlatformToolError(f"the deployment pins no version for {tool}")
+
+    spec = UNPACK[tool]
+    archive = tmp_dir / f"{tool}.download"
+    logger.info("fetching platform tool", tool=tool, version=resolved, arch=cfg.arch)
+    result = download_to_file(
+        _cache_url(cfg, tool, resolved),
+        archive,
+        headers={"Authorization": f"Bearer {cfg.auth_token}"} if cfg.auth_token else {},
+        api_url=cfg.api_url,
+        retries=cfg.download_retries,
+        retry_delay_seconds=cfg.download_retry_delay_seconds,
+        client=client,
+    )
+    if not result.ok:
+        raise PlatformToolError(
+            f"could not download {tool} {resolved} for {cfg.os}/{cfg.arch} from the "
+            f"binary cache (HTTP {result.status}). The API verifies the publisher "
+            f"checksum before caching, so a failure here is a fetch problem, not a "
+            f"trust one — check the API's upstream reach, or pre-warm the cache if "
+            f"the deployment is sealed."
+        )
+
+    _extract(archive, spec, dest)
+    dest.chmod(0o755)
+    try:
+        archive.unlink()
+    except OSError:
+        pass
+    logger.info("platform tool ready", tool=tool, version=resolved, path=str(dest))
+    return dest
+
+
+def tool_path_or_name(
+    cfg: RunnerConfig,
+    tool: str,
+    *,
+    versions: dict[str, str] | None = None,
+    client: httpx.Client | None = None,
+) -> tuple[str, str | None]:
+    """`ensure_tool` for callers that must not raise.
+
+    Returns `(path, None)` on success or `("", reason)` on failure, so a
+    best-effort caller (the scan phase) can record why it produced nothing
+    instead of crashing the run. The reason is operator-facing text.
+    """
+    try:
+        return str(ensure_tool(cfg, tool, versions=versions, client=client)), None
+    except PlatformToolError as exc:
+        return "", str(exc)

--- a/services/terrapod/runner/phases/security_scan.py
+++ b/services/terrapod/runner/phases/security_scan.py
@@ -42,6 +42,7 @@ from typing import Any
 import httpx
 import structlog
 
+from terrapod.runner.phases import platform_tool
 from terrapod.runner.runner_config import RunnerConfig
 
 logger = structlog.get_logger("runner.security_scan")
@@ -370,23 +371,40 @@ def run_and_post(
     errors: list[str] = []
     any_errored = False
 
+    # The engines are fetched from the binary cache rather than baked into the
+    # image (#1208), and only the ones this run actually selected — a checkov
+    # workspace never pulls trivy. A fetch failure is recorded as an errored
+    # engine rather than raised: this whole phase is best-effort, and the
+    # server's post-plan gate already fails closed on an errored result for an
+    # enforced workspace. Crashing here would take out the *run*, which is a
+    # heavier response than the scan being unavailable warrants.
     if engine in ("checkov", "both"):
-        ok, ck_findings, err = _run_checkov(plan_json, skip_rules)
-        if ok:
-            findings += ck_findings
-        else:
+        binary, why = platform_tool.tool_path_or_name(cfg, "checkov", client=client)
+        if not binary:
             any_errored = True
-            if err:
-                errors.append(f"checkov: {err}")
+            errors.append(f"checkov: {why}")
+        else:
+            ok, ck_findings, err = _run_checkov(plan_json, skip_rules, binary=binary)
+            if ok:
+                findings += ck_findings
+            else:
+                any_errored = True
+                if err:
+                    errors.append(f"checkov: {err}")
 
     if engine in ("trivy", "both"):
-        ok, tv_findings, err = _run_trivy(plan_json, skip_rules)
-        if ok:
-            findings += tv_findings
-        else:
+        binary, why = platform_tool.tool_path_or_name(cfg, "trivy", client=client)
+        if not binary:
             any_errored = True
-            if err:
-                errors.append(f"trivy: {err}")
+            errors.append(f"trivy: {why}")
+        else:
+            ok, tv_findings, err = _run_trivy(plan_json, skip_rules, binary=binary)
+            if ok:
+                findings += tv_findings
+            else:
+                any_errored = True
+                if err:
+                    errors.append(f"trivy: {err}")
 
     outcome, summary = compute_outcome(findings, threshold, errored=any_errored)
     logger.info(

--- a/services/terrapod/services/api_opa.py
+++ b/services/terrapod/services/api_opa.py
@@ -1,0 +1,137 @@
+"""Obtain OPA for the API's write-time Rego check (#1208).
+
+The API image no longer bakes OPA in. It fetches it through the same binary
+cache the runner uses and keeps it on the ephemeral PVC, so the version is an
+operator-set Helm value rather than something frozen into an image.
+
+**This path degrades; it does not fail closed.** That is the opposite of the
+runner's policy gate, and deliberately so — the two uses are not the same thing:
+
+    runner   `opa eval`   the gate itself         a run that cannot be evaluated
+                                                  must not proceed
+    API      `opa check`  write-time Rego syntax  a policy saved without its
+                                                  syntax checked still fails
+                                                  closed later, at eval
+
+So when OPA is unavailable here the policy-set write reports that validation is
+unavailable and proceeds. The cost is a syntax error surfacing at the next run
+instead of at save time; the cost of the alternative is an operator unable to
+edit any policy because an unrelated fetch failed.
+
+Fetched lazily on first use rather than at startup: an install that never writes
+a policy set never pays for it, and a slow or unreachable upstream cannot delay
+the API becoming ready.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import platform
+import stat
+import tempfile
+from pathlib import Path
+
+import httpx
+import structlog
+
+from terrapod.config import settings
+from terrapod.services.platform_tools import (
+    configured_version,
+    download_url,
+    verify_platform_tool,
+)
+
+logger = structlog.get_logger(__name__)
+
+#: Serialises concurrent first-uses so two policy writes don't both download.
+_lock = asyncio.Lock()
+_cached_path: str | None = None
+
+
+def _tool_dir() -> Path:
+    """Where to keep the binary.
+
+    The attached ephemeral PVC when one is configured — `/tmp` on the API pod is
+    RAM-backed and OPA is ~50MB, which is exactly the kind of thing rule 14
+    exists to keep out of memory. Falls back to the system default for local dev
+    and tests, where there is no PVC and nothing at stake.
+    """
+    configured = settings.vcs.tmpdir
+    base = configured if configured and os.path.isdir(configured) else tempfile.gettempdir()
+    return Path(base) / "terrapod-tools"
+
+
+async def _download(version: str, dest: Path) -> None:
+    """Fetch the static linux binary for this pod's architecture.
+
+    Streamed to disk in a worker thread — never held in memory, and never
+    blocking the event loop on the write (rule 13).
+    """
+    arch = "arm64" if platform.machine().lower() in ("aarch64", "arm64") else "amd64"
+    # Same upstream and same checksum gate the cache itself applies. This is the
+    # API fetching for its own use, so it goes direct rather than back through
+    # its own HTTP surface.
+    url = download_url("opa", version, "linux", arch)
+    tmp = dest.with_suffix(".partial")
+    digest = hashlib.sha256()
+    async with httpx.AsyncClient(follow_redirects=True, timeout=120) as client:
+        async with client.stream("GET", url) as resp:
+            if resp.status_code != 200:
+                raise RuntimeError(f"HTTP {resp.status_code} fetching {url}")
+            with tmp.open("wb") as fh:
+                async for chunk in resp.aiter_bytes(1024 * 256):
+                    digest.update(chunk)
+                    await asyncio.to_thread(fh.write, chunk)
+        # Fail closed on the artifact even though the *feature* degrades: "we
+        # could not get OPA" is a fine outcome, "we ran an unverified binary"
+        # is not.
+        await verify_platform_tool(client, "opa", version, "linux", arch, digest.hexdigest())
+
+    tmp.chmod(tmp.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    tmp.replace(dest)
+
+
+async def opa_binary() -> str | None:
+    """Path to a usable `opa`, or None if it could not be obtained.
+
+    None is a normal outcome the caller is expected to handle by reporting that
+    validation is unavailable — see the module docstring.
+    """
+    global _cached_path
+    if _cached_path:
+        return _cached_path
+
+    async with _lock:
+        if _cached_path:  # another waiter won while we queued
+            return _cached_path
+
+        version = configured_version("opa")
+        dest = _tool_dir() / f"opa-{version}"
+        if dest.exists():
+            _cached_path = str(dest)
+            return _cached_path
+
+        try:
+            await asyncio.to_thread(dest.parent.mkdir, parents=True, exist_ok=True)
+            await _download(version, dest)
+        except Exception as exc:  # noqa: BLE001 — every failure degrades the same way
+            logger.warning(
+                "could not obtain OPA for write-time Rego validation — policy-set "
+                "writes will report validation as unavailable and proceed. Rego is "
+                "still checked at evaluation time on the runner, which fails closed.",
+                version=version,
+                error=str(exc),
+            )
+            return None
+
+        logger.info("OPA ready for Rego validation", version=version, path=str(dest))
+        _cached_path = str(dest)
+        return _cached_path
+
+
+def _reset_for_tests() -> None:
+    """Clear the memoised path. Tests only."""
+    global _cached_path
+    _cached_path = None

--- a/services/terrapod/services/policy_engine.py
+++ b/services/terrapod/services/policy_engine.py
@@ -8,10 +8,16 @@ document compiles and is well-formed at the moment an operator creates
 or updates a policy, so broken Rego is rejected up front rather than
 silently failing later inside the runner.
 
-The bundled ``opa`` binary on the API image is used **only** for
-``opa check`` here. The heavy evaluation work — per-run, per-policy,
-high-volume — lives on the runner, where the plan JSON is already
-local and CPU/memory naturally scales with K8s.
+``opa`` is used here **only** for ``opa check``. The heavy evaluation
+work — per-run, per-policy, high-volume — lives on the runner, where the
+plan JSON is already local and CPU/memory naturally scales with K8s.
+
+Since #1208 the binary is fetched on demand (see
+:mod:`terrapod.services.api_opa`) rather than baked into the API image,
+so its version is a Helm value. If it cannot be obtained this check
+reports that validation is unavailable and the write proceeds: Rego that
+slips past a *syntax* check here still fails closed at evaluation time on
+the runner, so degrading is the proportionate response.
 
 Terrapod policy convention
 --------------------------
@@ -31,14 +37,25 @@ import tempfile
 
 import structlog
 
+from terrapod.services import api_opa
+
 logger = structlog.get_logger(__name__)
 
-# The bundled OPA binary (installed on PATH by docker/Dockerfile.api).
+# Kept as the name to exec when a caller supplies no path — the test image still
+# bakes OPA in (docker/Dockerfile.test), so the 143 policy tests keep exercising
+# a real binary rather than a mock.
 OPA_BINARY = "opa"
 
 # Hard ceiling on `opa check`. The command is fast — this just guards
 # against a wedged subprocess.
 CHECK_TIMEOUT_SECONDS = 15.0
+
+#: Returned when OPA itself could not be obtained, as distinct from "your Rego
+#: is broken". The caller must tell the two apart: rejecting a policy write
+#: because an unrelated fetch failed would leave an operator unable to edit any
+#: policy, while the thing that was skipped — a syntax check — still happens at
+#: evaluation time on the runner, which fails closed.
+VALIDATION_UNAVAILABLE = "OPA binary not available on the API server"
 
 
 def _write_rego_to_tempdir(rego: str) -> str:
@@ -51,12 +68,23 @@ def _write_rego_to_tempdir(rego: str) -> str:
     return tmpdir
 
 
-async def check_rego(rego: str, *, opa_binary: str = OPA_BINARY) -> str | None:
+async def check_rego(rego: str, *, opa_binary: str | None = None) -> str | None:
     """Validate that a Rego document compiles. Returns an error string
     on failure, or ``None`` if it is well-formed. Used by the policy
     CRUD API to reject broken Rego at write time rather than at
     runner-eval time.
+
+    With no ``opa_binary`` the binary is obtained on demand (#1208). If it
+    cannot be — no upstream reach, a sealed install with a cold cache — the
+    returned string says validation is unavailable, and the caller treats that
+    as a warning rather than a rejection: see the module docstring for why
+    degrading is the proportionate response here.
     """
+    if opa_binary is None:
+        opa_binary = await api_opa.opa_binary()
+        if opa_binary is None:
+            return VALIDATION_UNAVAILABLE
+
     tmpdir = await asyncio.to_thread(_write_rego_to_tempdir, rego)
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -76,7 +104,7 @@ async def check_rego(rego: str, *, opa_binary: str = OPA_BINARY) -> str | None:
             await proc.wait()
             return "opa check timed out"
     except FileNotFoundError:
-        return "OPA binary not available on the API server"
+        return VALIDATION_UNAVAILABLE
     finally:
         await asyncio.to_thread(shutil.rmtree, tmpdir, ignore_errors=True)
 

--- a/services/tests/runner/test_phase_opa.py
+++ b/services/tests/runner/test_phase_opa.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -287,3 +288,67 @@ class TestEvaluatePolicies:
             client=client,
         )
         assert n == 0
+
+
+class TestOPAIsFetchedNotBaked:
+    """#1208: OPA is pulled from the binary cache, and the policy gate is the
+    one path where a failed fetch must stop the run."""
+
+    def test_no_fetch_when_no_policy_set_applies(self, tmp_path: Path) -> None:
+        """Most runs have no policy. They must not pay for a ~50MB download
+        they will never execute."""
+        fetch = MagicMock()
+        with (
+            patch.object(opa, "fetch_policy_bundle", return_value={"policy_sets": []}),
+            patch.object(opa.platform_tool, "ensure_tool", fetch),
+        ):
+            count = opa.evaluate_policies(
+                _cfg(), plan_json=tmp_path / "plan.json", work_dir=tmp_path / "w"
+            )
+        assert count == 0
+        fetch.assert_not_called()
+
+    def test_a_failed_fetch_fails_the_run_closed(self, tmp_path: Path) -> None:
+        """Letting a policy set go unevaluated because its engine did not arrive
+        would pass a gate that was supposed to block — a worse defect than the
+        CVE exposure #1208 removes."""
+        plan = tmp_path / "plan.json"
+        plan.write_text("{}")
+        bundle = {
+            "policy_sets": [
+                {"id": "ps-1", "name": "prod", "enforcement_level": "mandatory", "policies": []}
+            ],
+            "context": {},
+        }
+        with (
+            patch.object(opa, "fetch_policy_bundle", return_value=bundle),
+            patch.object(
+                opa.platform_tool,
+                "ensure_tool",
+                side_effect=opa.platform_tool.PlatformToolError("cache unreachable"),
+            ),
+        ):
+            with pytest.raises(opa.PolicyEvaluationError, match="cannot be evaluated"):
+                opa.evaluate_policies(_cfg(), plan_json=plan, work_dir=tmp_path / "w")
+
+    def test_an_explicit_binary_skips_the_fetch(self, tmp_path: Path) -> None:
+        """Callers that already have a path — tests, and the baked test image —
+        must not trigger a network fetch."""
+        plan = tmp_path / "plan.json"
+        plan.write_text("{}")
+        bundle = {
+            "policy_sets": [
+                {"id": "ps-1", "name": "prod", "enforcement_level": "advisory", "policies": []}
+            ],
+            "context": {},
+        }
+        fetch = MagicMock()
+        with (
+            patch.object(opa, "fetch_policy_bundle", return_value=bundle),
+            patch.object(opa.platform_tool, "ensure_tool", fetch),
+            patch.object(opa, "post_results"),
+        ):
+            opa.evaluate_policies(
+                _cfg(), plan_json=plan, work_dir=tmp_path / "w", opa_binary="/usr/bin/opa"
+            )
+        fetch.assert_not_called()

--- a/services/tests/runner/test_phase_security_scan.py
+++ b/services/tests/runner/test_phase_security_scan.py
@@ -25,6 +25,16 @@ def _cfg(**overrides) -> RunnerConfig:
     return RunnerConfig.from_env(env=base)
 
 
+def _fetched(tool_name: str = "/tmp/bin/engine"):
+    """Stub the platform-tool fetch (#1208).
+
+    The engines are no longer on PATH — `run_and_post` pulls them from the
+    binary cache — so a test about scan *outcomes* has to say the fetch
+    succeeded before it can exercise the thing it is actually about.
+    """
+    return patch.object(scan.platform_tool, "tool_path_or_name", return_value=(tool_name, None))
+
+
 # ── severity helpers ──────────────────────────────────────────────────────
 
 
@@ -374,6 +384,7 @@ class TestRunAndPost:
         plan.write_text('{"x":1}')
         posted = {}
         with (
+            _fetched(),
             patch.object(
                 scan,
                 "_run_checkov",
@@ -394,6 +405,7 @@ class TestRunAndPost:
         plan.write_text('{"x":1}')
         posted = {}
         with (
+            _fetched(),
             patch.object(
                 scan,
                 "_run_checkov",
@@ -418,9 +430,31 @@ class TestRunAndPost:
         plan.write_text('{"x":1}')
         posted = {}
         with (
+            _fetched(),
             patch.object(scan, "_run_checkov", return_value=(False, [], "checkov exploded")),
             patch.object(scan, "post_scan_result", side_effect=lambda cfg, **kw: posted.update(kw)),
         ):
             outcome = scan.run_and_post(cfg, {"engine": "checkov"}, plan_json=plan)
         assert outcome == "errored"
         assert "checkov exploded" in posted["error"]
+
+    def test_an_engine_that_cannot_be_fetched_is_errored_not_fatal(self, tmp_path: Path) -> None:
+        """#1208: the engines are pulled at run time now, so "could not fetch"
+        is a new failure mode. It must land as an errored *result* — which the
+        server's gate then fails closed on for an enforced workspace — rather
+        than raising and taking the whole run down."""
+        cfg = _cfg()
+        plan = tmp_path / "plan.json"
+        plan.write_text('{"x":1}')
+        posted = {}
+        with (
+            patch.object(
+                scan.platform_tool,
+                "tool_path_or_name",
+                return_value=("", "binary cache unreachable"),
+            ),
+            patch.object(scan, "post_scan_result", side_effect=lambda cfg, **kw: posted.update(kw)),
+        ):
+            outcome = scan.run_and_post(cfg, {"engine": "checkov"}, plan_json=plan)
+        assert outcome == "errored"
+        assert "binary cache unreachable" in posted["error"]

--- a/services/tests/runner/test_platform_tool.py
+++ b/services/tests/runner/test_platform_tool.py
@@ -1,0 +1,262 @@
+"""Runner-side platform-tool fetch (#1208).
+
+The behaviours worth pinning are the ones that replaced a guarantee the image
+used to give for free: the tool arrives, it is unpacked from whatever shape
+upstream ships, and — when it does not arrive — the *right* thing happens for
+the caller. The policy path must fail closed; the scan path must not take the
+run down with it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from terrapod.runner.phases import platform_tool
+from terrapod.runner.phases.platform_tool import (
+    UNPACK,
+    PlatformToolError,
+    ensure_tool,
+    fetch_versions,
+    tool_path_or_name,
+)
+from terrapod.runner.runner_config import RunnerConfig
+
+
+def _cfg(**over) -> RunnerConfig:
+    """A RunnerConfig with the fields these tests care about.
+
+    `os`/`arch` are derived from the host in `from_env`, so tests that assert on
+    them override the built config directly rather than through the env.
+    """
+    cfg = RunnerConfig.from_env(
+        env={
+            "TP_API_URL": "https://terrapod.test",
+            "TP_AUTH_TOKEN": "tok",
+            "TP_RUN_ID": "run-1",
+            "TP_BACKEND": "tofu",
+            "TP_VERSION": "1.12.1",
+        }
+    )
+    fields = {"os": "linux", "arch": "amd64", **over}
+    return dataclasses.replace(cfg, **fields)
+
+
+def _ok_result():
+    r = MagicMock()
+    r.ok = True
+    r.status = 200
+    return r
+
+
+def _bad_result(status: int = 404):
+    r = MagicMock()
+    r.ok = False
+    r.status = status
+    return r
+
+
+class TestFetchVersions:
+    def test_reads_the_pinned_versions(self):
+        client = MagicMock()
+        client.get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "data": {
+                    "attributes": {
+                        "opa-version": "1.19.0",
+                        "trivy-version": "0.72.0",
+                        "checkov-version": "3.3.8",
+                    }
+                }
+            },
+        )
+        assert fetch_versions(_cfg(), client=client) == {
+            "opa": "1.19.0",
+            "trivy": "0.72.0",
+            "checkov": "3.3.8",
+        }
+
+    def test_raises_on_a_non_200(self):
+        """Without a version there is nothing to ask the cache for, and guessing
+        one would fetch the wrong binary rather than fail."""
+        client = MagicMock()
+        client.get.return_value = MagicMock(status_code=503)
+        with pytest.raises(PlatformToolError, match="could not read"):
+            fetch_versions(_cfg(), client=client)
+
+    def test_raises_when_the_api_reports_nothing(self):
+        client = MagicMock()
+        client.get.return_value = MagicMock(
+            status_code=200, json=lambda: {"data": {"attributes": {}}}
+        )
+        with pytest.raises(PlatformToolError, match="no platform-tool versions"):
+            fetch_versions(_cfg(), client=client)
+
+
+class TestEnsureTool:
+    def test_unpacks_a_bare_binary(self, tmp_path: Path):
+        """opa ships as a bare executable — nothing to extract."""
+
+        def fake_download(url, dest, **kw):
+            Path(dest).write_bytes(b"#!/opa\n")
+            return _ok_result()
+
+        with patch.object(platform_tool, "download_to_file", fake_download):
+            got = ensure_tool(
+                _cfg(),
+                "opa",
+                versions={"opa": "1.19.0"},
+                tmp_dir=tmp_path,
+                bin_dir=tmp_path / "bin",
+            )
+        assert got.read_bytes() == b"#!/opa\n"
+        assert got.stat().st_mode & 0o111  # executable
+
+    def test_extracts_the_member_from_a_tarball(self, tmp_path: Path):
+        """trivy ships a .tar.gz whose only interesting member is the binary."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+            for name, payload in (("README.md", b"docs"), ("trivy", b"TRIVYBIN")):
+                info = tarfile.TarInfo(name)
+                info.size = len(payload)
+                tf.addfile(info, io.BytesIO(payload))
+        blob = buf.getvalue()
+
+        def fake_download(url, dest, **kw):
+            Path(dest).write_bytes(blob)
+            return _ok_result()
+
+        with patch.object(platform_tool, "download_to_file", fake_download):
+            got = ensure_tool(
+                _cfg(),
+                "trivy",
+                versions={"trivy": "0.72.0"},
+                tmp_dir=tmp_path,
+                bin_dir=tmp_path / "bin",
+            )
+        assert got.read_bytes() == b"TRIVYBIN"
+
+    def test_extracts_the_member_from_a_zip(self, tmp_path: Path):
+        """checkov ships a PyInstaller bundle as dist/checkov inside a zip."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("dist/checkov", b"CHECKOVBIN")
+        blob = buf.getvalue()
+
+        def fake_download(url, dest, **kw):
+            Path(dest).write_bytes(blob)
+            return _ok_result()
+
+        with patch.object(platform_tool, "download_to_file", fake_download):
+            got = ensure_tool(
+                _cfg(),
+                "checkov",
+                versions={"checkov": "3.3.8"},
+                tmp_dir=tmp_path,
+                bin_dir=tmp_path / "bin",
+            )
+        assert got.read_bytes() == b"CHECKOVBIN"
+
+    def test_a_second_call_reuses_the_first_fetch(self, tmp_path: Path):
+        """The plan and apply phases of one run must not download twice."""
+        calls = []
+
+        def fake_download(url, dest, **kw):
+            calls.append(url)
+            Path(dest).write_bytes(b"x")
+            return _ok_result()
+
+        with patch.object(platform_tool, "download_to_file", fake_download):
+            for _ in range(3):
+                ensure_tool(
+                    _cfg(),
+                    "opa",
+                    versions={"opa": "1.19.0"},
+                    tmp_dir=tmp_path,
+                    bin_dir=tmp_path / "bin",
+                )
+        assert len(calls) == 1
+
+    def test_asks_the_cache_for_this_runner_architecture(self, tmp_path: Path):
+        seen = []
+
+        def fake_download(url, dest, **kw):
+            seen.append(url)
+            Path(dest).write_bytes(b"x")
+            return _ok_result()
+
+        with patch.object(platform_tool, "download_to_file", fake_download):
+            ensure_tool(
+                _cfg(arch="arm64"),
+                "opa",
+                versions={"opa": "1.19.0"},
+                tmp_dir=tmp_path,
+                bin_dir=tmp_path / "bin",
+            )
+        assert seen[0].endswith("/binary-cache/opa/1.19.0/linux/arm64")
+
+    def test_a_download_failure_raises_rather_than_falling_back(self, tmp_path: Path):
+        """There is no binary on PATH to fall back to any more, so returning a
+        bare name would surface as a confusing 'not found' at exec time."""
+        with patch.object(platform_tool, "download_to_file", lambda *a, **k: _bad_result(500)):
+            with pytest.raises(PlatformToolError, match="could not download"):
+                ensure_tool(
+                    _cfg(),
+                    "opa",
+                    versions={"opa": "1.19.0"},
+                    tmp_dir=tmp_path,
+                    bin_dir=tmp_path / "bin",
+                )
+
+    def test_rejects_a_tool_it_does_not_know(self, tmp_path: Path):
+        with pytest.raises(PlatformToolError, match="not a platform tool"):
+            ensure_tool(_cfg(), "terraform", tmp_dir=tmp_path, bin_dir=tmp_path / "bin")
+
+    def test_no_api_url_is_a_clear_error(self, tmp_path: Path):
+        with pytest.raises(PlatformToolError, match="no Terrapod API URL"):
+            ensure_tool(
+                _cfg(api_url=""),
+                "opa",
+                versions={"opa": "1.19.0"},
+                tmp_dir=tmp_path,
+                bin_dir=tmp_path / "bin",
+            )
+
+
+class TestToolPathOrName:
+    """The non-raising wrapper the scan phase uses."""
+
+    def test_returns_a_reason_instead_of_raising(self):
+        with patch.object(
+            platform_tool, "ensure_tool", side_effect=PlatformToolError("upstream down")
+        ):
+            path, why = tool_path_or_name(_cfg(), "trivy")
+        assert path == ""
+        assert "upstream down" in why
+
+    def test_returns_the_path_on_success(self, tmp_path: Path):
+        with patch.object(platform_tool, "ensure_tool", return_value=tmp_path / "trivy"):
+            path, why = tool_path_or_name(_cfg(), "trivy")
+        assert path.endswith("trivy")
+        assert why is None
+
+
+def test_unpack_table_agrees_with_the_server_spec():
+    """The runner declares the archive shapes itself because the server module
+    imports terrapod.config, which the runner image does not carry. Two copies
+    of the same fact drift silently, so assert they match — a server-side
+    change to how a tool is packaged would otherwise leave the runner
+    extracting from the wrong shape."""
+    from terrapod.services.platform_tools import SPECS
+
+    assert set(UNPACK) == set(SPECS)
+    for tool, spec in SPECS.items():
+        assert UNPACK[tool].kind == spec.archive, tool
+        assert UNPACK[tool].member == spec.member, tool

--- a/services/tests/services/test_api_opa.py
+++ b/services/tests/services/test_api_opa.py
@@ -1,0 +1,84 @@
+"""API-side OPA acquisition and its degradation contract (#1208).
+
+The point of these tests is the asymmetry with the runner: there, a missing OPA
+must stop the run; here it must not stop an operator editing a policy. What is
+*not* negotiable on either side is the artifact — an unverifiable download is
+rejected rather than executed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from terrapod.services import api_opa, policy_engine
+
+
+@pytest.fixture(autouse=True)
+def _clear_memo():
+    api_opa._reset_for_tests()
+    yield
+    api_opa._reset_for_tests()
+
+
+class TestOpaBinary:
+    async def test_returns_none_when_the_download_fails(self):
+        """None is a normal outcome the caller handles, not an exception."""
+        with patch.object(api_opa, "_download", AsyncMock(side_effect=RuntimeError("no route"))):
+            assert await api_opa.opa_binary() is None
+
+    async def test_reuses_an_already_downloaded_binary(self, tmp_path, monkeypatch):
+        """A restart that finds the PVC warm must not re-download."""
+        monkeypatch.setattr(api_opa, "_tool_dir", lambda: tmp_path)
+        version = api_opa.configured_version("opa")
+        (tmp_path / f"opa-{version}").write_text("#!/opa")
+        download = AsyncMock()
+        with patch.object(api_opa, "_download", download):
+            path = await api_opa.opa_binary()
+        assert path == str(tmp_path / f"opa-{version}")
+        download.assert_not_awaited()
+
+    async def test_downloads_once_under_concurrent_first_use(self, tmp_path, monkeypatch):
+        """Two policy writes arriving together must not both fetch ~50MB."""
+        import asyncio
+
+        monkeypatch.setattr(api_opa, "_tool_dir", lambda: tmp_path)
+        version = api_opa.configured_version("opa")
+
+        calls = []
+
+        async def fake_download(v, dest):
+            calls.append(v)
+            await asyncio.sleep(0)
+            dest.write_text("#!/opa")
+
+        with patch.object(api_opa, "_download", fake_download):
+            results = await asyncio.gather(*(api_opa.opa_binary() for _ in range(5)))
+
+        assert calls == [version]
+        assert set(results) == {str(tmp_path / f"opa-{version}")}
+
+
+class TestCheckRegoDegrades:
+    async def test_reports_unavailable_rather_than_a_compile_error(self):
+        """The distinction matters: the caller accepts one and rejects the
+        other, so conflating them would reject every policy write whenever an
+        unrelated fetch failed."""
+        with patch.object(api_opa, "opa_binary", AsyncMock(return_value=None)):
+            assert await policy_engine.check_rego("package terrapod") == (
+                policy_engine.VALIDATION_UNAVAILABLE
+            )
+
+    async def test_uses_the_fetched_binary_when_available(self):
+        with patch.object(api_opa, "opa_binary", AsyncMock(return_value="/does/not/exist/opa")):
+            result = await policy_engine.check_rego("package terrapod")
+        # The path doesn't exist, so exec fails — which routes through the same
+        # unavailable signal rather than being reported as broken Rego.
+        assert result == policy_engine.VALIDATION_UNAVAILABLE
+
+    async def test_still_reports_genuinely_broken_rego(self):
+        """Degrading must not swallow the thing this check exists for."""
+        err = await policy_engine.check_rego("package terrapod\n\nthis is not rego {{{")
+        assert err is not None
+        assert err != policy_engine.VALIDATION_UNAVAILABLE


### PR DESCRIPTION
The consumer half of #1208. The runner and API now pull these three from the binary cache #1223 added, and the published images stop carrying them.

**Measured:** the runner image goes **748MB → 305MB** (443MB, 59% smaller), and every module those three vendor stops being attributed to Terrapod's artifacts. The api image drops its bundled OPA.

Saying the honest thing plainly: **this does not reduce attack surface.** The same code still runs on the runner. What changes is that the version is an operator-set Helm value, so an upstream fix arrives with a `helm upgrade` rather than waiting for a Terrapod release — which is precisely the `ignore-unfixed` window [docs/cve-policy.md](https://github.com/mattrobinsonsre/terrapod/blob/main/docs/cve-policy.md) documents.

## Lazily, and only what the run needs

OPA is fetched only *after* the policy bundle turns out to contain applicable sets; trivy only when it is the selected engine. Most runs fetch neither.

## Three call sites, three different failure postures — deliberately

| Site | Posture | Why |
|---|---|---|
| Runner policy gate | **FATAL** | Letting a policy go unevaluated because its engine did not arrive would **pass a gate that was supposed to block** — a worse defect than the CVE exposure this removes. |
| Runner security scan | **errored result**, not an exception | The phase is best-effort by design and the server's post-plan gate already fails closed on an errored result for an enforced workspace. Taking the whole run down is heavier than the scan being unavailable warrants. |
| API `opa check` | **degrades** | This is write-time Rego *syntax* validation, not the gate — Rego that slips past it still fails closed at evaluation time on the runner. Refusing the write would leave an operator unable to edit **any** policy because of an unrelated fetch failure. |

That last one needed a real change, not just a comment: the router 422s on any error string from `check_rego`, so without `policy_engine.VALIDATION_UNAVAILABLE` to tell "we could not check" apart from "your Rego is broken", every policy write would have been rejected whenever a fetch failed.

## API-side detail

The fetch is **lazy rather than at startup**, so an install that never writes a policy set never pays for it and a slow upstream cannot delay readiness. It lands on the ephemeral PVC, not `/tmp`, which is RAM-backed on the API pod (rule 14). The artifact itself still fails closed — the *feature* degrading is fine, running an unverified binary is not.

## Notes

- **`Dockerfile.test` keeps OPA baked.** It is not a published image, and a test image that fetched would need upstream reach on every CI run to exercise a code path that has nothing to do with fetching. The 143 policy tests keep hitting a real binary.
- **The runner declares the archive shapes itself** rather than importing them, because the server module imports `terrapod.config` and the runner image deliberately does not carry it. Two copies of one fact drift silently, so a test imports both and asserts they agree.
- **`values-eval.yaml` stays batteries-included** — the eval stack fetches on first use, the same egress it already needs for the provider and binary caches, so what has to hold is that it knows *what* to fetch. Asserted in the eval render step.

## Verification

- `make test` — 4115 passed
- Both images built locally; `opa`, `trivy` and `checkov` confirmed absent from the runner image and the phase module confirmed importable inside it
- `helm lint` + `helm template` on all three profiles; new helm-smoke assertions for the stock and eval renders

Part of #1208