### PR TITLE
feat(1255): review the accepted-risk register on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,7 @@ jobs:
   # (dependency findings may be public, code findings and per-release detail may
   # not).
   rescan-test:
-    name: Re-scan Scripts Test
+    name: Security Scripts Test
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
@@ -525,7 +525,7 @@ jobs:
         with:
           python-version: "3.13"
       - run: pip install pytest
-      - name: Run release re-scan script tests
+      - name: Run the re-scan and register-review script tests
         run: python -m pytest scripts/tests -v
 
   # ── Migration smoke (#544) ────────────────────────────

--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -302,6 +302,149 @@ jobs:
             codecount.json
           retention-days: 7
 
+  # ── Accepted-risk register review (#1255) ────────────────────────────
+  #
+  # Different question from everything above, and a different issue. The jobs
+  # above ask "is there anything wrong with a release we support"; this one asks
+  # "is anything in our accepted-risk register no longer worth accepting".
+  #
+  # Every entry in the register exists because there was no fix to take, and the
+  # release gate agrees by construction: it runs `ignore-unfixed` alongside the
+  # register. So re-running each scanner with the register DISABLED and fix-only
+  # KEPT reports exactly the entries upstream has since fixed. No advisory API,
+  # no version arithmetic of our own.
+  #
+  # It targets `main` rather than the released tags above: the register lives on
+  # main, and what we act on is a bump there.
+  register-scan:
+    name: Scan ${{ matrix.image }} without the register
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # amd64 only, deliberately. A suppression is per-package and the
+        # register has never carried an arch-specific entry, so scanning both
+        # would double the work to re-confirm the same package list.
+        image: [terrapod-api, terrapod-web, terrapod-runner, terrapod-listener, terrapod-migrations]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Log in to GHCR
+        uses: ./.github/actions/ghcr-login
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+
+      - name: Trivy
+        continue-on-error: true
+        env:
+          TRIVY_PLATFORM: linux/amd64
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}:latest
+          format: json
+          output: trivy-${{ matrix.image }}.json
+          severity: HIGH,CRITICAL
+          # `ignore-unfixed` stays ON while `trivyignores` is deliberately
+          # ABSENT. Together those two mean exactly "everything we suppress
+          # that now has a fix" — which is the whole question this job asks.
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: register-${{ matrix.image }}
+          path: trivy-${{ matrix.image }}.json
+          retention-days: 7
+
+  register:
+    name: Review the accepted-risk register
+    needs: register-scan
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: scans
+          pattern: register-*
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.13'
+
+      # No --ignore-vuln, and `-r requirements.txt` rather than the ambient
+      # environment: the gate audits what we ship, and auditing the runner's own
+      # toolchain would report dev-only packages as accepted risks of ours.
+      - name: pip-audit without the register
+        continue-on-error: true
+        working-directory: services
+        run: |
+          set -uo pipefail
+          pip install --quiet poetry poetry-plugin-export pip-audit
+          poetry export -f requirements.txt -o requirements.txt --without-hashes
+          pip-audit -r requirements.txt --format json \
+            --output "$GITHUB_WORKSPACE/scans/pip-audit.json" || true
+
+      - name: npm audit without the allowlist
+        continue-on-error: true
+        working-directory: web
+        run: |
+          set -uo pipefail
+          npm ci --ignore-scripts --no-audit --no-fund > /dev/null 2>&1 || true
+          npm audit --audit-level=high --json > "$GITHUB_WORKSPACE/scans/npm-audit.json" || true
+
+      - name: Compare against the register
+        id: review
+        run: python3 scripts/register_review.py scans body.md >> "$GITHUB_OUTPUT"
+
+      # Unlike the report job below, this issue carries full detail. Every id in
+      # it is already committed in the register files, whose headers say the
+      # reasoning is written to be read from outside the project — so listing
+      # them discloses nothing, and the detail is the actionable part.
+      - name: Open or refresh the register issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "Security: accepted risks that can now be resolved"
+          HAS_FINDINGS: ${{ steps.review.outputs.has_findings }}
+          FINGERPRINT: ${{ steps.review.outputs.fingerprint }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,body --jq '.[0] // empty')
+
+          if [ "$HAS_FINDINGS" != "true" ]; then
+            # An empty register review is the goal, not an event. Any open issue
+            # is left alone: someone may be mid-bump on it, and a list that
+            # empties because a scan leg was skipped must not read as "done".
+            echo "Register is clean. Nothing to raise."
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            number=$(echo "$existing" | jq -r '.number')
+            # Refresh the body every run; comment only when the set changed.
+            # Two decisions — conflating them leaves stale content on the issue.
+            gh issue edit "$number" --body-file body.md
+            if echo "$existing" | jq -r '.body' | grep -q "terrapod-register-review:$FINGERPRINT"; then
+              echo "Issue #$number refreshed; entry set unchanged, not re-notifying."
+            else
+              gh issue comment "$number" --body \
+                "The register review changed: an accepted risk became resolvable, or an entry stopped matching."
+              echo "Refreshed issue #$number and notified"
+            fi
+          else
+            gh issue create --title "$TITLE" --body-file body.md --label security 2>/dev/null \
+              || gh issue create --title "$TITLE" --body-file body.md
+          fi
+
   report:
     name: Report
     needs: [discover, artifacts, source]

