### PR TITLE
fix: make the auto-apply e2e test auto-apply again

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../fixtures/auth.js';
+import { getStoredToken, createWorkspace, uniqueName } from '../helpers/api.js';
 
 test.describe('Admin access control', () => {
   test('admin user sees admin nav links', async ({ adminPage }) => {
@@ -77,5 +78,49 @@ test.describe('Cache bulk-warm (#606)', () => {
       .isVisible()
       .catch(() => false);
     expect(hasContent).toBe(false);
+  });
+});
+
+test.describe('Bulk update — auto-apply mode (#1276)', () => {
+  // This page had no functional spec at all, only a redirect check in
+  // rbac-negatives. The mode select is worth covering specifically because it
+  // is one of the two paths that writes TWO columns from a single input:
+  // auto_apply_mode AND the legacy auto_apply boolean. If they ever drift
+  // apart, a workspace claims one thing in the projection and does another.
+  test('a conditional mode previews as a change to BOTH auto-apply columns', async ({ adminPage }) => {
+    const token = getStoredToken();
+    const prefix = uniqueName('e2e-bulkmode');
+    await createWorkspace(token, `${prefix}-a`);
+    await createWorkspace(token, `${prefix}-b`);
+
+    await adminPage.goto('/admin/bulk-update');
+
+    // 1. Select by name prefix — scoped to this test's own workspaces so the
+    //    assertions never depend on what else is in the org.
+    await adminPage.getByPlaceholder('prod-').fill(prefix);
+    await adminPage.getByRole('button', { name: 'Search' }).click();
+    await expect(adminPage.getByText(/Matched/)).toContainText('2');
+
+    // 2. The control must be the four-value mode select, not a boolean.
+    const mode = adminPage.getByRole('combobox', { name: 'Auto-apply' });
+    await expect(mode).toHaveValue(''); // "(unchanged)" — absent must not write
+    await mode.selectOption('create_update');
+
+    // 3. Dry run is on by default, so nothing is written by this assertion.
+    await adminPage.getByRole('button', { name: 'Preview (dry run)' }).click();
+
+    // Both workspaces are affected — the summary states it, and the diff table
+    // heading is the section we then read the per-column changes out of.
+    await expect(adminPage.getByText(/2 would change/)).toBeVisible({ timeout: 15_000 });
+    await expect(
+      adminPage.getByRole('heading', { name: /Would change \(2\)/ }),
+    ).toBeVisible();
+
+    // Both columns move together. Asserting only the mode would pass even if
+    // the boolean were left stale, which is the bug this guards.
+    const table = adminPage.locator('table').last();
+    await expect(table).toContainText('auto_apply_mode');
+    await expect(table).toContainText('create_update');
+    await expect(table).toContainText('auto_apply');
   });
 });

--- a/e2e/tests/workspaces.spec.ts
+++ b/e2e/tests/workspaces.spec.ts
@@ -149,10 +149,17 @@ test.describe('Workspaces', () => {
     // Click Edit on the overview tab
     await page.click('button:has-text("Edit")');
 
-    // Toggle auto-apply (it's a checkbox or toggle)
-    const autoApplyToggle = page.locator('input[type="checkbox"]').first();
-    const wasBefore = await autoApplyToggle.isChecked();
-    await autoApplyToggle.click();
+    // Auto-apply is a four-value mode select, not a boolean (#1274). Locate it
+    // by its accessible name, NOT positionally: this test used to say
+    // `input[type=checkbox].first()`, which silently re-aimed at the Terragrunt
+    // checkbox when the control became a select, and kept passing while testing
+    // nothing (#1280). A named locator fails closed instead.
+    const autoApply = page.getByRole('combobox', { name: 'Auto Apply' });
+    await expect(autoApply).toHaveValue('never'); // default for a new workspace
+
+    // Pick a conditional mode — the interesting case, since it has to survive
+    // the round trip as a mode rather than collapsing back to a boolean.
+    await autoApply.selectOption('create_update');
 
     // Save
     await page.click('button:has-text("Save")');
@@ -160,13 +167,13 @@ test.describe('Workspaces', () => {
     // Wait for save to complete (Edit button re-appears)
     await expect(page.locator('button:has-text("Edit")')).toBeVisible({ timeout: 10_000 });
 
-    // Reload and verify the toggle changed
-    await page.reload();
+    // The read view must name the mode, not a yes/no.
+    await expect(page.getByText('create/update', { exact: true })).toBeVisible();
 
-    // Click Edit again to check the value
+    // Reload proves it persisted server-side rather than living in React state.
+    await page.reload();
     await page.click('button:has-text("Edit")');
-    const isAfter = await page.locator('input[type="checkbox"]').first().isChecked();
-    expect(isAfter).not.toBe(wasBefore);
+    await expect(page.getByRole('combobox', { name: 'Auto Apply' })).toHaveValue('create_update');
   });
 
   test('terragrunt toggle + version persists through settings (#534)', async ({ page }) => {

--- a/web/src/app/admin/bulk-update/page.tsx
+++ b/web/src/app/admin/bulk-update/page.tsx
@@ -496,6 +496,7 @@ export default function BulkUpdatePage() {
             <div>
               <label className={labelCls}>{t('update.autoApply')}</label>
               <select
+                aria-label={t('update.autoApply')}
                 value={uAutoApplyMode}
                 onChange={(e) => setUAutoApplyMode(e.target.value)}
                 className={inputCls}

--- a/web/src/app/workspaces/[id]/page.tsx
+++ b/web/src/app/workspaces/[id]/page.tsx
@@ -1967,6 +1967,7 @@ function WorkspaceDetailContent() {
                   <dt className="text-xs text-slate-500">{t('fields.autoApply')}</dt>
                   {editing ? (
                     <select
+                      aria-label={t('fields.autoApply')}
                       value={editAutoApplyMode}
                       onChange={(e) => setEditAutoApplyMode(e.target.value)}
                       className="mt-1 w-full px-2 py-1 text-sm rounded bg-slate-700 border border-slate-600 text-slate-200"


### PR DESCRIPTION
Closes #1280. Found while answering "is the conditional auto-apply feature fully implemented across every surface?" — everything was wired, but one test had quietly stopped testing it.

## The drift

When #1274 turned the workspace auto-apply control into a four-value select, `workspaces.spec.ts` kept its old positional locator:

```ts
// Toggle auto-apply (it's a checkbox or toggle)
const autoApplyToggle = page.locator('input[type="checkbox"]').first();
```

There is no auto-apply checkbox any more, so `.first()` re-aimed at the first checkbox that still **is** on the form — `editTerragruntEnabled` — and the test kept passing while covering none of what it is named after, as a weaker duplicate of the Terragrunt test directly below it.

The new locator is the field's accessible name, so it **fails closed** rather than silently re-aiming, and it round-trips a *conditional* mode (`create_update`) rather than a boolean: select → save → assert the read view names the mode → reload → assert it persisted server-side.

## The accessible names are a real fix, not test scaffolding

The workspace select's only nearby text was a `<dt>`, which is not a label — so it had no accessible name and announced as unlabelled to a screen reader. Same story on bulk update, where the `<label>` is a sibling with no `htmlFor`. Both now carry `aria-label` sourced from the **existing** translated field label, so there are no new locale keys and every offered language is covered by construction.

## New: the first functional spec for /admin/bulk-update

That page had only a redirect check in `rbac-negatives`. The new spec asserts a conditional mode previews as a change to **both** auto-apply columns — asserting the mode alone would still pass with the boolean left stale, which is exactly the drift the pair exists to prevent.

## Verified by running, not by typechecking

Given the bug here is "a test that passed while testing nothing", `tsc` was not going to be good enough:

- both specs **fail** against a server build without the feature, and pass against one with it
- full suite **137/137** against freshly built images

That run also turned up #1281 — `scripts/e2e.sh` only builds images when absent, so `make test-e2e` can silently run the current specs against a weeks-old server. It cost me four false failures here (including `estate` and `state-graph`, which nothing local had touched), and it can just as easily produce a false pass. CI is unaffected.