### PR TITLE
fix(1313): record every workspace setting in the delete marker

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4172,7 +4172,7 @@ Response attributes:
 | `restored-from` | The deleted workspace's id, so the provenance is on the record |
 | `state-versions-restored` | How many were copied |
 | `state-versions-skipped` | Each with a `key` and a `reason` — unreadable blob, duplicate serial, or beyond the version cap. **A partial-failure signal**: a caller that ignores it can believe it recovered history it did not |
-| `suppressed` | Settings forced off (`auto_apply`, `drift_detection_enabled`, `vcs_connection`) — what to re-enable deliberately |
+| `suppressed` | Settings forced off (`auto_apply`, `drift_detection_enabled`, `auto_merge`, `vcs_connection`) — what to re-enable deliberately. **What each one *was* is on the deleted workspace's `settings`**, which the list and show endpoints return: `auto_apply` is only a boolean projection, so a workspace held at `create` or `create_update` reads `auto_apply_mode` there to put the same guardrail back rather than re-enabling it as `always` |
 | `dropped-references` | Things pointing at other resources that were not re-attached, e.g. a VCS connection whose id may since have been reused |
 
 The source prefix and its marker are left untouched, so the original remains

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1463,12 +1463,21 @@ Read this before telling anyone the workspace is "back":
 - **Lineage and serial are preserved exactly**, recovered from inside the state
   documents. This is the part that matters — it means the next plan continues
   the original state rather than treating live infrastructure as unmanaged.
-- **It comes back inert.** Auto-apply off, drift detection off, VCS *not*
-  re-attached, whatever the workspace had before. The response's `suppressed`
-  and `dropped-references` list what to switch back on. Re-enabling is a
-  deliberate act, because a restored workspace that applies immediately —
+- **It comes back inert.** Auto-apply off, drift detection off, auto-merge off,
+  VCS *not* re-attached, whatever the workspace had before. The response's
+  `suppressed` and `dropped-references` list what to switch back on. Re-enabling
+  is a deliberate act, because a restored workspace that applies immediately —
   against infrastructure that may have drifted or been partly torn down since
   the delete — is the worst thing this feature could do.
+- **Check the mode before re-enabling auto-apply.** `suppressed` says auto-apply
+  was on; it does not say *how*. A workspace deliberately held at `create` or
+  `create_update` — auto-applying creations while holding anything that changes
+  or destroys — reads as plain "on", and the obvious way to turn it back on is
+  `always`, which applies destroys. The original `auto_apply_mode` is on the
+  deleted workspace's `settings` (`GET /deleted-workspaces/{id}`), which is also
+  where the security-scan, plan-expiry and AI-summary settings are recorded.
+  Settings that only affect how a run is *evaluated* — the security-scan config
+  among them — are restored as they were, since they cannot start anything.
 - **Variables and run history do not come back.** The marker records variable
   *names* and categories so you know what to recreate; values were never stored
   in it.

--- a/services/terrapod/services/deleted_workspace_service.py
+++ b/services/terrapod/services/deleted_workspace_service.py
@@ -97,6 +97,24 @@ def _settings_snapshot(ws: Workspace) -> dict[str, Any]:
         "resource_cpu": ws.resource_cpu,
         "resource_memory": ws.resource_memory,
         "auto_apply": ws.auto_apply,
+        # The boolean above is only a projection — it is true for `always`,
+        # `create` and `create_update` alike. Recording the mode as well is what
+        # makes a guardrail recoverable: without it an operator restoring a
+        # `create_update` workspace knows auto-apply was on but not that it was
+        # deliberately held back from changes and destroys, and the obvious way
+        # to turn it back on is `always` (#1313).
+        "auto_apply_mode": ws.auto_apply_mode,
+        "auto_merge": ws.auto_merge,
+        "auto_merge_strategy": ws.auto_merge_strategy,
+        "plan_expiry_seconds": ws.plan_expiry_seconds,
+        "security_scan_enforcement": ws.security_scan_enforcement,
+        "security_scan_engine": ws.security_scan_engine,
+        "security_scan_severity_threshold": ws.security_scan_severity_threshold,
+        "security_scan_skip_rules": list(ws.security_scan_skip_rules or []),
+        "ai_summary_mode": ws.ai_summary_mode,
+        "ai_summary_context": ws.ai_summary_context,
+        "slack_channel": ws.slack_channel,
+        "trigger_prefixes": list(ws.trigger_prefixes or []),
         "vcs_connection_id": str(ws.vcs_connection_id) if ws.vcs_connection_id else None,
         "vcs_repo_url": ws.vcs_repo_url,
         "vcs_branch": ws.vcs_branch,
