### PR TITLE
fix(1260): pin the Go toolchain floor in every module

### DIFF
--- a/go-terrapod/go.mod
+++ b/go-terrapod/go.mod
@@ -1,3 +1,3 @@
 module github.com/mattrobinsonsre/terrapod/go-terrapod
 
-go 1.26
+go 1.26.5

--- a/loadtest/go.mod
+++ b/loadtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/loadtest
 
-go 1.26
+go 1.26.5
 
 require github.com/mattrobinsonsre/terrapod/go-terrapod v0.0.0-00010101000000-000000000000
 

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/mcp
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/mattrobinsonsre/terrapod/go-terrapod v0.0.0

--- a/migrate/go.mod
+++ b/migrate/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/migrate
 
-go 1.26
+go 1.26.5
 
 require (
 	cloud.google.com/go/storage v1.62.2

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/provider
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.13.0

--- a/publish/go.mod
+++ b/publish/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/publish
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/ProtonMail/go-crypto v1.4.1

--- a/query/go.mod
+++ b/query/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/query
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/hashicorp/hcl/v2 v2.24.0


### PR DESCRIPTION
Follows the v1.2.2 patch, which hit this for real.

Every module carried a bare `go 1.26`, and CI builds each with `go-version-file: <module>/go.mod`. `setup-go` resolves that to whatever 1.26.x it offers on the day, so which patch release built a given artifact depended on when the build ran — and was recorded nowhere.

`CVE-2026-39822` (Go stdlib `os.Root` symlink following) is fixed in **1.26.5**, and `terrapod-query` — baked into the api and runner images — was reported against it. The build had very likely already used a new enough toolchain, but that is not a basis for a security patch, and rebuilding the same tag six months from now would silently produce a different one.

Pinning to `go 1.26.5` makes it deterministic and checkable with `go version -m` on the artifact:

```
/tmp/tq: go1.26.5
    dep  golang.org/x/text  v0.39.0
```

**All seven modules, not just the baked one.** `query` is scanned as part of our images, but `provider`, `migrate`, `publish` and `mcp` ship as binaries operators run — a stdlib advisory there is equally real, and nothing of ours scans them. `go-terrapod` and `loadtest` are included for consistency rather than because they ship.

All seven build clean on the pinned floor.

Closes #1260