### PR TITLE
fix: offer the auto-apply mode on the bulk-update and autodiscovery pages

### DIFF
--- a/services/tests/api/test_auto_apply_mode_admin.py
+++ b/services/tests/api/test_auto_apply_mode_admin.py
@@ -1,0 +1,78 @@
+"""Auto-apply mode on the two admin write paths (#1274 / #1276).
+
+Both bulk-update and the autodiscovery rule template write TWO columns from
+one input key, which is why neither goes through the ordinary field map. That
+makes them the paths where the pair could silently drift apart — the exact
+failure the mode's whole skew story is built to prevent — so they get their
+own tests rather than riding on the single-workspace ones.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from terrapod.api.routers.autodiscovery_rules import _coerce_attrs
+from terrapod.api.routers.workspace_bulk import _validate_auto_apply
+
+
+class TestBulkUpdate:
+    def test_mode_writes_both_columns(self):
+        got = _validate_auto_apply({"auto-apply-mode": "create_update"}, {})
+        assert got == {"auto_apply_mode": "create_update", "auto_apply": True}
+
+    def test_never_clears_the_boolean(self):
+        # The pair must stay consistent in BOTH directions, or a workspace
+        # reading the projection would think it still auto-applies.
+        got = _validate_auto_apply({"auto-apply-mode": "never"}, {})
+        assert got == {"auto_apply_mode": "never", "auto_apply": False}
+
+    @pytest.mark.parametrize(("boolean", "expected"), [(True, "always"), (False, "never")])
+    def test_legacy_boolean_still_maps(self, boolean, expected):
+        # An un-upgraded caller sending only the boolean keeps working.
+        got = _validate_auto_apply({"auto-apply": boolean}, {"auto_apply": boolean})
+        assert got == {"auto_apply_mode": expected}
+
+    def test_both_keys_is_422_not_a_guess(self):
+        with pytest.raises(HTTPException) as e:
+            _validate_auto_apply({"auto-apply": True, "auto-apply-mode": "create"}, {})
+        assert e.value.status_code == 422
+
+    def test_unknown_mode_is_422(self):
+        with pytest.raises(HTTPException) as e:
+            _validate_auto_apply({"auto-apply-mode": "sometimes"}, {})
+        assert e.value.status_code == 422
+
+    def test_absent_touches_nothing(self):
+        # A bulk update of unrelated fields must not write auto-apply at all,
+        # or every such update would silently reset it.
+        assert _validate_auto_apply({"terraform-version": "1.12"}, {}) == {}
+
+
+class TestAutodiscoveryRuleTemplate:
+    def test_mode_writes_both_columns(self):
+        out = _coerce_attrs({"auto-apply-mode": "create"}, on_create=False)
+        assert out["auto_apply_mode"] == "create"
+        assert out["auto_apply"] is True
+
+    def test_never_clears_the_boolean(self):
+        out = _coerce_attrs({"auto-apply-mode": "never"}, on_create=False)
+        assert out["auto_apply_mode"] == "never"
+        assert out["auto_apply"] is False
+
+    def test_legacy_boolean_still_maps(self):
+        out = _coerce_attrs({"auto-apply": True}, on_create=False)
+        assert out["auto_apply"] is True
+        assert out["auto_apply_mode"] == "always"
+
+    def test_both_keys_is_422(self):
+        with pytest.raises(HTTPException) as e:
+            _coerce_attrs({"auto-apply": False, "auto-apply-mode": "create"}, on_create=False)
+        assert e.value.status_code == 422
+
+    def test_unknown_mode_is_422(self):
+        with pytest.raises(HTTPException) as e:
+            _coerce_attrs({"auto-apply-mode": "occasionally"}, on_create=False)
+        assert e.value.status_code == 422
+
+    def test_absent_touches_nothing(self):
+        out = _coerce_attrs({"name-prefix": "svc-"}, on_create=False)
+        assert "auto_apply" not in out and "auto_apply_mode" not in out

--- a/web/src/app/admin/autodiscovery/page.tsx
+++ b/web/src/app/admin/autodiscovery/page.tsx
@@ -40,6 +40,7 @@ interface AutodiscoveryRule {
     'resource-cpu': string
     'resource-memory': string
     'auto-apply': boolean
+    'auto-apply-mode'?: string
     'on-directory-delete': 'flag' | 'destroy'
     labels: Record<string, string>
     'owner-email': string
@@ -72,6 +73,7 @@ type SortKey = 'name' | 'repo' | 'pattern' | 'enabled' | 'created'
 export default function AutodiscoveryPage() {
   const router = useRouter()
   const t = useTranslations('adminAutodiscovery')
+  const tMode = useTranslations('common.autoApplyMode')
   const fmt = useFormat()
   const [rules, setRules] = useState<AutodiscoveryRule[]>([])
   const [connections, setConnections] = useState<VCSConnection[]>([])
@@ -98,7 +100,7 @@ export default function AutodiscoveryPage() {
   const [terraformVersion, setTerraformVersion] = useState('1.11')
   const [resourceCpu, setResourceCpu] = useState('1')
   const [resourceMemory, setResourceMemory] = useState('2Gi')
-  const [autoApply, setAutoApply] = useState(false)
+  const [autoApplyMode, setAutoApplyMode] = useState('never')
   const [onDirectoryDelete, setOnDirectoryDelete] = useState<'flag' | 'destroy'>('flag')
   const [labels, setLabels] = useState<Record<string, string>>({})
   const [ownerEmail, setOwnerEmail] = useState('')
@@ -188,7 +190,7 @@ export default function AutodiscoveryPage() {
     setTerraformVersion('1.11')
     setResourceCpu('1')
     setResourceMemory('2Gi')
-    setAutoApply(false)
+    setAutoApplyMode('never')
     setOnDirectoryDelete('flag')
     setLabels({})
     setOwnerEmail('')
@@ -220,7 +222,8 @@ export default function AutodiscoveryPage() {
     setTerraformVersion(a['terraform-version'])
     setResourceCpu(a['resource-cpu'])
     setResourceMemory(a['resource-memory'])
-    setAutoApply(a['auto-apply'])
+    // Fall back to the boolean for a rule created before #1274.
+    setAutoApplyMode(a['auto-apply-mode'] || (a['auto-apply'] ? 'always' : 'never'))
     setOnDirectoryDelete(a['on-directory-delete'] === 'destroy' ? 'destroy' : 'flag')
     setLabels(a.labels || {})
     setOwnerEmail(a['owner-email'] || '')
@@ -257,7 +260,7 @@ export default function AutodiscoveryPage() {
       'terraform-version': terraformVersion,
       'resource-cpu': resourceCpu,
       'resource-memory': resourceMemory,
-      'auto-apply': autoApply,
+      'auto-apply-mode': autoApplyMode,
       'on-directory-delete': onDirectoryDelete,
       labels,
       'owner-email': ownerEmail,
@@ -368,7 +371,7 @@ export default function AutodiscoveryPage() {
             'terraform-version': terraformVersion,
             'resource-cpu': resourceCpu,
             'resource-memory': resourceMemory,
-            'auto-apply': autoApply,
+            'auto-apply-mode': autoApplyMode,
             labels,
             'owner-email': ownerEmail,
           },
@@ -615,12 +618,17 @@ export default function AutodiscoveryPage() {
                 </div>
                 <div className="flex items-center gap-4 pt-6">
                   <label className="flex items-center gap-2 text-sm text-slate-300">
-                    <input
-                      type="checkbox"
-                      checked={autoApply}
-                      onChange={e => setAutoApply(e.target.checked)}
-                    />
                     {t('form.autoApply')}
+                    <select
+                      value={autoApplyMode}
+                      onChange={e => setAutoApplyMode(e.target.value)}
+                      className="px-2 py-1 text-sm rounded bg-slate-700 border border-slate-600 text-slate-200"
+                    >
+                      <option value="never">{tMode('never')}</option>
+                      <option value="always">{tMode('always')}</option>
+                      <option value="create">{tMode('create')}</option>
+                      <option value="create_update">{tMode('createUpdate')}</option>
+                    </select>
                   </label>
                   <label className="flex items-center gap-2 text-sm text-slate-300">
                     <input

--- a/web/src/app/admin/bulk-update/page.tsx
+++ b/web/src/app/admin/bulk-update/page.tsx
@@ -78,6 +78,7 @@ function fmtVal(v: unknown, noneLabel: string): string {
 export default function BulkUpdatePage() {
   const router = useRouter()
   const t = useTranslations('adminBulkUpdate')
+  const tMode = useTranslations('common.autoApplyMode')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [pools, setPools] = useState<AgentPool[]>([])
@@ -99,7 +100,8 @@ export default function BulkUpdatePage() {
   const [uTfVersion, setUTfVersion] = useState('')
   const [uExecBackend, setUExecBackend] = useState('')
   const [uExecMode, setUExecMode] = useState('')
-  const [uAutoApply, setUAutoApply] = useState('')
+  // '' means "leave unchanged"; anything else is an auto-apply mode (#1276).
+  const [uAutoApplyMode, setUAutoApplyMode] = useState('')
   const [uAgentPoolId, setUAgentPoolId] = useState('')
   const [uResourceCpu, setUResourceCpu] = useState('')
   const [uResourceMemory, setUResourceMemory] = useState('')
@@ -163,7 +165,8 @@ export default function BulkUpdatePage() {
     if (uTfVersion.trim()) u['terraform-version'] = uTfVersion.trim()
     if (uExecBackend) u['execution-backend'] = uExecBackend
     if (uExecMode) u['execution-mode'] = uExecMode
-    if (uAutoApply) u['auto-apply'] = uAutoApply === 'true'
+    // Send the mode, never the boolean — the endpoint 422s if both are set.
+    if (uAutoApplyMode) u['auto-apply-mode'] = uAutoApplyMode
     if (uAgentPoolId) u['agent-pool-id'] = uAgentPoolId
     if (uResourceCpu.trim()) u['resource-cpu'] = uResourceCpu.trim()
     if (uResourceMemory.trim()) u['resource-memory'] = uResourceMemory.trim()
@@ -493,13 +496,15 @@ export default function BulkUpdatePage() {
             <div>
               <label className={labelCls}>{t('update.autoApply')}</label>
               <select
-                value={uAutoApply}
-                onChange={(e) => setUAutoApply(e.target.value)}
+                value={uAutoApplyMode}
+                onChange={(e) => setUAutoApplyMode(e.target.value)}
                 className={inputCls}
               >
                 <option value="">{t('unchangedOption')}</option>
-                <option value="true">true</option>
-                <option value="false">false</option>
+                <option value="never">{tMode('never')}</option>
+                <option value="always">{tMode('always')}</option>
+                <option value="create">{tMode('create')}</option>
+                <option value="create_update">{tMode('createUpdate')}</option>
               </select>
             </div>
             <div>


### PR DESCRIPTION
Closes #1276. Follow-up to #1274.

Both admin surfaces still presented auto-apply as a boolean, so an operator could set `create/update` on a single workspace but not roll it across a fleet, and could not make new autodiscovered workspaces inherit it — which is where a conditional mode earns its keep.

Both endpoints already accepted `auto-apply-mode`; only the UI was missing. Reuses the existing `common.autoApplyMode.*` labels, so **no new locale keys** and every offered language is covered by construction.

## Also closes a test gap I left in #1274

Neither new write path had a test. They are the two paths that write **both** auto-apply columns from a single input key — the place the pair could silently drift apart, which is the exact failure the mode's skew handling exists to prevent.

13 tests now pin, for each path:

- the mode writes both columns
- `never` clears the boolean, so the projection cannot claim a workspace still auto-applies
- the legacy boolean still maps (`true` → `always`, `false` → `never`)
- both keys together is a **422**, not a guess
- an unknown mode is a **422**
- an update touching unrelated fields writes neither column — otherwise every bulk edit would quietly reset auto-apply

## Verified live, not just rendered

Both selects offer the four values on the running stack. A real bulk-update across two labelled workspaces produced:

```
auto_apply_mode: never -> create_update
auto_apply:      false -> true          (same diff, both columns together)
```

and the DB confirms `bulkmode-a` / `bulkmode-b` both at `mode=create_update bool=true`. Both 422 paths confirmed against the live API.

The autodiscovery rule could **not** be smoke-tested end to end — this stack has no VCS connection, and a rule requires one. That path is covered by the unit tests above rather than live, and I would rather say so than imply otherwise.

4217 python tests, tsc, eslint, both i18n gates, full next build.