### PR TITLE
fix: engage log follow when a confirmed run starts applying

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -105,6 +105,11 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
     },
     {
+      name: 'log-follow',
+      testMatch: 'log-follow.spec.ts',
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },
+    },
+    {
       name: 'impact-graph',
       testMatch: 'impact-graph.spec.ts',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_AUTH },

--- a/e2e/tests/log-follow.spec.ts
+++ b/e2e/tests/log-follow.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Log follow engages when an apply starts (#1270).
+ *
+ * Confirming a planned run switches to the Apply tab BEFORE the run is
+ * refetched, so `LogPanel` mounts while the run still reports its pre-confirm
+ * status. `following` was seeded with `useState(isStreaming)`, and `useState`
+ * reads its argument only on the first render — so it captured `false` and
+ * never re-read it once the run became `applying`.
+ *
+ * Two things this spec has to get right, both learned the hard way:
+ *
+ *  - **No reload between the two statuses.** A reload remounts the panel
+ *    already-streaming, which makes the stale initialiser accidentally
+ *    correct — the test would pass on the broken code. The status is moved in
+ *    place instead, via an SSE-driven refetch.
+ *
+ *  - **Assert on scroll position, not the toggle.** `aria-pressed` reads
+ *    `true` in BOTH arms; only the actual scroll offset distinguishes them
+ *    (measured: 59,528px adrift before the fix, 0px after, 3 runs each side
+ *    with no variance). Asserting the toggle alone is a test that cannot fail.
+ *
+ * The E2E stack has no runner pool, so a seeded run never really applies. The
+ * bug is entirely client-side — `isStreaming` is just `status === 'applying'`
+ * — so the run's reported status and its apply log are served by interception
+ * while everything else goes through the real BFF chain.
+ */
+import { test, expect } from '@playwright/test';
+import { getStoredToken, createWorkspace, seedRun, uniqueName } from '../helpers/api';
+
+/** Enough lines that a followed pane is unambiguously scrolled, not near-top. */
+const LOG_LINES = 3000;
+
+test.describe('Run log follow', () => {
+  test('engages when a confirmed run starts applying', async ({ page }) => {
+    // Login, seeding, the confirm round-trip and an SSE reconnect all happen
+    // before the assertion — the default budget leaves too little for the
+    // retry window, which would surface a real failure as a bare test timeout.
+    test.setTimeout(120_000);
+
+    const token = getStoredToken();
+    const wsId = await createWorkspace(token, uniqueName('e2e-follow'));
+    const runId = await seedRun(token, wsId, false);
+    const bareRunId = runId.replace(/^run-/, '');
+
+    let status = 'planned';
+
+    // Rewrite only the status/actionability on the real run payload.
+    await page.route(`**/api/v2/runs/${runId}`, async (route) => {
+      const res = await route.fetch();
+      const body = await res.json();
+      body.data.attributes.status = status;
+      body.data.attributes['is-confirmable'] = status === 'planned';
+      body.data.attributes['is-discardable'] = status === 'planned';
+      await route.fulfill({ response: res, body: JSON.stringify(body) });
+    });
+
+    // Swallow the confirm — this is a UI test, not a state mutation. (TFE V2
+    // confirms a planned run with `actions/apply`.)
+    await page.route(`**/api/v2/runs/${runId}/actions/apply`, async (route) => {
+      status = 'confirmed';
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: '{"data":{}}',
+      });
+    });
+
+    await page.route(`**/api/terrapod/v1/runs/${runId}/apply`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: JSON.stringify({
+          data: {
+            id: 'apply-1',
+            type: 'applies',
+            attributes: { 'log-read-url': '/__e2e_follow_log', status: 'running' },
+          },
+        }),
+      }));
+
+    // Serve the log body ONCE. A log that keeps growing keeps moving the
+    // scroll geometry, which would make the assertion below racy.
+    let logServed = false;
+    await page.route('**/__e2e_follow_log*', (route) => {
+      const body = logServed
+        ? ''
+        : Array.from(
+            { length: LOG_LINES },
+            (_, i) => `apply ${i}  aws_instance.demo: Still creating...`,
+          ).join('\n') + '\n';
+      logServed = true;
+      return route.fulfill({ status: 200, contentType: 'text/plain', body });
+    });
+
+    // A finite SSE body makes EventSource reconnect, so the route is hit
+    // repeatedly and each hit re-drives loadRun() — which is how the status
+    // moves from `confirmed` to `applying` without a reload.
+    await page.route(`**/workspaces/${wsId}/runs/events`, (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+        body: `data: ${JSON.stringify({
+          event: 'run_status_change',
+          run_id: bareRunId,
+        })}\n\n`,
+      }));
+
+    await page.goto(`/workspaces/${wsId}/runs/${runId}`);
+
+    const confirmBtn = page.getByRole('button', { name: /^confirm|^apply/i }).first();
+    await expect(confirmBtn).toBeVisible({ timeout: 20_000 });
+
+    // Confirming is guarded by a native confirm() on every pointer type.
+    page.once('dialog', (d) => d.accept());
+    await confirmBtn.click();
+
+    // `handleAction` switches to the apply view before it refetches the run,
+    // so the panel is now mounted while the run still reports a non-streaming
+    // status. That is the precondition for the bug, and the URL is the
+    // observable proof it happened. The panel renders an empty state at this
+    // point — the apply log is not fetched until the run is `applying` — so
+    // there is deliberately no `<pre>` to wait for yet.
+    await expect(page).toHaveURL(/[?&]view=apply/, { timeout: 20_000 });
+
+    status = 'applying';
+
+    const pane = page.locator('pre').first();
+    await expect(pane).toBeVisible({ timeout: 30_000 });
+
+    // The pane must end up pinned to the tail. `toPass` retries the whole
+    // assertion, so this rides out the SSE reconnect interval without a
+    // fixed sleep.
+    await expect(async () => {
+      const distanceFromTail = await pane.evaluate(
+        (el) => el.scrollHeight - el.scrollTop - el.clientHeight,
+      );
+      // Not `=== 0`: sub-pixel line heights leave a fractional remainder.
+      expect(distanceFromTail).toBeLessThan(60);
+    }).toPass({ timeout: 30_000 });
+
+    // And it says so. (True on the broken code too — kept as a consistency
+    // check between what the pane does and what the control claims, never as
+    // the discriminating assertion.)
+    await expect(page.locator('button[aria-pressed]').first()).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+});

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -331,6 +331,17 @@ function LogPanel({
   // Follow the tail by default while streaming; a static (finished) log opens
   // at the top so the operator reads from the start.
   const [following, setFollowing] = useState(isStreaming)
+  // `useState` reads its argument once, and this panel routinely mounts before
+  // the run is streaming — confirming an apply switches to this tab while the
+  // run is still `confirmed`. Re-engage on the false->true edge, adjusted
+  // during render so there is no frame with follow wrongly off. Only the edge:
+  // tracking `isStreaming` wholesale would re-pin the tail on every render and
+  // fight an operator who scrolled up to read.
+  const [wasStreaming, setWasStreaming] = useState(isStreaming)
+  if (wasStreaming !== isStreaming) {
+    setWasStreaming(isStreaming)
+    if (isStreaming) setFollowing(true)
+  }
   const [copied, setCopied] = useState(false)
   const preRef = useRef<HTMLPreElement>(null)
 


### PR DESCRIPTION
Confirming a planned run switches to the Apply log tab as expected, but "Follow" did not engage — the pane sat at the top of the log while the apply streamed.

## Cause

`handleAction("confirm")` calls `switchView("apply")` **before** `await loadRun()`, so `LogPanel` mounts while the run still reports its pre-confirm status. `following` was seeded with `useState(isStreaming)`, and `useState` reads its argument only on the first render — so it captured `false` and never re-read it when the run subsequently became `applying`. The auto-scroll layout effect is gated on `following`, so the tail was never pinned.

The fix re-engages on the `false -> true` edge, adjusted during render so there is no frame with follow wrongly off. Only the edge — tracking `isStreaming` wholesale would re-pin the tail on every render and fight an operator who has scrolled up to read.

## The test had to be built carefully, twice over

**No reload between the two statuses.** A reload remounts the panel already-streaming, which makes the stale initialiser accidentally correct — the spec would pass on the broken code. The status is moved in place instead, via an SSE-driven refetch.

**Assert scroll position, not the toggle.** `aria-pressed` reads `true` in *both* arms. A spec that asserts the control is one that cannot fail. Only the actual scroll offset separates them.

Verified by building the web image from both trees and running the spec against each:

| arm | result |
|---|---|
| pre-fix image | **fails**, `Received: 59528` (px adrift from the tail) |
| fixed image | **passes**, 6.2s |

That 59,528px matches what a live stack measured independently, 3 runs per arm with no variance.

## Scoped out

Disengaging follow by scrolling up is separately broken in this same flow and is tracked in #1271. A first attempt at it here — adding `hasLog` to the scroll effect's dependency array so it re-runs once the `<pre>` exists — was measured across three runs and made **no difference**, so it is not included rather than shipped on the assumption that it helps.

Closes #1270