### PR TITLE
fix: let scrolling up disengage log follow

### DIFF
--- a/e2e/tests/log-follow.spec.ts
+++ b/e2e/tests/log-follow.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Log follow engages when an apply starts (#1270).
+ * Log follow: engages when an apply starts (#1270), and can be turned off by
+ * scrolling up to read (#1271).
  *
  * Confirming a planned run switches to the Apply tab BEFORE the run is
  * refetched, so `LogPanel` mounts while the run still reports its pre-confirm
@@ -14,10 +15,12 @@
  *    correct — the test would pass on the broken code. The status is moved in
  *    place instead, via an SSE-driven refetch.
  *
- *  - **Assert on scroll position, not the toggle.** `aria-pressed` reads
- *    `true` in BOTH arms; only the actual scroll offset distinguishes them
- *    (measured: 59,528px adrift before the fix, 0px after, 3 runs each side
- *    with no variance). Asserting the toggle alone is a test that cannot fail.
+ *  - **Assert on scroll position, not just the toggle.** Measured: 59,528px
+ *    adrift before the #1270 fix, 0px after, 3 runs each side with no
+ *    variance. And when the toggle IS asserted, select it BY NAME — the Color
+ *    toggle also carries `aria-pressed` and comes first in the DOM, so
+ *    `locator('button[aria-pressed]').first()` reads colorMode, which is
+ *    always true and can never fail.
  *
  * The E2E stack has no runner pool, so a seeded run never really applies. The
  * bug is entirely client-side — `isStreaming` is just `status === 'applying'`
@@ -31,7 +34,7 @@ import { getStoredToken, createWorkspace, seedRun, uniqueName } from '../helpers
 const LOG_LINES = 3000;
 
 test.describe('Run log follow', () => {
-  test('engages when a confirmed run starts applying', async ({ page }) => {
+  test('engages when a confirmed run starts applying, and disengages on scroll', async ({ page }) => {
     // Login, seeding, the confirm round-trip and an SSE reconnect all happen
     // before the assertion — the default budget leaves too little for the
     // retry window, which would surface a real failure as a bare test timeout.
@@ -138,12 +141,33 @@ test.describe('Run log follow', () => {
       expect(distanceFromTail).toBeLessThan(60);
     }).toPass({ timeout: 30_000 });
 
-    // And it says so. (True on the broken code too — kept as a consistency
-    // check between what the pane does and what the control claims, never as
-    // the discriminating assertion.)
-    await expect(page.locator('button[aria-pressed]').first()).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
+    // And the control says so. Select it by NAME: the Color toggle also
+    // carries aria-pressed and comes first in the DOM, so
+    // `locator('button[aria-pressed]').first()` silently reads colorMode —
+    // which is always true, and therefore an assertion that cannot fail.
+    const follow = page.getByRole('button', { name: /follow/i });
+    await expect(follow).toHaveAttribute('aria-pressed', 'true');
+
+    // #1271: scrolling up to read must disengage follow. The panel mounts with
+    // no <pre> in this flow, so a plain ref left the scroll listener with
+    // nothing to attach to and no dependency change to make it retry — the
+    // listener was never registered and follow could not be turned off by
+    // scrolling at all.
+    //
+    // A real wheel over the pane, not a synthetic scroll event: the point is
+    // that the browser's own scroll reaches a registered listener.
+    await pane.hover();
+    await page.mouse.wheel(0, -40_000);
+
+    await expect(follow).toHaveAttribute('aria-pressed', 'false');
+    // It must STAY off — an operator scrolled up to read, and the next log
+    // chunk must not yank them back to the tail.
+    await expect(async () => {
+      const distanceFromTail = await pane.evaluate(
+        (el) => el.scrollHeight - el.scrollTop - el.clientHeight,
+      );
+      expect(distanceFromTail).toBeGreaterThan(60);
+    }).toPass({ timeout: 10_000 });
+    await expect(follow).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
+++ b/web/src/app/workspaces/[id]/runs/[runId]/page.tsx
@@ -343,7 +343,14 @@ function LogPanel({
     if (isStreaming) setFollowing(true)
   }
   const [copied, setCopied] = useState(false)
-  const preRef = useRef<HTMLPreElement>(null)
+  // A callback ref, not `useRef`, because this panel renders an empty state
+  // until the log arrives: on the first render there is no <pre> at all. A
+  // plain ref leaves the scroll effect below with nothing to attach to AND no
+  // dependency change to make it retry once the element appears, so the
+  // listener is simply never registered — which is how follow became
+  // impossible to disengage by scrolling (#1271). Holding the node in state
+  // makes its arrival a render, so everything keyed on it re-runs.
+  const [pre, setPre] = useState<HTMLPreElement | null>(null)
 
   const cleanLog = useMemo(() => (log ? stripStxEtx(log) : null), [log])
 
@@ -364,18 +371,17 @@ function LogPanel({
       const doc = document.documentElement
       return window.innerHeight + window.scrollY >= doc.scrollHeight - 80
     }
-    const el = preRef.current
-    if (!el) return true
-    return el.scrollHeight - el.scrollTop - el.clientHeight < 60
-  }, [isTouch])
+    if (!pre) return true
+    return pre.scrollHeight - pre.scrollTop - pre.clientHeight < 60
+  }, [isTouch, pre])
 
   const scrollToBottom = useCallback(
     (smooth = false) => {
       const opts: ScrollToOptions = { behavior: smooth ? 'smooth' : 'auto' }
       if (isTouch) window.scrollTo({ top: document.documentElement.scrollHeight, ...opts })
-      else preRef.current?.scrollTo({ top: preRef.current.scrollHeight, ...opts })
+      else pre?.scrollTo({ top: pre.scrollHeight, ...opts })
     },
-    [isTouch],
+    [isTouch, pre],
   )
 
   // Pin the active scroller to the tail when following and the content changes.
@@ -392,12 +398,15 @@ function LogPanel({
     const onScroll = () => {
       setFollowing(isAtBottom())
     }
-    const el = isTouch ? window : preRef.current
+    const el = isTouch ? window : pre
     if (!el) return
     el.addEventListener('scroll', onScroll, { passive: true })
+    // Seed from the current position. This runs after the layout effect above
+    // has already pinned the tail, so attaching mid-stream does not read a
+    // stale "not at bottom" and immediately disengage follow.
     onScroll()
     return () => el.removeEventListener('scroll', onScroll)
-  }, [isTouch, isAtBottom])
+  }, [isTouch, isAtBottom, pre])
 
   if (loading) {
     return (
@@ -536,14 +545,14 @@ function LogPanel({
           the JS tail-follow logic agree. */}
       {colorMode ? (
         <pre
-          ref={preRef}
+          ref={setPre}
           data-testid={`log-pre-${phase}`}
           className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words fine:max-h-[70vh] fine:overflow-y-auto"
           dangerouslySetInnerHTML={{ __html: htmlContent }}
         />
       ) : (
         <pre
-          ref={preRef}
+          ref={setPre}
           data-testid={`log-pre-${phase}`}
           className="p-4 text-sm text-slate-300 font-mono whitespace-pre-wrap break-words fine:max-h-[70vh] fine:overflow-y-auto"
         >


### PR DESCRIPTION
Scrolling up to read a streaming log did not turn "Follow" off, so the next chunk yanked the view back to the tail. Clicking the toggle worked — which is what made this look like a stuck-state bug.

## It was not a state bug: nothing was listening

`DOMDebugger.getEventListeners` on the `<pre>`, against merged `main`:

```
at tail:        {"scrollTop":59528,"dist":0,"followPressed":"true"}
<pre> listeners: []
after wheel up: {"scrollTop":19528,"dist":40000,"followPressed":"true"}
```

The wheel scrolled the pane perfectly well (59528 → 19528). There was simply no listener.

In the confirm → apply flow the panel mounts with **no log**, so it early-returns its empty state and `preRef.current` is still null when the scroll effect runs — it bails at `if (!el) return`. Its deps (`[isTouch, isAtBottom]`) do not change when the `<pre>` later appears, so it never retries.

The fix holds the node in state via a callback ref rather than `useRef`, so the element's arrival is a render and everything keyed on it re-runs. After:

```
<pre> listeners: ["scroll"]
after wheel up: {"scrollTop":19528,"dist":40000,"followPressed":"false"}
+4s later:      {"scrollTop":19528,"dist":40000,"followPressed":"false"}
```

## It also fixes a test that could not fail

The spec added with #1270 selected the Follow control as `locator('button[aria-pressed]').first()`. That is the **Color** toggle — it comes first in the DOM and also carries `aria-pressed`. `colorMode` is always true, so the assertion was hard-wired to pass, and my earlier "aria-pressed reads true in both arms" note was simply reading the wrong button. It now selects by accessible name, which is what makes the new disengage assertion mean anything.

## Verification

Built the web image from both trees and ran the spec against each:

| arm | result |
|---|---|
| merged `main` | **fails** — `Expected: "false", Received: "true"` |
| callback ref | **passes**, 7.0s |

Closes #1271