### PR TITLE
fix(1257): the register review must scan unfixed findings too

### DIFF
--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -348,10 +348,20 @@ jobs:
           format: json
           output: trivy-${{ matrix.image }}.json
           severity: HIGH,CRITICAL
-          # `ignore-unfixed` stays ON while `trivyignores` is deliberately
-          # ABSENT. Together those two mean exactly "everything we suppress
-          # that now has a fix" — which is the whole question this job asks.
-          ignore-unfixed: true
+          # Both `trivyignores` and `ignore-unfixed` are deliberately ABSENT,
+          # and the second one is the correction from #1257.
+          #
+          # Carrying `ignore-unfixed` over from the gate looked right — the gate
+          # only reports fixable findings, so surely the review should too. It
+          # is exactly wrong. An entry is in the register BECAUSE it is unfixed,
+          # so fix-only scanning renders every legitimate entry invisible, and
+          # the review then reports it as matching nothing — telling you to
+          # delete a live suppression.
+          #
+          # Scanning everything gives both signals from one pass, the way
+          # pip-audit already worked: present with a `FixedVersion` means take
+          # the fix, present without one means the entry is still doing its
+          # job, and absent means genuinely stale.
           exit-code: '0'
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/pentest/pip-audit-ignore.txt
+++ b/pentest/pip-audit-ignore.txt
@@ -9,15 +9,15 @@
 # Consumed by the `python-audit` job in ci.yml (the release gate) and by
 # release-rescan.yml (which re-checks supported releases against *current*
 # reasoning). One file so the two can never drift apart.
-
-# PYSEC-2025-183 — pyjwt.
 #
-# Disputed by the supplier: the advisory concerns weak HMAC keys, but key
-# length is chosen by the application using the library, not by the library.
-# No fix version has been published.
+# Currently empty. PYSEC-2025-183 (pyjwt, a disputed HMAC key-strength
+# advisory) lived here and was removed on 2026-08-04 under rule 4 — not because
+# it was fixed, but because it stopped applying: the advisory's affected range
+# ends at pyjwt 2.10.1 and our floating pin now resolves 2.13.0. pip-audit
+# reports nothing against the shipped requirements.
 #
-# Re-verified 2026-08-01: our pin already floats to the latest pyjwt (2.13.0)
-# and the advisory still has no fix, so there is nothing to bump to.
-#
-# EXIT: a fix is published, or the dispute is resolved upstream.
-PYSEC-2025-183
+# Worth noting how it was found, since the entry had been re-read a few days
+# earlier and kept. Its exit condition was "a fix is published, or the dispute
+# is resolved upstream", and neither happened — the entry aged out by a third
+# route nobody had written down. The automated review (#1255) does not read
+# exit conditions, it just asks the scanners, which is why it caught this.

--- a/scripts/register_review.py
+++ b/scripts/register_review.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 """Review the accepted-risk register against current advisory data (#1255).
 
-Every entry in the register exists because there was no fix to take. The
-release gate enforces that: it runs with `ignore-unfixed` alongside the
-register, so a suppressed advisory is one the gate would not have reported
-anyway. Re-running each scanner with the **register disabled** and **fix-only
-kept** therefore yields exactly one thing — the entries that have since become
-fixable. No advisory API, no version comparison of our own; the scanners
-already know what they would tell us if we stopped suppressing.
+Every entry in the register exists because there was no fix to take. Re-running
+each scanner with the **register disabled** shows what we would be told if we
+stopped suppressing — no advisory API and no version comparison of our own,
+because the scanners already know.
+
+**The scan must include unfixed findings**, and getting that wrong was #1257.
+The release gate runs `ignore-unfixed`, so carrying that setting over here
+looks natural and is exactly backwards: an entry is in the register BECAUSE it
+is unfixed, so a fix-only scan renders every legitimate entry invisible and the
+review reports it as matching nothing — telling you to delete a live
+suppression. Scanning everything yields both signals from one pass instead.
 
 That matters because re-reading an entry by hand checks the wrong thing. An
 entry's stated exit condition is a *prediction* about how upstream will fix it,
@@ -94,10 +98,11 @@ def _load(path: pathlib.Path):
 def from_trivy(data) -> dict[str, dict]:
     """{id: {package, installed, fixed}} from a Trivy JSON report.
 
