### PR TITLE
test(1253): cover the restore paths a real deployment actually hits

### DIFF
--- a/mcp/internal/mcpserver/deleted_workspaces_tools_test.go
+++ b/mcp/internal/mcpserver/deleted_workspaces_tools_test.go
@@ -1,0 +1,198 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// The undelete tools (#1253) driven end to end: a real MCP client speaking to
+// a real server over an in-memory transport, backed by a fake Terrapod.
+//
+// The catalogue golden pins that these tools are REGISTERED, with the right
+// annotations and input schema. It says nothing about whether calling one
+// reaches the right endpoint or returns anything useful — which is what a
+// wrapper this thin can still get wrong (a typo'd path, a dropped argument, a
+// result that never surfaces the fields an agent needs).
+
+// toolCaller wires a fake Terrapod to an MCP client session.
+func toolCaller(t *testing.T, handler http.HandlerFunc) *mcp.ClientSession {
+	t.Helper()
+	api := httptest.NewServer(handler)
+	t.Cleanup(api.Close)
+
+	c, err := terrapod.NewClient(terrapod.Options{BaseURL: api.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	registerObserve(srv, c)
+	registerAct(srv, c)
+
+	ct, st := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := srv.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	sess, err := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil).
+		Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+func resultText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			sb.WriteString(tc.Text)
+		}
+	}
+	return sb.String()
+}
+
+func TestDeletedWorkspaceListToolReturnsTheMarkers(t *testing.T) {
+	var gotPath string
+	sess := toolCaller(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"11111111-1111-4111-8111-111111111111",
+		  "type":"deleted-workspaces","attributes":{
+		    "workspace-id":"11111111-1111-4111-8111-111111111111",
+		    "workspace-name":"prod-network","deleted-at":"2026-08-01T09:00:00Z",
+		    "marker-reason":"deleted","state-versions-available":12,
+		    "restorable-until":"2026-08-31T09:00:00Z",
+		    "variable-names":[{"key":"region","category":"terraform","sensitive":false}]}}],
+		  "meta":{"pagination":{"current-page":1,"page-size":100,"total-pages":1,"total-count":1}}}`))
+	})
+
+	res, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "terrapod_deleted_workspace_list", Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool reported an error: %s", resultText(t, res))
+	}
+	if !strings.Contains(gotPath, "/api/terrapod/v1/deleted-workspaces") {
+		t.Errorf("tool hit the wrong endpoint: %q", gotPath)
+	}
+
+	var out struct {
+		Count   int                         `json:"count"`
+		Deleted []terrapod.DeletedWorkspace `json:"deleted_workspaces"`
+	}
+	if err := json.Unmarshal([]byte(resultText(t, res)), &out); err != nil {
+		t.Fatalf("decode tool result: %v (raw: %s)", err, resultText(t, res))
+	}
+	if out.Count != 1 || len(out.Deleted) != 1 {
+		t.Fatalf("want 1 deleted workspace, got count=%d len=%d", out.Count, len(out.Deleted))
+	}
+	// The fields an agent needs in order to advise: what it was, and how long
+	// is left to act.
+	if out.Deleted[0].WorkspaceName != "prod-network" {
+		t.Errorf("name not surfaced: %+v", out.Deleted[0])
+	}
+	if out.Deleted[0].RestorableUntil == "" || out.Deleted[0].StateVersionsAvailable != 12 {
+		t.Errorf("window/count not surfaced: %+v", out.Deleted[0])
+	}
+}
+
+func TestDeletedWorkspaceRestoreToolPostsAndReportsSuppression(t *testing.T) {
+	var gotMethod, gotPath string
+	sess := toolCaller(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":{"id":"ws-99999999-9999-4999-8999-999999999999",
+		  "type":"workspaces","attributes":{
+		    "name":"prod-network","restored-from":"11111111-1111-4111-8111-111111111111",
+		    "state-versions-restored":12,"state-versions-skipped":[],
+		    "suppressed":["auto_apply","vcs_connection"],
+		    "dropped-references":[{"field":"vcs","connection_id":"c-1"}]}}}`))
+	})
+
+	res, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "terrapod_deleted_workspace_restore",
+		Arguments: map[string]any{"workspace_id": "11111111-1111-4111-8111-111111111111"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool reported an error: %s", resultText(t, res))
+	}
+	if gotMethod != http.MethodPost || !strings.HasSuffix(gotPath, "/restore") {
+		t.Errorf("want POST .../restore, got %s %s", gotMethod, gotPath)
+	}
+
+	var out terrapod.RestoredWorkspace
+	if err := json.Unmarshal([]byte(resultText(t, res)), &out); err != nil {
+		t.Fatalf("decode tool result: %v (raw: %s)", err, resultText(t, res))
+	}
+	// The suppression report is the whole point of the response: an agent must
+	// be able to tell the user what did NOT come back.
+	if len(out.Suppressed) != 2 {
+		t.Errorf("suppression report not surfaced to the agent: %+v", out)
+	}
+	if out.StateVersionsRestored != 12 {
+		t.Errorf("restored count not surfaced: %+v", out)
+	}
+}
+
+func TestDeletedWorkspaceRestoreToolRequiresAWorkspaceID(t *testing.T) {
+	// Guards against a silent no-arg call reaching the API and restoring
+	// something unintended.
+	called := false
+	sess := toolCaller(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	res, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "terrapod_deleted_workspace_restore", Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("want an error result when workspace_id is missing")
+	}
+	if called {
+		t.Error("the tool called the API despite a missing workspace_id")
+	}
+}
+
+func TestDeletedWorkspaceRestoreToolSurfacesAConflict(t *testing.T) {
+	// A restore past the retention window is a 409. The agent must see that as
+	// an error rather than reporting a successful recovery of nothing.
+	sess := toolCaller(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"errors":[{"detail":"No state could be recovered","status":"409"}]}`))
+	})
+
+	res, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "terrapod_deleted_workspace_restore",
+		Arguments: map[string]any{"workspace_id": "11111111-1111-4111-8111-111111111111"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("a 409 must surface as an error, got: %s", resultText(t, res))
+	}
+	if !strings.Contains(resultText(t, res), "recovered") {
+		t.Errorf("the reason should reach the agent, got: %s", resultText(t, res))
+	}
+}

--- a/mcp/internal/mcpserver/observe.go
+++ b/mcp/internal/mcpserver/observe.go
@@ -300,6 +300,19 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 		if err != nil {
 			return errResult(err), nil, nil
 		}
+		// A nil map/slice marshals to `null`, which fails the tool's derived
+		// output schema ("want object") and takes the whole call down rather
+		// than degrading. The server always sends `{}`/`[]` today, but a
+		// marker written by another version need not, and one absent field
+		// should not cost the agent the entire listing.
+		for i := range items {
+			if items[i].Settings == nil {
+				items[i].Settings = map[string]any{}
+			}
+			if items[i].VariableNames == nil {
+				items[i].VariableNames = []terrapod.DeletedWorkspaceVariable{}
+			}
+		}
 		return nil, &deletedWSOut{Count: len(items), Deleted: items}, nil
 	})
 }

--- a/services/tests/integration/test_deleted_workspace_restore.py
+++ b/services/tests/integration/test_deleted_workspace_restore.py
@@ -358,3 +358,148 @@ class TestDeletedWorkspaceRBAC:
             WS_ENDPOINT, params={"search[name]": "rbac-restore"}, headers=AUTH
         )
         assert listing.json()["data"] == []
+
+
+class TestRestoreResilience:
+    """The paths a real deployment hits that the happy path doesn't.
+
+    Restore reads blobs written by an older Terrapod, possibly under a rotated
+    key, possibly with a marker the reaper synthesised rather than the delete
+    path writing. None of that should turn into a failed recovery.
+    """
+
+    async def test_restores_from_a_reaper_written_marker(self, app, client):
+        """The pre-existing-orphan case — very likely the FIRST real restore.
+
+        A workspace deleted before this feature shipped has no marker until the
+        reaper stamps one, and a discovery marker carries no name and an empty
+        `settings`. Restore must fall back to defaults across the board rather
+        than KeyError its way out, because this is exactly the workspace an
+        operator most wants back.
+        """
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(client, "restore-orphan", [7], "lin-orphan")
+
+        storage = get_storage()
+        # Replace the real marker with the reaper's synthesised one.
+        await dws.write_marker(storage, old_id, dws.build_discovery_marker(old_id))
+        marker = await dws.read_marker(storage, old_id)
+        assert marker["marker_reason"] == dws.REASON_DISCOVERED
+        assert marker["settings"] == {}
+        assert marker["workspace_name"] is None
+
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore", headers=AUTH
+        )
+        assert resp.status_code == 201, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["state-versions-restored"] == 1
+        # Named from the fallback, since the marker records no name.
+        assert attrs["name"]
+
+        # And the serial/lineage still come from the state itself, not the
+        # marker — which is why an unnamed orphan is still worth recovering.
+        new_id = resp.json()["data"]["id"]
+        current = await client.get(
+            f"/api/v2/workspaces/{new_id}/current-state-version", headers=AUTH
+        )
+        assert current.json()["data"]["attributes"]["serial"] == 7
+        assert current.json()["data"]["attributes"]["lineage"] == "lin-orphan"
+
+    async def test_an_unreadable_blob_is_skipped_and_reported(self, app, client):
+        """One corrupt object must not sink the whole recovery.
+
+        Reporting it matters as much as surviving it: a silently-dropped
+        version would leave the operator believing they got everything back.
+        """
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(client, "restore-corrupt", [1, 2], "lin-corrupt")
+
+        storage = get_storage()
+        keys = sorted(
+            o.key
+            for o in await storage.list_prefix(f"state/{old_id}/")
+            if o.key.endswith(".tfstate")
+        )
+        await storage.put(keys[0], b"this is not json at all", content_type="application/json")
+
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore", headers=AUTH
+        )
+        assert resp.status_code == 201, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["state-versions-restored"] == 1
+        skipped = attrs["state-versions-skipped"]
+        assert len(skipped) == 1
+        assert keys[0] in skipped[0]["key"]
+        assert skipped[0]["reason"]
+
+    async def test_a_state_document_with_no_serial_is_skipped(self, app, client):
+        """Serial is what makes a version a version; without one there is
+        nothing to reconstruct and guessing would corrupt the history."""
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(client, "restore-noserial", [1], "lin-noserial")
+
+        storage = get_storage()
+        keys = [
+            o.key
+            for o in await storage.list_prefix(f"state/{old_id}/")
+            if o.key.endswith(".tfstate")
+        ]
+        await storage.put(
+            keys[0],
+            json.dumps({"version": 4, "lineage": "lin-noserial"}).encode(),
+            content_type="application/json",
+        )
+
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore", headers=AUTH
+        )
+        # Nothing recoverable is a conflict, not an empty success.
+        assert resp.status_code == 409
+
+    async def test_two_blobs_claiming_one_serial_do_not_abort_the_restore(self, app, client):
+        """`(workspace_id, serial)` is unique, so inserting both would roll the
+        whole transaction back and lose an otherwise fine recovery."""
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(client, "restore-dupserial", [1], "lin-dup")
+
+        storage = get_storage()
+        # A second object under the same prefix carrying the same serial.
+        await storage.put(
+            f"state/{old_id}/00000000-0000-4000-8000-00000000dead.tfstate",
+            json.dumps({"version": 4, "serial": 1, "lineage": "lin-dup", "resources": []}).encode(),
+            content_type="application/json",
+        )
+
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore", headers=AUTH
+        )
+        assert resp.status_code == 201, resp.text
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["state-versions-restored"] == 1
+        assert any("duplicate serial" in s["reason"] for s in attrs["state-versions-skipped"])
+
+    async def test_a_reserved_label_in_the_marker_is_stripped_not_fatal(self, app, client):
+        """Markers are files in a bucket and can predate a key becoming
+        reserved. Refusing to restore over a label would be a poor trade, so
+        it is stripped and reported."""
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(client, "restore-badlabel", [1], "lin-label")
+
+        storage = get_storage()
+        marker = await dws.read_marker(storage, old_id)
+        marker["settings"]["labels"] = {"team": "platform", "status": "not-allowed"}
+        await dws.write_marker(storage, old_id, marker)
+
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore", headers=AUTH
+        )
+        assert resp.status_code == 201, resp.text
+        dropped = resp.json()["data"]["attributes"]["dropped-references"]
+        assert any(d.get("field") == "labels" and "status" in d["keys"] for d in dropped)
+
+        new_id = resp.json()["data"]["id"]
+        ws = await client.get(f"/api/v2/workspaces/{new_id}", headers=AUTH)
+        labels = ws.json()["data"]["attributes"]["labels"]
+        assert labels == {"team": "platform"}


### PR DESCRIPTION
You said have at it, so I audited the whole #1253 surface rather than just the one gap I'd named. Two of these found real defects.

## Integration — the paths that fire on real data (5, each mutation-checked)

The happy path was covered. These weren't:

- **Restore from a reaper-written marker.** A workspace deleted *before* this feature shipped gets its marker synthesised by the reaper — no name, empty `settings` — so it's very likely the **first real restore anyone performs**, and every field has to fall back to a default. Serial and lineage still come from the state itself, which is what makes an unnamed orphan worth recovering at all.
- **An unreadable blob** is skipped *and reported* — surviving it isn't enough, since a silently-dropped version leaves the operator thinking they got everything.
- **A state document with no serial** leaves nothing to reconstruct, so it's a 409 rather than a guess.
- **Two blobs claiming one serial** don't abort the transaction on the unique constraint and lose an otherwise fine recovery.
- **A reserved label in the marker** is stripped and reported, not fatal — markers are files in a bucket and can predate a key becoming reserved.

## MCP — 4 handler tests, and a real bug

No handler-test precedent existed, but the SDK ships `NewInMemoryTransports`, so these drive a **real MCP client against a real server** backed by a fake Terrapod. The catalogue golden pins that the tools are *registered* with the right schema; it says nothing about whether calling one reaches the right endpoint or returns anything usable.

That immediately found one: **the list tool hard-failed its own output-schema validation whenever `settings` was absent** — a nil Go map marshals to `null` where the derived schema wants an object, so one missing field cost the agent the *entire* listing. Nil maps and slices are now normalised. The server always sends `{}` today; this is about not shattering when a marker written by another version doesn't.

## Verification

19 integration tests green (14 existing + 5 new). Mutation-checked: removing the duplicate-serial guard and the settings fallback each fail exactly the test written for them. Full `mcp/` suite green; catalogue golden unchanged (these are behaviour tests, not surface changes).

Part of #1253.