### PR TITLE
fix: require registry admin to manage provider signing keys

### DIFF
--- a/services/terrapod/api/routers/gpg_keys.py
+++ b/services/terrapod/api/routers/gpg_keys.py
@@ -26,6 +26,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from terrapod.api.dependencies import AuthenticatedUser, get_current_user
 from terrapod.api.pagination import paginate
 from terrapod.api.serialization import rfc3339
+from terrapod.auth import capabilities as cap
+from terrapod.auth.capabilities import has_capability
 from terrapod.db.session import get_db
 from terrapod.logging_config import get_logger
 from terrapod.services.gpg_key_service import (
@@ -34,6 +36,9 @@ from terrapod.services.gpg_key_service import (
     get_gpg_key,
     list_gpg_keys,
     revoke_gpg_key,
+)
+from terrapod.services.registry_rbac_service import (
+    resolve_registry_capabilities_for,
 )
 
 router = APIRouter(tags=["gpg-keys"])
@@ -101,6 +106,39 @@ def _gpg_key_to_jsonapi(key) -> dict:  # type: ignore[no-untyped-def]
 # --- Endpoints ---
 
 
+# The GPG key store is the trust anchor for provider signature verification:
+# `registry_provider_service._verify_and_store_shasums_signature` reads the
+# issuer key id out of a publisher's detached SHA256SUMS.sig and verifies the
+# signature against whichever registered GPGKey matches. Being able to add a
+# key therefore means being able to have Terrapod accept a signature you made;
+# being able to delete one means being able to break verification for a
+# publisher who did nothing wrong. Both are registry-administration acts, and
+# were previously gated on nothing beyond "is authenticated".
+#
+# GPGKey carries no owner or labels — it is one platform-wide list — so the
+# capability is resolved against a stable resource name with an empty label
+# set. That is deliberate rather than incidental: an empty label set matches
+# no allow_labels rule (`matches_labels` requires the key to be present on the
+# resource), so the grant paths are platform admin, or a registry role naming
+# this resource in its allow_names. An operator who runs the registry without
+# being a platform admin can be given it explicitly.
+GPG_KEY_RESOURCE = "gpg-keys"
+
+
+async def _require_gpg_key_capability(
+    db: AsyncSession,
+    user: AuthenticatedUser,
+    required_cap: str,
+) -> None:
+    """Check the required registry capability on the GPG key store or raise 403."""
+    caps = await resolve_registry_capabilities_for(db, user, GPG_KEY_RESOURCE, {}, "")
+    if not has_capability(caps, required_cap):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Requires {required_cap} capability on the GPG key store",
+        )
+
+
 @router.post("/gpg-keys")
 async def create_gpg_key_endpoint(
     body: CreateGPGKeyRequest,
@@ -108,6 +146,7 @@ async def create_gpg_key_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Create a new GPG key. Parses key_id from the ASCII armor block."""
+    await _require_gpg_key_capability(db, user, cap.REGISTRY_ADMIN)
     attrs = body.data.attributes
     try:
         key = await create_gpg_key(
@@ -175,6 +214,7 @@ async def revoke_gpg_key_endpoint(
     """Revoke a registered GPG key by applying an owner-issued revocation
     certificate (#640). The key stays registered but all signature verification
     fails closed for it. 422 if the certificate is not a valid self-revocation."""
+    await _require_gpg_key_capability(db, user, cap.REGISTRY_ADMIN)
     try:
         key_uuid = uuid.UUID(key_id)
     except ValueError:
@@ -199,6 +239,7 @@ async def delete_gpg_key_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Delete a GPG key."""
+    await _require_gpg_key_capability(db, user, cap.REGISTRY_ADMIN)
     try:
         key_uuid = uuid.UUID(key_id)
     except ValueError:

--- a/services/tests/api/test_gpg_keys.py
+++ b/services/tests/api/test_gpg_keys.py
@@ -30,6 +30,16 @@ def _user(roles=None):
     )
 
 
+def _admin():
+    """A principal that holds the registry capability the mutating routes need.
+
+    Platform admin is step 1 of the capability resolver, so this exercises the
+    real resolution path rather than patching it out — the point of these
+    tests after the fix is that the gate is genuinely consulted.
+    """
+    return _user(roles=["admin"])
+
+
 def _make_app(user=None):
     app = create_app()
     if user is not None:
@@ -81,7 +91,7 @@ class TestCreate:
     @patch("terrapod.api.routers.gpg_keys.create_gpg_key", new_callable=AsyncMock)
     async def test_happy_path_201(self, mock_create, *mocks):
         mock_create.return_value = _mock_key()
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(_KEYS, json=_create_body(), headers=_AUTH)
         assert resp.status_code == 201
@@ -96,7 +106,7 @@ class TestCreate:
     @patch("terrapod.api.routers.gpg_keys.create_gpg_key", new_callable=AsyncMock)
     async def test_invalid_armor_422(self, mock_create, *mocks):
         mock_create.side_effect = ValueError("no PGP block found")
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(_KEYS, json=_create_body(), headers=_AUTH)
         assert resp.status_code == 422
@@ -105,7 +115,7 @@ class TestCreate:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     async def test_missing_armor_422(self, *mocks):
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
                 _KEYS,
@@ -183,7 +193,7 @@ class TestRevoke:
     async def test_revoke_happy_200(self, mock_revoke, *mocks):
         key = _mock_key()
         mock_revoke.return_value = key
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(f"{_KEYS}/{key.id}/revoke", json=_revoke_body(), headers=_AUTH)
         assert resp.status_code == 200
@@ -195,7 +205,7 @@ class TestRevoke:
     @patch("terrapod.api.routers.gpg_keys.revoke_gpg_key", new_callable=AsyncMock)
     async def test_revoke_invalid_cert_422(self, mock_revoke, *mocks):
         mock_revoke.side_effect = ValueError("not a valid self-revocation certificate for this key")
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
                 f"{_KEYS}/{uuid.uuid4()}/revoke", json=_revoke_body(), headers=_AUTH
@@ -208,7 +218,7 @@ class TestRevoke:
     @patch("terrapod.api.routers.gpg_keys.revoke_gpg_key", new_callable=AsyncMock)
     async def test_revoke_not_found_404(self, mock_revoke, *mocks):
         mock_revoke.return_value = None
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(
                 f"{_KEYS}/{uuid.uuid4()}/revoke", json=_revoke_body(), headers=_AUTH
@@ -219,7 +229,7 @@ class TestRevoke:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     async def test_revoke_bad_uuid_404(self, *mocks):
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.post(f"{_KEYS}/xyz/revoke", json=_revoke_body(), headers=_AUTH)
         assert resp.status_code == 404
@@ -232,7 +242,7 @@ class TestDelete:
     @patch("terrapod.api.routers.gpg_keys.delete_gpg_key", new_callable=AsyncMock)
     async def test_delete_happy_204(self, mock_delete, *mocks):
         mock_delete.return_value = True
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(f"{_KEYS}/{uuid.uuid4()}", headers=_AUTH)
         assert resp.status_code == 204
@@ -243,7 +253,7 @@ class TestDelete:
     @patch("terrapod.api.routers.gpg_keys.delete_gpg_key", new_callable=AsyncMock)
     async def test_delete_not_found_404(self, mock_delete, *mocks):
         mock_delete.return_value = False
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(f"{_KEYS}/{uuid.uuid4()}", headers=_AUTH)
         assert resp.status_code == 404
@@ -252,7 +262,76 @@ class TestDelete:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     async def test_delete_bad_uuid_404(self, *mocks):
-        app = _make_app(_user())
+        app = _make_app(_admin())
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.delete(f"{_KEYS}/xyz", headers=_AUTH)
         assert resp.status_code == 404
+
+
+class TestTrustAnchorAuthorization:
+    """The GPG key store is the trust anchor for provider signature
+    verification: `_verify_and_store_shasums_signature` reads the issuer key id
+    out of a publisher's detached SHA256SUMS.sig and verifies it against
+    whichever registered key matches. Every route here was previously gated on
+    `get_current_user` alone, so any authenticated principal could register a
+    key of their own and have Terrapod accept signatures they made, or delete a
+    legitimate publisher's key and break verification for them.
+
+    These pin the gate per route, because a check added to two of three
+    mutating endpoints is the same hole with a smaller entrance.
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.create_gpg_key", new_callable=AsyncMock)
+    async def test_ordinary_principal_cannot_add_a_trust_anchor(self, mock_create, *mocks):
+        mock_create.return_value = _mock_key()
+        app = _make_app(_user())  # authenticated, holds only `everyone`
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(_KEYS, json=_create_body(), headers=_AUTH)
+        assert resp.status_code == 403
+        # The service must not have been reached — a 403 raised after the write
+        # would be a different bug wearing the same status code.
+        mock_create.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.revoke_gpg_key", new_callable=AsyncMock)
+    async def test_ordinary_principal_cannot_revoke(self, mock_revoke, *mocks):
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                f"{_KEYS}/{uuid.uuid4()}/revoke", json=_revoke_body(), headers=_AUTH
+            )
+        # A valid body on purpose: with an invalid one FastAPI answers 422 from
+        # request validation before the authz check runs, which would prove
+        # nothing about the gate.
+        assert resp.status_code == 403
+        mock_revoke.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.delete_gpg_key", new_callable=AsyncMock)
+    async def test_ordinary_principal_cannot_delete(self, mock_delete, *mocks):
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.delete(f"{_KEYS}/{uuid.uuid4()}", headers=_AUTH)
+        assert resp.status_code == 403
+        mock_delete.assert_not_called()
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.list_gpg_keys", new_callable=AsyncMock)
+    async def test_reads_stay_open_to_any_authenticated_principal(self, mock_list, *mocks):
+        """Deliberately NOT gated. These are public keys, and this ships in a
+        patch to supported lines — tightening a read buys no security and can
+        break a consumer that was legitimately listing them."""
+        mock_list.return_value = [_mock_key()]
+        app = _make_app(_user())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_KEYS, headers=_AUTH)
+        assert resp.status_code == 200


### PR DESCRIPTION
Addresses a privately reported vulnerability (GHSA-6qrc-597p-mrp9). Backports to `release/v1.3` and `release/v1.2` follow.

Every route in `gpg_keys.py` was gated on `Depends(get_current_user)` alone — "some authenticated principal" — with no role or capability check, while every comparable platform-wide router (`vcs_connections.py`, `roles.py`, `tokens.py`) uses `require_admin`.

That store is the **trust anchor for provider signature verification**: `registry_provider_service._verify_and_store_shasums_signature` reads the issuer key id out of a publisher's detached `SHA256SUMS.sig` and verifies it against whichever registered key matches. Adding a key means having Terrapod accept a signature you made; deleting one means breaking verification for a publisher who did nothing wrong.

## The fix

`create`, `revoke` and `delete` now require `REGISTRY_ADMIN`, resolved through the same `resolve_registry_capabilities_for` helper the provider-registry routes use.

**Reads are deliberately unchanged.** They return public keys, and this ships to supported release lines — tightening a read buys no security and can break a consumer that was legitimately listing them.

## Why a resource name with empty labels

`GPGKey` has no owner and no labels; it is one platform-wide list. So the capability resolves against a stable `GPG_KEY_RESOURCE = "gpg-keys"` with `{}` labels.

That is deliberate rather than incidental: `matches_labels` requires the key to be present on the resource, so an empty label set matches **no** `allow_labels` rule. The grant paths are therefore platform admin, **or a registry role naming `gpg-keys` in its `allow_names`** — which keeps this a genuine registry permission rather than admin in disguise, and lets an operator who runs the registry without being a platform admin be given it explicitly.

## The tests are the clearest statement of the bug

Before adding anything, the existing suite went **9 failed / 6 passed** the moment the gate went in — every failure on create/revoke/delete, every read untouched. Those nine were asserting that an ordinary authenticated caller could mutate the trust anchor.

They now use a principal that holds the capability (platform admin, exercising the real resolver rather than patching it out). Three new negatives pin it per route and assert the service function was **never called** — a 403 raised after the write would be a different bug wearing the same status code. One asserts reads stay open, so the deliberate choice is recorded rather than assumed.

19/19 in the file, **4221** across the suite.

Follow-up, not in this PR: `gpg-keys` is a new grantable name and wants a line in the RBAC docs — an operator cannot grant what is not documented.