### PR TITLE
fix: enable the version check in terrapod-publish and the provider

### DIFF
--- a/provider/internal/provider/provider.go
+++ b/provider/internal/provider/provider.go
@@ -62,7 +62,18 @@ type terrapodProviderModel struct {
 }
 
 // New returns a new provider.Provider.
+//
+// Hands our build-time version to the SDK so the compatibility check in
+// Configure has something to compare against. Without this it can never fire:
+// VersionCheck returns nil immediately when SDKVersion is "dev", SDKVersion
+// defaults to "dev", and the provider's GoReleaser stamps main.version — not
+// the SDK's variable. terrapod-mcp already does the same assignment; this
+// brings the provider in line (#1287).
+//
+// A source build passes "dev", which the SDK treats as "cannot compare" and
+// skips, so local provider development is unaffected.
 func New(version string) func() provider.Provider {
+	terrapod.SDKVersion = version
 	return func() provider.Provider {
 		return &terrapodProvider{version: version}
 	}

--- a/publish/cmd/terrapod-publish/main.go
+++ b/publish/cmd/terrapod-publish/main.go
@@ -26,6 +26,20 @@ func warnVersionMismatch(c *terrapod.Client) {
 // Version is stamped at build time via -ldflags "-X main.Version=...".
 var Version = "dev"
 
+// init hands our stamped version to the SDK so its VersionCheck has something
+// to compare against.
+//
+// Without this the warning above can never fire: VersionCheck returns nil
+// immediately when SDKVersion is "dev", SDKVersion defaults to "dev", and this
+// tool's GoReleaser stamps main.Version — not the SDK's variable. terrapod-mcp
+// already does the same assignment; this brings publish in line (#1287).
+//
+// A source build leaves Version as "dev", which the SDK treats as "cannot
+// compare" and skips, so `go run` keeps working.
+func init() {
+	terrapod.SDKVersion = Version
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		usage()


### PR DESCRIPTION
Closes #1287. Completes the sweep started in #1286.

Both call `VersionCheck` and **neither assigned `SDKVersion`**, so both checks have returned `nil` unconditionally in every released build:

- `VersionCheck` short-circuits when `SDKVersion` is `"dev"`
- `SDKVersion` defaults to `"dev"`
- each tool's GoReleaser stamps **its own** version variable, not the SDK's

So `terrapod-publish` could not warn on a mismatch, and the provider could not raise its plan-time diagnostic. Both behaviours were written, wired to a caller, and inert.

`terrapod-mcp` already did the right thing (`server.go:71`) and is the pattern both now follow. **No build change** — each already stamps a version.

The provider takes its version as a parameter rather than a package var, so the assignment goes in `New()`, which is where the version arrives.

## Blast radius

The provider will now start emitting a plan-time **warning** to practitioners running a version-skewed pair. That is the intended behaviour and it is a warning, not a failure — the existing code is explicit that it must never fail a plan over version skew. This is why it was kept out of #1286 and landed deliberately.

Source builds are unaffected: they pass `"dev"`, which the SDK treats as "cannot compare" and skips.

## Verification

`go build`, `go vet`, `go test` and `golangci-lint` (0 issues) clean in both modules. All four consumers now assign `SDKVersion` — migrate, publish, provider, mcp.