### PR TITLE
feat(1296): concurrent lanes for triggered tasks, and a queued-summary placeholder (#1295)

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -137,6 +137,27 @@ scrape_configs:
 | `terrapod_scheduler_trigger_enqueued_total` | Counter | type | Triggers enqueued |
 | `terrapod_scheduler_trigger_deduplicated_total` | Counter | type | Triggers skipped (dedup) |
 | `terrapod_scheduler_trigger_processed_total` | Counter | type, status | Triggers processed |
+| `terrapod_scheduler_queue_depth` | Gauge | lane | Items waiting in each lane. Sampled every 15s by every replica against one shared list, so aggregate with `max()` |
+| `terrapod_scheduler_trigger_wait_seconds` | Histogram | type | Time queued before a consumer picked the item up — **not** how long the handler then ran |
+
+### Reading the two queue signals together
+
+They answer different questions, and keeping them apart is the point:
+
+- **Wait high, handler duration normal** → not enough consumers. Raise
+  `api.config.scheduler.lane_consumers` for that lane (or add replicas — the
+  two multiply).
+- **Wait low, handler duration high** → the handler itself got slower. More
+  consumers will not help.
+- **Depth climbing and not returning to zero** → producers are outpacing that
+  lane over a sustained period, not just bursting.
+
+The `ai` lane is the one worth an alert. Its items are enqueued in bursts (a
+VCS poll cycle emits one per changed workspace) and back a user-visible
+feature, so a sustained backlog shows up as "my plan summary never appeared"
+long before anything else complains. Alert on
+`terrapod_scheduler_trigger_wait_seconds` at the lane's p95 rather than on
+depth alone — a deep queue that drains fast is fine.
 
 ### VCS
 

--- a/helm/terrapod/templates/configmap-api.yaml
+++ b/helm/terrapod/templates/configmap-api.yaml
@@ -424,6 +424,15 @@ data:
     metrics:
       enabled: {{ .Values.api.config.metrics.enabled }}
     {{- end }}
+    {{- with .Values.api.config.scheduler }}
+    scheduler:
+      {{- with .lane_consumers }}
+      lane_consumers:
+        {{- range $lane, $count := . }}
+        {{ $lane }}: {{ int $count }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
     runner_artifacts:
       # int64 cast keeps Helm from emitting YAML scientific notation
       # for values above ~1M (Pydantic refuses to parse those as int).

--- a/helm/terrapod/values.schema.json
+++ b/helm/terrapod/values.schema.json
@@ -2583,6 +2583,20 @@
               }
             }
           }
+        },
+        "scheduler": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lane_consumers": {
+              "type": "object",
+              "description": "Consumers per replica for each triggered-task lane, as {lane: count}. Unset lanes fall back to their built-in default.",
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
         }
       }
     }

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -858,6 +858,26 @@ api:
       # fronts more distinct API clients than this. 0 = unlimited.
       distinct_credentials_per_minute: 200
 
+    # Background triggered-task scheduler (#1296).
+    #
+    # Consumers PER REPLICA for each lane; deployment-wide concurrency is this
+    # times the replica count. Lanes are independent queues, so these numbers
+    # do not interact.
+    #
+    # `default` stays at 1: that work is sub-second, and more consumers would
+    # buy nothing. `ai` is 10 because those items are independent, I/O-bound
+    # model calls — they were previously drained one at a time behind the
+    # sub-second majority, which turned a single VCS poll cycle across many
+    # workspaces into minutes of queue for a user-visible feature.
+    #
+    # Raise `ai` to drain a backlog faster; lower it if your model provider's
+    # rate limits complain. Watch `terrapod_scheduler_queue_depth{lane="ai"}`
+    # and `terrapod_scheduler_trigger_wait_seconds` to decide which.
+    scheduler:
+      lane_consumers:
+        default: 1
+        ai: 10
+
     # Prometheus metrics
     metrics:
       enabled: true

--- a/services/terrapod/api/app.py
+++ b/services/terrapod/api/app.py
@@ -97,6 +97,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     # Register and start distributed scheduler (multi-replica safe)
     from terrapod.services.scheduler import (
+        AI_LANE,
         register_periodic_task,
         register_trigger_handler,
         start_scheduler,
@@ -333,6 +334,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             "ai_plan_summary",
             handler=handle_ai_plan_summary,
             description="Summarise plan changes or analyse plan failures via LLM",
+            # Its own lane: independent, I/O-bound model calls that a VCS poll
+            # emits in bursts. Left in the default lane they were drained one
+            # at a time behind (and in front of) sub-second status posts.
+            lane=AI_LANE,
         )
 
         # AI cost narrative (#871) — the optional enhancement over the
@@ -343,6 +348,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             "ai_cost_summary",
             handler=handle_ai_cost_summary,
             description="Narrate a run's cost estimate + suggest savings via LLM",
+            lane=AI_LANE,
         )
 
     # Run reconciler (drives run state transitions based on Job outcomes)

--- a/services/terrapod/api/metrics.py
+++ b/services/terrapod/api/metrics.py
@@ -102,6 +102,35 @@ SCHEDULER_TRIGGER_PROCESSED = Counter(
     ["type", "status"],
 )
 
