### PR TITLE
docs(1298): close the discoverability gaps found in the v1.4.0 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Everything below is implemented and shipped today.
 | TFE V2 CLI surface | The `cloud`-backend subset of the TFE V2 API (JSON:API) consumed by `terraform`/`tofu` + `terraform login` — not the full TFE V2 API |
 | Run triggers | Cross-workspace dependency chains — a source apply triggers downstream runs |
 | Conditional auto-apply | Auto-apply only when the plan is within a declared safety standard — adds only, or adds and in-place updates. Anything that destroys or replaces a resource stops for a human |
+| Workspace undelete | Deleting a workspace leaves its state behind a delete marker, so an admin can salvage it into a new workspace within the retention window. A salvage operation, not an undo — the recovered workspace has a new id and comes back inert |
 | Stale-plan guards | Auto-discard a plan that no longer reflects reality: state-version drift (always on) + optional per-workspace time-based plan expiry |
 
 ### Governance & security

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -430,6 +430,18 @@ All workspace responses (show and list) include a `permissions` object reflectin
 DELETE /api/terrapod/v1/workspaces/{id}
 ```
 
+**Deleting does not delete the state.** The state blobs stay in object storage
+and a delete marker records what they belonged to, so a mistaken delete is
+recoverable for
+`api.config.artifact_retention.deleted_workspace_retention_days` (default 30)
+— see [Deleted Workspaces (undelete)](#deleted-workspaces-undelete) and
+[the runbook](runbooks.md#i-deleted-a-workspace-by-mistake). After that window
+the reaper removes the state permanently and it is unrecoverable.
+
+Recovery produces a **new workspace with a new id**, so anything referencing the
+old id needs repointing — it is a salvage operation, not an undo.
+
+
 **Required permission:** `admin` on the workspace.
 
 ### Lock Workspace
@@ -4079,6 +4091,12 @@ Notable attributes:
 | `marker-reason` | `deleted` — written by the delete, so `deleted-at` is the true deletion time. `discovered-orphaned` — the reaper found state with no marker (deleted before this feature shipped, or the marker write failed), so `deleted-at` is when it was first seen |
 | `state-versions-available` | Counted from storage at request time, not taken from the marker — a partial reap or an incomplete replication shows up here and nowhere else |
 | `restorable-until` | When the state becomes eligible for reaping. Empty when retention is disabled |
+| `workspace-id` | The deleted workspace's id — also the resource `id`. Accepted bare or `ws-`-prefixed on the routes below |
+| `workspace-name` | Its name at delete time. `null` on a reaper-discovered marker, which has no name to record |
+| `deleted-at` / `deleted-by` | When, and by whom. On a `discovered-orphaned` marker `deleted-at` is when the reaper first *saw* it, not when it was deleted |
+| `age-days` | Days since `deleted-at`, rounded — what the retention window is measured against |
+| `last-serial` / `lineage` | The state's serial and lineage at delete time, so you can tell which workspace's state this is before restoring |
+| `settings` | The workspace's non-secret configuration snapshot (labels, owner, execution mode, VCS reference, …), used to rebuild it |
 | `restored-to` | Workspace ids this deletion has already been restored into; empty until the first restore. Check it before offering a restore — a repeat would produce a second live workspace over the same infrastructure |
 | `restored-at` / `restored-by` | When and by whom the most recent restore happened |
 | `variable-names` | Names and categories only. Values are **never** recorded: the marker is a plain object in the bucket and replicates to any standby |
@@ -4145,6 +4163,17 @@ Three properties worth knowing before you call it:
   drift. The second attempt is refused with a `409` naming the workspace that
   already exists. Pass `force` only when that earlier restore is known to be
   gone.
+
+Response attributes:
+
+| Attribute | Meaning |
+|---|---|
+| `name` | The new workspace's name — the original if free, suffixed if taken, or the one you supplied |
+| `restored-from` | The deleted workspace's id, so the provenance is on the record |
+| `state-versions-restored` | How many were copied |
+| `state-versions-skipped` | Each with a `key` and a `reason` — unreadable blob, duplicate serial, or beyond the version cap. **A partial-failure signal**: a caller that ignores it can believe it recovered history it did not |
+| `suppressed` | Settings forced off (`auto_apply`, `drift_detection_enabled`, `vcs_connection`) — what to re-enable deliberately |
+| `dropped-references` | Things pointing at other resources that were not re-attached, e.g. a VCS connection whose id may since have been reused |
 
 The source prefix and its marker are left untouched, so the original remains
 recoverable until its window expires.

--- a/docs/artifact-retention.md
+++ b/docs/artifact-retention.md
@@ -148,8 +148,11 @@ Three Prometheus metrics track retention activity:
 | Metric | Type | Labels | Description |
 |---|---|---|---|
 | `terrapod_retention_deleted_total` | Counter | category | Artifacts successfully deleted |
+| `terrapod_retention_orphan_reap_blocked` | Gauge | — | `1` while the deleted-workspace reaper is refusing to reap an implausibly large orphan set (the signature of a stale or repointed database). **Alert on this** — while it is `1` nothing is reclaimed, and if the cause really is a stale database then reaping is exactly what must not happen. See [the runbook](runbooks.md#orphaned-state-reaper-refusing-to-reap-terrapod_retention_orphan_reap_blocked--1) |
 | `terrapod_retention_errors_total` | Counter | category | Per-item deletion errors |
 | `terrapod_retention_duration_seconds` | Histogram | -- | Wall-clock duration of the full cleanup cycle |
+
+> `category="deleted_workspaces"` counts **irreversible destruction of customer state** — the reaper deleting the state of a workspace past its undelete window. It is the one category worth alerting on rather than merely graphing.
 
 Categories: `state_versions`, `run_artifacts`, `config_versions`, `config_versions_count`, `provider_cache`, `binary_cache`, `module_overrides`, `vcs_archives`.
 

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -221,6 +221,18 @@ per-backend toggles below.
 Object storage holds state, config tarballs, logs, registry artifacts **and**
 (when enabled) the DB dumps above. Turn on the provider's native protections:
 
+> **For a workspace deleted by mistake, try undelete first.** Deleting a
+> workspace does not delete its state — a marker keeps it findable and
+> recoverable for
+> `api.config.artifact_retention.deleted_workspace_retention_days` (default 30),
+> from **Admin → Deleted workspaces**. That is a two-click recovery and does not
+> need bucket versioning at all. See
+> [the runbook](runbooks.md#i-deleted-a-workspace-by-mistake).
+>
+> Bucket versioning below is the layer *beneath* that: it is what remains once
+> the retention window has passed and the reaper has deleted the state for
+> good, and it is the only thing that can recover from that. Keep it on.
+
 | Backend | Versioning (undo overwrite/delete) | Off-site copy |
 |---|---|---|
 | **AWS S3** | `aws s3api put-bucket-versioning --versioning-configuration Status=Enabled` | S3 Cross-Region Replication (CRR) to a bucket in another account/region |

--- a/docs/high-availability.md
+++ b/docs/high-availability.md
@@ -637,8 +637,20 @@ The classes, in the order a report lists them:
 | Tier | Classes |
 |---|---|
 | Irreplaceable | `state`, `state_index`, `configuration_versions`, `registry_modules`, `registry_providers` |
-| History | `run_logs`, `run_plans`, `run_vars` |
+| History | `run_logs`, `run_plans`, `run_vars`, `deleted_workspace_markers` |
 | Re-derivable | `provider_cache`, `binary_cache`, `platform_provider_cache`, `cost_pricesheet`, `vcs_archives`, `module_overrides` |
+
+> **`deleted_workspace_markers` is History, and it must be replicated.** The
+> markers are what makes deleted-workspace state findable again — the undelete
+> index. It sits at its own prefix (`state/deleted/`) rather than inside
+> `state/` precisely so that it is *not* the `state` class, which is
+> `encrypted_at_rest` and which replication declines wholesale when app-layer
+> encryption is on. Excluding this class on an encrypted deployment leaves the
+> standby with no undelete index at all — the state blobs would be there and
+> nothing would know which workspace they belonged to. It is History rather
+> than Irreplaceable only because a marker cannot be verified from database
+> rows (that is its whole point), and an unverifiable class in the
+> irreplaceable tier puts a line in the readiness report nobody can ever clear.
 
 An unknown class name is **rejected** — by `helm lint` before install, and again at
 startup for the paths the chart never sees. A typo that silently left a class on

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ Beyond broad TFE compatibility, Terrapod is built with three deliberate design f
 | **Remote State Management** | Versioned state storage with locking, rollback, encryption at rest via CSP services |
 | **Agent Execution** | Plan/apply runs on the server via K8s Job-based runner infrastructure |
 | **VCS Integration** | GitHub (App) and GitLab (access token); inbound webhooks supported (GitHub HMAC + GitLab token) for instant triggers, plus outbound polling so webhooks are optional, never required |
+| **Conditional auto-apply** | Per-workspace `auto_apply_mode` — apply automatically only when the plan is within a declared safety standard (`create`, `create_update`); anything that destroys or replaces stops for a human |
+| **Workspace undelete** | Deleting a workspace leaves its state behind a delete marker; an admin can salvage it into a new workspace within the retention window. See [runbooks.md](runbooks.md#i-deleted-a-workspace-by-mistake) |
 | **VCS Workflows** | Default merge-then-apply (TFE standard) plus opt-in apply-then-merge mode (Atlantis-style: PR comments drive applies, `terrapod apply` from a PR comment, auto-merge after apply) |
 | **Variables & Secrets** | Per-workspace env and Terraform variables; sensitive values protected by database encryption-at-rest; variable sets |
 | **Private Module Source Auth** | First-class auth for private `git::https://` / `git::ssh://` module sources — a scoped `git_http_auth` / `git_ssh_auth` variable (static token or minted from a VCS connection), ssh↔https protocol rewrite, log-safe per-run-Secret delivery ([module-auth.md](module-auth.md)) |