--- a/docs/cve-policy.md
+++ b/docs/cve-policy.md
@@ -122,6 +122,33 @@ often a distribution marking an issue as not warranting a backport.
 
 There used to be a second kind, and how it went away is worth recording.
 
+### The register is reviewed automatically, every week
+
+Rule 3 is a human re-reading each entry, and that is not sufficient on its own,
+because what gets re-read is the entry's **exit condition** — and an exit
+condition is a *prediction* about how upstream will fix something.
+
+One entry sat accepted behind the prediction that the fix required a major
+version we could not take, and was re-tested against exactly that and correctly
+left in place. Upstream had backported the fix to a patch release instead. The
+re-reading was diligent; it was watching the wrong thing.
+
+So the [weekly re-scan](../.github/workflows/release-rescan.yml) also reviews
+the register itself. Every entry exists because there was no fix to take, and
+the release gate agrees by construction — it runs `ignore-unfixed` alongside the
+register. Re-running each scanner with the register **disabled** and fix-only
+reporting **kept** therefore reports precisely two things:
+
+- entries upstream has since fixed, which should be bumped and deleted; and
+- entries that match nothing at all, which are stale under rule 4.
+
+Either raises a tracking issue. It is a reporter, not a gate — the release-time
+scan remains the gate.
+
+The practical lesson, for anyone adding an entry: re-read the advisory's own
+affected and patched ranges each cycle, not only the exit condition you wrote
+down when you added it.
+
 ## We stopped shipping other people's binaries
 
 Terrapod used to bake three upstream tools into its published images: `opa`

