### PR TITLE
fix(1294): four conditional auto-apply blockers, with regression cover

### DIFF
--- a/docs/cve-policy.md
+++ b/docs/cve-policy.md
@@ -171,8 +171,8 @@ api:
     registry:
       platform_tools:
         opa_version: "1.19.0"
-        trivy_version: "0.72.0"
-        checkov_version: "3.3.8"
+        trivy_version: "0.73.0"
+        checkov_version: "3.3.9"
 ```
 
 So an upstream fix is a `helm upgrade` away rather than a release away, and

--- a/docs/rbac-capabilities.md
+++ b/docs/rbac-capabilities.md
@@ -162,9 +162,14 @@ unchanged, lives in `registry_rbac_service`.)
 | admin | `registry:admin` | DELETE module/provider/version/platform; PATCH module/provider (labels) — **owner reassignment additionally requires platform admin**; PATCH module vcs; POST/DELETE workspace-links |
 
 `platform:registry-admin` (not registry-RBAC) covers: binary-cache + provider-cache
-admin endpoints, and registry resource **owner** reassignment. **Gap flagged:**
-`gpg_keys.py` CRUD is currently authenticated-only (no registry or admin gate) —
-a pre-existing surface noted for follow-up, not changed by the faithful migration.
+admin endpoints, and registry resource **owner** reassignment.
+
+**GPG signing keys** are the provider registry's trust anchor, so registering,
+revoking or deleting one requires `registry:admin`. Reads stay open to any
+authenticated caller — a public key is not secret, and `terraform init` needs to
+see it. Note this resolves against an empty resource (a `GPGKey` carries no owner
+and no labels — it is one platform-wide list, not a per-resource thing), so only
+unscoped grants apply.
 
 ---
 

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -122,8 +122,8 @@ api:
   config:
     registry:
       platform_tools:
-        checkov_version: "3.3.8"
-        trivy_version: "0.72.0"
+        checkov_version: "3.3.9"
+        trivy_version: "0.73.0"
 ```
 
 Only the engine a run actually selects is fetched — a Checkov workspace never

--- a/helm/terrapod/values.yaml
+++ b/helm/terrapod/values.yaml
@@ -354,8 +354,8 @@ api:
       # applies to a run, trivy only when it is the selected scan engine.
       platform_tools:
         opa_version: "1.19.0"
-        trivy_version: "0.72.0"
-        checkov_version: "3.3.8"
+        trivy_version: "0.73.0"
+        checkov_version: "3.3.9"
         opa_mirror_url: "https://github.com/open-policy-agent/opa/releases/download"
         trivy_mirror_url: "https://github.com/aquasecurity/trivy/releases/download"
         checkov_mirror_url: "https://github.com/bridgecrewio/checkov/releases/download"