@@ -174,6 +176,7 @@ See [Architecture](architecture.md) for the full breakdown.
 | [HA Topologies](ha-topologies.md) | Where to put the pieces: single-region, two-region, two-cloud and air-gapped layouts; dedicated vs shared listener fleets; multi-pool execution routing; a worked layout and how to rehearse a failover |
 | [HA Operations](ha-operations.md) | The operator procedures: the shared-vs-per-node naming model, planned and unplanned failover, failback, maintenance, adding and removing a node, and version skew across the pair |
 | [Disaster Recovery](disaster-recovery.md) | Break-glass state recovery, shipped DB backup CronJob + restore-verification DR drill, per-backend object-storage protection |
+| [Runbooks](runbooks.md) | Incident procedures — including **recovering a workspace deleted by mistake**, what to do when the orphan reaper has destroyed state, and why a workspace has stopped auto-applying |
 | [API Reference](api-reference.md) | All API endpoints with examples |
 
 ---

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -107,6 +107,7 @@ Every tool is namespaced `terrapod_*` and carries a safety annotation
 | `terrapod_run_plan_json` | The structured JSON plan output (`tofu show -json`) — reason precisely about resource changes. |
 | `terrapod_run_cost` | A run's monthly cost estimate — the plan's cost *delta* (projected total, this-run delta, previous, per-resource, unpriced). Data only, no AI. |
 | `terrapod_workspace_cost` | A workspace's *current* monthly cost from its latest state — total, per-resource, unpriced, and which state version was priced. Data only, no AI. |
