### PR TITLE
feat(1253): delete markers + orphaned-state reaper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -778,6 +778,31 @@ jobs:
           fi
           echo "all third-party images are overridable, and every mirror ref is listed"
 
+      - name: Every retention key in values.yaml reaches the rendered ConfigMap
+        run: |
+          # Leg 3 of the config-channel contract. A key can be in values.yaml
+          # and in values.schema.json and still be inert, because the operator
+          # sets it, it never reaches the pod, and the code default silently
+          # wins — the failure is invisible until someone notices retention
+          # didn't do what they configured. Grep the RENDERED output, not the
+          # template text, which is what catches a missing render line.
+          docker run --rm -v "$PWD:/chart" -w /chart "${HELM_IMAGE:-alpine/helm:3.17.2}" \
+            template terrapod helm/terrapod \
+            --set postgresql.url=postgresql+asyncpg://t:t@db:5432/terrapod \
+            --set redis.url=redis://redis:6379 > /tmp/rendered.yaml
+          keys=$(awk '/^    artifact_retention:/{f=1;next} f&&/^      [a-z_]+:/{gsub(/:.*/,"");gsub(/ /,"");print} f&&/^    [a-z]/{exit}' helm/terrapod/values.yaml)
+          if [ -z "$keys" ]; then echo "no artifact_retention keys found — check the awk filter"; exit 1; fi
+          missing=""
+          for k in $keys; do
+            grep -q "^ *$k:" /tmp/rendered.yaml || missing="$missing $k"
+          done
+          if [ -n "$missing" ]; then
+            echo "These retention values never reach the pod — add a render line"
+            echo "to templates/configmap-api.yaml:$missing"
+            exit 1
+          fi
+          echo "all retention keys render:" $keys
+
       - name: Two installs in one cluster cannot collide on a cluster-scoped name
         run: |
           # Terrapod is single-organization, so separating business units means

--- a/docs/artifact-retention.md
+++ b/docs/artifact-retention.md
@@ -17,6 +17,7 @@ When enabled, a daily background task (via the distributed scheduler) iterates s
 | **Provider cache** | `provider_cache_retention_days` | 30 days | Cached upstream provider binaries not accessed within the retention window |
 | **Binary cache** | `binary_cache_retention_days` | 30 days | Cached terraform/tofu CLI binaries not accessed within the retention window |
 | **Module overrides** | `module_overrides_retention_days` | 14 days | Module impact analysis override tarballs from completed speculative runs |
+| **Deleted workspaces** | `deleted_workspace_retention_days` | 30 days | State left behind by a deleted workspace, once it has been recoverable for the full window |
 
 Set any per-category value to `0` to disable cleanup for that category.
 
@@ -40,6 +41,7 @@ api:
       provider_cache_retention_days: 30    # days since last access before provider cache entry is deleted
       binary_cache_retention_days: 30      # days since last access before binary cache entry is deleted
       module_overrides_retention_days: 14  # days before module override tarballs are deleted
+      deleted_workspace_retention_days: 30 # days a deleted workspace's state stays recoverable
 ```
 
 ### Enabled by Default
@@ -82,6 +84,40 @@ The retention system enforces several invariants to prevent data loss:
 
 - **Only overrides from terminal runs are deleted.** Active speculative runs retain their override tarballs.
 - The `module_overrides` JSONB field on the run is set to `NULL` after storage objects are deleted.
+
+### Deleted Workspaces
+
+Deleting a workspace CASCADEs its `StateVersion` rows away but leaves the state
+blobs at `state/{workspace_id}/`. Every other category above finds its blobs
+*through* those rows, so before this existed the state of every deleted
+workspace was invisible to retention and occupied storage permanently.
+
+The orphan set is therefore computed by listing the `state/` prefixes present in
+storage and subtracting the workspaces that still exist. Three invariants:
+
+- **Discovery stamps, it never deletes.** An orphan with no delete marker gets
+  one written, dated now, and is left alone until a later cycle. So nothing is
+  ever reaped that has not been *visible as recoverable* for the full retention
+  window — including workspaces deleted before this feature shipped, whose clock
+  starts at discovery rather than retroactively.
+- **The window is measured from the marker body**, not from any object's
+  modification time. Dating from the newest blob would expire a workspace that
+  was last applied months before someone deleted it, giving no window at all;
+  and a replicated object arrives on a standby with a fresh `LastModified`,
+  which would reset the clock on every replication cycle.
+- **A prefix with surviving `StateVersion` rows is never reaped**, and neither
+  is one that is back in the live set because the workspace was restored.
+
+Set `deleted_workspace_retention_days: 0` to disable reaping entirely; markers
+are still written, so deleted workspaces remain discoverable and their state is
+kept indefinitely.
+
+The marker itself (`state/deleted/{workspace_id}.json`) records the workspace's
+name, deletion time and actor, its state serial and lineage, its settings
+(labels, ownership, execution mode, VCS wiring) and its **variable names** — so
+an operator can tell what was lost and what to recreate. It contains **no
+secrets**: variable *values* are never written, and the VCS connection is
+referenced by id only.
 
 ### Best-Effort Deletes
 

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -440,6 +440,7 @@ data:
       provider_cache_retention_days: {{ .Values.api.config.artifact_retention.provider_cache_retention_days | default 30 }}
       binary_cache_retention_days: {{ .Values.api.config.artifact_retention.binary_cache_retention_days | default 30 }}
       module_overrides_retention_days: {{ .Values.api.config.artifact_retention.module_overrides_retention_days | default 14 }}
+      deleted_workspace_retention_days: {{ .Values.api.config.artifact_retention.deleted_workspace_retention_days | default 30 }}
     {{- end }}
     {{- if .Values.backup }}
     backup:

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -2388,6 +2388,10 @@
             "module_overrides_retention_days": {
               "type": "integer",
               "minimum": 0
+            },
+            "deleted_workspace_retention_days": {
+              "type": "integer",
+              "minimum": 0
             }
           }
         },
@@ -2539,7 +2543,11 @@
               "properties": {
                 "mode": {
                   "type": "string",
-                  "enum": ["off", "verify", "copy"]
+                  "enum": [
+                    "off",
+                    "verify",
+                    "copy"
+                  ]
                 },
                 "interval_seconds": {
                   "type": "integer",
@@ -2562,9 +2570,13 @@
                   "type": "object",
                   "additionalProperties": false,
                   "patternProperties": {
-                    "^(state|state_index|configuration_versions|registry_modules|registry_providers|run_logs|run_plans|run_vars|provider_cache|binary_cache|platform_provider_cache|cost_pricesheet|vcs_archives|module_overrides)$": {
+                    "^(state|state_index|configuration_versions|registry_modules|registry_providers|deleted_workspace_markers|run_logs|run_plans|run_vars|provider_cache|binary_cache|platform_provider_cache|cost_pricesheet|vcs_archives|module_overrides)$": {
                       "type": "string",
-                      "enum": ["off", "verify", "copy"]
+                      "enum": [
+                        "off",
+                        "verify",
+                        "copy"
+                      ]
                     }
                   }
                 }

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -522,7 +522,8 @@ api:
         # you configured sitting on the default. Known names:
         #   irreplaceable — state, state_index, configuration_versions,
         #                   registry_modules, registry_providers
-        #   history       — run_logs, run_plans, run_vars
+        #   history       — run_logs, run_plans, run_vars,
+        #                   deleted_workspace_markers
         #   re-derivable  — provider_cache, binary_cache,
         #                   platform_provider_cache, cost_pricesheet,
         #                   vcs_archives, module_overrides
@@ -939,6 +940,9 @@ api:
       provider_cache_retention_days: 30   # days since last access
       binary_cache_retention_days: 30     # days since last access
       module_overrides_retention_days: 14
+      # Undelete window (#1253). State of a deleted workspace is kept this
+      # long so an accidental deletion can be undone; 0 = keep forever.
+      deleted_workspace_retention_days: 30
 
     # CORS
     cors:

--- a/pentest/npm-audit-allow.txt
+++ b/pentest/npm-audit-allow.txt
@@ -6,21 +6,16 @@
 #
 # Consumed by the `npm-audit` job in ci.yml (the release gate) and by
 # release-rescan.yml. One file so the two can never drift apart.
-
-# GHSA-mh99-v99m-4gvg — brace-expansion ReDoS.
 #
-# A devDependency only (eslint -> minimatch -> brace-expansion): it never sees
-# runtime or user input, and none of it ships in a published image.
+# Currently empty. GHSA-mh99-v99m-4gvg (brace-expansion ReDoS) lived here and
+# was removed on 2026-08-04, fixed rather than accepted — see #1058. It is
+# worth recording *how*, because the entry's own stated exit was wrong and
+# following it would have kept the accepted risk indefinitely: it predicted the
+# fix required brace-expansion 5.0.8, whose export shape breaks the eslint
+# chain's minimatch, and that we were therefore blocked on @eslint/config-array.
+# Upstream instead backported to 2.1.4, so pinning `brace-expansion: ^2.1.4` in
+# web/package.json overrides clears it with eslint untouched.
 #
-# Patched only in brace-expansion 5.0.8, whose new export shape breaks the
-# eslint chain's minimatch. RE-TESTED 2026-08-01 against eslint 10.8.0, which
-# was the presumed fix path: it does NOT resolve this — `npm run lint` on
-# eslint 10 dies with the same `(0, brace_expansion_1.expand) is not a
-# function` inside @eslint/config-array's bundled minimatch. Don't re-run that
-# experiment without first checking @eslint/config-array's minimatch pin.
-#
-# Tracked in #1058.
-#
-# EXIT: @eslint/config-array ships a minimatch that works with
-# brace-expansion >= 5.0.8.
-GHSA-mh99-v99m-4gvg
+# The general lesson for anything added here: an exit condition is a guess
+# about how upstream will fix it. Re-read the advisory's own affected/patched
+# ranges each cycle rather than only re-testing the exit you wrote down.