@@ -444,14 +462,41 @@ async def restore_workspace(
         resource_cpu=settings.get("resource_cpu") or "1",
         resource_memory=settings.get("resource_memory") or "2Gi",
         drift_ignore_rules=list(settings.get("drift_ignore_rules") or []),
-        # Constraint 2 — inert on return.
+        # Settings that only describe how a run is evaluated, and cannot start
+        # one, come back as they were. Restoring a workspace with its security
+        # scanning silently back at the defaults would be its own quiet
+        # downgrade (#1313).
+        plan_expiry_seconds=settings.get("plan_expiry_seconds"),
+        security_scan_enforcement=settings.get("security_scan_enforcement") or "advisory",
+        security_scan_engine=settings.get("security_scan_engine") or "checkov",
+        security_scan_severity_threshold=(
+            settings.get("security_scan_severity_threshold") or "high"
+        ),
+        security_scan_skip_rules=list(settings.get("security_scan_skip_rules") or []),
+        ai_summary_mode=settings.get("ai_summary_mode") or "default",
+        ai_summary_context=settings.get("ai_summary_context") or "",
+        slack_channel=settings.get("slack_channel") or "",
+        trigger_prefixes=list(settings.get("trigger_prefixes") or []),
+        auto_merge_strategy=settings.get("auto_merge_strategy") or "merge",
+        # Constraint 2 — inert on return. Anything that can act on its own is
+        # off, whatever it was: auto-apply (in both columns, so the boolean and
+        # the mode cannot disagree), drift detection, and auto-merge, which
+        # writes to a VCS provider.
         auto_apply=False,
+        auto_apply_mode="never",
         drift_detection_enabled=False,
+        auto_merge=False,
     )
     if settings.get("auto_apply"):
+        # Plain field names, so the list stays machine-readable. What it *was*
+        # — which matters, because "auto_apply" alone would send an operator
+        # restoring a `create_update` workspace to `always` — is on the
+        # marker's `settings`, which the undelete surface returns (#1313).
         report["suppressed"].append("auto_apply")
     if settings.get("drift_detection_enabled"):
         report["suppressed"].append("drift_detection_enabled")
+    if settings.get("auto_merge"):
+        report["suppressed"].append("auto_merge")
     # Constraint 3 — VCS is described, never re-attached.
     if settings.get("vcs_connection_id") or settings.get("vcs_repo_url"):
         report["dropped_references"].append(

--- a/services/tests/integration/test_deleted_workspace_restore.py
+++ b/services/tests/integration/test_deleted_workspace_restore.py
@@ -33,21 +33,28 @@ def _state_doc(serial: int, lineage: str) -> bytes:
     ).encode()
 
 
-async def _delete_with_state(client, name: str, serials: list[int], lineage: str) -> str:
-    """Create a workspace, give it state versions, delete it. Returns its raw id."""
+async def _delete_with_state(
+    client, name: str, serials: list[int], lineage: str, **extra_attrs
+) -> str:
+    """Create a workspace, give it state versions, delete it. Returns its raw id.
+
+    Restore refuses a workspace with no recoverable state, so anything testing
+    the restore path has to go through here rather than creating a bare one.
+    """
+    attributes = {
+        "name": name,
+        "auto-apply": True,
+        "drift-detection-enabled": True,
+        "labels": {"team": "platform"},
+    }
+    attributes.update(extra_attrs)
+    # The API rejects both forms at once — the mode supersedes the boolean — so
+    # a caller asking for a mode drops the default boolean rather than 422ing.
+    if "auto-apply-mode" in extra_attrs:
+        attributes.pop("auto-apply", None)
     create = await client.post(
         WS_ENDPOINT,
-        json={
-            "data": {
-                "type": "workspaces",
-                "attributes": {
-                    "name": name,
-                    "auto-apply": True,
-                    "drift-detection-enabled": True,
-                    "labels": {"team": "platform"},
-                },
-            }
-        },
+        json={"data": {"type": "workspaces", "attributes": attributes}},
         headers=AUTH,
     )
     assert create.status_code == 201, create.text