+| `terrapod_deleted_workspace_list` | Deleted workspaces whose state is still recoverable — name, when and by whom, how many state versions survive, when the window closes, and whether it has already been restored. Platform admin only. |
 
 ### Act (gated) — the normal run lifecycle
 
@@ -123,7 +124,8 @@ Every tool is namespaced `terrapod_*` and carries a safety annotation
 |---|---|---|
 | `terrapod_workspace_create` | — | Create a workspace (name required; execution mode, VCS wiring, agent pool, labels, …). |
 | `terrapod_workspace_update` | — | Update a workspace's settings (only the fields you pass change; applies on its next run). |
-| `terrapod_workspace_delete` | destructive | Delete a workspace + its Terrapod records. Does **not** destroy the tracked infra — queue a destroy run first. Catalog-managed workspaces are refused. |
+| `terrapod_workspace_delete` | destructive | Delete a workspace + its Terrapod records. Does **not** destroy the tracked infra — queue a destroy run first. Catalog-managed workspaces are refused. Its **state survives** and stays recoverable for the deployment's retention window (default 30 days) via `terrapod_deleted_workspace_restore`, but recovery yields a NEW workspace with a NEW id and is admin-only — so this is reversible-with-effort, not undoable. |
+| `terrapod_deleted_workspace_restore` | destructive | Recover a deleted workspace's state into a **new** workspace. Platform admin only. A salvage operation, not an undo: new id, comes back inert (auto-apply and drift off, VCS not re-attached), variables and run history do not return. Refuses a second restore of the same deletion. |
 | `terrapod_variable_list` | read-only | List a workspace's variables (sensitive values masked). |
 | `terrapod_variable_set` | — | Upsert a variable by key (terraform or env; `hcl` for non-string values). |
 | `terrapod_variable_delete` | destructive | Delete a variable by key. |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -135,6 +135,11 @@ Two cases are **not** refused, with or without the flag:
 - **A probe that fails** (the discovery endpoint is unreachable, times out,
   or errors). A version check that cannot complete must not stand between
   you and a migration; the tool warns and continues.
