### PR TITLE
fix: bound the eval-boot teardown and always rebuild the e2e images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1243,6 +1243,10 @@ jobs:
             done
           fi
       - name: make eval (install into the cluster)
+        # Bounded below the job's own timeout so an install that will not
+        # converge FAILS this step — leaving budget for diagnostics and
+        # teardown — instead of cancelling the job and skipping both.
+        timeout-minutes: 12
         env:
           CI: "1"
           EVAL_NO_PORT_FORWARD: "1"
@@ -1287,14 +1291,24 @@ jobs:
           ctx=$([ "${{ matrix.tool }}" = "kind" ] && echo kind-terrapod-eval || echo k3d-terrapod-eval)
           scripts/eval-smoke-plan.sh "$ctx" terrapod-eval
       - name: Diagnostics on failure
-        if: failure()
+        # `failure()` alone does NOT run when the job is cancelled by its own
+        # timeout-minutes — only `always()`/`cancelled()` do. A hung boot is
+        # exactly the case we most want diagnostics for, and it is the case
+        # this condition used to skip.
+        if: failure() || cancelled()
+        timeout-minutes: 3
         run: |
           ctx=$([ "${{ matrix.tool }}" = "kind" ] && echo kind-terrapod-eval || echo k3d-terrapod-eval)
           kubectl --context "$ctx" -n terrapod-eval get pods,jobs || true
           kubectl --context "$ctx" -n terrapod-eval logs deploy/terrapod-listener --tail=80 || true
           kubectl --context "$ctx" -n terrapod-eval logs -l app.kubernetes.io/name=terrapod-runner --tail=120 --prefix || true
       - name: Teardown
+        # `k3d cluster delete` has hung for 23 minutes here, consuming the rest
+        # of the job budget and turning "one step failed" into "the whole job
+        # was killed" — which is a much harder thing to read. A cluster delete
+        # that cannot finish in 3 minutes is not going to.
         if: always()
+        timeout-minutes: 3
         env:
           TERRAPOD_EVAL_TOOL: ${{ matrix.tool }}
         run: scripts/eval.sh down

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -14,20 +14,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Build images if they don't exist
-info "Ensuring Docker images exist..."
-if ! docker image inspect terrapod-api:local > /dev/null 2>&1; then
-  info "Building terrapod-api:local..."
-  docker build -f "$REPO_ROOT/docker/Dockerfile.api" -t terrapod-api:local "$REPO_ROOT"
-fi
-if ! docker image inspect terrapod-web:local > /dev/null 2>&1; then
-  info "Building terrapod-web:local..."
-  docker build -f "$REPO_ROOT/docker/Dockerfile.web" -t terrapod-web:local "$REPO_ROOT"
-fi
-if ! docker image inspect terrapod-migrations:local > /dev/null 2>&1; then
-  info "Building terrapod-migrations:local..."
-  docker build -f "$REPO_ROOT/docker/Dockerfile.migrations" -t terrapod-migrations:local "$REPO_ROOT"
-fi
+# Always rebuild. This used to build only when the image was ABSENT, which
+# meant the suite ran against whatever `terrapod-api:local` happened to be —
+# potentially weeks old — while the specs came from the working tree. That
+# produces false failures (a spec written for a feature the image predates)
+# and, worse, false passes: a spec written to guard a regression passes
+# happily against an image built before the regression existed. Layer caching
+# makes a no-change rebuild cheap, so the guard bought very little. (#1281)
+info "Building images from the working tree..."
+docker build -f "$REPO_ROOT/docker/Dockerfile.api" -t terrapod-api:local "$REPO_ROOT"
+docker build -f "$REPO_ROOT/docker/Dockerfile.web" -t terrapod-web:local "$REPO_ROOT"
+docker build -f "$REPO_ROOT/docker/Dockerfile.migrations" -t terrapod-migrations:local "$REPO_ROOT"
 
 # Start the stack
 info "Starting E2E stack..."


### PR DESCRIPTION
Two CI/dev-loop failures that both **hid evidence rather than producing it**.

## Eval Boot (#1279)

The job has a 25-minute cap and **not one step had its own**. When a boot hung, the job was *cancelled* — and `Diagnostics on failure` is guarded by `if: failure()`, which **does not run on cancellation**; only `always()`/`cancelled()` do.

So the single step guaranteed to run was the teardown, and `k3d cluster delete` then hung for **23 minutes**, ate the rest of the budget, and turned "one step failed" into "the whole job was killed" — a much harder thing to read. The failing step's output was simply gone.

- `Diagnostics` → `if: failure() || cancelled()`, bounded at 3 min
- `Teardown` → bounded at 3 min (a cluster delete that cannot finish in 3 minutes is not going to)
- `make eval` → bounded at 12 min, so an install that will not converge **fails its own step** and leaves budget for the other two

**Correction to the issue as I filed it:** I wrote that there were no diagnostics. There were — they were skipped by a condition that does not cover the case they were most needed for. The fix is the guard, not the step.

## Stale e2e images (#1281)

`scripts/e2e.sh` built images only when **absent**, so the suite ran against whatever `terrapod-api:local` happened to be — potentially weeks old — while the specs came from the working tree.

That produced **four false failures** against a 45-hour-old image (including `estate` and `state-graph`, which nothing local had touched). The dangerous direction is the other one: a spec written to guard a regression passes happily against an image built *before* the regression existed — the same shape of defect as a test whose locator has drifted onto the wrong element.

Layer caching makes a no-change rebuild cheap, so the `if ! docker image inspect` guard bought very little.

CI is unaffected by this one — fresh runners have no cached image, which is exactly why it went unnoticed.

## Verification

`ci.yml` parses as YAML; `bash -n scripts/e2e.sh` clean. The eval-boot changes are timeout/condition guards, so the real proof is the job running green on this PR — which is what the kind and k3d legs will show.