+SCHEDULER_QUEUE_DEPTH = Gauge(
+    "terrapod_scheduler_queue_depth",
+    (
+        "Triggered tasks currently waiting in each queue lane. Deployment-wide "
+        "concurrency is (replicas x consumers-per-lane), so a lane whose depth "
+        "climbs and does not drain is one whose producers are outrunning its "
+        "consumers. Depth is the signal that matters rather than per-item cost: "
+        "a VCS poll cycle enqueues one AI item per changed workspace at once, so "
+        "even individually quick items become minutes of user-visible latency "
+        "when they are drained one at a time (#1296). Before this gauge existed "
+        "a deep backlog was invisible until somebody noticed a missing summary."
+    ),
+    ["lane"],
+)
+
+SCHEDULER_TRIGGER_WAIT = Histogram(
+    "terrapod_scheduler_trigger_wait_seconds",
+    (
+        "Time a triggered task spent queued, from enqueue to the moment a "
+        "consumer picked it up. Deliberately separate from the handler's own "
+        "duration, because the two call for different fixes and conflating them "
+        "sends you after the wrong one: wait time is removed by more consumers, "
+        "execution time is not. Buckets run to an hour — a saturated lane is "
+        "minutes deep even when every individual item is quick."
+    ),
+    ["type"],
+    buckets=(0.1, 0.5, 1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600),
+)
+
 # ---------------------------------------------------------------------------
 # VCS metrics
 # ---------------------------------------------------------------------------

