### PR TITLE
fix(1244): VCS polling completely broken by transposed positional args

### DIFF
--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -990,10 +990,18 @@ async def _poll_workspace(
 
     try:
         # 1. Check tracked branch for new commits → real runs
-        await _poll_workspace_branch(db, ws, conn, owner, repo, branch, cache, fetch_paths, meta)
+        # Keyword-only past `branch`: the tail of both signatures is
+        # (cache, meta, fetch_paths), and passing them positionally silently
+        # transposed `fetch_paths` into `meta` — every poll then died on
+        # `'list' object has no attribute 'get_or_fetch'`. Keep these named.
+        await _poll_workspace_branch(
+            db, ws, conn, owner, repo, branch, cache=cache, meta=meta, fetch_paths=fetch_paths
+        )
 
         # 2. Check open PRs/MRs targeting the tracked branch → speculative plans
-        await _poll_workspace_prs(db, ws, conn, owner, repo, branch, cache, fetch_paths, meta)
+        await _poll_workspace_prs(
+            db, ws, conn, owner, repo, branch, cache=cache, meta=meta, fetch_paths=fetch_paths
+        )
 
         # Success: update last-polled timestamp and clear any previous error
         ws.vcs_last_polled_at = now_utc()

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -1353,3 +1353,87 @@ class TestCommitClaimReleasedOnFailure:
 
         mock_create.assert_not_called()
         mock_release.assert_not_awaited()
+
+
+class TestPollWorkspacePassesMetadataCacheCorrectly:
+    """Regression: the poll-cycle argument binding into the per-repo helpers.
+
+    v1.3.0 shipped a total VCS outage — every VCS-connected workspace failed
+    every cycle with `'list' object has no attribute 'get_or_fetch'`. The tail
+    of `_poll_workspace_branch`/`_poll_workspace_prs` is
+    `(cache, meta, fetch_paths)`, but `_poll_workspace` passed them positionally
+    as `(cache, fetch_paths, meta)`, so the `fetch_paths` LIST landed in the
+    `meta` slot and the metadata cache landed in `fetch_paths`.
+
+    Nothing caught it because every other `_poll_workspace` test omits `meta`
+    entirely (taking the `meta is None` short-circuit inside the helpers), and
+    the tests that do build a `VCSMetadataCache` call the inner helpers
+    directly. Production is the only caller that passes BOTH — which is exactly
+    what these tests do, mocking only at the provider boundary so the real
+    argument binding is exercised.
+    """
+
+    @patch("terrapod.services.vcs_poller.github_service.list_open_pull_requests")
+    @patch("terrapod.services.vcs_poller._provider_get_branch_sha")
+    @patch("terrapod.services.vcs_poller._parse_repo_url")
+    async def test_poll_with_meta_and_fetch_paths_does_not_error(
+        self, mock_parse, mock_sha, mock_prs
+    ):
+        from terrapod.services.vcs_metadata_cache import VCSMetadataCache
+        from terrapod.services.vcs_poller import _poll_workspace
+
+        ws = _mock_workspace(vcs_last_commit_sha="aaa111")
+        conn = _mock_connection()
+        mock_parse.return_value = ("org", "repo")
+        # No new commit and no open PRs: the poll should be a clean no-op.
+        mock_sha.return_value = "aaa111"
+        mock_prs.return_value = []
+
+        mock_db = AsyncMock()
+        mock_db.get.return_value = conn
+
+        meta = VCSMetadataCache()
+        paths_unions = {(conn.id, "org", "repo"): ["environments/dev"]}
+
+        await _poll_workspace(mock_db, ws, meta=meta, paths_unions=paths_unions)
+
+        # The transposition surfaced as a caught exception recorded on the
+        # workspace, not a raise — so asserting "no error" is the real check.
+        assert ws.vcs_last_error is None, f"poll recorded an error: {ws.vcs_last_error}"
+        assert ws.vcs_last_polled_at is not None
+
+    @patch("terrapod.services.vcs_poller._poll_workspace_prs")
+    @patch("terrapod.services.vcs_poller._poll_workspace_branch")
+    @patch("terrapod.services.vcs_poller._resolve_branch")
+    @patch("terrapod.services.vcs_poller._parse_repo_url")
+    async def test_meta_and_fetch_paths_bind_to_their_own_parameters(
+        self, mock_parse, mock_resolve, mock_branch, mock_prs
+    ):
+        """Pin the binding itself, so a future positional call fails loudly."""
+        from terrapod.services.vcs_metadata_cache import VCSMetadataCache
+        from terrapod.services.vcs_poller import _poll_workspace
+
+        ws = _mock_workspace()
+        conn = _mock_connection()
+        mock_parse.return_value = ("org", "repo")
+        mock_resolve.return_value = "main"
+        mock_branch.return_value = None
+        mock_prs.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.get.return_value = conn
+
+        meta = VCSMetadataCache()
+        await _poll_workspace(
+            mock_db,
+            ws,
+            meta=meta,
+            paths_unions={(conn.id, "org", "repo"): ["environments/dev"]},
+        )
+
+        for mock in (mock_branch, mock_prs):
+            kwargs = mock.call_args.kwargs
+            assert kwargs["meta"] is meta, (
+                f"{mock._mock_name or 'helper'} got meta={type(kwargs['meta']).__name__}"
+            )
+            assert kwargs["fetch_paths"] == ["environments/dev"]


### PR DESCRIPTION
v1.3.0 shipped a total VCS outage: every VCS-connected workspace fails every poll
cycle with `'list' object has no attribute 'get_or_fetch'`. No branch pushes are
detected and no speculative PR plans are created.

## Root cause

`_poll_workspace` called both per-repo helpers positionally:

```python
await _poll_workspace_branch(db, ws, conn, owner, repo, branch, cache, fetch_paths, meta)
```

but both signatures end `(cache, meta, fetch_paths)`. So `fetch_paths` (a `list`)
bound to `meta`, the helper took its `meta is not None` branch, and called
`meta.get_or_fetch(...)` on a list. Introduced in #1097.

The exception is caught per-workspace, so it presented as a VCS error on every
workspace rather than a crash.

## Fix

Pass the tail arguments by keyword at both call sites.

## Why nothing caught it

Every existing `_poll_workspace` test omits `meta`, so it takes the `meta is None`
short-circuit inside the helpers and never reaches the transposed binding. The tests
that *do* build a `VCSMetadataCache` call the inner helpers directly. Production was
the only caller passing **both** `meta` and `fetch_paths`.

Two regression tests close that gap, both verified to fail on the pre-fix code:

- `test_poll_with_meta_and_fetch_paths_does_not_error` — behavioural, mocking only at
  the provider boundary so the real argument binding runs. On the buggy code it
  reproduces the exact production `AttributeError`.
- `test_meta_and_fetch_paths_bind_to_their_own_parameters` — pins the binding itself,
  so a future positional call fails loudly.

Note the first test only reproduces because the `paths_unions` key is the **raw**
`conn.id`, not `str(conn.id)` — with the wrong key `fetch_paths` stays `None`, binds
harmlessly, and the test passes against broken code.

Closes #1244