### PR TITLE
refactor: drop the invented resource name from the GPG key gate

### DIFF
--- a/services/terrapod/api/routers/gpg_keys.py
+++ b/services/terrapod/api/routers/gpg_keys.py
@@ -115,14 +115,18 @@ def _gpg_key_to_jsonapi(key) -> dict:  # type: ignore[no-untyped-def]
 # publisher who did nothing wrong. Both are registry-administration acts, and
 # were previously gated on nothing beyond "is authenticated".
 #
-# GPGKey carries no owner or labels — it is one platform-wide list — so the
-# capability is resolved against a stable resource name with an empty label
-# set. That is deliberate rather than incidental: an empty label set matches
-# no allow_labels rule (`matches_labels` requires the key to be present on the
-# resource), so the grant paths are platform admin, or a registry role naming
-# this resource in its allow_names. An operator who runs the registry without
-# being a platform admin can be given it explicitly.
-GPG_KEY_RESOURCE = "gpg-keys"
+# GPGKey carries no owner and no labels — it is one platform-wide list, not a
+# per-resource thing — so there is nothing to scope the capability against and
+# no name is invented for it. The empty resource means only the unscoped grants
+# resolve: platform admin (and audit's read floor). A role's allow_labels
+# cannot match, because `matches_labels` requires the label key to be present
+# on the resource.
+#
+# An earlier version of this passed the literal "gpg-keys" as a resource name
+# so a registry role could name it in allow_names. That put a magic string into
+# the same namespace as real provider names (`_require_provider_capability`
+# passes `provider.name`), so a provider called "gpg-keys" would have collided
+# with the trust-anchor store in both directions. Not worth the flexibility.
 
 
 async def _require_gpg_key_capability(
@@ -131,7 +135,7 @@ async def _require_gpg_key_capability(
     required_cap: str,
 ) -> None:
     """Check the required registry capability on the GPG key store or raise 403."""
-    caps = await resolve_registry_capabilities_for(db, user, GPG_KEY_RESOURCE, {}, "")
+    caps = await resolve_registry_capabilities_for(db, user, "", {}, "")
     if not has_capability(caps, required_cap):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
Follow-up to #1290. You were right that this did not need a new grantable name.

The authz fix resolved the registry capability against a literal `"gpg-keys"` resource name so a registry role could grant it via `allow_names`. That put a magic string into **the same namespace as real provider names** — `_require_provider_capability` passes `provider.name` into the same field — so a registry provider called `gpg-keys` would have collided with the platform trust-anchor store in both directions.

The flexibility was not worth that. The key store is one platform-wide list with no owner and no labels, so there is nothing to scope against: the capability now resolves with an **empty resource**, which means only the unscoped grants apply — platform admin, and audit's read floor.

## Not a behaviour change, and not being backported

No real deployment has a provider named `gpg-keys`, and the endpoints were already closed to ordinary principals in **v1.3.3** and **v1.2.3**. This removes a latent collision rather than fixing a live one, so the release lines keep what they have.

## Tests unchanged

Deliberately — they assert *who can and cannot reach the routes*, which is exactly what should be insensitive to how the resource is named internally. 19/19 in the file, **4221** across the suite.

Also retracts the "wants a line in the RBAC docs" follow-up I raised: `docs/rbac.md:194` documents `allow-names` as *workspace* names, so there was never a general grantable-name registry to add to. With the magic name gone there is nothing to document.