### PR TITLE
fix(1307): run-trigger runs can be applied on VCS-connected workspaces

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3887,7 +3887,7 @@ Queues an `is_destroy` run with source **`catalog-lifecycle`**. On a **successfu
 
 Returns a reference to the queued destroy run. **Required permission:** catalog `use`.
 
-> **Run sources:** catalog runs carry `source = "catalog"` (provision / reconfigure) or `source = "catalog-lifecycle"` (destroy → archive). These appear on the run object alongside the existing sources (`tfe-api`, `vcs`, `drift-detection`, `autodiscovery-lifecycle`, `module-test`, `module-publish`, `onboarding-discovery`).
+> **Run sources:** catalog runs carry `source = "catalog"` (provision / reconfigure) or `source = "catalog-lifecycle"` (destroy → archive). These appear on the run object alongside the existing sources (`tfe-api`, `vcs`, `run-trigger`, `drift-detection`, `autodiscovery-lifecycle`, `module-test`, `module-publish`, `onboarding-discovery`).
 
 ### Confirm / Discard a Catalog Instance Run
 

--- a/docs/run-triggers.md
+++ b/docs/run-triggers.md
@@ -13,6 +13,18 @@ This is useful for multi-layer infrastructure where changes in a base layer (e.g
 3. For each trigger, a new run is created and queued in the destination workspace
 4. The triggered run respects the destination workspace's `auto_apply` setting
 
+Triggered runs carry `source = "run-trigger"`, so they are distinguishable from
+CLI-initiated ones in the UI, the API, the audit log and the SDK — "why did this
+workspace just apply?" is answerable from the run itself.
+
+**On a VCS-connected workspace, a triggered run applies the code the VCS poller
+last fetched.** Terrapod picks the destination's latest uploaded configuration
+version; on a VCS-connected workspace that is the poller's, so the run is
+applying VCS-managed code and is confirmable like any other. If the latest
+configuration version was instead uploaded over the API, the apply is refused —
+a VCS-connected workspace applies VCS-managed code only, and that rule is not
+weakened by the run having arrived via a trigger.
+
 No data is passed between workspaces via the trigger mechanism. Downstream workspaces read outputs from upstream workspaces using the `terraform_remote_state` data source independently.
 
 ---

--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -49,6 +49,7 @@ from terrapod.auth import capabilities as cap
 from terrapod.auth.capabilities import has_capability
 from terrapod.config import settings
 from terrapod.db.models import (
+    ConfigurationVersion,
     CostSummary,
     CostSummaryMessage,
     PlanSummary,
@@ -712,22 +713,39 @@ async def confirm_run(
             detail="Plan reported no changes — there is nothing to apply.",
         )
 
-    # Block apply for CLI-uploaded code on VCS-connected agent workspaces.
-    # Destroy runs are exempt — they don't depend on uploaded code.
-    # Runs with vcs_commit_sha were fetched from VCS (UI-queued or poller)
-    # and are safe to apply even if source is "tfe-api".
-    if (
-        run.source not in ("vcs", "drift-detection")
-        and not run.is_destroy
-        and not run.vcs_commit_sha
-    ):
+    # Block apply of CLI-uploaded code on VCS-connected agent workspaces.
+    #
+    # The test is the CONFIGURATION VERSION's source, not the run's (#1307).
+    # What this guard protects against is applying code that came in over the
+    # API on a workspace whose code is supposed to come from VCS — that is a
+    # property of the code, and the code is the CV. Keying it off the run's
+    # source instead made it a proxy that was wrong in one direction: a run
+    # trigger fired by an upstream apply created its run with `source="tfe-api"`
+    # and pointed it at the destination's latest VCS-fetched CV, so it was
+    # refused for not being VCS-managed while applying VCS-managed code. That
+    # left the downstream half of run triggers non-functional on exactly the
+    # workspaces most likely to use them.
+    #
+    # Exempt for the same reasons as before: destroys don't depend on uploaded
+    # code at all, and a run already carrying a `vcs_commit_sha` was fetched
+    # from VCS by the poller or a UI-queued ref.
+    if not run.is_destroy and not run.vcs_commit_sha and run.source != "drift-detection":
         ws = await db.get(Workspace, run.workspace_id)
         if ws and ws.execution_mode == "agent" and ws.vcs_connection_id is not None:
-            raise HTTPException(
-                status_code=422,
-                detail="Apply is not supported for CLI-uploaded code on VCS-connected agent workspaces. "
-                "Only VCS-managed code can be applied on VCS-connected workspaces.",
-            )
+            cv_source = ""
+            if run.configuration_version_id:
+                cv = await db.get(ConfigurationVersion, run.configuration_version_id)
+                cv_source = (cv.source if cv else "") or ""
+            if cv_source != "vcs":
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "This run's configuration version was uploaded over the API "
+                        f"(source '{cv_source or 'unknown'}'), and this workspace is "
+                        "VCS-connected — only VCS-managed code can be applied here. "
+                        "Push the change and let the VCS poller create the run."
+                    ),
+                )
 
     try:
         run = await run_service.confirm_run(db, run)

