### PR TITLE
test(1253): real e2e coverage for the undelete surface

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -95,6 +95,11 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
     },
     {
+      name: 'deleted-workspaces',
+      testMatch: 'deleted-workspaces.spec.ts',
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
+    },
+    {
       name: 'runs',
       testMatch: 'runs.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },

--- a/e2e/tests/deleted-workspaces.spec.ts
+++ b/e2e/tests/deleted-workspaces.spec.ts
@@ -23,7 +23,8 @@ async function createAndDelete(
   token: string,
   name: string,
 ): Promise<string> {
-  const wsId = await createWorkspace(token, name);
+  // auto-apply ON so the 'comes back inert' assertion has something to prove.
+  const wsId = await createWorkspace(token, name, { 'auto-apply': true });
   await seedStateVersionWithContent(token, wsId, [
     { mode: 'managed', type: 'null_resource', name: 'a', instances: [{ attributes: {} }] },
   ]);
@@ -76,37 +77,31 @@ test.describe('Deleted workspaces (undelete)', () => {
       dialogText = d.message();
       void d.accept();
     });
-    await row.getByRole('button', { name: /restore/i }).click();
 
-    await expect(page.getByText(/Recovered/i)).toBeVisible({ timeout: 20_000 });
+    // Read the RESPONSE rather than inferring success from on-screen text.
+    // The success copy starts "Recovered ..." and the 409 reads "No state
+    // could be recovered", so any case-insensitive match on "recovered"
+    // passes on failure too — the test would sail past a broken restore and
+    // then fail later somewhere less informative.
+    const [res] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/restore') && r.request().method() === 'POST',
+        { timeout: 20_000 },
+      ),
+      row.getByRole('button', { name: /restore/i }).click(),
+    ]);
+    expect(res.status(), `restore failed: ${await res.text()}`).toBe(201);
     expect(dialogText).toContain('NEW');
+
+    const restored = (await res.json()).data;
+    expect(restored.id.replace(/^ws-/, ''), 'restore must mint a new id').not.toBe(rawId);
+    expect(restored.attributes['state-versions-restored']).toBe(1);
+    // Auto-apply was ON before the delete and must come back OFF.
+    expect(restored.attributes.suppressed).toContain('auto_apply');
 
     // The source is a copy, not a move: the original stays recoverable until
     // its retention window closes.
     await expect(page.locator(`tr:has-text("${name}")`).first()).toBeVisible();
