### PR TITLE
fix: pin js-yaml past the omap CPU-consumption advisory

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6611,9 +6611,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -51,6 +51,7 @@
     "postcss": "^8.5.23",
     "@babel/core": "^7.29.6",
     "brace-expansion": "^2.1.4",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, high) was published overnight (2026-08-06T20:27Z) and turns the **npm audit gate red on `main`** and on every open PR.

It reaches us only through `eslint` → `@eslint/eslintrc`, so it is a lint-time dependency — nothing in it ships to a browser.

The 4.x line has a fix, so this takes the **bump rather than an allowlist entry**: `4.3.1` sits outside the advisory's `4.0.0 - 4.3.0` range and is a patch within the same major.

## Verified, not assumed

eslint is the thing that actually loads js-yaml, so `npm run lint` passing is the check that matters — the last override added to this block (`brace-expansion`) broke lint outright by changing an export shape, and needed reverting.

- `npm audit` → **0 vulnerabilities** (was 1 high)
- `npm run lint` → clean
- `npx tsc --noEmit` → clean
- `npm run build` → clean

Unblocks #1277.