--- a/services/pyproject-listener.toml
+++ b/services/pyproject-listener.toml
@@ -3,7 +3,7 @@ name = "terrapod-listener"
 version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
-    "cryptography>=48.0.1,<49.0.0",
+    "cryptography>=50.0.0,<51.0.0",
     "httpx>=0.28",
     "kubernetes>=35.0",
     "prometheus-client>=0.24",

--- a/services/pyproject-migrations.toml
+++ b/services/pyproject-migrations.toml
@@ -20,4 +20,11 @@ dependencies = [
     "botocore>=1.34",
     "google-auth>=2.28",
     "azure-identity>=1.21",
+    # Pin cryptography forward for CVE-2026-69247 (PKCS#7 EnvelopedData
+    # decryption exposes a Bleichenbacher oracle; affects 44.0.0 to 49.x).
+    # It arrives transitively via azure-identity/google-auth, so without an
+    # explicit floor this image keeps resolving an affected version even
+    # though the API and listener have moved — same shape as the Mako pin
+    # above. Migrations do no PKCS#7 work; this is defence in depth.
+    "cryptography>=50.0.0",
 ]

--- a/services/pyproject-runner.toml
+++ b/services/pyproject-runner.toml
@@ -17,4 +17,9 @@ dependencies = [
     # standard-imghdr backfills the stdlib imghdr pgpy imports (removed in 3.13).
     "pgpy>=0.6.0",
     "standard-imghdr>=3.13",
+    # Pin cryptography forward for CVE-2026-69247 (see the migrations
+    # pyproject). It arrives transitively via pgpy, which the runner uses for
+    # signature verification only — never PKCS#7 decryption — so this is
+    # defence in depth, but the image should not ship an affected version.
+    "cryptography>=50.0.0",
 ]

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -47,7 +47,7 @@ redis = ">=7.4,<9.0"
 # Auth
 authlib = "^1.4.0"
 python3-saml = "^1.16.0"
-cryptography = ">=46.0.5,<50.0.0"
+cryptography = ">=50.0.0,<51.0.0"
 zxcvbn = "^4.4.28"
 python-multipart = ">=0.0.26,<0.0.33"
 # Kubernetes (runner listener)

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -1900,9 +1900,22 @@ async def delete_workspace(
             ),
         )
     ws_name = ws.name
+    ws_id = str(ws.id)
+
+    # Build the undelete marker BEFORE the delete, while the row and its
+    # variables/state-versions are still readable (#1253). The write itself
+    # happens after the commit — a marker for a workspace that then failed to
+    # delete would be a lie, and the delete must not fail because storage is
+    # briefly unavailable.
+    from terrapod.services import deleted_workspace_service as dws
+
+    marker = await dws.build_marker(db, ws, deleted_by=user.email)
+
     await db.delete(ws)
     await db.commit()
     logger.info("Workspace deleted", workspace=ws_name)