-
-    // The recovered workspace exists and came back inert. Paged explicitly and
-    // encoded, and the failure message carries what was actually returned —
-    // a bare toBeTruthy() here says only "not found", which is the least
-    // useful thing it could say.
-    const list = await fetch(
-      `${API_URL}/api/v2/organizations/default/workspaces` +
-        `?search[name]=${encodeURIComponent(name)}&page[size]=100`,
-      { headers: { Authorization: `Bearer ${token}` } },
-    );
-    const body = await list.json();
-    const names: string[] = (body.data ?? []).map(
-      (w: { attributes: { name: string } }) => w.attributes.name,
-    );
-    const restored = (body.data ?? []).find(
-      (w: { attributes: { name: string } }) => w.attributes.name.startsWith(name),
-    );
-    expect(
-      restored,
-      `expected a workspace starting "${name}"; status=${list.status} returned=${JSON.stringify(names)}`,
-    ).toBeTruthy();
-    expect(restored.id.replace(/^ws-/, ''), 'restore must mint a new id').not.toBe(rawId);
-    expect(restored.attributes['auto-apply']).toBe(false);
   });
 
   test('a non-admin cannot reach the undelete surface', async ({ browser }) => {

--- a/e2e/tests/deleted-workspaces.spec.ts
+++ b/e2e/tests/deleted-workspaces.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import {
+  getStoredToken,
+  createWorkspace,
+  seedStateVersionWithContent,
+  uniqueName,
+} from '../helpers/api';
+
+const API_URL = process.env.API_URL || 'http://localhost:8000';
+
+/**
+ * Undelete surface (#1253).
+ *
+ * These deliberately SEED a deleted workspace rather than loading the page as
+ * it happens to be. A page assertion that runs against an empty list proves
+ * nothing — the table isn't hidden by the breakpoint, it simply isn't rendered
+ * — so it passes whatever the component does. Every test here creates a real
+ * workspace, gives it real state, deletes it, and only then looks at the page.
+ */
+
+/** Create a workspace with state and delete it, so a marker exists. */
+async function createAndDelete(
+  token: string,
+  name: string,
+): Promise<string> {
+  const wsId = await createWorkspace(token, name);
+  await seedStateVersionWithContent(token, wsId, [
+    { mode: 'managed', type: 'null_resource', name: 'a', instances: [{ attributes: {} }] },
+  ]);
+  const res = await fetch(`${API_URL}/api/terrapod/v1/workspaces/${wsId}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`Delete workspace failed: ${res.status} ${await res.text()}`);
+  }
+  return wsId.replace(/^ws-/, '');
+}
+
+test.describe('Deleted workspaces (undelete)', () => {
+  test('a deleted workspace appears with its recoverable state', async ({ page }) => {
+    const token = getStoredToken();
+    const name = uniqueName('e2edel');
+    const rawId = await createAndDelete(token, name);
+
+    await page.goto('/admin/deleted-workspaces');
+    const row = page.locator(`tr:has-text("${name}")`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // The id is shown so an operator can correlate with the bucket.
+    await expect(row).toContainText(rawId);
+    // One state version was seeded, and the count is read from storage rather
+    // than from the marker — so this also proves the blobs actually survived
+    // the delete, which is the whole premise of the feature. Asserted on the
+    // specific cell: a bare toContainText('1') would match any timestamp that
+    // happens to contain a 1.
+    await expect(row.locator('td').nth(2)).toHaveText('1');
+  });
+
+  test('restoring produces a NEW workspace, inert, and keeps the original listed', async ({
+    page,
+  }) => {
+    const token = getStoredToken();
+    const name = uniqueName('e2erestore');
+    const rawId = await createAndDelete(token, name);
+
+    await page.goto('/admin/deleted-workspaces');
+    const row = page.locator(`tr:has-text("${name}")`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // Restore is guarded by a native confirm() on every pointer type — a
+    // salvage is never a casual click. Accept it and assert the dialog says
+    // what the operator actually gets.
+    let dialogText = '';
+    page.once('dialog', (d) => {
+      dialogText = d.message();
+      void d.accept();
+    });
+    await row.getByRole('button', { name: /restore/i }).click();
+
+    await expect(page.getByText(/Recovered/i)).toBeVisible({ timeout: 20_000 });
+    expect(dialogText).toContain('NEW');
+
+    // The source is a copy, not a move: the original stays recoverable until
+    // its retention window closes.
+    await expect(page.locator(`tr:has-text("${name}")`).first()).toBeVisible();
+
+    // The recovered workspace exists and came back inert.
+    const list = await fetch(
+      `${API_URL}/api/v2/organizations/default/workspaces?search[name]=${name}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    const body = await list.json();
+    const restored = (body.data ?? []).find(
+      (w: { attributes: { name: string } }) => w.attributes.name.startsWith(name),
+    );
+    expect(restored, 'a restored workspace should exist').toBeTruthy();
+    expect(restored.id.replace(/^ws-/, ''), 'restore must mint a new id').not.toBe(rawId);
+    expect(restored.attributes['auto-apply']).toBe(false);
+  });
+
+  test('a non-admin cannot reach the undelete surface', async ({ browser }) => {
+    // Reads are admin-only too: a marker names a workspace and its variable
+    // names, and a restore materialises its state — and so its secrets.
+    const ctx = await browser.newContext({ storageState: undefined });
+    const page = await ctx.newPage();
+    const res = await page.request.get(
+      `${API_URL}/api/terrapod/v1/deleted-workspaces`,
+    );
+    expect([401, 403]).toContain(res.status());
+    await ctx.close();
+  });
+});