--- a/provider/internal/provider/auto_apply_default_test.go
+++ b/provider/internal/provider/auto_apply_default_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+	adr "github.com/mattrobinsonsre/terrapod/provider/internal/resources/autodiscovery_rule"
+	ws "github.com/mattrobinsonsre/terrapod/provider/internal/resources/workspace"
+)
+
+// TestAutoApplyHasNoSchemaDefault guards the #1294 fix.
+//
+// The server derives `auto_apply` from `auto_apply_mode` (`mode != "never"`),
+// and the request builder sends ONLY the mode when one is configured. A schema
+// default therefore makes the planned value a *known* false while the applied
+// value comes back true, which Terraform core rejects outright:
+//
+//	Provider produced inconsistent result after apply:
+//	.auto_apply: was cty.False, but now cty.True
+//
+// That made every non-`never` mode un-appliable on both resources.
+//
+// The schema golden cannot catch a regression here: it records optional and
+// computed flags, not defaults, and stayed byte-identical across this fix.
+// Hence an explicit assertion on the field itself.
+func TestAutoApplyHasNoSchemaDefault(t *testing.T) {
+	cases := []struct {
+		name string
+		res  fwresource.Resource
+	}{
+		{"terrapod_workspace", ws.NewResource()},
+		{"terrapod_autodiscovery_rule", adr.NewResource()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &fwresource.SchemaResponse{}
+			tc.res.Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+
+			attr, ok := resp.Schema.Attributes["auto_apply"]
+			if !ok {
+				t.Fatalf("%s has no auto_apply attribute", tc.name)
+			}
+			boolAttr, ok := attr.(schema.BoolAttribute)
+			if !ok {
+				t.Fatalf("%s.auto_apply is %T, expected schema.BoolAttribute", tc.name, attr)
+			}
+
+			if boolAttr.Default != nil {
+				t.Errorf(
+					"%s.auto_apply must NOT carry a schema default. The server projects "+
+						"it from auto_apply_mode, so a known planned value produces "+
+						"'inconsistent result after apply' and no conditional mode can be "+
+						"applied at all (#1294).",
+					tc.name,
+				)
+			}
+			// Optional+Computed is what lets the server's projection land
+			// without a planned value to contradict it — the default's removal
+			// is only safe in that combination.
+			if !boolAttr.Optional || !boolAttr.Computed {
+				t.Errorf(
+					"%s.auto_apply must stay Optional+Computed (got optional=%v computed=%v)",
+					tc.name, boolAttr.Optional, boolAttr.Computed,
+				)
+			}
+		})
+	}
+}
+
+// TestAutoApplyModeIsSentIndependentlyOfTheBoolean guards the second half.
+//
+// On terrapod_autodiscovery_rule the mode branch was originally nested inside
+// an `auto_apply is known` guard, which only worked while the boolean carried
+// a default. Removing that default would have silently stopped `auto-apply-mode`
+// being sent at all — the two defects masked each other, so fixing one without
+// the other is worse than fixing neither.
+func TestAutoApplyModeIsNotGatedOnTheBoolean(t *testing.T) {
+	resp := &fwresource.SchemaResponse{}
+	adr.NewResource().Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+
+	mode, ok := resp.Schema.Attributes["auto_apply_mode"]
+	if !ok {
+		t.Fatal("terrapod_autodiscovery_rule has no auto_apply_mode attribute")
+	}
+	strAttr, ok := mode.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("auto_apply_mode is %T, expected schema.StringAttribute", mode)
+	}
+	// If the mode were ever given a default it would always be "known" and the
+	// either/or the API enforces (422 when both are sent) becomes reachable.
+	if strAttr.Default != nil {
+		t.Error("auto_apply_mode must not carry a default — the API 422s when both are sent")
+	}
+}

--- a/provider/internal/resources/autodiscovery_rule/resource.go
+++ b/provider/internal/resources/autodiscovery_rule/resource.go
@@ -247,11 +247,14 @@ func (r *autodiscoveryRuleResource) Schema(_ context.Context, _ resource.SchemaR
 				Computed:    true,
 				Default:     stringdefault.StaticString("2Gi"),
 			},
