### PR TITLE
fix: group multi-part report strings explicitly

### DIFF
--- a/scripts/register_review.py
+++ b/scripts/register_review.py
@@ -270,10 +270,12 @@ def main() -> int:
         "Automated review of the accepted-risk register "
         f"([policy](https://github.com/{_REPO}/blob/main/docs/cve-policy.md)).",
         "",
-        "Each entry was accepted because no fix existed. This re-runs every scanner "
-        "with the register **disabled**, so anything listed below is either an "
-        "accepted risk that upstream has since fixed, or an entry that no longer "
-        "matches anything at all.",
+        (
+            "Each entry was accepted because no fix existed. This re-runs every "
+            "scanner with the register **disabled**, so anything listed below is "
+            "either an accepted risk that upstream has since fixed, or an entry "
+            "that no longer matches anything at all."
+        ),
         "",
     ]
 
@@ -281,14 +283,20 @@ def main() -> int:
         body += [
             "## Fixable now — take the fix",
             "",
-            "A patched version exists. Rule 1 of the register: bump to it, and delete "
-            "the entry in the **same** pull request rather than leaving it behind.",
+            (
+                "A patched version exists. Rule 1 of the register: bump to it, and "
+                "delete the entry in the **same** pull request rather than leaving "
+                "it behind."
+            ),
             "",
             *_table(fixable, with_fix=True),
             "",
-            "Check the advisory's own affected/patched ranges rather than the entry's "
-            "written exit condition — the exit is a guess about how upstream would fix "
-            "it, and a backport to an older line is exactly the case that guess misses.",
+            (
+                "Check the advisory's own affected/patched ranges rather than the "
+                "entry's written exit condition — the exit is a guess about how "
+                "upstream would fix it, and a backport to an older line is exactly "
+                "the case that guess misses."
+            ),
             "",
         ]
 
@@ -296,9 +304,11 @@ def main() -> int:
         body += [
             "## Matching nothing — delete",
             "",
-            "Reported by no scanner, including as an unfixed finding. Rule 4: a stale "
-            "entry is a liability rather than a leftover, because it silently shadows "
-            "the regression that would bring the finding back.",
+            (
+                "Reported by no scanner, including as an unfixed finding. Rule 4: a "
+                "stale entry is a liability rather than a leftover, because it "
+                "silently shadows the regression that would bring the finding back."
+            ),
             "",
             "| Advisory | Register |",
             "|---|---|",


### PR DESCRIPTION
Clears the four open code-scanning alerts — `py/implicit-string-concatenation-in-list`, all in the register review's report builder, all introduced by #1256 earlier today.

The concatenation was deliberate: long prose split across source lines. But it sits inside a **list literal**, where adjacent string literals are precisely what a missing comma looks like — the rule cannot distinguish the two, and neither can someone skimming the code. Wrapping each in parentheses makes the grouping explicit instead of something you have to infer.

No behaviour change. The rendered report is character-identical and the fingerprint is unchanged (`4f53cda18c2baa0c` against the same input), and the 44 script tests pass.

That takes open code-scanning alerts to zero.