### PR TITLE
fix(1301): consumer-surface polish from the v1.4.0 review

### DIFF
--- a/go-terrapod/deleted_workspaces.go
+++ b/go-terrapod/deleted_workspaces.go
@@ -141,9 +141,15 @@ func (c *Client) ListDeletedWorkspaces(ctx context.Context, opts DeletedWorkspac
 		out.Items = append(out.Items, d.Attributes)
 	}
 	meta, err := parseListMeta(body)
-	if err == nil {
-		out.Meta = meta
+	if err != nil {
+		// Not swallowed (#1301). With meta discarded, TotalPages stays 0 and
+		// ListAllDeletedWorkspaces below stops after page one — returning a
+		// truncated list as a SUCCESS. For this feature that fails in the
+		// worst direction: "there is nothing else to restore" is exactly the
+		// answer an operator must not be given wrongly.
+		return nil, fmt.Errorf("decode deleted workspaces pagination: %w", err)
 	}
+	out.Meta = meta
 	return out, nil
 }
 

--- a/go-terrapod/deleted_workspaces_test.go
+++ b/go-terrapod/deleted_workspaces_test.go
@@ -204,3 +204,24 @@ func TestGetDeletedWorkspaceNotFound(t *testing.T) {
 		t.Errorf("want a NotFoundError, got %T: %v", err, err)
 	}
 }
+
+func TestListDeletedWorkspacesRejectsUnparseableMeta(t *testing.T) {
+	// Silently discarded, TotalPages stayed 0 and ListAllDeletedWorkspaces
+	// stopped after page one — returning a TRUNCATED list as a success. For
+	// undelete that fails in the worst direction: "there is nothing else to
+	// restore" is exactly the answer an operator must not be given wrongly
+	// (#1301).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":[],"meta":{"pagination":"not-an-object"}}`))
+	}))
+	defer srv.Close()
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if _, err := c.ListDeletedWorkspaces(context.Background(), DeletedWorkspaceListOptions{}); err == nil {
+		t.Fatal("want an error for unparseable pagination, got nil — a truncated list would be reported as success")
+	}
+}

