### PR TITLE
fix(1329): share the cycle's metadata cache with the autodiscovery pass

### DIFF
--- a/services/terrapod/api/routers/runs.py
+++ b/services/terrapod/api/routers/runs.py
@@ -385,7 +385,7 @@ async def _fetch_vcs_config(
 
     if ref_override:
         # Try as branch first, then tag, then treat as raw SHA
-        sha = await _get_branch_sha(conn, owner, repo, ref_override)
+        sha = await _get_branch_sha(conn, owner, repo, ref_override, meta=None)
         ref_name = ref_override
         if not sha:
             tags = await _list_tags(conn, owner, repo)
@@ -399,7 +399,7 @@ async def _fetch_vcs_config(
         ref_name = await _resolve_branch(conn, ws, owner, repo) or ""
         if not ref_name:
             raise HTTPException(status_code=422, detail="Cannot determine VCS branch")
-        sha = await _get_branch_sha(conn, owner, repo, ref_name)
+        sha = await _get_branch_sha(conn, owner, repo, ref_name, meta=None)
         if not sha:
             raise HTTPException(status_code=422, detail="Cannot get branch HEAD SHA")
 

--- a/services/terrapod/services/drift_detection_service.py
+++ b/services/terrapod/services/drift_detection_service.py
@@ -223,7 +223,7 @@ async def _create_drift_run_vcs(
         return None
 
     try:
-        sha = await _get_branch_sha(conn, owner, repo, branch)
+        sha = await _get_branch_sha(conn, owner, repo, branch, meta=None)
     except Exception as e:
         logger.error("Failed to get branch SHA for drift check", workspace=ws.name, error=str(e))
         return None

--- a/services/terrapod/services/vcs_poller.py
+++ b/services/terrapod/services/vcs_poller.py
@@ -90,12 +90,21 @@ async def _get_branch_sha(
     owner: str,
     repo: str,
     branch: str,
-    meta: VCSMetadataCache | None = None,
+    *,
+    meta: VCSMetadataCache | None,
 ) -> str | None:
     """Head SHA of `branch`, deduplicated across workspaces in this cycle (#1096).
 
     Many workspaces share a repo+branch, and the answer is identical for all of
-    them. `meta` is None for one-shot callers, which behave exactly as before.
+    them.
+
+    `meta` is keyword-only and has no default on purpose (#1329). As an optional
+    trailing argument it made the *uncached* path the default, so a call site
+    that forgot it looked correct, read correctly in review, and silently spent
+    provider quota — which is how the autodiscovery pass ended up re-fetching
+    metadata the workspace poll had already cached in the same cycle. Omitting
+    it is now a TypeError, so every caller has to say which it wants; one-shot
+    callers with no cycle to share pass `meta=None` explicitly.
     """
     if meta is None:
         return await _provider_get_branch_sha(conn, owner, repo, branch)
@@ -106,8 +115,12 @@ async def _get_branch_sha(
 
 
 async def _get_default_branch(
-    conn: VCSConnection, owner: str, repo: str, meta: VCSMetadataCache | None = None
+    conn: VCSConnection, owner: str, repo: str, *, meta: VCSMetadataCache | None
 ) -> str | None:
+    """Default branch, deduplicated across workspaces in this cycle (#1096).
+
+    `meta` is keyword-only and required — see `_get_branch_sha` (#1329).
+    """
     if meta is None:
         return await _provider_get_default_branch(conn, owner, repo)
     # "" in the branch slot — this lookup has no branch of its own.
@@ -259,15 +272,19 @@ async def _list_open_prs(
     owner: str,
     repo: str,
     base_branch: str,
-    meta: VCSMetadataCache | None = None,
+    *,
+    meta: VCSMetadataCache | None,
 ) -> list[PullRequest]:
-    """Open PRs/MRs targeting `base_branch`, deduplicated per cycle (#1096)."""
+    """Open PRs/MRs targeting `base_branch`, deduplicated per cycle (#1096).
+
+    `meta` is keyword-only and required — see `_get_branch_sha` (#1329).
+    """
     if meta is not None:
         # Distinct key space from the branch-SHA lookup, which shares the same
         # (conn, owner, repo, branch) tuple.
         return await meta.get_or_fetch(
             (str(conn.id), owner, repo, f"prs:{base_branch}"),
-            lambda: _list_open_prs(conn, owner, repo, base_branch),
+            lambda: _list_open_prs(conn, owner, repo, base_branch, meta=None),
         )
     if conn.provider == "gitlab":
         return await gitlab_service.list_open_prs(conn, owner, repo, base_branch)
@@ -358,7 +375,7 @@ async def _resolve_branch(
     if ws.vcs_branch:
         return ws.vcs_branch
 
-    default_branch = await _get_default_branch(conn, owner, repo, meta)
+    default_branch = await _get_default_branch(conn, owner, repo, meta=meta)
     if default_branch:
         return default_branch
     logger.warning(
@@ -507,7 +524,7 @@ async def _poll_workspace_branch(
     fetch_paths: list[str] | None = None,
 ) -> None:
     """Check the tracked branch for new commits and create a run."""
-    sha = await _get_branch_sha(conn, owner, repo, branch, meta)
+    sha = await _get_branch_sha(conn, owner, repo, branch, meta=meta)
 
     if sha is None:
         logger.warning(
@@ -836,7 +853,7 @@ async def _poll_workspace_prs(
     fetch_paths: list[str] | None = None,
 ) -> None:
     """Check open PRs/MRs targeting the tracked branch for speculative plans."""
-    prs = await _list_open_prs(conn, owner, repo, branch, meta)
+    prs = await _list_open_prs(conn, owner, repo, branch, meta=meta)
 
     # Hook-and-poll fallbacks (#282). Only run for apply-then-merge —
     # default-mode PR runs are plan-only and don't drive any of this.
@@ -1472,6 +1489,8 @@ async def _poll_autodiscovery_for_connection(
     db: AsyncSession,
     conn: VCSConnection,
     rules: list[AutodiscoveryRule],
+    *,
+    meta: VCSMetadataCache | None,
 ) -> int:
     """Scan open PRs for one connection's rules and auto-create workspaces.
 
@@ -1501,7 +1520,7 @@ async def _poll_autodiscovery_for_connection(
         target_branch = branch
         if not target_branch:
             try:
-                target_branch = await _get_default_branch(conn, owner, repo) or "main"
+                target_branch = await _get_default_branch(conn, owner, repo, meta=meta) or "main"
             except Exception:
                 logger.warning(
                     "Autodiscovery: failed to resolve default branch — skipping",
@@ -1516,12 +1535,12 @@ async def _poll_autodiscovery_for_connection(
         # of firing a premature plan+apply for a directory that only
         # exists on the (still-open) PR branch (#313). None on failure —
         # falls back to the prior NULL-seed behaviour.
-        baseline_sha = await _get_branch_sha(conn, owner, repo, target_branch)
+        baseline_sha = await _get_branch_sha(conn, owner, repo, target_branch, meta=meta)
 
         # Pull open PRs and the default-branch tip — both are sources of
         # discoverable changed files.
         try:
-            prs = await _list_open_prs(conn, owner, repo, target_branch)
+            prs = await _list_open_prs(conn, owner, repo, target_branch, meta=meta)
         except Exception:
             logger.warning(
                 "Autodiscovery: failed to list PRs — skipping",
@@ -1649,7 +1668,10 @@ async def _poll_autodiscovery_for_connection(
 
 
 async def _poll_autodiscovery(
-    *, owner_repo: tuple[str, str] | None = None, provider: str | None = None
+    *,
+    meta: VCSMetadataCache | None,
+    owner_repo: tuple[str, str] | None = None,
+    provider: str | None = None,
 ) -> int:
     """Run autodiscovery across every VCS connection that has at least
     one enabled rule.
@@ -1709,7 +1731,7 @@ async def _poll_autodiscovery(
             if conn is None or conn.status != "active":
                 continue
             try:
-                created = await _poll_autodiscovery_for_connection(db, conn, conn_rules)
+                created = await _poll_autodiscovery_for_connection(db, conn, conn_rules, meta=meta)
                 total_created += created
             except Exception:
                 # Per-connection isolation: log and continue.
@@ -1735,11 +1757,20 @@ async def poll_cycle() -> None:
     """
     start = time_mod.monotonic()
 
+    # One metadata cache for the whole cycle (#1096, #1329). Branch-SHA and
+    # open-PR lookups are identical for every workspace on the same repo+branch,
+    # and the autodiscovery pass below asks for the same metadata again; without
+    # this, each caller re-asked and a modest estate exhausted the provider's
+    # hourly quota. Built here, before autodiscovery, so both passes share one
+    # set of answers. Per-cycle by design — holding results across cycles would
+    # stop the poller noticing new commits.
+    meta = VCSMetadataCache()
+
     # Autodiscovery first — any newly-created workspaces will be
     # picked up by the workspace scan below (or, if their query
     # snapshot already ran, by the next cycle).
     try:
-        await _poll_autodiscovery()
+        await _poll_autodiscovery(meta=meta)
     except Exception:
         logger.warning("Autodiscovery pass failed", exc_info=True)
 
@@ -1760,12 +1791,6 @@ async def poll_cycle() -> None:
     # One cache instance per cycle — coalesces concurrent (conn, sha, paths)
     # fetches across all workspace polls in this cycle.
     cache = VCSArchiveCache()
-    # One metadata cache per cycle too (#1096). Branch-SHA and open-PR lookups
-    # are identical for every workspace on the same repo+branch; without this,
-    # each workspace re-asked and a modest estate exhausted the provider's
-    # hourly quota. Per-cycle by design — holding results across cycles would
-    # stop the poller noticing new commits.
-    meta = VCSMetadataCache()
     semaphore = asyncio.Semaphore(_MAX_PARALLEL_WORKSPACE_POLLS)
     results = await asyncio.gather(
         *[
@@ -1801,10 +1826,19 @@ async def handle_immediate_poll(payload: dict) -> None:
     # workspaces get picked up by the workspace scan that follows. The
     # repo string in the webhook payload is "owner/repo" — split for
     # the autodiscovery filter.
+    # One metadata cache for the whole cycle (#1096, #1329). Branch-SHA and
+    # open-PR lookups are identical for every workspace on the same repo+branch,
+    # and the autodiscovery pass below asks for the same metadata again; without
+    # this, each caller re-asked and a modest estate exhausted the provider's
+    # hourly quota. Built here, before autodiscovery, so both passes share one
+    # set of answers. Per-cycle by design — holding results across cycles would
+    # stop the poller noticing new commits.
+    meta = VCSMetadataCache()
+
     if repo and "/" in repo:
         owner, repo_name = repo.split("/", 1)
         try:
-            await _poll_autodiscovery(owner_repo=(owner, repo_name), provider=provider)
+            await _poll_autodiscovery(meta=meta, owner_repo=(owner, repo_name), provider=provider)
         except Exception:
             logger.warning(
                 "Autodiscovery: webhook-triggered scan failed",
@@ -1834,12 +1868,6 @@ async def handle_immediate_poll(payload: dict) -> None:
     # Webhook-triggered polls also share one cache instance — same coalescing
     # benefit when multiple workspaces map to the same repo.
     cache = VCSArchiveCache()
-    # One metadata cache per cycle too (#1096). Branch-SHA and open-PR lookups
-    # are identical for every workspace on the same repo+branch; without this,
-    # each workspace re-asked and a modest estate exhausted the provider's
-    # hourly quota. Per-cycle by design — holding results across cycles would
-    # stop the poller noticing new commits.
-    meta = VCSMetadataCache()
     semaphore = asyncio.Semaphore(_MAX_PARALLEL_WORKSPACE_POLLS)
     results = await asyncio.gather(
         *[

--- a/services/tests/services/test_vcs_poller.py
+++ b/services/tests/services/test_vcs_poller.py
@@ -1155,7 +1155,7 @@ class TestMetadataDeduplication:
         ) as prov:
             # Eleven workspaces on one repo+branch, as in a real monorepo estate.
             for _ in range(11):
-                assert await _get_branch_sha(conn, "org", "repo", "main", meta) == "deadbeef"
+                assert await _get_branch_sha(conn, "org", "repo", "main", meta=meta) == "deadbeef"
 
         assert prov.await_count == 1
 
@@ -1173,7 +1173,7 @@ class TestMetadataDeduplication:
             return_value=[],
         ) as prov:
             for _ in range(11):
-                assert await _list_open_prs(conn, "org", "repo", "main", meta) == []
+                assert await _list_open_prs(conn, "org", "repo", "main", meta=meta) == []
 
         assert prov.await_count == 1
 
@@ -1191,7 +1191,7 @@ class TestMetadataDeduplication:
             return_value="main",
         ) as prov:
             for _ in range(5):
-                assert await _get_default_branch(conn, "org", "repo", meta) == "main"
+                assert await _get_default_branch(conn, "org", "repo", meta=meta) == "main"
 
         assert prov.await_count == 1
 
@@ -1208,7 +1208,7 @@ class TestMetadataDeduplication:
             return_value="deadbeef",
         ) as prov:
             for _ in range(3):
-                await _get_branch_sha(conn, "org", "repo", "main")
+                await _get_branch_sha(conn, "org", "repo", "main", meta=None)
 
         assert prov.await_count == 3, "no cache passed -> no caching, exactly as before"
 
@@ -1227,8 +1227,10 @@ class TestMetadataDeduplication:
             "terrapod.services.vcs_poller._provider_get_branch_sha",
             new=AsyncMock(side_effect=by_branch),
         ) as prov:
-            assert await _get_branch_sha(conn, "org", "repo", "main", meta) == "sha-of-main"
-            assert await _get_branch_sha(conn, "org", "repo", "develop", meta) == "sha-of-develop"
+            assert await _get_branch_sha(conn, "org", "repo", "main", meta=meta) == "sha-of-main"
+            assert (
+                await _get_branch_sha(conn, "org", "repo", "develop", meta=meta) == "sha-of-develop"
+            )
 
         assert prov.await_count == 2
 
@@ -1637,3 +1639,76 @@ class TestFilteredPRIsDecidedOnce:
         mock_remembered.assert_not_called()
         mock_changed.assert_not_called()
         mock_create.assert_called_once()
+
+
+class TestAutodiscoverySharesTheCycleCache:
+    """The autodiscovery pass must reuse the cycle's metadata cache (#1329).
+
+    Autodiscovery asks for the same default branch, branch SHA and open-PR
+    list that the workspace poll asks for, on the same repos, in the same
+    cycle. Before this it passed no cache and re-fetched all three from the
+    provider every cycle — pure duplicate spend against the rate limit, on
+    exactly the repos the workspace poll had just looked at.
+    """
+
+    async def test_a_second_lookup_in_the_cycle_does_not_hit_the_provider(self):
+        """The cache is what makes the saving, so prove it end to end rather
+        than asserting the argument was passed."""
+        from terrapod.services.vcs_metadata_cache import VCSMetadataCache
+        from terrapod.services.vcs_poller import _get_branch_sha, _get_default_branch
+
+        meta = VCSMetadataCache()
+        conn = _mock_connection()
+
+        with patch(
+            "terrapod.services.vcs_poller._provider_get_default_branch",
+            new=AsyncMock(return_value="main"),
+        ) as prov_default:
+            # The workspace poll asks first...
+            assert await _get_default_branch(conn, "org", "repo", meta=meta) == "main"
+            # ...then the autodiscovery pass asks for the same thing.
+            assert await _get_default_branch(conn, "org", "repo", meta=meta) == "main"
+            assert prov_default.await_count == 1, "autodiscovery re-fetched the default branch"
+
+        with patch(
+            "terrapod.services.vcs_poller._provider_get_branch_sha",
+            new=AsyncMock(return_value="aaa111"),
+        ) as prov_sha:
+            assert await _get_branch_sha(conn, "org", "repo", "main", meta=meta) == "aaa111"
+            assert await _get_branch_sha(conn, "org", "repo", "main", meta=meta) == "aaa111"
+            assert prov_sha.await_count == 1, "autodiscovery re-fetched the branch SHA"
+
+    async def test_omitting_the_cache_is_a_typeerror_not_a_silent_slow_path(self):
+        """The guard that stops #1329 recurring.
+
+        `meta` was an optional trailing argument, which made the uncached path
+        the default and a forgetful call site indistinguishable from a correct
+        one — the same shape as #1244 and #1250. Keyword-only and required
+        means a call site that omits it cannot even be called.
+        """
+        from terrapod.services.vcs_poller import (
+            _get_branch_sha,
+            _get_default_branch,
+            _list_open_prs,
+        )
+
+        conn = _mock_connection()
+        for call in (
+            lambda: _get_default_branch(conn, "org", "repo"),
+            lambda: _get_branch_sha(conn, "org", "repo", "main"),
+            lambda: _list_open_prs(conn, "org", "repo", "main"),
+        ):
+            with pytest.raises(TypeError, match="meta"):
+                await call()
+
+        # And positionally, which is how the old signature accepted it.
+        with pytest.raises(TypeError):
+            await _get_default_branch(conn, "org", "repo", None)  # type: ignore[misc]
+
+    async def test_the_autodiscovery_pass_is_given_the_cycle_cache(self):
+        """Wiring check: the cache reaches the autodiscovery pass at all."""
+        from terrapod.services.vcs_poller import _poll_autodiscovery
+
+        with patch("terrapod.services.vcs_poller.get_db_session"):
+            with pytest.raises(TypeError, match="meta"):
+                await _poll_autodiscovery()  # type: ignore[call-arg]


### PR DESCRIPTION
Closes #1329.

The autodiscovery pass fetched the default branch, the branch SHA and the open-PR list straight from the provider, on repos the workspace poll had already fetched and cached in the same cycle — its three call sites passed no cache, and each helper opens with `if meta is None:` and goes to the provider. On an instance with autodiscovery rules that is duplicate spend against the rate limit every cycle, on exactly the repos the poll just looked at. The function already groups rules `by_repo_branch` "so we don't re-fetch the same PR list once per rule", so the intent was there; it just predates the shared cache.

The cache is now built once at the top of each cycle — before autodiscovery rather than immediately before the workspace fan-out — and threaded through `_poll_autodiscovery` into the per-connection scan, so both passes share one set of answers. Both cycle entry points (the periodic poll and the webhook-triggered one) do this.

### The signature is the actual fix

Passing the cache at three call sites would leave the trap in place. `meta` was an optional trailing argument on all three helpers, which makes the *uncached* path the default: a call site that omits it is not a visible mistake, it reads correctly, and it silently spends quota. That is the third appearance of this exact shape — #1244 was a total VCS outage caused by the cache being reached through an optional `meta` that every poll-cycle test omitted, and #1250 then had to gate positional optional args in this same module.

So `meta` is now keyword-only with no default. Omitting it is a `TypeError`, not a slow path, and every caller has to say which it wants. One-shot callers that legitimately have no cycle to share — the VCS-ref lookups in `runs.py`, drift detection — pass `meta=None` explicitly, which is a statement rather than an oversight.

### Tests

- The cache genuinely dedupes: a second lookup in the same cycle does not reach the provider, asserted through `_get_default_branch` / `_get_branch_sha` rather than by checking an argument was passed.
- Omitting `meta` raises `TypeError` on all three helpers, positionally as well as by keyword — the guard against a fourth recurrence.
- `_poll_autodiscovery` cannot be called without a cache.

**Revert-and-prove:** restoring the old optional signature makes the guard test fail — and instructively, it fails not by raising but by *proceeding down the uncached path* into the real provider. That is exactly the silent behaviour being removed. Full suite green at 4380.

### Not touched

`policy_vcs_poller` and `module_impact_service` define their own local `_get_default_branch` / `_get_branch_sha` / `_list_open_prs` shims that call the provider directly. Despite the identical names they are unrelated functions and are left alone. (Whether those two should share a cache is a separate question, and `module_impact_service` in particular is a plausible future candidate.)

No route, response attribute, wire field, config key, Helm value or database column changes.