### PR TITLE
chore(deps): dependabot rollup — CI actions, python, web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,7 +684,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -692,7 +692,7 @@ jobs:
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4
         with:
           category: codeql-${{ matrix.language }}
 
@@ -1349,7 +1349,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep
@@ -1807,7 +1807,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4
         with:
           sarif_file: trivy-${{ matrix.image }}-${{ matrix.arch }}.sarif
           category: trivy-${{ matrix.image }}-${{ matrix.arch }}

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release-rescan.yml
+++ b/.github/workflows/release-rescan.yml
@@ -260,7 +260,7 @@ jobs:
         id: sarif
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4
         with:
           sarif_file: semgrep.sarif
           category: release-rescan-${{ matrix.tag }}

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -20,7 +20,7 @@ fastapi = ">=0.135.2,!=0.136.3,<0.137.0"
 # tests/test_dependency_pins.py — keep the upper bound. Bump this line in
 # lock-step when intentionally taking a new starlette.
 starlette = ">=1.3.1,<1.4.0"
-uvicorn = {extras = ["standard"], version = ">=0.42,<0.52"}
+uvicorn = {extras = ["standard"], version = ">=0.42,<0.53"}
 pydantic = "^2.10.0"
 pydantic-settings = "^2.14.2"
 structlog = ">=25.5,<27.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,10 +33,10 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.3",
-        "@types/node": "^26.1.1",
-        "@types/react": "^19.2.17",
+        "@types/node": "^26.1.2",
+        "@types/react": "^19.2.18",
         "@types/react-dom": "^19",
-        "@types/three": "^0.185.1",
+        "@types/three": "^0.185.3",
         "eslint": "^9.39.5",
         "eslint-config-next": "^16.2.12",
         "postcss": "^8.5.23",
@@ -3081,9 +3081,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3091,18 +3091,18 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3117,9 +3117,9 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.185.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
-      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "version": "0.185.3",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.3.tgz",
+      "integrity": "sha512-8TqTn1+fjPWuJ4mR6Igtg56DCf9b5EeAlwhb5xaa6WlBrsg7SvG0NQbyctGRkHCKwg0uftfCspOEsTXelgktMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -37,10 +37,10 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",
-    "@types/node": "^26.1.1",
-    "@types/react": "^19.2.17",
+    "@types/node": "^26.1.2",
+    "@types/react": "^19.2.18",
     "@types/react-dom": "^19",
-    "@types/three": "^0.185.1",
+    "@types/three": "^0.185.3",
     "eslint": "^9.39.5",
     "eslint-config-next": "^16.2.12",
     "postcss": "^8.5.23",


### PR DESCRIPTION
Nine Dependabot pull requests, landed as one.

They all touch a small number of shared files — three of them the same workflow,
four the same lockfile — so merging them individually means each merge
invalidates the rest and they take turns going out of date. This is the same
rollup pattern used for previous batches.

| Dependency | From | To | PRs |
|---|---|---|---|
| `github/codeql-action` (init, analyze, upload-sarif) | v4.37.3 | v4.37.5 | #1321 #1322 #1325 |
| `docker/login-action` | v4.5.2 | v4.6.0 | #1323 |
| `uvicorn` | `<0.52` | `<0.53` | #1324 |
| `@types/react` | 19.2.17 | 19.2.18 | #1317 |
| `@types/node` | 26.1.1 | 26.1.2 | #1318 |
| `@types/three` | 0.185.1 | 0.185.3 | #1319 |
| `@types/react-dom` | 19.2.3 | 19.2.4 | #1320 |

None is a security update — Dependabot alerts are at zero, and these are all
routine version updates.

**Faithful union of what was proposed, nothing more.** A plain `npm install`
floats further than Dependabot asked — it took `@types/node` to 26.2.0 and
`@types/three` to 0.185.4, both permitted by the existing carets — so each was
pinned back to the proposed version. `@types/react-dom` keeps its `^19` declared
range rather than being narrowed to `^19.2.4` by the lockfile bump, matching what
#1320 actually did.

The three codeql-action bumps resolve to the same commit, so one SHA replacement
covers init, analyze and upload-sarif across `ci.yml` and `release-rescan.yml`.

## Verification

- `make test` — 4371 passed
- `npm run build`, `tsc --noEmit`, `npm run lint`, `i18n:check`, `i18n:lint` — all clean
- `npm audit` — 0 vulnerabilities
- Every `uses:` in `.github/workflows/` still pinned to a 40-character SHA, and all
  workflows still parse

Closes #1317, closes #1318, closes #1319, closes #1320, closes #1321, closes #1322, closes #1323, closes #1324, closes #1325