### PR TITLE
fix(1251): retry transient offer downloads in pricegen

### DIFF
--- a/pricegen/fetch_offers.py
+++ b/pricegen/fetch_offers.py
@@ -22,6 +22,8 @@ import argparse
 import json
 import os
 import shutil
+import time
+import ssl
 import sys
 import tempfile
 import urllib.parse
@@ -40,10 +42,54 @@ _AWS_BULK = "https://pricing.us-east-1.amazonaws.com"
 _BIG_OFFER_CACHE: dict[str, str] = {}
 
 
+#: Bounded retry for the offer downloads. These are large files (an EC2 region
+#: offer is hundreds of MB) pulled from public cloud endpoints, and a single
+#: transient reset used to fail the whole shard — and with it the fan-out and
+#: the weekly publish. Seen live: the 2026-07-27 run died on
+#: `ConnectionReset [Errno 104]` mid-TLS-handshake for one of ~36 regions.
+_RETRIES = 4
+_BACKOFF = 3.0  # seconds, doubled per attempt: 3, 6, 12
+
+
+def _urlopen_retrying(url: str, *, timeout: int = 300):
+    """`urlopen` with bounded backoff on transient failures.
+
+    Retries connection errors, timeouts, and 5xx/429. A definitive 4xx is a
+    real answer — a wrong URL or a withdrawn offer — so it raises immediately
+    rather than burning four attempts on it.
+    """
+    req = urllib.request.Request(url, headers=_UA)
+    for attempt in range(_RETRIES):
+        try:
+            return urllib.request.urlopen(req, timeout=timeout)  # noqa: S310 — pinned cloud hosts
+        except urllib.error.HTTPError as e:
+            if e.code < 500 and e.code != 429:
+                raise
+            last: Exception = e
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            ConnectionError,
+            ssl.SSLError,
+        ) as e:
+            last = e
+        if attempt == _RETRIES - 1:
+            raise RuntimeError(
+                f"giving up on {url} after {_RETRIES} attempts: {last!r}"
+            ) from last
+        delay = _BACKOFF * (2**attempt)
+        print(
+            f"  transient fetch failure ({last!r}); retrying in {delay:.0f}s "
+            f"[{attempt + 1}/{_RETRIES - 1}]",
+            file=sys.stderr,
+            flush=True,
+        )
+        time.sleep(delay)
+    raise AssertionError("unreachable")
+
+
 def _get_json(url: str) -> dict:
-    with urllib.request.urlopen(  # noqa: S310 — trusted pinned cloud hosts
-        urllib.request.Request(url, headers=_UA)
-    ) as resp:
+    with _urlopen_retrying(url) as resp:
         return json.load(resp)
 
 
@@ -77,9 +123,7 @@ def _stream_filter_aws(region_url: str, families: list, keep_attrs: dict) -> dic
         fd, tmp = tempfile.mkstemp(suffix=".json")
         os.close(fd)
         with (
-            urllib.request.urlopen(  # noqa: S310 — trusted pinned host
-                urllib.request.Request(region_url, headers=_UA)
-            ) as resp,
+            _urlopen_retrying(region_url) as resp,
             open(tmp, "wb") as out,
         ):
             shutil.copyfileobj(resp, out)  # stream to disk, low RAM

--- a/pricegen/tests/test_fetch_offers.py
+++ b/pricegen/tests/test_fetch_offers.py
@@ -8,6 +8,8 @@ is ABSENT (canonical "apply only where present") or its value is allowed.
 
 from __future__ import annotations
 
+import pytest
+
 import pricegen.fetch_offers as fo
 from pricegen.shard import ALL
 
@@ -182,3 +184,72 @@ def test_fetch_azure_all_regions_drops_filter(monkeypatch):
     out = fo.fetch_azure({"service_name": "Storage"}, ALL)
     assert "armRegionName" not in captured["url"]  # no region filter
     assert {i["armRegionName"] for i in out["Items"]} == {"eastus", "westus"}