--- a/mcp/internal/mcpserver/act.go
+++ b/mcp/internal/mcpserver/act.go
@@ -32,7 +32,7 @@ func registerAct(s *mcp.Server, c *terrapod.Client) {
 		PlanOnly  *bool  `json:"plan_only,omitempty" jsonschema:"plan only, no apply (default true — the safe choice)"`
 		IsDestroy bool   `json:"is_destroy,omitempty" jsonschema:"plan a destroy (tear-down) run"`
 		Message   string `json:"message,omitempty" jsonschema:"an optional human message describing why"`
-		AutoApply *bool  `json:"auto_apply,omitempty" jsonschema:"auto-apply on success (default: the workspace setting)"`
+		AutoApply *bool  `json:"auto_apply,omitempty" jsonschema:"auto-apply on success. Omit to use the workspace setting. Passing true does NOT mean 'use the workspace setting' — on a workspace configured with a conditional mode (create / create_update) an explicit true maps the run to 'always', applying it past a guardrail the operator set, including a plan containing destroys. Only pass it when you intend that for this one run."`
 		Refresh   *bool  `json:"refresh,omitempty" jsonschema:"refresh state before planning (default true)"`
 	}
 	mcp.AddTool(s, &mcp.Tool{

--- a/mcp/internal/mcpserver/observe.go
+++ b/mcp/internal/mcpserver/observe.go
@@ -111,6 +111,13 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 		// Which agent pool actually ran it (#1231) — on a multi-pool
 		// workspace this is the only place the answer is visible.
 		AgentPoolID string `json:"agent_pool_id,omitempty"`
+		// Conditional auto-apply (#1274/#1301). A run held back by its mode
+		// sits at `planned` looking exactly like one awaiting a human — the
+		// reason is the only thing that distinguishes them, and held runs are
+		// the interesting case when listing. Without these an agent has to
+		// fetch every run individually to find out which need attention.
+		AutoApplyMode           string `json:"auto_apply_mode,omitempty"`
+		AutoApplyDeclinedReason string `json:"auto_apply_declined_reason,omitempty"`
 	}
 	type runListOut struct {
 		Count int          `json:"count"`
@@ -118,7 +125,7 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "terrapod_run_list",
-		Description: "List recent runs for a workspace (newest first) with status, whether each is plan-only/destroy, and whether the plan had changes.",
+		Description: "List recent runs for a workspace (newest first) with status, whether each is plan-only/destroy, whether the plan had changes, and — for conditional auto-apply — the run's mode and why it was held. A run showing auto_apply_declined_reason reached `planned` and stopped because its plan contained something its mode does not auto-apply (a destroy or replace, or an in-place update under `create`); it is waiting for a human to confirm or discard.",
 		Annotations: readOnly,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runListIn) (*mcp.CallToolResult, runListOut, error) {
 		if in.WorkspaceID == "" {
@@ -138,7 +145,9 @@ func registerObserve(s *mcp.Server, c *terrapod.Client) {
 			out.Runs = append(out.Runs, runSummary{
 				ID: r.ID, Status: r.Status, PlanOnly: r.PlanOnly, IsDestroy: r.IsDestroy,
 				HasChanges: r.HasChanges, Source: r.Source, CreatedAt: r.CreatedAt,
-				AgentPoolID: r.AgentPoolID,
+				AgentPoolID:             r.AgentPoolID,
+				AutoApplyMode:           r.AutoApplyMode,
+				AutoApplyDeclinedReason: r.AutoApplyDeclinedReason,
 			})
 		}
 		return nil, out, nil

--- a/mcp/internal/mcpserver/tool_catalogue.json
+++ b/mcp/internal/mcpserver/tool_catalogue.json
@@ -272,7 +272,7 @@
       "additionalProperties": false,
       "properties": {
         "auto_apply": {
-          "description": "auto-apply on success (default: the workspace setting)",
+          "description": "auto-apply on success. Omit to use the workspace setting. Passing true does NOT mean 'use the workspace setting' — on a workspace configured with a conditional mode (create / create_update) an explicit true maps the run to 'always', applying it past a guardrail the operator set, including a plan containing destroys. Only pass it when you intend that for this one run.",
           "type": [
             "null",
             "boolean"

--- a/services/terrapod/api/routers/workspace_bulk.py
+++ b/services/terrapod/api/routers/workspace_bulk.py
@@ -278,6 +278,61 @@ def _validate_auto_apply(update: dict[str, Any], fields: dict[str, Any]) -> dict
     return {}
 
 
+def _validate_update_fields_for_test(update: dict) -> dict[str, Any]:
+    """The field-validation half of `_validate_update`, without the DB.
+
+    `_validate_update` is async and resolves agent pools against the database,
+    which is irrelevant to the scalar field rules — so tests drive this rather
+    than re-implementing the loop and drifting from it.
+    """
+    fields: dict[str, Any] = {}
+    for key, attr in _FIELD_MAP.items():
+        if key not in update:
+            continue
+        val = update[key]
+        if key == "auto-apply" and not isinstance(val, bool):
+            raise HTTPException(
+                status_code=422,
+                detail="auto-apply must be true or false, not a string or number",
+            )
+        fields[attr] = val
+    fields.update(_validate_auto_apply(update, fields))
+    return fields
+
+
+def _reject_auto_apply_on_apply_then_merge(fields: dict[str, Any], workspaces: list) -> None:
+    """Refuse to switch auto-apply on for an `apply_then_merge` workspace.
+
+    The single-workspace PATCH has always refused this pair: under
+    `apply_then_merge` the apply runs BEFORE the PR merges, so auto-applying
+    would apply infrastructure changes from a branch nobody has approved —
+    which is the whole thing that workflow exists to prevent. Bulk-update had
+    no such check at all, so the one path that can hit a hundred workspaces at
+    once was the one that could set it (#1301).
+
+    It cannot be checked in `_validate_update`, which validates the homogeneous
+    payload once with no workspace in hand — so it runs against the matched set
+    instead, before any mutation, and names the offenders. All-or-nothing,
+    matching the endpoint's own contract: a partial application here would be
+    worse than a refusal.
+    """
+    if not fields.get("auto_apply"):
+        return
+    offenders = [w.name for w in workspaces if getattr(w, "vcs_workflow", "") == "apply_then_merge"]
+    if not offenders:
+        return
+    shown = ", ".join(sorted(offenders)[:10])
+    more = f" (and {len(offenders) - 10} more)" if len(offenders) > 10 else ""
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            "auto-apply is incompatible with the 'apply_then_merge' VCS workflow, and "
+            f"{len(offenders)} matched workspace(s) use it: {shown}{more}. "
+            "Narrow the filter, or change those workspaces' workflow first."
+        ),
+    )
+
+
 async def _validate_update(
     update: dict, db: AsyncSession, user: AuthenticatedUser
 ) -> dict[str, Any]:
@@ -304,7 +359,17 @@ async def _validate_update(
         if key == "labels":
             val = validate_labels(val)  # reserved-key chokepoint (#316) → 422
         if key == "auto-apply":
-            val = bool(val)
+            # Type-check rather than coerce (#1301). `bool("false")` is True,
+            # so a JSON string sailed through as an enable AND — since the
+            # pairing landed — wrote the string itself into a Boolean column
+            # while `auto_apply_mode` was set to "always". A caller who typed
+            # the value wrong gets told, instead of getting the opposite of
+            # what they asked for.
+            if not isinstance(val, bool):
+                raise HTTPException(
+                    status_code=422,
+                    detail="auto-apply must be true or false, not a string or number",
+                )
         if key == "var-files":
             if not isinstance(val, list):
                 raise HTTPException(status_code=422, detail="var-files must be a list")
@@ -470,6 +535,7 @@ async def bulk_update_workspaces(
     plan = await _validate_update(body.get("update", {}), db, user)
 
     workspaces = list((await db.execute(query)).scalars().all())
+    _reject_auto_apply_on_apply_then_merge(plan["fields"], workspaces)
 
     try:
         changed, unchanged = await _apply(db, workspaces, plan, user.email)

--- a/services/terrapod/services/catalog_service.py
+++ b/services/terrapod/services/catalog_service.py
@@ -544,7 +544,16 @@ async def provision_instance(
     ws = Workspace(
         name=name,
         execution_mode="agent",
+        # Both columns, always (#1301). `auto_apply_mode` carries the intent
+        # and `auto_apply` is its boolean projection; the model comment asserts
+        # they cannot disagree, and every other write path pairs them. Setting
+        # only the boolean left catalog rows persistently inconsistent — benign
+        # today because `resolve_auto_apply_mode` composes asymmetrically and
+        # errs towards less automation either way, but a trap for anyone who
+        # later reads the column directly. The catalog offers no conditional
+        # modes, so the pair is always one of the two flat ones.
         auto_apply=auto_apply,
+        auto_apply_mode="always" if auto_apply else "never",
         execution_backend=settings.default_execution_backend,
         terraform_version=settings.default_terraform_version,
         labels=labels or {},
@@ -606,7 +615,9 @@ async def reconfigure_instance(
         raise CatalogError("Catalog item no longer exists", status_code=409)
 
     ws.catalog_version_pin = version_pin
+    # Both columns, always — see the construction above (#1301).
     ws.auto_apply = auto_apply
+    ws.auto_apply_mode = "always" if auto_apply else "never"
     # catalog_input_values (non-sensitive only) is refreshed inside _materialise.
 
     run = await _materialise(

--- a/services/tests/api/test_auto_apply_mode_admin.py
+++ b/services/tests/api/test_auto_apply_mode_admin.py
@@ -7,6 +7,8 @@ failure the mode's whole skew story is built to prevent — so they get their
 own tests rather than riding on the single-workspace ones.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 from fastapi import HTTPException
 
@@ -76,3 +78,102 @@ class TestAutodiscoveryRuleTemplate:
     def test_absent_touches_nothing(self):
         out = _coerce_attrs({"name-prefix": "svc-"}, on_create=False)
         assert "auto_apply" not in out and "auto_apply_mode" not in out
+
+
+class TestBulkUpdateTypeChecksTheBoolean:
+    """`bool("false")` is True (#1301).
+
+    A JSON string sailed through as an *enable* — and once the columns were
+    paired, wrote the string itself into a Boolean column while setting
+    `auto_apply_mode` to "always". A caller who typed the value wrong got the
+    opposite of what they asked for, on every matched workspace at once.
+    """
+
+    @pytest.mark.parametrize("bad", ["false", "true", 0, 1, "", None, []])
+    def test_a_non_boolean_is_refused(self, bad):
+        from terrapod.api.routers.workspace_bulk import _validate_update_fields_for_test
+
+        with pytest.raises(HTTPException) as e:
+            _validate_update_fields_for_test({"auto-apply": bad})
+        assert e.value.status_code == 422
+        assert "true or false" in str(e.value.detail)
+
+    @pytest.mark.parametrize(("val", "mode"), [(True, "always"), (False, "never")])
+    def test_real_booleans_still_work(self, val, mode):
+        from terrapod.api.routers.workspace_bulk import _validate_update_fields_for_test
+
+        got = _validate_update_fields_for_test({"auto-apply": val})
+        assert got["auto_apply"] is val
+        assert got["auto_apply_mode"] == mode
+
+
+class TestBulkUpdateApplyThenMergeCrossCheck:
+    """The single-workspace PATCH has always refused auto-apply on an
+    `apply_then_merge` workspace — under that workflow the apply runs BEFORE
+    the PR merges, so auto-applying would apply changes from a branch nobody
+    approved. Bulk-update had no such check, so the one path that can hit a
+    hundred workspaces at once was the one that could set it (#1301)."""
+
+    @staticmethod
+    def _ws(name, workflow):
+        w = MagicMock()
+        w.name = name
+        w.vcs_workflow = workflow
+        return w
+
+    def test_enabling_auto_apply_over_an_apply_then_merge_workspace_is_refused(self):
+        from terrapod.api.routers.workspace_bulk import (
+            _reject_auto_apply_on_apply_then_merge,
+        )
+
+        with pytest.raises(HTTPException) as e:
+            _reject_auto_apply_on_apply_then_merge(
+                {"auto_apply": True},
+                [self._ws("safe", "merge_then_apply"), self._ws("risky", "apply_then_merge")],
+            )
+        assert e.value.status_code == 422
+        # Names the offender — the operator has to know which to exclude.
+        assert "risky" in str(e.value.detail)
+        assert "safe" not in str(e.value.detail)
+
+    def test_disabling_auto_apply_is_always_allowed(self):
+        """Turning it OFF is the safe direction and must never be blocked."""
+        from terrapod.api.routers.workspace_bulk import (
+            _reject_auto_apply_on_apply_then_merge,
+        )
+
+        _reject_auto_apply_on_apply_then_merge(
+            {"auto_apply": False}, [self._ws("risky", "apply_then_merge")]
+        )
+
+    def test_an_update_that_does_not_touch_auto_apply_is_allowed(self):
+        from terrapod.api.routers.workspace_bulk import (
+            _reject_auto_apply_on_apply_then_merge,
+        )
+
+        _reject_auto_apply_on_apply_then_merge(
+            {"terraform_version": "1.12"}, [self._ws("risky", "apply_then_merge")]
+        )
+
+    def test_no_offenders_means_no_refusal(self):
+        from terrapod.api.routers.workspace_bulk import (
+            _reject_auto_apply_on_apply_then_merge,
+        )
+
+        _reject_auto_apply_on_apply_then_merge(
+            {"auto_apply": True}, [self._ws("a", "merge_then_apply"), self._ws("b", "")]
+        )
+
+    def test_a_long_offender_list_is_truncated_but_counted(self):
+        """A filter matching hundreds must not produce an unreadable error —
+        but the count has to be honest."""
+        from terrapod.api.routers.workspace_bulk import (
+            _reject_auto_apply_on_apply_then_merge,
+        )
+
+        many = [self._ws(f"ws-{i:03d}", "apply_then_merge") for i in range(25)]
+        with pytest.raises(HTTPException) as e:
+            _reject_auto_apply_on_apply_then_merge({"auto_apply": True}, many)
+        detail = str(e.value.detail)
+        assert "25 matched workspace(s)" in detail
+        assert "and 15 more" in detail

--- a/services/tests/services/test_conditional_auto_apply.py
+++ b/services/tests/services/test_conditional_auto_apply.py
@@ -291,3 +291,37 @@ class TestAutoApplyGuardsAreSharedByBothEntryPoints:
             await run_service._auto_apply_if_permitted(db, run)
         discard.assert_awaited_once()
         transition.assert_not_awaited(), "a stale plan must never be applied"
+
+
+class TestCatalogWritesBothColumns:
+    """The model comment asserts the pair cannot disagree, and every other
+    write path honours it — `catalog_service` set only the boolean, on both
+    provision and reconfigure (#1301). Harmless today because
+    `resolve_auto_apply_mode` composes asymmetrically and errs towards less
+    automation either way, but it left catalog rows persistently inconsistent
+    and is a trap for anyone who later reads the column directly.
+    """
+
+    def test_the_service_never_writes_one_column_alone(self):
+        """Source-level, because the two sites are a constructor kwarg and a
+        plain attribute assignment — no single function to call. This is the
+        introspection tier the contract calls for when the invariant is 'X must
+        never happen'."""
+        import inspect
+
+        from terrapod.services import catalog_service
+
+        src = inspect.getsource(catalog_service)
+        assert src.count("auto_apply_mode") >= 2, (
+            "catalog_service must set auto_apply_mode wherever it sets auto_apply — "
+            "both the Workspace construction and the reconfigure assignment"
+        )
+
+    @pytest.mark.parametrize(("auto_apply", "expected"), [(True, "always"), (False, "never")])
+    def test_the_pair_the_catalog_writes_round_trips(self, auto_apply, expected):
+        """Whatever the catalog writes must resolve back to the same intent —
+        the catalog offers no conditional modes, so the pair is always one of
+        the two flat ones."""
+        mode = "always" if auto_apply else "never"
+        obj = SimpleNamespace(auto_apply=auto_apply, auto_apply_mode=mode)
+        assert resolve_auto_apply_mode(obj) == expected

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -67,6 +67,7 @@
       "agentPool": "مجموعة الوكلاء",
       "none": "لا شيء",
       "autoApply": "التطبيق التلقائي",
+      "autoApplyModeHint": "never: انتظر إنسانًا دائمًا. always: طبّق كل خطة ناجحة. create / create/update: طبّق فقط الخطط المقتصرة على تلك الإجراءات — ولا تطبّق أبدًا حذفًا أو استبدالًا.",
       "enabled": "مُفعّل",
       "workingDirectory": "دليل العمل",
       "workingDirectoryPlaceholder": "مثل environments/dev",

--- a/web/messages/cs.json
+++ b/web/messages/cs.json
@@ -67,6 +67,7 @@
       "agentPool": "Fond agentů",
       "none": "Žádný",
       "autoApply": "Automatické použití",
+      "autoApplyModeHint": "never: vždy počkat na člověka. always: aplikovat každý úspěšný plán. create / create/update: aplikovat jen plány omezené na tyto akce — nikdy ne mazání ani nahrazení.",
       "enabled": "Povoleno",
       "workingDirectory": "Pracovní adresář",
       "workingDirectoryPlaceholder": "např. environments/dev",

--- a/web/messages/cy.json
+++ b/web/messages/cy.json
@@ -67,6 +67,7 @@
       "agentPool": "Pwll Asiantau",
       "none": "Dim",
       "autoApply": "Gweithredu Awtomatig",
+      "autoApplyModeHint": "never: aros am berson bob tro. always: cymhwyso pob cynllun llwyddiannus. create / create/update: cymhwyso dim ond cynlluniau sy''n gyfyngedig i''r camau hynny — byth dileu na disodli.",
       "enabled": "Wedi'i alluogi",
       "workingDirectory": "Cyfeiriadur Gwaith",
       "workingDirectoryPlaceholder": "e.e. environments/dev",

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -67,6 +67,7 @@
       "agentPool": "Agentpulje",
       "none": "Ingen",
       "autoApply": "Anvend automatisk",
+      "autoApplyModeHint": "never: vent altid på et menneske. always: anvend hver vellykket plan. create / create/update: anvend kun planer begrænset til de handlinger — aldrig en sletning eller en udskiftning.",
       "enabled": "Aktiveret",
       "workingDirectory": "Arbejdsmappe",
       "workingDirectoryPlaceholder": "f.eks. environments/dev",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -67,6 +67,7 @@
       "agentPool": "Agent-Pool",
       "none": "Keiner",
       "autoApply": "Automatisch anwenden",
+      "autoApplyModeHint": "never: immer auf einen Menschen warten. always: jeden erfolgreichen Plan anwenden. create / create/update: nur Pläne anwenden, die auf diese Aktionen beschränkt sind — niemals ein Löschen oder Ersetzen.",
       "enabled": "Aktiviert",
       "workingDirectory": "Arbeitsverzeichnis",
       "workingDirectoryPlaceholder": "z. B. environments/dev",

--- a/web/messages/en-x-leet.json
+++ b/web/messages/en-x-leet.json
@@ -67,6 +67,7 @@
       "agentPool": "4g3n7 P00l",
       "none": "N0n3",
       "autoApply": "4u70 4pply",
+      "autoApplyModeHint": "n3v3r: 4lw4y5 w417 f0r 4 hum4n. 4lw4y5: 4pply 3v3ry 5ucc355ful pl4n. cr3473 / cr3473/upd473: 4pply 0nly pl4n5 l1m173d 70 7h053 4c710n5 — n3v3r 4 d357r0y 0r 4 r3pl4c3.",
       "enabled": "3n4bl3d",
       "workingDirectory": "W0rk1ng D1r3c70ry",
       "workingDirectoryPlaceholder": "3.g. 3nv1r0nm3n75/d3v",

--- a/web/messages/en-x-lolcat.json
+++ b/web/messages/en-x-lolcat.json
@@ -67,6 +67,7 @@
       "agentPool": "Agent Pool",
       "none": "Noes",
       "autoApply": "Auto Apploy",
+      "autoApplyModeHint": "never: alwayz waits for a hooman. always: applyz every gud plan. create / create/update: onlee applyz planz wif just dose akshuns — NEVAR a destroy or a replace. srsly.",
       "enabled": "Enabuld",
       "workingDirectory": "Werkin Direktoree",
       "workingDirectoryPlaceholder": "e.g. environments/dev",

--- a/web/messages/en-x-marklar.json
+++ b/web/messages/en-x-marklar.json
@@ -67,6 +67,7 @@
       "agentPool": "Marklar Marklar",
       "none": "None",
       "autoApply": "Auto Apply",
+      "autoApplyModeHint": "never: always wait for a marklar. always: apply every successful marklar. create / create/update: apply only marklars limited to those marklars — never a marklar or a marklar.",
       "enabled": "Enabled",
       "workingDirectory": "Marklar Marklar",
       "workingDirectoryPlaceholder": "e.g. environments/dev",

--- a/web/messages/en-x-pirate.json
+++ b/web/messages/en-x-pirate.json
@@ -67,6 +67,7 @@
       "agentPool": "Agent Crew",
       "none": "None",
       "autoApply": "Auto Apply",
+      "autoApplyModeHint": "never: always await a livin'' soul. always: apply every plan that sails true. create / create/update: apply only plans holdin'' to those deeds — never a scuttlin'' nor a swappin''.",
       "enabled": "Enabled",
       "workingDirectory": "Workin'' Directory",
       "workingDirectoryPlaceholder": "e.g. environments/dev",

--- a/web/messages/en-x-yoda.json
+++ b/web/messages/en-x-yoda.json
@@ -67,6 +67,7 @@
       "agentPool": "Pool, Agent",
       "none": "None",
       "autoApply": "Apply, Auto",
+      "autoApplyModeHint": "never: wait for a human, always you must. always: apply every successful plan, it does. create / create/update: only plans limited to those actions, apply it will — a destroy or a replace, never.",
       "enabled": "Enabled",
       "workingDirectory": "Directory, Working",
       "workingDirectoryPlaceholder": "e.g. environments/dev",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -67,6 +67,7 @@
       "agentPool": "Agent Pool",
       "none": "None",
       "autoApply": "Auto Apply",
+      "autoApplyModeHint": "never: always wait for a human. always: apply every successful plan. create / create/update: apply only plans limited to those actions — never a destroy or a replace.",
       "enabled": "Enabled",
       "workingDirectory": "Working Directory",
       "workingDirectoryPlaceholder": "e.g. environments/dev",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -67,6 +67,7 @@
       "agentPool": "Grupo de agentes",
       "none": "Ninguno",
       "autoApply": "Aplicación automática",
+      "autoApplyModeHint": "never: esperar siempre a una persona. always: aplicar todos los planes correctos. create / create/update: aplicar solo los planes limitados a esas acciones — nunca una destrucción ni un reemplazo.",
       "enabled": "Habilitado",
       "workingDirectory": "Directorio de trabajo",
       "workingDirectoryPlaceholder": "p. ej. environments/dev",

--- a/web/messages/fa.json
+++ b/web/messages/fa.json
@@ -67,6 +67,7 @@
       "agentPool": "استخر عامل",
       "none": "هیچ‌کدام",
       "autoApply": "اعمال خودکار",
+      "autoApplyModeHint": "never: همیشه منتظر یک انسان بمان. always: هر طرح موفق را اعمال کن. create / create/update: فقط طرح‌هایی را اعمال کن که به همان کنش‌ها محدودند — هرگز حذف یا جایگزینی.",
       "enabled": "فعال",
       "workingDirectory": "پوشهٔ کاری",
       "workingDirectoryPlaceholder": "مثلاً environments/dev",

--- a/web/messages/fi.json
+++ b/web/messages/fi.json
@@ -67,6 +67,7 @@
       "agentPool": "Agenttipooli",
       "none": "Ei mitään",
       "autoApply": "Automaattinen käyttöönotto",
+      "autoApplyModeHint": "never: odota aina ihmistä. always: toteuta jokainen onnistunut suunnitelma. create / create/update: toteuta vain niihin toimiin rajoittuvat suunnitelmat — ei koskaan poistoa tai korvausta.",
       "enabled": "Käytössä",
       "workingDirectory": "Työhakemisto",
       "workingDirectoryPlaceholder": "esim. environments/dev",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -67,6 +67,7 @@
       "agentPool": "Pool d'agents",
       "none": "Aucun",
       "autoApply": "Application automatique",
+      "autoApplyModeHint": "never : toujours attendre une personne. always : appliquer chaque plan réussi. create / create/update : n''appliquer que les plans limités à ces actions — jamais une destruction ni un remplacement.",
       "enabled": "Activé",
       "workingDirectory": "Répertoire de travail",
       "workingDirectoryPlaceholder": "par ex. environments/dev",

--- a/web/messages/he.json
+++ b/web/messages/he.json
@@ -67,6 +67,7 @@
       "agentPool": "מאגר סוכנים",
       "none": "ללא",
       "autoApply": "החלה אוטומטית",
+      "autoApplyModeHint": "never: תמיד להמתין לאדם. always: להחיל כל תוכנית מוצלחת. create / create/update: להחיל רק תוכניות המוגבלות לפעולות אלה — לעולם לא מחיקה או החלפה.",
       "enabled": "מופעל",
       "workingDirectory": "ספריית עבודה",
       "workingDirectoryPlaceholder": "למשל environments/dev",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -67,6 +67,7 @@
       "agentPool": "Pool di agenti",
       "none": "Nessuno",
       "autoApply": "Applica automaticamente",
+      "autoApplyModeHint": "never: attendere sempre una persona. always: applicare ogni piano riuscito. create / create/update: applicare solo i piani limitati a quelle azioni — mai una distruzione né una sostituzione.",
       "enabled": "Attivato",
       "workingDirectory": "Directory di lavoro",
       "workingDirectoryPlaceholder": "es. environments/dev",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -67,6 +67,7 @@
       "agentPool": "エージェントプール",
       "none": "なし",
       "autoApply": "自動適用",
+      "autoApplyModeHint": "never: 常に人の確認を待ちます。always: 成功したプランをすべて適用します。create / create/update: それらの操作だけに限られたプランのみを適用し、破棄や置換は決して適用しません。",
       "enabled": "有効",
       "workingDirectory": "作業ディレクトリ",
       "workingDirectoryPlaceholder": "例: environments/dev",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -67,6 +67,7 @@
       "agentPool": "에이전트 풀",
       "none": "없음",
       "autoApply": "자동 적용",
+      "autoApplyModeHint": "never: 항상 사람의 확인을 기다립니다. always: 성공한 모든 플랜을 적용합니다. create / create/update: 해당 작업으로만 이루어진 플랜만 적용하며, 삭제나 교체는 절대 적용하지 않습니다.",
       "enabled": "사용",
       "workingDirectory": "작업 디렉터리",
       "workingDirectoryPlaceholder": "예: environments/dev",

--- a/web/messages/la.json
+++ b/web/messages/la.json
@@ -67,6 +67,7 @@
       "agentPool": "Copia Actorum",
       "none": "Nullus",
       "autoApply": "Applicatio Automatica",
+      "autoApplyModeHint": "never: semper hominem exspecta. always: omne consilium prosperum applica. create / create/update: sola consilia iis actionibus circumscripta applica — numquam deletionem aut substitutionem.",
       "enabled": "Activatum",
       "workingDirectory": "Directorium Operandi",
       "workingDirectoryPlaceholder": "e.g. environments/dev",

--- a/web/messages/nb.json
+++ b/web/messages/nb.json
@@ -67,6 +67,7 @@
       "agentPool": "Agentpulje",
       "none": "Ingen",
       "autoApply": "Auto-anvend",
+      "autoApplyModeHint": "never: vent alltid på et menneske. always: bruk hver vellykket plan. create / create/update: bruk bare planer begrenset til de handlingene — aldri en sletting eller en erstatning.",
       "enabled": "Aktivert",
       "workingDirectory": "Arbeidskatalog",
       "workingDirectoryPlaceholder": "f.eks. environments/dev",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -67,6 +67,7 @@
       "agentPool": "Agent-pool",
       "none": "Geen",
       "autoApply": "Automatisch toepassen",
+      "autoApplyModeHint": "never: wacht altijd op een mens. always: pas elk geslaagd plan toe. create / create/update: pas alleen plannen toe die tot die acties beperkt zijn — nooit een verwijdering of een vervanging.",
       "enabled": "Ingeschakeld",
       "workingDirectory": "Werkmap",
       "workingDirectoryPlaceholder": "bijv. environments/dev",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -67,6 +67,7 @@
       "agentPool": "Pula agentów",
       "none": "Brak",
       "autoApply": "Automatyczne zastosowanie",
+      "autoApplyModeHint": "never: zawsze czekaj na człowieka. always: zastosuj każdy udany plan. create / create/update: zastosuj tylko plany ograniczone do tych działań — nigdy usunięcia ani zastąpienia.",
       "enabled": "Włączone",
       "workingDirectory": "Katalog roboczy",
       "workingDirectoryPlaceholder": "np. environments/dev",

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -67,6 +67,7 @@
       "agentPool": "Agent Pool",
       "none": "Nenhum",
       "autoApply": "Aplicação Automática",
+      "autoApplyModeHint": "never: sempre esperar por uma pessoa. always: aplicar todo plano bem-sucedido. create / create/update: aplicar apenas planos limitados a essas ações — nunca uma destruição ou uma substituição.",
       "enabled": "Ativado",
       "workingDirectory": "Diretório de Trabalho",
       "workingDirectoryPlaceholder": "ex.: environments/dev",

--- a/web/messages/pt-PT.json
+++ b/web/messages/pt-PT.json
@@ -67,6 +67,7 @@
       "agentPool": "Agent Pool",
       "none": "Nenhum",
       "autoApply": "Aplicação Automática",
+      "autoApplyModeHint": "never: esperar sempre por uma pessoa. always: aplicar todos os planos bem-sucedidos. create / create/update: aplicar apenas planos limitados a essas ações — nunca uma destruição ou uma substituição.",
       "enabled": "Ativado",
       "workingDirectory": "Diretório de Trabalho",
       "workingDirectoryPlaceholder": "ex.: environments/dev",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -67,6 +67,7 @@
       "agentPool": "Пул агентов",
       "none": "Нет",
       "autoApply": "Автоприменение",
+      "autoApplyModeHint": "never: всегда ждать человека. always: применять каждый успешный план. create / create/update: применять только планы, ограниченные этими действиями, — никогда удаление или замену.",
       "enabled": "Включено",
       "workingDirectory": "Рабочий каталог",
       "workingDirectoryPlaceholder": "например, environments/dev",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -67,6 +67,7 @@
       "agentPool": "Agentpool",
       "none": "Ingen",
       "autoApply": "Auto-applicera",
+      "autoApplyModeHint": "never: vänta alltid på en människa. always: tillämpa varje lyckad plan. create / create/update: tillämpa endast planer begränsade till dessa åtgärder — aldrig en borttagning eller en ersättning.",
       "enabled": "Aktiverad",
       "workingDirectory": "Arbetskatalog",
       "workingDirectoryPlaceholder": "t.ex. environments/dev",

--- a/web/messages/tlh.json
+++ b/web/messages/tlh.json
@@ -67,6 +67,7 @@
       "agentPool": "Duy bIQ'a'",
       "none": "pagh",
       "autoApply": "tlhoS lo'",
+      "autoApplyModeHint": "never: reH Human loSlu''. always: Hoch nab Qapchu''bogh lo''lu''. create / create/update: neH nabmey vetlh vangmeH poHmey lo''lu'' — not QIH ''ej not chIl.",
       "enabled": "chu'lu'pu'",
       "workingDirectory": "vum tetlh",
       "workingDirectoryPlaceholder": "Da environments/dev",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -67,6 +67,7 @@
       "agentPool": "Agent Havuzu",
       "none": "Yok",
       "autoApply": "Otomatik Uygula",
+      "autoApplyModeHint": "never: her zaman bir insanı bekle. always: başarılı her planı uygula. create / create/update: yalnızca bu işlemlerle sınırlı planları uygula — asla bir silme ya da değiştirme.",
       "enabled": "Etkin",
       "workingDirectory": "Çalışma Dizini",
       "workingDirectoryPlaceholder": "örn. environments/dev",

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -67,6 +67,7 @@
       "agentPool": "Пул агентів",
       "none": "Немає",
       "autoApply": "Автозастосування",
+      "autoApplyModeHint": "never: завжди чекати на людину. always: застосовувати кожен успішний план. create / create/update: застосовувати лише плани, обмежені цими діями, — ніколи видалення чи заміну.",
       "enabled": "Увімкнено",
       "workingDirectory": "Робочий каталог",
       "workingDirectoryPlaceholder": "наприклад, environments/dev",

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -67,6 +67,7 @@
       "agentPool": "代理池",
       "none": "无",
       "autoApply": "自动应用",
+      "autoApplyModeHint": "never：始终等待人工确认。always：应用每一个成功的计划。create / create/update：只应用仅限于这些操作的计划——绝不应用销毁或替换。",
       "enabled": "已启用",
       "workingDirectory": "工作目录",
       "workingDirectoryPlaceholder": "例如 environments/dev",

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -67,6 +67,7 @@
       "agentPool": "代理池",
       "none": "無",
       "autoApply": "自動應用",
+      "autoApplyModeHint": "never：一律等待人工確認。always：套用每一個成功的計畫。create / create/update：只套用僅限於這些操作的計畫——絕不套用銷毀或取代。",
       "enabled": "已啟用",
       "workingDirectory": "工作目錄",
       "workingDirectoryPlaceholder": "例如 environments/dev",

--- a/web/src/app/workspaces/page.tsx
+++ b/web/src/app/workspaces/page.tsx
@@ -78,6 +78,7 @@ function WorkspacesPageInner() {
   const searchParams = useSearchParams()
   const t = useTranslations('workspaces')
   const ts = useTranslations('status')
+  const tMode = useTranslations('common.autoApplyMode')
   const fmt = useFormat()
   // Translate a filter-suggestion's category hint (its stable English key stays
   // the internal value; only the displayed label is localized).
@@ -219,7 +220,10 @@ function WorkspacesPageInner() {
   const [showCreate, setShowCreate] = useState(false)
   const [newName, setNewName] = useState('')
   const [newExecMode, setNewExecMode] = useState('local')
-  const [newAutoApply, setNewAutoApply] = useState(false)
+  // The mode, not the boolean (#1301). The API accepts `auto-apply-mode` on
+  // POST, but this form only ever sent `auto-apply` — so a conditional mode
+  // could only be reached by creating the workspace and then editing it.
+  const [newAutoApplyMode, setNewAutoApplyMode] = useState('never')
   const [newBackend, setNewBackend] = useState('tofu')
   const [newVersion, setNewVersion] = useState('1.11')
   const [newCpu, setNewCpu] = useState('1')
@@ -487,7 +491,10 @@ function WorkspacesPageInner() {
               'execution-mode': newExecMode,
               'execution-backend': newBackend,
               'terraform-version': newVersion,
-              'auto-apply': newAutoApply,
+              // Send the mode alone. The API derives `auto-apply` from it and
+              // rejects both keys in one request, so sending the pair would be
+              // a 422.
+              'auto-apply-mode': newAutoApplyMode,
               'resource-cpu': newCpu,
               'resource-memory': newMemory,
               'working-directory': newWorkingDir,
@@ -513,7 +520,7 @@ function WorkspacesPageInner() {
       setNewExecMode('local')
       setNewBackend('tofu')
       setNewVersion('1.11')
-      setNewAutoApply(false)
+      setNewAutoApplyMode('never')
       setNewCpu('1')
       setNewMemory('2Gi')
       setNewWorkingDir('')
@@ -657,16 +664,19 @@ function WorkspacesPageInner() {
               </div>
               )}
               <div>
-                <span className="block text-sm font-medium text-slate-300 mb-1">{t('form.autoApply')}</span>
-                <label className="flex items-center gap-2 h-[42px] px-3 cursor-pointer border border-slate-600 rounded-lg bg-slate-700">
-                  <input
-                    type="checkbox"
-                    checked={newAutoApply}
-                    onChange={(e) => setNewAutoApply(e.target.checked)}
-                    className="rounded border-slate-600 bg-slate-700 text-brand-600 focus:ring-brand-500"
-                  />
-                  <span className="text-sm text-slate-300">{t('form.enabled')}</span>
-                </label>
+                <label htmlFor="ws-auto-apply-mode" className="block text-sm font-medium text-slate-300 mb-1">{t('form.autoApply')}</label>
+                <select
+                  id="ws-auto-apply-mode"
+                  value={newAutoApplyMode}
+                  onChange={(e) => setNewAutoApplyMode(e.target.value)}
+                  className="w-full px-3 py-2 border border-slate-600 rounded-lg bg-slate-700 text-slate-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+                >
+                  <option value="never">{tMode('never')}</option>
+                  <option value="always">{tMode('always')}</option>
+                  <option value="create">{tMode('create')}</option>
+                  <option value="create_update">{tMode('createUpdate')}</option>
+                </select>
+                <p className="mt-1 text-xs text-slate-500">{t('form.autoApplyModeHint')}</p>
               </div>
               <div>
                 <label htmlFor="ws-workdir" className="block text-sm font-medium text-slate-300 mb-1">{t('form.workingDirectory')}</label>


### PR DESCRIPTION
Five smaller consumer-contract items from the v1.4.0 pre-release review, none release-blocking on its own.

### `catalog_service` broke the stated "always write both columns" invariant

It set `ws.auto_apply` without `ws.auto_apply_mode` — both in its `Workspace(...)` construction and on reconfigure. Harmless *today*: `resolve_auto_apply_mode` composes asymmetrically and errs towards less automation in both directions. But it left catalog rows persistently inconsistent with the model comment asserting they cannot disagree, and it is a trap for anyone who later reads the column directly. Pinned by a source-introspection test, since the two sites are a constructor kwarg and a plain attribute assignment with no function to call.

### Bulk-update coerced `auto-apply` instead of type-checking it

`bool("false")` is `True`. So `{"auto-apply": "false"}` sailed through as an **enable** — and once the column pairing landed, wrote the string itself into a Boolean column while setting the mode to `"always"`. A caller who typed the value wrong got the opposite of what they asked for, on every matched workspace at once.

### Bulk-update had no `apply_then_merge` cross-check at all

The single-workspace PATCH has always refused auto-apply on an `apply_then_merge` workspace — under that workflow the apply runs **before** the PR merges, so auto-applying would apply changes from a branch nobody approved, which is the whole thing that workflow exists to prevent. The one path that can hit a hundred workspaces at once was the one with no check.

It cannot live in `_validate_update`, which validates the homogeneous payload once with no workspace in hand — so it runs against the matched set, before any mutation, and names the offenders (truncated at 10, with an honest count). All-or-nothing, matching the endpoint's own contract.

### The workspace create form only offered the boolean

The API accepts `auto-apply-mode` on `POST`, but the form declared and posted `auto-apply` only — so a conditional mode could be reached only by creating the workspace and *then* editing it. Now a mode select matching the detail form, with a hint translated into every offered locale.

### MCP understated the override and hid the interesting runs

- `terrapod_run_create`'s `auto_apply` said "default: the workspace setting". On a `create`-mode workspace an explicit `true` does **not** use the workspace setting — `create_run` maps it to `"always"`, silently upgrading that run past the operator's guardrail, destroys included. It now says so.
- `runSummary` gained `auto_apply_mode` and `auto_apply_declined_reason`. A held run sits at `planned` looking exactly like one awaiting a human; the reason is the only thing that distinguishes them — and held runs are the interesting case when listing. Without them an agent had to fetch every run individually to find which need attention.

### `ListDeletedWorkspaces` swallowed a meta-parse failure

`if err == nil { out.Meta = meta }` — with meta discarded, `TotalPages` stayed `0` and `ListAllDeletedWorkspaces` terminated after page one, returning a truncated list **as a success**. For undelete that fails in the worst direction: *"there is nothing else to restore"* is exactly the answer an operator must not be given wrongly.

### Verification

`make test` services + api tiers — 3299 passed (was 3282), including the new bulk-update type/cross-check tests and the catalog invariant test. `go build ./... && go test ./...` in `go-terrapod` and `mcp` (catalogue golden regenerated). `npx tsc --noEmit`, `npm run i18n:check`, `npm run i18n:lint`, `npm run build` all clean.

Closes #1301