-    The report is produced WITHOUT the ignore file, so an id appearing here is
-    unsuppressed; and WITH `ignore-unfixed`, so it appearing at all means a fix
-    exists. `FixedVersion` is recorded anyway — the report should say what to
-    bump to, not merely that one could.
+    Produced WITHOUT the ignore file and WITHOUT `ignore-unfixed`, so presence
+    means "still there" and `FixedVersion` alone decides whether anything can be
+    done about it — the same shape pip-audit has always had. See the module
+    docstring for why fix-only scanning here is a bug rather than an
+    optimisation (#1257).
     """
     found: dict[str, dict] = {}
     for result in (data or {}).get("Results") or []:
@@ -266,9 +271,9 @@ def main() -> int:
         f"([policy](https://github.com/{_REPO}/blob/main/docs/cve-policy.md)).",
         "",
         "Each entry was accepted because no fix existed. This re-runs every scanner "
-        "with the register **disabled** and fix-only reporting **kept**, so anything "
-        "listed below is an accepted risk that upstream has since fixed, or an entry "
-        "that no longer matches anything.",
+        "with the register **disabled**, so anything listed below is either an "
+        "accepted risk that upstream has since fixed, or an entry that no longer "
+        "matches anything at all.",
         "",
     ]
 
@@ -291,11 +296,16 @@ def main() -> int:
         body += [
             "## Matching nothing — delete",
             "",
-            "Reported by no scanner. Rule 4: a stale entry is a liability rather than a "
-            "leftover, because it silently shadows the regression that would bring the "
-            "finding back.",
+            "Reported by no scanner, including as an unfixed finding. Rule 4: a stale "
+            "entry is a liability rather than a leftover, because it silently shadows "
+            "the regression that would bring the finding back.",
             "",
-            *_table(unmatched, with_fix=False),
+            "| Advisory | Register |",
+            "|---|---|",
+            *[
+                f"| `{r['id']}` | {REGISTERS.get(r['scanner'], r['scanner'])} |"
+                for r in unmatched
+            ],
             "",
         ]
 

--- a/scripts/tests/test_register_review.py
+++ b/scripts/tests/test_register_review.py
@@ -166,6 +166,70 @@ def test_entry_with_a_fix_is_fixable_and_one_without_is_holding():
     assert unmatched == []
 
 
+def test_an_unfixed_trivy_finding_is_holding_not_stale():
+    """The #1257 regression, and the reason the scan must not use
+    `ignore-unfixed`.
+
+    An entry is in the register BECAUSE it is unfixed, so it comes back from
+    Trivy with an empty `FixedVersion`. If that reads as "nothing to do" it is
+    fine; if the scan never reports it at all — which is what `ignore-unfixed`
+    causes — the entry looks stale, and this report tells you to DELETE a live
+    suppression. That is the one direction this tool must never be wrong in.
+    """
+    found = rr.from_trivy(
+        {
+            "Results": [
+                {
+                    "Vulnerabilities": [
+                        {
+                            "VulnerabilityID": "CVE-2025-69720",
+                            "PkgName": "libncursesw6",
+                            "InstalledVersion": "6.5+20250216-2",
+                            "FixedVersion": "",
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+    fixable, unmatched, holding = rr.classify(
+        {"trivy": ["CVE-2025-69720"], "pip-audit": [], "npm-audit": []},
+        {"trivy": found},
+    )
+    assert [r["id"] for r in holding] == ["CVE-2025-69720"]
+    assert unmatched == [], "an unfixed entry must never be reported as stale"
+    assert fixable == []
+
+
+def test_the_workflow_does_not_scan_fix_only():
+    """Guards the setting itself, not just the parser.
+
+    The bug was in the workflow rather than the code: the parser handled an
+    empty `FixedVersion` correctly all along, but Trivy was never asked for
+    those rows. A unit test of the parser cannot see that, so this reads the
+    register scan job and asserts the setting is absent.
+    """
+    wf = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / ".github/workflows/release-rescan.yml"
+    )
+    text = wf.read_text()
+    start = text.index("register-scan:")
+    end = text.index("\n  register:", start)
+    # Match the YAML key, not the substring: the block deliberately *mentions*
+    # ignore-unfixed in a comment explaining why it is absent, and a naive
+    # substring check fails on its own documentation.
+    settings = [
+        ln.strip()
+        for ln in text[start:end].splitlines()
+        if ln.strip().startswith("ignore-unfixed:")
+    ]
+    assert settings == [], (
+        f"the register scan must include unfixed findings, or every legitimate "
+        f"entry reads as stale — see #1257 (found {settings})"
+    )
+
+
 def test_entry_reported_by_nobody_is_stale():
     fixable, unmatched, holding = rr.classify(
         {"trivy": ["CVE-GONE"], "pip-audit": [], "npm-audit": []}, {"trivy": {}}


### PR DESCRIPTION
The register review's first live run ([#1257](https://github.com/mattrobinsonsre/terrapod/issues/1257)) reported both entries as "matching nothing — delete". One was right. The other was the tool telling us to delete a **live** suppression, which is the single direction it must never be wrong in.

## The bug

I carried `ignore-unfixed: true` over from the release gate. It looks natural — the gate reports only fixable findings, so surely the review should too — and it is exactly backwards. **An entry is in the register because it is unfixed**, so fix-only scanning makes every legitimate entry invisible, and "absent" then reads as "stale".

Verified rather than reasoned. Scanning the published image without the flag:

```
CVE-2025-69720  libncursesw6  6.5+20250216-2  FixedVersion: ""
```

Still present, still unfixed, still earning its place in the register.

Removing the setting also makes the tool **simpler**, because one pass now yields both signals in the shape pip-audit always had:

- present, with a fixed version → take the fix
- present, without one → the entry is doing its job
- absent → genuinely stale

## The real finding, actioned

`PYSEC-2025-183` (pyjwt) genuinely matches nothing now — the advisory's affected range ends at **2.10.1** ([OSV](https://api.osv.dev/v1/vulns/PYSEC-2025-183)) and our floating pin resolves **2.13.0**, so pip-audit reports nothing against the shipped requirements. Deleted under rule 4.

Worth recording *why* it survived: the entry was re-read and kept four days ago, and its exit condition was "a fix is published, or the dispute is resolved upstream". Neither happened. It aged out by a third route nobody had written down — which is the whole argument for a review that asks the scanners instead of re-reading predictions.

## Tests

Two regressions, and the second is the one that would actually have caught this:

- an unfixed Trivy finding classifies as **holding**, never stale;
- the **workflow** is asserted not to set `ignore-unfixed` in the register scan.

The bug lived in the workflow, not the code — the parser handled an empty `FixedVersion` correctly all along, it was simply never given those rows. A unit test of the parser cannot see that, so the guard reads the YAML. Mutation-checked: re-introducing the setting turns it red.

## After this lands

Re-running the review against real scan data now reports `has_findings=false`, with ncurses correctly filed under "still doing their job". #1257 can be closed once merged — I'll confirm with a live re-run rather than assume.

Closes #1257