@@ -167,6 +174,52 @@ class TestRestore:
 
         # Non-dangerous settings ARE carried over — the restore is still useful.
         assert ws.json()["data"]["attributes"]["labels"] == {"team": "platform"}
+
+    async def test_a_conditional_guardrail_is_recorded_and_not_downgraded(self, app, client):
+        """A `create_update` workspace must not come back as `always` (#1313).
+
+        The `auto_apply` boolean is true for every non-`never` mode, so a marker
+        recording only the boolean tells an operator auto-apply was on but not
+        that it was deliberately held back from changes and destroys — and the
+        obvious way to switch it back on is `always`, which applies destroys.
+        The restore stays inert in *both* columns, and the marker keeps the
+        original mode so the guardrail can be put back as it was.
+        """
+        set_auth(app, admin_user())
+        old_id = await _delete_with_state(
+            client,
+            "restore-guardrail",
+            [1],
+            "lin-guardrail",
+            **{
+                "auto-apply-mode": "create_update",
+                "security-scan-enforcement": "enforced",
+                "security-scan-severity-threshold": "medium",
+            },
+        )
+
+        # The marker is the only surviving account of what the workspace was.
+        marker = await dws.read_marker(get_storage(), old_id)
+        assert marker["settings"]["auto_apply_mode"] == "create_update"
+        assert marker["settings"]["security_scan_enforcement"] == "enforced"
+
+        resp = await client.post(
+            f"/api/terrapod/v1/deleted-workspaces/{old_id}/restore", headers=AUTH
+        )
+        assert resp.status_code == 201, resp.text
+        assert "auto_apply" in resp.json()["data"]["attributes"]["suppressed"]
+
+        attrs = (
+            await client.get(f"/api/v2/workspaces/{resp.json()['data']['id']}", headers=AUTH)
+        ).json()["data"]["attributes"]
+        # Inert in both columns — never `always`, and never a boolean that
+        # disagrees with the mode.
+        assert attrs["auto-apply"] is False
+        assert attrs["auto-apply-mode"] == "never"
+        # Evaluation settings cannot start a run, so they come back as they
+        # were rather than silently reverting to the defaults.
+        assert attrs["security-scan-enforcement"] == "enforced"
+        assert attrs["security-scan-severity-threshold"] == "medium"
 
     async def test_restore_renames_when_the_name_is_taken(self, app, client):
         """The original name is usually free, but must never block a restore."""

--- a/services/tests/services/test_deleted_workspace_markers.py
+++ b/services/tests/services/test_deleted_workspace_markers.py
@@ -220,6 +220,77 @@ class TestMarkerContents:
         assert offenders == [], f"secret-shaped key in marker snapshot: {offenders}"
         assert "labels" in snap and "owner_email" in snap
 
