### PR TITLE
fix: drop curl from every published image

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -67,7 +67,6 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 ARG PKG_REFRESH=2026-07-13
 RUN echo "pkg-refresh=${PKG_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    curl \
     git \
     postgresql-client \
     xmlsec1 \
@@ -123,9 +122,15 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app \
     PORT=8000
 
-# Health check
+# Health check.
+#
+# Kubernetes does NOT use this — the chart defines its own httpGet liveness and
+# readiness probes. It exists for a plain `docker run`, and it used to be the
+# only reason curl was installed. curl has generated real CVE findings against
+# our published images, so the check is now a stdlib urlopen: same behaviour
+# (non-2xx or a connection error raises, which exits non-zero) and no package.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD ["python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=4)"]
 
 # Expose port
 EXPOSE 8000

--- a/docker/Dockerfile.listener
+++ b/docker/Dockerfile.listener
@@ -34,9 +34,11 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/terrapo
 # works only until someone forgets, which is how five already-patched libexpat
 # CVEs stayed in the images for 18 days (#1177).
 ARG PKG_REFRESH=2026-07-13
+# The listener installs NO extra packages — it is Python talking to the K8s API
+# and the Terrapod API, and nothing else. The upgrade still runs, because that
+# is what picks up base-image security patches.
 RUN echo "pkg-refresh=${PKG_REFRESH}" \
-    && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    curl \
+    && apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -62,8 +64,15 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPATH=/app
 
+# Health check.
+#
+# Kubernetes does NOT use this — the chart defines its own httpGet liveness and
+# readiness probes. It exists for a plain `docker run`, and it used to be the
+# only reason curl was installed. curl has generated real CVE findings against
+# our published images, so the check is now a stdlib urlopen: same behaviour
+# (non-2xx or a connection error raises, which exits non-zero) and no package.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8081/health || exit 1
+    CMD ["python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8081/health', timeout=4)"]
 
 EXPOSE 8081
 

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -63,7 +63,10 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8000/health"]
+      # The api image carries no curl (it was only ever there for a Docker
+      # HEALTHCHECK that Kubernetes never runs). Same stdlib check the image
+      # itself uses: non-2xx or a refused connection raises and exits non-zero.
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=4)"]
       interval: 5s
       timeout: 5s
       retries: 20


### PR DESCRIPTION
`curl` was installed in the api and listener images for exactly one thing: a Docker `HEALTHCHECK`.

**Kubernetes never runs it.** The chart defines its own `httpGet` liveness and readiness probes, so in the deployment model Terrapod actually supports, curl was pure surface.

Not theoretical surface, either — **two of the five findings in the report that opened #1206 were curl CVEs** (`CVE-2026-5773`, `CVE-2026-6276`), reported against images that only carried curl to shell out to localhost.

## What replaces it

The `HEALTHCHECK` still works for a plain `docker run`; it is a stdlib `urlopen` now, with the same semantics as `curl -f` — non-2xx or a connection error raises, which exits non-zero.

## Verified on built images, not just the Dockerfile

| Check | api | listener |
|---|---|---|
| `command -v curl` | not found | not found |
| healthcheck vs a 200 | exit 0 | — |
| healthcheck vs a 404 | exit 1 | — |
| healthcheck vs refused connection | — | exit 1 |

## Also

The listener's package block installed *nothing* once curl was removed, so it now just runs the upgrade — which is the part that picks up base-image security patches and must not be lost in the tidy-up.

`Dockerfile.test` keeps curl. It is not a published image and it needs curl to fetch the OPA and tofu binaries the test suite exercises.

Follow-up to #1208.