+			// No schema default — see the matching note on
+			// terrapod_workspace.auto_apply. The server derives this from
+			// auto_apply_mode, so a known planned `false` against an applied
+			// `true` fails the run with "inconsistent result after apply".
 			"auto_apply": schema.BoolAttribute{
-				Description: "Default auto-apply setting for created workspaces. Defaults to false.",
+				Description: "Default auto-apply setting for created workspaces. Superseded by `auto_apply_mode` when that is set.",
 				Optional:    true,
 				Computed:    true,
-				Default:     booldefault.StaticBool(false),
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
@@ -574,12 +577,17 @@ func buildAutodiscoveryRuleAttrs(m *autodiscoveryRuleModel) map[string]any {
 	if !m.ResourceMemory.IsNull() && !m.ResourceMemory.IsUnknown() {
 		attrs["resource-memory"] = m.ResourceMemory.ValueString()
 	}
-	if !m.AutoApply.IsNull() && !m.AutoApply.IsUnknown() {
-		if !m.AutoApplyMode.IsNull() && !m.AutoApplyMode.IsUnknown() && m.AutoApplyMode.ValueString() != "" {
-			attrs["auto-apply-mode"] = m.AutoApplyMode.ValueString()
-		} else {
-			attrs["auto-apply"] = m.AutoApply.ValueBool()
-		}
+	// Mode first, and deliberately NOT nested inside the auto_apply guard.
+	// The two are alternatives (the API 422s if both are sent), so the mode
+	// has to be reachable whether or not the boolean happens to be known.
+	// Nesting it worked only while `auto_apply` carried a schema default
+	// that made it always known; the moment that default goes, the outer
+	// guard fails on an unconfigured boolean and the mode silently stops
+	// being sent at all.
+	if !m.AutoApplyMode.IsNull() && !m.AutoApplyMode.IsUnknown() && m.AutoApplyMode.ValueString() != "" {
+		attrs["auto-apply-mode"] = m.AutoApplyMode.ValueString()
+	} else if !m.AutoApply.IsNull() && !m.AutoApply.IsUnknown() {
+		attrs["auto-apply"] = m.AutoApply.ValueBool()
 	}
 
 	if !m.Labels.IsNull() && !m.Labels.IsUnknown() {

--- a/provider/internal/resources/workspace/resource.go
+++ b/provider/internal/resources/workspace/resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -233,11 +232,26 @@ func (r *workspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Computed:    true,
 				Default:     stringdefault.StaticString("local"),
 			},
+			// No schema default, deliberately — same shape as `auto_merge`
+			// below and as `auto_apply_mode` above.
+			//
+			// The server derives this boolean from the mode (`auto_apply =
+			// mode != "never"`), and when a mode is configured the request
+			// builder sends ONLY the mode. A `booldefault.StaticBool(false)`
+			// therefore made the planned value a *known* false while the
+			// applied value came back true, which Terraform core rejects
+			// outright: "Provider produced inconsistent result after apply:
+			// .auto_apply: was cty.False, but now cty.True". That made every
+			// non-`never` mode un-appliable. Optional+Computed with
+			// UseStateForUnknown lets the server's projection land without a
+			// planned value to contradict it.
 			"auto_apply": schema.BoolAttribute{
 				Description: "Automatically apply successful plans. Superseded by `auto_apply_mode` when that is set; prefer `auto_apply_mode` for new configurations.",
 				Optional:    true,
 				Computed:    true,
-				Default:     booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"auto_apply_mode": schema.StringAttribute{
 				Description: "Conditional auto-apply: `never`, `always`, `create` (apply only plans that add resources) or `create_update` (also allow in-place updates). `create` and `create_update` never apply a plan that destroys or replaces a resource — that is left for a human. Optional + Computed with no default, so a configuration that does not set it inherits whatever the workspace has and never drifts.",

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -227,9 +227,19 @@ def _run_json(
                 # only possible for legacy runs created before that fix.
                 # Hide the buttons so the UI doesn't push users into the
                 # state-upload 500 path.
+                #
+                # The auto-apply test is on the resolved MODE, not the boolean
+                # column. `create_run` sets `run.auto_apply = True` for every
+                # non-`never` mode, so keying off the boolean hid Confirm on a
+                # conditional run that had been *held* — the run sat in
+                # `planned` with a declined-reason and no consumer offered the
+                # one action that resolves it, while `confirm_run` (which only
+                # checks `status == "planned"`) would have accepted it. Only
+                # `always` genuinely needs the button hidden: such a run
+                # applies itself and never waits for a human.
                 "actions": {
                     "is-confirmable": run.status == "planned"
-                    and not run.auto_apply
+                    and run_service.resolve_auto_apply_mode(run) != "always"
                     and not run.plan_only
                     and run.has_changes is not False,
                     "is-discardable": run.status == "planned"

--- a/services/terrapod/api/routers/tfe_v2.py
+++ b/services/terrapod/api/routers/tfe_v2.py
@@ -1692,9 +1692,17 @@ async def update_workspace(
     pending_workflow = ws.vcs_workflow
     # Read the post-update value: a PATCH may have set it via either
     # attribute, and both paths have already landed on `ws` above.
+    #
+    # The trigger set below must therefore name BOTH attributes too.
+    # `auto-apply-mode` writes `ws.auto_apply` just as `auto-apply` does
+    # (see the paired write above), so omitting it from the trigger let a
+    # mode-only PATCH set auto_apply=True on an apply_then_merge workspace
+    # while skipping this block entirely — reaching by curl exactly the
+    # state the boolean attribute is refused for. Any future attribute
+    # that writes `auto_apply` belongs in this list.
     pending_auto_apply = ws.auto_apply
     if pending_workflow == "apply_then_merge" and (
-        "vcs-workflow" in attrs or "auto-apply" in attrs
+        "vcs-workflow" in attrs or "auto-apply" in attrs or "auto-apply-mode" in attrs
     ):
         if ws.vcs_connection_id is None:
             raise HTTPException(

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -1098,6 +1098,24 @@ async def complete_plan(
     if resolve_auto_apply_mode(run) == "always" and not run.plan_only:
         run = await _auto_apply_if_permitted(db, run)
 
+    # ...and the conditional modes get a second chance here, because the
+    # plan-JSON upload is not always the last thing to happen.
+    #
+    # `evaluate_conditional_auto_apply` returns immediately unless the run
+    # is already `planned`. When a post-plan gate is outstanding — a run
+    # task stage, a mandatory OPA policy, an enforced security scan — this
+    # function leaves the run in `planning`, and the runner uploads the
+    # plan JSON *after* the plan-result POST. So on a gated workspace the
+    # upload-side evaluation always fired against a `planning` run and
+    # declined, and nothing evaluated again when the gate cleared and the
+    # reconciler re-drove us to `planned`: the run parked in `planned`
+    # forever with no error and no declined-reason. Re-running it here
+    # covers every path that reaches `planned` late. It is idempotent —
+    # the status guard makes the common (ungated) case a no-op, since the
+    # upload-side call already settled it.
+    if not run.plan_only and run.status == "planned":
+        run = await evaluate_conditional_auto_apply(db, run)
+
     # Born-superseded (planning race): a run that settled into `planned`
     # awaiting confirmation, only to find a newer full run already waiting,
     # was superseded while it planned — the queued-time supersede couldn't

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -1719,3 +1719,91 @@ class TestListRunsPagination:
 
         assert resp.status_code == 200, resp.text
         assert mock_list.await_args.args[2:] == (1, 20)
+
+
+class TestHeldConditionalRunIsActionable:
+    """A conditional run that was held must offer the action that resolves it.
+
+    `create_run` sets `run.auto_apply = True` for *every* non-`never` mode, so
+    keying `is-confirmable` off that boolean hid Confirm on exactly the runs
+    that need it: a `create_update` run correctly held back because its plan
+    contained a destroy rendered the "held" banner and then no button, in the
+    UI, the SDK and MCP alike — while `confirm_run` (which only checks
+    `status == "planned"`) would have accepted it. The flagship feature failed
+    at the moment it exists for (#1294).
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_a_held_conditional_run_is_confirmable(self, mock_get_run, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("write")
+        run = _mock_run(status="planned", auto_apply=True)
+        run.auto_apply_mode = "create_update"
+        run.auto_apply_declined_reason = "2 to destroy"
+        run.has_changes = True
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["actions"]["is-confirmable"] is True, (
+            "a held run must offer the one action that resolves it"
+        )
+        assert attrs["permissions"]["can-apply"] is True
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_an_always_run_still_hides_confirm(self, mock_get_run, mock_resolve, *mocks):
+        """The behaviour that must NOT change: an `always` run applies itself,
+        so offering Confirm would be offering to do what is already happening."""
+        mock_resolve.return_value = caps_for_level("write")
+        run = _mock_run(status="planned", auto_apply=True)
+        run.auto_apply_mode = "always"
+        run.has_changes = True
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        assert resp.json()["data"]["attributes"]["actions"]["is-confirmable"] is False
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_a_no_op_conditional_run_is_still_not_confirmable(
+        self, mock_get_run, mock_resolve, *mocks
+    ):
+        """The has_changes guard is unaffected — a no-op plan stays
+        unconfirmable regardless of mode, or we hand the user the
+        state-upload 500 path."""
+        mock_resolve.return_value = caps_for_level("write")
+        run = _mock_run(status="planned", auto_apply=True)
+        run.auto_apply_mode = "create"
+        run.has_changes = False
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        assert resp.json()["data"]["attributes"]["actions"]["is-confirmable"] is False

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -976,6 +976,92 @@ class TestVcsWorkflowAttributes:
     @patch("terrapod.api.app.init_redis")
     @patch("terrapod.api.app.init_db")
     @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_apply_then_merge_guard_also_fires_for_auto_apply_mode(
+        self, mock_resolve, *_mocks
+    ):
+        """The same invariant, reached via the newer attribute (#1294).
+
+        `auto-apply-mode` writes `ws.auto_apply` exactly as the boolean does,
+        but the guard's trigger set originally named only `vcs-workflow` and
+        `auto-apply`. A mode-only PATCH therefore set auto_apply=True on an
+        apply_then_merge workspace and skipped the check entirely — reaching
+        by curl the precise state the test above proves is refused. The UI
+        now sends only the new attribute, so the invariant was unenforceable
+        through the primary consumer.
+        """
+        mock_resolve.return_value = caps_for_level("admin")
+        ws = _mock_workspace(auto_apply=False)
+        ws.vcs_workflow = "apply_then_merge"
+        ws.vcs_connection_id = uuid.uuid4()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"auto-apply-mode": "always"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422, "a mode-only PATCH must not bypass the invariant"
+        assert "auto-apply" in resp.json()["detail"]
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_a_conditional_mode_is_refused_on_apply_then_merge_too(
+        self, mock_resolve, *_mocks
+    ):
+        """`create` is still auto-apply — the server derives auto_apply=True
+        from any non-`never` mode, so the incompatibility is not limited to
+        the unconditional case."""
+        mock_resolve.return_value = caps_for_level("admin")
+        ws = _mock_workspace(auto_apply=False)
+        ws.vcs_workflow = "apply_then_merge"
+        ws.vcs_connection_id = uuid.uuid4()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"auto-apply-mode": "create_update"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 422
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_never_is_still_allowed_on_apply_then_merge(self, mock_resolve, *_mocks):
+        """The negative case — the guard must not have become a blanket ban.
+        `never` means no auto-apply, which is the whole point of the mode."""
+        mock_resolve.return_value = caps_for_level("admin")
+        ws = _mock_workspace(auto_apply=True)
+        ws.vcs_workflow = "apply_then_merge"
+        ws.vcs_connection_id = uuid.uuid4()
+        app, mock_db = _make_app(_user())
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": {"auto-apply-mode": "never"}}},
+                headers=_AUTH,
+            )
+        assert resp.status_code == 200, resp.text
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
     async def test_combined_flip_off_auto_apply_and_into_apply_then_merge_succeeds(
         self, mock_resolve, *_mocks
     ):

--- a/services/tests/services/test_conditional_auto_apply.py
+++ b/services/tests/services/test_conditional_auto_apply.py
@@ -6,10 +6,13 @@ run apply itself or wait for a human? Every ambiguous case must resolve to
 infrastructure changes nobody looked at.
 """
 
+import uuid
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from terrapod.services import run_service
 from terrapod.services.run_service import (
     AUTO_APPLY_MODES,
     describe_plan_shape,
@@ -147,3 +150,144 @@ def test_mode_list_is_the_documented_set():
     # The API validates against this tuple and the docs enumerate it; a
     # silent addition would be accepted by the API but understood by nothing.
     assert AUTO_APPLY_MODES == ("never", "always", "create", "create_update")
+
+
+# ── The decider, not just the decision (#1294) ─────────────────────────────
+#
+# Everything above tests the pure predicates. These test the function that
+# *acts* on them — which had no coverage at all, and which is where the
+# release review found three of its four blockers. A green predicate suite
+# proved the decision was right while the decider was entirely unexercised.
+
+
+def _decider_run(**kw):
+    """A `planned`, apply-capable run on a conditional mode."""
+    base = {
+        "id": uuid.uuid4(),
+        "workspace_id": uuid.uuid4(),
+        "status": "planned",
+        "plan_only": False,
+        # what create_run sets for any non-`never` mode
+        "auto_apply": True,
+        "auto_apply_mode": "create",
+        "auto_apply_declined_reason": None,
+        "resource_additions": 1,
+        "resource_changes": 0,
+        "resource_destructions": 0,
+        "resource_replacements": 0,
+        "has_changes": True,
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class TestEvaluateConditionalAutoApply:
+    async def test_a_permitted_plan_is_confirmed(self):
+        run = _decider_run()
+        db = AsyncMock()
+        with patch.object(
+            run_service, "_auto_apply_if_permitted", AsyncMock(return_value=run)
+        ) as gate:
+            await run_service.evaluate_conditional_auto_apply(db, run)
+        gate.assert_awaited_once()
+
+    async def test_a_destroy_is_declined_and_the_reason_recorded(self):
+        # `create` must never apply a plan that destroys. The reason is what
+        # the UI renders to explain why the run is sitting there.
+        run = _decider_run(resource_destructions=2)
+        db = AsyncMock()
+        with patch.object(run_service, "_auto_apply_if_permitted", AsyncMock()) as gate:
+            await run_service.evaluate_conditional_auto_apply(db, run)
+        gate.assert_not_awaited()
+        assert run.status == "planned"
+        assert run.auto_apply_declined_reason, "the operator needs to know why it stopped"
+
+    async def test_an_unknown_plan_shape_is_declined(self):
+        # Plan JSON never arrived / failed to parse — fail toward "a human
+        # looks at it", never toward applying something unexamined.
+        run = _decider_run(
+            resource_additions=None, resource_changes=None, resource_destructions=None
+        )
+        db = AsyncMock()
+        with patch.object(run_service, "_auto_apply_if_permitted", AsyncMock()) as gate:
+            await run_service.evaluate_conditional_auto_apply(db, run)
+        gate.assert_not_awaited()
+        assert run.status == "planned"
+
+    async def test_a_run_that_is_not_planned_is_left_alone(self):
+        # Without this guard a run already applying/errored/discarded would be
+        # driven to `confirmed` a second time.
+        for status in ("planning", "applying", "errored", "discarded", "applied"):
+            run = _decider_run(status=status)
+            db = AsyncMock()
+            with patch.object(run_service, "_auto_apply_if_permitted", AsyncMock()) as gate:
+                await run_service.evaluate_conditional_auto_apply(db, run)
+            gate.assert_not_awaited(), f"status={status} must not auto-apply"
+
+    async def test_a_plan_only_run_never_auto_applies(self):
+        run = _decider_run(plan_only=True)
+        db = AsyncMock()
+        with patch.object(run_service, "_auto_apply_if_permitted", AsyncMock()) as gate:
+            await run_service.evaluate_conditional_auto_apply(db, run)
+        gate.assert_not_awaited()
+
+    async def test_always_and_never_do_not_travel_this_path(self):
+        # `always` decides in complete_plan (on the plan-result POST, before
+        # the counts exist); `never` decides nowhere. Only the conditional
+        # modes are settled here.
+        for mode in ("always", "never"):
+            run = _decider_run(auto_apply_mode=mode)
+            db = AsyncMock()
+            with patch.object(run_service, "_auto_apply_if_permitted", AsyncMock()) as gate:
+                await run_service.evaluate_conditional_auto_apply(db, run)
+            gate.assert_not_awaited(), f"mode={mode} must not decide here"
+
+
+class TestAutoApplyGuardsAreSharedByBothEntryPoints:
+    """`_auto_apply_if_permitted` was extracted so `always` and the
+    conditional modes cannot drift apart on the guards. Nothing pinned that
+    the new caller actually honours them — which is the whole point of the
+    extraction."""
+
+    async def test_a_manual_workspace_lock_blocks_the_conditional_path(self):
+        # An unattended apply past an operator's explicit lock is exactly the
+        # failure the lock exists to prevent.
+        run = _decider_run()
+        ws = SimpleNamespace(id=run.workspace_id, locked=True, lock_id="held-by-a-human")
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=ws)
+        with (
+            patch.object(run_service, "_staleness_reason", AsyncMock(return_value=None)),
+            patch.object(run_service, "transition_run", AsyncMock()) as transition,
+        ):
+            await run_service._auto_apply_if_permitted(db, run)
+        transition.assert_not_awaited(), "must not confirm past a manual lock"
+
+    async def test_an_unlocked_workspace_is_confirmed(self):
+        run = _decider_run()
+        ws = SimpleNamespace(id=run.workspace_id, locked=False, lock_id=None)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=ws)
+        with (
+            patch.object(run_service, "_staleness_reason", AsyncMock(return_value=None)),
+            patch.object(run_service, "transition_run", AsyncMock(return_value=run)) as transition,
+        ):
+            await run_service._auto_apply_if_permitted(db, run)
+        assert transition.await_args.args[2] == "confirmed"
+
+    async def test_a_stale_plan_is_discarded_not_applied(self):
+        # #646/#647: state moved or the TTL lapsed between plan and apply.
+        run = _decider_run()
+        ws = SimpleNamespace(id=run.workspace_id, locked=False, lock_id=None)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=ws)
+        with (
+            patch.object(
+                run_service, "_staleness_reason", AsyncMock(return_value="state moved on")
+            ),
+            patch.object(run_service, "discard_run", AsyncMock(return_value=run)) as discard,
+            patch.object(run_service, "transition_run", AsyncMock()) as transition,
+        ):
+            await run_service._auto_apply_if_permitted(db, run)
+        discard.assert_awaited_once()
+        transition.assert_not_awaited(), "a stale plan must never be applied"


### PR DESCRIPTION
Pre-release audit for v1.4.0 (#1294). Four defects in the #1274 conditional auto-apply feature, each found by the adversarial review, each verified against the code before fixing, and each now covered by a test that can detect its own regression.

## The four

**A held conditional run had no Apply button anywhere.** `create_run` sets `run.auto_apply = True` for *every* non-`never` mode, and `is-confirmable` keyed off that boolean. So a `create_update` run correctly held back because its plan contained a destroy rendered the amber "held" banner and then hid the one control that resolves it — in the UI, the SDK and MCP alike — while `confirm_run` (which only checks `status == "planned"`) would have accepted it. The flagship feature failed at exactly the moment it exists for. Now keyed on the resolved mode: only `always` hides Confirm, because such a run applies itself.

**`auto-apply-mode` bypassed the `apply_then_merge` invariant.** The guard fired only when the request carried `vcs-workflow` or `auto-apply`, but the new attribute writes `ws.auto_apply` too — so a mode-only PATCH reached by curl precisely the state the boolean is refused for. The shipped UI now sends *only* the new attribute, which made the invariant unenforceable through the primary consumer.

**Conditional auto-apply never fired on a gated workspace.** Its sole caller is the plan-JSON upload, and it early-returns unless the run is already `planned` — but a run task, mandatory OPA policy or enforced security scan holds the run in `planning` at exactly that moment, and nothing re-evaluated when the gate later cleared. Runs parked in `planned` silently, no error, no declined-reason. `complete_plan` now re-runs the evaluation on every path that reaches `planned` late; the status guard keeps the ungated case a no-op.

**The provider could not apply any non-`never` mode.** `auto_apply` carried a schema default, making it a *known* `false` in the plan, while the request builder sends only the mode and the server projects the boolean back as `true` — which Terraform core rejects as `Provider produced inconsistent result after apply`. Dropped the default for the Optional+Computed + `UseStateForUnknown` shape `auto_merge` already uses. The autodiscovery rule needed its mode branch hoisted out of the `auto_apply` guard *first*: that nesting only worked while the default made the boolean always known, so the two defects were masking each other and fixing one alone is worse than fixing neither.

## Why they survived

The predicate suite was thorough about the functions that cannot cause harm and silent about the ones that can. `evaluate_conditional_auto_apply` and `_auto_apply_if_permitted` — the code that actually applies infrastructure — were named by no test at all. A green suite said nothing about the part that acts.

So the tests here cover the *decider*, not just the decision: the manual-lock guard, the staleness guard, the status and plan-only guards, the declined path and its reason. Plus the endpoint-level invariants and, for the provider, an assertion on the schema field directly — the golden records optional/computed but not defaults and stayed byte-identical across the fix, so it could never have caught it. I verified that guard genuinely fails rather than trusting it: re-adding `booldefault.StaticBool(false)` turns it red.

## Also in here

The per-minor platform-tool review (**trivy 0.72.0 → 0.73.0**, **checkov 3.3.8 → 3.3.9**; opa is current), and a correction to `docs/rbac-capabilities.md`, which still described the GPG key endpoints as authenticated-only after #1290 gated them.

## Verification

`make test` services+api shards: **3219 passed**. Provider `go build` + `go test` green. `helm lint` clean. Contract snapshots untouched — nothing here changes a public surface.

## Not in scope

The broader test-coverage backlog the same review turned up (SDKVersion wiring, the deleted-workspace blob class, `write_marker_best_effort`, the missing admin RBAC-negative) is #1297 and lands separately.