### PR TITLE
fix: retry cosign signing so one timeout does not lose a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2101,10 +2101,35 @@ jobs:
           version="${{ needs.prepare.outputs.version }}"
           chart_version="${version#v}"
 
+          # Keyless signing reaches out to the Actions OIDC endpoint, Fulcio and
+          # Rekor, so it fails for the usual transient network reasons — and a
+          # release is an expensive thing to lose to one of them. A v1.4.0 tag
+          # died on a single TLS handshake timeout fetching the OIDC token.
+          #
+          # The retry also side-steps the way that failure presents: with no
+          # ambient token, cosign falls back to the interactive device flow,
+          # prints a verification URL no one is watching, and waits out the full
+          # five-minute code validity before failing. The next attempt fetches
+          # the token normally.
+          sign() {
+            local subject="$1"
+            for attempt in 1 2 3; do
+              if cosign sign "$subject"; then
+                return 0
+              fi
+              echo "cosign sign failed for $subject (attempt $attempt/3)"
+              if [ "$attempt" -lt 3 ]; then
+                sleep $((attempt * 15))
+              fi
+            done
+            echo "::error::cosign sign gave up on $subject after 3 attempts"
+            return 1
+          }
+
           for image in terrapod-api terrapod-web terrapod-runner terrapod-listener terrapod-migrations; do
             digest=$(docker buildx imagetools inspect "$REGISTRY/$image:$version" --format '{{.Manifest.Digest}}')
             echo "Signing $image@$digest"
-            cosign sign "$REGISTRY/$image@$digest"
+            sign "$REGISTRY/$image@$digest"
             # Expose the digest (hyphens → underscores for the output key) so the
             # SBOM + SLSA provenance steps below can attest the same immutable
             # subject as OCI 1.1 referrers.
@@ -2113,7 +2138,7 @@ jobs:
 
           # Helm chart OCI artifact (cosign resolves the tag to its digest).
           echo "Signing Helm chart terrapod:$chart_version"
-          cosign sign "$REGISTRY/terrapod:$chart_version"
+          sign "$REGISTRY/terrapod:$chart_version"
 
       # SLSA build provenance per image, published as an OCI referrer next to
       # the image (verifiable with `gh attestation verify` / `cosign verify-attestation`).


### PR DESCRIPTION
The v1.4.0 tag failed on this:

```
error fetching GitHub OIDC token (will retry): … net/http: TLS handshake timeout
Non-interactive mode detected, using device flow.
Enter the verification code ZKDL-KNZB in your browser at: …
Error: signing […terrapod-runner@sha256:5794…]: … error obtaining token: expired_token
```

Three images into keyless signing, a transient TLS timeout to the Actions OIDC
endpoint. Everything before it — the full test suite, five image builds, the
Helm package — was discarded for one network blip, and `Cleanup Tag` deleted
the tag.

It also presents badly: with no ambient token cosign falls back to the
**interactive device flow**, prints a verification URL nobody is watching, and
waits out the full five-minute code validity before failing. The log reads like
a hang rather than a blip.

Signing reaches the OIDC endpoint, Fulcio and Rekor — exactly the shape of
outbound call AGENTS.md already requires bounded retry on ("every outbound HTTP
call … MUST use a bounded retry with backoff"). This step was simply missed.

Three attempts with 15s/30s backoff, each re-fetching the token, and the step
still fails if all three do — a signature that cannot be produced must never be
silently skipped.

Verified by driving the retry function with a stubbed `cosign`: a subject that
fails twice then succeeds is signed and reported as recovered; a subject that
always fails logs all three attempts, emits a `::error::`, and returns non-zero
so the step fails. Also `bash -n` on the extracted step and a YAML parse of the
workflow.