+- **An API that reports no version at all** (`ErrVersionUnreported`) — an
+  instance older than v0.24, before the discovery document carried one. There
+  is nothing to compare, so the tool warns and continues, exactly as for a
+  failed probe. Only a version it can read *and* finds incompatible is
+  refused.
 
 ## Quickstart
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -210,8 +210,11 @@ depth alone — a deep queue that drains fast is fine.
 | Metric | Type | Labels | Description |
 |---|---|---|---|
 | `terrapod_retention_deleted_total` | Counter | category | Artifacts deleted by retention cleanup |
+| `terrapod_retention_orphan_reap_blocked` | Gauge | — | `1` while the deleted-workspace reaper is refusing to reap. Alert on it: nothing is being reclaimed, and a stale database is one of the causes |
 | `terrapod_retention_errors_total` | Counter | category | Errors during retention cleanup |
 | `terrapod_retention_duration_seconds` | Histogram | -- | Duration of retention cleanup cycle |
+
+> `category="deleted_workspaces"` counts **irreversible destruction of customer state** — the reaper deleting the state of a workspace past its undelete window. It is the one category worth alerting on rather than merely graphing.
 
 Categories: `state_versions`, `run_artifacts`, `config_versions`, `provider_cache`, `binary_cache`, `module_overrides`.
 

--- a/docs/registry-publishing.md
+++ b/docs/registry-publishing.md
@@ -58,6 +58,13 @@ are best managed declaratively with the `terrapod` Terraform provider in
 a small platform-config repo, so they live in version control and can
 be reviewed — but the equivalent API calls are shown for completeness.
 
+> **A version-mismatch warning on stderr is expected, not an error.** From
+> v1.4.0 `terrapod-publish` compares its own build version against the API's and
+> prints `warning: ...` on a mismatch. It is a *warning* — the publish proceeds.
+> A released binary talking to an API more than a minor apart is the case it
+> exists to surface; a source build (`go run`) reports itself as `dev` and skips
+> the check entirely. Upgrade the binary to match the instance to silence it.
+
 ### 1. Register the publisher's GPG public key
 
 The server verifies provider signatures against keys you register ahead

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1417,3 +1417,183 @@ stops reaping entirely, which is a bigger hammer and hides the signal.
 - Alert on the gauge. While it is `1`, storage is not being reclaimed — and if
   the cause is a stale database, reaping is exactly what must not happen.
 - Never point a Terrapod deployment at another deployment's storage prefix.
