### PR TITLE
fix(1300): make GPG signing-key management delegable, and document it

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1865,13 +1865,28 @@ All provider responses (show and list) include a `permissions` object:
 
 ### GPG Keys
 
-```
-GET    /api/terrapod/v1/gpg-keys
-POST   /api/terrapod/v1/gpg-keys
-GET    /api/terrapod/v1/gpg-keys/{id}
-POST   /api/terrapod/v1/gpg-keys/{id}/revoke
-DELETE /api/terrapod/v1/gpg-keys/{id}
-```
+| Endpoint | Permission |
+|---|---|
+| `GET /api/terrapod/v1/gpg-keys` | Any authenticated caller |
+| `GET /api/terrapod/v1/gpg-keys/{id}` | Any authenticated caller |
+| `POST /api/terrapod/v1/gpg-keys` | `registry:admin` |
+| `POST /api/terrapod/v1/gpg-keys/{id}/revoke` | `registry:admin` |
+| `DELETE /api/terrapod/v1/gpg-keys/{id}` | `registry:admin` |
+
+**The read/write split is deliberate.** The reads return public key material —
+the same bytes `terraform init` receives in every provider download response —
+so gating them would protect nothing while removing the ability to check which
+keys an instance trusts. A *registration* is the opposite: it adds a trust
+anchor, and every provider version signed by that key becomes installable by
+every runner on the instance.
+
+**The writes were open before v1.4.0** (authentication alone sufficed), so a
+service token that registers keys now needs a role granting registry admin —
+see [registry-publishing.md](registry-publishing.md#1-register-the-publishers-gpg-public-key).
+Grant it with `registry_permission = "admin"` and **no** `allow_names` or
+`allow_labels`: a role scoped to part of the registry cannot register a key,
+because a key is not scoped to part of the registry. Denied requests return
+`403 Requires registry:admin capability on the GPG key store`.
 
 The **public** key registered here is the trust anchor for client-signed
 provider publishing: `PUT .../shasums.sig` is verified against it. Register

--- a/docs/registry-publishing.md
+++ b/docs/registry-publishing.md
@@ -64,6 +64,27 @@ The server verifies provider signatures against keys you register ahead
 of time. Register the **public** half of the key `terrapod-publish` will
 sign with.
 
+> **Registering a key requires registry admin — this changed in v1.4.0.**
+> Before v1.4.0 any authenticated account could register a signing key.
+> That was a hole: a key is a *trust anchor*, so anyone who could add one
+> could make a provider of their choosing installable by every runner on
+> the instance. Create, revoke and delete now require `registry:admin`;
+> reading keys is still open to any authenticated caller, because the
+> reads return public key material that `terraform init` already sees.
+>
+> **If you publish with a service token, this step now needs a token
+> whose role grants registry admin**, or it will fail with `403 Requires
+> registry:admin capability on the GPG key store` — including on the next
+> `terraform apply` of an existing `terrapod_gpg_key` resource. Grant it
+> by giving the role `registry_permission = "admin"` **without**
+> `allow_names` or `allow_labels`: a role scoped to a subset of the
+> registry deliberately cannot register a key, because a key is not
+> scoped to a subset. Platform admins are unaffected.
+>
+> The rest of publishing — uploading versions, shasums and binaries —
+> still needs only `registry:write`, so a narrow publishing token remains
+> the right thing for CI. Registering the key is a one-off setup step.
+
 Declaratively (recommended), in your platform-config repo:
 
 ```hcl

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -439,6 +439,17 @@ Publish, version, and share Terraform providers internally with GPG signing.
 
 ### GPG Key Management
 
+**Permissions (changed in v1.4.0):** registering, revoking and deleting a
+signing key require `registry:admin`; listing and showing keys are open to any
+authenticated caller. The split is deliberate — the reads return public key
+material `terraform init` already receives, while a registration adds a *trust
+anchor* that makes every provider signed by that key installable instance-wide.
+
+A role grants it via `registry_permission = "admin"` with no `allow_names` or
+`allow_labels`: a role scoped to part of the registry cannot register a key,
+because a key is not scoped to part of the registry. See
+[registry-publishing.md](registry-publishing.md#1-register-the-publishers-gpg-public-key).
+
 Before publishing providers, register a GPG key for signature verification:
 
 ```zsh

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -16,6 +16,19 @@ for every public surface below.
 | **MINOR** (`0.58.0 → 0.59.0`) | New, **backward-compatible** features. Existing routes, response attributes, wire protocol, SDK methods, Helm values, and config keys keep working unchanged. Additive only. Safe to take without config changes. |
 | **MAJOR** (`0.x → 1.0`, `1.x → 2.0`) | The only release that may contain a **breaking change** to a stable surface — and only after the deprecation window below. Read the migration notes before upgrading. |
 
+> **The one exception: closing a security hole.** A MINOR may *tighten* a
+> permission on a surface that was wrongly open, because leaving it open is
+> itself the harm and a deprecation window would mean shipping a known hole for
+> two more minors. This is narrow — it covers removing access that should never
+> have been granted, never removing a route, an attribute, or a config key. It
+> has been used once, in **v1.4.0**, when GPG signing-key registration went from
+> "any authenticated caller" to requiring `registry:admin`; an unprivileged
+> account could otherwise add a trust anchor for the whole provider registry.
+> When it is used, the release notes say so plainly and the affected doc pages
+> carry the migration step, so an operator meets it before their next apply
+> fails rather than after — see
+> [registry-publishing.md](registry-publishing.md#1-register-the-publishers-gpg-public-key).
+
 > **Stability note.** As of **`1.0.0`**, the MAJOR/MINOR/PATCH contract below is
 > absolute and enforced in CI: no stable surface is removed, renamed, or retyped
 > outside a MAJOR release that has completed the deprecation window. (Before

--- a/provider/internal/resources/gpg_key/resource.go
+++ b/provider/internal/resources/gpg_key/resource.go
@@ -48,7 +48,7 @@ func (r *gpgKeyResource) Metadata(_ context.Context, req resource.MetadataReques
 
 func (r *gpgKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages a GPG key for provider signing in the Terrapod registry.",
+		Description: "Manages a GPG key for provider signing in the Terrapod registry. Requires registry admin as of Terrapod v1.4.0 — before that, authentication alone sufficed. A key is a trust anchor: every provider signed by it becomes installable instance-wide, so an existing resource managed by a service token whose role lacks registry admin will start failing on its next apply. Grant it with registry_permission = \"admin\" and no allow_names or allow_labels — a role scoped to part of the registry deliberately cannot register a key.",
 		Attributes: map[string]schema.Attribute{
 			"id":          schema.StringAttribute{Computed: true, Description: "GPG key ID.", PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 			"ascii_armor": schema.StringAttribute{Required: true, Sensitive: true, Description: "ASCII-armored PGP public key (write-only).", PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},

--- a/services/terrapod/api/routers/gpg_keys.py
+++ b/services/terrapod/api/routers/gpg_keys.py
@@ -8,12 +8,23 @@ admin endpoint. They're Terrapod-native management surface and live at
 The historical TFE-shaped path was `/api/registry/private/v2/gpg-keys`;
 it was removed in v0.24.0 (see #278) and is no longer routable.
 
-Endpoints (canonical):
-    POST   /api/terrapod/v1/gpg-keys                  — create
-    GET    /api/terrapod/v1/gpg-keys                   — list
-    GET    /api/terrapod/v1/gpg-keys/{key_id}          — show
-    POST   /api/terrapod/v1/gpg-keys/{key_id}/revoke   — revoke (#640)
-    DELETE /api/terrapod/v1/gpg-keys/{key_id}          — delete
+Endpoints (canonical), with the permission each requires:
+    POST   /api/terrapod/v1/gpg-keys                  — create  · registry:admin
+    GET    /api/terrapod/v1/gpg-keys                   — list    · any authenticated
+    GET    /api/terrapod/v1/gpg-keys/{key_id}          — show    · any authenticated
+    POST   /api/terrapod/v1/gpg-keys/{key_id}/revoke   — revoke  · registry:admin (#640)
+    DELETE /api/terrapod/v1/gpg-keys/{key_id}          — delete  · registry:admin
+
+**Reads are open, writes are not, and the asymmetry is deliberate** (#1300).
+The reads return public key material — the same bytes `terraform init` already
+receives in every provider download response — so gating them would protect
+nothing while breaking the ability to check which keys an instance trusts.
+
+Registering one is the opposite: a signing key is a *trust anchor*. Every
+provider version signed by it becomes installable by every runner on the
+instance, so create / revoke / delete require `registry:admin`. Before v1.4.0
+authentication alone sufficed, which let any account add a trust anchor; see
+`docs/registry-publishing.md` for what publishers need to do about it.
 """
 
 import uuid
@@ -134,8 +145,18 @@ async def _require_gpg_key_capability(
     user: AuthenticatedUser,
     required_cap: str,
 ) -> None:
-    """Check the required registry capability on the GPG key store or raise 403."""
-    caps = await resolve_registry_capabilities_for(db, user, "", {}, "")
+    """Check the required registry capability on the GPG key store or raise 403.
+
+    `unscoped=True` because the key store is the registry itself rather than a
+    thing inside it. Without it the ordinary allow rules cannot match an empty
+    name and empty labels, so *only platform admin* ever resolved the
+    capability — a role explicitly granted `registry_permission: admin` was
+    locked out and `registry:admin` here named something undelegable (#1300).
+    An unscoped registry-admin role now resolves; a label- or name-scoped one
+    still does not, because a signing key is a trust anchor for the whole
+    registry and not for that role's slice of it.
+    """
+    caps = await resolve_registry_capabilities_for(db, user, "", {}, "", unscoped=True)
     if not has_capability(caps, required_cap):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/services/terrapod/services/capability_resolver.py
+++ b/services/terrapod/services/capability_resolver.py
@@ -39,8 +39,32 @@ def role_effective_capabilities(role: Role) -> frozenset[str]:
     return frozenset(cap.normalize_capabilities(role.capabilities))
 
 
-def _role_matches(role: Role, resource_name: str, resource_labels: dict) -> bool:
-    """Deny-then-allow label/name match (the shared per-role gate)."""
+def _role_matches(
+    role: Role, resource_name: str, resource_labels: dict, *, unscoped: bool = False
+) -> bool:
+    """Deny-then-allow label/name match (the shared per-role gate).
+
+    `unscoped` is for a resource that is the axis ITSELF rather than a thing
+    within it — the GPG signing-key store is the only one today (#1300). Such a
+    resource has no name, no labels and no owner, so the ordinary allow rules
+    can never match it: `allow_names` has nothing to compare against and
+    `matches_labels` requires the key to be present on the resource. Without
+    this flag the capability is reachable only by platform admin, whatever a
+    role was granted — which makes the `registry:admin` name a lie.
+
+    A role matches an unscoped resource only when it is itself unscoped: no
+    `allow_names` and no `allow_labels`. That distinction is the point. A role
+    granted authority over *some* providers must not be able to register a
+    signing key, because a key is a trust anchor for the whole registry — every
+    provider signed by it becomes installable, including ones outside that
+    role's scope. A role granted registry admin over everything already has
+    that reach, so letting it manage keys widens nothing.
+
+    Deny rules are inert here for the same reason allow rules are — there is no
+    name or label to match — so an unscoped role cannot be excluded by them.
+    That is why the unscoped grant is deliberately narrow: it is all-or-nothing
+    by construction.
+    """
     deny_labels: dict[str, set[str]] = {}
     merge_labels(deny_labels, role.deny_labels)
     if resource_name in set(role.deny_names):
@@ -52,7 +76,9 @@ def _role_matches(role: Role, resource_name: str, resource_labels: dict) -> bool
     merge_labels(allow_labels, role.allow_labels)
     if resource_name in set(role.allow_names):
         return True
-    return matches_labels(resource_labels, allow_labels)
+    if matches_labels(resource_labels, allow_labels):
+        return True
+    return unscoped and not role.allow_names and not allow_labels
 
 
 async def resolve_capabilities(
@@ -68,6 +94,7 @@ async def resolve_capabilities(
     apply_everyone_floor: bool = True,
     auth_method: str = "",
     is_catalog_managed: bool = False,
+    unscoped: bool = False,
 ) -> frozenset[str]:
     """The capability set a principal holds on a resource, for one axis.
 
@@ -110,7 +137,7 @@ async def resolve_capabilities(
             result = await db.execute(select(Role).where(Role.name.in_(custom_role_names)))
             roles = list(result.scalars().all())
         for role in roles:
-            if _role_matches(role, resource_name, resource_labels):
+            if _role_matches(role, resource_name, resource_labels, unscoped=unscoped):
                 caps |= role_effective_capabilities(role) & all_caps
 
     # 6. everyone-floor: read on resources labelled access=everyone. Catalog has
@@ -136,6 +163,7 @@ async def resolve_capabilities_for(
     preloaded_roles: list[Role] | None = None,
     token_preloaded_roles: list[Role] | None = None,
     is_catalog_managed: bool = False,
+    unscoped: bool = False,
 ) -> frozenset[str]:
     """Kind-aware capability set (#495): interactive → user roles;
     service_bound → user ∩ token; service_detached → token only (no owner
@@ -154,6 +182,7 @@ async def resolve_capabilities_for(
             apply_everyone_floor=False,
             auth_method="",
             is_catalog_managed=is_catalog_managed,
+            unscoped=unscoped,
         )
 
     user_caps = await resolve_capabilities(
@@ -167,6 +196,7 @@ async def resolve_capabilities_for(
         preloaded_roles=preloaded_roles,
         auth_method=auth_method,
         is_catalog_managed=is_catalog_managed,
+        unscoped=unscoped,
     )
     if user.kind == "service_bound":
         token_caps = await resolve_capabilities(
@@ -181,6 +211,7 @@ async def resolve_capabilities_for(
             apply_everyone_floor=False,
             auth_method="",
             is_catalog_managed=is_catalog_managed,
+            unscoped=unscoped,
         )
         return user_caps & token_caps
     return user_caps

--- a/services/terrapod/services/registry_rbac_service.py
+++ b/services/terrapod/services/registry_rbac_service.py
@@ -45,11 +45,17 @@ async def resolve_registry_capabilities_for(
     *,
     preloaded_roles: list[Role] | None = None,
     token_preloaded_roles: list[Role] | None = None,
+    unscoped: bool = False,
 ) -> frozenset[str]:
     """Capability set a principal holds on a registry resource (#585).
 
     Registry-typed wrapper over ``capability_resolver`` (axis="registry"; the
-    runner-token read floor is applied inside via ``user.auth_method``)."""
+    runner-token read floor is applied inside via ``user.auth_method``).
+
+    ``unscoped`` is for the registry-wide GPG signing-key store, which has no
+    name, labels or owner of its own — see ``_role_matches`` (#1300). Leave it
+    False for every resource that is a *thing in* the registry.
+    """
     from terrapod.services.capability_resolver import resolve_capabilities_for
 
     return await resolve_capabilities_for(
@@ -61,4 +67,5 @@ async def resolve_registry_capabilities_for(
         axis="registry",
         preloaded_roles=preloaded_roles,
         token_preloaded_roles=token_preloaded_roles,
+        unscoped=unscoped,
     )

--- a/services/tests/services/test_unscoped_capability.py
+++ b/services/tests/services/test_unscoped_capability.py
@@ -1,0 +1,151 @@
+"""Unscoped resources — the GPG signing-key store (#1300).
+
+Most resources are things *in* an axis: a workspace, a provider, a pool. They
+have a name, labels and an owner, and role scoping is expressed against those.
+
+The GPG key store is the axis itself. It has none of them, so the gate resolves
+against an empty name / labels / owner — and the ordinary allow rules can never
+match that: `allow_names` has nothing to compare against, and `matches_labels`
+requires the key to be present on the resource. The consequence was that
+`registry:admin` on the GPG endpoints was reachable only by platform admin,
+whatever a role had been granted, which made the capability's name a lie.
+
+The rule these pin: a role matches an unscoped resource only when it is itself
+unscoped. That is not a technicality — a role granted authority over *some*
+providers must not be able to register a signing key, because a key is a trust
+anchor for the whole registry and every provider signed by it becomes
+installable, including ones outside that role's scope.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from terrapod.auth import capabilities as cap
+from terrapod.services.capability_resolver import resolve_capabilities
+
+pytestmark = pytest.mark.asyncio
+
+
+def _role(name, *, allow_names=None, allow_labels=None, level="admin"):
+    r = MagicMock()
+    r.name = name
+    r.allow_names = allow_names or []
+    r.deny_names = []
+    r.allow_labels = allow_labels or {}
+    r.deny_labels = {}
+    r.capabilities = sorted(
+        cap.expand_preset(
+            workspace_permission=None,
+            pool_permission=None,
+            registry_permission=level,
+            catalog_permission=None,
+        )
+    )
+    return r
+
+
+async def _registry_caps(roles, *, unscoped):
+    """Resolve against the empty resource the GPG gate actually passes."""
+    return await resolve_capabilities(
+        AsyncMock(),
+        "publisher@example.com",
+        [r.name for r in roles],
+        "",
+        {},
+        "",
+        axis="registry",
+        preloaded_roles=roles,
+        unscoped=unscoped,
+    )
+
+
+class TestUnscopedRolesReachTheStore:
+    async def test_an_unscoped_registry_admin_role_resolves(self):
+        caps = await _registry_caps([_role("registry-owner")], unscoped=True)
+        assert cap.REGISTRY_ADMIN in caps
+
+    async def test_the_same_role_does_not_reach_a_named_resource_it_was_not_granted(self):
+        """Sanity: `unscoped` is about the store, not a blanket widening. The
+        empty-resource call is the only one that gets this treatment."""
+        caps = await resolve_capabilities(
+            AsyncMock(),
+            "publisher@example.com",
+            ["scoped"],
+            "some-provider",
+            {"team": "y"},
+            "",
+            axis="registry",
+            preloaded_roles=[_role("scoped", allow_labels={"team": ["x"]})],
+            unscoped=True,
+        )
+        assert cap.REGISTRY_ADMIN not in caps
+
+    async def test_an_unscoped_write_role_gets_write_not_admin(self):
+        """The unscoped match decides *whether* a role applies, never *what* it
+        grants — that still comes from the role's own capabilities."""
+        caps = await _registry_caps([_role("publisher", level="write")], unscoped=True)
+        assert cap.REGISTRY_WRITE in caps
+        assert cap.REGISTRY_ADMIN not in caps
+
+
+class TestScopedRolesDoNot:
+    @pytest.mark.parametrize(
+        ("desc", "role"),
+        [
+            ("label-scoped", _role("team-x", allow_labels={"team": ["x"]})),
+            ("name-scoped", _role("aws-only", allow_names=["aws"])),
+            ("both", _role("narrow", allow_names=["aws"], allow_labels={"team": ["x"]})),
+        ],
+    )
+    async def test_a_scoped_registry_admin_cannot_register_a_trust_anchor(self, desc, role):
+        caps = await _registry_caps([role], unscoped=True)
+        assert cap.REGISTRY_ADMIN not in caps, (
+            f"a {desc} role was granted authority over a subset of the registry; "
+            "a signing key is a trust anchor for all of it"
+        )
+
+    async def test_platform_admin_still_reaches_it(self):
+        caps = await resolve_capabilities(
+            AsyncMock(),
+            "admin@example.com",
+            ["admin"],
+            "",
+            {},
+            "",
+            axis="registry",
+            preloaded_roles=[],
+            unscoped=True,
+        )
+        assert cap.REGISTRY_ADMIN in caps
+
+
+class TestScopedResolutionIsUnchanged:
+    """`unscoped` defaults to False everywhere else, so no other gate moves.
+    Without this the flag would be a silent widening of every axis."""
+
+    async def test_an_unscoped_role_does_not_match_an_empty_resource_by_default(self):
+        caps = await _registry_caps([_role("registry-owner")], unscoped=False)
+        assert caps == frozenset()
+
+    @pytest.mark.parametrize("axis", ["workspace", "pool", "catalog"])
+    async def test_other_axes_are_untouched_by_the_default(self, axis):
+        role = MagicMock()
+        role.name = "broad"
+        role.allow_names = []
+        role.deny_names = []
+        role.allow_labels = {}
+        role.deny_labels = {}
+        role.capabilities = sorted(cap.axis_all_caps(axis))
+
+        caps = await resolve_capabilities(
+            AsyncMock(),
+            "u@example.com",
+            ["broad"],
+            "",
+            {},
+            "",
+            axis=axis,
+            preloaded_roles=[role],
+        )
+        assert caps == frozenset()


### PR DESCRIPTION
From the v1.4.0 pre-release review. The authz fix itself was right; its consequences were unstated — and one of them turned out to be worse than "unstated".

### The capability was undelegable

The GPG gate resolves against an empty resource name, empty labels and no owner, because the signing-key store is *the registry itself* rather than a thing inside it. The ordinary allow rules cannot match that: `allow_names` has nothing to compare against and `matches_labels` requires the key to be present on the resource.

So **only platform admin ever resolved `registry:admin` there.** A role explicitly granted `registry_permission = "admin"` was locked out, and the capability's name did not describe what it did.

I verified this against the real resolver before changing anything — an unscoped registry-admin role, a label-scoped one and a name-scoped one all resolved to no capability; only platform admin got through. (The test I added under #1297 mocked the resolver, so it proved the *router* honours the capability, not that any role can *obtain* it. That distinction is the whole finding.)

`_role_matches` now takes an `unscoped` flag, passed only by the GPG gate. **A role matches an unscoped resource when it is itself unscoped** — no `allow_names`, no `allow_labels`. That line is the point: a role granted authority over *some* providers must not be able to register a signing key, because a key is a trust anchor for the whole registry and every provider signed by it becomes installable, including ones outside that role's scope. A role granted registry admin over everything already has that reach, so this widens nothing. The flag defaults to `False` everywhere else, so no other gate moves — pinned by a test per axis.

### Documented the new prerequisite where a publisher will meet it

- **`registry-publishing.md` step 1** — the step that now 403s, with the grant that fixes it and the note that an existing `terrapod_gpg_key` under a service token will fail on its *next apply*.
- **`registry.md`** GPG section.
- **The `terrapod_gpg_key` resource description** — what an operator actually reads when their apply fails.
- **`api-reference.md`** — listed all five endpoints with no permission line at all; now a table.

### Documented the read/write asymmetry

Deliberate, and nowhere stated. Reads stay open because they return public key material `terraform init` already receives in every provider download response — gating them would protect nothing while removing the ability to check which keys an instance trusts. A registration is the opposite: it adds a trust anchor.

### Recorded the versioning decision

The issue asked for this to be a conscious call rather than an implicit one. `versioning-and-support.md` now carries the one exception to the MINOR contract:

> A MINOR may **tighten** a permission on a surface that was wrongly open, because leaving it open is itself the harm and a deprecation window would mean shipping a known hole for two more minors.

Narrow by construction — it covers removing access that should never have been granted, never removing a route, an attribute, or a config key. Used once, here; the release notes will say so.

### Verification

`make test` services + api tiers — 3282 passed, including 11 new tests pinning both directions of the unscoped rule and the no-movement-elsewhere property. `ruff check` + `format --check` clean. `go build ./...` + provider schema contract green.

Closes #1300
