### PR TITLE
fix: stop the re-scan raising advisories with nothing in them

### DIFF
--- a/scripts/rescan_advisory.py
+++ b/scripts/rescan_advisory.py
@@ -77,8 +77,11 @@ _RAISED_BY = (
     "(`.github/workflows/release-rescan.yml`)."
 )
 _DRAFT_NOTE = (
-    "This is a **draft** — private to maintainers, and not published. It becomes "
-    "the public record when the patch release that fixes it ships."
+    "This is a **draft**, and it stays one. Publishing a repository advisory is "
+    "irreversible — GitHub refuses to close a published advisory — so this is "
+    "never published, and is closed once the patch release that fixes it ships. "
+    "The operator-facing record is the release notes and the public re-scan "
+    "issue, both of which already name the advisories a patch clears."
 )
 _FIX_AVAILABLE = (
     "Everything below has a fix available upstream *now* that did not exist, or "
@@ -145,8 +148,16 @@ def main() -> int:
         if isinstance(d, dict) and "code_findings" in d:
             code_counts[d["release"]] = code_counts.get(d["release"], 0) + int(d["code_findings"])
 
-    if not any(by_release.values()) and not any(code_counts.values()):
-        print("nothing to record")
+    # Gate on DEPENDENCY findings alone. A code-finding count is not advisory
+    # material: an advisory's payload is its `vulnerabilities` array, which is
+    # built from dependency rows, so a release with only code findings produces
+    # an advisory whose table is a bare header and whose vulnerabilities array
+    # is empty. Those findings are already in code scanning — the correct
+    # private channel, and the one this workflow deliberately sends them to.
+    # Raising an advisory to say "look over there" adds an irreversible-if-ever-
+    # published artifact carrying nothing the other channel does not hold.
+    if not any(by_release.values()):
+        print("no dependency findings — nothing to record in an advisory")
         urls_out.write_text("{}")
         return 0
 
@@ -169,10 +180,10 @@ def main() -> int:
     }
 
     urls: dict[str, str] = {}
-    for release in sorted(set(by_release) | set(code_counts), reverse=True):
+    for release in sorted(by_release, reverse=True):
         findings = by_release.get(release, [])
         code = code_counts.get(release, 0)
-        if not findings and not code:
+        if not findings:
             continue
         summary = f"Findings in {release}"
         payload = {

--- a/scripts/rescan_report.py
+++ b/scripts/rescan_report.py
@@ -103,8 +103,10 @@ _CODESCAN = (
     "analysis findings in Terrapod's own source at that tag."
 )
 _PUBLISH = (
-    "Drafts are published when the patch release that fixes them ships — that "
-    "is what turns them into the operator-facing record."
+    "Those drafts stay drafts. Publishing a repository advisory is irreversible "
+    "— GitHub refuses to close a published one — so they are closed, not "
+    "published, once the patch that fixes them ships. The operator-facing "
+    "record is the release notes, which name the advisories the patch clears."
 )
 _REFS = (
     f"Policy: [docs/cve-policy.md]({_REPO_URL}/blob/main/docs/cve-policy.md). "

--- a/scripts/tests/test_rescan.py
+++ b/scripts/tests/test_rescan.py
@@ -390,3 +390,52 @@ def test_advisory_never_publishes():
     assert '"published"' not in source
     assert "'published'" not in source
     assert "state=published" not in source
+
+
+def test_advisory_not_raised_for_code_findings_alone(tmp_path, monkeypatch):
+    """A code-finding count must not mint an advisory.
+
+    An advisory's payload is its `vulnerabilities` array, built from dependency
+    rows. With none, the result is a table that is a bare header and an empty
+    vulnerabilities array — an advisory that says only "look at code scanning",
+    which is where those findings already are. This is what raised the two
+    content-free drafts behind #1269.
+
+    Asserting on the token is the sharp end: the script demands ADVISORY_TOKEN
+    the moment it decides to write, so reaching the API at all would fail here.
+    """
+    monkeypatch.delenv("ADVISORY_TOKEN", raising=False)
+    _write(tmp_path, "codecount.json",
+           {"release": "v1.3.2", "code_findings": 8, "findings": []})
+    urls = tmp_path / "urls.json"
+    advisory.main.__globals__["sys"].argv = ["x", str(tmp_path), str(urls)]
+
+    assert advisory.main() == 0
+    assert json.loads(urls.read_text()) == {}
+
+
+def test_advisory_still_raised_when_a_dependency_finding_exists(tmp_path, monkeypatch):
+    """The gate is on dependency findings, not on silence. One real row still
+    raises, and the code-finding count still rides along as context."""
+    body = advisory.describe(
+        "v1.3.2",
+        [{"severity": "high", "package": "js-yaml", "installed": "4.3.0",
+          "fixed": "4.3.1", "id": "GHSA-x"}],
+        code_count=8,
+    )
+    assert "js-yaml" in body
+    assert "8 code finding(s)" in body
+
+
+def test_advisory_note_does_not_promise_publication():
+    """The note used to say the draft 'becomes the public record' when the patch
+    ships. It cannot: a published advisory is permanent and GitHub refuses to
+    close one. Two were published on that promise and are stuck. The code never
+    published — only the text said it would, which is how a wording bug becomes
+    an irreversible act performed by a human following instructions."""
+    body = advisory.describe("v1.3.2", [], code_count=0)
+    assert "becomes the public record" not in body
+    assert "irreversible" in body
+
+    report_source = pathlib.Path(report.__file__).read_text()
+    assert "Drafts are published when" not in report_source


### PR DESCRIPTION
The two drafts behind #1269 have **empty dependency tables**. Their entire content is a bare table header plus "Plus N code finding(s) — see code scanning".

## Why

`rescan_advisory.py` skipped a release only when `not findings and not code`, so a code-finding *count* alone was enough to mint a draft advisory. But `vulnerabilities(findings)` returns `[]` with no dependency rows — an advisory whose payload array is empty. Those code findings are already in code scanning, which is the correct private channel and the one this workflow deliberately sends them to (its own comment at lines 250-258 explains why). Raising an advisory to point at the other channel adds an irreversible-if-ever-published artifact carrying nothing that channel does not already hold.

The gate is now on **dependency findings alone**. Code findings still go to code scanning, and still count towards notifying on the public issue — that behaviour is unchanged.

## The wording was the dangerous half

Both the advisory and the issue claimed a draft *"becomes the public record when the patch release that fixes it ships"*.

It cannot. Publishing a repository advisory is irreversible — GitHub returns **422 on any attempt to close a published one** — so a draft published on that promise is permanent. Two already are.

The code never published (`test_advisory_never_publishes` pins that). Only the *text* said it would, which is how a wording bug becomes an irreversible act carried out by a human following instructions. Both copies now say what actually happens: drafts are closed, not published, and the operator-facing record is the release notes naming the advisories a patch clears.

## Verification

Three new tests. I checked they fail against the old source rather than assuming — reverting just the two scripts fails both the gate test and the wording test, and the full file is 31/31 after.

Not waiting on the full image-build-and-e2e suite for a scripts change; `scripts/tests/test_rescan.py` is the job that actually covers this and it is green locally.