--- a/scripts/register_review.py
+++ b/scripts/register_review.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Review the accepted-risk register against current advisory data (#1255).
+
+Every entry in the register exists because there was no fix to take. The
+release gate enforces that: it runs with `ignore-unfixed` alongside the
+register, so a suppressed advisory is one the gate would not have reported
+anyway. Re-running each scanner with the **register disabled** and **fix-only
+kept** therefore yields exactly one thing — the entries that have since become
+fixable. No advisory API, no version comparison of our own; the scanners
+already know what they would tell us if we stopped suppressing.
+
+That matters because re-reading an entry by hand checks the wrong thing. An
+entry's stated exit condition is a *prediction* about how upstream will fix it,
+and GHSA-mh99-v99m-4gvg sat accepted for months behind a prediction that the
+fix required a major bump we could not take. Upstream backported to a patch
+release instead. The entry was re-tested against its exit and correctly stayed;
+the exit was simply the wrong thing to watch.
+
+Two classifications, and they call for opposite actions:
+
+``fixable``
+    Still present, and a fix is now available. Bump, and delete the entry in
+    the same pull request — rule 1 of the register.
+``unmatched``
+    Present in the register, reported by nothing. Stale: rule 4 says it is a
+    liability rather than a leftover, because it silently shadows the
+    regression that would bring the finding back.
+
+**Unlike its sibling, this report carries full detail, and that is deliberate.**
+`rescan_report.py` withholds ids and versions because naming a supported
+release alongside what is wrong with it is a map for anyone deciding where to
+look. Nothing here is new information: the register files are committed, and
+their headers say the reasoning is "written to be read by someone outside the
+project". Every id below is already public in this repository, so listing it
+discloses nothing an attacker could not read from `main` — and the detail is
+the entire value, since the action is "bump X to Y".
+
+    register_review.py <scan-dir> <out.md>
+
+Writes the report to <out.md> and prints `has_findings` / `fingerprint` for
+the workflow step to consume.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pathlib
+import sys
+
+MARKER = "terrapod-register-review"
+_REPO = os.environ.get("GITHUB_REPOSITORY", "mattrobinsonsre/terrapod")
+
+#: Where each register lives, and the scan whose output covers it. Keeping the
+#: mapping here rather than in the workflow means a new register file is one
+#: line, and the pairing can be exercised without a scheduled run.
+REGISTERS = {
+    "trivy": "pentest/trivy/.trivyignore",
+    "pip-audit": "pentest/pip-audit-ignore.txt",
+    "npm-audit": "pentest/npm-audit-allow.txt",
+}
+
+
+def read_register(path: pathlib.Path) -> list[str]:
+    """Ids from a register file.
+
+    All three use the same convention — one id per line, `#` starts a comment —
+    which is what lets the CI gate, the re-scan and this share the same files.
+    A missing file is empty rather than fatal: a register we have emptied is a
+    success, not a reason to fail the review.
+    """
+    if not path.exists():
+        return []
+    ids = []
+    for line in path.read_text().splitlines():
+        entry = line.split("#", 1)[0].strip()
+        if entry:
+            ids.append(entry)
+    return ids
+
+
+def _load(path: pathlib.Path):
+    try:
+        text = path.read_text().strip()
+        return json.loads(text) if text else None
+    except (OSError, json.JSONDecodeError) as exc:
+        print(
+            f"note: {path} unreadable ({exc}); treating as no findings", file=sys.stderr
+        )
+        return None
+
+
+def from_trivy(data) -> dict[str, dict]:
+    """{id: {package, installed, fixed}} from a Trivy JSON report.
+
+    The report is produced WITHOUT the ignore file, so an id appearing here is
+    unsuppressed; and WITH `ignore-unfixed`, so it appearing at all means a fix
+    exists. `FixedVersion` is recorded anyway — the report should say what to
+    bump to, not merely that one could.
+    """
+    found: dict[str, dict] = {}
+    for result in (data or {}).get("Results") or []:
+        for v in result.get("Vulnerabilities") or []:
+            vid = v.get("VulnerabilityID")
+            if not vid:
+                continue
+            found.setdefault(
+                vid,
+                {
+                    "package": v.get("PkgName", "?"),
+                    "installed": v.get("InstalledVersion", "?"),
+                    "fixed": v.get("FixedVersion", ""),
+                },
+            )
+    return found
+
+
+def from_pip_audit(data) -> dict[str, dict]:
+    """{id: {...}} from pip-audit JSON, run without --ignore-vuln.
+
+    pip-audit reports unfixed advisories too, so unlike Trivy the fix has to be
+    read off the entry: `fix_versions` empty means still unfixed, which is the
+    entry doing its job rather than something to act on.
+    """
+    found: dict[str, dict] = {}
+    for dep in (data or {}).get("dependencies") or []:
+        for v in dep.get("vulns") or []:
+            vid = v.get("id")
+            if not vid:
+                continue
+            fixes = v.get("fix_versions") or []
+            entry = {
+                "package": dep.get("name", "?"),
+                "installed": dep.get("version", "?"),
+                "fixed": ", ".join(fixes),
+            }
+            # Index by the aliases too. The same advisory has a PYSEC id and a
+            # CVE, and which one lands in the register depends on where the
+            # person adding it was reading. Matching on the primary id alone
+            # would report a live suppression as matching nothing — and this
+            # report tells you to DELETE those, so the failure is not cosmetic.
+            for key in [vid, *(v.get("aliases") or [])]:
+                found.setdefault(key, entry)
+    return found
+
+
+def from_npm_audit(data) -> dict[str, dict]:
+    """{id: {...}} from `npm audit --json`, with no allowlist applied.
+
+    npm keys by package rather than advisory, so the ids come out of `via` —
+    the same path the CI gate walks. `fixAvailable` is a bool or an object
+    describing the upgrade; both mean a fix exists, and the object's version is
+    worth carrying through.
+    """
+    found: dict[str, dict] = {}
+    for name, v in ((data or {}).get("vulnerabilities") or {}).items():
+        fix = v.get("fixAvailable")
+        if isinstance(fix, dict):
+            fixed = f"{fix.get('name', name)}@{fix.get('version', '?')}"
+        else:
+            fixed = "available" if fix else ""
+        for via in v.get("via") or []:
+            if not isinstance(via, dict) or not via.get("url"):
+                continue
+            found.setdefault(
+                via["url"].rstrip("/").split("/")[-1],
+                {
+                    "package": name,
+                    "installed": v.get("range", "?"),
+                    "fixed": fixed,
+                },
+            )
+    return found
+
+
+_PARSERS = {
+    "trivy": from_trivy,
+    "pip-audit": from_pip_audit,
+    "npm-audit": from_npm_audit,
+}
+
+
+def collect(scan_dir: pathlib.Path) -> tuple[dict[str, dict[str, dict]], set[str]]:
+    """Merge every scan output in the directory, keyed by scanner.
+
+    Files are named `<scanner>[-anything].json` so one scanner can contribute
+    several (Trivy runs per image and per architecture). An unparseable file
+    contributes nothing rather than sinking the run — but see `missing` below:
+    a scanner that produced no file at all is reported, because "nothing to do"
+    and "nobody looked" must not render identically.
+    """
+    merged: dict[str, dict[str, dict]] = {s: {} for s in _PARSERS}
+    seen: set[str] = set()
+    for path in sorted(scan_dir.rglob("*.json")):
+        scanner = next((s for s in _PARSERS if path.name.startswith(s)), None)
+        if scanner is None:
+            continue
+        seen.add(scanner)
+        merged[scanner].update(_PARSERS[scanner](_load(path)))
+    return merged, seen
+
+
+def classify(registers: dict[str, list[str]], found: dict[str, dict[str, dict]]):
+    fixable, unmatched, holding = [], [], []
+    for scanner, ids in registers.items():
+        for vid in ids:
+            hit = found.get(scanner, {}).get(vid)
+            row = {"scanner": scanner, "id": vid, **(hit or {})}
+            if hit is None:
+                unmatched.append(row)
+            elif hit.get("fixed"):
+                fixable.append(row)
+            else:
+                holding.append(row)
+    return fixable, unmatched, holding
+
+
+def _table(rows: list[dict], with_fix: bool) -> list[str]:
+    head = "| Advisory | Register | Package | Installed |"
+    sep = "|---|---|---|---|"
+    if with_fix:
+        head += " Fixed in |"
+        sep += "---|"
+    out = [head, sep]
+    for r in rows:
+        line = (
+            f"| `{r['id']}` | {REGISTERS.get(r['scanner'], r['scanner'])} "
+            f"| {r.get('package', '?')} | {r.get('installed', '?')} |"
+        )
+        if with_fix:
+            line += f" **{r.get('fixed', '?')}** |"
+        out.append(line)
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 2
+    scan_dir, out = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+
+    registers = {s: read_register(pathlib.Path(p)) for s, p in REGISTERS.items()}
+    found, scanned = collect(scan_dir)
+    fixable, unmatched, holding = classify(registers, found)
+
+    # A scanner whose output never arrived cannot distinguish "this entry
+    # matches nothing" from "nothing looked for it", so its entries are not
+    # reported as stale — and the gap is named rather than swallowed.
+    skipped = [s for s, ids in registers.items() if ids and s not in scanned]
+    if skipped:
+        unmatched = [r for r in unmatched if r["scanner"] not in skipped]
+
+    fp = hashlib.sha256(
+        json.dumps(
+            sorted(
+                (r["scanner"], r["id"], kind)
+                for kind, rows in (("fixable", fixable), ("unmatched", unmatched))
+                for r in rows
+            ),
+        ).encode()
+    ).hexdigest()[:16]
+
+    body = [
+        "Automated review of the accepted-risk register "
+        f"([policy](https://github.com/{_REPO}/blob/main/docs/cve-policy.md)).",
+        "",
+        "Each entry was accepted because no fix existed. This re-runs every scanner "
+        "with the register **disabled** and fix-only reporting **kept**, so anything "
+        "listed below is an accepted risk that upstream has since fixed, or an entry "
+        "that no longer matches anything.",
+        "",
+    ]
+
+    if fixable:
+        body += [
+            "## Fixable now — take the fix",
+            "",
+            "A patched version exists. Rule 1 of the register: bump to it, and delete "
+            "the entry in the **same** pull request rather than leaving it behind.",
+            "",
+            *_table(fixable, with_fix=True),
+            "",
+            "Check the advisory's own affected/patched ranges rather than the entry's "
+            "written exit condition — the exit is a guess about how upstream would fix "
+            "it, and a backport to an older line is exactly the case that guess misses.",
+            "",
+        ]
+
+    if unmatched:
+        body += [
+            "## Matching nothing — delete",
+            "",
+            "Reported by no scanner. Rule 4: a stale entry is a liability rather than a "
+            "leftover, because it silently shadows the regression that would bring the "
+            "finding back.",
+            "",
+            *_table(unmatched, with_fix=False),
+            "",
+        ]
+
+    if holding:
+        body += [
+            f"<details><summary>{len(holding)} still doing their job (no fix upstream)"
+            "</summary>",
+            "",
+            *_table(holding, with_fix=False),
+            "",
+            "</details>",
+            "",
+        ]
+
+    if skipped:
+        body += [
+            "> **Incomplete run.** No output from: "
+            + ", ".join(f"`{s}`" for s in sorted(skipped))
+            + ". Their entries are not reported as stale above, because a scanner that "
+            "did not run looks identical to one that found nothing.",
+            "",
+        ]
+
+    body += [f"<!-- {MARKER}:{fp} -->"]
+    out.write_text("\n".join(body) + "\n")
+
+    print(f"fingerprint={fp}")
+    print(f"has_findings={'true' if (fixable or unmatched) else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -25,3 +25,4 @@ def _load(name: str):
 normalise = _load("rescan_normalise")
 report = _load("rescan_report")
 advisory = _load("rescan_advisory")
+register_review = _load("register_review")

--- a/scripts/tests/test_register_review.py
+++ b/scripts/tests/test_register_review.py
@@ -1,0 +1,325 @@
+"""Tests for the accepted-risk register review (#1255).
+
+The whole job is a comparison between two lists, and every way it can break
+produces a green run reporting nothing: a parser reading the wrong field, an id
+that does not match because of case or a trailing slash, a scanner that failed
+to run being indistinguishable from one that found nothing. None of that raises.
+
+So these pin the classification itself — that a fixable entry is reported, that
+an unfixed one is not, and that a scanner which did not run cannot cause an
+entry to be called stale.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from conftest import register_review as rr
+
+# ── register parsing ────────────────────────────────────────────────
+
+
+def test_register_parsing_ignores_comments_and_blank_lines(tmp_path):
+    """All three registers are mostly prose. A parser that took whole lines
+    would compare reasoning paragraphs against advisory ids and match nothing,
+    reporting a clean review forever."""
+    f = tmp_path / ".trivyignore"
+    f.write_text(
+        "# CVE-2025-69720 — ncurses, discussed at length\n"
+        "#\n"
+        "# EXIT: Debian ships a fix.\n"
+        "CVE-2025-69720\n"
+        "\n"
+        "GHSA-aaaa-bbbb-cccc  # trailing comment\n"
+    )
+    assert rr.read_register(f) == ["CVE-2025-69720", "GHSA-aaaa-bbbb-cccc"]
+
+
+def test_a_missing_register_is_empty_not_fatal(tmp_path):
+    """An emptied register is the goal, and deleting the file is a reasonable
+    end state. It must not take the review down with it."""
+    assert rr.read_register(tmp_path / "nope.txt") == []
+
+
+# ── scanner parsing ─────────────────────────────────────────────────
+
+
+def test_trivy_fix_version_is_carried_through():
+    """The report has to say what to bump to. Reporting only that a fix exists
+    leaves the reader doing the lookup the scanner already did."""
+    found = rr.from_trivy(
+        {
+            "Results": [
+                {
+                    "Vulnerabilities": [
+                        {
+                            "VulnerabilityID": "CVE-2026-69247",
+                            "PkgName": "cryptography",
+                            "InstalledVersion": "49.0.0",
+                            "FixedVersion": "50.0.0",
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+    assert found["CVE-2026-69247"]["fixed"] == "50.0.0"
+    assert found["CVE-2026-69247"]["package"] == "cryptography"
+
+
+def test_pip_audit_unfixed_advisory_reports_no_fix():
+    """pip-audit lists unfixed advisories too — unlike Trivy, which is run
+    fix-only. Treating presence as fixability would report every entry that is
+    correctly still accepted, which is the noise that gets a report muted."""
+    found = rr.from_pip_audit(
+        {
+            "dependencies": [
+                {
+                    "name": "pyjwt",
+                    "version": "2.13.0",
+                    "vulns": [{"id": "PYSEC-2025-183", "fix_versions": []}],
+                }
+            ]
+        }
+    )
+    assert found["PYSEC-2025-183"]["fixed"] == ""
+
+
+def test_pip_audit_aliases_match_too():
+    """Real pip-audit output carries `aliases`, and the same advisory has both a
+    PYSEC id and a CVE. Which one is in the register depends on where whoever
+    added it was reading. Matching only the primary id would call a live
+    suppression stale — and stale entries are reported as safe to delete."""
+    found = rr.from_pip_audit(
+        {
+            "dependencies": [
+                {
+                    "name": "pkg",
+                    "version": "1.0",
+                    "vulns": [
+                        {
+                            "id": "PYSEC-2026-2463",
+                            "aliases": ["CVE-2026-11111", "GHSA-aaaa-bbbb-cccc"],
+                            "fix_versions": ["1.2.5"],
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    assert found["PYSEC-2026-2463"]["fixed"] == "1.2.5"
+    assert found["CVE-2026-11111"]["fixed"] == "1.2.5"
+    assert found["GHSA-aaaa-bbbb-cccc"]["fixed"] == "1.2.5"
+
+
+def test_npm_ids_come_out_of_via_urls():
+    """npm keys by package, not advisory, so the GHSA only exists at the end of
+    the advisory URL — the same path the CI gate walks."""
+    found = rr.from_npm_audit(
+        {
+            "vulnerabilities": {
+                "brace-expansion": {
+                    "severity": "high",
+                    "range": "2.0.0 - 2.1.3",
+                    "fixAvailable": {"name": "brace-expansion", "version": "2.1.4"},
+                    "via": [
+                        {"url": "https://github.com/advisories/GHSA-rgw5-rvv9-x895"}
+                    ],
+                }
+            }
+        }
+    )
+    assert found["GHSA-rgw5-rvv9-x895"]["fixed"] == "brace-expansion@2.1.4"
+
+
+def test_npm_fix_available_false_is_not_a_fix():
+    found = rr.from_npm_audit(
+        {
+            "vulnerabilities": {
+                "thing": {
+                    "fixAvailable": False,
+                    "via": [{"url": "https://x/advisories/GHSA-z"}],
+                }
+            }
+        }
+    )
+    assert found["GHSA-z"]["fixed"] == ""
+
+
+# ── classification ──────────────────────────────────────────────────
+
+
+def test_entry_with_a_fix_is_fixable_and_one_without_is_holding():
+    """The distinction the whole report rests on. Getting it backwards would
+    either bury a real bump among entries doing their job, or nag weekly about
+    something with nothing to bump to."""
+    fixable, unmatched, holding = rr.classify(
+        {"trivy": ["CVE-A"], "pip-audit": ["PYSEC-B"], "npm-audit": []},
+        {
+            "trivy": {"CVE-A": {"package": "p", "installed": "1", "fixed": "2"}},
+            "pip-audit": {"PYSEC-B": {"package": "q", "installed": "1", "fixed": ""}},
+        },
+    )
+    assert [r["id"] for r in fixable] == ["CVE-A"]
+    assert [r["id"] for r in holding] == ["PYSEC-B"]
+    assert unmatched == []
+
+
+def test_entry_reported_by_nobody_is_stale():
+    fixable, unmatched, holding = rr.classify(
+        {"trivy": ["CVE-GONE"], "pip-audit": [], "npm-audit": []}, {"trivy": {}}
+    )
+    assert [r["id"] for r in unmatched] == ["CVE-GONE"]
+    assert fixable == [] and holding == []
+
+
+# ── end to end ──────────────────────────────────────────────────────
+
+
+def _run(tmp_path, monkeypatch, scans: dict, registers: dict):
+    scan_dir = tmp_path / "scans"
+    scan_dir.mkdir(parents=True)
+    for name, payload in scans.items():
+        (scan_dir / name).write_text(json.dumps(payload))
+
+    pentest = tmp_path / "pentest"
+    (pentest / "trivy").mkdir(parents=True)
+    paths = {}
+    for scanner, body in registers.items():
+        rel = rr.REGISTERS[scanner]
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+        paths[scanner] = rel
+    monkeypatch.chdir(tmp_path)
+
+    out = tmp_path / "body.md"
+    monkeypatch.setattr("sys.argv", ["register_review.py", str(scan_dir), str(out)])
+    rc = rr.main()
+    return rc, out.read_text()
+
+
+def test_a_newly_fixable_entry_is_reported_with_its_bump(tmp_path, monkeypatch, capsys):
+    """The case this exists for: an entry accepted because nothing could be
+    done, which upstream has since fixed."""
+    rc, body = _run(
+        tmp_path,
+        monkeypatch,
+        {
+            "trivy-api.json": {
+                "Results": [
+                    {
+                        "Vulnerabilities": [
+                            {
+                                "VulnerabilityID": "CVE-2026-69247",
+                                "PkgName": "cryptography",
+                                "InstalledVersion": "49.0.0",
+                                "FixedVersion": "50.0.0",
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {"trivy": "# reasoning\nCVE-2026-69247\n"},
+    )
+    assert rc == 0
+    assert "Fixable now" in body
+    assert "CVE-2026-69247" in body and "50.0.0" in body
+    assert "has_findings=true" in capsys.readouterr().out
+
+
+def test_a_scanner_that_did_not_run_cannot_make_an_entry_look_stale(
+    tmp_path, monkeypatch, capsys
+):
+    """The failure that would erode trust fastest. If a Trivy leg dies and its
+    output never lands, every Trivy entry matches nothing — and telling someone
+    to delete a live suppression on that basis is worse than saying nothing."""
+    rc, body = _run(
+        tmp_path,
+        monkeypatch,
+        {},  # no scanner output at all
+        {"trivy": "CVE-2025-69720\n"},
+    )
+    assert rc == 0
+    assert "CVE-2025-69720" not in body
+    assert "Incomplete run" in body
+    assert "has_findings=false" in capsys.readouterr().out
+
+
+def test_an_empty_register_reports_nothing_to_do(tmp_path, monkeypatch, capsys):
+    """The steady state we want. It must not raise an issue."""
+    rc, _ = _run(
+        tmp_path,
+        monkeypatch,
+        {"trivy-api.json": {"Results": []}},
+        {"trivy": "# none\n"},
+    )
+    assert rc == 0
+    assert "has_findings=false" in capsys.readouterr().out
+
+
+def test_the_fingerprint_tracks_the_finding_set_not_the_run(
+    tmp_path, monkeypatch, capsys
+):
+    """The fingerprint decides whether to re-notify. If it changed every run the
+    issue would comment weekly and be muted; if it never changed, a newly
+    fixable entry would be added silently to a body nobody re-reads."""
+    scan = {
+        "trivy-api.json": {
+            "Results": [
+                {
+                    "Vulnerabilities": [
+                        {
+                            "VulnerabilityID": "CVE-A",
+                            "PkgName": "p",
+                            "InstalledVersion": "1",
+                            "FixedVersion": "2",
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    _run(tmp_path / "a", monkeypatch, scan, {"trivy": "CVE-A\n"})
+    first = capsys.readouterr().out
+
+    _run(tmp_path / "b", monkeypatch, scan, {"trivy": "CVE-A\n"})
+    same = capsys.readouterr().out
+    assert _fp(first) == _fp(same), "identical finding sets must not re-notify"
+
+    scan["trivy-api.json"]["Results"][0]["Vulnerabilities"].append(
+        {
+            "VulnerabilityID": "CVE-B",
+            "PkgName": "q",
+            "InstalledVersion": "1",
+            "FixedVersion": "3",
+        }
+    )
+    _run(tmp_path / "c", monkeypatch, scan, {"trivy": "CVE-A\nCVE-B\n"})
+    changed = capsys.readouterr().out
+    assert _fp(first) != _fp(changed), "a new fixable entry must re-notify"
+
+
+def _fp(stdout: str) -> str:
+    return next(
+        ln.split("=", 1)[1]
+        for ln in stdout.splitlines()
+        if ln.startswith("fingerprint=")
+    )
+
+
+def test_the_real_registers_parse(tmp_path):
+    """Guards the convention rather than the content: if a register ever grows a
+    format the parser does not understand, the review silently reviews nothing."""
+    root = pathlib.Path(__file__).resolve().parents[2]
+    for rel in rr.REGISTERS.values():
+        path = root / rel
+        if not path.exists():
+            continue
+        for entry in rr.read_register(path):
+            assert entry.startswith(("CVE-", "GHSA-", "PYSEC-", "OSV-")), (
+                f"{rel}: {entry!r} does not look like an advisory id — either the "
+                f"file grew a new format or a comment marker was missed"
+            )


### PR DESCRIPTION
Adds a weekly review of the accepted-risk register that raises an issue when an advisory we previously ignored has become fixable, or when an entry has stopped matching anything.

## Why

The register's own rules say every entry is temporary and re-examined every release. Nothing checked that automatically, and what the manual re-examination reads is each entry's written **exit condition** — a *prediction* about how upstream will fix the thing.

`GHSA-mh99-v99m-4gvg` is the worked example. Its exit was "@eslint/config-array ships a minimatch that works with brace-expansion >= 5.0.8", because 5.0.8 was the only fix available and its export shape breaks the eslint chain. It was re-tested against precisely that on 2026-08-01 and correctly left in place. Upstream had backported to **2.1.4** — a one-line override change, eslint untouched. The re-reading was diligent; it was watching the wrong thing.

## How it detects a fix

No advisory API and no version arithmetic of our own. Every entry exists *because* the release gate found no fix — and the gate runs `ignore-unfixed: true` alongside the register. So re-running each scanner with the register **disabled** and fix-only reporting **kept** yields exactly the entries upstream has since fixed:

| Scanner | Gate | Register review |
|---|---|---|
| Trivy | `ignore-unfixed` + `trivyignores:` | `ignore-unfixed`, no `trivyignores` |
| pip-audit | `--ignore-vuln` per entry | none, read `fix_versions` |
| npm audit | allowlist applied in-script | none, read `fixAvailable` |

The same pass gives the second signal free: an entry matching **nothing** is stale under rule 4, where it silently shadows the regression that would bring the finding back. The two call for opposite actions — bump versus delete — so they are reported separately.

## Shape

Two jobs in `release-rescan.yml`, mirroring the scan→report structure already there. Reporter, not a gate: the release-time scan is the gate, and a permanently red scheduled job gets muted then ignored when it matters.

**Its own issue**, per your call — the existing one drives a patch release, this one drives register maintenance, and merging them buries each in the other. Same refresh-in-place behaviour: body updated every run, comment only when the set changes.

**It carries full detail, deliberately**, which is the one place it diverges from `rescan_report.py`. That report withholds ids because naming a supported release alongside what is wrong with it is a map for anyone deciding where to look. Nothing here is new information — the register files are committed, and their headers say the reasoning is "written to be read by someone outside the project". The detail *is* the actionable part, since the action is "bump X to Y".

## Verified

Against the real register, with a synthetic upstream fix for the live ncurses entry:

```
## Fixable now — take the fix
| Advisory | Register | Package | Installed | Fixed in |
| `CVE-2025-69720` | pentest/trivy/.trivyignore | ncurses | 6.5 | **6.6+20251231-1** |

<details><summary>1 still doing their job (no fix upstream)</summary>
| `PYSEC-2025-183` | pentest/pip-audit-ignore.txt | pyjwt | 2.13.0 |
```

The genuinely-unfixed pyjwt entry stays collapsed rather than nagging weekly — that noise is what gets a report muted.

## A bug found on the way

I checked the pip-audit parser against the real tool's output rather than assuming its shape, and its entries carry `aliases`. The same advisory has both a PYSEC id and a CVE, and which one is in the register depends on where whoever added it was reading. Matching on the primary id alone would report a **live** suppression as matching nothing — and this report tells you to delete those. Now indexed by aliases too, with a test.

## Tests

14 new, in the existing `scripts/tests` job (renamed from "Re-scan Scripts Test", which no longer covered everything it runs). Every failure mode here is silence — a parser reading the wrong field reports zero and the run goes green — so they pin the classification itself, including that a scanner which *did not run* can never cause an entry to be called stale.

`docs/cve-policy.md` records the mechanism and the lesson: re-read the advisory's own affected/patched ranges each cycle, not only the exit condition you wrote down.

Closes #1255
