### PR TITLE
fix(1332): key the filtered-PR memo on the filter, not just the PR

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -587,6 +587,7 @@ Currently registered trigger handlers:
 | `tp:sched:{name}:last` | Last completed execution timestamp | -- |
 | `tp:sched:triggers` | Triggered task queue (Redis LIST) | -- |
 | `tp:sched:trigger:{dedup}` | Trigger deduplication key | 5 min |
+| `tp:pr_skip:{workspace}:{pr}:{head-sha}:{prefix-digest}` | A pull request the trigger-prefix filter rejected, so the decision is made once per PR head rather than once per poll cycle. The digest covers the resolved prefixes, so editing them re-evaluates. Safe to delete by hand. | 30 days |
 
 ### Adding New Scheduled Tasks
 

--- a/docs/vcs-integration.md
+++ b/docs/vcs-integration.md
@@ -387,6 +387,8 @@ Now commits to `modules/vpc/main.tf` will trigger runs for this workspace.
 - When `trigger-prefixes` is set, the working directory is NOT automatically included — add it explicitly if needed
 - Set to `[]` (empty list) to revert to default working directory filtering
 
+**The decision is cached per pull-request head.** Working out that a pull request touches nothing under the prefixes costs one call to the VCS provider, and the answer cannot change until the pull request is pushed to — so Terrapod records it in Redis (`tp:pr_skip:…`, 30-day TTL) rather than recomputing it on every poll cycle. The key includes the resolved prefixes, so **editing `trigger-prefixes` or `working-directory` re-evaluates every open pull request on the next cycle** — you do not have to wait out the TTL or push a commit to see the effect of a change. If you ever need to force a re-evaluation without changing anything (for instance after force-pushing the tracked branch), delete the key: `DEL tp:pr_skip:{workspace-id}:{pr-number}:{head-sha}:*`, or simply push to the pull request.
+
 **Sparse fetch implication.** `working-directory` and `trigger-prefixes` also narrow the actual git fetch — Terrapod only downloads blobs reachable under those paths. For a workspace tracking `environments/dev` of a 500 MB monorepo, the wire fetch is bounded by the size of `environments/dev/` plus any declared `trigger-prefixes`, not the full repo.
 
 ### Supported URL Formats

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -18,6 +18,7 @@ the scheduler's trigger queue with deduplication.
 """
 
 import asyncio
+import hashlib
 import time as time_mod
 import uuid
 from datetime import UTC, datetime
@@ -119,22 +120,37 @@ async def _get_default_branch(
 # A PR head the trigger-prefix filter rejected. Remembered so the decision is
 # made once per PR head rather than once per poll cycle (#1330).
 #
-# Keying on the head SHA is sound because the filter compares
-# `ws.vcs_last_commit_sha ... pr.head_sha` (three-dot): the PR head is fixed
-# while the tracked branch only moves forward, so that diff can only shrink and
-# a skip stays a skip. The TTL covers the one case where it could grow again —
-# a force-push or re-seed that rewinds the workspace's last-seen commit.
+# The key carries every input the decision depends on: the PR head SHA and the
+# resolved prefixes. Changing the filter is therefore a cache miss, so an
+# operator who widens a prefix sees the PR re-evaluated on the next cycle rather
+# than staying silently suppressed (#1332). The tracked-branch SHA is
+# deliberately NOT in the key — it advances constantly, and including it would
+# invalidate the memo on every push to the branch, which is the cost this exists
+# to avoid.
+#
+# Leaving it out is sound in the ordinary case: the filter compares
+# `ws.vcs_last_commit_sha ... pr.head_sha` (three-dot), and as the tracked branch
+# advances the merge base advances with it, so the diff normally only shrinks and
+# a skip stays a skip. Two residual cases can make it grow again — a force-push
+# that rewinds the tracked branch, and a merge base that advances past a commit
+# on the PR branch (a stacked or partially-merged PR) so a change-then-revert
+# pair stops cancelling out. Both are rare, both resolve as soon as the PR is
+# pushed to, and the TTL bounds them; `DEL tp:pr_skip:*` clears one by hand.
 _PR_SKIP_TTL_SECONDS = 30 * 24 * 60 * 60
 
 
-def _pr_skip_key(workspace_id: uuid.UUID, pr_number: int, head_sha: str) -> str:
-    return f"tp:pr_skip:{workspace_id}:{pr_number}:{head_sha}"
+def _pr_skip_key(
+    workspace_id: uuid.UUID, pr_number: int, head_sha: str, prefixes: list[str]
+) -> str:
+    # Order-insensitive: reordering the prefixes does not change the decision.
+    digest = hashlib.sha256("\x00".join(sorted(prefixes)).encode()).hexdigest()[:12]
+    return f"tp:pr_skip:{workspace_id}:{pr_number}:{head_sha}:{digest}"
 
 
 async def _pr_decision_is_remembered(
-    workspace_id: uuid.UUID, pr_number: int, head_sha: str
+    workspace_id: uuid.UUID, pr_number: int, head_sha: str, prefixes: list[str]
 ) -> bool:
-    """True if this PR head was already evaluated and skipped for this workspace.
+    """True if this PR head was already evaluated and skipped under these prefixes.
 
     Fails open: if Redis is unavailable we return False and re-evaluate, which
     costs one provider call and behaves exactly as before. The opposite default
@@ -143,29 +159,31 @@ async def _pr_decision_is_remembered(
     try:
         from terrapod.redis.client import get_redis_client
 
-        return bool(
-            await get_redis_client().exists(_pr_skip_key(workspace_id, pr_number, head_sha))
-        )
+        key = _pr_skip_key(workspace_id, pr_number, head_sha, prefixes)
+        return bool(await get_redis_client().exists(key))
     except Exception:
         return False
 
 
-async def _remember_pr_decision(workspace_id: uuid.UUID, pr_number: int, head_sha: str) -> None:
+async def _remember_pr_decision(
+    workspace_id: uuid.UUID, pr_number: int, head_sha: str, prefixes: list[str]
+) -> None:
     """Record that this PR head was evaluated and did not warrant a run."""
     try:
         from terrapod.redis.client import get_redis_client
 
-        await get_redis_client().set(
-            _pr_skip_key(workspace_id, pr_number, head_sha), "1", ex=_PR_SKIP_TTL_SECONDS
-        )
-    except Exception:
+        key = _pr_skip_key(workspace_id, pr_number, head_sha, prefixes)
+        await get_redis_client().set(key, "1", ex=_PR_SKIP_TTL_SECONDS)
+    except Exception as e:
         # Best effort. Losing the marker costs a repeated provider call, never
-        # correctness.
+        # correctness. Logged without a traceback: a sustained Redis outage
+        # reaches this line once per filtered PR per cycle, and stack traces at
+        # that rate bury everything else.
         logger.warning(
             "Could not record skipped-PR decision; it will be re-evaluated",
             workspace_id=str(workspace_id),
             pr_number=pr_number,
-            exc_info=True,
+            error=repr(e),
         )
 
 
@@ -845,6 +863,26 @@ async def _poll_workspace_prs(
         if existing.scalar_one_or_none() is not None:
             continue
 
+        # VCS subdirectory filtering for PRs: compare PR head against tracked branch.
+        # Resolved before anything else in the loop does work, because a PR we have
+        # already decided not to run is done, exactly as a PR we have run is done —
+        # but only a run leaves a row for the guard above to find. Without the memo
+        # the skip is indistinguishable from "never processed" and is recomputed, at
+        # the cost of one provider call, every cycle forever (#1330). Checking it here
+        # rather than further down also keeps a permanently-filtered PR from
+        # incrementing VCS_PRS_DETECTED and logging "New PR commit detected" on every
+        # cycle, which would leave the counter useless for alerting (#1332).
+        pr_prefixes = (
+            ws.trigger_prefixes
+            if ws.trigger_prefixes
+            else ([ws.working_directory] if ws.working_directory else [])
+        )
+        prefix_filtered = bool(pr_prefixes and ws.vcs_last_commit_sha)
+        if prefix_filtered and await _pr_decision_is_remembered(
+            ws.id, pr.number, pr.head_sha, pr_prefixes
+        ):
+            continue
+
         # Cancel any existing non-terminal runs for this PR (superseded by new commit)
         stale_result = await db.execute(
             select(Run).where(
@@ -880,20 +918,7 @@ async def _poll_workspace_prs(
             title=pr.title,
         )
 
-        # VCS subdirectory filtering for PRs: compare PR head against tracked branch
-        pr_prefixes = (
-            ws.trigger_prefixes
-            if ws.trigger_prefixes
-            else ([ws.working_directory] if ws.working_directory else [])
-        )
-        if pr_prefixes and ws.vcs_last_commit_sha:
-            # A PR we have already decided not to run is done, exactly as a PR
-            # we have run is done — but only a run leaves a row for the guard
-            # above to find, so without this the skip is indistinguishable from
-            # "never processed" and is recomputed, at the cost of one provider
-            # call, every cycle forever (#1330).
-            if await _pr_decision_is_remembered(ws.id, pr.number, pr.head_sha):
-                continue
+        if prefix_filtered:
             try:
                 changed = await _get_changed_files(
                     conn, owner, repo, ws.vcs_last_commit_sha, pr.head_sha
@@ -908,7 +933,7 @@ async def _poll_workspace_prs(
                         changed_files=changed[:20],
                         changed_files_count=len(changed),
                     )
-                    await _remember_pr_decision(ws.id, pr.number, pr.head_sha)
+                    await _remember_pr_decision(ws.id, pr.number, pr.head_sha, pr_prefixes)
                     continue
             except Exception as e:
                 logger.warning(

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -1439,9 +1439,32 @@ class TestPollWorkspacePassesMetadataCacheCorrectly:
             assert kwargs["fetch_paths"] == ["environments/dev"]
 
 
+class _FakeRedis:
+    """Enough of the Redis surface for the skip marker, and nothing else.
+
+    Deliberately a fake rather than a mock of `_pr_decision_is_remembered` /
+    `_remember_pr_decision`: those two wrappers ARE the fix, so mocking them
+    leaves their bodies — the key format, the TTL, the bool coercion, the
+    swallowing `except` — unexecuted, and a regression in any of them would
+    silently restore #1330 with a green suite. This mocks the boundary below
+    them instead, per the AGENTS.md rule (#1332).
+    """
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.set_calls: list[tuple[str, int | None]] = []
+
+    async def exists(self, key):
+        return 1 if key in self.store else 0
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+        self.set_calls.append((key, ex))
+
+
 class TestFilteredPRIsDecidedOnce:
     """A PR the trigger-prefix filter rejects must be decided once, not once
-    per cycle (#1330).
+    per cycle (#1330) — and the decision must not outlive its inputs (#1332).
 
     The loop's "already handled" guard looks for a Run, so every path that
     creates one terminates. The filter is the only path that creates no run —
@@ -1468,74 +1491,127 @@ class TestFilteredPRIsDecidedOnce:
         db.execute = AsyncMock(return_value=result)
         return db
 
-    @patch("terrapod.services.vcs_poller._remember_pr_decision")
-    @patch("terrapod.services.vcs_poller._pr_decision_is_remembered")
+    async def _cycle(self, ws, redis, prs):
+        """One poll cycle against a real Redis-backed memo."""
+        from terrapod.services.vcs_poller import _poll_workspace_prs
+
+        with patch("terrapod.redis.client.get_redis_client", return_value=redis):
+            await _poll_workspace_prs(
+                self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
+            )
+        return prs
+
     @patch("terrapod.services.vcs_poller._create_vcs_run")
     @patch("terrapod.services.vcs_poller._get_changed_files")
     @patch("terrapod.services.vcs_poller._list_open_prs")
-    async def test_a_skip_is_recorded(
-        self, mock_prs, mock_changed, mock_create, mock_remembered, mock_remember
+    async def test_the_second_cycle_costs_no_provider_call(
+        self, mock_prs, mock_changed, mock_create
     ):
-        from terrapod.services.vcs_poller import _poll_workspace_prs
-
+        """The defect itself, driven end to end: two cycles, one compare call."""
+        redis = _FakeRedis()
         ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
         mock_prs.return_value = self._prs()
         mock_changed.return_value = ["frontend/app.tsx"]  # no prefix match
-        mock_remembered.return_value = False
 
-        await _poll_workspace_prs(
-            self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
-        )
+        await self._cycle(ws, redis, mock_prs)
+        assert mock_changed.await_count == 1
+        assert len(redis.store) == 1, "the skip was not recorded"
 
+        # Nothing about the PR or the workspace has changed, so the second
+        # cycle must reach its decision from the marker alone.
+        await self._cycle(ws, redis, mock_prs)
+        assert mock_changed.await_count == 1, "re-evaluated a PR already decided"
         mock_create.assert_not_called()
-        mock_remember.assert_awaited_once_with(ws.id, 7, "ccc333")
 
-    @patch("terrapod.services.vcs_poller._remember_pr_decision")
-    @patch("terrapod.services.vcs_poller._pr_decision_is_remembered")
     @patch("terrapod.services.vcs_poller._create_vcs_run")
     @patch("terrapod.services.vcs_poller._get_changed_files")
     @patch("terrapod.services.vcs_poller._list_open_prs")
-    async def test_a_remembered_skip_costs_no_provider_call(
-        self, mock_prs, mock_changed, mock_create, mock_remembered, mock_remember
-    ):
-        """The defect itself: the second cycle must not re-fetch changed files."""
+    async def test_editing_the_prefixes_re_evaluates(self, mock_prs, mock_changed, mock_create):
+        """#1332: widening a prefix is exactly what an operator does when a PR
+        is not planning, so it must dislodge the skip rather than be swallowed
+        by it for the TTL."""
+        redis = _FakeRedis()
+        ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
+        mock_prs.return_value = self._prs()
+        mock_changed.return_value = ["frontend/app.tsx"]
+        mock_create.return_value = MagicMock(id=uuid.uuid4())
+
+        await self._cycle(ws, redis, mock_prs)
+        assert mock_changed.await_count == 1
+        mock_create.assert_not_called()
+
+        # The operator notices the prefix was wrong and widens it.
+        ws.trigger_prefixes = ["frontend"]
+
+        await self._cycle(ws, redis, mock_prs)
+        assert mock_changed.await_count == 2, "stale marker suppressed the re-evaluation"
+        mock_create.assert_called_once()
+
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._list_open_prs")
+    async def test_a_new_head_sha_is_evaluated_afresh(self, mock_prs, mock_changed, mock_create):
+        """A PR update is a new head SHA, so it must not inherit the old skip."""
+        redis = _FakeRedis()
+        ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
+        mock_prs.return_value = self._prs()
+        mock_changed.return_value = ["frontend/app.tsx"]
+        mock_create.return_value = MagicMock(id=uuid.uuid4())
+
+        await self._cycle(ws, redis, mock_prs)
+        assert mock_changed.await_count == 1
+
+        # The author pushes a commit that does touch the watched subtree.
+        mock_prs.return_value = self._prs(head_sha="ddd444")
+        mock_changed.return_value = ["terraform/auth0/main.tf"]
+
+        await self._cycle(ws, redis, mock_prs)
+        assert mock_changed.await_count == 2, "a new head SHA reused the old decision"
+        mock_create.assert_called_once()
+
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._list_open_prs")
+    async def test_the_marker_carries_a_bounded_ttl(self, mock_prs, mock_changed, mock_create):
+        """A marker that never expired would make a rewound tracked branch a
+        permanent suppression rather than a temporary one."""
+        from terrapod.services.vcs_poller import _PR_SKIP_TTL_SECONDS
+
+        redis = _FakeRedis()
+        ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
+        mock_prs.return_value = self._prs()
+        mock_changed.return_value = ["frontend/app.tsx"]
+
+        await self._cycle(ws, redis, mock_prs)
+
+        assert len(redis.set_calls) == 1
+        key, ttl = redis.set_calls[0]
+        assert ttl == _PR_SKIP_TTL_SECONDS
+        assert key.startswith("tp:pr_skip:")
+        assert "ccc333" in key, "the head SHA must scope the marker"
+
+    @patch("terrapod.services.vcs_poller._create_vcs_run")
+    @patch("terrapod.services.vcs_poller._get_changed_files")
+    @patch("terrapod.services.vcs_poller._list_open_prs")
+    async def test_a_redis_outage_fails_open(self, mock_prs, mock_changed, mock_create):
+        """Losing Redis must cost a repeated provider call, never a lost run —
+        the pre-#1330 behaviour, which was wasteful but correct."""
         from terrapod.services.vcs_poller import _poll_workspace_prs
 
         ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
         mock_prs.return_value = self._prs()
-        mock_remembered.return_value = True  # decided on a previous cycle
-
-        await _poll_workspace_prs(
-            self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
-        )
-
-        mock_changed.assert_not_called()
-        mock_create.assert_not_called()
-
-    @patch("terrapod.services.vcs_poller._remember_pr_decision")
-    @patch("terrapod.services.vcs_poller._pr_decision_is_remembered")
-    @patch("terrapod.services.vcs_poller._create_vcs_run")
-    @patch("terrapod.services.vcs_poller._get_changed_files")
-    @patch("terrapod.services.vcs_poller._list_open_prs")
-    async def test_a_new_head_sha_is_evaluated_afresh(
-        self, mock_prs, mock_changed, mock_create, mock_remembered, mock_remember
-    ):
-        """A PR update is a new head SHA, so it must not inherit the old skip."""
-        from terrapod.services.vcs_poller import _poll_workspace_prs
-
-        ws = _mock_workspace(trigger_prefixes=["terraform/auth0"], vcs_last_commit_sha="aaa111")
-        mock_prs.return_value = self._prs(head_sha="ddd444")
-        mock_remembered.return_value = False  # keyed on head SHA, so a miss
-        mock_changed.return_value = ["terraform/auth0/main.tf"]  # now matches
+        mock_changed.return_value = ["terraform/auth0/main.tf"]  # matches: must run
         mock_create.return_value = MagicMock(id=uuid.uuid4())
 
-        await _poll_workspace_prs(
-            self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
-        )
+        with patch(
+            "terrapod.redis.client.get_redis_client", side_effect=RuntimeError("redis is down")
+        ):
+            await _poll_workspace_prs(
+                self._db_with_no_existing_run(), ws, _mock_connection(), "org", "repo", "main"
+            )
 
         mock_changed.assert_awaited_once()
         mock_create.assert_called_once()
-        mock_remember.assert_not_awaited()  # it ran; nothing to remember
 
     @patch("terrapod.services.vcs_poller._pr_decision_is_remembered")
     @patch("terrapod.services.vcs_poller._create_vcs_run")
@@ -1545,7 +1621,9 @@ class TestFilteredPRIsDecidedOnce:
         self, mock_prs, mock_changed, mock_create, mock_remembered
     ):
         """No prefixes means the filter block is never entered, so the new
-        lookup must not run either — these workspaces were never the problem."""
+        lookup must not run either — these workspaces were never the problem.
+        (Patching the wrapper is legitimate here: the assertion is that it is
+        never called, so its body is not under test.)"""
         from terrapod.services.vcs_poller import _poll_workspace_prs
 
         ws = _mock_workspace(trigger_prefixes=[], working_directory="")


### PR DESCRIPTION
Closes #1332. Found by the pre-release review of v1.4.1, before it shipped — so #1330's fix and this hardening land in the same release and no version ever carries the regression.

### The memo now expires when its inputs change

`tp:pr_skip:{workspace}:{pr}:{head_sha}` identified the subject of the decision but none of its inputs. `trigger-prefixes` and `working-directory` are mutable on any workspace PATCH and nothing clears the key, so widening a prefix — exactly what an operator does when a PR is not planning — left the PR suppressed for 30 days. The key now carries a digest of the resolved prefixes (sorted, so reordering is not a change), making an edit an automatic cache miss.

The tracked-branch SHA is deliberately still out of the key: it advances constantly, and including it would invalidate the memo on every push to the branch, which is the cost the memo exists to avoid. The comment above the constant now states the residual honestly rather than claiming the TTL "covers" a force-push and that the three-dot diff "can only shrink" — neither of which holds as stated.

### The check moved above the per-cycle work it was meant to stop

`VCS_PRS_DETECTED`, the "New PR commit detected" INFO line and the stale-run query all sat above the memo check, so a permanently filtered PR kept incrementing that counter and logging a false detection every cycle regardless. At the scale that motivated #1330 that is thousands of spurious increments an hour, which makes the counter useless for PR-activity alerting.

### The tests now execute the code they are named after

All four previous tests patched `_pr_decision_is_remembered` / `_remember_pr_decision` — the wrappers that *are* the fix — so the key format, the TTL, the bool coercion, both `except` branches and the lazy `get_redis_client` import were never executed. `get_redis_client()` raises when Redis is not initialised and that raise is inside the swallowing `try`, so a breakage there would return `False` forever and silently restore #1330 with a fully green suite. This is the AGENTS.md rule for exactly this shape, and the #1244 failure mode it was written for.

They now drive `_poll_workspace_prs` across multiple cycles against a fake Redis, mocking the boundary *below* the wrappers:

- two cycles, one compare call (the original defect, end to end)
- editing the prefixes re-evaluates (the regression above)
- a new head SHA is evaluated afresh — previously asserted by a comment, since the mocked lookup returned `False` for any SHA
- the marker carries the bounded TTL and is scoped to the head SHA
- a Redis outage fails open: the run still happens

**Revert-and-prove:** with the key reverted to its previous form, `test_editing_the_prefixes_re_evaluates` fails (`assert 1 == 2`, "stale marker suppressed the re-evaluation") and the rest still pass; with the fix restored, all 73 in the file pass. Note this required rebuilding the test image — it COPYs source, so a host-side edit alone proves nothing.

### Also

- `tp:pr_skip:` is documented in the Redis table and in the trigger-prefix docs, which previously did not mention the decision was cached at all — even though deleting the key is the only manual escape.
- The write-path warning drops its traceback: a sustained Redis outage reaches it once per filtered PR per cycle, and stack traces at that rate bury everything else.

No route, response attribute, wire field, config key, Helm value or database column changes.