--- a/services/terrapod/api/routers/run_artifacts.py
+++ b/services/terrapod/api/routers/run_artifacts.py
@@ -362,7 +362,7 @@ async def upload_plan_json_output(
             from terrapod.services import run_service
 
             await run_service.evaluate_conditional_auto_apply(db, run)
-        return await _enqueue_plan_json_followups(run)
+        return await _enqueue_plan_json_followups(run, db)
     finally:
         try:
             await asyncio.to_thread(os.unlink, tmp_path)
@@ -370,7 +370,7 @@ async def upload_plan_json_output(
             pass
 
 
-async def _enqueue_plan_json_followups(run: Run) -> Response:
+async def _enqueue_plan_json_followups(run: Run, db: AsyncSession) -> Response:
     """Fire the AI-summary + drift-completion triggers after plan-JSON lands.
 
     Split out of `upload_plan_json_output` so the streamed-tempfile
@@ -391,6 +391,7 @@ async def _enqueue_plan_json_followups(run: Run) -> Response:
     if settings.ai_summary.enabled:
         try:
             from terrapod.services.scheduler import enqueue_trigger
+            from terrapod.services.summariser import mark_summary_queued
 
             await enqueue_trigger(
                 "ai_plan_summary",
@@ -398,6 +399,15 @@ async def _enqueue_plan_json_followups(run: Run) -> Response:
                 dedup_key=f"aisum:{run.id}:plan_summary",
                 dedup_ttl=300,
             )
+            # Placeholder row so the summary endpoint stops 404ing the moment
+            # the work exists, rather than only once a consumer picks it up
+            # (#1295). Written after the enqueue so a failed enqueue leaves no
+            # row: a summary stuck at `pending` forever would be a worse lie
+            # than the 404 it replaces. Insert-if-absent, so if a consumer has
+            # already finished — entirely possible now the AI lane runs several
+            # at once — the real result stands.
+            await mark_summary_queued(db, run_id=run.id, kind="plan_summary")
+            await db.commit()
         except Exception as e:
             logger.debug("Failed to enqueue ai_plan_summary after upload", error=str(e))
 

--- a/services/terrapod/config.py
+++ b/services/terrapod/config.py
@@ -1254,6 +1254,25 @@ class RunnerArtifactsConfig(BaseModel):
     )
 
 
+class SchedulerConfig(BaseModel):
+    """Background triggered-task scheduler (#1296)."""
+
+    lane_consumers: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Concurrent consumers PER REPLICA for each triggered-task lane, as "
+            "{lane: count}. Deployment-wide concurrency for a lane is this "
+            "times the replica count. Unset lanes use their built-in default: "
+            "1 for `default` (sub-second work, where more would buy nothing) "
+            "and 10 for `ai` (independent, I/O-bound model calls that were "
+            "previously drained one at a time). Raise `ai` to clear a backlog "
+            "faster, lower it to stay inside a model provider's rate limits. "
+            "Values below 1 are clamped up — a lane with no consumers would "
+            "accept work and never drain it."
+        ),
+    )
+
+
 class MetricsConfig(BaseModel):
     """Prometheus metrics configuration."""
 
@@ -2424,6 +2443,7 @@ class Settings(BaseSettings):
 
     # Metrics
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
+    scheduler: SchedulerConfig = Field(default_factory=SchedulerConfig)
 
     # Artifact Retention
     artifact_retention: ArtifactRetentionConfig = Field(default_factory=ArtifactRetentionConfig)

--- a/services/terrapod/services/scheduler.py
+++ b/services/terrapod/services/scheduler.py
@@ -17,11 +17,24 @@ Triggered tasks:
     consumer loop dequeues and executes. Deduplication via Redis SET NX
     prevents duplicate items in the queue.
 
+    Items travel in **lanes**, each a separate list with its own pool of
+    consumers. Triggered tasks are mutually independent, so the only reason to
+    process them one at a time is that a consumer awaits its handler inline —
+    and for a long time there was exactly one consumer per replica for every
+    kind of work at once. That made throughput (replicas x 1) regardless of how
+    much was queued, so a poll cycle fanning out across an estate turned a set
+    of independent, I/O-bound model calls into a multi-minute FIFO (#1296).
+    Lanes let the AI class run several-at-a-time without also multiplying
+    concurrency for the sub-second majority, and stop either class queueing
+    behind the other.
+
 Redis keys:
     tp:sched:{name}:claim       — NX mutex for periodic tasks (TTL = interval)
     tp:sched:{name}:running     — set while task is executing (TTL = 3x interval)
     tp:sched:{name}:last        — UNIX timestamp of last completed execution
-    tp:sched:triggers           — LIST queue for triggered tasks
+    tp:sched:triggers           — LIST queue, `default` lane (name unchanged so
+                                  a mid-upgrade replica keeps draining it)
+    tp:sched:triggers:{lane}    — LIST queue for any non-default lane
     tp:sched:trigger:{dedup}    — NX dedup key for triggered tasks (TTL = 5min)
 """
 
@@ -32,11 +45,13 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from terrapod.api.metrics import (
+    SCHEDULER_QUEUE_DEPTH,
     SCHEDULER_TASK_DURATION,
     SCHEDULER_TASK_EXECUTIONS,
     SCHEDULER_TRIGGER_DEDUPLICATED,
     SCHEDULER_TRIGGER_ENQUEUED,
     SCHEDULER_TRIGGER_PROCESSED,
+    SCHEDULER_TRIGGER_WAIT,
 )
 from terrapod.logging_config import get_logger
 from terrapod.redis.client import get_redis_client
@@ -62,6 +77,28 @@ class PeriodicTaskDef:
     description: str = ""
 
 
+#: The lane every handler uses unless it declares otherwise. Its queue key is
+#: the historical `{PREFIX}:triggers`, unchanged — which is what makes lanes a
+#: rolling-upgrade-safe addition: an un-upgraded replica keeps draining exactly
+#: the key it always did, and only handlers that opt into a new lane move.
+DEFAULT_LANE = "default"
+
+#: Lane for work that is individually slow relative to the sub-second majority
+#: (model calls). Not "slow" in absolute terms — the point is the *contrast*:
+#: mixed into one FIFO with high-frequency status posts, a burst of these adds
+#: minutes of head-of-line delay in both directions (#1296).
+AI_LANE = "ai"
+
+#: Per-replica AI-lane consumers when the operator has not said otherwise.
+#: These handlers spend nearly all their time awaiting a model call, so this is
+#: a concurrency ceiling rather than a thread count — the cost of a waiting
+#: coroutine is negligible. It is a ceiling at all because each in-flight
+#: handler holds a DB session and consumes provider rate-limit budget, and
+#: because an unbounded fan-out would turn one busy poll cycle into a
+#: thundering herd against the model endpoint.
+DEFAULT_AI_LANE_CONSUMERS = 10
+
+
 @dataclass
 class TriggerHandlerDef:
     """Definition of a triggered task handler."""
@@ -69,6 +106,10 @@ class TriggerHandlerDef:
     name: str
     handler: Callable[[dict], Awaitable[None]]
     description: str = ""
+    #: Which queue lane this handler's items are enqueued to and consumed from.
+    #: Lanes are isolated: each has its own Redis list and its own pool of
+    #: consumers, so a saturated lane delays only itself.
+    lane: str = DEFAULT_LANE
 
 
 _periodic_tasks: dict[str, PeriodicTaskDef] = {}
@@ -90,10 +131,63 @@ def register_trigger_handler(
     name: str,
     handler: Callable[[dict], Awaitable[None]],
     description: str = "",
+    lane: str = DEFAULT_LANE,
 ) -> None:
-    """Register a handler for triggered tasks of the given type."""
-    _trigger_handlers[name] = TriggerHandlerDef(name, handler, description)
-    logger.info("Registered trigger handler", handler=name)
+    """Register a handler for triggered tasks of the given type.
+
+    `lane` picks which queue the type's items travel through. Leave it at the
+    default unless the handler is materially slower than the sub-second norm:
+    a lane exists to stop one class of work from delaying another, so putting
+    everything in its own lane would just recreate the original problem with
+    more moving parts.
+    """
+    _trigger_handlers[name] = TriggerHandlerDef(name, handler, description, lane)
+    logger.info("Registered trigger handler", handler=name, lane=lane)
+
+
+def _lane_queue_key(lane: str) -> str:
+    """Redis list backing a lane.
+
+    The default lane deliberately keeps the original un-suffixed key so that
+    during a rolling upgrade an old replica and a new one are still reading and
+    writing the same list. Only opted-in lanes get a new key, and those are
+    written and read exclusively by upgraded replicas.
+    """
+    if lane == DEFAULT_LANE:
+        return f"{PREFIX}:triggers"
+    return f"{PREFIX}:triggers:{lane}"
+
+
+def _consumers_for_lane(lane: str) -> int:
+    """How many consumers this replica runs for a lane.
+
+    The default lane stays at 1 so nothing about existing behaviour changes
+    just because lanes arrived; the `ai` lane defaults higher because its items
+    are independent and I/O-bound, which is the whole argument for concurrency.
+    Operators can override per lane via `scheduler.lane_consumers`.
+
+    Clamped to at least 1: a lane with a registered handler and zero consumers
+    would accept enqueues and never drain them, which is a worse failure than
+    any value an operator was trying to express by setting 0.
+    """
+    from terrapod.config import settings
+
+    configured = (settings.scheduler.lane_consumers or {}).get(lane)
+    if configured is None:
+        configured = DEFAULT_AI_LANE_CONSUMERS if lane == AI_LANE else 1
+    return max(1, int(configured))
+
+
+def _lane_for(trigger_type: str) -> str:
+    """Lane a trigger type belongs to, defaulting when the type is unknown.
+
+    An unknown type reaching here means the enqueuing replica knows about a
+    handler this one does not (mid-upgrade, or a follower running older code).
+    Falling back to the default lane keeps such an item on the key every
+    replica drains, so it is delayed rather than stranded.
+    """
+    handler_def = _trigger_handlers.get(trigger_type)
+    return handler_def.lane if handler_def else DEFAULT_LANE
 
 
 # ---------------------------------------------------------------------------
@@ -184,9 +278,10 @@ async def enqueue_trigger(
             "enqueued_at": time.time(),
         }
     )
-    await redis.lpush(f"{PREFIX}:triggers", item)
+    lane = _lane_for(trigger_type)
+    await redis.lpush(_lane_queue_key(lane), item)
     SCHEDULER_TRIGGER_ENQUEUED.labels(type=trigger_type).inc()
-    logger.info("Trigger enqueued", type=trigger_type, dedup_key=dedup_key)
+    logger.info("Trigger enqueued", type=trigger_type, dedup_key=dedup_key, lane=lane)
     return True
 
 
@@ -319,11 +414,30 @@ async def _run_periodic_loop(
     logger.info("Periodic task loop stopped", task=task.name)
 
 
-async def _run_trigger_consumer(shutdown: asyncio.Event) -> None:
-    """Background loop consuming triggered tasks from the Redis queue."""
+async def _run_trigger_consumer(shutdown: asyncio.Event, lane: str = DEFAULT_LANE) -> None:
+    """Background loop consuming triggered tasks from one queue lane.
+
+    This awaits its handler to completion before popping again, so one of these
+    processes strictly one item at a time. That is not a property the work
+    needs — triggered tasks are mutually independent, and the expensive ones are
+    almost entirely `await`-ing a network call — it is simply what an inline
+    `await handler(...)` in a pop loop gives you. Throughput is therefore
+    (replicas x consumers-for-this-lane), and for a long time that was
+    (replicas x 1) for everything, which is how a burst of independent AI
+    summaries turned into a multi-minute FIFO (#1296).
+
+    Concurrency comes from running several of these per lane
+    (`scheduler.lane_consumers`); the lane split is what lets that number be
+    raised for model calls without also raising it for the sub-second majority,
+    and stops either class from queueing behind the other.
+
+    Bounded rather than unbounded on purpose: in-flight handlers each hold a DB
+    session and count against the model provider's rate limits and the daily
+    token budget, so the ceiling is a capacity decision, not a formality.
+    """
     redis = get_redis_client()
-    queue_key = f"{PREFIX}:triggers"
-    logger.info("Trigger consumer started")
+    queue_key = _lane_queue_key(lane)
+    logger.info("Trigger consumer started", lane=lane)
 
     while not shutdown.is_set():
         try:
@@ -337,6 +451,16 @@ async def _run_trigger_consumer(shutdown: asyncio.Event) -> None:
             trigger_type = item["type"]
             payload = item.get("payload", {})
             dedup_key = item.get("dedup_key")
+
+            # How long this item sat in the queue, as distinct from how long
+            # its handler then takes. Only the former is fixed by adding
+            # consumers, so keeping them apart is what stops a capacity problem
+            # being misread as a slow handler (#1296).
+            enqueued_at = item.get("enqueued_at")
+            if isinstance(enqueued_at, int | float):
+                SCHEDULER_TRIGGER_WAIT.labels(type=trigger_type).observe(
+                    max(0.0, time.time() - enqueued_at)
+                )
 
             handler_def = _trigger_handlers.get(trigger_type)
 
@@ -374,13 +498,46 @@ async def _run_trigger_consumer(shutdown: asyncio.Event) -> None:
         except asyncio.CancelledError:
             break
         except Exception as e:
-            logger.error("Trigger consumer error", error=str(e))
+            logger.error("Trigger consumer error", error=str(e), lane=lane)
             # Brief backoff on unexpected errors
             try:
                 await asyncio.wait_for(shutdown.wait(), timeout=1)
                 break
             except TimeoutError:
                 pass
+
+
+async def _run_queue_depth_sampler(shutdown: asyncio.Event, interval: int = 15) -> None:
+    """Publish each lane's backlog to `terrapod_scheduler_queue_depth`.
+
+    Runs on every replica rather than leader-only. The depth is a property of
+    one shared Redis list, so every replica reports the same number — which
+    costs one cheap LLEN per lane per interval and means the signal survives a
+    leadership change. Aggregate across pods with max() when graphing.
+
+    Sampled on a timer rather than maintained inline because the interesting
+    case is precisely when every consumer is busy: a counter incremented by the
+    consumers themselves would stop updating exactly when the queue is deepest.
+    """
+    redis = get_redis_client()
+    lanes = sorted({h.lane for h in _trigger_handlers.values()})
+
+    while not shutdown.is_set():
+        try:
+            for lane in lanes:
+                depth = await redis.llen(_lane_queue_key(lane))
+                SCHEDULER_QUEUE_DEPTH.labels(lane=lane).set(depth)
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            # Never let a metrics sample take the scheduler down with it.
+            logger.warning("Queue depth sample failed", error=str(e))
+
+        try:
+            await asyncio.wait_for(shutdown.wait(), timeout=interval)
+            break
+        except TimeoutError:
+            continue
 
     logger.info("Trigger consumer stopped")
 
@@ -409,17 +566,31 @@ async def start_scheduler() -> None:
         )
         _scheduler_tasks.append(t)
 
+    lane_counts: dict[str, int] = {}
     if _trigger_handlers:
-        t = asyncio.create_task(
-            _run_trigger_consumer(_shutdown_event),
-            name="sched:trigger_consumer",
+        _scheduler_tasks.append(
+            asyncio.create_task(
+                _run_queue_depth_sampler(_shutdown_event),
+                name="sched:queue_depth_sampler",
+            )
         )
-        _scheduler_tasks.append(t)
+        # One pool per lane that actually has a handler registered. Starting
+        # consumers for a lane nobody uses would just be idle BRPOPs.
+        for lane in sorted({h.lane for h in _trigger_handlers.values()}):
+            count = _consumers_for_lane(lane)
+            lane_counts[lane] = count
+            for i in range(count):
+                t = asyncio.create_task(
+                    _run_trigger_consumer(_shutdown_event, lane),
+                    name=f"sched:trigger_consumer:{lane}:{i}",
+                )
+                _scheduler_tasks.append(t)
 
     logger.info(
         "Scheduler started",
         periodic_tasks=list(_periodic_tasks.keys()),
         trigger_handlers=list(_trigger_handlers.keys()),
+        lane_consumers=lane_counts,
     )
 
 

--- a/services/terrapod/services/summariser.py
+++ b/services/terrapod/services/summariser.py
@@ -1170,6 +1170,50 @@ async def _emit_ready_event(workspace_id: uuid.UUID, run_id: uuid.UUID) -> None:
     await _emit_summary_event("plan_summary_ready", workspace_id, run_id)
 
 
+async def mark_summary_queued(
+    db: AsyncSession,
+    *,
+    run_id: uuid.UUID,
+    kind: str = "plan_summary",
+) -> None:
+    """Create a `pending` placeholder the moment the work is enqueued.
+
+    Without this the row only appeared when a consumer *started* the item, so
+    for the whole time it sat in the queue `GET /runs/{id}/plan-summary`
+    returned 404 — identical to "this run has no summary and never will".
+    There was no way, from the API, the SDK, the MCP tools or the UI, to tell
+    "queued, N minutes out" from "broken" (#1295). Diagnosing which it was
+    once cost an afternoon of log archaeology, and the answer was "queued".
+
+    `ON CONFLICT DO NOTHING` rather than an upsert, deliberately: this races
+    the consumer pool, and if a handler has already finished the run's real
+    result must win. A placeholder is only ever allowed to fill a gap, never
+    to overwrite an outcome.
+
+    Called AFTER a successful enqueue, so a failed enqueue leaves no row —
+    a permanently-`pending` summary would be a worse lie than the 404 was.
+    """
+    stmt = (
+        pg_insert(PlanSummary)
+        .values(
+            id=uuid.uuid4(),
+            run_id=run_id,
+            kind=kind,
+            status="pending",
+            description="",
+            risk_level="",
+            risk_factors=[],
+            model=settings.ai_summary.model,
+            input_tokens=0,
+            output_tokens=0,
+            error_message="",
+            updated_at=now_utc(),
+        )
+        .on_conflict_do_nothing(index_elements=["run_id"])
+    )
+    await db.execute(stmt)
+
+
 async def _upsert_summary(
     db: AsyncSession,
     *,

--- a/services/tests/config/config_key_contract.json
+++ b/services/tests/config/config_key_contract.json
@@ -257,6 +257,7 @@
   "registry.provider_cache.warm_on_first_request",
   "registry.signing_key",
   "runner_artifacts.plan_artifacts_max_bytes",
+  "scheduler.lane_consumers",
   "slack.app_token",
   "slack.bot_token",
   "slack.command",

--- a/services/tests/helm/helm_values_contract.json
+++ b/services/tests/helm/helm_values_contract.json
@@ -196,6 +196,8 @@
   "api.config.registry.provider_cache.upstream_registries",
   "api.config.registry.provider_cache.verify",
   "api.config.registry.provider_cache.warm_on_first_request",
+  "api.config.scheduler.lane_consumers.ai",
+  "api.config.scheduler.lane_consumers.default",
   "api.config.slack.command",
   "api.config.slack.enabled",
   "api.config.slack.existingSecret",

--- a/services/tests/integration/test_summary_placeholder.py
+++ b/services/tests/integration/test_summary_placeholder.py
@@ -1,0 +1,199 @@
+"""Integration tests: the queued-summary placeholder (#1295).
+
+`GET /runs/{id}/plan-summary` used to 404 for the entire time the work sat in
+the trigger queue, because the row was only written when a consumer *started*
+the item. A queued summary was therefore indistinguishable from a run that had
+none and never would — which is how a twelve-minute backlog got diagnosed as a
+broken feature.
+
+`mark_summary_queued` closes that by inserting a `pending` placeholder at
+enqueue time. These live against real Postgres rather than a mock because the
+whole behaviour *is* a database semantic: an insert that must lose to any row
+already present, resolved by a unique constraint rather than by a read the
+caller performs first. With the AI lane now running several consumers at once
+(#1296), that read-then-write window is not theoretical.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from tests.integration.conftest import AUTH, admin_user, set_auth
+
+pytestmark = pytest.mark.integration
+
+WS_ENDPOINT = "/api/v2/organizations/default/workspaces"
+
+
+async def _make_run(client, name: str) -> uuid.UUID:
+    """Create a workspace + run via the API, return the run's UUID."""
+    resp = await client.post(
+        WS_ENDPOINT,
+        json={"data": {"type": "workspaces", "attributes": {"name": name}}},
+        headers=AUTH,
+    )
+    assert resp.status_code == 201, resp.text
+
+    from terrapod.db.models import ConfigurationVersion, Run, Workspace
+    from terrapod.db.session import get_db_session
+
+    async with get_db_session() as db:
+        ws = (await db.execute(select(Workspace).where(Workspace.name == name))).scalar_one()
+        cv = ConfigurationVersion(workspace_id=ws.id, source="api", status="uploaded")
+        db.add(cv)
+        await db.flush()
+        run = Run(
+            workspace_id=ws.id,
+            configuration_version_id=cv.id,
+            status="planned",
+            created_by="tests",
+        )
+        db.add(run)
+        await db.commit()
+        return run.id
+
+
+async def test_placeholder_is_created_when_no_summary_exists(app, client):
+    """The gap case: enqueue happened, no consumer has touched it yet."""
+    set_auth(app, admin_user())
+    from terrapod.db.models import PlanSummary
+    from terrapod.db.session import get_db_session
+    from terrapod.services.summariser import mark_summary_queued
+
+    run_id = await _make_run(client, f"ph-gap-{uuid.uuid4().hex[:8]}")
+
+    async with get_db_session() as db:
+        mark = await db.execute(select(PlanSummary).where(PlanSummary.run_id == run_id))
+        assert mark.scalar_one_or_none() is None, "precondition: no row yet"
+
+        await mark_summary_queued(db, run_id=run_id)
+        await db.commit()
+
+    async with get_db_session() as db:
+        row = (
+            await db.execute(select(PlanSummary).where(PlanSummary.run_id == run_id))
+        ).scalar_one()
+        assert row.status == "pending"
+        assert row.kind == "plan_summary"
+
+
+async def test_placeholder_never_overwrites_a_finished_summary(app, client):
+    """The race that matters: a consumer finished before the placeholder landed.
+
+    The AI lane runs several consumers concurrently, so a fast handler really
+    can complete before the enqueuing request gets round to its insert. The
+    real result must survive; a placeholder is only ever allowed to fill a gap.
+    """
+    set_auth(app, admin_user())
+    from terrapod.db.models import PlanSummary
+    from terrapod.db.session import get_db_session
+    from terrapod.services.summariser import _upsert_summary, mark_summary_queued
+
+    run_id = await _make_run(client, f"ph-race-{uuid.uuid4().hex[:8]}")
+
+    async with get_db_session() as db:
+        await _upsert_summary(
+            db,
+            run_id=run_id,
+            kind="plan_summary",
+            status="ready",
+            description="the real answer",
+            risk_level="high",
+        )
+        await db.commit()
+
+    async with get_db_session() as db:
+        await mark_summary_queued(db, run_id=run_id)
+        await db.commit()
+
+    async with get_db_session() as db:
+        row = (
+            await db.execute(select(PlanSummary).where(PlanSummary.run_id == run_id))
+        ).scalar_one()
+        assert row.status == "ready", "a placeholder must never demote a finished summary"
+        assert row.description == "the real answer"
+        assert row.risk_level == "high"
+
+
+async def test_placeholder_does_not_clobber_a_terminal_failure(app, client):
+    """`errored` is an answer too — the user should keep seeing why it failed."""
+    set_auth(app, admin_user())
+    from terrapod.db.models import PlanSummary
+    from terrapod.db.session import get_db_session
+    from terrapod.services.summariser import _upsert_summary, mark_summary_queued
+
+    run_id = await _make_run(client, f"ph-err-{uuid.uuid4().hex[:8]}")
+
+    async with get_db_session() as db:
+        await _upsert_summary(
+            db,
+            run_id=run_id,
+            kind="plan_summary",
+            status="errored",
+            error_message="model refused",
+        )
+        await db.commit()
+
+    async with get_db_session() as db:
+        await mark_summary_queued(db, run_id=run_id)
+        await db.commit()
+
+    async with get_db_session() as db:
+        row = (
+            await db.execute(select(PlanSummary).where(PlanSummary.run_id == run_id))
+        ).scalar_one()
+        assert row.status == "errored"
+        assert row.error_message == "model refused"
+
+
+async def test_it_is_idempotent(app, client):
+    """A re-enqueue (dedup expired, or a retry) must not duplicate the row.
+
+    `run_id` is unique, so a second plain insert would raise rather than
+    quietly no-op — which is exactly what ON CONFLICT DO NOTHING prevents.
+    """
+    set_auth(app, admin_user())
+    from terrapod.db.models import PlanSummary
+    from terrapod.db.session import get_db_session
+    from terrapod.services.summariser import mark_summary_queued
+
+    run_id = await _make_run(client, f"ph-idem-{uuid.uuid4().hex[:8]}")
+
+    async with get_db_session() as db:
+        await mark_summary_queued(db, run_id=run_id)
+        await mark_summary_queued(db, run_id=run_id)
+        await mark_summary_queued(db, run_id=run_id)
+        await db.commit()
+
+    async with get_db_session() as db:
+        rows = (
+            (await db.execute(select(PlanSummary).where(PlanSummary.run_id == run_id)))
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
+
+async def test_the_endpoint_stops_404ing_once_queued(app, client):
+    """The user-visible invariant: after enqueue, never 404.
+
+    This is the whole point of #1295 — a 404 reads as "this feature is broken
+    for this run", and that reading was wrong for minutes at a time.
+    """
+    set_auth(app, admin_user())
+    from terrapod.db.session import get_db_session
+    from terrapod.services.summariser import mark_summary_queued
+
+    run_id = await _make_run(client, f"ph-api-{uuid.uuid4().hex[:8]}")
+
+    before = await client.get(f"/api/terrapod/v1/runs/run-{run_id}/plan-summary", headers=AUTH)
+    assert before.status_code == 404, "precondition: nothing enqueued yet"
+
+    async with get_db_session() as db:
+        await mark_summary_queued(db, run_id=run_id)
+        await db.commit()
+
+    after = await client.get(f"/api/terrapod/v1/runs/run-{run_id}/plan-summary", headers=AUTH)
+    assert after.status_code == 200, after.text
+    assert after.json()["data"]["attributes"]["status"] == "pending"

--- a/services/tests/services/test_scheduler.py
+++ b/services/tests/services/test_scheduler.py
@@ -2,15 +2,23 @@
 
 import asyncio
 import json
+import time
 from unittest.mock import AsyncMock, patch
 
 from terrapod.services.scheduler import (
+    AI_LANE,
+    DEFAULT_AI_LANE_CONSUMERS,
+    DEFAULT_LANE,
     PREFIX,
     PeriodicTaskDef,
     TriggerHandlerDef,
     _clear_dedup,
+    _consumers_for_lane,
+    _lane_queue_key,
     _run_periodic_loop,
+    _run_queue_depth_sampler,
     _run_trigger_consumer,
+    _trigger_handlers,
     enqueue_trigger,
     get_last_run,
     mark_completed,
@@ -333,3 +341,187 @@ def unittest_mock_any():
             return True
 
     return _Any()
+
+
+# ── Lanes (#1296) ──────────────────────────────────────────────────────
+#
+# The defect these cover: every triggered task shared one queue drained by a
+# single consumer per replica, so deployment throughput was (replicas x 1) for
+# all work at once. Independent, I/O-bound AI summaries therefore queued behind
+# each other — and behind sub-second status posts — for minutes.
+
+
+class TestLaneRouting:
+    """Which queue an item is pushed to, and which key backs it."""
+
+    def test_default_lane_keeps_the_original_key(self):
+        # Load-bearing for rolling upgrades: an un-upgraded replica BRPOPs this
+        # exact key. Suffixing it would strand every item a new replica wrote.
+        assert _lane_queue_key(DEFAULT_LANE) == f"{PREFIX}:triggers"
+
+    def test_non_default_lanes_are_suffixed(self):
+        assert _lane_queue_key(AI_LANE) == f"{PREFIX}:triggers:ai"
+
+    @patch("terrapod.services.scheduler.get_redis_client")
+    async def test_enqueue_routes_to_the_handlers_lane(self, mock_get_redis):
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        _trigger_handlers["slow_thing"] = TriggerHandlerDef("slow_thing", AsyncMock(), lane=AI_LANE)
+        try:
+            await enqueue_trigger("slow_thing", {"run_id": "r1"})
+        finally:
+            _trigger_handlers.pop("slow_thing", None)
+
+        pushed_key = redis.lpush.await_args.args[0]
+        assert pushed_key == f"{PREFIX}:triggers:ai"
+
+    @patch("terrapod.services.scheduler.get_redis_client")
+    async def test_an_unknown_type_falls_back_to_the_default_lane(self, mock_get_redis):
+        # Mid-upgrade, a replica may enqueue a type this one has never
+        # registered. Delayed on the shared key beats stranded on a key nobody
+        # is reading.
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        await enqueue_trigger("type_from_the_future", {})
+        assert redis.lpush.await_args.args[0] == f"{PREFIX}:triggers"
+
+    @patch("terrapod.services.scheduler.get_redis_client")
+    async def test_a_default_lane_handler_still_uses_the_original_key(self, mock_get_redis):
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        _trigger_handlers["quick_thing"] = TriggerHandlerDef("quick_thing", AsyncMock())
+        try:
+            await enqueue_trigger("quick_thing", {})
+        finally:
+            _trigger_handlers.pop("quick_thing", None)
+        assert redis.lpush.await_args.args[0] == f"{PREFIX}:triggers"
+
+
+class TestLaneConsumerCounts:
+    """How much concurrency each lane gets — the actual fix for #1296."""
+
+    def test_ai_lane_is_concurrent_by_default(self):
+        with patch("terrapod.config.settings") as s:
+            s.scheduler.lane_consumers = {}
+            assert _consumers_for_lane(AI_LANE) == DEFAULT_AI_LANE_CONSUMERS
+            assert DEFAULT_AI_LANE_CONSUMERS > 1
+
+    def test_default_lane_stays_serial(self):
+        # Deliberate: that work is sub-second, and leaving it at 1 means lanes
+        # changed nothing about existing behaviour.
+        with patch("terrapod.config.settings") as s:
+            s.scheduler.lane_consumers = {}
+            assert _consumers_for_lane(DEFAULT_LANE) == 1
+
+    def test_operator_override_wins(self):
+        with patch("terrapod.config.settings") as s:
+            s.scheduler.lane_consumers = {"ai": 3}
+            assert _consumers_for_lane(AI_LANE) == 3
+
+    def test_zero_is_clamped_up_rather_than_stranding_the_lane(self):
+        # A lane with a registered handler and no consumers would accept
+        # enqueues forever and drain none of them — worse than any intent
+        # behind setting 0.
+        with patch("terrapod.config.settings") as s:
+            s.scheduler.lane_consumers = {"ai": 0}
+            assert _consumers_for_lane(AI_LANE) == 1
+
+    def test_negative_is_clamped_too(self):
+        with patch("terrapod.config.settings") as s:
+            s.scheduler.lane_consumers = {"ai": -5}
+            assert _consumers_for_lane(AI_LANE) == 1
+
+
+class TestQueueWaitObservation:
+    """Wait time is recorded separately from handler duration."""
+
+    @patch("terrapod.services.scheduler.SCHEDULER_TRIGGER_WAIT")
+    @patch("terrapod.services.scheduler.get_redis_client")
+    async def test_wait_is_observed_from_the_enqueue_stamp(self, mock_get_redis, mock_wait):
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        item = json.dumps(
+            {
+                "type": "waity",
+                "payload": {},
+                "dedup_key": None,
+                "enqueued_at": time.time() - 42,
+            }
+        )
+        redis.brpop.side_effect = [(f"{PREFIX}:triggers", item), None]
+
+        handler = AsyncMock()
+        _trigger_handlers["waity"] = TriggerHandlerDef("waity", handler)
+        shutdown = asyncio.Event()
+
+        async def stop_after_first():
+            await asyncio.sleep(0.05)
+            shutdown.set()
+
+        try:
+            with patch(
+                "terrapod.services.scheduler.ha_role.is_leader", AsyncMock(return_value=True)
+            ):
+                await asyncio.gather(
+                    _run_trigger_consumer(shutdown, DEFAULT_LANE), stop_after_first()
+                )
+        finally:
+            _trigger_handlers.pop("waity", None)
+
+        observed = mock_wait.labels.return_value.observe.call_args[0][0]
+        assert 40 < observed < 45, f"expected ~42s of queue wait, got {observed}"
+
+    @patch("terrapod.services.scheduler.SCHEDULER_TRIGGER_WAIT")
+    @patch("terrapod.services.scheduler.get_redis_client")
+    async def test_a_legacy_item_without_a_stamp_does_not_blow_up(self, mock_get_redis, mock_wait):
+        # Items enqueued by an older replica mid-upgrade have no enqueued_at.
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        item = json.dumps({"type": "stampless", "payload": {}, "dedup_key": None})
+        redis.brpop.side_effect = [(f"{PREFIX}:triggers", item), None]
+
+        _trigger_handlers["stampless"] = TriggerHandlerDef("stampless", AsyncMock())
+        shutdown = asyncio.Event()
+
+        async def stop_after_first():
+            await asyncio.sleep(0.05)
+            shutdown.set()
+
+        try:
+            with patch(
+                "terrapod.services.scheduler.ha_role.is_leader", AsyncMock(return_value=True)
+            ):
+                await asyncio.gather(
+                    _run_trigger_consumer(shutdown, DEFAULT_LANE), stop_after_first()
+                )
+        finally:
+            _trigger_handlers.pop("stampless", None)
+
+        mock_wait.labels.return_value.observe.assert_not_called()
+
+
+class TestQueueDepthSampler:
+    @patch("terrapod.services.scheduler.SCHEDULER_QUEUE_DEPTH")
+    @patch("terrapod.services.scheduler.get_redis_client")
+    async def test_it_samples_every_lane_that_has_a_handler(self, mock_get_redis, mock_gauge):
+        redis = AsyncMock()
+        mock_get_redis.return_value = redis
+        redis.llen.return_value = 7
+
+        _trigger_handlers["quick"] = TriggerHandlerDef("quick", AsyncMock())
+        _trigger_handlers["slow"] = TriggerHandlerDef("slow", AsyncMock(), lane=AI_LANE)
+        shutdown = asyncio.Event()
+
+        async def stop_soon():
+            await asyncio.sleep(0.05)
+            shutdown.set()
+
+        try:
+            await asyncio.gather(_run_queue_depth_sampler(shutdown, interval=60), stop_soon())
+        finally:
+            _trigger_handlers.pop("quick", None)
+            _trigger_handlers.pop("slow", None)
+
+        sampled = {c.kwargs.get("lane") for c in mock_gauge.labels.call_args_list}
+        assert sampled == {DEFAULT_LANE, AI_LANE}
+        mock_gauge.labels.return_value.set.assert_called_with(7)


### PR DESCRIPTION
Closes #1296, closes #1295.

Two changes that turned out to be the same problem seen from both ends: AI analysis was slow to arrive, and while it was slow there was no way to tell it was coming.

---

## #1296 — throughput

Every triggered task shared one Redis list, drained by a single consumer per replica that awaited each handler inline before popping again. Deployment-wide concurrency for **all** background work was `replicas x 1`.

Nothing about the work needs that. Triggered tasks are mutually independent, and the expensive ones are almost entirely `await`-ing a model call. So a VCS poll cycle emitted one AI summary per changed workspace and drained them one at a time, interleaved with sub-second status posts.

Measured on a two-replica deployment: **~1.6 summaries/min**, and one run sat queued **eight minutes** between its plan JSON landing and its handler starting. Nothing was lost and FIFO order held — a pure rate problem, worsening linearly with estate size while the drain rate stays flat.

Handlers now declare a **lane**; each lane is its own list with its own pool of consumers, sized by a Helm value:

- `default` stays at **1** — sub-second work, where more consumers buy nothing. Existing behaviour unchanged.
- `ai` defaults to **10 per replica**. Bounded, not unbounded: each in-flight handler holds a DB session and spends provider rate-limit budget, and unbounded fan-out would make a busy poll cycle a thundering herd.

Two signals added, deliberately separate: per-lane **queue depth**, and **enqueue-to-start wait** distinct from handler duration. Those point at different fixes (more consumers vs. a faster handler); conflating them is what left this undiagnosed.

## #1295 — visibility

`GET /runs/{id}/plan-summary` 404'd for the whole time the work was queued, because the row was only written when a consumer *started* the item. "Queued, minutes out" and "no summary, ever" looked identical, and both read as broken.

A `pending` placeholder is now inserted at enqueue time. Two details are load-bearing:

- **`ON CONFLICT DO NOTHING`, not an upsert.** It races the consumer pool — which now runs several at once, so a handler really can finish first. A placeholder may fill a gap, never demote a `ready` or `errored` row.
- **Written after the enqueue, not before.** A failed enqueue then leaves no row: a summary stuck at `pending` forever is a worse lie than the 404 it replaces.

---

## Rolling-upgrade safety

The `default` lane keeps the original `tp:sched:triggers` key, so an un-upgraded replica keeps draining exactly what it always did; only opted-in lanes get a new key, written and read solely by upgraded replicas. An unknown trigger type falls back to the default lane — delayed rather than stranded on a key nobody reads. Items enqueued before the upgrade carry no `enqueued_at`; the wait observation skips them rather than failing.

## Verification

- 3191 passing on the services+api shards; **12 new scheduler tests** (lane routing, the default-key invariant, unknown-type fallback, consumer counts, the clamp at 1, wait observation, depth sampling) and **5 new integration tests** against real Postgres for the placeholder (gap case, both no-clobber cases, idempotency, and the after-enqueue-never-404 invariant).
- `helm lint` clean; renders on all three profiles; no non-secret config leaked into Deployment env.
- Config + Helm contract snapshots regenerated **purely additively** (3 insertions, 0 removals) — the config gate blocked first and required conscious acceptance.

## Operator note

Concurrency multiplies per replica, so the default is 20 concurrent model calls at 2 replicas — roughly 12x today's throughput. Worth watching the first busy poll cycle for provider throttling; `api.config.scheduler.lane_consumers` tunes it without a release.