### PR TITLE
feat(1231): report which agent pool executed a run

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -795,6 +795,28 @@ OOM (`exit 137 + reason "OOMKilled"`) is uncatchable, so the runner path never f
 
 See [runners.md — Memory Pressure & OOM Visibility](runners.md#memory-pressure--oom-visibility-430) for the operator-facing tuning workflow.
 
+### Run Response Attributes (Agent Pool)
+
+Which agent pool has a run, and which pools could have claimed it. With multi-pool
+workspace routing (#1085) a queued run is offered to every pool in the workspace's set
+at once and whichever has a live listener claims it first — so "where did this actually
+execute?" is not answerable from the workspace's configuration alone.
+
+| Attribute | Type | Description |
+|---|---|---|
+| `agent-pool-id` | string or null | The pool that has the run. At creation this is element 0 of the workspace's pool set; **on claim it is rewritten to the pool that actually took the run**, so on a finished run it is where the run executed. `null` for local-execution runs, and for agent runs whose pool has since been deleted |
+| `candidate-agent-pool-ids` | array of string | Every pool that could have claimed the run, snapshotted at run creation and preserved (only re-ordered, winner first) across the claim |
+
+The `agent-pool` relationship carries the same id as `agent-pool-id` and is the canonical
+link form; the attribute is kept alongside it.
+
+> **Note the difference from a workspace.** On a workspace, `agent-pool-id` is always a
+> projection of `agent-pool-ids[0]` and carries no routing preference. On a run it is the
+> *claimant*. Likewise `candidate-agent-pool-ids` is deliberately named apart from the
+> workspace's `agent-pool-ids`: the workspace attribute is the live configured set, while
+> the run attribute is a point-in-time snapshot that does not move when the workspace is
+> later re-pointed at different pools.
+
 ### Show Run
 
 ```

--- a/go-terrapod/runs.go
+++ b/go-terrapod/runs.go
@@ -87,6 +87,17 @@ type Run struct {
 	// Workspace context.
 	WorkspaceID   string `json:"workspace-id,omitempty"` // from the `workspace` relationship
 	WorkspaceName string `json:"workspace-name,omitempty"`
+	// Which agent pool has this run. At creation it is element 0 of the
+	// workspace's pool set; on claim it is rewritten to the pool that actually
+	// took it, so on a finished run this is where it executed. Empty for
+	// local-execution runs. Note this differs from the same-named field on a
+	// Workspace, which is always a projection of element 0.
+	AgentPoolID string `json:"agent-pool-id,omitempty"`
+	// Every pool that could have claimed the run, snapshotted at creation and
+	// preserved across the claim. Named apart from Workspace.AgentPoolIDs
+	// because that is the live configured set; this is a point-in-time
+	// snapshot that does not move when the workspace is later re-pointed.
+	CandidateAgentPoolIDs []string `json:"candidate-agent-pool-ids,omitempty"`
 	// VCS metadata (empty / nil for CLI runs).
 	VCSCommitSHA         string `json:"vcs-commit-sha,omitempty"`
 	VCSBranch            string `json:"vcs-branch,omitempty"`
@@ -331,14 +342,21 @@ func runFromResource(res *Resource) *Run {
 		HasCostEstimate:   GetBoolAttr(res, "has-cost-estimate"),
 		CostCurrency:      GetStringAttr(res, "cost-currency"),
 		WorkspaceName:     GetStringAttr(res, "workspace-name"),
-		VCSCommitSHA:      GetStringAttr(res, "vcs-commit-sha"),
-		VCSBranch:         GetStringAttr(res, "vcs-branch"),
-		CreatedBy:         GetStringAttr(res, "created-by"),
-		CreatedAt:         GetStringAttr(res, "created-at"),
-		UpdatedAt:         GetStringAttr(res, "updated-at"),
+		// #1231. The relationship below wins when present; the attribute is
+		// the fallback for a server that only emits the flat form.
+		AgentPoolID:           GetStringAttr(res, "agent-pool-id"),
+		CandidateAgentPoolIDs: GetListAttr(res, "candidate-agent-pool-ids"),
+		VCSCommitSHA:          GetStringAttr(res, "vcs-commit-sha"),
+		VCSBranch:             GetStringAttr(res, "vcs-branch"),
+		CreatedBy:             GetStringAttr(res, "created-by"),
+		CreatedAt:             GetStringAttr(res, "created-at"),
+		UpdatedAt:             GetStringAttr(res, "updated-at"),
 	}
 	if v := GetRelationshipID(res, "workspace"); v != "" {
 		r.WorkspaceID = v
+	}
+	if v := GetRelationshipID(res, "agent-pool"); v != "" {
+		r.AgentPoolID = v
 	}
 	r.PeakMemoryBytes = nullableInt(res, "peak-memory-bytes")
 	r.PeakCPUUsec = nullableInt(res, "peak-cpu-usec")

--- a/go-terrapod/runs_test.go
+++ b/go-terrapod/runs_test.go
@@ -22,6 +22,8 @@ const runAttrs = `{
   "has-cost-estimate":true,"cost-currency":"USD","cost-monthly-min":12.5,"cost-monthly-max":40.0,
   "peak-memory-bytes":536870912,"peak-cpu-usec":null,"runner-exit-code":0,
   "runner-exit-reason":"","workspace-name":"app",
+  "agent-pool-id":"apool-11111111-1111-1111-1111-111111111111",
+  "candidate-agent-pool-ids":["apool-11111111-1111-1111-1111-111111111111","apool-22222222-2222-2222-2222-222222222222"],
   "vcs-commit-sha":"abc123","vcs-branch":"main","vcs-pull-request-number":null,
   "created-by":"alice@example.com",
   "created-at":"2026-07-17T10:00:00Z","updated-at":"2026-07-17T10:05:00Z",
@@ -31,7 +33,7 @@ const runAttrs = `{
 
 func runPayload(id string) string {
 	return `{"data":{"id":"` + id + `","type":"runs","attributes":` + runAttrs +
-		`,"relationships":{"workspace":{"data":{"id":"ws-app","type":"workspaces"}}}}}`
+		`,"relationships":{"workspace":{"data":{"id":"ws-app","type":"workspaces"}},"agent-pool":{"data":{"id":"apool-11111111-1111-1111-1111-111111111111","type":"agent-pools"}}}}}`
 }
 
 func newRunsFixture(t *testing.T) *Client {
@@ -136,6 +138,14 @@ func TestGetRunParsesNativeFields(t *testing.T) {
 	// Workspace comes from the relationship.
 	if run.WorkspaceID != "ws-app" {
 		t.Errorf("workspace id: %q", run.WorkspaceID)
+	}
+	// Which pool ran it, and which could have (#1231).
+	if run.AgentPoolID != "apool-11111111-1111-1111-1111-111111111111" {
+		t.Errorf("agent-pool-id: %q", run.AgentPoolID)
+	}
+	if len(run.CandidateAgentPoolIDs) != 2 ||
+		run.CandidateAgentPoolIDs[0] != "apool-11111111-1111-1111-1111-111111111111" {
+		t.Errorf("candidate-agent-pool-ids: %+v", run.CandidateAgentPoolIDs)
 	}
 	// Terrapod-native fields go-tfe can't model.
 	if !run.HasJSONOutput {

--- a/go-terrapod/surface.golden
+++ b/go-terrapod/surface.golden
@@ -579,8 +579,10 @@ field RoleAssignment.Email string `json:"email"`
 field RoleAssignment.ProviderName string `json:"provider-name"`
 field RoleAssignment.RoleName string `json:"role-name"`
 field Run.Actions RunActions `json:"actions"`
+field Run.AgentPoolID string `json:"agent-pool-id,omitempty"`
 field Run.AllowEmptyApply bool `json:"allow-empty-apply"`
 field Run.AutoApply bool `json:"auto-apply"`
+field Run.CandidateAgentPoolIDs []string `json:"candidate-agent-pool-ids,omitempty"`
 field Run.CostCurrency string `json:"cost-currency,omitempty"`
 field Run.CostMonthlyMax *float64 `json:"cost-monthly-max,omitempty"`
 field Run.CostMonthlyMin *float64 `json:"cost-monthly-min,omitempty"`

--- a/mcp/internal/mcpserver/observe.go
+++ b/mcp/internal/mcpserver/observe.go
@@ -108,6 +108,9 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 		HasChanges *bool  `json:"has_changes,omitempty"`
 		Source     string `json:"source,omitempty"`
 		CreatedAt  string `json:"created_at,omitempty"`
+		// Which agent pool actually ran it (#1231) — on a multi-pool
+		// workspace this is the only place the answer is visible.
+		AgentPoolID string `json:"agent_pool_id,omitempty"`
 	}
 	type runListOut struct {
 		Count int          `json:"count"`
@@ -135,6 +138,7 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 			out.Runs = append(out.Runs, runSummary{
 				ID: r.ID, Status: r.Status, PlanOnly: r.PlanOnly, IsDestroy: r.IsDestroy,
 				HasChanges: r.HasChanges, Source: r.Source, CreatedAt: r.CreatedAt,
+				AgentPoolID: r.AgentPoolID,
 			})
 		}
 		return nil, out, nil
@@ -146,7 +150,7 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "terrapod_run_get",
-		Description: "Get one run's full status incl. Terrapod-native detail: has-changes, drift flag, error message, the resource profile (peak memory / runner exit), and which lifecycle actions (apply/discard/cancel) are currently permitted.",
+		Description: "Get one run's full status incl. Terrapod-native detail: has-changes, drift flag, error message, the resource profile (peak memory / runner exit), which agent pool executed it (and which pools could have), and which lifecycle actions (apply/discard/cancel) are currently permitted.",
 		Annotations: readOnly,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runGetIn) (*mcp.CallToolResult, *terrapod.Run, error) {
 		if in.RunID == "" {

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -61,7 +61,7 @@ from terrapod.db.models import (
 )
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
-from terrapod.services import agent_pool_service, plan_graph_service, run_service
+from terrapod.services import agent_pool_service, plan_graph_service, pool_set, run_service
 from terrapod.services.workspace_rbac_service import (
     resolve_workspace_capabilities_for,
 )
@@ -146,6 +146,27 @@ def _run_json(
                 "terragrunt-version": run.terragrunt_version,
                 "resource-cpu": run.resource_cpu,
                 "resource-memory": run.resource_memory,
+                # Which agent pool has this run (#1231). At creation this is
+                # element 0 of the workspace's pool set; on claim it is
+                # REWRITTEN to the pool that actually took it. So on a finished
+                # run this answers "where did this execute?" — which with
+                # multi-pool routing (#1085) is the first thing you want to know
+                # and was previously only visible in the database.
+                #
+                # Note this differs from the same-named attribute on a
+                # workspace, where it is always a projection of element 0. On a
+                # run it is the claimant. Null on local-execution runs, and on
+                # agent runs whose pool has since been deleted.
+                "agent-pool-id": (f"apool-{run.pool_id}" if run.pool_id else None),
+                # Every pool that COULD have claimed it, snapshotted at run
+                # creation and preserved (only re-ordered) across the claim.
+                # Deliberately named apart from the workspace's
+                # `agent-pool-ids`, because that is the live configured set
+                # and this is a point-in-time snapshot that does not move when
+                # the workspace is later re-pointed. Together with the
+                # attribute above: "these were the candidates, that one took
+                # it."
+                "candidate-agent-pool-ids": [f"apool-{p}" for p in pool_set.run_pool_ids(run)],
                 # Runner resource profile + OOM detection (#430). All
                 # nullable / empty-string for runs that pre-date the
                 # feature (or where the runner died before capturing).
@@ -233,6 +254,15 @@ def _run_json(
             "relationships": {
                 "workspace": {
                     "data": {"id": f"ws-{run.workspace_id}", "type": "workspaces"},
+                },
+                # The canonical link form for the pool that has the run; the
+                # `agent-pool-id` attribute above is kept alongside it (#1063).
+                "agent-pool": {
+                    "data": (
+                        {"id": f"apool-{run.pool_id}", "type": "agent-pools"}
+                        if run.pool_id
+                        else None
+                    ),
                 },
                 "configuration-version": {
                     "data": (

--- a/services/tests/api/api_attribute_contract.json
+++ b/services/tests/api/api_attribute_contract.json
@@ -483,8 +483,10 @@
   ],
   "runs._run_json": [
     "actions",
+    "agent-pool-id",
     "allow-empty-apply",
     "auto-apply",
+    "candidate-agent-pool-ids",
     "cost-currency",
     "cost-monthly-max",
     "cost-monthly-min",

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -1914,7 +1914,9 @@
       "prMr": "طلب السحب/الدمج",
       "stateVersion": "إصدار الحالة",
       "viewState": "عرض الحالة",
-      "runOptions": "خيارات التشغيل"
+      "runOptions": "خيارات التشغيل",
+      "agentPool": "مجموعة الوكلاء",
+      "agentPoolCandidates": "{count, plural, other {# مجموعة مرشحة}}"
     },
     "timeline": {
       "heading": "الجدول الزمني",

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Verze stavu",
       "viewState": "Zobrazit stav",
-      "runOptions": "Možnosti běhu"
+      "runOptions": "Možnosti běhu",
+      "agentPool": "Fond agentů",
+      "agentPoolCandidates": "{count, plural, one {# kandidátský fond} few {# kandidátské fondy} other {# kandidátských fondů}}"
     },
     "timeline": {
       "heading": "Časová osa",

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Fersiwn Cyflwr",
       "viewState": "Gweld y Cyflwr",
-      "runOptions": "Opsiynau Rhediad"
+      "runOptions": "Opsiynau Rhediad",
+      "agentPool": "Pwll asiant",
+      "agentPoolCandidates": "{count, plural, one {# pwll ymgeisydd} other {# pyllau ymgeisydd}}"
     },
     "timeline": {
       "heading": "Llinell Amser",

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Tilstandsversion",
       "viewState": "Vis tilstand",
-      "runOptions": "Kørselsindstillinger"
+      "runOptions": "Kørselsindstillinger",
+      "agentPool": "Agentpulje",
+      "agentPoolCandidates": "{count, plural, one {# kandidatpulje} other {# kandidatpuljer}}"
     },
     "timeline": {
       "heading": "Tidslinje",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Zustandsversion",
       "viewState": "Zustand anzeigen",
-      "runOptions": "Ausführungsoptionen"
+      "runOptions": "Ausführungsoptionen",
+      "agentPool": "Agent-Pool",
+      "agentPoolCandidates": "{count, plural, one {# Kandidaten-Pool} other {# Kandidaten-Pools}}"
     },
     "timeline": {
       "heading": "Zeitverlauf",

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "57473 V3r510n",
       "viewState": "V13w 57473",
-      "runOptions": "Run 0p710n5"
+      "runOptions": "Run 0p710n5",
+      "agentPool": "4g3n7 p00l",
+      "agentPoolCandidates": "{count, plural, one {# candidate pool} other {# candidate pools}}"
     },
     "timeline": {
       "heading": "71m3l1n3",

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "State Vershun",
       "viewState": "View State",
-      "runOptions": "Run Opshuns"
+      "runOptions": "Run Opshuns",
+      "agentPool": "Agent Poolz",
+      "agentPoolCandidates": "{count, plural, one {# candidat poolz} other {# candidat poolz}}"
     },
     "timeline": {
       "heading": "Timeline",

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -1914,7 +1914,9 @@
       "prMr": "Marklar/Marklar",
       "stateVersion": "Marklar Marklar",
       "viewState": "View Marklar",
-      "runOptions": "Marklar Marklars"
+      "runOptions": "Marklar Marklars",
+      "agentPool": "Marklar marklar",
+      "agentPoolCandidates": "{count, plural, one {# candidate marklar} other {# candidate marklars}}"
     },
     "timeline": {
       "heading": "Marklar",

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "State Version",
       "viewState": "View State",
-      "runOptions": "Run Options"
+      "runOptions": "Run Options",
+      "agentPool": "Agent crew",
+      "agentPoolCandidates": "{count, plural, one {# candidate crew} other {# candidate crews}}"
     },
     "timeline": {
       "heading": "Timeline",

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Version, State",
       "viewState": "State, View",
-      "runOptions": "Options, Run"
+      "runOptions": "Options, Run",
+      "agentPool": "Agent pool",
+      "agentPoolCandidates": "{count, plural, one {# candidate pool, there is} other {# candidate pools, there are}}"
     },
     "timeline": {
       "heading": "Timeline",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1920,7 +1920,9 @@
       "prMr": "PR/MR",
       "stateVersion": "State Version",
       "viewState": "View State",
-      "runOptions": "Run Options"
+      "runOptions": "Run Options",
+      "agentPool": "Agent pool",
+      "agentPoolCandidates": "{count, plural, one {# candidate pool} other {# candidate pools}}"
     },
     "timeline": {
       "heading": "Timeline",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Versión de estado",
       "viewState": "Ver estado",
-      "runOptions": "Opciones de ejecución"
+      "runOptions": "Opciones de ejecución",
+      "agentPool": "Grupo de agentes",
+      "agentPoolCandidates": "{count, plural, one {# grupo candidato} other {# grupos candidatos}}"
     },
     "timeline": {
       "heading": "Cronología",

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "نسخهٔ وضعیت",
       "viewState": "مشاهدهٔ وضعیت",
-      "runOptions": "گزینه‌های اجرا"
+      "runOptions": "گزینه‌های اجرا",
+      "agentPool": "استخر عامل",
+      "agentPoolCandidates": "{count, plural, other {# استخر نامزد}}"
     },
     "timeline": {
       "heading": "خط زمانی",

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Tilaversio",
       "viewState": "Näytä tila",
-      "runOptions": "Ajon vaihtoehdot"
+      "runOptions": "Ajon vaihtoehdot",
+      "agentPool": "Agenttiryhmä",
+      "agentPoolCandidates": "{count, plural, one {# ehdokasryhmä} other {# ehdokasryhmää}}"
     },
     "timeline": {
       "heading": "Aikajana",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Version d'état",
       "viewState": "Voir l'état",
-      "runOptions": "Options d'exécution"
+      "runOptions": "Options d'exécution",
+      "agentPool": "Pool d''agents",
+      "agentPoolCandidates": "{count, plural, one {# pool candidat} other {# pools candidats}}"
     },
     "timeline": {
       "heading": "Chronologie",

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "גרסת מצב",
       "viewState": "הצג מצב",
-      "runOptions": "אפשרויות הרצה"
+      "runOptions": "אפשרויות הרצה",
+      "agentPool": "מאגר סוכנים",
+      "agentPoolCandidates": "{count, plural, other {# מאגרים מועמדים}}"
     },
     "timeline": {
       "heading": "ציר זמן",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Versione dello stato",
       "viewState": "Visualizza stato",
-      "runOptions": "Opzioni di esecuzione"
+      "runOptions": "Opzioni di esecuzione",
+      "agentPool": "Pool di agenti",
+      "agentPoolCandidates": "{count, plural, one {# pool candidato} other {# pool candidati}}"
     },
     "timeline": {
       "heading": "Cronologia",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "状態バージョン",
       "viewState": "状態を表示",
-      "runOptions": "実行オプション"
+      "runOptions": "実行オプション",
+      "agentPool": "エージェントプール",
+      "agentPoolCandidates": "{count, plural, other {候補プール #件}}"
     },
     "timeline": {
       "heading": "タイムライン",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "상태 버전",
       "viewState": "상태 보기",
-      "runOptions": "실행 옵션"
+      "runOptions": "실행 옵션",
+      "agentPool": "에이전트 풀",
+      "agentPoolCandidates": "{count, plural, other {후보 풀 #개}}"
     },
     "timeline": {
       "heading": "타임라인",

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Versio Status",
       "viewState": "Statum Videre",
-      "runOptions": "Optiones Exsecutionis"
+      "runOptions": "Optiones Exsecutionis",
+      "agentPool": "Copia agentium",
+      "agentPoolCandidates": "{count, plural, one {# copia candidata} other {# copiae candidatae}}"
     },
     "timeline": {
       "heading": "Series Temporum",

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Tilstandsversjon",
       "viewState": "Vis tilstand",
-      "runOptions": "Kjøringsalternativer"
+      "runOptions": "Kjøringsalternativer",
+      "agentPool": "Agentgruppe",
+      "agentPoolCandidates": "{count, plural, one {# kandidatgruppe} other {# kandidatgrupper}}"
     },
     "timeline": {
       "heading": "Tidslinje",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "State-versie",
       "viewState": "State bekijken",
-      "runOptions": "Uitvoeringsopties"
+      "runOptions": "Uitvoeringsopties",
+      "agentPool": "Agentpool",
+      "agentPoolCandidates": "{count, plural, one {# kandidaat-pool} other {# kandidaat-pools}}"
     },
     "timeline": {
       "heading": "Tijdlijn",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Wersja stanu",
       "viewState": "Wyświetl stan",
-      "runOptions": "Opcje przebiegu"
+      "runOptions": "Opcje przebiegu",
+      "agentPool": "Pula agentów",
+      "agentPoolCandidates": "{count, plural, one {# pula kandydatów} few {# pule kandydatów} other {# pul kandydatów}}"
     },
     "timeline": {
       "heading": "Oś czasu",

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Versão do Estado",
       "viewState": "Ver Estado",
-      "runOptions": "Opções de Execução"
+      "runOptions": "Opções de Execução",
+      "agentPool": "Pool de agentes",
+      "agentPoolCandidates": "{count, plural, one {# pool candidato} other {# pools candidatos}}"
     },
     "timeline": {
       "heading": "Linha do Tempo",

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Versão do Estado",
       "viewState": "Ver Estado",
-      "runOptions": "Opções de Execução"
+      "runOptions": "Opções de Execução",
+      "agentPool": "Conjunto de agentes",
+      "agentPoolCandidates": "{count, plural, one {# conjunto candidato} other {# conjuntos candidatos}}"
     },
     "timeline": {
       "heading": "Cronologia",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Версия состояния",
       "viewState": "Просмотр состояния",
-      "runOptions": "Параметры запуска"
+      "runOptions": "Параметры запуска",
+      "agentPool": "Пул агентов",
+      "agentPoolCandidates": "{count, plural, one {# пул-кандидат} few {# пула-кандидата} other {# пулов-кандидатов}}"
     },
     "timeline": {
       "heading": "Хронология",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Tillståndsversion",
       "viewState": "Visa tillstånd",
-      "runOptions": "Körningsalternativ"
+      "runOptions": "Körningsalternativ",
+      "agentPool": "Agentpool",
+      "agentPoolCandidates": "{count, plural, one {# kandidatpool} other {# kandidatpooler}}"
     },
     "timeline": {
       "heading": "Tidslinje",

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Dotlh mI'",
       "viewState": "Dotlh legh",
-      "runOptions": "Sar wIvmey"
+      "runOptions": "Sar wIvmey",
+      "agentPool": "toy''wI'' ghom",
+      "agentPoolCandidates": "{count, plural, one {# ghom wIvlu''bogh} other {# ghom wIvlu''bogh}}"
     },
     "timeline": {
       "heading": "poH tlhegh",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Durum Sürümü",
       "viewState": "Durumu Görüntüle",
-      "runOptions": "Çalıştırma Seçenekleri"
+      "runOptions": "Çalıştırma Seçenekleri",
+      "agentPool": "Aracı havuzu",
+      "agentPoolCandidates": "{count, plural, other {# aday havuz}}"
     },
     "timeline": {
       "heading": "Zaman Çizelgesi",

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "Версія стану",
       "viewState": "Переглянути стан",
-      "runOptions": "Опції запуску"
+      "runOptions": "Опції запуску",
+      "agentPool": "Пул агентів",
+      "agentPoolCandidates": "{count, plural, one {# пул-кандидат} few {# пули-кандидати} other {# пулів-кандидатів}}"
     },
     "timeline": {
       "heading": "Хронологія",

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "状态版本",
       "viewState": "查看状态",
-      "runOptions": "运行选项"
+      "runOptions": "运行选项",
+      "agentPool": "代理池",
+      "agentPoolCandidates": "{count, plural, other {# 个候选池}}"
     },
     "timeline": {
       "heading": "时间线",

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -1914,7 +1914,9 @@
       "prMr": "PR/MR",
       "stateVersion": "狀態版本",
       "viewState": "檢視狀態",
-      "runOptions": "執行選項"
+      "runOptions": "執行選項",
+      "agentPool": "代理集區",
+      "agentPoolCandidates": "{count, plural, other {# 個候選集區}}"
     },
     "timeline": {
       "heading": "時間線",

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -50,6 +50,9 @@ interface RunAttrs {
   'discard-reason': string | null
   'error-message': string | null
   'execution-backend': string
+  // Which pool actually ran it, and which could have (#1231).
+  'agent-pool-id'?: string | null
+  'candidate-agent-pool-ids'?: string[]
   'created-at': string
   'auto-apply': boolean
   'plan-only': boolean
@@ -1443,6 +1446,26 @@ function RunDetailPageInner() {
               <dt className="text-xs text-slate-500">{t('details.source')}</dt>
               <dd className="mt-1 text-sm text-slate-200">{attrs.source}</dd>
             </div>
+            {attrs['agent-pool-id'] ? (
+              <div>
+                <dt className="text-xs text-slate-500">{t('details.agentPool')}</dt>
+                <dd className="mt-1 text-sm text-slate-200">
+                  <Link
+                    href={`/admin/agent-pools/${attrs['agent-pool-id']}`}
+                    className="hover:text-brand-400 transition-colors"
+                  >
+                    {attrs['agent-pool-id']}
+                  </Link>
+                  {(attrs['candidate-agent-pool-ids']?.length ?? 0) > 1 ? (
+                    <span className="block text-xs text-slate-500 mt-0.5">
+                      {t('details.agentPoolCandidates', {
+                        count: attrs['candidate-agent-pool-ids']!.length,
+                      })}
+                    </span>
+                  ) : null}
+                </dd>
+              </div>
+            ) : null}
             <div>
               <dt className="text-xs text-slate-500">{t('details.autoApply')}</dt>
               <dd className="mt-1 text-sm text-slate-200">{attrs['auto-apply'] ? t('common.yes') : t('common.no')}</dd>


### PR DESCRIPTION
With multi-pool routing (#1085) a queued run is offered to every pool in the
workspace's set at once, and whichever has a live listener claims it first. The
server already rewrites `run.pool_id` to the claiming pool on claim — but never
serialized it, so **"where did this run actually execute?" was not answerable
from the API**, only from the database.

## What's added to the run resource

| | |
|---|---|
| `agent-pool-id` | The pool that has the run. At creation, element 0 of the workspace's pool set; **after a claim, the pool that ran it**. `null` for local-execution runs |
| `candidate-agent-pool-ids` | Every pool that could have claimed it, snapshotted at creation and preserved (re-ordered, winner first) across the claim |
| `agent-pool` relationship | The canonical link form; the attribute is kept alongside it per the JSON:API house style (#1063) |

Together they answer "these were the candidates, that one took it."

## Two naming decisions worth flagging

Both are deliberate, and both are documented in `api-reference.md` so they don't
read as inconsistencies:

- **`agent-pool-id` means something different on a run than on a workspace.** On
  a workspace it is always a projection of `agent-pool-ids[0]` and carries no
  routing preference. On a run it is the *claimant*.
- **`candidate-agent-pool-ids` is named apart from the workspace's
  `agent-pool-ids`** because the workspace attribute is the live configured set,
  while the run attribute is a point-in-time snapshot that does not move when the
  workspace is later re-pointed at different pools.

## Consumers

Carried through per the API↔consumer contract: **go-terrapod** (prefers the
relationship, falls back to the attribute — mirroring how `WorkspaceID` is
decoded), the **MCP** `terrapod_run_get` / `terrapod_run_list` tools, the **run
detail page** (links to the pool, with a candidate count when there was more than
one), and **api-reference**. i18n filled for all 32 offered locales — including
the novelty locales, transformed per each dialect's style rather than copied, and
guarded against being left equal to the English source. `en-GB` is untouched
because it is a spelling-delta subset and these strings are identical in British
English.

## Contract

Purely additive: the attribute snapshot gains two entries and removes none, and
the go-terrapod surface golden gains two fields. MINOR-safe.

Verified: `make test` (4132 passed), `go build`/`go test` in go-terrapod and mcp,
`tsc --noEmit`, `i18n:check` (every locale complete + ICU-valid), `i18n:lint`.

Closes #1231