+
+
+class TestUrlopenRetrying:
+    """Bounded retry around the offer downloads (#1251).
+
+    The weekly publish fans out to ~36 AWS regions, and every shard must
+    succeed for the pricesheet to be published. Before this, each download was
+    a bare `urlopen`, so one transient reset failed a shard and with it the
+    whole run — which is exactly what happened on 2026-07-27:
+    `ConnectionResetError [Errno 104]` mid-TLS-handshake for ap-southeast-2.
+
+    The offers are large (an EC2 region offer is hundreds of MB) and pulled
+    from public endpoints, so a mid-flight cut is not rare — it is the expected
+    failure mode at this size and fan-out.
+    """
+
+    @staticmethod
+    def _patch(monkeypatch, impl):
+        calls = {"n": 0}
+
+        def wrapped(req, timeout=None):
+            calls["n"] += 1
+            return impl(calls["n"])
+
+        monkeypatch.setattr(fo.urllib.request, "urlopen", wrapped)
+        monkeypatch.setattr(fo, "_BACKOFF", 0.001)
+        return calls
+
+    def test_recovers_from_a_transient_reset(self, monkeypatch):
+        sentinel = object()
+
+        def impl(n):
+            if n < 3:
+                raise fo.urllib.error.URLError(ConnectionResetError(104, "reset"))
+            return sentinel
+
+        calls = self._patch(monkeypatch, impl)
+        assert fo._urlopen_retrying("https://example.invalid/o.json") is sentinel
+        assert calls["n"] == 3
+
+    def test_gives_up_after_a_bounded_number_of_attempts(self, monkeypatch):
+        def impl(_n):
+            raise fo.urllib.error.URLError(ConnectionResetError(104, "reset"))
+
+        calls = self._patch(monkeypatch, impl)
+        with pytest.raises(RuntimeError, match="giving up"):
+            fo._urlopen_retrying("https://example.invalid/o.json")
+        assert calls["n"] == fo._RETRIES
+
+    def test_a_4xx_is_final_and_not_retried(self, monkeypatch):
+        """A 404 is a real answer — a withdrawn offer or a wrong URL. Retrying
+        it just delays a failure that will not change."""
+
+        def impl(_n):
+            raise fo.urllib.error.HTTPError("u", 404, "Not Found", {}, None)
+
+        calls = self._patch(monkeypatch, impl)
+        with pytest.raises(fo.urllib.error.HTTPError):
+            fo._urlopen_retrying("https://example.invalid/gone.json")
+        assert calls["n"] == 1
+
+    def test_a_5xx_is_retried(self, monkeypatch):
+        def impl(_n):
+            raise fo.urllib.error.HTTPError("u", 503, "Unavailable", {}, None)
+
+        calls = self._patch(monkeypatch, impl)
+        with pytest.raises(RuntimeError):
+            fo._urlopen_retrying("https://example.invalid/o.json")
+        assert calls["n"] == fo._RETRIES


### PR DESCRIPTION
The weekly pricesheet job has been failing since **2026-07-27**; the last
success was a manual dispatch on 07-23, so the published pricesheet is going
stale.

## Cause

One shard of ~36 failed — `generate (aws-ap-southeast-2)`, at "Fetch this
shard's offers":

```
File "pricegen/fetch_offers.py", line 129, in fetch_aws
File "pricegen/fetch_offers.py", line 44, in _get_json
  ...
  File ".../ssl.py", line 1372, in do_handshake
ConnectionResetError: [Errno 104] Connection reset by peer
```

A transient TLS reset. Both download sites were bare `urlopen` with **no
retry**:

- `_get_json` — the region index and small offers
- `_stream_filter_aws` — the big ones, and an EC2 region offer is hundreds of
  MB, so it's the most likely to be cut mid-flight

Every shard must succeed for the merge and publish to run, so a single reset
anywhere in a 36-way fan-out fails the entire weekly publish. At this size a
mid-flight cut isn't an anomaly — it's the expected failure mode.

It also contradicts the repo's own standing rule that *every outbound HTTP call
uses a bounded retry with backoff*. pricegen is a build-time tool rather than a
runtime process, so it sat outside where that rule was applied — but the
rationale is identical, and the cost of the omission was a stale pricesheet.

## Fix

`_urlopen_retrying` wrapping both sites: 4 attempts, 3s doubling, retrying
connection errors / timeouts / SSL errors / 5xx / 429.

**A definitive 4xx raises immediately.** A 404 is a real answer — a withdrawn
offer or a wrong URL — and retrying it only delays a failure that will not
change, while making a genuine config error look like a network problem.

## Tests

Four cases in `pricegen/tests/test_fetch_offers.py`, each asserting the attempt
count so the bound is real and not incidental:

| | |
|---|---|
| recovers from a transient reset | succeeds on attempt 3 |
| gives up bounded | exactly `_RETRIES` attempts, then `RuntimeError` |
| 4xx is final | **1** attempt, re-raises `HTTPError` |
| 5xx is retried | `_RETRIES` attempts |

`python -m pytest pricegen/tests` — 113 passed. `ruff check pricegen/` clean
(note pricegen sits outside the pre-commit hook's scope, so it was linted
explicitly).

## After merge

I'll dispatch the workflow manually rather than waiting a week, so the
pricesheet is refreshed and the fix is confirmed against the real endpoints.

Closes #1251