--- a/services/terrapod/services/run_service.py
+++ b/services/terrapod/services/run_service.py
@@ -1325,7 +1325,12 @@ async def fire_run_triggers(
             message=f"Triggered by successful apply in workspace '{source_name}'",
             auto_apply=dest_ws.auto_apply,
             plan_only=False,
-            source="tfe-api",
+            # Its own source (#1307). `tfe-api` is the CLI-upload source, and
+            # labelling a triggered run with it made it indistinguishable from
+            # a CLI run in the UI, the API, the audit log and the SDK — so
+            # "why did this workspace just apply?" had no answer on the run
+            # itself. Every other non-CLI origin already has its own source.
+            source="run-trigger",
             configuration_version_id=latest_cv_id,
         )
         await queue_run(db, run)

--- a/services/tests/integration/test_run_execution.py
+++ b/services/tests/integration/test_run_execution.py
@@ -1369,3 +1369,151 @@ class TestPlanStaleness:
         # Guarded: discarded as stale — NOT auto-applied (confirmed/applying).
         assert after["status"] == "discarded", after["status"]
         assert "state changed" in (after["discard-reason"] or "")
+
+
+class TestRunTriggerRunsAreApplicable:
+    """A run created by a run trigger on a VCS-connected agent workspace must
+    be applicable (#1307).
+
+    It was not. `fire_run_triggers` created the run with `source="tfe-api"` —
+    the CLI-upload source — and the apply guard keyed off the run's source, so
+    a triggered run was refused for not being VCS-managed while pointing at the
+    destination's latest VCS-fetched CV. The downstream half of run triggers
+    was non-functional on exactly the workspaces most likely to use it.
+
+    The guard now tests the CONFIGURATION VERSION's source, which is what it
+    was always trying to ask.
+    """
+
+    @staticmethod
+    async def _attach_vcs_connection(client, ws_id, name):
+        """Attach a VCS connection to an existing workspace, in the DB.
+
+        Deliberately not through the API: creating a VCS-connected workspace
+        (or a run on one) makes the server resolve refs against the live
+        provider, which a test has no business doing. The guard reads exactly
+        one thing — `ws.vcs_connection_id is not None` — so attaching it
+        directly puts the workspace in precisely the state under test without
+        dragging the network in.
+
+        Called AFTER the plan, so the run gets created and planned normally and
+        only the confirm meets the guard, which is where it lives.
+        """
+        import uuid as _uuid
+
+        from terrapod.db.models import VCSConnection, Workspace
+        from terrapod.db.session import get_db_session
+
+        async with get_db_session() as db:
+            conn = VCSConnection(
+                name=f"conn-{name}",
+                provider="gitlab",
+                server_url="https://example.invalid",
+                token="not-used-by-this-test",
+            )
+            db.add(conn)
+            await db.flush()
+            ws = await db.get(Workspace, _uuid.UUID(ws_id.removeprefix("ws-")))
+            ws.vcs_connection_id = conn.id
+            ws.vcs_repo_url = "https://example.invalid/org/repo"
+            ws.vcs_branch = "main"
+            await db.commit()
+
+    @staticmethod
+    async def _set_cv_source(ws_id, source):
+        """Mark the workspace's CV as VCS- or API-sourced.
+
+        Set directly because the API has no way to declare a CV VCS-sourced —
+        only the poller writes those — and the guard reads exactly this field.
+        """
+        import uuid as _uuid
+
+        from sqlalchemy import select
+
+        from terrapod.db.models import ConfigurationVersion
+        from terrapod.db.session import get_db_session
+
+        async with get_db_session() as db:
+            res = await db.execute(
+                select(ConfigurationVersion).where(
+                    ConfigurationVersion.workspace_id == _uuid.UUID(ws_id.removeprefix("ws-"))
+                )
+            )
+            for cv in res.scalars().all():
+                cv.source = source
+            await db.commit()
+
+    @staticmethod
+    async def _set_run_source(run_id, source):
+        """What `fire_run_triggers` stamps. Set directly rather than firing a
+        real trigger, so the test is about the guard rather than about the
+        upstream apply that would drive it."""
+        import uuid as _uuid
+
+        from terrapod.db.models import Run
+        from terrapod.db.session import get_db_session
+
+        async with get_db_session() as db:
+            r = await db.get(Run, _uuid.UUID(run_id.removeprefix("run-")))
+            r.source = source
+            await db.commit()
+
+    async def test_a_triggered_run_against_vcs_code_can_be_applied(self, app, client, setup):
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "trigger-dest-vcs")
+        await self._set_cv_source(ws_id, "vcs")
+
+        run = await _create_run(client, ws_id)
+        await self._set_run_source(run["id"], "run-trigger")
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+        assert (await _get_run(client, run["id"]))["attributes"]["status"] == "planned"
+
+        await self._attach_vcs_connection(client, ws_id, "vcs")
+
+        resp = await client.post(f"/api/v2/runs/{run['id']}/actions/apply", headers=AUTH)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["attributes"]["status"] == "confirmed"
+
+    async def test_a_run_against_cli_uploaded_code_is_still_refused(self, app, client, setup):
+        """The property the guard exists for. A CV that came in over the API on
+        a VCS-connected workspace must still not be applicable, whatever the
+        run's source says."""
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "trigger-dest-cli")
+        await self._set_cv_source(ws_id, "tfe-api")
+
+        run = await _create_run(client, ws_id)
+        await self._set_run_source(run["id"], "run-trigger")
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+        await self._attach_vcs_connection(client, ws_id, "cli")
+
+        resp = await client.post(f"/api/v2/runs/{run['id']}/actions/apply", headers=AUTH)
+        assert resp.status_code == 422, resp.text
+        # Names the CV's origin rather than blaming the caller for using a CLI
+        # they may never have touched.
+        assert "configuration version" in resp.text.lower()
+
+    async def test_a_destroy_is_still_exempt(self, app, client, setup):
+        """Destroys don't depend on uploaded code at all."""
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "trigger-dest-destroy")
+        await self._set_cv_source(ws_id, "tfe-api")
+
+        run = await _create_run(client, ws_id, **{"is-destroy": True})
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+        await self._attach_vcs_connection(client, ws_id, "destroy")
+
+        resp = await client.post(f"/api/v2/runs/{run['id']}/actions/apply", headers=AUTH)
+        assert resp.status_code == 200, resp.text
+
+    async def test_a_non_vcs_workspace_is_unaffected(self, app, client, setup):
+        """CLI apply on a plain agent workspace is a supported workflow and
+        must keep working — the guard is scoped to VCS-connected ones."""
+        pool_id, listener_id = setup
+        ws_id = await _create_remote_workspace(client, pool_id, "trigger-dest-plain")
+
+        run = await _create_run(client, ws_id)
+        await _run_plan_lifecycle(client, listener_id, run["id"])
+
+        resp = await client.post(f"/api/v2/runs/{run['id']}/actions/apply", headers=AUTH)
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
The bug you hit on the live deployment: a run created by a **run trigger** on a VCS-connected agent workspace reached `planned` and then could not be applied.

