### PR TITLE
fix(1330): decide a filtered-out PR once, not once per poll cycle

### DIFF
--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -116,6 +116,59 @@ async def _get_default_branch(
     )
 
 
+# A PR head the trigger-prefix filter rejected. Remembered so the decision is
+# made once per PR head rather than once per poll cycle (#1330).
+#
+# Keying on the head SHA is sound because the filter compares
+# `ws.vcs_last_commit_sha ... pr.head_sha` (three-dot): the PR head is fixed
+# while the tracked branch only moves forward, so that diff can only shrink and
+# a skip stays a skip. The TTL covers the one case where it could grow again —
+# a force-push or re-seed that rewinds the workspace's last-seen commit.
+_PR_SKIP_TTL_SECONDS = 30 * 24 * 60 * 60
+
+
+def _pr_skip_key(workspace_id: uuid.UUID, pr_number: int, head_sha: str) -> str:
+    return f"tp:pr_skip:{workspace_id}:{pr_number}:{head_sha}"
+
+
+async def _pr_decision_is_remembered(
+    workspace_id: uuid.UUID, pr_number: int, head_sha: str
+) -> bool:
+    """True if this PR head was already evaluated and skipped for this workspace.
+
+    Fails open: if Redis is unavailable we return False and re-evaluate, which
+    costs one provider call and behaves exactly as before. The opposite default
+    would silently suppress runs, which is far worse than a wasted call.
+    """
+    try:
+        from terrapod.redis.client import get_redis_client
+
+        return bool(
+            await get_redis_client().exists(_pr_skip_key(workspace_id, pr_number, head_sha))
+        )
+    except Exception:
+        return False
+
+
+async def _remember_pr_decision(workspace_id: uuid.UUID, pr_number: int, head_sha: str) -> None:
+    """Record that this PR head was evaluated and did not warrant a run."""
+    try:
+        from terrapod.redis.client import get_redis_client
+
+        await get_redis_client().set(
+            _pr_skip_key(workspace_id, pr_number, head_sha), "1", ex=_PR_SKIP_TTL_SECONDS
+        )
+    except Exception:
+        # Best effort. Losing the marker costs a repeated provider call, never
+        # correctness.
+        logger.warning(
+            "Could not record skipped-PR decision; it will be re-evaluated",
+            workspace_id=str(workspace_id),
+            pr_number=pr_number,
+            exc_info=True,
+        )
+
+
 async def _download_archive(conn: VCSConnection, owner: str, repo: str, ref: str) -> bytes:
     return await _provider_download_archive(conn, owner, repo, ref)
 
@@ -834,6 +887,13 @@ async def _poll_workspace_prs(
             else ([ws.working_directory] if ws.working_directory else [])
         )
         if pr_prefixes and ws.vcs_last_commit_sha:
