### PR TITLE
fix: override nanoid past the zero-size infinite-loop advisory

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8031,9 +8031,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -52,6 +52,7 @@
     "@babel/core": "^7.29.6",
     "brace-expansion": "^2.1.4",
     "sharp": "^0.35.3",
-    "js-yaml": "^4.3.1"
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.17"
   }
 }


### PR DESCRIPTION
`GHSA-2v37-7h3g-55p8` (high — custom generators can loop indefinitely when size
is zero) was published against `nanoid < 3.3.17`, and npm audit began failing
every pull request on it, including ones that touch no JavaScript at all.

It reaches us only through `postcss`, which still resolves 3.3.16 at its own
latest, so an override is what moves it.

Taken as a bump rather than an allowlist entry, per the register's first rule: a
patched version exists and is reachable, so there is nothing to accept. The
override resolves **3.3.18**.

Verified: `npm audit` reports 0 vulnerabilities, and `npm run lint`, `tsc
--noEmit` and the production `npm run build` all pass — that last part being the
check that matters, since the brace-expansion override in #1278 resolved
perfectly well and still broke eslint.