```
422 Apply is not supported for CLI-uploaded code on VCS-connected agent
workspaces. Only VCS-managed code can be applied on VCS-connected workspaces.
```

The downstream half of run triggers was therefore non-functional on exactly the workspaces most likely to use it. The run planned, showed its changes, and dead-ended.

### The guard was asking the wrong question

What it protects against is applying code that arrived **over the API** on a workspace whose code is supposed to come from **VCS**. That is a property of the *code* — and the code is the configuration version.

It keyed off the **run's** source instead, which is a proxy that was wrong in one direction:

```python
source="tfe-api",                       # ← fire_run_triggers
configuration_version_id=latest_cv_id,  # ← the poller's VCS-fetched CV
```

`tfe-api` is the CLI-upload source, so the run was refused for not being VCS-managed *while applying VCS-managed code*.

The guard now tests `ConfigurationVersion.source`:

- a run against a `vcs` CV **applies**;
- a run against an API-uploaded CV is **still refused**, whatever its own source says — that is the property the guard exists for, now stated directly rather than approximated;
- destroys and runs already carrying a `vcs_commit_sha` stay exempt for the same reasons as before.

The message also names the CV's origin instead of blaming the caller for using a CLI they may never have touched.

### Triggered runs also get their own source

`tfe-api` made a triggered run indistinguishable from a CLI run in the UI, the API, the audit log and the SDK — so "why did this workspace just apply?" had no answer on the run itself, even when the guard didn't bite. Every other non-CLI origin already has one (`vcs`, `drift-detection`, `catalog`, `catalog-lifecycle`, `module-test`, `module-publish`); triggers now use `run-trigger`.

Additive — nothing reads the value as an enum — and the two docs that enumerate sources are updated, along with a note in `run-triggers.md` explaining which code a triggered run applies and when it will still be refused.

### Regression cover

Four integration tests through the real runner protocol: a triggered run against a VCS CV is confirmable; one against an API-uploaded CV still is not; a destroy stays exempt; a non-VCS agent workspace is unaffected (CLI apply there is a supported workflow).

**I verified the first one fails against the old guard** — reverted the change, watched it fail, restored it.

The tests attach the VCS connection in the DB after the plan rather than creating a VCS-connected workspace through the API, because the API path resolves refs against the live provider and a test has no business doing that. The guard reads exactly one thing (`ws.vcs_connection_id is not None`), so that puts the workspace in precisely the state under test.

### Verification

`make test` integration + api tiers — 1296 passed. `ruff check` + `format --check` clean.

Closes #1307