+            # A PR we have already decided not to run is done, exactly as a PR
+            # we have run is done — but only a run leaves a row for the guard
+            # above to find, so without this the skip is indistinguishable from
+            # "never processed" and is recomputed, at the cost of one provider
+            # call, every cycle forever (#1330).
+            if await _pr_decision_is_remembered(ws.id, pr.number, pr.head_sha):
+                continue
             try:
                 changed = await _get_changed_files(
                     conn, owner, repo, ws.vcs_last_commit_sha, pr.head_sha
@@ -848,6 +908,7 @@ async def _poll_workspace_prs(
                         changed_files=changed[:20],
                         changed_files_count=len(changed),
                     )
+                    await _remember_pr_decision(ws.id, pr.number, pr.head_sha)
                     continue
             except Exception as e:
                 logger.warning(

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -1437,3 +1437,125 @@ class TestPollWorkspacePassesMetadataCacheCorrectly:
                 f"{mock._mock_name or 'helper'} got meta={type(kwargs['meta']).__name__}"
             )
             assert kwargs["fetch_paths"] == ["environments/dev"]
+
+
+class TestFilteredPRIsDecidedOnce:
+    """A PR the trigger-prefix filter rejects must be decided once, not once
+    per cycle (#1330).
+
+    The loop's "already handled" guard looks for a Run, so every path that
+    creates one terminates. The filter is the only path that creates no run —
+    which made a deliberate skip indistinguishable from "never processed", so
+    it was re-evaluated against the provider every 60s forever. On one instance
+    that was 11,439 redundant compare calls an hour against a 5,000/hr budget.
+    """
+
+    def _prs(self, number=7, head_sha="ccc333"):
+        pr = MagicMock()
+        pr.number = number
+        pr.head_sha = head_sha
+        pr.head_ref = "feature"
+        pr.title = "some app change"
+        return [pr]
+
+    def _db_with_no_existing_run(self):
+        """No Run row for this PR+SHA — which is the state a filtered PR is
+        permanently in, since the skip never creates one."""
+        db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(return_value=result)
+        return db
+
+    @patch("terrapod.services.vcs_poller._remember_pr_decision")
+    @patch("terrapod.services.vcs_poller._pr_decision_is_remembered")
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._list_open_prs")
+    async def test_a_skip_is_recorded(
+        self, mock_prs, mock_changed, mock_create, mock_remembered, mock_remember
+    ):
+        from terrapod.services.vcs_poller import _poll_workspace_prs
+
+        ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
+        mock_prs.return_value = self._prs()
+        mock_changed.return_value = ["frontend/app.tsx"]  # no prefix match
+        mock_remembered.return_value = False
+
+        await _poll_workspace_prs(
+            self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
+        )
+
+        mock_create.assert_not_called()
+        mock_remember.assert_awaited_once_with(ws.id, 7, "ccc333")
+
+    @patch("terrapod.services.vcs_poller._remember_pr_decision")
+    @patch("terrapod.services.vcs_poller._pr_decision_is_remembered")
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._list_open_prs")
+    async def test_a_remembered_skip_costs_no_provider_call(
+        self, mock_prs, mock_changed, mock_create, mock_remembered, mock_remember
+    ):
+        """The defect itself: the second cycle must not re-fetch changed files."""
+        from terrapod.services.vcs_poller import _poll_workspace_prs
+
+        ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
+        mock_prs.return_value = self._prs()
+        mock_remembered.return_value = True  # decided on a previous cycle
+
+        await _poll_workspace_prs(
+            self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
+        )
+
+        mock_changed.assert_not_called()
+        mock_create.assert_not_called()
+
+    @patch("terrapod.services.vcs_poller._remember_pr_decision")
+    @patch("terrapod.services.vcs_poller._pr_decision_is_remembered")
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._list_open_prs")
+    async def test_a_new_head_sha_is_evaluated_afresh(
+        self, mock_prs, mock_changed, mock_create, mock_remembered, mock_remember
+    ):
+        """A PR update is a new head SHA, so it must not inherit the old skip."""
+        from terrapod.services.vcs_poller import _poll_workspace_prs
+
+        ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
+        mock_prs.return_value = self._prs(head_sha="ddd444")
+        mock_remembered.return_value = False  # keyed on head SHA, so a miss
+        mock_changed.return_value = ["terraform/auth0/main.tf"]  # now matches
+        mock_create.return_value = MagicMock(id=uuid.uuid4())
+
+        await _poll_workspace_prs(
+            self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
+        )
+
+        mock_changed.assert_awaited_once()
+        mock_create.assert_called_once()
+        mock_remember.assert_not_awaited()  # it ran; nothing to remember
+
+    @patch("terrapod.services.vcs_poller._pr_decision_is_remembered")
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._list_open_prs")
+    async def test_workspaces_without_prefixes_are_untouched(
+        self, mock_prs, mock_changed, mock_create, mock_remembered
+    ):
+        """No prefixes means the filter block is never entered, so the new
+        lookup must not run either — these workspaces were never the problem."""
+        from terrapod.services.vcs_poller import _poll_workspace_prs
+
+        ws = _mock_workspace(trigger_prefixes=[], working_directory="")
+        mock_prs.return_value = self._prs()
+        mock_create.return_value = MagicMock(id=uuid.uuid4())
+
+        await _poll_workspace_prs(
+            self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
+        )
+
+        mock_remembered.assert_not_called()
+        mock_changed.assert_not_called()
+        mock_create.assert_called_once()


### PR DESCRIPTION
## What was wrong

The PR loop decides it has already handled a PR by looking for a Run:

```python
existing = <Run where workspace_id, vcs_pull_request_number, vcs_commit_sha>
if existing is not None: continue      # job done
```

"Done" is *defined as* "a Run row exists". Every path that creates a run
terminates correctly — including a truncated compare (>300 files) and a compare
that raises, both of which create the run anyway.

The trigger-prefix filter is the only path that creates **no** run. It logged
the skip and moved on, recording nothing — so a deliberate skip was
indistinguishable from "never processed". The next cycle re-detected the same
PR, spent a provider `compare` call re-fetching the changed files, reached the
same conclusion, and skipped again. Every 60 seconds, forever.

## Evidence

**11,439 `Skipping PR run` events in one hour** on the affected instance, each
preceded by one compare call, against a 5,000/hr GitHub budget. The quota was
continuously exhausted — polls returned `403, 0 requests remaining`, and every
workspace on that connection stopped picking up pushes and PRs until the hourly
window reset, whereupon it drained again.

A single cycle shows the same pairs recurring: workspaces watching
`terraform/auth0` and `terraform/superset` both re-evaluating PRs whose 132 and
155 changed files are entirely application code.

## Who was paying

Only workspaces with `trigger_prefixes` or a `working_directory` enter the
filter block. Workspaces without them fall straight through, create a run, and
are found by the guard next cycle — zero waste.

So the cost was `(workspaces with prefixes) × (non-matching open PRs) × (cycles)`,
which inverts the intent: **the filter exists to reduce work, and was the only
thing generating sustained API load.** The better a prefix excluded, the more it
cost, and it scaled the wrong way on workspace count, open-PR count and poll
frequency simultaneously.

## The fix

Remember the skip against the same `(workspace, pr_number, head_sha)` triple the
existing guard already uses, so a filtered PR costs one provider call instead of
one per cycle — `O(new PR heads)` rather than `O(PRs × cycles)`, the same shape
the run path already had.

Keying on the head SHA is sound: the filter compares
`ws.vcs_last_commit_sha ... pr.head_sha` (three-dot), and since the PR head is
fixed while the tracked branch only moves forward, that diff can only shrink —
a skip stays a skip. The TTL covers the one case where it could grow again, a
force-push or re-seed that rewinds the last-seen commit.

**Redis, not a table.** Re-deciding is harmless, so this is a cache rather than
a record, and a patch release shouldn't carry a migration for it. Both helpers
fail open: if Redis is unavailable we re-evaluate, costing one call and
behaving exactly as today, rather than risk silently suppressing a run.

## Tests

Four in the services-api tier, driven through `_poll_workspace_prs`:

- a skip is recorded
- **a remembered skip costs no provider call** — the defect itself
- a new head SHA is evaluated afresh, so a PR update still runs
- workspaces without prefixes are untouched (they were never the problem)

Verified the key test bites: removing only the early-return guard fails
`test_a_remembered_skip_costs_no_provider_call`; restoring it passes all four.

`make test` — 4375 passed.

## Not the cause

Ruled out during investigation, recorded so nobody re-treads it: the per-cycle
`VCSMetadataCache` (#1096) is correctly wired on the workspace-poll path, and
the autodiscovery cache bypass (#1329) never executes on the affected instance
— it has zero autodiscovery rules.

Closes #1330