### PR TITLE
chore(deps): build the Go modules with 1.26.6

### DIFF
--- a/go-terrapod/go.mod
+++ b/go-terrapod/go.mod
@@ -1,3 +1,3 @@
 module github.com/mattrobinsonsre/terrapod/go-terrapod
 
-go 1.26.5
+go 1.26.6

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/mcp
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/mattrobinsonsre/terrapod/go-terrapod v0.0.0

--- a/migrate/go.mod
+++ b/migrate/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/migrate
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/storage v1.62.2

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/provider
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.13.0

--- a/publish/go.mod
+++ b/publish/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/publish
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/ProtonMail/go-crypto v1.4.1

--- a/query/go.mod
+++ b/query/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/terrapod/query
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/hashicorp/hcl/v2 v2.24.0


### PR DESCRIPTION
Two Go stdlib advisories landed against 1.26.5, both fixed in 1.26.6:

- **CVE-2026-39821** — `golang.org/x/net/idna`, privilege escalation via incorrect Punycode label processing (HIGH)
- **CVE-2026-46600** — `golang.org/x/net/dns/dnsmessage`, denial of service on invalid DNS record parsing (HIGH)

They show up as Trivy failures on `terrapod-api` and `terrapod-runner` only, on both arches. That is not arbitrary: those are the two images that bake in `terrapod-query`, and the `build-query` job builds it with `go-version-file: query/go.mod`. The scan is reading the stdlib compiled into that binary.

All six modules move together rather than just `query/`, so the released `provider`, `migrate`, `publish` and `mcp` binaries and the SDK carry the patched stdlib too — otherwise we would fix only the module that happened to trip a scan and leave the others shipping the same vulnerable runtime until something noticed.

Per the release checklist's preference: where a fix exists upstream and is reachable, take the bump rather than adding an entry to the accepted-risk register.

Verified `go build ./...` on the modules after the bump.