### PR TITLE
test(1297): cover the orchestrators and wiring lines shipped in v1.4.0

### DIFF
--- a/e2e/tests/deleted-workspaces.spec.ts
+++ b/e2e/tests/deleted-workspaces.spec.ts
@@ -5,8 +5,10 @@ import {
   seedStateVersionWithContent,
   uniqueName,
 } from '../helpers/api';
+import path from 'path';
 
 const API_URL = process.env.API_URL || 'http://localhost:8000';
+const USER_AUTH = path.join(__dirname, '..', '.auth', 'user.json');
 
 /**
  * Undelete surface (#1253).
@@ -104,15 +106,45 @@ test.describe('Deleted workspaces (undelete)', () => {
     await expect(page.locator(`tr:has-text("${name}")`).first()).toBeVisible();
   });
 
-  test('a non-admin cannot reach the undelete surface', async ({ browser }) => {
-    // Reads are admin-only too: a marker names a workspace and its variable
-    // names, and a restore materialises its state — and so its secrets.
+  test('an anonymous caller cannot reach the undelete surface', async ({ browser }) => {
     const ctx = await browser.newContext({ storageState: undefined });
     const page = await ctx.newPage();
     const res = await page.request.get(
       `${API_URL}/api/terrapod/v1/deleted-workspaces`,
     );
     expect([401, 403]).toContain(res.status());
+    await ctx.close();
+  });
+
+  test('an authenticated non-admin cannot reach the undelete surface', async ({ browser }) => {
+    // This is the test that matters, and it was missing (#1297). The
+    // anonymous case above passes on 401 alone, so it would still be green if
+    // `require_admin` were downgraded to `get_current_user` — the exact
+    // regression that would expose every marker to every logged-in user.
+    //
+    // Reads are admin-only for the same reason writes are: a marker names a
+    // workspace, its labels and its variable names, and a restore
+    // materialises its state — and therefore its secrets — into a workspace
+    // the caller can then read. The original's ACL died with its rows, so
+    // there is nothing to delegate to.
+    const ctx = await browser.newContext({ storageState: USER_AUTH });
+    const page = await ctx.newPage();
+
+    for (const path of [
+      '/api/terrapod/v1/deleted-workspaces',
+      '/api/terrapod/v1/deleted-workspaces/00000000-0000-4000-8000-000000000000',
+    ]) {
+      const res = await page.request.get(`${API_URL}${path}`);
+      expect(res.status(), `${path} must be forbidden for a non-admin`).toBe(403);
+    }
+
+    // ...and the restore itself, which is the one that would materialise
+    // somebody else's secrets.
+    const restore = await page.request.post(
+      `${API_URL}/api/terrapod/v1/deleted-workspaces/00000000-0000-4000-8000-000000000000/restore`,
+    );
+    expect(restore.status()).toBe(403);
+
     await ctx.close();
   });
 });

--- a/e2e/tests/deleted-workspaces.spec.ts
+++ b/e2e/tests/deleted-workspaces.spec.ts
@@ -5,10 +5,8 @@ import {
   seedStateVersionWithContent,
   uniqueName,
 } from '../helpers/api';
-import path from 'path';
 
 const API_URL = process.env.API_URL || 'http://localhost:8000';
-const USER_AUTH = path.join(__dirname, '..', '.auth', 'user.json');
 
 /**
  * Undelete surface (#1253).
@@ -127,21 +125,30 @@ test.describe('Deleted workspaces (undelete)', () => {
     // materialises its state — and therefore its secrets — into a workspace
     // the caller can then read. The original's ACL died with its rows, so
     // there is nothing to delegate to.
-    const ctx = await browser.newContext({ storageState: USER_AUTH });
+    // The token lives in localStorage, not a cookie, so a storageState alone
+    // authenticates the *app* and not `page.request` — sending it explicitly
+    // is what makes this an authenticated call rather than an anonymous one
+    // (the difference between asserting 403 and re-asserting the 401 above).
+    const userToken = getStoredToken('user.json');
+    expect(userToken, 'the non-admin auth state must carry a token').toBeTruthy();
+    const auth = { Authorization: `Bearer ${userToken}` };
+
+    const ctx = await browser.newContext();
     const page = await ctx.newPage();
 
-    for (const path of [
+    for (const p of [
       '/api/terrapod/v1/deleted-workspaces',
       '/api/terrapod/v1/deleted-workspaces/00000000-0000-4000-8000-000000000000',
     ]) {
-      const res = await page.request.get(`${API_URL}${path}`);
-      expect(res.status(), `${path} must be forbidden for a non-admin`).toBe(403);
+      const res = await page.request.get(`${API_URL}${p}`, { headers: auth });
+      expect(res.status(), `${p} must be forbidden for a non-admin`).toBe(403);
     }
 
     // ...and the restore itself, which is the one that would materialise
     // somebody else's secrets.
     const restore = await page.request.post(
       `${API_URL}/api/terrapod/v1/deleted-workspaces/00000000-0000-4000-8000-000000000000/restore`,
+      { headers: auth },
     );
     expect(restore.status()).toBe(403);
 

--- a/e2e/tests/rbac-negatives.spec.ts
+++ b/e2e/tests/rbac-negatives.spec.ts
@@ -25,6 +25,11 @@ const ADMIN_LINKS = [
   '/admin/bulk-update',
   '/admin/catalog',
   '/admin/provider-templates',
+  // The most sensitive new admin page was the one not covered (#1297): a
+  // delete marker names a workspace and its variable names, and a restore
+  // materialises its state — and therefore its secrets — into a workspace
+  // the caller can then read.
+  '/admin/deleted-workspaces',
 ];
 
 test.describe('RBAC — regular user is blocked from admin', () => {

--- a/migrate/cmd/terrapod-migrate/main.go
+++ b/migrate/cmd/terrapod-migrate/main.go
@@ -38,8 +38,19 @@ import (
 // A source build leaves Version as "dev", which the SDK treats as "cannot
 // compare" and skips — so `go run ./cmd/terrapod-migrate` keeps working
 // without the override flag.
-func init() {
+// wireSDKVersion is the assignment itself, named so a test can drive it.
+//
+// A test that only reads terrapod.SDKVersion after init() cannot tell the
+// assignment happened: in a source build Version is "dev" and SDKVersion
+// already defaults to "dev", so the comparison holds either way and deleting
+// the line leaves the suite green — which is the failure mode this whole
+// exercise is about (#1297).
+func wireSDKVersion() {
 	terrapod.SDKVersion = Version
+}
+
+func init() {
+	wireSDKVersion()
 }
 
 // checkAPIVersion gates a run on tool↔API compatibility (#550).

--- a/migrate/cmd/terrapod-migrate/version_wiring_test.go
+++ b/migrate/cmd/terrapod-migrate/version_wiring_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+)
+
+// TestSDKVersionIsWired pins the one line that makes the version gate real.
+//
+// VersionCheck returns nil immediately when SDKVersion is "dev", SDKVersion
+// defaults to "dev", and GoReleaser stamps main.Version — not the SDK's
+// variable. So without the assignment every released binary skipped the check
+// entirely (#1286).
+//
+// version_gate_test.go cannot catch that: its withSDKVersion helper overwrites
+// the very variable the fix assigns, before each case. Delete the wiring and
+// that table still goes green (#1297).
+func TestSDKVersionIsWired(t *testing.T) {
+	prev := terrapod.SDKVersion
+	t.Cleanup(func() { terrapod.SDKVersion = prev })
+	origVersion := Version
+	t.Cleanup(func() { Version = origVersion })
+
+	terrapod.SDKVersion = "not-wired"
+	Version = "v9.9.9"
+	wireSDKVersion()
+
+	if terrapod.SDKVersion != "v9.9.9" {
+		t.Fatalf(
+			"SDKVersion = %q after wireSDKVersion() — the assignment is missing, so the "+
+				"version gate is inert in every released binary",
+			terrapod.SDKVersion,
+		)
+	}
+}
+
+// TestInitRanTheWiring — wireSDKVersion existing is no use if init() stops
+// calling it. Package init has already run by the time a test executes, so
+// this is the only window in which that is observable, and it must run before
+// anything else reassigns the variable.
+func TestInitRanTheWiring(t *testing.T) {
+	if terrapod.SDKVersion != Version {
+		t.Fatalf("SDKVersion = %q after package init, want %q", terrapod.SDKVersion, Version)
+	}
+}

--- a/provider/internal/provider/version_wiring_test.go
+++ b/provider/internal/provider/version_wiring_test.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"testing"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+)
+
+// TestSDKVersionIsWired pins the one line that makes the version gate real.
+//
+// VersionCheck returns nil immediately when SDKVersion is "dev", SDKVersion
+// defaults to "dev", and GoReleaser stamps main.version — not the SDK's
+// variable. So without the assignment in New() the gate is inert in every
+// released provider while every other test still passes, which is exactly the
+// bug this file exists to stop recurring (#1287, #1297).
+//
+// The schema-contract test already calls New("test"); it asserts nothing about
+// this, so deleting the assignment left the whole suite green.
+func TestSDKVersionIsWired(t *testing.T) {
+	prev := terrapod.SDKVersion
+	t.Cleanup(func() { terrapod.SDKVersion = prev })
+
+	terrapod.SDKVersion = "not-set-by-new"
+	New("v9.9.9")
+
+	if terrapod.SDKVersion != "v9.9.9" {
+		t.Fatalf(
+			"SDKVersion = %q after New(\"v9.9.9\") — the assignment in New() is missing, "+
+				"so Configure's compatibility check can never fire in a released provider",
+			terrapod.SDKVersion,
+		)
+	}
+}
+
+// TestSourceBuildStaysUncompared — "dev" is how the SDK is told it cannot
+// compare. Local provider development must keep working, so the wiring must
+// pass the value through rather than substituting something comparable.
+func TestSourceBuildStaysUncompared(t *testing.T) {
+	prev := terrapod.SDKVersion
+	t.Cleanup(func() { terrapod.SDKVersion = prev })
+
+	New("dev")
+	if terrapod.SDKVersion != "dev" {
+		t.Fatalf("SDKVersion = %q, want \"dev\" passed straight through", terrapod.SDKVersion)
+	}
+}

--- a/publish/cmd/terrapod-publish/main.go
+++ b/publish/cmd/terrapod-publish/main.go
@@ -36,8 +36,19 @@ var Version = "dev"
 //
 // A source build leaves Version as "dev", which the SDK treats as "cannot
 // compare" and skips, so `go run` keeps working.
-func init() {
+// wireSDKVersion is the assignment itself, named so a test can drive it.
+//
+// A test that only reads terrapod.SDKVersion after init() cannot tell the
+// assignment happened: in a source build Version is "dev" and SDKVersion
+// already defaults to "dev", so the comparison holds either way and deleting
+// the line leaves the suite green — which is the failure mode this whole
+// exercise is about (#1297).
+func wireSDKVersion() {
 	terrapod.SDKVersion = Version
+}
+
+func init() {
+	wireSDKVersion()
 }
 
 func main() {

--- a/publish/cmd/terrapod-publish/version_wiring_test.go
+++ b/publish/cmd/terrapod-publish/version_wiring_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	terrapod "github.com/mattrobinsonsre/terrapod/go-terrapod"
+)
+
+// TestSDKVersionIsWired pins the one line that makes the version gate real.
+//
+// VersionCheck returns nil immediately when SDKVersion is "dev", SDKVersion
+// defaults to "dev", and GoReleaser stamps main.Version — not the SDK's
+// variable. So without the assignment the gate is inert in every released
+// binary while every other test stays green, which is the bug this file exists
+// to stop recurring (#1287, #1297).
+//
+// It drives wireSDKVersion() from a sentinel rather than reading the variable
+// after init(): in a source build both values are "dev", so a plain equality
+// check would hold whether or not the assignment exists.
+func TestSDKVersionIsWired(t *testing.T) {
+	prev := terrapod.SDKVersion
+	t.Cleanup(func() { terrapod.SDKVersion = prev })
+	origVersion := Version
+	t.Cleanup(func() { Version = origVersion })
+
+	terrapod.SDKVersion = "not-wired"
+	Version = "v9.9.9"
+	wireSDKVersion()
+
+	if terrapod.SDKVersion != "v9.9.9" {
+		t.Fatalf(
+			"SDKVersion = %q after wireSDKVersion() — the assignment is missing, so the "+
+				"compatibility warning can never fire in a released build",
+			terrapod.SDKVersion,
+		)
+	}
+}
+
+// TestInitRanTheWiring — wireSDKVersion existing is no use if init() stops
+// calling it. Package init has already run by the time a test executes, so
+// this is the only window in which that is observable.
+func TestInitRanTheWiring(t *testing.T) {
+	if terrapod.SDKVersion != Version {
+		t.Fatalf("SDKVersion = %q after package init, want %q", terrapod.SDKVersion, Version)
+	}
+}

--- a/services/tests/api/test_gpg_keys.py
+++ b/services/tests/api/test_gpg_keys.py
@@ -335,3 +335,82 @@ class TestTrustAnchorAuthorization:
         async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
             resp = await c.get(_KEYS, headers=_AUTH)
         assert resp.status_code == 200
+
+
+class TestNonPlatformAdminGrant:
+    """The allow path for a role-granted registry admin.
+
+    Every existing test here uses platform admin, which is step 1 of the
+    capability resolver — so nothing proved a *role*-granted registry admin
+    actually resolves through the empty resource this gate passes
+    (`resolve_registry_capabilities_for(db, user, "", {}, "")`) (#1297).
+
+    The empty resource is deliberate: the GPG store is a single trust anchor
+    with no name of its own, so only unscoped grants can match. A role's
+    `allow_labels` cannot — `matches_labels` requires the key to be present on
+    the resource — and an earlier version that passed a literal "gpg-keys"
+    name put a magic string in the same namespace as real provider names. So
+    "does an ordinary registry-admin role actually work here" is a real
+    question, not a formality.
+    """
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.create_gpg_key", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.gpg_keys.resolve_registry_capabilities_for")
+    async def test_a_role_granted_registry_admin_may_create(
+        self, mock_resolve, mock_create, *mocks
+    ):
+        from terrapod.auth.capabilities import _REGISTRY_LEVELS
+
+        mock_resolve.return_value = _REGISTRY_LEVELS["admin"]
+        mock_create.return_value = _mock_key()
+
+        app = _make_app(_user(roles=["registry-owner"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(_KEYS, json=_create_body(), headers=_AUTH)
+
+        assert resp.status_code == 201, resp.text
+        # The gate is consulted against the unscoped store — no name, no
+        # labels, no owner — which is what makes a label-scoped role unable to
+        # reach it and a plain registry-admin role able to.
+        args = mock_resolve.await_args.args
+        assert args[2] == "" and args[3] == {} and args[4] == ""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.resolve_registry_capabilities_for")
+    async def test_registry_read_is_not_enough_to_register_a_key(self, mock_resolve, *mocks):
+        """Registering a signing key is adding a trust anchor: every provider
+        signed by it is then installable. Read is not that."""
+        from terrapod.auth.capabilities import _REGISTRY_LEVELS
+
+        mock_resolve.return_value = _REGISTRY_LEVELS["read"]
+
+        app = _make_app(_user(roles=["registry-reader"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(_KEYS, json=_create_body(), headers=_AUTH)
+
+        assert resp.status_code == 403
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.gpg_keys.list_gpg_keys", new_callable=AsyncMock)
+    @patch("terrapod.api.routers.gpg_keys.resolve_registry_capabilities_for")
+    async def test_registry_read_can_list(self, mock_resolve, mock_list, *mocks):
+        """Public keys are public by nature — reading them is not the
+        privileged act, registering one is."""
+        from terrapod.auth.capabilities import _REGISTRY_LEVELS
+
+        mock_resolve.return_value = _REGISTRY_LEVELS["read"]
+        mock_list.return_value = [_mock_key()]
+
+        app = _make_app(_user(roles=["registry-reader"]))
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(_KEYS, headers=_AUTH)
+
+        assert resp.status_code == 200
+        assert len(resp.json()["data"]) == 1

--- a/services/tests/api/test_runs.py
+++ b/services/tests/api/test_runs.py
@@ -35,6 +35,8 @@ def _mock_run(
     auto_apply=False,
     plan_only=False,
     message="",
+    pool_id=None,
+    pool_extra_ids=None,
 ):
     run = MagicMock()
     run.id = run_id or uuid.uuid4()
@@ -102,6 +104,13 @@ def _mock_run(
     run.runner_exit_code = None
     run.runner_exit_reason = ""
     run.runner_exit_status = ""
+    # #1231/#960: the executing pool and the candidate set. Left unset these
+    # serialise from a MagicMock, so `agent-pool-id` came out as a repr of a
+    # mock rather than `apool-<uuid>` and nothing noticed — while the UI's
+    # pool link is built from exactly that prefix (#1297). None is the honest
+    # default: a run on a local-execution workspace has no pool.
+    run.pool_id = pool_id
+    run.pool_extra_ids = list(pool_extra_ids or [])
     return run
 
 
@@ -1807,3 +1816,84 @@ class TestHeldConditionalRunIsActionable:
             resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
 
         assert resp.json()["data"]["attributes"]["actions"]["is-confirmable"] is False
+
+
+class TestExecutingPoolSerialisation:
+    """#1231 exposes the pool that ran a run, and the UI builds its pool link
+    from the `apool-` prefix. `_mock_run` never set `pool_id`, so every test in
+    this file serialised it from a MagicMock — a repr, not an id — and nothing
+    noticed (#1297)."""
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_the_executing_pool_is_a_prefixed_id(self, mock_get_run, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("read")
+        pool_id = uuid.uuid4()
+        run = _mock_run(status="applied", pool_id=pool_id)
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        body = resp.json()["data"]
+        assert body["attributes"]["agent-pool-id"] == f"apool-{pool_id}"
+        assert body["attributes"]["candidate-agent-pool-ids"] == [f"apool-{pool_id}"]
+        # The relationship is the canonical link form; the attribute above is
+        # the back-compat projection of it (#1063).
+        assert body["relationships"]["agent-pool"]["data"]["id"] == f"apool-{pool_id}"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_a_run_with_no_pool_serialises_null_not_a_repr(
+        self, mock_get_run, mock_resolve, *mocks
+    ):
+        """A local-execution run genuinely has no pool. `null` says that;
+        `apool-<MagicMock id=...>` says something the UI would try to link to."""
+        mock_resolve.return_value = caps_for_level("read")
+        run = _mock_run(status="applied")
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        body = resp.json()["data"]
+        assert body["attributes"]["agent-pool-id"] is None
+        assert body["attributes"]["candidate-agent-pool-ids"] == []
+        assert body["relationships"]["agent-pool"]["data"] is None
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.runs.resolve_workspace_capabilities_for")
+    @patch("terrapod.api.routers.runs.run_service.get_run")
+    async def test_the_candidate_set_carries_every_pool(self, mock_get_run, mock_resolve, *mocks):
+        """A multi-pool run (#960) shows where it ran AND where it could have."""
+        mock_resolve.return_value = caps_for_level("read")
+        primary, fallback = uuid.uuid4(), uuid.uuid4()
+        run = _mock_run(status="applied", pool_id=primary, pool_extra_ids=[str(fallback)])
+        mock_get_run.return_value = run
+
+        ws = _mock_workspace(ws_id=run.workspace_id)
+        app, mock_db = _make_app(_user())
+        mock_db.get.return_value = ws
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.get(f"/api/v2/runs/run-{run.id}", headers=_AUTH)
+
+        attrs = resp.json()["data"]["attributes"]
+        assert attrs["agent-pool-id"] == f"apool-{primary}"
+        assert set(attrs["candidate-agent-pool-ids"]) == {f"apool-{primary}", f"apool-{fallback}"}

--- a/services/tests/api/test_workspaces.py
+++ b/services/tests/api/test_workspaces.py
@@ -1401,3 +1401,158 @@ class TestListWorkspacesSeeAllFastPath:
         body = resp.json()
         assert len(body["data"]) == 3
         assert body["meta"]["pagination"]["total-count"] == 3
+
+
+class TestAutoApplyModeOnTheWorkspaceEndpoints:
+    """The single-workspace create/update paths for `auto-apply-mode` (#1274).
+
+    `test_auto_apply_mode_admin.py` opens by saying the two admin write paths
+    get their own tests "rather than riding on the single-workspace ones" —
+    and the single-workspace ones did not exist. That absence concealed a live
+    guard bypass, fixed under #1294 (#1297).
+
+    The pair of columns is the thing under test: `auto_apply_mode` carries the
+    intent and `auto_apply` is its boolean projection, and every path that
+    writes one must write the other, or a replica reading the projection
+    across a rolling upgrade sees a different answer from the one configured.
+    """
+
+    @staticmethod
+    def _created(mock_db):
+        """The Workspace handed to db.add() by the create path."""
+        assert mock_db.add.call_count == 1
+        return mock_db.add.call_args.args[0]
+
+    async def _create(self, attrs):
+        user = _user(roles=["admin"])
+        app, mock_db = _make_app(user)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+        mock_db.refresh = AsyncMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.post(
+                "/api/v2/organizations/default/workspaces",
+                json={"data": {"type": "workspaces", "attributes": {"name": "m", **attrs}}},
+                headers=_AUTH,
+            )
+        return resp, mock_db
+
+    async def _patch(self, attrs, ws=None):
+        ws = ws or _mock_workspace()
+        app, mock_db = _make_app(_user(roles=["admin"]))
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute.return_value = mock_result
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=_BASE) as c:
+            resp = await c.patch(
+                f"/api/v2/workspaces/ws-{ws.id}",
+                json={"data": {"attributes": attrs}},
+                headers=_AUTH,
+            )
+        return resp, ws
+
+    # ── create ────────────────────────────────────────────────────────
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
+    async def test_create_with_a_mode_writes_both_columns(self, *mocks):
+        resp, mock_db = await self._create({"auto-apply-mode": "create"})
+        assert resp.status_code == 201, resp.text
+        ws = self._created(mock_db)
+        assert ws.auto_apply_mode == "create"
+        assert ws.auto_apply is True
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
+    async def test_create_with_never_clears_the_boolean(self, *mocks):
+        resp, mock_db = await self._create({"auto-apply-mode": "never"})
+        assert resp.status_code == 201, resp.text
+        ws = self._created(mock_db)
+        assert ws.auto_apply_mode == "never"
+        assert ws.auto_apply is False
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.redis.client.publish_workspace_event", new_callable=AsyncMock)
+    async def test_create_with_only_the_legacy_boolean_still_works(self, *mocks):
+        """An un-upgraded client sends the boolean alone and must be unaffected."""
+        resp, mock_db = await self._create({"auto-apply": True})
+        assert resp.status_code == 201, resp.text
+        ws = self._created(mock_db)
+        assert ws.auto_apply_mode == "always"
+        assert ws.auto_apply is True
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_rejects_both_at_once(self, *mocks):
+        """Two sources of truth in one request is ambiguous, not resolvable —
+        so it is refused rather than silently ranked."""
+        resp, _ = await self._create({"auto-apply": True, "auto-apply-mode": "create"})
+        assert resp.status_code == 422
+        assert "not both" in resp.text
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    async def test_create_rejects_an_unknown_mode(self, *mocks):
+        resp, _ = await self._create({"auto-apply-mode": "whenever-you-like"})
+        assert resp.status_code == 422
+        # The message enumerates the real set, so the caller can fix it.
+        assert "create_update" in resp.text
+
+    # ── update ────────────────────────────────────────────────────────
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_patching_a_mode_writes_both_columns(self, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("admin")
+        resp, ws = await self._patch({"auto-apply-mode": "create_update"})
+        assert resp.status_code == 200, resp.text
+        assert ws.auto_apply_mode == "create_update"
+        assert ws.auto_apply is True
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_patching_the_boolean_off_clears_the_mode(self, mock_resolve, *mocks):
+        """The consistency has to hold in BOTH directions. An old client turning
+        auto-apply off must not leave a conditional mode behind that a newer
+        replica would still act on."""
+        mock_resolve.return_value = caps_for_level("admin")
+        ws = _mock_workspace()
+        ws.auto_apply, ws.auto_apply_mode = True, "create"
+        resp, ws = await self._patch({"auto-apply": False}, ws=ws)
+        assert resp.status_code == 200, resp.text
+        assert ws.auto_apply is False
+        assert ws.auto_apply_mode == "never"
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_patch_rejects_both_at_once(self, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("admin")
+        resp, _ = await self._patch({"auto-apply": True, "auto-apply-mode": "never"})
+        assert resp.status_code == 422
+        assert "not both" in resp.text
+
+    @patch("terrapod.api.app.init_storage", new_callable=AsyncMock)
+    @patch("terrapod.api.app.init_redis")
+    @patch("terrapod.api.app.init_db")
+    @patch("terrapod.api.routers.tfe_v2.resolve_workspace_capabilities_for")
+    async def test_patch_rejects_an_unknown_mode(self, mock_resolve, *mocks):
+        mock_resolve.return_value = caps_for_level("admin")
+        resp, ws = await self._patch({"auto-apply-mode": "sometimes"})
+        assert resp.status_code == 422
+        # ...and leaves the workspace exactly as it was.
+        assert ws.auto_apply_mode != "sometimes"

--- a/services/tests/integration/test_deleted_workspace_restore.py
+++ b/services/tests/integration/test_deleted_workspace_restore.py
@@ -222,6 +222,37 @@ class TestRestore:
         )
         assert resp.status_code == 422
 
+    @pytest.mark.parametrize("bad", [42, True, [], {}, {"name": "nested"}])
+    async def test_a_non_string_name_is_a_422_not_a_500(self, app, client, bad):
+        """A wrong-typed name must be a validation failure, not a crash inside
+        the validator — the difference between "fix your request" and "the
+        server is broken" (#1297)."""
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(
+            client, f"restore-badtype-{abs(hash(str(bad))) % 9999}", [1], "lin-badtype"
+        )
+
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore",
+            json={"data": {"attributes": {"name": bad}}},
+            headers=AUTH,
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_an_absent_name_still_uses_the_marker(self, app, client):
+        """Omitting the key is not the same as sending an empty one: absent
+        means "use the original", and must not trip the validator."""
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(client, "restore-noname", [1], "lin-noname")
+
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore",
+            json={"data": {"attributes": {}}},
+            headers=AUTH,
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["data"]["attributes"]["name"].startswith("restore-noname")
+
     async def test_a_rejected_name_leaves_the_deleted_workspace_restorable(self, app, client):
         """A 422 must be a retryable typo, not a way to burn the one recovery."""
         set_auth(app, admin_user())

--- a/services/tests/integration/test_run_execution.py
+++ b/services/tests/integration/test_run_execution.py
@@ -979,6 +979,235 @@ class TestRunSerializationAndLocking:
         assert (await _get_run(client, run_id))["attributes"]["status"] == "confirmed"
 
 
+# ---------------------------------------------------------------------------
+# Conditional auto-apply (#1274) — the orchestrator, not the predicate
+# ---------------------------------------------------------------------------
+#
+# `tests/services/test_conditional_auto_apply.py` covers the pure decision
+# functions exhaustively and stops there. What was untested is everything
+# that runs *around* them: the guards `_auto_apply_if_permitted` shares with
+# the `always` path, the early returns, the declined path that records a
+# reason, and `complete_plan`'s narrowing from `if run.auto_apply` to
+# `resolve_auto_apply_mode(run) == "always"` — a regression to the old
+# predicate would auto-apply every conditional run on plan-result, before the
+# counts that decide it even exist (#1297).
+
+
+def _plan_json(*, add=0, change=0, destroy=0, replace=0) -> bytes:
+    """A plan JSON whose resource_changes produce the requested counts.
+
+    A replace is the {create, delete} action pair — the shape a "no destroys"
+    check misses, because it is counted as a replacement rather than a
+    destruction.
+    """
+    changes = []
+    for i in range(add):
+        changes.append({"address": f"null_resource.add{i}", "change": {"actions": ["create"]}})
+    for i in range(change):
+        changes.append({"address": f"null_resource.upd{i}", "change": {"actions": ["update"]}})
+    for i in range(destroy):
+        changes.append({"address": f"null_resource.del{i}", "change": {"actions": ["delete"]}})
+    for i in range(replace):
+        changes.append(
+            {"address": f"null_resource.rep{i}", "change": {"actions": ["create", "delete"]}}
+        )
+    return json.dumps({"format_version": "1.2", "resource_changes": changes}).encode()
+
+
+async def _create_conditional_workspace(client, pool_id: str, name: str, mode: str) -> str:
+    resp = await client.post(
+        WS_ENDPOINT,
+        json={
+            "data": {
+                "type": "workspaces",
+                "attributes": {
+                    "name": name,
+                    "execution-mode": "agent",
+                    "agent-pool-id": pool_id,
+                    "auto-apply-mode": mode,
+                },
+            }
+        },
+        headers=AUTH,
+    )
+    assert resp.status_code == 201, resp.text
+    ws_id = resp.json()["data"]["id"]
+    await _seed_uploaded_cv(client, ws_id)
+    return ws_id
+
+
+async def _plan_then_upload_json(client, listener_id: str, ws_id: str, plan_json: bytes) -> dict:
+    """Drive a run through plan, then upload the plan JSON — the real order.
+
+    The runner POSTs plan-result (which drives `complete_plan`) BEFORE it
+    uploads the JSON, so the conditional decision genuinely happens after the
+    run has already reached `planned`. Reproducing that order is the point:
+    a `complete_plan` that auto-applied on the boolean alone would have
+    applied by the time the JSON arrives.
+    """
+    run = await _create_run(client, ws_id)
+    run_id = run["id"]
+    runner_token = await _run_plan_lifecycle(client, listener_id, run_id)
+
+    assert (
+        await _upload_artifact(client, run_id, "plan-json-output", plan_json, runner_token)
+    ) == 204
+    return await _get_run(client, run_id)
+
+
+class TestConditionalAutoApplyOrchestration:
+    async def test_create_mode_applies_a_pure_addition(self, app, client, setup):
+        pool_id, listener_id = setup
+        ws_id = await _create_conditional_workspace(client, pool_id, "cond-create", "create")
+
+        run = await _plan_then_upload_json(client, listener_id, ws_id, _plan_json(add=3))
+
+        assert run["attributes"]["status"] == "confirmed"
+        assert run["attributes"]["auto-apply-declined-reason"] in (None, "")
+
+    async def test_create_mode_holds_an_update_and_says_why(self, app, client, setup):
+        """The declined path is the one a human reads. A hold with no reason
+        is indistinguishable from a run nobody got to."""
+        pool_id, listener_id = setup
+        ws_id = await _create_conditional_workspace(client, pool_id, "cond-create-upd", "create")
+
+        run = await _plan_then_upload_json(client, listener_id, ws_id, _plan_json(add=1, change=2))
+
+        assert run["attributes"]["status"] == "planned"
+        assert "2 updates" in (run["attributes"]["auto-apply-declined-reason"] or "")
+
+    async def test_create_update_mode_applies_additions_and_updates(self, app, client, setup):
+        pool_id, listener_id = setup
+        ws_id = await _create_conditional_workspace(client, pool_id, "cond-cu", "create_update")
+
+        run = await _plan_then_upload_json(client, listener_id, ws_id, _plan_json(add=2, change=2))
+
+        assert run["attributes"]["status"] == "confirmed"
+
+    async def test_a_replacement_is_held_in_every_conditional_mode(self, app, client, setup):
+        """The case a naive "no destroys" check sails straight past."""
+        pool_id, listener_id = setup
+        for mode in ("create", "create_update"):
+            ws_id = await _create_conditional_workspace(client, pool_id, f"cond-rep-{mode}", mode)
+            run = await _plan_then_upload_json(
+                client, listener_id, ws_id, _plan_json(add=1, replace=1)
+            )
+            assert run["attributes"]["status"] == "planned", mode
+            assert "1 replace" in (run["attributes"]["auto-apply-declined-reason"] or ""), mode
+
+    async def test_complete_plan_does_not_apply_before_the_counts_exist(self, app, client, setup):
+        """The narrowing in `complete_plan`.
+
+        A conditional run reaches `planned` on plan-result and must STAY there
+        until the JSON arrives. If that condition regressed to the old
+        `if run.auto_apply` — which is True for every non-`never` mode — every
+        conditional run would auto-apply here, before anything had looked at
+        its shape.
+        """
+        pool_id, listener_id = setup
+        ws_id = await _create_conditional_workspace(client, pool_id, "cond-noearly", "create")
+
+        run = await _create_run(client, ws_id)
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+
+        after_plan = await _get_run(client, run["id"])
+        assert after_plan["attributes"]["status"] == "planned"
+
+    async def test_a_plan_json_that_never_arrives_leaves_the_run_for_a_human(
+        self, app, client, setup
+    ):
+        """The upload is best-effort, so failing to arrive must mean "nobody
+        auto-applies" — never "apply anyway"."""
+        pool_id, listener_id = setup
+        ws_id = await _create_conditional_workspace(client, pool_id, "cond-nojson", "create")
+
+        run = await _create_run(client, ws_id)
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+
+        from terrapod.services.run_reconciler import reconcile_runs
+
+        await reconcile_runs()
+        assert (await _get_run(client, run["id"]))["attributes"]["status"] == "planned"
+
+    async def test_an_unparseable_plan_json_holds_rather_than_applies(self, app, client, setup):
+        """Unknown shape is not a pass — it is exactly the run to look at."""
+        pool_id, listener_id = setup
+        ws_id = await _create_conditional_workspace(client, pool_id, "cond-badjson", "create")
+
+        run = await _plan_then_upload_json(client, listener_id, ws_id, b"not json at all")
+
+        assert run["attributes"]["status"] == "planned"
+
+
+class TestConditionalAutoApplySharesTheGuards:
+    """`_auto_apply_if_permitted` was extracted so the conditional path would
+    inherit the `always` path's guards. Nothing pinned that it does — and both
+    guards protect against applying something a human did not sanction."""
+
+    async def test_a_manual_lock_holds_a_permitted_conditional_run(self, app, client, setup):
+        pool_id, listener_id = setup
+        ws_id = await _create_conditional_workspace(client, pool_id, "cond-locked", "create")
+
+        run = await _create_run(client, ws_id)
+        runner_token = await _run_plan_lifecycle(client, listener_id, run["id"])
+        # Lock AFTER the plan: the operator's lock has to win over a decision
+        # that would otherwise be an unambiguous yes.
+        await _lock_workspace(client, ws_id)
+
+        assert (
+            await _upload_artifact(
+                client, run["id"], "plan-json-output", _plan_json(add=1), runner_token
+            )
+        ) == 204
+
+        held = await _get_run(client, run["id"])
+        assert held["attributes"]["status"] == "planned"
+
+        # ...and it is still applicable once the lock comes off, rather than
+        # having been discarded.
+        await _unlock_workspace(client, ws_id)
+        resp = await client.post(f"{RUNS_ENDPOINT}/{run['id']}/actions/apply", headers=AUTH)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["attributes"]["status"] == "confirmed"
+
+    async def test_a_stale_plan_is_discarded_not_auto_applied(self, app, client, setup):
+        """State moved between plan and decision. Applying a plan computed
+        against state that no longer exists is the worst outcome available."""
+        import uuid as _uuid
+
+        from terrapod.db.models import StateVersion
+        from terrapod.db.session import get_db_session
+
+        pool_id, listener_id = setup
+        ws_id = await _create_conditional_workspace(client, pool_id, "cond-stale", "create")
+        ws_uuid = _uuid.UUID(ws_id.removeprefix("ws-"))
+
+        # A baseline the plan can be measured stale against. Without one the
+        # guard correctly declines to call anything stale, so seeding it is
+        # what makes this test about the guard rather than about its absence.
+        async with get_db_session() as db:
+            db.add(StateVersion(workspace_id=ws_uuid, serial=1, lineage="x"))
+            await db.commit()
+
+        run = await _create_run(client, ws_id)
+        runner_token = await _run_plan_lifecycle(client, listener_id, run["id"])
+
+        # Somebody else writes state under it, between the plan and the
+        # decision.
+        async with get_db_session() as db:
+            db.add(StateVersion(workspace_id=ws_uuid, serial=2, lineage="x"))
+            await db.commit()
+
+        assert (
+            await _upload_artifact(
+                client, run["id"], "plan-json-output", _plan_json(add=1), runner_token
+            )
+        ) == 204
+
+        stale = await _get_run(client, run["id"])
+        assert stale["attributes"]["status"] == "discarded"
+
+
 class TestPlanStaleness:
     """State-drift (#647, always on) and time-based expiry (#646, per-workspace)
     auto-discard of stale apply-capable planned runs — against real Postgres

--- a/services/tests/services/test_blob_sync.py
+++ b/services/tests/services/test_blob_sync.py
@@ -353,6 +353,24 @@ class TestOwningClassResolvesOverlaps:
         assert blob_classes.owning_class("state/index.yaml").name == "state_index"
         assert blob_classes.owning_class("state/ws-1/sv-1.tfstate").name == "state"
 
+    def test_delete_markers_are_their_own_class_not_state(self):
+        """`state/deleted/` sits under `state/` too, and the whole reason it is
+        a separate class is that `state` is `encrypted_at_rest` — which
+        replication declines wholesale when app-layer encryption is on. If
+        ownership resolved to `state`, an encrypted deployment's standby would
+        carry no undelete index at all: precisely what the flat prefix exists
+        to prevent, and invisible until somebody needed to restore (#1297).
+        """
+        marker = "state/deleted/0192f3a1-0000-7000-8000-00000000000a.json"
+        owner = blob_classes.owning_class(marker)
+        assert owner is not None
+        assert owner.name == "deleted_workspace_markers"
+        assert not owner.encrypted_at_rest
+
+        # ...and a real state object under the same root still resolves to
+        # `state`, so the narrower prefix has not swallowed its neighbour.
+        assert blob_classes.owning_class("state/0192f3a1/sv-1.tfstate").name == "state"
+
     def test_an_unregistered_key_belongs_to_nothing(self):
         assert blob_classes.owning_class("nowhere/x") is None
 

--- a/services/tests/services/test_deleted_workspace_markers.py
+++ b/services/tests/services/test_deleted_workspace_markers.py
@@ -14,11 +14,10 @@ that follow from that and are easy to regress:
 
 from __future__ import annotations
 
+import contextlib
 import json
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
-
-import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from terrapod.services import deleted_workspace_service as dws
 from terrapod.services.artifact_retention_service import _cleanup_deleted_workspaces
@@ -222,14 +221,115 @@ class TestMarkerContents:
         assert "labels" in snap and "owner_email" in snap
 
 
-@pytest.mark.parametrize("days", [0])
-async def test_zero_retention_disables_the_category(days):
-    """`0 = disabled` is the convention every other retention category follows;
-    the dispatch loop skips on threshold 0, so an operator opting out keeps
-    deleted state forever rather than losing it immediately."""
-    from terrapod.config import settings
+@contextlib.asynccontextmanager
+async def _fake_db_session():
+    """The cycle opens a session per category; none of these tests touch the
+    database, so a stub keeps the run about dispatch rather than about
+    connectivity."""
+    yield AsyncMock()
 
-    assert settings.artifact_retention.deleted_workspace_retention_days >= 0
+
+async def test_zero_retention_never_reaches_the_reaper():
+    """`0 = disabled` is the convention every other retention category
+    follows, and the direction matters more than the convention: an operator
+    opting out must keep deleted state **forever**, not lose it immediately.
+
+    It is enforced by the dispatch loop, not by the handler — pass 0 straight
+    to `_cleanup_deleted_workspaces` and it happily reaps everything, because
+    every marker is older than a zero-day window. So this drives the cycle and
+    asserts the handler is never reached at all.
+
+    (Replaces a test that asserted the configured value was `>= 0`, which is
+    true of every possible configuration including the broken one — #1297.)
+    """
+    from terrapod.config import settings
+    from terrapod.services import artifact_retention_service as ars
+
+    original = settings.artifact_retention.deleted_workspace_retention_days
+    settings.artifact_retention.deleted_workspace_retention_days = 0
+    called = False
+
+    async def _spy(*a, **kw):
+        nonlocal called
+        called = True
+        return 0
+
+    try:
+        with (
+            patch.object(ars, "_cleanup_deleted_workspaces", _spy),
+            patch("terrapod.storage.get_storage", return_value=FakeStore()),
+            patch("terrapod.db.session.get_db_session", _fake_db_session),
+        ):
+            await ars.artifact_retention_cycle()
+    finally:
+        settings.artifact_retention.deleted_workspace_retention_days = original
+
+    assert not called, "a zero window must disable the category, not expire everything in it"
+
+
+async def test_a_positive_retention_does_reach_the_reaper():
+    """Pins the contrast, so the test above cannot pass merely because the
+    category has been unregistered or the cycle is broken outright."""
+    from terrapod.config import settings
+    from terrapod.services import artifact_retention_service as ars
+
+    original = settings.artifact_retention.deleted_workspace_retention_days
+    settings.artifact_retention.deleted_workspace_retention_days = 30
+    called = False
+
+    async def _spy(*a, **kw):
+        nonlocal called
+        called = True
+        return 0
+
+    try:
+        with (
+            patch.object(ars, "_cleanup_deleted_workspaces", _spy),
+            patch("terrapod.storage.get_storage", return_value=FakeStore()),
+            patch("terrapod.db.session.get_db_session", _fake_db_session),
+        ):
+            await ars.artifact_retention_cycle()
+    finally:
+        settings.artifact_retention.deleted_workspace_retention_days = original
+
+    assert called
+
+
+class TestMarkerWriteNeverFailsTheDelete:
+    """`write_marker_best_effort` exists for exactly one reason: the delete has
+    already committed by the time it runs. Raising would return a 500 for a
+    workspace that IS gone — the operator retries, gets a 404, and is left
+    believing the delete failed (#1297). Only the happy path was exercised.
+    """
+
+    async def test_a_storage_failure_is_swallowed(self):
+        storage = MagicMock()
+        storage.put = AsyncMock(side_effect=RuntimeError("bucket unreachable"))
+        with patch.object(dws, "get_storage", return_value=storage):
+            await dws.write_marker_best_effort(WS_A, {"workspace_id": WS_A})
+
+    async def test_an_unresolvable_store_is_swallowed_too(self):
+        """Resolving the store is inside the guard, not before it: an
+        unconfigured or unavailable backend must degrade to "no marker" — the
+        reaper stamps one on a later cycle — never to a failed delete."""
+        with patch.object(dws, "get_storage", side_effect=RuntimeError("no storage configured")):
+            await dws.write_marker_best_effort(WS_A, {"workspace_id": WS_A})
+
+    async def test_an_unserialisable_body_is_swallowed(self):
+        """The failure need not come from the network. A body carrying
+        something json cannot encode still must not sink the delete."""
+        storage = MagicMock()
+        storage.put = AsyncMock()
+        with patch.object(dws, "get_storage", return_value=storage):
+            await dws.write_marker_best_effort(WS_A, {"bad": object()})
+
+    async def test_the_happy_path_still_writes_the_marker(self):
+        """Swallowing everything is only correct if the normal case works —
+        otherwise the guard would hide a permanently broken writer."""
+        store = FakeStore()
+        with patch.object(dws, "get_storage", return_value=store):
+            await dws.write_marker_best_effort(WS_A, {"workspace_id": WS_A})
+        assert deleted_workspace_marker_key(WS_A) in store.objects
 
 
 class TestReapIsObservable:

--- a/services/tests/services/test_workspace_autodiscovery_service.py
+++ b/services/tests/services/test_workspace_autodiscovery_service.py
@@ -369,3 +369,110 @@ class TestAutodiscoverBaselineSha:
             foc.return_value = (MagicMock(), True)
             await autodiscover_for_paths(db, [rule], ["accounts/a/network/main.tf"])
         assert foc.await_args.kwargs["baseline_sha"] is None
+
+
+def _materialise_rule(**overrides):
+    """A rule with every field materialisation reads, as real values.
+
+    MagicMock defaults would let a missing assignment pass silently — the
+    Workspace would carry a mock rather than the rule's value, and nothing
+    would notice until an operator looked at the workspace.
+    """
+    r = _rule()
+    defaults = {
+        "execution_mode": "agent",
+        "execution_backend": "tofu",
+        "terraform_version": "1.12",
+        "resource_cpu": "1",
+        "resource_memory": "2Gi",
+        "auto_apply": True,
+        "auto_apply_mode": "create_update",
+        "owner_email": "platform@example.com",
+        "var_files": [],
+        "vcs_connection_id": uuid.uuid4(),
+        "repo_url": "https://example.invalid/org/repo",
+        "branch": "main",
+        "labels": {},
+        "run_task_templates": [],
+        "notification_templates": [],
+        "execution_hook_ids": [],
+        "agent_pool_id": None,
+        "terragrunt_enabled": False,
+        "terragrunt_version": "1.0",
+        "drift_detection_enabled": False,
+        "drift_detection_interval_seconds": 300,
+        "on_directory_delete": "flag",
+    }
+    for k, v in {**defaults, **overrides}.items():
+        setattr(r, k, v)
+    return r
+
+
+def _autocreate_db() -> AsyncMock:
+    """A session where neither the directory nor the name is taken, so
+    `find_or_autocreate_workspace` takes the create branch."""
+    db = AsyncMock()
+    empty = MagicMock()
+    empty.all = MagicMock(return_value=[])
+    empty.scalar_one_or_none = MagicMock(return_value=None)
+    db.execute = AsyncMock(return_value=empty)
+    db.add = MagicMock()
+    return db
+
+
+class TestMaterialisationInheritsTheRule:
+    """The read half of the autodiscovery template.
+
+    `test_auto_apply_mode_admin.py` covers the *write* half — the rule's two
+    columns staying consistent — but nothing asserted the workspace actually
+    inherits the mode when the rule materialises one. Carrying only the
+    boolean would silently turn a `create_update` rule into `always` on every
+    workspace it creates: the operator configured "apply additions and updates
+    only" and gets "apply anything", including destroys (#1297).
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_conditional_mode_is_carried_across(self):
+        from terrapod.services.workspace_autodiscovery_service import (
+            find_or_autocreate_workspace,
+        )
+
+        rule = _materialise_rule(auto_apply=True, auto_apply_mode="create_update")
+        db = _autocreate_db()
+
+        ws, created = await find_or_autocreate_workspace(db, rule, "accounts/prod/vpc")
+
+        assert created is True
+        assert ws.auto_apply_mode == "create_update"
+        assert ws.auto_apply is True
+
+    @pytest.mark.asyncio
+    async def test_a_never_rule_materialises_a_never_workspace(self):
+        from terrapod.services.workspace_autodiscovery_service import (
+            find_or_autocreate_workspace,
+        )
+
+        rule = _materialise_rule(auto_apply=False, auto_apply_mode="never")
+        db = _autocreate_db()
+
+        ws, _ = await find_or_autocreate_workspace(db, rule, "accounts/dev/vpc")
+
+        assert ws.auto_apply_mode == "never"
+        assert ws.auto_apply is False
+
+    @pytest.mark.asyncio
+    async def test_a_legacy_rule_without_the_column_defaults_to_never(self):
+        """A rule row written before the column existed reads as absent. The
+        safe reading is `never` — inventing `always` from a missing field
+        would auto-apply workspaces nobody configured to."""
+        from terrapod.services.workspace_autodiscovery_service import (
+            find_or_autocreate_workspace,
+        )
+
+        rule = _materialise_rule(auto_apply=False)
+        del rule.auto_apply_mode
+        db = _autocreate_db()
+
+        ws, _ = await find_or_autocreate_workspace(db, rule, "accounts/legacy/vpc")
+
+        assert ws.auto_apply_mode == "never"


### PR DESCRIPTION
From the v1.4.0 pre-release review. Two systemic patterns, both instances of rules AGENTS.md already states.

### Pure predicates were tested; the orchestrators that call them were not

**Conditional auto-apply.** `evaluate_conditional_auto_apply` and `_auto_apply_if_permitted` were named by *no test file* — `test_conditional_auto_apply.py` covers the decision functions exhaustively and stops there. Now covered end-to-end through the real runner protocol, in the real order (plan-result drives `complete_plan` **before** the JSON arrives):

- each mode's permitted and declined paths, and the declined *reason* a human reads — a hold with no reason is indistinguishable from a run nobody got to;
- a replacement held in every conditional mode (the case a naive "no destroys" check sails past);
- an unparseable plan JSON, and one that never arrives at all, both holding rather than applying — the upload is best-effort, so failing to arrive must mean "nobody auto-applies";
- the two guards `_auto_apply_if_permitted` was *extracted* to share: a manual lock holding an otherwise-permitted run (and the run still being applicable after the unlock, rather than discarded), and a plan gone stale between the plan and the decision being discarded;
- the narrowing in `complete_plan` — a conditional run must still be `planned` after plan-result. A regression to the old `if run.auto_apply` (True for every non-`never` mode) would auto-apply every conditional run there, before the counts that decide it exist.

**`write_marker_best_effort`** exists solely so a storage failure cannot turn a committed delete into a 500 — the operator retries, gets a 404, and believes the delete failed. Only the happy path was exercised. Now: a failing put, an unresolvable store (resolution is inside the guard on purpose), an unserialisable body, and the happy path — because swallowing everything is only correct if the normal case works.

**Workspace create/update `auto-apply-mode`** had no endpoint test at all. `test_auto_apply_mode_admin.py` opens by saying the admin write paths get their own tests "rather than riding on the single-workspace ones", and the single-workspace ones did not exist — an absence that concealed a live guard bypass (fixed under #1294). Both directions of the column pair, the legacy-boolean path, both-at-once, and an unknown mode.

### Three fixes this cycle were "a wiring line was missing", and none shipped a test for the wiring line

`SDKVersion` must be assigned from the build-stamped version or `VersionCheck` returns nil immediately and the gate is inert in every released binary (#1286/#1287/#1293).

A test that merely reads the variable after `init()` **cannot catch that**: in a source build `Version` and `SDKVersion` are both `"dev"`, so the comparison holds whether or not the assignment exists. So the assignment is now a named `wireSDKVersion()` in publish and migrate, driven from a sentinel; the provider's is driven through `New()`. Verified by deleting each assignment and watching the tests fail, then restoring.

migrate's existing `version_gate_test.go` cannot catch it either — its `withSDKVersion` helper overwrites the very variable the fix assigns, before each case.

### Other gaps

- **`deleted_workspace_markers` blob class** had no test anywhere, and its whole reason for existing is that `state/deleted/` must NOT resolve to `state` — which is `encrypted_at_rest`, and replication declines that class wholesale under app-layer encryption. Wrong ownership leaves an encrypted deployment's standby with no undelete index at all, invisible until somebody needs to restore. Pinned, along with its neighbour still resolving to `state`.
- **A test that asserted nothing.** `test_zero_retention_disables_the_category` asserted `>= 0` on an unsigned config value — true of every possible configuration, including the one that would break the feature. Replaced with the property that matters, at the layer that enforces it: a zero window must keep deleted state *forever* rather than expiring all of it, so the cycle must not reach the reaper at all. Paired with the positive case so it cannot pass because reaping is broken outright.
- **`test_runs.py::_mock_run`** never set `pool_id`, so #1231's `agent-pool-id` serialised from a MagicMock and nothing noticed — while the UI's pool link is built from exactly that `apool-` prefix. Honest defaults plus tests for the prefixed id, the no-pool null, and the multi-pool candidate set.
- **`/admin/deleted-workspaces` was absent from the e2e `ADMIN_LINKS` sweep** — the most sensitive new admin page was the one not covered. Its own "non-admin" test used an *unauthenticated* context and accepted `401`, so it would still pass if `require_admin` were downgraded to `get_current_user`. Added an authenticated non-admin test asserting `403` on list, show and restore.
- **Autodiscovery materialisation** inheriting the rule's `auto_apply_mode` — carrying only the boolean would turn a `create_update` rule into `always` on every workspace it creates, so the operator configured "additions and updates only" and gets "anything, including destroys". Plus the legacy-rule default (`never`, not `always`).
- **Restore payload negatives** for non-string names — a 422, not a crash inside the validator — and the absent-name path still using the marker.
- **The GPG gate's allow path** for a role-granted registry admin. Every existing test there used platform admin, which is step 1 of the resolver, so nothing proved an ordinary registry-admin role resolves through the empty resource the gate passes.

### Verification

`make test` — 4336 passed (was 4282). `go build ./... && go test ./...` across all six Go modules. `ruff check` + `ruff format --check` clean.

Closes #1297