+    def test_the_snapshot_covers_every_configured_workspace_setting(self):
+        """A setting the marker never records cannot be recovered from anywhere
+        — the workspace row is gone and the marker is the only account of what
+        it was. This shipped having quietly dropped twelve of them, including
+        the whole security-scan config and the conditional auto-apply mode
+        (#1313), so the coverage is asserted rather than maintained by hand.
+
+        Adding a column to `Workspace` therefore forces a decision: snapshot it,
+        or name it below as runtime state that would be meaningless restored.
+        """
+        from terrapod.db.models import Workspace
+
+        # Identity, lifecycle bookkeeping, and state observed *about* a
+        # workspace rather than configured *on* it. Restoring any of these
+        # would be restoring a stale observation.
+        runtime_or_identity = {
+            "id",
+            "name",
+            "created_at",
+            "updated_at",
+            "locked",
+            "lock_id",
+            "lock_reason",
+            "last_state_at",
+            "state_stale_at",
+            "state_diverged",
+            "deleted_at",
+            "lifecycle_state",
+            "lifecycle_reason",
+            "drift_status",
+            "drift_last_checked_at",
+            "drift_latest_run_id",
+            "vcs_last_commit_sha",
+            "vcs_last_polled_at",
+            "vcs_last_attempted_at",
+            "vcs_last_error",
+            "vcs_last_error_at",
+            "autodiscovery_rule_id",
+            "autodiscovery_pr_number",
+            # Catalog-managed workspaces are restored through the catalog, not
+            # through undelete — the wrapper config is regenerated, not copied.
+            "catalog_item_id",
+            "catalog_version_pin",
+            "catalog_input_values",
+        }
+
+        ws = MagicMock()
+        ws.labels = {}
+        snapshotted = set(dws._settings_snapshot(ws))
+        columns = {c.name for c in Workspace.__table__.columns}
+        unaccounted = sorted(columns - snapshotted - runtime_or_identity)
+        assert unaccounted == [], (
+            "workspace settings the delete marker would silently lose: "
+            f"{unaccounted} — snapshot them in `_settings_snapshot`, or add "
+            "them above if they are runtime state rather than configuration"
+        )
+
+    def test_a_conditional_auto_apply_mode_reaches_the_marker(self):
+        """The `auto_apply` boolean is only a projection — true for `always`,
+        `create` and `create_update` alike. Recording it alone tells a restoring
+        operator that auto-apply was on but not that it was deliberately held
+        back from changes and destroys, and the obvious way to turn it back on
+        is `always`, which applies destroys (#1313)."""
+        ws = MagicMock()
+        ws.labels = {}
+        ws.auto_apply = True
+        ws.auto_apply_mode = "create_update"
+        snap = dws._settings_snapshot(ws)
+        assert snap["auto_apply"] is True
+        assert snap["auto_apply_mode"] == "create_update"
+
 
 @contextlib.asynccontextmanager
 async def _fake_db_session():


### PR DESCRIPTION
Found by the v1.4.0 third-party completeness review.

The delete marker is the only surviving account of a deleted workspace — the row
is gone — and it was recording 19 fields while silently dropping 12:
`auto_apply_mode`, the four `security_scan_*` settings, `auto_merge` and
`auto_merge_strategy`, `plan_expiry_seconds`, `ai_summary_mode`,
`ai_summary_context`, `slack_channel`, and `trigger_prefixes`.

Two of those lose a guardrail rather than a preference:

- **`auto_apply_mode`.** The `auto_apply` boolean is only a projection — true for
  `always`, `create` and `create_update` alike. A workspace deliberately held
  back from applying changes and destroys restored as plain "auto-apply was on",
  and the obvious way to turn that back on is `always`, which applies destroys.
- **`security_scan_*`.** A workspace with scanning at `enforced` / `high` came
  back at the defaults, with nothing recording that it had ever been configured.

Both features ship in v1.4.0, so they should not ship mutually inconsistent.

## What changed

The snapshot covers every operator-configured column. On restore, settings that
only affect how a run is *evaluated* come back as they were, since they cannot
start anything. Everything that can act on its own stays off under the existing
inert-on-return constraint — auto-apply in **both** columns, so the boolean and
the mode cannot disagree; drift detection; and now `auto_merge`, which writes to
a VCS provider and was previously neither restored nor reported as suppressed.

`suppressed` keeps its shape (plain field names, so it stays machine-readable).
What each setting *was* is on the marker's `settings`, which the undelete
endpoints already return — the docs now point there, because "auto_apply" alone
is exactly the information that sends someone to `always`.

## Tests

Rather than list the fields correctly once and hope, a test derives the expected
set from the `Workspace` model and asserts the snapshot covers it, with an
explicit allowlist for columns that are runtime state rather than configuration.
Adding a column now forces that decision instead of quietly dropping it.

Verified it bites: removing `security_scan_engine` from the snapshot fails it
with that field named, and restoring it goes green again. Plus an integration
test over real Postgres and storage that a `create_update` workspace round-trips
with its mode on the marker, comes back inert in both columns, and keeps its
security-scan settings.

`make test` — 4371 passed.

Closes #1313