+
+---
+
+## I deleted a workspace by mistake
+
+Deleting a workspace removes its rows, but **not its state**. The state blobs
+stay in object storage and a delete marker records what they belonged to, so a
+mistaken delete is recoverable — for a while.
+
+**Act promptly.** The window is
+`api.config.artifact_retention.deleted_workspace_retention_days` (default 30);
+once it passes, the reaper deletes the state permanently and there is nothing
+left to recover.
+
+### Recovery
+
+1. Find it. **Admin only** — on every route, including the reads, because a
+   marker names a workspace and its variable *names* and a restore materialises
+   its state (and therefore its secrets) into a workspace the caller can read.
+   The original's ACL died with its rows, so there is nothing to delegate to.
+
+   UI: **Admin → Deleted workspaces**. API:
+   ```
+   GET /api/terrapod/v1/deleted-workspaces
+   ```
+   Check `restorable-until` before anything else. `state-versions-available` is
+   counted from storage at request time, so it tells you what is actually
+   recoverable rather than what existed at delete time.
+
+2. Restore it.
+   ```
+   POST /api/terrapod/v1/deleted-workspaces/{workspace_id}/restore
+   ```
+   Optionally `{"data":{"attributes":{"name":"..."}}}` to name it.
+
+### What you get back, and what you do not
+
+Read this before telling anyone the workspace is "back":
+
+- **A NEW workspace with a NEW id.** Not a revival. Anything referencing the old
+  id — `terraform_remote_state` consumers, run triggers, bookmarks, the
+  `cloud {}` block if it pinned an id — needs repointing. This is deliberate: a
+  one-keystroke undo makes deletion feel free, and deletion should not feel free.
+- **Lineage and serial are preserved exactly**, recovered from inside the state
+  documents. This is the part that matters — it means the next plan continues
+  the original state rather than treating live infrastructure as unmanaged.
+- **It comes back inert.** Auto-apply off, drift detection off, VCS *not*
+  re-attached, whatever the workspace had before. The response's `suppressed`
+  and `dropped-references` list what to switch back on. Re-enabling is a
+  deliberate act, because a restored workspace that applies immediately —
+  against infrastructure that may have drifted or been partly torn down since
+  the delete — is the worst thing this feature could do.
+- **Variables and run history do not come back.** The marker records variable
+  *names* and categories so you know what to recreate; values were never stored
+  in it.
+- **Only the newest state versions are copied**, bounded by
+  `state_versions_keep`. Anything beyond that is listed in
+  `state-versions-skipped` rather than dropped silently.
+
+### One restore per deletion
+
+A second restore would produce a second live workspace holding the same state
+lineage over the same real infrastructure — after which an apply in either makes
+the other's next plan read as wholesale drift. The API refuses it with a `409`
+naming the workspace that already exists. `{"force": true}` overrides, and is
+only correct when that earlier restore is genuinely gone.
+
+### If the window has passed
+
+`409 No state could be recovered` means the reaper has already run. Fall back to
+bucket-level protection (S3 Versioning, Azure soft-delete, GCS Object
+Versioning) if you enabled it — see
+[disaster-recovery.md](disaster-recovery.md). Nothing in Terrapod can help at
+that point.
+
+### Prevention
+
+- Raise `deleted_workspace_retention_days` if 30 is tight for your review cycle.
+  `0` disables reaping entirely — deleted state is kept forever.
+- Keep bucket versioning on. It is the only thing that survives the reaper.
+
+---
+
+## The reaper permanently deleted state
+
+The orphaned-state reaper irreversibly deletes everything under `state/{id}/`
+once its marker is older than the retention window. There is no undo. If storage
+has shrunk unexpectedly, or a workspace has vanished from **Admin → Deleted
+workspaces**, this is the first thing to check.
+
+### Diagnosis
+
+```bash
+# What has it reclaimed, and when?
+terrapod_retention_deleted_total{category="deleted_workspaces"}
+```
+
+Then the logs: a reap emits `Reaped state for deleted workspace past its
+retention window` with the workspace id, name and age. Every reap is logged, so
+absence of the line means it was not the reaper.
+
+**Is it refusing to reap instead?** Check
+`terrapod_retention_orphan_reap_blocked`. While that is `1` nothing is being
+reclaimed — see [the reaper-guard runbook
+above](#orphaned-state-reaper-refusing-to-reap-terrapod_retention_orphan_reap_blocked--1).
+
+### Resolution
+
+The state is gone. Recovery is only possible from outside Terrapod:
+
+1. **Bucket versioning**, if enabled — the reaper issues deletes, so a versioned
+   bucket keeps the prior versions and they can be restored. This is why
+   [disaster-recovery.md](disaster-recovery.md) recommends it.
+2. **A bucket-level backup or replica**, if you keep one.
+3. Otherwise: the state is unrecoverable. The infrastructure still exists; it is
+   now unmanaged, and the path back is `terraform import` (or Terrapod's
+   [onboarding](onboarding.md) flow) against a fresh workspace.
+
+### Prevention
+
+- **`deleted_workspace_retention_days: 0` is the kill switch** — it disables the
+  category entirely and keeps deleted state forever. The cost is storage; the
+  benefit is that nothing is ever reaped by a clock.
+- Alert on `terrapod_retention_orphan_reap_blocked`, which fires when the reaper
+  distrusts its own view of the database.
+- Enable bucket versioning. It is the only layer beneath this one.
+
+---
+
+## My workspace stopped auto-applying
+
+A workspace configured with a conditional auto-apply mode (`create` or
+`create_update`) leaves the run at `planned` whenever the plan contains
+something the mode does not auto-apply. That is the feature working.
+
+### Diagnosis
+
+Look at the run's `auto-apply-declined-reason`:
+
+```
+GET /api/v2/runs/{run_id}
+```
+
+- **A reason like `2 destroys, 1 replace`** — the plan contained an action the
+  mode refuses. Confirm or discard it yourself; the run is confirmable. This is
+  the intended behaviour, not a fault.
+- **No reason, and the run is still `planned`** — the plan's *shape was never
+  known*. `plan_shape_permits_auto_apply` returns "undecidable" when the
+  resource counts are null, which happens when the plan JSON never arrived or
+  did not parse. The upload is best-effort, so a failed upload means nobody
+  auto-applies — the correct direction to fail, but it leaves no explanation on
+  the run. Check the runner log for the plan-json upload, and whether
+  `has-json-output` is true.
+- **The workspace is manually locked** — the lock is honoured even on the
+  auto-apply path, and the run is left `planned` for a human rather than applied
+  past the lock. Unlock, then confirm.
+- **The plan went stale** — if state moved between the plan and the decision the
+  run is *discarded*, not held, with a `discard-reason` saying so. Queue a fresh
+  run.
+
+### Resolution
+
+Confirm the run yourself once you have read the plan, or switch the workspace's
+`auto-apply-mode` if the guardrail is tighter than you want:
+
+| Mode | Applies |
+|---|---|
+| `never` | nothing — always waits for a human |
+| `create` | plans containing only additions |
+| `create_update` | additions and in-place updates |
+| `always` | every successful plan |
+
+Neither conditional mode ever auto-applies a **destroy** or a **replace**. A
+replace is the create+delete action pair and is counted separately, so a "no
+destroys" reading of a plan is not the same thing.
+
+### Verification
+
+The next run with a qualifying plan auto-applies without intervention, and a run
+that is held shows a reason explaining which action stopped it.

--- a/docs/terraform-provider.md
+++ b/docs/terraform-provider.md
@@ -179,3 +179,44 @@ resource/data source uses `vcs_provider` for the provider-kind attribute
   Atlantis estates onto Terrapod.
 - [API reference](api-reference.md) — the underlying `/api/terrapod/v1` surface
   the provider drives via `go-terrapod`.
+
+
+## Tool ↔ API version compatibility
+
+From Terrapod v1.4.0 the provider compares its own build version against the
+API's during `Configure` and raises a **warning diagnostic** on a mismatch. It
+appears on every plan and apply against a skewed instance:
+
+```
+Warning: Terrapod API version mismatch
+```
+
+It is a warning, never an error — the plan and apply proceed. It exists so a
+provider several minors adrift of the instance is visible before it produces a
+confusing failure, rather than after. Align the two versions to silence it. A
+provider built from source reports itself as `dev`, which the SDK treats as
+"cannot compare" and skips, so local development is unaffected.
+
+## `auto_apply_mode`
+
+`terrapod_workspace` carries both `auto_apply` (boolean) and `auto_apply_mode`
+(`never` / `always` / `create` / `create_update`). The mode is the richer form:
+the conditional values apply a successful plan only when its shape is within the
+declared standard, and **never** auto-apply a plan containing a destroy or a
+replace.
+
+**Set one or the other, not both.** The API rejects a request carrying both, and
+the provider mirrors that: when `auto_apply_mode` is configured, a configured
+`auto_apply` is dropped from the request rather than sent alongside it. If you
+set both in HCL you will get the mode's behaviour and the boolean will appear to
+have been ignored — because it was. Configure the mode alone:
+
+```hcl
+resource "terrapod_workspace" "app" {
+  name            = "app-prod"
+  auto_apply_mode = "create_update"   # not auto_apply
+}
+```
+
+Both attributes are `Optional + Computed`, so a configuration that manages
+neither will not drift when the server projects one from the other.

--- a/docs/vcs-workflows.md
+++ b/docs/vcs-workflows.md
@@ -163,3 +163,21 @@ Project / Group access tokens need `api` scope (the existing requirement covers 
 - [`docs/vcs-integration.md`](vcs-integration.md) — VCS connection setup
 - [`docs/rbac.md`](rbac.md) — Terrapod's RBAC (which does *not* gate comment-driven applies)
 - [`docs/audit-logging.md`](audit-logging.md) — dual-actor audit model
+
+
+## `apply_then_merge` and auto-apply are incompatible
+
+A workspace using `apply_then_merge` cannot have auto-apply enabled, in any
+mode. The API refuses the pair with a `422` — on workspace create, on PATCH, and
+on bulk-update, which checks it against every matched workspace before touching
+any of them.
+
+The reason is the ordering the workflow is named for. Under `apply_then_merge`
+the apply runs **before** the PR merges, so an auto-apply would apply
+infrastructure changes from a branch nobody has approved — which is precisely
+what the workflow exists to prevent. Under the default `merge_then_apply` the
+review has already happened by the time the apply is queued, so auto-apply is
+compatible there.
+
+To move a workspace between them, change one setting at a time: turn auto-apply
+off first, then switch the workflow.

--- a/llms.txt
+++ b/llms.txt
@@ -109,6 +109,7 @@ How each capability is turned on. **Platform-level** features are Helm values un
 | VCS integration | Admin creates a VCS connection, then sets the workspace's `vcs_*` fields | [vcs-integration.md](docs/vcs-integration.md) |
 | Drift detection | Per-workspace setting (enable + interval) via API/UI/provider | [drift-detection.md](docs/drift-detection.md) |
 | Conditional auto-apply | Per-workspace `auto_apply_mode`: `never`, `always`, `create`, `create_update`. The conditional modes never auto-apply a plan that destroys or replaces a resource — it parks in `planned` with the reason. Settable via API/UI/provider/MCP/bulk-update and templatable from an autodiscovery rule | [api-reference.md](docs/api-reference.md) |
+| Workspace undelete | Always on — deleting a workspace writes a delete marker and leaves its state. The window is `api.config.artifact_retention.deleted_workspace_retention_days` (default 30; `0` = never reap, keep forever). Admin-only surface at `/admin/deleted-workspaces` | [runbooks.md](docs/runbooks.md#i-deleted-a-workspace-by-mistake) |
 | Stale-plan guards | State-drift auto-discard (#647) is always on; time-based plan expiry (#646) is per-workspace `plan_expiry_seconds` (off by default) | [api-reference.md](docs/api-reference.md) |
 | Notifications / Run tasks | Per-workspace config via API/UI/provider | [notifications.md](docs/notifications.md), [run-tasks.md](docs/run-tasks.md) |
 | Impact graph | Always on — the run page's **Impact** tab appears on any run with plan JSON output; no config | [impact-graph.md](docs/impact-graph.md) |


### PR DESCRIPTION
The pages written this cycle were fine; the gaps were almost entirely in surfaces the diff did **not** touch, plus statements it silently falsified.

### Three runbook entries

`runbooks.md` has 30 entries and gained none this cycle. Three of the release's highest-blast-radius surfaces qualified by the file's own precedent:

- **"I deleted a workspace by mistake"** — the single most likely reason anyone touches the feature, previously with no runbook path to it. Covers the window, the admin-only gate *and why*, and — under a heading that says read this before telling anyone the workspace is "back" — what you actually get: a NEW workspace with a NEW id, inert, without variables or run history, with only the newest state versions.
- **"The reaper permanently deleted state"** — how to tell whether it was the reaper (every reap is logged; the counter now exists), that recovery is only possible from bucket versioning or a backup, and that `deleted_workspace_retention_days: 0` is the kill switch.
- **"My workspace stopped auto-applying"** — including the case with no explanation anywhere: when the plan's shape was never known, the run is held and `auto_apply_declined_reason` is **not** set, which looks identical to a stalled run.

### `disaster-recovery.md` never mentioned undelete

The page an operator opens when they lose a workspace still presented bucket versioning as the only protection against accidental deletion — so someone following it would reach for S3 versioning when a two-click restore exists. It now leads with undelete and frames versioning as the layer *beneath* it (which it is: it's what survives the reaper).

### `api-reference.md`

- **Delete Workspace** said nothing about the marker or the recovery window; the destructive half and the recovery half sat ~3,600 lines apart with no cross-reference from the former.
- **Undocumented attributes.** The contract registers 12 marker and 6 restore attributes; the reference documented 4. `state-versions-skipped` especially — it is a partial-failure signal that a caller who ignores it will mistake for a complete recovery.

### Two shipped MCP tools were invisible in `mcp.md`

`terrapod_deleted_workspace_list` and `_restore` were in `tool_catalogue.json` and in neither enumeration table — an agent reading `mcp.md` to decide what it can do would not know it can recover a deleted workspace. And `terrapod_workspace_delete` still described deletion as final.

### The `high-availability.md` blob-class table was stale — and this one has teeth

`deleted_workspace_markers` was missing, `values.schema.json` **rejects** unknown class names, and the table is the only enumeration an operator has when writing `ha.blobs.classes`. On an encrypted deployment — where the `state` class is declined wholesale, which is precisely why this class exists separately — a stale table leaves the standby with **no undelete index at all**. Added, with a note explaining why it is History rather than Irreplaceable.

### Feature catalogues had diverged

README carried conditional auto-apply; `docs/index.md` carried neither it nor undelete; `llms.txt`'s enable table had no row for `deleted_workspace_retention_days`. `docs/index.md` also had no route into the undelete material at all — the runbooks page is now listed.

### Silent tool behaviour changes

`terrapod-publish` and the Terraform provider both started version-checking this cycle (#1287/#1293). Correctly scoped as warnings, but neither doc mentioned tool↔API compatibility, so an operator meeting the new warning had nothing to search for. Both now say what it is, that it is a warning and not an error, and how to silence it.

### Smaller

- `terraform-provider.md` had no `auto_apply_mode` coverage — including the gotcha that setting it makes the provider drop a configured `auto_apply`.
- `vcs-workflows.md` never documented the `apply_then_merge` + auto-apply incompatibility, or why the ordering makes it one.
- `migration.md`'s refusal policy omitted that `ErrVersionUnreported` also warns-and-continues.

### Two items that needed no change

- **The retention-metric gap was the same gap as the code gap**, and closing the code half in #1299 closed it. Both metric tables now document `terrapod_retention_deleted_total{category="deleted_workspaces"}` plus the new `terrapod_retention_orphan_reap_blocked` gauge — the one worth alerting on, since it means either nothing is being reclaimed or the database is not trusted.
- **`runners.md` already documented** that a run records its claiming pool (#1231), so I left it alone rather than adding a redundant paragraph.

### Verification

Route and attribute contract snapshots unmoved (docs-only change). Every added link target checked to resolve.

Closes #1298