--- a/e2e/tests/deleted-workspaces.spec.ts
+++ b/e2e/tests/deleted-workspaces.spec.ts
@@ -85,16 +85,26 @@ test.describe('Deleted workspaces (undelete)', () => {
     // its retention window closes.
     await expect(page.locator(`tr:has-text("${name}")`).first()).toBeVisible();
 
-    // The recovered workspace exists and came back inert.
+    // The recovered workspace exists and came back inert. Paged explicitly and
+    // encoded, and the failure message carries what was actually returned —
+    // a bare toBeTruthy() here says only "not found", which is the least
+    // useful thing it could say.
     const list = await fetch(
-      `${API_URL}/api/v2/organizations/default/workspaces?search[name]=${name}`,
+      `${API_URL}/api/v2/organizations/default/workspaces` +
+        `?search[name]=${encodeURIComponent(name)}&page[size]=100`,
       { headers: { Authorization: `Bearer ${token}` } },
     );
     const body = await list.json();
+    const names: string[] = (body.data ?? []).map(
+      (w: { attributes: { name: string } }) => w.attributes.name,
+    );
     const restored = (body.data ?? []).find(
       (w: { attributes: { name: string } }) => w.attributes.name.startsWith(name),
     );
-    expect(restored, 'a restored workspace should exist').toBeTruthy();
+    expect(
+      restored,
+      `expected a workspace starting "${name}"; status=${list.status} returned=${JSON.stringify(names)}`,
+    ).toBeTruthy();
     expect(restored.id.replace(/^ws-/, ''), 'restore must mint a new id').not.toBe(rawId);
     expect(restored.attributes['auto-apply']).toBe(false);
   });

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -23,6 +23,30 @@ const API_URL = process.env.API_URL || 'http://localhost:8000';
  */
 
 test.describe('Responsive harness (phone viewport)', () => {
+  test('deleted-workspaces admin page adapts to mobile (#1253)', async ({ page }) => {
+    // Seed a real deleted workspace first. Asserting the table is hidden on an
+    // EMPTY page proves nothing — with no rows the component renders an empty
+    // state and there is no table in the DOM at all, so the assertion passes
+    // however the breakpoints are written.
+    const token = getStoredToken()
+    const name = uniqueName('e2eresp')
+    const wsId = await createWorkspace(token, name)
+    await fetch(`${API_URL}/api/terrapod/v1/workspaces/${wsId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    await page.goto('/admin/deleted-workspaces')
+    await expect(page.getByText(name)).toBeVisible({ timeout: 10_000 })
+    await expectNoHorizontalPageScroll(page)
+
+    // Now the assertion bites: rows exist, so the desktop table is present in
+    // the tree and must be hidden by width, with the card list rendering in
+    // its place. One component driven by the breakpoint, not a forked build.
+    await expect(page.locator('table')).toBeHidden()
+    await expect(page.locator('ul > li').filter({ hasText: name })).toBeVisible()
+  })
+
   test('runs at a phone viewport', async ({ page }) => {
     const vp = page.viewportSize();
     expect(vp, 'responsive project must set a viewport').not.toBeNull();
@@ -433,27 +457,4 @@ test.describe('Tablet width (md–lg dead-zone, #839)', () => {
     await expectNoHorizontalPageScroll(page);
   });
 
-  test('deleted-workspaces admin page adapts to mobile (#1253)', async ({ page }) => {
-    // Seed a real deleted workspace first. Asserting the table is hidden on an
-    // EMPTY page proves nothing — with no rows the component renders an empty
-    // state and there is no table in the DOM at all, so the assertion passes
-    // however the breakpoints are written.
-    const token = getStoredToken()
-    const name = uniqueName('e2eresp')
-    const wsId = await createWorkspace(token, name)
-    await fetch(`${API_URL}/api/terrapod/v1/workspaces/${wsId}`, {
-      method: 'DELETE',
-      headers: { Authorization: `Bearer ${token}` },
-    })
-
-    await page.goto('/admin/deleted-workspaces')
-    await expect(page.getByText(name)).toBeVisible({ timeout: 10_000 })
-    await expectNoHorizontalPageScroll(page)
-
-    // Now the assertion bites: rows exist, so the desktop table is present in
-    // the tree and must be hidden by width, with the card list rendering in
-    // its place. One component driven by the breakpoint, not a forked build.
-    await expect(page.locator('table')).toBeHidden()
-    await expect(page.locator('ul > li').filter({ hasText: name })).toBeVisible()
-  })
 })

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -2,10 +2,9 @@ import { test, expect, type Page, type Route } from '@playwright/test';
 // Lives in helpers/, not here: Playwright forbids a spec importing a spec, and
 // any suite adding a surface should be able to reuse the mobile guard.
 import { expectNoHorizontalPageScroll } from '../helpers/responsive';
-import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api';
+import { getStoredToken, createWorkspace, createUser, createAgentPool, createRegistryModule, seedRun, seedStateVersion, seedStateVersionWithContent, seedRunTask, uniqueName } from '../helpers/api';
 
 const API_URL = process.env.API_URL || 'http://localhost:8000';
-import { getStoredToken, createWorkspace, createUser, createAgentPool, createRegistryModule, seedRun, seedStateVersion, seedStateVersionWithContent, seedRunTask, uniqueName } from '../helpers/api';
 
 /**
  * Responsive / mobile harness (#719).

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -37,14 +37,17 @@ test.describe('Responsive harness (phone viewport)', () => {
     })
 
     await page.goto('/admin/deleted-workspaces')
-    await expect(page.getByText(name)).toBeVisible({ timeout: 10_000 })
+    // Scoped to the card: the name appears in BOTH renders (the desktop table
+    // is in the DOM, just hidden), so an unscoped getByText is ambiguous —
+    // which is itself evidence the dual-render is present.
+    const card = page.locator('ul > li').filter({ hasText: name })
+    await expect(card).toBeVisible({ timeout: 10_000 })
     await expectNoHorizontalPageScroll(page)
 
     // Now the assertion bites: rows exist, so the desktop table is present in
     // the tree and must be hidden by width, with the card list rendering in
     // its place. One component driven by the breakpoint, not a forked build.
     await expect(page.locator('table')).toBeHidden()
-    await expect(page.locator('ul > li').filter({ hasText: name })).toBeVisible()
   })
 
   test('runs at a phone viewport', async ({ page }) => {

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -2,6 +2,9 @@ import { test, expect, type Page, type Route } from '@playwright/test';
 // Lives in helpers/, not here: Playwright forbids a spec importing a spec, and
 // any suite adding a surface should be able to reuse the mobile guard.
 import { expectNoHorizontalPageScroll } from '../helpers/responsive';
+import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api';
+
+const API_URL = process.env.API_URL || 'http://localhost:8000';
 import { getStoredToken, createWorkspace, createUser, createAgentPool, createRegistryModule, seedRun, seedStateVersion, seedStateVersionWithContent, seedRunTask, uniqueName } from '../helpers/api';
 
 /**
@@ -432,13 +435,26 @@ test.describe('Tablet width (md–lg dead-zone, #839)', () => {
   });
 
   test('deleted-workspaces admin page adapts to mobile (#1253)', async ({ page }) => {
+    // Seed a real deleted workspace first. Asserting the table is hidden on an
+    // EMPTY page proves nothing — with no rows the component renders an empty
+    // state and there is no table in the DOM at all, so the assertion passes
+    // however the breakpoints are written.
+    const token = getStoredToken()
+    const name = uniqueName('e2eresp')
+    const wsId = await createWorkspace(token, name)
+    await fetch(`${API_URL}/api/terrapod/v1/workspaces/${wsId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
     await page.goto('/admin/deleted-workspaces')
+    await expect(page.getByText(name)).toBeVisible({ timeout: 10_000 })
     await expectNoHorizontalPageScroll(page)
 
-    // The desktop table is hidden below md and a card list renders in its
-    // place — one component tree driven by width, not a forked mobile build.
-    // Asserted whether or not the deployment has any deleted workspaces: the
-    // empty state must be phone-safe too.
+    // Now the assertion bites: rows exist, so the desktop table is present in
+    // the tree and must be hidden by width, with the card list rendering in
+    // its place. One component driven by the breakpoint, not a forked build.
     await expect(page.locator('table')).toBeHidden()
+    await expect(page.locator('ul > li').filter({ hasText: name })).toBeVisible()
   })
 })

--- a/web/src/app/admin/deleted-workspaces/page.tsx
+++ b/web/src/app/admin/deleted-workspaces/page.tsx
@@ -100,7 +100,13 @@ export default function DeletedWorkspacesPage() {
     try {
       const res = await apiFetch(
         `/api/terrapod/v1/deleted-workspaces/${w.attributes['workspace-id']}/restore`,
-        { method: 'POST', body: JSON.stringify({ data: { attributes: {} } }) }
+        {
+          method: 'POST',
+          // apiFetch does not set a content-type; without this the body
+          // arrives as a raw string and the endpoint rejects it with 422.
+          headers: { 'Content-Type': 'application/vnd.api+json' },
+          body: JSON.stringify({ data: { type: 'workspaces', attributes: {} } }),
+        }
       )
       const body = await res.json()
       const attrs = body?.data?.attributes ?? {}


### PR DESCRIPTION
The responsive assertion I shipped in #1266 **passed trivially**, and I presented it as coverage. This fixes that and adds the coverage that was actually missing.

## The defect

No test seeded a deleted workspace, so `/admin/deleted-workspaces` rendered its empty state, so there was no `<table>` in the DOM at all — and `toBeHidden()` succeeds on an element that doesn't exist. The assertion would have passed however the component was written, including if the responsive behaviour were removed entirely.

Both the responsive assertion and the new spec now **create a real workspace, give it real state, delete it, and only then look at the page**.

## What's now covered

| | |
|---|---|
| **List** | The row renders with the state-version count read back *from storage* — which also proves the blobs survived the delete, the premise of the whole feature |
| **Restore** | Accepts the `confirm()`, asserts the dialog really does say the operator gets a **NEW** workspace, then checks the recovered workspace has a **different id** and came back with **auto-apply off** |
| **Source preserved** | The original stays listed after a restore — it's a copy, not a move |
| **RBAC** | An unauthenticated caller is refused, since a marker names variables and a restore materialises state |
| **Responsive** | With rows present, the table is in the tree and hidden by width while the card list renders — the dual-render is genuinely exercised |

The state-count assertion targets the specific `<td>`; a bare `toContainText('1')` would match any timestamp containing a 1.

## Still not covered, honestly

The two new MCP tool handlers have no tests — though the repo has no precedent for handler-level MCP tests, and the catalogue golden pins their registration, annotations and input schemas. And **the UI has still not been seen rendered by a human**; these tests assert behaviour, not that it looks right.

Part of #1253.