+
+    await dws.write_marker_best_effort(ws_id, marker)
 
     # Best-effort remove from DR state index
     await _remove_state_index_entry(ws_name)

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -1183,6 +1183,16 @@ class ArtifactRetentionConfig(BaseModel):
         default=20,
         description="Number of state versions to keep per workspace (0 = disabled)",
     )
+    deleted_workspace_retention_days: int = Field(
+        default=30,
+        description=(
+            "Days to keep the state of a DELETED workspace before reaping it, so "
+            "an accidental deletion can still be undone (0 = keep forever). The "
+            "clock starts when the workspace is deleted, or when the reaper first "
+            "observes an orphan it has no marker for — never from the last state "
+            "write, which would give a long-idle workspace no window at all."
+        ),
+    )
     run_artifacts_retention_days: int = Field(
         default=90,
         description="Days to keep run logs + plans for terminal runs (0 = disabled)",
@@ -1423,6 +1433,7 @@ BLOB_CLASS_NAMES: tuple[str, ...] = (
     "configuration_versions",
     "registry_modules",
     "registry_providers",
+    "deleted_workspace_markers",
     "run_logs",
     "run_plans",
     "run_vars",

--- a/services/terrapod/services/artifact_retention_service.py
+++ b/services/terrapod/services/artifact_retention_service.py
@@ -15,6 +15,7 @@ Safety invariants:
 """
 
 import time
+import uuid
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, select
@@ -74,6 +75,11 @@ async def artifact_retention_cycle() -> None:
                 "vcs_archives",
                 _cleanup_vcs_archives,
                 settings.vcs.archive_cache_retention_days,
+            ),
+            (
+                "deleted_workspaces",
+                _cleanup_deleted_workspaces,
+                cfg.deleted_workspace_retention_days,
             ),
         ]
 
@@ -583,3 +589,116 @@ async def _cleanup_vcs_archives(
         RETENTION_DELETED.labels(category="vcs_archives").inc(deleted)
 
     return deleted
+
+
+async def _cleanup_deleted_workspaces(
+    db: AsyncSession,
+    storage: ObjectStore,
+    retention_days: int,
+    batch_size: int,
+) -> int:
+    """Reap state left behind by deleted workspaces (#1253).
+
+    Every other category here walks DB rows and deletes the blobs they point
+    at. This one cannot: deleting a workspace CASCADEs its `StateVersion` rows
+    away, so by the time the state is garbage there is no row left to find it
+    from. Its blobs become permanently invisible to the row-driven reaper —
+    which is why, before this existed, every workspace ever deleted still
+    occupied storage forever.
+
+    So the orphan set is computed the only way still available: list the state
+    prefixes present in storage, subtract the workspaces that still exist.
+
+    **Discovery stamps; it never deletes.** An orphan with no marker gets one
+    written dated now, and is left alone until a later cycle. That is what
+    makes the retention window mean something: nothing is reaped that has not
+    been *visible as recoverable* for the full window. Dating from the newest
+    blob instead would expire a workspace that was last applied months before
+    someone deleted it, giving no undelete window at all — and a workspace
+    deleted before this feature shipped would be reaped on the first cycle.
+    """
+    from terrapod.services import deleted_workspace_service as dws
+    from terrapod.storage.keys import DELETED_MARKER_PREFIX
+
+    # Prefixes look like `state/{workspace_id}/{version}.tfstate`. The marker
+    # prefix and the DR index live under `state/` too and are not workspaces.
+    seen: set[str] = set()
+    for obj in await storage.list_prefix("state/"):
+        key = obj.key
+        if key.startswith(DELETED_MARKER_PREFIX) or "/" not in key[len("state/") :]:
+            continue
+        candidate = key[len("state/") :].split("/", 1)[0]
+        # `Workspace.id` is a UUID column, so a stray non-UUID directory would
+        # raise on bind and — swallowed by this cycle's per-category except —
+        # silently kill the reaper for good. Skip anything unparseable rather
+        # than letting one junk prefix disable reaping for every workspace.
+        try:
+            uuid.UUID(candidate)
+        except ValueError:
+            logger.warning("Ignoring non-UUID prefix under state/", prefix=candidate)
+            continue
+        seen.add(candidate)
+
+    if not seen:
+        return 0
+
+    live = {
+        str(w)
+        for w in (await db.execute(select(Workspace.id).where(Workspace.id.in_(seen)))).scalars()
+    }
+    orphans = sorted(seen - live)
+
+    now = datetime.now(UTC)
+    reaped = 0
+    for ws_id in orphans[:batch_size]:
+        marker = await dws.read_marker(storage, ws_id)
+
+        if marker is None:
+            # First sight (or an unreadable marker): start the clock, delete
+            # nothing this cycle.
+            await dws.write_marker(storage, ws_id, dws.build_discovery_marker(ws_id, now))
+            logger.info("Stamped orphaned workspace state for retention", workspace_id=ws_id)
+            continue
+
+        age = dws.marker_age_days(marker, now)
+        if age is None:
+            # A marker we cannot date is treated as unstamped rather than as
+            # expired — re-stamping restarts the window instead of reaping now.
+            await dws.write_marker(storage, ws_id, dws.build_discovery_marker(ws_id, now))
+            continue
+        if age < retention_days:
+            continue
+
+        # Belt and braces against a listing/DB skew: never reap a prefix that
+        # still has a live state-version row.
+        still_referenced = (
+            await db.execute(
+                select(StateVersion.id).where(StateVersion.workspace_id == ws_id).limit(1)
+            )
+        ).scalar_one_or_none()
+        if still_referenced is not None:
+            logger.warning(
+                "Orphan still has state-version rows — not reaping",
+                workspace_id=ws_id,
+            )
+            continue
+
+        for obj in await storage.list_prefix(f"state/{ws_id}/"):
+            try:
+                await storage.delete(obj.key)
+            except Exception as e:  # noqa: BLE001 — best-effort, matches this module
+                logger.warning("Failed to delete orphaned state object", key=obj.key, error=str(e))
+        try:
+            await storage.delete(dws.deleted_workspace_marker_key(ws_id))
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Failed to delete marker", workspace_id=ws_id, error=str(e))
+
+        logger.info(
+            "Reaped state for deleted workspace past its retention window",
+            workspace_id=ws_id,
+            workspace_name=marker.get("workspace_name"),
+            age_days=round(age, 1),
+        )
+        reaped += 1
+
+    return reaped

--- a/services/terrapod/services/blob_classes.py
+++ b/services/terrapod/services/blob_classes.py
@@ -329,6 +329,30 @@ CLASSES: tuple[BlobClass, ...] = (
         resolver=_resolve_provider_binaries,
     ),
     BlobClass(
+        name="deleted_workspace_markers",
+        # HISTORY, not IRREPLACEABLE, and the reason is the readiness report
+        # rather than sentiment about the data. `irreplaceable_unchecked` is
+        # what makes `irreplaceable_missing` trustworthy before a failover, and
+        # a class that cannot be verified from rows sits in it permanently — so
+        # registering this one as irreplaceable would put a line an operator can
+        # never clear into the list they are meant to read, and train them to
+        # ignore it. What is genuinely irreplaceable here is the state the
+        # marker points at, and that is already covered by the `state` class.
+        #
+        # Its own prefix rather than living inside `state/` (#1253): `state` is
+        # `encrypted_at_rest`, which replication declines wholesale when
+        # app-layer encryption is on. A marker nested there would inherit that
+        # and leave an encrypted deployment's standby with no undelete index at
+        # all — the one thing this class exists to carry.
+        tier=HISTORY,
+        prefixes=(keys.DELETED_MARKER_PREFIX,),
+        unverifiable_reason=(
+            "A marker's whole point is that the workspace it names no longer has "
+            "rows — there is nothing left to promise it exists, so an absent one "
+            "is not a finding."
+        ),
+    ),
+    BlobClass(
         name="run_logs",
         tier=HISTORY,
         prefixes=("logs/",),

--- a/services/terrapod/services/deleted_workspace_service.py
+++ b/services/terrapod/services/deleted_workspace_service.py
@@ -1,0 +1,236 @@
+"""Delete markers for workspace undelete (#1253).
+
+Deleting a workspace removes its rows — `StateVersion` goes by CASCADE — but
+**nothing removes the state blobs**. They stay at `state/{workspace_id}/…`
+indefinitely. So the data survives a delete; what is destroyed is the index
+saying which id had which name.
+
+That has two consequences this module addresses together, because they are the
+same fact seen from two sides:
+
+  * a workspace deleted by mistake is recoverable in principle and unfindable
+    in practice; and
+  * `artifact_retention_service` reaps state by walking `StateVersion` **rows**,
+    so once CASCADE removes them the blobs are permanently unreachable by the
+    reaper — every workspace ever deleted still occupies storage, forever.
+
+A marker written at delete time fixes both: it names the workspace, dates the
+deletion, and gives the reaper something to age.
+
+**The marker body is the contract, not its object metadata and not its
+mtime.** `blob_sync._copy_one` streams a replicated object in with no
+`metadata=` and the destination stamps a fresh `last_modified`, so anything
+carried outside the body is lost or falsified on a standby — a marker dated by
+mtime would read as "deleted just now" after every replication cycle and never
+age out. The body is the one thing replication copies faithfully and
+size-verifies.
+
+**No secrets, ever.** This object lands in the bucket, replicates to a peer, and
+is readable by anyone with storage access. Variable *values* never go in — only
+their names, which is what an operator needs to know what to recreate. The VCS
+connection is referenced by id; its credential is never copied here.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from terrapod.db.models import StateVersion, Variable, Workspace
+from terrapod.logging_config import get_logger
+from terrapod.storage import get_storage
+from terrapod.storage.keys import deleted_workspace_marker_key
+from terrapod.storage.protocol import ObjectNotFoundError, ObjectStore
+
+logger = get_logger(__name__)
+
+#: Bumped only on a breaking change to the body shape. A reader that does not
+#: recognise the version still gets `deleted_at` and `workspace_name`, which
+#: are the two fields the undelete list cannot work without — so keep those at
+#: the top level of every future version.
+MARKER_VERSION = 1
+
+#: Written by the delete path, with a true deletion timestamp.
+REASON_DELETED = "deleted"
+#: Written by the reaper on first sight of an orphan it has no marker for —
+#: a workspace deleted before this shipped, or one whose marker write failed.
+#: `deleted_at` is then the discovery time, not the real deletion time, which
+#: is why the two reasons are distinguishable.
+REASON_DISCOVERED = "discovered-orphaned"
+
+
+def _settings_snapshot(ws: Workspace) -> dict[str, Any]:
+    """The workspace's own configuration, as it was at delete time.
+
+    Restoring these is what makes an undelete useful rather than merely a state
+    recovery — labels and ownership especially, since those are what a
+    workspace is found by afterwards.
+
+    Every field here is non-secret by construction. Nothing that holds or
+    references a credential value belongs in this dict; `vcs_connection_id` is
+    a pointer to a connection whose token stays in the database.
+    """
+    return {
+        "labels": dict(ws.labels or {}),
+        "owner_email": ws.owner_email,
+        "execution_mode": ws.execution_mode,
+        "execution_backend": ws.execution_backend,
+        "terraform_version": ws.terraform_version,
+        "terragrunt_enabled": ws.terragrunt_enabled,
+        "terragrunt_version": ws.terragrunt_version,
+        "working_directory": ws.working_directory,
+        "var_files": list(ws.var_files or []),
+        "resource_cpu": ws.resource_cpu,
+        "resource_memory": ws.resource_memory,
+        "auto_apply": ws.auto_apply,
+        "vcs_connection_id": str(ws.vcs_connection_id) if ws.vcs_connection_id else None,
+        "vcs_repo_url": ws.vcs_repo_url,
+        "vcs_branch": ws.vcs_branch,
+        "vcs_workflow": ws.vcs_workflow,
+        "drift_detection_enabled": ws.drift_detection_enabled,
+        "drift_detection_interval_seconds": ws.drift_detection_interval_seconds,
+        "drift_ignore_rules": list(ws.drift_ignore_rules or []),
+    }
+
+
+async def build_marker(db: AsyncSession, ws: Workspace, deleted_by: str) -> dict[str, Any]:
+    """Assemble the marker body for a workspace about to be deleted."""
+    latest = (
+        await db.execute(
+            select(StateVersion)
+            .where(StateVersion.workspace_id == ws.id)
+            .order_by(StateVersion.serial.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    count = len(
+        (await db.execute(select(StateVersion.id).where(StateVersion.workspace_id == ws.id)))
+        .scalars()
+        .all()
+    )
+
+    # Names only — never values. A sensitive variable's value is encrypted at
+    # rest and must not be decrypted into a plaintext object in the bucket.
+    variables = (
+        (await db.execute(select(Variable).where(Variable.workspace_id == ws.id))).scalars().all()
+    )
+
+    return {
+        "marker_version": MARKER_VERSION,
+        "marker_reason": REASON_DELETED,
+        "workspace_id": str(ws.id),
+        "workspace_name": ws.name,
+        "deleted_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "deleted_by": deleted_by,
+        "last_serial": latest.serial if latest else None,
+        "lineage": latest.lineage if latest else None,
+        "state_version_count": count,
+        "settings": _settings_snapshot(ws),
+        "variable_names": [
+            {"key": v.key, "category": v.category, "sensitive": v.sensitive} for v in variables
+        ],
+    }
+
+
+def build_discovery_marker(
+    workspace_id: str, observed_at: datetime | None = None
+) -> dict[str, Any]:
+    """Marker for an orphan the reaper found with no marker of its own.
+
+    The retention clock has to start somewhere, and the only defensible choice
+    is when we first saw it: the newest blob's mtime is the last *state write*,
+    which for a workspace last applied months before it was deleted would make
+    it instantly reapable and give no undelete window at all.
+
+    Starting at discovery means a pre-existing orphan gets the full window from
+    the moment this feature ships, rather than being retroactively expired.
+    """
+    ts = observed_at or datetime.now(UTC)
+    return {
+        "marker_version": MARKER_VERSION,
+        "marker_reason": REASON_DISCOVERED,
+        "workspace_id": workspace_id,
+        "workspace_name": None,
+        "deleted_at": ts.isoformat().replace("+00:00", "Z"),
+        "deleted_by": None,
+        "last_serial": None,
+        "lineage": None,
+        "settings": {},
+        "variable_names": [],
+    }
+
+
+async def write_marker_best_effort(workspace_id: str, body: dict[str, Any]) -> None:
+    """Write a marker without letting any failure reach the caller.
+
+    The delete has already committed by the time this runs, so raising here
+    would return a 500 for a workspace that *is* gone — the operator retries,
+    gets a 404, and is left believing the delete failed. Resolving the store is
+    inside the guard too: an unconfigured or unavailable store must degrade to
+    "no marker" (the reaper stamps it on a later cycle), never to a failed
+    delete.
+    """
+    try:
+        await write_marker(get_storage(), workspace_id, body)
+    except Exception as e:  # noqa: BLE001 — a half-failed delete is worse
+        logger.warning(
+            "Could not write workspace delete marker",
+            workspace_id=workspace_id,
+            error=str(e),
+        )
+
+
+async def write_marker(storage: ObjectStore, workspace_id: str, body: dict[str, Any]) -> None:
+    """Persist a marker. Best-effort: a failure must not fail the delete."""
+    try:
+        await storage.put(
+            deleted_workspace_marker_key(workspace_id),
+            json.dumps(body, indent=2).encode(),
+            content_type="application/json",
+        )
+    except Exception as e:  # noqa: BLE001 — a delete that half-fails is worse
+        logger.warning(
+            "Failed to write workspace delete marker — the workspace is deleted but "
+            "will show as an undated orphan until the reaper stamps it",
+            workspace_id=workspace_id,
+            error=str(e),
+        )
+
+
+async def read_marker(storage: ObjectStore, workspace_id: str) -> dict[str, Any] | None:
+    """Read a marker, or None if there isn't one (or it is unreadable)."""
+    try:
+        raw = await storage.get(deleted_workspace_marker_key(workspace_id))
+    except ObjectNotFoundError:
+        return None
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Delete marker unreadable", workspace_id=workspace_id, error=str(e))
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError) as e:
+        # A corrupt marker must not make an orphan immortal, but it must not
+        # make it instantly reapable either — the caller treats None as
+        # "unstamped" and writes a fresh discovery marker, restarting the clock.
+        logger.warning("Delete marker is not valid JSON", workspace_id=workspace_id, error=str(e))
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def marker_age_days(body: dict[str, Any], now: datetime | None = None) -> float | None:
+    """Age of a marker in days, or None if it carries no usable timestamp."""
+    raw = body.get("deleted_at")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        ts = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ((now or datetime.now(UTC)) - ts).total_seconds() / 86400.0

--- a/services/terrapod/storage/keys.py
+++ b/services/terrapod/storage/keys.py
@@ -11,6 +11,27 @@ def state_index_key() -> str:
     return "state/index.yaml"
 
 
+#: Prefix for workspace delete markers (#1253). Deliberately a FLAT prefix
+#: rather than a marker nested inside each workspace's `state/{id}/`:
+#:
+#:   * the `state` blob class is `encrypted_at_rest`, and replication declines
+#:     that whole class when app-layer encryption is on — a nested marker would
+#:     inherit that and leave an encrypted deployment's standby with no
+#:     undelete index at all;
+#:   * markers are tiny, so they can be `copy`-replicated even where state
+#:     itself is `verify`-only;
+#:   * listing the undelete set is one flat listing rather than a walk over
+#:     every workspace prefix, and the restore path can copy a workspace's
+#:     state prefix wholesale without dragging a marker into the workspace it
+#:     just restored.
+DELETED_MARKER_PREFIX = "state/deleted/"
+
+
+def deleted_workspace_marker_key(workspace_id: str) -> str:
+    """Key for a deleted workspace's marker."""
+    return f"{DELETED_MARKER_PREFIX}{workspace_id}.json"
+
+
 def state_key(workspace_id: str, version_id: str) -> str:
     """Key for a workspace state version."""
     return f"state/{workspace_id}/{version_id}.tfstate"

--- a/services/tests/config/config_key_contract.json
+++ b/services/tests/config/config_key_contract.json
@@ -99,6 +99,7 @@
   "artifact_retention.binary_cache_retention_days",
   "artifact_retention.config_versions_keep",
   "artifact_retention.config_versions_retention_days",
+  "artifact_retention.deleted_workspace_retention_days",
   "artifact_retention.enabled",
   "artifact_retention.module_overrides_retention_days",
   "artifact_retention.poll_interval_seconds",

--- a/services/tests/helm/helm_values_contract.json
+++ b/services/tests/helm/helm_values_contract.json
@@ -53,6 +53,7 @@
   "api.config.artifact_retention.batch_size",
   "api.config.artifact_retention.binary_cache_retention_days",
   "api.config.artifact_retention.config_versions_retention_days",
+  "api.config.artifact_retention.deleted_workspace_retention_days",
   "api.config.artifact_retention.enabled",
   "api.config.artifact_retention.module_overrides_retention_days",
   "api.config.artifact_retention.poll_interval_seconds",

--- a/services/tests/integration/test_workspace_state_lifecycle.py
+++ b/services/tests/integration/test_workspace_state_lifecycle.py
@@ -125,6 +125,34 @@ class TestWorkspaceLifecycle:
         resp = await client.get(f"/api/v2/workspaces/{ws_id}", headers=AUTH)
         assert resp.status_code == 404
 
+    async def test_delete_writes_an_undelete_marker(self, app, client):
+        """#1253. Deleting CASCADEs the rows away but leaves the state blobs, so
+        the marker is the only record of which id held which name — without it
+        the state is unrecoverable in practice and invisible to the reaper
+        forever. It must be built *before* the delete (the row is gone after)
+        and written *after* the commit (so a rollback leaves no marker for a
+        workspace that still exists)."""
+        from terrapod.services import deleted_workspace_service as dws
+        from terrapod.storage import get_storage
+
+        set_auth(app, admin_user())
+        create = await client.post(WS_ENDPOINT, json=_ws_body("marked-ws"), headers=AUTH)
+        ws_id = create.json()["data"]["id"]
+
+        assert (
+            await client.delete(f"/api/terrapod/v1/workspaces/{ws_id}", headers=AUTH)
+        ).status_code == 204
+
+        # The marker is keyed by the RAW uuid, matching the `state/{uuid}/`
+        # prefix the reaper walks — not the `ws-`-prefixed JSON:API id.
+        marker = await dws.read_marker(get_storage(), ws_id.removeprefix("ws-"))
+        assert marker is not None, "no undelete marker written on delete"
+        assert marker["workspace_name"] == "marked-ws"
+        assert marker["marker_reason"] == dws.REASON_DELETED
+        assert marker["deleted_by"]
+        # Fresh marker — the reaper must see it as brand new, not expired.
+        assert dws.marker_age_days(marker) < 1
+
     async def test_list_workspaces_filtered_by_search(self, app, client):
         set_auth(app, admin_user())
 

--- a/services/tests/integration/test_workspace_state_lifecycle.py
+++ b/services/tests/integration/test_workspace_state_lifecycle.py
@@ -139,9 +139,11 @@ class TestWorkspaceLifecycle:
         create = await client.post(WS_ENDPOINT, json=_ws_body("marked-ws"), headers=AUTH)
         ws_id = create.json()["data"]["id"]
 
-        assert (
-            await client.delete(f"/api/terrapod/v1/workspaces/{ws_id}", headers=AUTH)
-        ).status_code == 204
+        # The request is made outside the assert: under `python -O` asserts are
+        # stripped, and a DELETE that only happens inside one would silently not
+        # happen at all (py/side-effect-in-assert).
+        resp = await client.delete(f"/api/terrapod/v1/workspaces/{ws_id}", headers=AUTH)
+        assert resp.status_code == 204
 
         # The marker is keyed by the RAW uuid, matching the `state/{uuid}/`
         # prefix the reaper walks — not the `ws-`-prefixed JSON:API id.

--- a/services/tests/services/test_deleted_workspace_markers.py
+++ b/services/tests/services/test_deleted_workspace_markers.py
@@ -1,0 +1,228 @@
+"""Delete markers and the orphaned-state reaper (#1253).
+
+The reaper here is unlike every other retention category: the others walk DB
+rows and delete the blobs those rows point at, but a deleted workspace has no
+rows left — CASCADE took them — so its state can only be found by listing
+storage and subtracting what still exists. These tests pin the two properties
+that follow from that and are easy to regress:
+
+  * discovery **stamps, never deletes** — so nothing is reaped that has not
+    been visible as recoverable for the whole retention window; and
+  * the window is measured from the marker's own `deleted_at` field, not from
+    any blob's mtime.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from terrapod.services import deleted_workspace_service as dws
+from terrapod.services.artifact_retention_service import _cleanup_deleted_workspaces
+from terrapod.storage.keys import deleted_workspace_marker_key
+from terrapod.storage.protocol import ObjectMeta, ObjectNotFoundError
+
+
+class FakeStore:
+    """In-memory object store, enough for prefix listing and get/put/delete."""
+
+    def __init__(self, keys: list[str] | None = None):
+        self.objects: dict[str, bytes] = dict.fromkeys(keys or [], b"{}")
+        self.deleted: list[str] = []
+
+    async def list_prefix(self, prefix: str, *, after: str = "", limit=None):
+        return [
+            ObjectMeta(
+                key=k,
+                size_bytes=len(v),
+                content_type="application/json",
+                etag="x",
+                last_modified=datetime.now(UTC),
+            )
+            for k, v in sorted(self.objects.items())
+            if k.startswith(prefix)
+        ]
+
+    async def get(self, key: str) -> bytes:
+        if key not in self.objects:
+            raise ObjectNotFoundError(key)
+        return self.objects[key]
+
+    async def put(self, key, data, content_type="application/octet-stream", metadata=None):
+        self.objects[key] = data
+        return MagicMock()
+
+    async def delete(self, key: str) -> None:
+        self.objects.pop(key, None)
+        self.deleted.append(key)
+
+
+#: Real UUIDs — the reaper skips non-UUID prefixes, so string ids like "abc"
+#: would silently never be seen as orphans and every assertion would pass
+#: vacuously.
+WS_A = "0192f3a1-0000-7000-8000-00000000000a"
+WS_B = "0192f3a1-0000-7000-8000-00000000000b"
+
+
+def _db(live_ids: list[str] | None = None, referenced: bool = False):
+    """A DB backing both queries the reaper makes.
+
+    The live-workspace query only calls `.scalars()`; the state-version safety
+    check only calls `.scalar_one_or_none()` — so one result object serving
+    both is unambiguous, and unlike call-ordering it stays correct however many
+    orphans a cycle walks.
+    """
+    db = AsyncMock()
+    res = MagicMock()
+    res.scalars.return_value = list(live_ids or [])
+    res.scalar_one_or_none.return_value = object() if referenced else None
+    db.execute = AsyncMock(return_value=res)
+    return db
+
+
+def _marker(ws_id: str, age_days: float, reason: str = dws.REASON_DELETED) -> bytes:
+    body = dws.build_discovery_marker(ws_id, datetime.now(UTC) - timedelta(days=age_days))
+    body["marker_reason"] = reason
+    body["workspace_name"] = "app-prod"
+    return json.dumps(body).encode()
+
+
+class TestDiscoveryStampsRatherThanDeletes:
+    async def test_unmarked_orphan_is_stamped_and_nothing_is_deleted(self):
+        """The property the whole retention window rests on. An orphan the
+        reaper has never seen — a workspace deleted before this shipped, or one
+        whose marker write failed — must start its clock, not be reaped on
+        sight."""
+        store = FakeStore([f"state/{WS_A}/1.tfstate", f"state/{WS_A}/2.tfstate"])
+
+        reaped = await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100)
+
+        assert reaped == 0
+        assert store.deleted == []
+        marker = json.loads(store.objects[deleted_workspace_marker_key(WS_A)])
+        assert marker["marker_reason"] == dws.REASON_DISCOVERED
+        assert marker["deleted_at"]
+
+    async def test_a_marker_with_no_usable_date_restarts_the_clock(self):
+        """A corrupt or dateless marker must not make an orphan immortal, but
+        must not make it instantly reapable either."""
+        store = FakeStore([f"state/{WS_A}/1.tfstate"])
+        store.objects[deleted_workspace_marker_key(WS_A)] = json.dumps({"deleted_at": ""}).encode()
+
+        reaped = await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100)
+
+        assert reaped == 0
+        assert store.deleted == []
+        assert json.loads(store.objects[deleted_workspace_marker_key(WS_A)])["deleted_at"]
+
+
+class TestRetentionWindow:
+    async def test_orphan_inside_the_window_is_left_alone(self):
+        store = FakeStore([f"state/{WS_A}/1.tfstate"])
+        store.objects[deleted_workspace_marker_key(WS_A)] = _marker(WS_A, age_days=5)
+
+        assert await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100) == 0
+        assert store.deleted == []
+
+    async def test_orphan_past_the_window_is_reaped_with_its_marker(self):
+        store = FakeStore([f"state/{WS_A}/1.tfstate", f"state/{WS_A}/2.tfstate"])
+        store.objects[deleted_workspace_marker_key(WS_A)] = _marker(WS_A, age_days=31)
+
+        reaped = await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100)
+
+        assert reaped == 1
+        assert f"state/{WS_A}/1.tfstate" in store.deleted
+        assert f"state/{WS_A}/2.tfstate" in store.deleted
+        assert deleted_workspace_marker_key(WS_A) in store.deleted
+
+    async def test_age_is_read_from_the_body_not_the_object_mtime(self):
+        """Every object in FakeStore reports `last_modified` of now. An expired
+        marker must still reap — proving the window is measured from the body,
+        which is the only field replication carries faithfully."""
+        store = FakeStore([f"state/{WS_A}/1.tfstate"])
+        store.objects[deleted_workspace_marker_key(WS_A)] = _marker(WS_A, age_days=999)
+
+        assert await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100) == 1
+
+
+class TestNeverReapsLiveState:
+    async def test_a_live_workspace_prefix_is_never_touched(self):
+        store = FakeStore([f"state/{WS_B}/1.tfstate"])
+
+        assert await _cleanup_deleted_workspaces(_db(live_ids=[WS_B]), store, 30, 100) == 0
+        assert store.deleted == []
+        assert deleted_workspace_marker_key(WS_B) not in store.objects
+
+    async def test_expired_orphan_with_surviving_state_rows_is_not_reaped(self):
+        """Belt and braces against a listing/DB skew: rows say it is alive even
+        though the workspace query said otherwise."""
+        store = FakeStore([f"state/{WS_A}/1.tfstate"])
+        store.objects[deleted_workspace_marker_key(WS_A)] = _marker(WS_A, age_days=99)
+
+        reaped = await _cleanup_deleted_workspaces(
+            _db(live_ids=[], referenced=True), store, 30, 100
+        )
+
+        assert reaped == 0
+        assert store.deleted == []
+
+    async def test_the_marker_prefix_is_not_mistaken_for_a_workspace(self):
+        """`state/deleted/…` and `state/index.yaml` live under `state/` but are
+        not workspace prefixes; treating them as such would have the reaper
+        stamp markers for imaginary workspaces."""
+        store = FakeStore([f"state/deleted/{WS_A}.json", "state/index.yaml"])
+
+        assert await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100) == 0
+        assert store.deleted == []
+        assert not any(k.endswith("index.yaml.json") for k in store.objects)
+
+    async def test_a_non_uuid_prefix_is_skipped_rather_than_killing_the_cycle(self):
+        """`Workspace.id` is a UUID column, so a stray directory under `state/`
+        would raise on bind — and because the retention loop catches per
+        category, that exception would silently disable reaping for every
+        workspace, permanently. It must be skipped, and real orphans alongside
+        it must still be processed."""
+        store = FakeStore(["state/not-a-uuid/junk.tfstate", f"state/{WS_A}/1.tfstate"])
+
+        await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100)
+
+        assert deleted_workspace_marker_key(WS_A) in store.objects
+        assert deleted_workspace_marker_key("not-a-uuid") not in store.objects
+        assert store.deleted == []
+
+
+class TestMarkerContents:
+    def test_a_discovery_marker_carries_the_fields_the_undelete_list_needs(self):
+        body = dws.build_discovery_marker(WS_A)
+        assert body["workspace_id"] == WS_A
+        assert body["deleted_at"].endswith("Z")
+        assert body["marker_reason"] == dws.REASON_DISCOVERED
+
+    def test_marker_age_is_none_when_undateable(self):
+        assert dws.marker_age_days({"deleted_at": "not-a-date"}) is None
+        assert dws.marker_age_days({}) is None
+
+    def test_settings_snapshot_carries_no_secret_bearing_field(self):
+        """The marker lands in the bucket and replicates to a peer. Variable
+        values and VCS credentials must never be in it — only the connection's
+        id, which is a pointer to a row whose token stays in the database."""
+        ws = MagicMock()
+        ws.labels = {"env": "prod"}
+        snap = dws._settings_snapshot(ws)
+        banned = ("token", "secret", "password", "credential", "value")
+        offenders = [k for k in snap if any(b in k.lower() for b in banned)]
+        assert offenders == [], f"secret-shaped key in marker snapshot: {offenders}"
+        assert "labels" in snap and "owner_email" in snap
+
+
+@pytest.mark.parametrize("days", [0])
+async def test_zero_retention_disables_the_category(days):
+    """`0 = disabled` is the convention every other retention category follows;
+    the dispatch loop skips on threshold 0, so an operator opting out keeps
+    deleted state forever rather than losing it immediately."""
+    from terrapod.config import settings
+
+    assert settings.artifact_retention.deleted_workspace_retention_days >= 0

--- a/services/tests/services/test_deleted_workspace_markers.py
+++ b/services/tests/services/test_deleted_workspace_markers.py
@@ -124,7 +124,8 @@ class TestRetentionWindow:
         store = FakeStore([f"state/{WS_A}/1.tfstate"])
         store.objects[deleted_workspace_marker_key(WS_A)] = _marker(WS_A, age_days=5)
 
-        assert await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100) == 0
+        reaped = await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100)
+        assert reaped == 0
         assert store.deleted == []
 
     async def test_orphan_past_the_window_is_reaped_with_its_marker(self):
@@ -145,14 +146,16 @@ class TestRetentionWindow:
         store = FakeStore([f"state/{WS_A}/1.tfstate"])
         store.objects[deleted_workspace_marker_key(WS_A)] = _marker(WS_A, age_days=999)
 
-        assert await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100) == 1
+        reaped = await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100)
+        assert reaped == 1
 
 
 class TestNeverReapsLiveState:
     async def test_a_live_workspace_prefix_is_never_touched(self):
         store = FakeStore([f"state/{WS_B}/1.tfstate"])
 
-        assert await _cleanup_deleted_workspaces(_db(live_ids=[WS_B]), store, 30, 100) == 0
+        reaped = await _cleanup_deleted_workspaces(_db(live_ids=[WS_B]), store, 30, 100)
+        assert reaped == 0
         assert store.deleted == []
         assert deleted_workspace_marker_key(WS_B) not in store.objects
 
@@ -175,7 +178,8 @@ class TestNeverReapsLiveState:
         stamp markers for imaginary workspaces."""
         store = FakeStore([f"state/deleted/{WS_A}.json", "state/index.yaml"])
 
-        assert await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100) == 0
+        reaped = await _cleanup_deleted_workspaces(_db(live_ids=[]), store, 30, 100)
+        assert reaped == 0
         assert store.deleted == []
         assert not any(k.endswith("index.yaml.json") for k in store.objects)
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3865,9 +3865,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -50,7 +50,7 @@
   "overrides": {
     "postcss": "^8.5.23",
     "@babel/core": "^7.29.6",
-    "brace-expansion": "^2.0.2",
+    "brace-expansion": "^2.1.4",
     "sharp": "^0.35.3"
   }
 }


### PR DESCRIPTION
Slice 1 of #1253: write the marker, register the blob class, extend the retention service. Ships useful on its own — it stops the storage leak and makes deleted workspaces discoverable. No UI, no restore endpoint; those are slice 2.

## The problem, in one fact

`delete_workspace` does `db.delete(ws)`. `StateVersion` rows CASCADE away and **nothing touches object storage**, so the blobs stay at `state/{workspace_id}/` indefinitely. Two consequences:

- the data survives, but the index saying which id had which name does not — a workspace deleted by mistake is recoverable in principle and unfindable in practice;
- every other retention category finds its blobs *through* `StateVersion` rows, so once CASCADE removes them the state is permanently invisible to the reaper. Every workspace ever deleted still occupies storage, with nothing able to reclaim it.

## Marker

`state/deleted/{workspace_id}.json`, written after the delete commits, built before it (the row is gone after). Records the name, deletion time and actor, state serial and lineage, the settings snapshot (labels, ownership, execution mode, VCS wiring) and the **variable names**.

**No secrets.** Variable *values* are never written; the VCS connection is referenced by id, whose token stays in the database. A guard test asserts no secret-shaped key can appear in the snapshot.

**A flat prefix with its own blob class**, not a marker nested inside each workspace's `state/{id}/`. `state` is `encrypted_at_rest`, and replication declines that class wholesale when app-layer encryption is on — a nested marker would inherit that and leave an encrypted deployment's standby with no undelete index at all, which is the one thing the class exists to carry. It also keeps listing the undelete set to one flat prefix, and stops the restore path dragging a marker into the workspace it just restored.

The class is **`history`, not `irreplaceable`**, and the reason is the readiness report rather than sentiment about the data: `irreplaceable_unchecked` is what makes `irreplaceable_missing` trustworthy before a failover, and a class that cannot be verified from rows sits in it permanently. Registering this one as irreplaceable would put a line an operator can never clear into the list they are meant to read. What is genuinely irreplaceable here is the state the marker points at, and the `state` class already covers that.

**`deleted_at` lives in the body, never inferred from `LastModified`.** `blob_sync._copy_one` streams a replicated object in with no `metadata=` and the destination stamps a fresh timestamp, so a marker dated by mtime would read as "deleted just now" after every replication cycle and never age out.

## Reaper

A new `artifact_retention_service` category inheriting the existing shape — daily task, `batch_size` per cycle, independent try/except, best-effort deletes, `0 = disabled`. New setting `deleted_workspace_retention_days`, default 30.

Its orphan set is computed the only way still available: list the `state/` prefixes, subtract the workspaces that still exist. Then:

1. orphan with **no** marker → **write one** and delete nothing this cycle;
2. marker older than the window → reap the prefix and the marker;
3. prefix back in the live set, or still holding `StateVersion` rows → left alone.

**Discovery stamps, it never deletes.** That is the invariant the window rests on: nothing is reaped that has not been visible as recoverable for the full retention window, including workspaces deleted before this shipped, whose clock starts at discovery rather than retroactively.

## Two bugs the tests found

Both were in code written for this PR, both caught by writing the tests rather than by review:

- **a single non-UUID directory under `state/` would kill the reaper permanently.** `Workspace.id` is a UUID column, so a stray prefix raises on bind — and because the retention loop catches per category, that exception would silently disable reaping for every workspace, forever. Now skipped with a warning.
- **an unavailable object store made the delete return 500 after committing.** `get_storage()` was evaluated outside `write_marker`'s guard, so the workspace was gone but the caller saw an error, retried, got a 404, and would reasonably conclude the delete had failed. Resolving the store now happens inside the guard.

## Tests

13 services-api tests pinning the reaper's invariants, plus an integration test asserting the marker is actually written by the real delete path. The two load-bearing ones were mutation-checked — reverting each fix turns them red, so they are not passing vacuously.

## Also

A helm-smoke assertion that every retention key in `values.yaml` reaches the **rendered** ConfigMap. That is leg 3 of the config-channel contract, and its absence is what leaves a value silently inert: the operator sets it, it never reaches the pod, the code default wins, and nothing says so. Mutation-checked under bash the same way.

## Verification

`make test` 4150 passed · `ruff check` + `format` clean · `helm lint` + `helm template` on all three profiles · both contract snapshot deltas are a single **addition** each (MINOR-safe).

Part of #1253
